### PR TITLE
i18n: Refactor calypso-products percentages to use `numberFormat`

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import i18n, { translate } from 'i18n-calypso';
+import i18n, { translate, numberFormat } from 'i18n-calypso';
 import {
 	FEATURE_13GB_STORAGE,
 	FEATURE_200GB_STORAGE,
@@ -627,7 +627,9 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 	getPlanComparisonFeatureLabels: () => {
 		const baseFeatures = {
 			[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: i18n.translate( '%d shares per month', { args: [ 30 ] } ),
-			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '10%' ),
+			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: numberFormat( 0.1, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
 			[ FEATURE_AI_ASSISTANT ]: i18n.translate( 'Limited to 20 requests' ),
 		};
 
@@ -840,7 +842,9 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		const baseFeatures = {
 			[ FEATURE_PREMIUM_THEMES ]: i18n.translate( 'Dozens of premium themes' ),
 			[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: i18n.translate( '%d shares per month', { args: [ 30 ] } ),
-			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '8%' ),
+			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: numberFormat( 0.08, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
 			[ FEATURE_SUPPORT ]: i18n.translate( 'Support from our expert\u00A0team' ),
 		};
 
@@ -1062,8 +1066,12 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		const baseFeatures = {
 			[ FEATURE_PREMIUM_THEMES ]: i18n.translate( 'All premium themes' ),
 			[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: i18n.translate( 'Unlimited shares' ),
-			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '0%' ),
-			[ FEATURE_COMMISSION_FEE_WOO_FEATURES ]: i18n.translate( '0%' ),
+			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: numberFormat( 0, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
+			[ FEATURE_COMMISSION_FEE_WOO_FEATURES ]: numberFormat( 0, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
 			[ FEATURE_SUPPORT ]: i18n.translate( 'Priority 24/7 support from our expert\u00A0team' ),
 		};
 
@@ -1428,7 +1436,9 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		const baseFeatures = {
 			[ FEATURE_PREMIUM_THEMES ]: i18n.translate( 'All premium themes' ),
 			[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: i18n.translate( 'Unlimited shares' ),
-			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '4%' ),
+			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: numberFormat( 0.04, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
 			[ FEATURE_SUPPORT ]: i18n.translate( 'Fast support from our expert\u00A0team' ),
 		};
 
@@ -1658,8 +1668,12 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 			[ FEATURE_SHIPPING_INTEGRATIONS ]: i18n.translate( 'Available with paid plugins' ),
 			[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: i18n.translate( 'Unlimited shares' ),
 			[ FEATURE_STORE_DESIGN ]: i18n.translate( 'Available with plugins' ),
-			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '2%' ),
-			[ FEATURE_COMMISSION_FEE_WOO_FEATURES ]: i18n.translate( '0%' ),
+			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: numberFormat( 0.02, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
+			[ FEATURE_COMMISSION_FEE_WOO_FEATURES ]: numberFormat( 0, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
 			[ FEATURE_SUPPORT ]: i18n.translate( 'Priority 24/7 support from our expert team' ),
 		};
 

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1,4 +1,4 @@
-import { translate, useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { translate, useTranslate, getLocaleSlug, numberFormat } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import {
 	PRODUCT_JETPACK_ANTI_SPAM_BI_YEARLY,
@@ -1102,7 +1102,14 @@ export const getJetpackProductsLightboxDescription = (): Record< string, Transla
 		'Seamlessly accept purchase orders as a payment method on your WooCommerce store.'
 	);
 	const woocommerceShippingLightboxDescription = translate(
-		'Print USPS and DHL labels right from the WooCommerce desktop and save up to 90% instantly. WooCommerce Shipping is free and saves you time and money.'
+		'Print USPS and DHL labels right from the WooCommerce desktop and save up to %(discountPercent)s instantly. WooCommerce Shipping is free and saves you time and money.',
+		{
+			args: {
+				discountPercent: numberFormat( 0.9, {
+					numberFormatOptions: { style: 'percent' },
+				} ),
+			},
+		}
 	);
 	const woocommerceAccommodationsBookingsLightboxDescription = translate(
 		'Book accommodation using WooCommerce and the WooCommerce Bookings extension.'
@@ -1332,7 +1339,13 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Paywall access' ),
 		translate( 'Newsletter' ),
 		translate( 'Priority support' ),
-		translate( '2% transaction fees' ),
+		translate( '%(transactionFee)s transaction fees', {
+			args: {
+				transactionFee: numberFormat( 0.02, {
+					numberFormatOptions: { style: 'percent' },
+				} ),
+			},
+		} ),
 	];
 	const antiSpamIncludesInfo = [
 		translate( 'Comment and form spam protection' ),
@@ -2001,7 +2014,14 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 		translate( 'Send targeted, multi-step campaigns and offer customer incentives' ),
 		translate( 'Measure the success of your campaigns' ),
 		translate( 'Unlimited email sends' ),
-		translate( 'AutomateWoo is 100% extendable' ),
+		translate( 'AutomateWoo is %(extentablePercent)s extendable', {
+			args: {
+				extentablePercent: numberFormat( 1, {
+					numberFormatOptions: { style: 'percent' },
+				} ),
+			},
+			comment: '100% extendable',
+		} ),
 		translate( 'Multilingual support. AutomateWoo has support for the popular WPML plugin' ),
 		translate( 'AutomateWoo integrates with your favorite plugins and services' ),
 	];
@@ -2640,7 +2660,13 @@ export const getJetpackPlansAlsoIncludedFeatures = (): Record<
 		translate( 'Paywall access' ),
 		translate( 'Newsletter' ),
 		translate( 'Priority support' ),
-		translate( '2% transaction fees' ),
+		translate( '%(transactionFee)s transaction fees', {
+			args: {
+				transactionFee: numberFormat( 0.02, {
+					numberFormatOptions: { style: 'percent' },
+				} ),
+			},
+		} ),
 	];
 
 	return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Proposed Changes

Refactors calypso-products package to use numberFormat for percentage values. 
Several cases that involve plan features, like transaction fees, and other translations where percentages are hardcoded in strings

## Media

Transaction fees Before/After in AR:

<img width="1471" alt="Screenshot 2025-03-06 at 11 49 24 AM" src="https://github.com/user-attachments/assets/481c8420-42d3-4ebd-8e0b-7e921b90b742" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For transaction fees:

- test between AR/EL/EN locales
- go to `/start/plans` and open comparison grid
- confirm "transition fees" render correctly as in media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
