### PR TITLE
Stats navigation: remove defaultProps

### DIFF
--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -12,7 +12,7 @@ const Intervals = ( props ) => {
 		selected,
 		pathTemplate,
 		className,
-		standalone,
+		standalone = false,
 		compact = true,
 		intervalValues = intervals,
 		onChange,
@@ -50,10 +50,6 @@ Intervals.propTypes = {
 	intervalValues: PropTypes.array,
 	onChange: PropTypes.func,
 	icon: PropTypes.object,
-};
-
-Intervals.defaultProps = {
-	standalone: false,
 };
 
 export default localize( Intervals );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I want to remove the following warning, because it's noisy and hard to see errors.

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/4975b938-1d84-48d5-84b4-08a641339af9" />


## Proposed Changes

* I removed the defaultProps. I realise there's lots of other occurrences in the codebase, but may main goal is to remove this warning logged in the console.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reduce the noise in the console.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In sandbox: `bin/install-plugin.sh odyssey-stats remove/default-props-stats-navigation`
* Check the wp-admin Dashboard with the Jetpack stats widget, the warning should be gone.
* Make sure you are sandboxed and have `SCRIPT_DEBUG` enabled:

```php
<?php
define( 'SCRIPT_DEBUG', true );
define( 'JETPACK_AUTOLOAD_DEV', true );

```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
