### PR TITLE
Help Center: Change 'chatting with support' label

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -110,7 +110,7 @@ export const MessageContent = ( {
 			</div>
 			{ displayChatWithSupportLabel && (
 				<ChatWithSupportLabel
-					labelText={ __( 'Chatting with support now', __i18n_text_domain__ ) }
+					labelText={ __( 'Chat with support started', __i18n_text_domain__ ) }
 				/>
 			) }
 			{ displayChatWithSupportEndedLabel && (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100839

- Changed the copy of the label

![image](https://github.com/user-attachments/assets/b779b252-590b-480c-90ab-70ad095b96a2)
