### PR TITLE
Hosting Logs: remove `atomic_site_id`

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -55,7 +55,7 @@ interface PHPLogFromEndpoint {
 	atomic_site_id: number;
 }
 
-export interface PHPLog extends PHPLogFromEndpoint {
+export interface PHPLog extends Omit< PHPLogFromEndpoint, 'atomic_site_id' > {
 	id: string;
 }
 
@@ -142,7 +142,12 @@ export function useSiteLogsQuery(
 				has_more: !! data.scroll_id,
 				total_results:
 					typeof data.total_results === 'number' ? data.total_results : data.total_results.value,
-				logs: data.logs.map( ( log, key ) => ( { ...log, id: String( key ) } ) ),
+				logs: data.logs.map( ( { atomic_site_id, ...restLog }: any, key ) => {
+					return {
+						...restLog,
+						id: String( key ),
+					};
+				} ),
 				scroll_id: data.scroll_id,
 			};
 		},

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -6,14 +6,14 @@ interface SiteLogsAPIResponse {
 	message: string;
 	data: {
 		total_results: number | { value: number; relation: string };
-		logs: ( PHPLogFromEndpoint | ServerLogFromEndpoint )[];
+		logs: (PHPLogFromEndpoint | ServerLogFromEndpoint)[];
 		scroll_id: string | null;
 	};
 }
 
 interface SiteLogsData {
 	total_results: number;
-	logs: ( ServerLog | PHPLog )[];
+	logs: (ServerLog | PHPLog)[];
 	scroll_id: string | null;
 	has_more: boolean;
 }
@@ -55,7 +55,7 @@ interface PHPLogFromEndpoint {
 	atomic_site_id: number;
 }
 
