### PR TITLE
Desktop: Fix release CI and bump version to 8.1.0-beta4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -56,7 +56,7 @@
 		"cross-env": "^7.0.3",
 		"electron-fetch": "^1.7.4",
 		"electron-store": "^8.1.0",
-		"electron-updater": "^6.3.0",
+		"electron-updater": "^4.2.5",
 		"js-yaml": "^4.0.0",
 		"make-dir": "^3.1.0",
 		"semver": "^7.3.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.1.0-beta3",
+	"version": "8.1.0-beta4",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11621,7 +11621,7 @@ __metadata:
     electron-fetch: "npm:^1.7.4"
     electron-rebuild: "npm:^2.3.5"
     electron-store: "npm:^8.1.0"
-    electron-updater: "npm:^6.3.0"
+    electron-updater: "npm:^4.2.5"
     jest: "npm:^29.7.0"
     js-yaml: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
@@ -13402,6 +13402,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builder-util-runtime@npm:8.7.3":
+  version: 8.7.3
+  resolution: "builder-util-runtime@npm:8.7.3"
+  dependencies:
+    debug: "npm:^4.3.2"
+    sax: "npm:^1.2.4"
+  checksum: 6a894afb424352197c2fd84b4a02db3b6ed9cfa67429efbf26562a235843382bbfaae03a54990701d08164ea32ad7e6fb8cda3a781b4e92a4052c312d939a96e
+  languageName: node
+  linkType: hard
+
 "builder-util-runtime@npm:9.0.0":
   version: 9.0.0
   resolution: "builder-util-runtime@npm:9.0.0"
@@ -13409,16 +13419,6 @@ __metadata:
     debug: "npm:^4.3.2"
     sax: "npm:^1.2.4"
   checksum: ec5782eb6037f5d6162a8efb4864ead99966b396cdb9463dba2544b6047d129d90d5e408ffdc7168a9bb0678f10f0017567ae7884418f0d2a77acdedc3379171
-  languageName: node
-  linkType: hard
-
-"builder-util-runtime@npm:9.3.1":
-  version: 9.3.1
-  resolution: "builder-util-runtime@npm:9.3.1"
-  dependencies:
-    debug: "npm:^4.3.4"
-    sax: "npm:^1.2.4"
-  checksum: 32de87e5f294154de707f40acf59a5600af9d1ce903ccbba53b81824de7a1dd9568c5f0c033ed765e14c4ea73347aac09ecbce686e1bc7fefbd7b4f64d2c9d68
   languageName: node
   linkType: hard
 
@@ -17365,19 +17365,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-updater@npm:^6.3.0":
-  version: 6.5.0
-  resolution: "electron-updater@npm:6.5.0"
+"electron-updater@npm:^4.2.5":
+  version: 4.3.8
+  resolution: "electron-updater@npm:4.3.8"
   dependencies:
-    builder-util-runtime: "npm:9.3.1"
-    fs-extra: "npm:^10.1.0"
-    js-yaml: "npm:^4.1.0"
-    lazy-val: "npm:^1.0.5"
-    lodash.escaperegexp: "npm:^4.1.2"
+    "@types/semver": "npm:^7.3.4"
+    builder-util-runtime: "npm:8.7.3"
+    fs-extra: "npm:^9.1.0"
+    js-yaml: "npm:^4.0.0"
+    lazy-val: "npm:^1.0.4"
     lodash.isequal: "npm:^4.5.0"
-    semver: "npm:^7.6.3"
-    tiny-typed-emitter: "npm:^2.1.0"
-  checksum: 278241cf4dd4f7ad642ca120fdf121eb962ddab926db43088a9316794b88e2061d3324b7407b9439dd149fb89d8449f21a56744377a5822c6c51f33e0dddbe4c
+    semver: "npm:^7.3.4"
+  checksum: 6a55a796d6d25d23d84c0593ef3db26f341533fadcc755696f68e547afcb45d077ea817f3e78e7a296545de11b9f88966180f1814c094ad2f5cee89fee6eb8cc
   languageName: node
   linkType: hard
 
@@ -19696,7 +19695,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1":
+"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1, fs-extra@npm:^9.1.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
   dependencies:
@@ -24235,13 +24234,6 @@ __metadata:
   version: 4.5.0
   resolution: "lodash.difference@npm:4.5.0"
   checksum: 5d52859218a7df427547ff1fadbc397879709fe6c788b037df7d6d92b676122c92bd35ec85d364edb596b65dfc6573132f420c9b4ee22bb6b9600cd454c90637
-  languageName: node
-  linkType: hard
-
-"lodash.escaperegexp@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "lodash.escaperegexp@npm:4.1.2"
-  checksum: 484ad4067fa9119bb0f7c19a36ab143d0173a081314993fe977bd00cf2a3c6a487ce417a10f6bac598d968364f992153315f0dbe25c9e38e3eb7581dd333e087
   languageName: node
   linkType: hard
 
@@ -31543,7 +31535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3":
+"semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.7.1
   resolution: "semver@npm:7.7.1"
   bin:
@@ -33531,13 +33523,6 @@ __metadata:
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
-  languageName: node
-  linkType: hard
-
-"tiny-typed-emitter@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "tiny-typed-emitter@npm:2.1.0"
-  checksum: 522bed4c579ee7ee16548540cb693a3d098b137496110f5a74bff970b54187e6b7343a359b703e33f77c5b4b90ec6cebc0d0ec3dbdf1bd418723c5c3ce36d8a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The release CI of the desktop app is [broken](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/263152/workflows/a74a6bb5-298a-42c1-89bb-21615bbefc08/jobs/1177325):

```
mv: rename latest-mac.yml to latest-mac-x64.yml: No such file or directory
Build error:  Error: Command failed: mv latest-mac.yml latest-mac-x64.yml
mv: rename latest-mac.yml to latest-mac-x64.yml: No such file or directory
```

The issue appears to be related to #92673 which updated `electron-updater` from `4.2.5` to `6.3.0`. Reverting those changes fixes the issue and the release CI [succeeds](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/263417/workflows/967c5157-6208-468a-9f6f-3561b536f04b/jobs/1177474/steps).