### PR TITLE
Reader: Fix unsubscribed reddit feed icons

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -16,6 +16,7 @@ import {
 	getSiteUrl,
 } from 'calypso/reader/get-helpers';
 import HeaderBack from 'calypso/reader/header-back';
+import { getSafeImageUrlForReader } from 'calypso/reader/utils';
 import ReaderFeedHeaderSiteBadge from './badge';
 import ReaderFeedHeaderFollow from './follow';
 import './style.scss';
@@ -59,7 +60,7 @@ class FeedHeader extends Component {
 		let fakeSite;
 
 		const safeSiteIcon = safeImageUrl( siteIcon );
-		const safeFeedIcon = safeImageUrl( feedIcon );
+		const safeFeedIcon = getSafeImageUrlForReader( feedIcon );
 
 		if ( safeSiteIcon ) {
 			fakeSite = {

--- a/client/blocks/site-icon/index.tsx
+++ b/client/blocks/site-icon/index.tsx
@@ -47,6 +47,7 @@ export function SiteIcon( {
 	title = '',
 	onClick = () => {},
 }: SiteIconProps ) {
+	iconUrl = iconUrl?.replace( /\/$/, '' ); // Remove trailing slash from URL as it may lead to 404 errors when adding size parameters.
 	const iconSrc = resizeImageUrl( iconUrl, imgSize, null );
 
 	const classes = clsx( 'site-icon', {

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -42,12 +42,12 @@ describe( 'reader utils', () => {
 	} );
 
 	describe( 'getSafeImageUrlForReader', () => {
-		test( 'returns the url as is if it is from trusted hosts', () => {
+		test( 'returns the url as is if it is from a trusted host', () => {
 			const url = 'https://www.redditstatic.com/image.jpg';
 			expect( getSafeImageUrlForReader( url ) ).toEqual( url );
 		} );
 
-		test( 'returns the Photon url if it is not from trusted hosts', () => {
+		test( 'returns the Photon url if it is not from a trusted host', () => {
 			const url = 'https://www.example.com/image.jpg';
 			expect( getSafeImageUrlForReader( url ) ).not.toEqual( url );
 		} );

--- a/client/reader/test/utils.js
+++ b/client/reader/test/utils.js
@@ -3,7 +3,7 @@
  */
 
 import page from '@automattic/calypso-router';
-import { showSelectedPost } from '../utils';
+import { getSafeImageUrlForReader, showSelectedPost } from '../utils';
 
 jest.mock( '@automattic/calypso-router', () => jest.fn() );
 
@@ -38,6 +38,18 @@ describe( 'reader utils', () => {
 				getState
 			);
 			expect( page ).toHaveBeenCalledWith( '/reader/feeds/1/posts/5#comments' );
+		} );
+	} );
+
+	describe( 'getSafeImageUrlForReader', () => {
+		test( 'returns the url as is if it is from trusted hosts', () => {
+			const url = 'https://www.redditstatic.com/image.jpg';
+			expect( getSafeImageUrlForReader( url ) ).toEqual( url );
+		} );
+
+		test( 'returns the Photon url if it is not from trusted hosts', () => {
+			const url = 'https://www.example.com/image.jpg';
+			expect( getSafeImageUrlForReader( url ) ).not.toEqual( url );
 		} );
 	} );
 } );

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { safeImageUrl, getUrlParts } from '@automattic/calypso-url';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getPostByKey } from 'calypso/state/reader/posts/selectors';
@@ -93,4 +94,20 @@ export function getStreamType( streamKey ) {
 	const indexOfColon = streamKey.indexOf( ':' );
 	const streamType = indexOfColon === -1 ? streamKey : streamKey.substring( 0, indexOfColon );
 	return streamType;
+}
+
+/**
+ * Wrapper around `safeImageUrl` of '@automattic/calypso-url' to be used in the reader.
+ * There are some places in reader where we need to show images from trusted hosts without running them through Photon.
+ */
+export function getSafeImageUrlForReader( url ) {
+	const parsedUrl = getUrlParts( url );
+	// Hosts that are trusted to serve images.
+	const TRUSTED_HOSTS = [ 'www.redditstatic.com' ];
+
+	if ( TRUSTED_HOSTS.includes( parsedUrl.hostname ) ) {
+		return url;
+	}
+
+	return safeImageUrl( url ) ?? '';
 }

--- a/packages/calypso-url/src/safe-image-url/index.ts
+++ b/packages/calypso-url/src/safe-image-url/index.ts
@@ -19,11 +19,6 @@ if ( typeof globalThis.location === 'object' ) {
 const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.com|a8c\.com)$/;
 
 /**
- * Hosts that are trusted to serve images.
- */
-const TRUSTED_HOSTS = [ 'www.redditstatic.com' ];
-
-/**
  * Query parameters to be treated as image dimensions
  */
 const SIZE_PARAMS = [ 'w', 'h', 'resize', 'fit', 's' ];
@@ -55,10 +50,7 @@ export function safeImageUrl( url?: string | null ) {
 
 	const parsedUrl = getUrlParts( url );
 
-	if (
-		REGEXP_A8C_HOST.test( parsedUrl.hostname ) ||
-		TRUSTED_HOSTS.includes( parsedUrl.hostname )
-	) {
+	if ( REGEXP_A8C_HOST.test( parsedUrl.hostname ) ) {
 		// Safely promote Automattic domains to HTTPS
 		parsedUrl.protocol = 'https';
 		return getUrlFromParts( parsedUrl ).toString();

--- a/packages/calypso-url/src/safe-image-url/index.ts
+++ b/packages/calypso-url/src/safe-image-url/index.ts
@@ -19,6 +19,11 @@ if ( typeof globalThis.location === 'object' ) {
 const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.com|a8c\.com)$/;
 
 /**
+ * Hosts that are trusted to serve images.
+ */
+const TRUSTED_HOSTS = [ 'www.redditstatic.com' ];
+
+/**
  * Query parameters to be treated as image dimensions
  */
 const SIZE_PARAMS = [ 'w', 'h', 'resize', 'fit', 's' ];
@@ -50,7 +55,10 @@ export function safeImageUrl( url?: string | null ) {
 
 	const parsedUrl = getUrlParts( url );
 
-	if ( REGEXP_A8C_HOST.test( parsedUrl.hostname ) ) {
+	if (
+		REGEXP_A8C_HOST.test( parsedUrl.hostname ) ||
+		TRUSTED_HOSTS.includes( parsedUrl.hostname )
+	) {
 		// Safely promote Automattic domains to HTTPS
 		parsedUrl.protocol = 'https';
 		return getUrlFromParts( parsedUrl ).toString();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/522

## Proposed Changes

- Prevent converting the reddit icon url (`www.redditstatic.com/icon.png`) to Photon (`https://i0.wp.com/www.redditstatic.com/icon.png`) by adding `TRUSTED_HOSTS` array which skips conversion.

- Remove trailing slash from icon URL to prevent 404s when resizing params are added. Example [https://www.redditstatic.com/icon.png/?w=120](https://www.redditstatic.com/icon.png/?w=120) vs [www.redditstatic.com/icon.png](www.redditstatic.com/icon.png).

| Before | After |
| -------|------|
|![image](https://github.com/user-attachments/assets/d4bafead-6dd0-4ed5-bba7-7d57d3d4f643)|![image](https://github.com/user-attachments/assets/667e9ad1-4ea0-4980-87a4-551250cf5114)|



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To resolve the issue of an icon disappearing on the detail page for an unsubscribed feed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /reader/feeds/167541688 (must be an unsubscribed reddit feed)
* Verify that icon is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
