### PR TITLE
Reader Editor: Make inline editor collapsible

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,9 @@
-{
-	"useTabs": true,
-	"tabWidth": 2,
-	"printWidth": 100,
-	"singleQuote": true,
-	"bracketSpacing": true,
-	"parenSpacing": true,
-	"bracketSameLine": false,
-	"semi": true,
-	"trailingComma": "es5"
-}
+useTabs: true
+tabWidth: 2
+printWidth: 100
+singleQuote: true
+bracketSpacing: true
+parenSpacing: true
+bracketSameLine: false
+semi: true
+trailingComma: 'es5'

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,11 @@
-useTabs: true
-tabWidth: 2
-printWidth: 100
-singleQuote: true
-bracketSpacing: true
-parenSpacing: true
-bracketSameLine: false
-semi: true
-trailingComma: 'es5'
+{
+	"useTabs": true,
+	"tabWidth": 2,
+	"printWidth": 100,
+	"singleQuote": true,
+	"bracketSpacing": true,
+	"parenSpacing": true,
+	"bracketSameLine": false,
+	"semi": true,
+	"trailingComma": "es5"
+}

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -152,9 +152,6 @@ function QuickPost( {
 
 	return (
 		<div className="quick-post-input">
-			<label htmlFor="quick-post-site-select" className="quick-post-input__label">
-				{ translate( 'Publish a post to' ) }
-			</label>
 			<div className="quick-post-input__fields">
 				<div className="quick-post-input__site-select-wrapper">
 					<SitesDropdown

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable scales/radii */
 .quick-post-input {
-	margin-bottom: 24px;
+	margin: 20px;
 
 	&--loading {
 		text-align: center;
@@ -15,14 +15,14 @@
 		margin-bottom: 16px;
 
 		.sites-dropdown__wrapper {
-			border-color: var(--color-border-subtle);
+			border-color: var( --color-border-subtle );
 			border-style: solid;
 			border-radius: 6px;
 			border-width: 1px;
 		}
 	}
 
-    &__actions {
+	&__actions {
 		display: flex;
 		justify-content: flex-end;
 		gap: 8px;
@@ -49,25 +49,25 @@
 		}
 	}
 
-    .verbum-editor-wrapper {
-        .editor__header {
-            border-color: var(--color-border-subtle);
-            border-style: solid;
-            border-radius: 6px 6px 0 0;
-            border-width: 1px;
-            border-bottom-width: 0;
-        }
+	.verbum-editor-wrapper {
+		.editor__header {
+			border-color: var( --color-border-subtle );
+			border-style: solid;
+			border-radius: 6px 6px 0 0;
+			border-width: 1px;
+			border-bottom-width: 0;
+		}
 
-        .block-editor-block-contextual-toolbar {
-            background-color: transparent;
-        }
+		.block-editor-block-contextual-toolbar {
+			background-color: transparent;
+		}
 
-        .editor__main {
-            border-color: var(--color-border-subtle);
-            border-style: solid;
-            border-radius: 0 0 6px 6px;
-            border-width: 1px;
-            border-top-width: 0;
-        }
-    }
+		.editor__main {
+			border-color: var( --color-border-subtle );
+			border-style: solid;
+			border-radius: 0 0 6px 6px;
+			border-width: 1px;
+			border-top-width: 0;
+		}
+	}
 }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { FoldableCard } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -64,7 +65,19 @@ function FollowingStream( { ...props } ) {
 					>
 						<ViewToggle />
 					</NavigationHeader>
-					{ config.isEnabled( 'reader/quick-post' ) && <QuickPost /> }
+					{ config.isEnabled( 'reader/quick-post' ) && (
+						<FoldableCard
+							header={ translate( 'Write a quick post' ) }
+							clickableHeader
+							compact
+							expanded={ false }
+							className="following-stream__quick-post-card"
+							smooth
+							contentExpandedStyle={ { maxHeight: '800px' } }
+						>
+							<QuickPost />
+						</FoldableCard>
+					) }
 					<ReaderOnboarding />
 				</ReaderStream>
 			) }

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,4 +1,4 @@
-@import '@wordpress/base-styles/breakpoints';
+@import "@wordpress/base-styles/breakpoints";
 
 .is-section-reader .navigation-header.following-stream-header {
 	&.reader-dual-column {
@@ -18,15 +18,6 @@
 	}
 }
 
-.following-stream__quick-post-card.card.is-compact {
-	margin-bottom: 20px !important;
-	border-radius: 6px; /* stylelint-disable-line scales/radii */
-
-	.foldable-card__main {
-		font-weight: 600;
-	}
-}
-
 .following .search {
 	margin-bottom: 0;
 }
@@ -34,16 +25,14 @@
 .following__search.card.is-compact {
 	padding: 0;
 	border-radius: 2px;
-	box-shadow:
-		0 0 0 2px var( --color-neutral-10 ),
-		0 1px 2px var( --color-neutral-10 );
-	z-index: z-index( 'root', '.reader-following-search' );
+	box-shadow: 0 0 0 2px var(--color-neutral-10), 0 1px 2px var(--color-neutral-10);
+	z-index: z-index("root", ".reader-following-search");
 }
 
 .following__search {
 	margin-top: 8px;
 
-	@include breakpoint-deprecated( '>660px' ) {
+	@include breakpoint-deprecated( ">660px" ) {
 		margin-top: 30px;
 	}
 }
@@ -51,21 +40,21 @@
 .following__view-toggle {
 	display: flex;
 	gap: 8px;
-
+	
 	.components-button {
 		height: 36px;
 		min-width: 36px;
 		padding: 6px;
-		color: var( --color-text );
-
+		color: var(--color-text);
+		
 		&.is-pressed {
-			background: var( --color-text );
-			color: var( --color-surface );
+			background: var(--color-text);
+			color: var(--color-surface);
 		}
-
+		
 		&:hover {
-			background: var( --color-text );
-			color: var( --color-surface );
+			background: var(--color-text);
+			color: var(--color-surface);
 		}
 	}
 }
@@ -78,8 +67,17 @@
 	.navigation-header {
 		padding-bottom: 0;
 
-		@media ( max-width: $break-medium ) {
+		@media (max-width: $break-medium) {
 			padding: 0 0 16px 0;
 		}
+	}
+}
+
+.following-stream__quick-post-card.card.is-compact {
+	margin-bottom: 20px !important;
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
+
+	.foldable-card__main {
+		font-weight: 600;
 	}
 }

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,4 +1,4 @@
-@import "@wordpress/base-styles/breakpoints";
+@import '@wordpress/base-styles/breakpoints';
 
 .is-section-reader .navigation-header.following-stream-header {
 	&.reader-dual-column {
@@ -18,6 +18,15 @@
 	}
 }
 
+.following-stream__quick-post-card.card.is-compact {
+	margin-bottom: 20px !important;
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
+
+	.foldable-card__main {
+		font-weight: 600;
+	}
+}
+
 .following .search {
 	margin-bottom: 0;
 }
@@ -25,14 +34,16 @@
 .following__search.card.is-compact {
 	padding: 0;
 	border-radius: 2px;
-	box-shadow: 0 0 0 2px var(--color-neutral-10), 0 1px 2px var(--color-neutral-10);
-	z-index: z-index("root", ".reader-following-search");
+	box-shadow:
+		0 0 0 2px var( --color-neutral-10 ),
+		0 1px 2px var( --color-neutral-10 );
+	z-index: z-index( 'root', '.reader-following-search' );
 }
 
 .following__search {
 	margin-top: 8px;
 
-	@include breakpoint-deprecated( ">660px" ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 30px;
 	}
 }
@@ -40,21 +51,21 @@
 .following__view-toggle {
 	display: flex;
 	gap: 8px;
-	
+
 	.components-button {
 		height: 36px;
 		min-width: 36px;
 		padding: 6px;
-		color: var(--color-text);
-		
+		color: var( --color-text );
+
 		&.is-pressed {
-			background: var(--color-text);
-			color: var(--color-surface);
+			background: var( --color-text );
+			color: var( --color-surface );
 		}
-		
+
 		&:hover {
-			background: var(--color-text);
-			color: var(--color-surface);
+			background: var( --color-text );
+			color: var( --color-surface );
 		}
 	}
 }
@@ -67,7 +78,7 @@
 	.navigation-header {
 		padding-bottom: 0;
 
-		@media (max-width: $break-medium) {
+		@media ( max-width: $break-medium ) {
 			padding: 0 0 16px 0;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1741179194108939-slack-C083J8DHLLD

## Proposed Changes

* Make the Reader Editor collapsible

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /reader and view that the reader editor is collapsible and that it still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?