### PR TITLE
Hosting Logs: uppercase using CSS

### DIFF
--- a/client/sites/logs/components/details-modal-php.tsx
+++ b/client/sites/logs/components/details-modal-php.tsx
@@ -30,27 +30,27 @@ const DetailsModalPHP = ( { item }: DetailsModalPHPProps ) => {
 			<div className="site-logs-details-modal__field-title">
 				{
 					// translators: %(siteGsmOffsetDisplay)s will be replaced with the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-					translate( 'DATE & TIME (%(siteGsmOffsetDisplay)s)', {
+					translate( 'Date & Time (%(siteGsmOffsetDisplay)s)', {
 						args: { siteGsmOffsetDisplay },
 					} )
 				}
 			</div>
 			<div>{ getFormattedDate( item.timestamp ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'SEVERITY' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Severity' ) }</div>
 			<div>
 				<Badge className={ `badge--${ item.severity }` }>{ item.severity }</Badge>
 			</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'MESSAGE' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Message' ) }</div>
 			<div>{ item.message }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'KIND' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Kind' ) }</div>
 			<div>{ item.kind }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'NAME' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Name' ) }</div>
 			<div>{ item.name }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'FILE' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'File' ) }</div>
 			<div>{ item.file }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'LINE' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Line' ) }</div>
 			<div>{ numberFormat( item.line ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'ATOMIC SITE ID' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Atomic Site Id' ) }</div>
 			<div>{ item.atomic_site_id }</div>
 		</div>
 	);

--- a/client/sites/logs/components/details-modal-server.tsx
+++ b/client/sites/logs/components/details-modal-server.tsx
@@ -30,51 +30,51 @@ const DetailsModalServer = ( { item }: DetailsModalServerProps ) => {
 			<div className="site-logs-details-modal__field-title">
 				{
 					// translators: %(siteGsmOffsetDisplay)s will be replaced with the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-					translate( 'DATE & TIME (%(siteGsmOffsetDisplay)s)', {
+					translate( 'Date & Time (%(siteGsmOffsetDisplay)s)', {
 						args: { siteGsmOffsetDisplay },
 					} )
 				}
 			</div>
 			<div>{ getFormattedDate( item.date ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'REQUEST TYPE' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Request Type' ) }</div>
 			<div>
 				<Badge className={ `badge--${ item.request_type }` }>{ item.request_type }</Badge>
 			</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP STATUS' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP Status' ) }</div>
 			<div>{ item.status }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'REQUEST URL' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Request URL' ) }</div>
 			<div>{ item.request_url }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'BODY BYTES SENT' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Body Bytes Sent' ) }</div>
 			<div>{ numberFormat( item.body_bytes_sent ) }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'CACHED' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Cached' ) }</div>
 			<div>{ item.cached }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP HOST' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP Host' ) }</div>
 			<div>{ item.http_host }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP REFERRER' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP Referrer' ) }</div>
 			<div>{ item.http_referer }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP/2' ) }</div>
 			<div>{ item.http2 }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'User AGENT' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'User Agent' ) }</div>
 			<div>{ item.http_user_agent }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP VERSION' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP Version' ) }</div>
 			<div>{ item.http_version }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'X-FORWARDED-FOR' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'X-Forwarded-For' ) }</div>
 			<div>{ item.http_x_forwarded_for }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'RENDERER' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Renderer' ) }</div>
 			<div>{ item.renderer }</div>
 			<div className="site-logs-details-modal__field-title">
-				{ translate( 'REQUEST COMPLETION' ) }
+				{ translate( 'Request Completion' ) }
 			</div>
 			<div>{ item.request_completion }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'REQUEST TIME' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Request Time' ) }</div>
 			<div>{ item.request_time }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'SCHEME' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Scheme' ) }</div>
 			<div>{ item.scheme }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'TIMESTAMP' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Timestamp' ) }</div>
 			<div>{ item.timestamp }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'TYPE' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Type' ) }</div>
 			<div>{ item.type }</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'USER IP' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'User IP' ) }</div>
 			<div>{ item.user_ip }</div>
 		</div>
 	);

--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -118,6 +118,7 @@
 		white-space: nowrap;
 		font-weight: 500;
 		font-size: 0.75rem;
+		text-transform: uppercase;
 	}
 	:not( .site-logs-details-modal__field-title ) {
 		word-wrap: break-word;


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/99056

## Proposed Changes

This PR uppercases the field names in the modals by using CSS.

## Why are these changes being made?

The strings are translated, which means we cannot rely on the case in use because translators can modify it. We need to actually set it dynamically.

## Testing Instructions

- Go to Hosting Logs screen.
- Open the "details" modal for PHP and and Web Server.
- Verify that the titles are uppercase.

| PHP | Server |
| --- | --- |
| <img width="509" alt="Screenshot 2025-03-05 at 13 43 01" src="https://github.com/user-attachments/assets/2d2cf4ee-271b-4a13-ae07-eff934cff220" /> | <img width="509" alt="Screenshot 2025-03-05 at 13 42 50" src="https://github.com/user-attachments/assets/30e51105-64bd-4ea2-b767-dec1f7aa60a8" /> |