-export interface PHPLog extends Omit< PHPLogFromEndpoint, 'atomic_site_id' > {
+export interface PHPLog extends Omit<PHPLogFromEndpoint, 'atomic_site_id'> {
 	id: string;
 }
 
@@ -77,7 +77,7 @@ export interface LogQueryParams {
 }
 
 export interface FilterType {
-	[ key: string ]: Array< string >;
+	[key: string]: Array<string>;
 }
 
 interface SiteLogsParams {
@@ -93,35 +93,32 @@ interface SiteLogsParams {
 export function useSiteLogsQuery(
 	siteId: number | null | undefined,
 	params: SiteLogsParams,
-	queryOptions: Omit<
-		UseQueryOptions< SiteLogsAPIResponse, unknown, SiteLogsData >,
-		'queryKey'
-	> = {}
+	queryOptions: Omit<UseQueryOptions<SiteLogsAPIResponse, unknown, SiteLogsData>, 'queryKey'> = {}
 ) {
 	const queryClient = useQueryClient();
-	const [ scrollId, setScrollId ] = useState< string | undefined >();
+	const [scrollId, setScrollId] = useState<string | undefined>();
 
 	// The scroll ID represents the state of a particular set of filtering arguments. If any of
 	// those filter arguments change we throw out the scroll ID so we can start over.
-	const [ previousSiteId, setPreviousSiteId ] = useState( siteId );
-	const [ previousParams, setPreviousParams ] = useState( params );
-	if ( previousSiteId !== siteId || ! areRequestParamsEqual( previousParams, params ) ) {
-		queryClient.removeQueries( {
-			queryKey: buildPartialQueryKey( previousSiteId, previousParams ),
-		} );
+	const [previousSiteId, setPreviousSiteId] = useState(siteId);
+	const [previousParams, setPreviousParams] = useState(params);
+	if (previousSiteId !== siteId || !areRequestParamsEqual(previousParams, params)) {
+		queryClient.removeQueries({
+			queryKey: buildPartialQueryKey(previousSiteId, previousParams),
+		});
 
 		// We're updating state directly in the render flow. This is preferable to using an effect.
 		// https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-		setPreviousSiteId( siteId );
-		setPreviousParams( params );
-		setScrollId( undefined );
+		setPreviousSiteId(siteId);
+		setPreviousParams(params);
+		setScrollId(undefined);
 	}
 
-	const queryResult = useQuery< SiteLogsAPIResponse, unknown, SiteLogsData >( {
-		queryKey: buildQueryKey( siteId, params ),
+	const queryResult = useQuery<SiteLogsAPIResponse, unknown, SiteLogsData>({
+		queryKey: buildQueryKey(siteId, params),
 		queryFn: () => {
 			const logTypeFragment = params.logType === LogType.PHP ? 'error-logs' : 'logs';
-			const path = `/sites/${ siteId }/hosting/${ logTypeFragment }`;
+			const path = `/sites/${siteId}/hosting/${logTypeFragment}`;
 			return wpcom.req.get(
 				{ path, apiNamespace: 'wpcom/v2' },
 				{
@@ -135,19 +132,19 @@ export function useSiteLogsQuery(
 			);
 		},
 		placeholderData: keepPreviousData,
-		enabled: !! siteId && params.start <= params.end,
+		enabled: !!siteId && params.start <= params.end,
 		staleTime: Infinity, // The logs within a specified time range never change.
-		select( { data }: SiteLogsAPIResponse ): SiteLogsData {
+		select({ data }: SiteLogsAPIResponse): SiteLogsData {
 			return {
-				has_more: !! data.scroll_id,
+				has_more: !!data.scroll_id,
 				total_results:
 					typeof data.total_results === 'number' ? data.total_results : data.total_results.value,
-				logs: data.logs.map( ( { atomic_site_id, ...restLog }: any, key ) => {
+				logs: data.logs.map(({ atomic_site_id, ...restLog }: any, key) => {
 					return {
 						...restLog,
-						id: String( key ),
+						id: String(key),
 					};
-				} ),
+				}),
 				scroll_id: data.scroll_id,
 			};
 		},
@@ -155,15 +152,15 @@ export function useSiteLogsQuery(
 			persist: false,
 		},
 		...queryOptions,
-	} );
+	});
 
 	const { data } = queryResult;
 
-	useEffect( () => {
-		if ( data?.has_more && scrollId !== data.scroll_id ) {
-			setScrollId( data.scroll_id ?? undefined );
+	useEffect(() => {
+		if (data?.has_more && scrollId !== data.scroll_id) {
+			setScrollId(data.scroll_id ?? undefined);
 		}
-	}, [ data, scrollId ] );
+	}, [data, scrollId]);
 
 	// The state represented by scroll ID will have already advanced to the next page, so we
 	// can't allow `refetch` to be used. Remember, the logs are fetched with a POST and the
@@ -175,13 +172,13 @@ export function useSiteLogsQuery(
 	};
 }
 
-function buildPartialQueryKey( siteId: number | null | undefined, params: SiteLogsParams ) {
-	return [ params.logType === LogType.PHP ? 'site-logs-php' : 'site-logs-web', siteId ];
+function buildPartialQueryKey(siteId: number | null | undefined, params: SiteLogsParams) {
+	return [params.logType === LogType.PHP ? 'site-logs-php' : 'site-logs-web', siteId];
 }
 
-function buildQueryKey( siteId: number | null | undefined, params: SiteLogsParams ) {
+function buildQueryKey(siteId: number | null | undefined, params: SiteLogsParams) {
 	return [
-		...buildPartialQueryKey( siteId, params ),
+		...buildPartialQueryKey(siteId, params),
 		params.start,
 		params.end,
 		params.filter,
@@ -193,34 +190,34 @@ function buildQueryKey( siteId: number | null | undefined, params: SiteLogsParam
 
 // Request params are equal if every field is the same _except_ for the page index.
 // The page index is not part of the request body, it is only part of the query key.
-function areRequestParamsEqual( a: SiteLogsParams, b: SiteLogsParams ) {
+function areRequestParamsEqual(a: SiteLogsParams, b: SiteLogsParams) {
 	return (
 		a.logType === b.logType &&
 		a.start === b.start &&
 		a.end === b.end &&
 		a.sortOrder === b.sortOrder &&
 		a.pageSize === b.pageSize &&
-		areFilterParamsEqual( a.filter, b.filter )
+		areFilterParamsEqual(a.filter, b.filter)
 	);
 }
 
-function areFilterParamsEqual( a: FilterType, b: FilterType ) {
-	for ( const filter in a ) {
-		if ( ! b.hasOwnProperty( filter ) ) {
+function areFilterParamsEqual(a: FilterType, b: FilterType) {
+	for (const filter in a) {
+		if (!b.hasOwnProperty(filter)) {
 			return false;
 		}
 
-		if ( a[ filter ].toString() !== b[ filter ].toString() ) {
+		if (a[filter].toString() !== b[filter].toString()) {
 			return false;
 		}
 	}
 
-	for ( const filter in b ) {
-		if ( ! a.hasOwnProperty( filter ) ) {
+	for (const filter in b) {
+		if (!a.hasOwnProperty(filter)) {
 			return false;
 		}
 
-		if ( b[ filter ].toString() !== a[ filter ].toString() ) {
+		if (b[filter].toString() !== a[filter].toString()) {
 			return false;
 		}
 	}

--- a/client/sites/logs/components/details-modal-php.tsx
+++ b/client/sites/logs/components/details-modal-php.tsx
@@ -10,19 +10,19 @@ interface DetailsModalPHPProps {
 	item: PHPLog;
 }
 
-const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
+const DetailsModalPHP = ({ item }: DetailsModalPHPProps) => {
 	const translate = useTranslate();
 	const siteGmtOffset = useCurrentSiteGmtOffset();
 	const siteGsmOffsetDisplay =
-		siteGmtOffset === 0 ? 'UTC' : `UTC${ siteGmtOffset > 0 ? '+' : '' }${ siteGmtOffset }`;
-	const locale = useSelector( getCurrentUserLocale );
+		siteGmtOffset === 0 ? 'UTC' : `UTC${siteGmtOffset > 0 ? '+' : ''}${siteGmtOffset}`;
+	const locale = useSelector(getCurrentUserLocale);
 
-	const getFormattedDate = ( value: string ) => {
+	const getFormattedDate = (value: string) => {
 		const dateFormat = locale === 'en' ? 'll [at] h:mm A' : 'h:mm A, ll';
-		const formattedDate = moment( value )
-			.utcOffset( siteGmtOffset * 60 )
-			.format( dateFormat );
-		return <span>{ formattedDate }</span>;
+		const formattedDate = moment(value)
+			.utcOffset(siteGmtOffset * 60)
+			.format(dateFormat);
+		return <span>{formattedDate}</span>;
 	};
 
 	return (
@@ -30,26 +30,26 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 			<div className="site-logs-details-modal__field-title">
 				{
 					// translators: %(siteGsmOffsetDisplay)s will be replaced with the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-					translate( 'Date & Time (%(siteGsmOffsetDisplay)s)', {
+					translate('Date & Time (%(siteGsmOffsetDisplay)s)', {
 						args: { siteGsmOffsetDisplay },
-					} )
+					})
 				}
 			</div>
-			<div>{ getFormattedDate( item.timestamp ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Severity' ) }</div>
+			<div>{getFormattedDate(item.timestamp)}</div>
+			<div className="site-logs-details-modal__field-title">{translate('Severity')}</div>
 			<div>
-				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
+				<Badge className={`badge--${item.severity}`}>{item.severity}</Badge>
 			</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Message' ) }</div>
-			<div>{ item.message }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Kind' ) }</div>
-			<div>{ item.kind }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Name' ) }</div>
-			<div>{ item.name }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'File' ) }</div>
-			<div>{ item.file }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Line' ) }</div>
-			<div>{ numberFormat( item.line ) }</div>
+			<div className="site-logs-details-modal__field-title">{translate('Message')}</div>
+			<div>{item.message}</div>
+			<div className="site-logs-details-modal__field-title">{translate('Kind')}</div>
+			<div>{item.kind}</div>
+			<div className="site-logs-details-modal__field-title">{translate('Name')}</div>
+			<div>{item.name}</div>
+			<div className="site-logs-details-modal__field-title">{translate('File')}</div>
+			<div>{item.file}</div>
+			<div className="site-logs-details-modal__field-title">{translate('Line')}</div>
+			<div>{numberFormat(item.line)}</div>
 		</div>
 	);
 };

--- a/client/sites/logs/components/details-modal-php.tsx
+++ b/client/sites/logs/components/details-modal-php.tsx
@@ -50,8 +50,6 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 			<div>{ item.file }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'Line' ) }</div>
 			<div>{ numberFormat( item.line ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'Atomic Site Id' ) }</div>
-			<div>{ item.atomic_site_id }</div>
 		</div>
 	);
 };

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -8,8 +8,8 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { useCurrentSiteGmtOffset } from './use-current-site-gmt-offset';
 import type { Field, Operator } from '@wordpress/dataviews';
 
-const getLabelCached = ( cached: string ) => {
-	switch ( cached ) {
+const getLabelCached = (cached: string) => {
+	switch (cached) {
 		case 'false':
 			return 'False';
 		case 'true':
@@ -18,8 +18,8 @@ const getLabelCached = ( cached: string ) => {
 			return cached;
 	}
 };
-const getLabelRenderer = ( renderer: string ) => {
-	switch ( renderer ) {
+const getLabelRenderer = (renderer: string) => {
+	switch (renderer) {
 		case 'php':
 			return 'PHP';
 		case 'static':
@@ -28,85 +28,85 @@ const getLabelRenderer = ( renderer: string ) => {
 			return renderer;
 	}
 };
-export const VALUES_CACHED = [ 'false', 'true' ];
-export const VALUES_RENDERER = [ 'php', 'static' ];
-export const VALUES_REQUEST_TYPE = [ 'GET', 'HEAD', 'POST', 'PUT', 'DELETE' ];
-export const VALUES_SEVERITY = [ 'User', 'Warning', 'Deprecated', 'Fatal error' ];
-export const VALUES_STATUS = [ '200', '301', '302', '400', '401', '403', '404', '429', '500' ];
+export const VALUES_CACHED = ['false', 'true'];
+export const VALUES_RENDERER = ['php', 'static'];
+export const VALUES_REQUEST_TYPE = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'];
+export const VALUES_SEVERITY = ['User', 'Warning', 'Deprecated', 'Fatal error'];
+export const VALUES_STATUS = ['200', '301', '302', '400', '401', '403', '404', '429', '500'];
 
-const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPLog >[] => {
+const useFields = ({ logType }: { logType: LogType }): Field<ServerLog | PHPLog>[] => {
 	const translate = useTranslate();
-	const locale = useSelector( getCurrentUserLocale );
+	const locale = useSelector(getCurrentUserLocale);
 	const siteGmtOffset = useCurrentSiteGmtOffset();
 	const siteGsmOffsetDisplay =
-		siteGmtOffset === 0 ? 'UTC' : `UTC${ siteGmtOffset > 0 ? '+' : '' }${ siteGmtOffset }`;
+		siteGmtOffset === 0 ? 'UTC' : `UTC${siteGmtOffset > 0 ? '+' : ''}${siteGmtOffset}`;
 
 	const getFormattedDate = useMemo(
-		() => ( value: string ) => {
+		() => (value: string) => {
 			const dateFormat = locale === 'en' ? 'll [at] h:mm A' : 'h:mm A, ll';
-			const formattedDate = moment( value )
-				.utcOffset( siteGmtOffset * 60 )
-				.format( dateFormat );
-			return <span>{ formattedDate }</span>;
+			const formattedDate = moment(value)
+				.utcOffset(siteGmtOffset * 60)
+				.format(dateFormat);
+			return <span>{formattedDate}</span>;
 		},
-		[ locale, siteGmtOffset ]
+		[locale, siteGmtOffset]
 	);
 
-	const fields = useMemo( () => {
-		if ( logType === LogType.PHP ) {
+	const fields = useMemo(() => {
+		if (logType === LogType.PHP) {
 			return [
 				{
 					id: 'timestamp',
 					type: 'date',
 					// translators: %(siteGsmOffsetDisplay)s will be replaced with the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-					label: translate( 'Date & time (%(siteGsmOffsetDisplay)s)', {
+					label: translate('Date & time (%(siteGsmOffsetDisplay)s)', {
 						args: { siteGsmOffsetDisplay },
-					} ),
-					render: ( { item }: { item: PHPLog } ) => getFormattedDate( item.timestamp ),
+					}),
+					render: ({ item }: { item: PHPLog }) => getFormattedDate(item.timestamp),
 					enableHiding: false,
 				},
 				{
 					id: 'severity',
 					type: 'text',
-					label: translate( 'Severity' ),
-					elements: VALUES_SEVERITY.map( ( severity ) => ( { value: severity, label: severity } ) ),
+					label: translate('Severity'),
+					elements: VALUES_SEVERITY.map((severity) => ({ value: severity, label: severity })),
 					filterBy: {
-						operators: [ 'isAny' as Operator ],
+						operators: ['isAny' as Operator],
 					},
-					render: ( { item }: { item: PHPLog } ) => {
+					render: ({ item }: { item: PHPLog }) => {
 						const severity = item.severity;
-						return <Badge className={ `badge--${ severity }` }>{ severity }</Badge>;
+						return <Badge className={`badge--${severity}`}>{severity}</Badge>;
 					},
 					enableSorting: false,
 				},
 				{
 					id: 'message',
 					type: 'text',
-					label: translate( 'Message' ),
-					render: ( { item }: { item: PHPLog } ) => {
-						return <span className="site-logs-table__message">{ item.message }</span>;
+					label: translate('Message'),
+					render: ({ item }: { item: PHPLog }) => {
+						return <span className="site-logs-table__message">{item.message}</span>;
 					},
 					enableSorting: false,
 				},
-				{ id: 'kind', type: 'text', label: translate( 'Kind' ), enableSorting: false },
-				{ id: 'name', type: 'text', label: translate( 'Name' ), enableSorting: false },
+				{ id: 'kind', type: 'text', label: translate('Kind'), enableSorting: false },
+				{ id: 'name', type: 'text', label: translate('Name'), enableSorting: false },
 				{
 					id: 'file',
 					type: 'text',
-					label: translate( 'File' ),
-					render: ( { item }: { item: PHPLog } ) => {
-						return <span className="site-logs-table__file">{ item.file }</span>;
+					label: translate('File'),
+					render: ({ item }: { item: PHPLog }) => {
+						return <span className="site-logs-table__file">{item.file}</span>;
 					},
 					enableSorting: false,
 				},
 				{
 					id: 'line',
 					type: 'integer',
-					label: translate( 'Line' ),
-					render: ( { item }: { item: PHPLog } ) => numberFormat( item.line ),
+					label: translate('Line'),
+					render: ({ item }: { item: PHPLog }) => numberFormat(item.line),
 					enableSorting: false,
 				},
-			] as Field< PHPLog | ServerLog >[];
+			] as Field<PHPLog | ServerLog>[];
 		}
 
 		return [
@@ -114,145 +114,145 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 				id: 'date',
 				type: 'datetime',
 				// translators: %(siteGsmOffsetDisplay)s will be replaced with the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-				label: translate( 'Date & time (%(siteGsmOffsetDisplay)s)', {
+				label: translate('Date & time (%(siteGsmOffsetDisplay)s)', {
 					args: { siteGsmOffsetDisplay },
-				} ),
-				render: ( { item }: { item: ServerLog } ) => getFormattedDate( item.date ),
+				}),
+				render: ({ item }: { item: ServerLog }) => getFormattedDate(item.date),
 				enableHiding: false,
 			},
 			{
 				id: 'request_type',
 				type: 'text',
-				label: translate( 'Request type' ),
-				elements: VALUES_REQUEST_TYPE.map( ( type ) => ( { value: type, label: type } ) ),
+				label: translate('Request type'),
+				elements: VALUES_REQUEST_TYPE.map((type) => ({ value: type, label: type })),
 				filterBy: {
-					operators: [ 'isAny' as Operator ],
+					operators: ['isAny' as Operator],
 				},
-				render: ( { item }: { item: ServerLog } ) => {
+				render: ({ item }: { item: ServerLog }) => {
 					const requestType = item.request_type;
-					return <Badge className={ `badge--${ requestType }` }>{ requestType }</Badge>;
+					return <Badge className={`badge--${requestType}`}>{requestType}</Badge>;
 				},
 				enableSorting: false,
 			},
 			{
 				id: 'status',
 				type: 'text',
-				label: translate( 'Status' ),
-				elements: VALUES_STATUS.map( ( status ) => ( { value: status, label: status } ) ),
+				label: translate('Status'),
+				elements: VALUES_STATUS.map((status) => ({ value: status, label: status })),
 				filterBy: {
-					operators: [ 'isAny' as Operator ],
+					operators: ['isAny' as Operator],
 				},
 				enableSorting: false,
 			},
 			{
 				id: 'request_url',
 				type: 'text',
-				label: translate( 'Request URL' ),
-				render: ( { item }: { item: ServerLog } ) => {
-					return <span className="site-logs-table__request-url">{ item.request_url }</span>;
+				label: translate('Request URL'),
+				render: ({ item }: { item: ServerLog }) => {
+					return <span className="site-logs-table__request-url">{item.request_url}</span>;
 				},
 				enableSorting: false,
 			},
 			{
 				id: 'body_bytes_sent',
 				type: 'integer',
-				label: translate( 'Body bytes sent' ),
-				render: ( { item }: { item: ServerLog } ) => numberFormat( item.body_bytes_sent ),
+				label: translate('Body bytes sent'),
+				render: ({ item }: { item: ServerLog }) => numberFormat(item.body_bytes_sent),
 				enableSorting: false,
 			},
 			{
 				id: 'cached',
 				type: 'text',
-				label: translate( 'Cached' ),
+				label: translate('Cached'),
 				enableSorting: false,
-				elements: VALUES_CACHED.map( ( cached ) => ( {
+				elements: VALUES_CACHED.map((cached) => ({
 					value: cached,
-					label: getLabelCached( cached ),
-				} ) ),
+					label: getLabelCached(cached),
+				})),
 				filterBy: {
-					operators: [ 'isAny' as Operator ],
+					operators: ['isAny' as Operator],
 				},
 			},
-			{ id: 'http_host', type: 'text', label: translate( 'HTTP Host' ), enableSorting: false },
+			{ id: 'http_host', type: 'text', label: translate('HTTP Host'), enableSorting: false },
 			{
 				id: 'http_referer',
 				type: 'text',
-				label: translate( 'HTTP Referrer' ),
-				render: ( { item }: { item: ServerLog } ) => {
-					return <span className="site-logs-table__http-referer">{ item.http_referer }</span>;
+				label: translate('HTTP Referrer'),
+				render: ({ item }: { item: ServerLog }) => {
+					return <span className="site-logs-table__http-referer">{item.http_referer}</span>;
 				},
 				enableSorting: false,
 			},
 			{
 				id: 'http2',
 				type: 'text',
-				label: translate( 'HTTP2' ),
+				label: translate('HTTP2'),
 				enableSorting: false,
 			},
 			{
 				id: 'http_user_agent',
 				type: 'text',
-				label: translate( 'HTTP User Agent' ),
+				label: translate('HTTP User Agent'),
 				enableSorting: false,
 			},
 			{
 				id: 'http_version',
 				type: 'text',
-				label: translate( 'HTTP Version' ),
+				label: translate('HTTP Version'),
 				enableSorting: false,
 			},
 			{
 				id: 'http_x_forwarded_for',
 				type: 'text',
-				label: translate( 'HTTP X Forwarded Port' ),
+				label: translate('HTTP X Forwarded Port'),
 				enableSorting: false,
 			},
 			{
 				id: 'renderer',
 				type: 'text',
-				label: translate( 'Renderer' ),
-				elements: VALUES_RENDERER.map( ( renderer ) => ( {
+				label: translate('Renderer'),
+				elements: VALUES_RENDERER.map((renderer) => ({
 					value: renderer,
-					label: getLabelRenderer( renderer ),
-				} ) ),
+					label: getLabelRenderer(renderer),
+				})),
 				filterBy: {
-					operators: [ 'isAny' as Operator ],
+					operators: ['isAny' as Operator],
 				},
 				enableSorting: false,
 			},
 			{
 				id: 'request_completion',
 				type: 'text',
-				label: translate( 'Request Completion' ),
+				label: translate('Request Completion'),
 				enableSorting: false,
 			},
 			{
 				id: 'request_time',
 				type: 'text',
-				label: translate( 'Request Time' ),
+				label: translate('Request Time'),
 				enableSorting: false,
 			},
 			{
 				id: 'scheme',
 				type: 'text',
-				label: translate( 'Scheme' ),
+				label: translate('Scheme'),
 				enableSorting: false,
 			},
-			{ id: 'timestamp', type: 'integer', label: translate( 'Timestamp' ), enableSorting: false },
+			{ id: 'timestamp', type: 'integer', label: translate('Timestamp'), enableSorting: false },
 			{
 				id: 'type',
 				type: 'text',
-				label: translate( 'Type' ),
+				label: translate('Type'),
 				enableSorting: false,
 			},
 			{
 				id: 'user_ip',
 				type: 'text',
-				label: translate( 'User IP' ),
+				label: translate('User IP'),
 				enableSorting: false,
 			},
-		] as Field< PHPLog | ServerLog >[];
-	}, [ getFormattedDate, logType, siteGsmOffsetDisplay, translate ] );
+		] as Field<PHPLog | ServerLog>[];
+	}, [getFormattedDate, logType, siteGsmOffsetDisplay, translate]);
 
 	return fields;
 };

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -106,12 +106,6 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					render: ( { item }: { item: PHPLog } ) => numberFormat( item.line ),
 					enableSorting: false,
 				},
-				{
-					id: 'atomic_site_id',
-					type: 'integer',
-					label: translate( 'Atomic Site ID' ),
-					enableSorting: false,
-				},
 			] as Field< PHPLog | ServerLog >[];
 		}
 

--- a/client/sites/logs/hooks/use-site-logs-downloader.ts
+++ b/client/sites/logs/hooks/use-site-logs-downloader.ts
@@ -12,7 +12,7 @@ import type { Moment } from 'moment';
 
 interface LogsAPIResponse {
 	data: {
-		logs: Record< string, unknown >[];
+		logs: Record<string, unknown>[];
 		scroll_id: string | null;
 		total_results: number;
 	};
@@ -48,7 +48,7 @@ const siteLogsDownloaderReducer = (
 	state: SiteLogsDownloaderReducerState = initialState,
 	action: SiteLogsDownloaderReducerAction
 ): SiteLogsDownloaderReducerState => {
-	if ( action.type === 'DOWNLOAD_START' ) {
+	if (action.type === 'DOWNLOAD_START') {
 		return {
 			status: 'downloading',
 			recordsDownloaded: 0,
@@ -56,20 +56,20 @@ const siteLogsDownloaderReducer = (
 		};
 	}
 
-	if ( action.type === 'DOWNLOAD_UPDATE' ) {
+	if (action.type === 'DOWNLOAD_UPDATE') {
 		return {
 			status: 'downloading',
 			...action.payload,
 		};
 	}
 
-	if ( action.type === 'DOWNLOAD_ERROR' ) {
+	if (action.type === 'DOWNLOAD_ERROR') {
 		return {
 			status: 'error',
 		};
 	}
 
-	if ( action.type === 'DOWNLOAD_COMPLETE' ) {
+	if (action.type === 'DOWNLOAD_COMPLETE') {
 		return {
 			status: 'complete',
 			...action.payload,
@@ -86,68 +86,68 @@ interface UseSiteLogsDownloaderArgs {
 	filter: FilterType;
 }
 
-export const useSiteLogsDownloader = ( {
+export const useSiteLogsDownloader = ({
 	roundDateRangeToWholeDays = true,
-}: { roundDateRangeToWholeDays?: boolean } = {} ) => {
+}: { roundDateRangeToWholeDays?: boolean } = {}) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
-	const localeDateFormat = moment.localeData().longDateFormat( 'L' );
+	const localeDateFormat = moment.localeData().longDateFormat('L');
 
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector(getSelectedSiteId);
+	const siteSlug = useSelector(getSelectedSiteSlug);
 
 	const reduxDispatch = useDispatch();
 
-	const recordDownloadStarted = ( props: Record< string, unknown > ) =>
-		reduxDispatch( recordTracksEvent( 'calypso_atomic_logs_download_started', props ) );
+	const recordDownloadStarted = (props: Record<string, unknown>) =>
+		reduxDispatch(recordTracksEvent('calypso_atomic_logs_download_started', props));
 
-	const recordDownloadCompleted = ( props: Record< string, unknown > ) =>
-		reduxDispatch( recordTracksEvent( 'calypso_atomic_logs_download_completed', props ) );
+	const recordDownloadCompleted = (props: Record<string, unknown>) =>
+		reduxDispatch(recordTracksEvent('calypso_atomic_logs_download_completed', props));
 
-	const recordDownloadError = ( props: Record< string, unknown > ) =>
-		reduxDispatch( recordTracksEvent( 'calypso_atomic_logs_download_error', props ) );
+	const recordDownloadError = (props: Record<string, unknown>) =>
+		reduxDispatch(recordTracksEvent('calypso_atomic_logs_download_error', props));
 
-	const downloadSuccessNotice = ( ...props: Parameters< typeof successNotice > ) =>
-		reduxDispatch( successNotice( ...props ) );
+	const downloadSuccessNotice = (...props: Parameters<typeof successNotice>) =>
+		reduxDispatch(successNotice(...props));
 
-	const downloadErrorNotice = ( ...props: Parameters< typeof errorNotice > ) =>
-		reduxDispatch( errorNotice( ...props ) );
+	const downloadErrorNotice = (...props: Parameters<typeof errorNotice>) =>
+		reduxDispatch(errorNotice(...props));
 
-	const [ state, dispatch ] = useReducer( siteLogsDownloaderReducer, initialState );
+	const [state, dispatch] = useReducer(siteLogsDownloaderReducer, initialState);
 
-	const downloadLogs = async ( {
+	const downloadLogs = async ({
 		logType,
 		startDateTime,
 		endDateTime,
 		filter,
-	}: UseSiteLogsDownloaderArgs ) => {
-		dispatch( {
+	}: UseSiteLogsDownloaderArgs) => {
+		dispatch({
 			type: 'DOWNLOAD_START',
-		} );
+		});
 
 		let path = null;
-		if ( logType === LogType.PHP ) {
-			path = `/sites/${ siteId }/hosting/error-logs`;
-		} else if ( logType === LogType.WEB ) {
-			path = `/sites/${ siteId }/hosting/logs`;
+		if (logType === LogType.PHP) {
+			path = `/sites/${siteId}/hosting/error-logs`;
+		} else if (logType === LogType.WEB) {
+			path = `/sites/${siteId}/hosting/logs`;
 		} else {
-			downloadErrorNotice( translate( 'Invalid log type specified' ) );
-			dispatch( {
+			downloadErrorNotice(translate('Invalid log type specified'));
+			dispatch({
 				type: 'DOWNLOAD_ERROR',
-			} );
+			});
 			return;
 		}
 
 		const startMoment = roundDateRangeToWholeDays
-			? moment.utc( startDateTime, localeDateFormat ).startOf( 'day' )
-			: moment.utc( startDateTime, localeDateFormat );
+			? moment.utc(startDateTime, localeDateFormat).startOf('day')
+			: moment.utc(startDateTime, localeDateFormat);
 		const endMoment = roundDateRangeToWholeDays
-			? moment.utc( endDateTime, localeDateFormat ).endOf( 'day' )
-			: moment.utc( endDateTime, localeDateFormat );
+			? moment.utc(endDateTime, localeDateFormat).endOf('day')
+			: moment.utc(endDateTime, localeDateFormat);
 
 		const dateFormat = 'YYYYMMDDHHmmss';
-		const startString = startMoment.format( dateFormat );
-		const endString = endMoment.format( dateFormat );
+		const startString = startMoment.format(dateFormat);
+		const endString = endMoment.format(dateFormat);
 
 		const startTime = startMoment.unix();
 		const endTime = endMoment.unix();
@@ -156,12 +156,12 @@ export const useSiteLogsDownloader = ( {
 		const tracksProps = {
 			site_slug: siteSlug,
 			site_id: siteId,
-			start_time: startMoment.format( trackDateFormat ),
-			end_time: endMoment.format( trackDateFormat ),
+			start_time: startMoment.format(trackDateFormat),
+			end_time: endMoment.format(trackDateFormat),
 			log_type: logType,
 		};
 
-		recordDownloadStarted( tracksProps );
+		recordDownloadStarted(tracksProps);
 
 		let scrollId = null;
 		let logs: string[] = [];
@@ -184,91 +184,91 @@ export const useSiteLogsDownloader = ( {
 						scroll_id: scrollId,
 					}
 				)
-				.then( ( response: LogsAPIResponse ) => {
-					const newLogData = get( response, 'data.logs', [] );
-					scrollId = get( response, 'data.scroll_id', null );
+				.then((response: LogsAPIResponse) => {
+					const newLogData = get(response, 'data.logs', []);
+					scrollId = get(response, 'data.scroll_id', null);
 
-					if ( isEmpty( logs ) ) {
-						if ( isEmpty( newLogData ) ) {
-							downloadErrorNotice( translate( 'No logs available for this time range' ) );
+					if (isEmpty(logs)) {
+						if (isEmpty(newLogData)) {
+							downloadErrorNotice(translate('No logs available for this time range'));
 							isError = true;
 						} else {
 							logs = [
-								Object.keys( newLogData[ 0 ] )
-									.filter( ( key ) => key !== 'atomic_site_id' )
-									.join( ',' ) + '\n',
+								Object.keys(newLogData[0])
+									.filter((key) => key !== 'atomic_site_id')
+									.join(',') + '\n',
 							];
-							totalLogs = get( response, 'data.total_results', 1 );
+							totalLogs = get(response, 'data.total_results', 1);
 						}
 					}
 
 					logs = [
 						...logs,
-						...map( newLogData, ( entry ) => {
+						...map(newLogData, (entry) => {
 							const cleanedEntry = Object.fromEntries(
-								Object.entries( entry ).filter( ( [ key ] ) => key !== 'atomic_site_id' )
+								Object.entries(entry).filter(([key]) => key !== 'atomic_site_id')
 							);
-							return Object.values( cleanedEntry ).join( ',' ) + '\n';
-						} ),
+							return Object.values(cleanedEntry).join(',') + '\n';
+						}),
 					];
 
-					if ( logs.length > MAX_LOGS_DOWNLOAD ) {
+					if (logs.length > MAX_LOGS_DOWNLOAD) {
 						scrollId = null;
 					}
 
-					dispatch( {
+					dispatch({
 						type: 'DOWNLOAD_UPDATE',
 						payload: {
 							recordsDownloaded: logs.length - 1,
 							totalRecordsAvailable: totalLogs,
 						},
-					} );
-				} )
-				.catch( ( error: { message: string; status: number } ) => {
+					});
+				})
+				.catch((error: { message: string; status: number }) => {
 					isError = true;
-					let message = get( error, 'message', 'Could not retrieve logs.' );
-					if ( error?.status === 500 ) {
-						message = translate( 'Could not retrieve logs. Please try again in a few minutes.' );
-					} else if ( error?.status === 400 ) {
-						message = translate( 'Could not retrieve. Please try with a different time range.' );
+					let message = get(error, 'message', 'Could not retrieve logs.');
+					if (error?.status === 500) {
+						message = translate('Could not retrieve logs. Please try again in a few minutes.');
+					} else if (error?.status === 400) {
+						message = translate('Could not retrieve. Please try with a different time range.');
 					}
-					downloadErrorNotice( message );
-					recordDownloadError( {
+					downloadErrorNotice(message);
+					recordDownloadError({
 						error_message: message,
 						...tracksProps,
-					} );
-				} );
-		} while ( null !== scrollId );
+					});
+				});
+		} while (null !== scrollId);
 
-		if ( isError ) {
-			dispatch( { type: 'DOWNLOAD_ERROR' } );
+		if (isError) {
+			dispatch({ type: 'DOWNLOAD_ERROR' });
 			return;
 		}
 
-		logFile = new Blob( logs );
+		logFile = new Blob(logs);
 
-		const url = window.URL.createObjectURL( logFile );
-		const link = document.createElement( 'a' );
+		const url = window.URL.createObjectURL(logFile);
+		const link = document.createElement('a');
 		const downloadFilename =
 			siteSlug + '-' + logType + '-logs-' + startString + '-' + endString + '.csv';
 		link.href = url;
-		link.setAttribute( 'download', downloadFilename );
+		link.setAttribute('download', downloadFilename);
 		link.click();
-		window.URL.revokeObjectURL( url );
+		window.URL.revokeObjectURL(url);
 
-		downloadSuccessNotice( translate( 'Logs downloaded.' ) );
-		recordDownloadCompleted( {
+		downloadSuccessNotice(translate('Logs downloaded.'));
+		recordDownloadCompleted({
 			download_filename: downloadFilename,
 			total_log_records_downloaded: totalLogs,
 			...tracksProps,
-		} );
-		dispatch( {
+		});
+		dispatch({
 			type: 'DOWNLOAD_COMPLETE',
 			payload: {
 				recordsDownloaded: logs.length - 1,
 				totalRecordsAvailable: totalLogs,
 			},
-		} );
+		});
 	};
 
 	return { downloadLogs, state };

--- a/client/sites/logs/hooks/use-site-logs-downloader.ts
+++ b/client/sites/logs/hooks/use-site-logs-downloader.ts
@@ -193,7 +193,11 @@ export const useSiteLogsDownloader = ( {
 							downloadErrorNotice( translate( 'No logs available for this time range' ) );
 							isError = true;
 						} else {
-							logs = [ Object.keys( newLogData[ 0 ] ).join( ',' ) + '\n' ];
+							logs = [
+								Object.keys( newLogData[ 0 ] )
+									.filter( ( key ) => key !== 'atomic_site_id' )
+									.join( ',' ) + '\n',
+							];
 							totalLogs = get( response, 'data.total_results', 1 );
 						}
 					}
@@ -201,7 +205,10 @@ export const useSiteLogsDownloader = ( {
 					logs = [
 						...logs,
 						...map( newLogData, ( entry ) => {
-							return Object.values( entry ).join( ',' ) + '\n';
+							const cleanedEntry = Object.fromEntries(
+								Object.entries( entry ).filter( ( [ key ] ) => key !== 'atomic_site_id' )
+							);
+							return Object.values( cleanedEntry ).join( ',' ) + '\n';
 						} ),
 					];
 


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/99056

## Proposed Changes

Removes the "Atomic Site ID" from the Fields API and the download logs.

## Why are these changes being made?

This is an implementation detail that is not useful to users.

## Testing Instructions

- Go to PHP Logs, and open the details modal. Verify the "Atomic Site ID" is not present there.
- Download the PHP Logs and verify the "atomic_site_id" field is not present and all the rest work fine.
