### PR TITLE
Newsletter importer: Give more info about Content Import

### DIFF
--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -123,7 +123,7 @@ export default function Content( {
 					<h2>{ __( 'Step 2: Import your content to WordPress.com' ) }</h2>
 					<p>
 						{ i18n.fixMe( {
-							text: '',
+							text: 'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to Reading Settings, and change "Your homepage displays" to a Static page.',
 							newCopy: createInterpolateElement(
 								__(
 									'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a Static page.'

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import i18n from 'i18n-calypso';
 import { useEffect } from 'react';
 import exportSubstackDataImg from 'calypso/assets/images/importer/export-substack-content.png';
 import importerConfig from 'calypso/lib/importer/importer-config';
@@ -120,6 +121,26 @@ export default function Content( {
 					</Button>
 					<hr />
 					<h2>{ __( 'Step 2: Import your content to WordPress.com' ) }</h2>
+					<p>
+						{ i18n.fixMe( {
+							text: '',
+							newCopy: createInterpolateElement(
+								__(
+									'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a Static page.'
+								),
+								{
+									a: (
+										<a
+											href={ `${ selectedSite.URL }/wp-admin/options-reading.php` }
+											target="_blank"
+											rel="noreferrer noopener"
+										/>
+									),
+								}
+							),
+							oldCopy: __( '' ),
+						} ) }
+					</p>
 				</>
 			) }
 			{ importerStatus && (

--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -123,10 +123,10 @@ export default function Content( {
 					<h2>{ __( 'Step 2: Import your content to WordPress.com' ) }</h2>
 					<p>
 						{ i18n.fixMe( {
-							text: 'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to Reading Settings, and change "Your homepage displays" to a Static page.',
+							text: 'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to Reading Settings, and change "Your homepage displays" to a static page.',
 							newCopy: createInterpolateElement(
 								__(
-									'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a Static page.'
+									'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a static page.'
 								),
 								{
 									a: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/551

## Proposed Changes

* Add copy about the imported posts possibly being added to the blog homepage.

Before | After
---- | ----
<img width="732" alt="Screen Shot 2025-03-05 at 9 46 35 AM" src="https://github.com/user-attachments/assets/ec83aa19-2b26-4bcc-9a67-ec766a391b67" /> | <img width="727" alt="Screen Shot 2025-03-05 at 9 46 18 AM" src="https://github.com/user-attachments/assets/bf66c3db-571a-4d7f-97ff-65eb873fe5f8" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To set expectations and address a customer issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /import/newsletter/substack/{site URL} and check that you see the correct copy.
* Check that the link to Reading Settings works on Simple, Atomic, and Jetpack.
* Switch locales and check that you don't see the copy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
