### PR TITLE
Reader: Allow users to answer daily prompts multiple times

### DIFF
--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -30,7 +30,15 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index, menu } ) => 
 	const thisIsAIPrompt = isAIBLoggingPrompt( prompts[ promptIndex ] );
 
 	const getPrompt = () => {
-		return prompts ? prompts[ promptIndex ] : null;
+		const selectedPrompt = prompts ? prompts[ promptIndex ] : null;
+
+		if ( ! selectedPrompt ) {
+			return null;
+		}
+
+		selectedPrompt.answered = true;
+
+		return selectedPrompt;
 	};
 
 	// If no site ID set, go through site selector before rendering post editor

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -30,15 +30,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index, menu } ) => 
 	const thisIsAIPrompt = isAIBLoggingPrompt( prompts[ promptIndex ] );
 
 	const getPrompt = () => {
-		const selectedPrompt = prompts ? prompts[ promptIndex ] : null;
-
-		if ( ! selectedPrompt ) {
-			return null;
-		}
-
-		selectedPrompt.answered = true;
-
-		return selectedPrompt;
+		return prompts ? prompts[ promptIndex ] : null;
 	};
 
 	// If no site ID set, go through site selector before rendering post editor

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -74,10 +74,6 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index, menu } ) => 
 		// Prevent navigating away so we have time to record the click.
 		e.preventDefault();
 
-		if ( getPrompt()?.answered ) {
-			return;
-		}
-
 		dispatch(
 			recordTracksEvent( tracksPrefix + 'answer_prompt', {
 				site_id: siteId,
@@ -234,19 +230,11 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index, menu } ) => 
 					href={ getNewPostLink() }
 					onClick={ handleBloggingPromptClick }
 					className="blogging-prompt__new-post-link"
-					disabled={ getPrompt()?.answered }
 				>
-					{ getPrompt()?.answered ? (
-						<>
-							<Gridicon icon="checkmark" size={ 18 } />
-							{ translate( 'Answered' ) }
-						</>
-					) : (
-						translate( 'Post Answer', {
-							comment:
-								'"Post" here is a verb meaning "to publish", as in "post an answer to this writing prompt"',
-						} )
-					) }
+					{ translate( 'Post Answer', {
+						comment:
+							'"Post" here is a verb meaning "to publish", as in "post an answer to this writing prompt"',
+					} ) }
 				</Button>
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/548

## Proposed Changes

Removed `disabled` attribute from the response button of daily prompts card so that user can answer the prompt more than once.

| Before | After |
|--------|------|
|![image](https://github.com/user-attachments/assets/e78b63c9-d092-4833-b9a2-ddb34aaebe45)|![image](https://github.com/user-attachments/assets/744d0189-5d5c-40fa-864b-057b5d3de685)|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently we have `350+` daily prompts and users can't answer the prompt more than once.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR `loop-548/allow-user-to-answer-daily-prompts-multiple-times`
* `git checkout 1b4092b2a4fd1b3c86b561526f06dd682d15f961` which manually add `answered` attribute on each prompt to observe the issue.
* Navigate to `/tag/dailyprompt`. Scroll until you find the "Daily Writing Prompt" card and note that there is no way to answer the prompt.
* `git checkout -`
* Navigate to `/tag/dailyprompt`. Scroll until you find the "Daily Writing Prompt" card and note that we are now able to answer the prompt.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
