### PR TITLE
Remove Give Wapuu a Chance experiment logic

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -25,7 +25,6 @@ export const MessageContent = ( {
 	displayChatWithSupportLabel?: boolean;
 } ) => {
 	const { __ } = useI18n();
-	const { experimentVariationName } = useOdieAssistantContext();
 	const messageClasses = clsx(
 		'odie-chatbox-message',
 		`odie-chatbox-message-${ message.role }`,
@@ -37,8 +36,8 @@ export const MessageContent = ( {
 		isNextMessageFromSameSender && 'next-chat-message-same-sender'
 	);
 
-	const stopConflatingNegativeRatingWithContactSupport =
-		experimentVariationName === 'give_wapuu_a_chance';
+	// Default to give_wapuu_a_chance behavior
+	const stopConflatingNegativeRatingWithContactSupport = true;
 
 	const isMessageWithOnlyText =
 		message.context?.flags?.hide_disclaimer_content ||

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -49,7 +49,7 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, botNameSlug, experimentVariationName, isChatLoaded, isUserEligibleForPaidSupport } =
+	const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport } =
 		useOdieAssistantContext();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const resetSupportInteraction = useResetSupportInteraction();
@@ -134,11 +134,10 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		return currentMessage === nextMessage;
 	};
 
-	const removeDislikeStatus = experimentVariationName === 'give_wapuu_a_chance';
+	// Default to give_wapuu_a_chance behavior
+	const removeDislikeStatus = true;
 
-	const availableStatusWithFeedback = removeDislikeStatus
-		? [ 'sending', 'transfer' ]
-		: [ 'sending', 'dislike', 'transfer' ];
+	const availableStatusWithFeedback = [ 'sending', 'transfer' ];
 
 	return (
 		<>

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -22,34 +22,19 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithoutEscalationOption?: boolean;
 } ) => {
-	const {
-		isUserEligibleForPaidSupport,
-		hasUserEverEscalatedToHumanSupport,
-		trackEvent,
-		chat,
-		experimentVariationName,
-	} = useOdieAssistantContext();
+	const { isUserEligibleForPaidSupport, hasUserEverEscalatedToHumanSupport, trackEvent, chat } =
+		useOdieAssistantContext();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
 	const hasFeedback = !! message?.rating_value;
 	const isBot = message.role === 'bot';
 	const isConnectedToZendesk = chat?.provider === 'zendesk';
-	const isPositiveFeedback =
-		hasFeedback && message && message.rating_value && +message.rating_value === 1;
 
-	const isExperimentGiveWapuuAChance = experimentVariationName === 'give_wapuu_a_chance';
+	// Default to give_wapuu_a_chance behavior
+	const showExtraContactOptions = isRequestingHumanSupport;
 
-	let showExtraContactOptions = false;
-	if ( isExperimentGiveWapuuAChance ) {
-		showExtraContactOptions = isRequestingHumanSupport;
-	} else {
-		showExtraContactOptions = ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
-	}
-
-	const showDirectEscalationLink = isExperimentGiveWapuuAChance
-		? hasUserEverEscalatedToHumanSupport
-		: ! ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
+	const showDirectEscalationLink = hasUserEverEscalatedToHumanSupport;
 
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -88,9 +88,10 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 		};
 	}, [] );
 
+	// Default to give_wapuu_a_chance behavior since the experiment has concluded
 	const [ experimentVariationName, setExperimentVariationName ] = useState<
 		string | null | undefined
-	>( null );
+	>( 'give_wapuu_a_chance' );
 
 	/**
 	 * The main chat thread.

--- a/packages/odie-client/src/hooks/use-auto-scroll.ts
+++ b/packages/odie-client/src/hooks/use-auto-scroll.ts
@@ -5,7 +5,7 @@ export const useAutoScroll = (
 	messagesContainerRef: RefObject< HTMLDivElement >,
 	isEnabled: boolean
 ) => {
-	const { chat, experimentVariationName } = useOdieAssistantContext();
+	const { chat } = useOdieAssistantContext();
 	const debounceTimeoutRef = useRef< number >( 500 );
 	const debounceTimeoutIdRef = useRef< number | null >( null );
 	const lastChatStatus = useRef< string | null >( null );
@@ -20,7 +20,7 @@ export const useAutoScroll = (
 			return;
 		}
 
-		if ( experimentVariationName === 'give_wapuu_a_chance' && chat.status === 'dislike' ) {
+		if ( chat.status === 'dislike' ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- The "Give Wapuu a Chance" experiment has concluded successfully and has been rolled out to all users
- This PR removes the experiment conditional logic and defaults to the behavior of the 'give_wapuu_a_chance' variation
- The backend changes have already been made

## Changes
- Removes experiment condition checks across multiple files in the Odie client
- Sets `experimentVariationName` default to 'give_wapuu_a_chance' in the context
- Removes unused variables that were previously used for the experiment logic

## Test plan
- Verify that the chat behavior matches the expected "Give Wapuu a Chance" variation
- Check that dislike status doesn't trigger auto-scroll
- Verify that contact options only appear when explicitly requesting human support
- Confirm that direct escalation links only appear in the correct circumstances
- Ensure there are no visual indicators for negative feedback

🤖 Generated with [Claude Code](https://claude.ai/code)