### PR TITLE
chore(deps): update `prettier` & `stylelint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
 		"postcss": "^8.5.1",
 		"postcss-cli": "^9.0.1",
 		"postcss-custom-properties": "^11.0.0",
-		"prettier": "npm:wp-prettier@3.0.3",
+		"prettier": "^3.5.3",
 		"react-refresh": "^0.14.0",
 		"readline-sync": "^1.4.10",
 		"recursive-copy": "^2.0.14",

--- a/packages/fingerprintjs/package.json
+++ b/packages/fingerprintjs/package.json
@@ -76,7 +76,7 @@
 		"karma-spec-reporter": "^0.0.36",
 		"karma-summary-reporter": "^3.1.1",
 		"karma-typescript": "^5.5.3",
-		"prettier": "^3.4.2",
+		"prettier": "^3.5.3",
 		"rimraf": "^3.0.2",
 		"rollup": "^3.3.0",
 		"rollup-plugin-dts": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,7 +1050,7 @@ __metadata:
     karma-spec-reporter: "npm:^0.0.36"
     karma-summary-reporter: "npm:^3.1.1"
     karma-typescript: "npm:^5.5.3"
-    prettier: "npm:^3.4.2"
+    prettier: "npm:^3.5.3"
     rimraf: "npm:^3.0.2"
     rollup: "npm:^3.3.0"
     rollup-plugin-dts: "npm:^5.2.0"
@@ -28546,21 +28546,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.4.2":
-  version: 3.4.2
-  resolution: "prettier@npm:3.4.2"
+"prettier@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "prettier@npm:3.5.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
-  languageName: node
-  linkType: hard
-
-"prettier@npm:wp-prettier@3.0.3":
-  version: 3.0.3
-  resolution: "wp-prettier@npm:3.0.3"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: a8026c481a9d7957826da0ab8bfa6d79032d159a0bb99a322a53962874913b08b9f0470803fc465da0a8287b78004079cba606fdcd89f3086edefd42de2a545c
+  checksum: 3880cb90b9dc0635819ab52ff571518c35bd7f15a6e80a2054c05dbc8a3aa6e74f135519e91197de63705bcb38388ded7e7230e2178432a1468005406238b877
   languageName: node
   linkType: hard
 
@@ -36009,7 +36000,7 @@ __metadata:
     postcss: "npm:^8.5.1"
     postcss-cli: "npm:^9.0.1"
     postcss-custom-properties: "npm:^11.0.0"
-    prettier: "npm:wp-prettier@3.0.3"
+    prettier: "npm:^3.5.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-hook-form: "npm:^7.52.2"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Extracted from https://github.com/Automattic/wp-calypso/pull/100186



## Proposed Changes

* Minor upgrades to prettier/stylelint

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
