### PR TITLE
i18n: Refactor A4A percentages in strings to use numberFormat

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/index.tsx
@@ -1,6 +1,6 @@
 import { Icon, check } from '@wordpress/icons';
 import PageSection, { PageSectionProps } from 'calypso/a8c-for-agencies/components/page-section';
-
+import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
 
 type Props = Omit< PageSectionProps, 'children' > & {
@@ -8,7 +8,7 @@ type Props = Omit< PageSectionProps, 'children' > & {
 	items: {
 		title: string;
 		description: string;
-		benefits: string[];
+		benefits: ( string | TranslateResult )[];
 	}[];
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/client-relationships.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/client-relationships.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { SectionBackground } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
 import HostingBenefitsSection from '../../../common/hosting-benefits-section';
 
@@ -20,7 +20,13 @@ export default function ClientRelationships( { background }: Props ) {
 						"With over 15 years of experience running hundreds of millions of sites on WordPress.com, including the highest-trafficked sites globally, we've developed a platform we confidently put up against any cloud service."
 					),
 					benefits: [
-						translate( '99.999% Uptime' ),
+						translate( '%(uptimePercent)s Uptime', {
+							args: {
+								uptimePercent: numberFormat( 0.99999, {
+									numberFormatOptions: { style: 'percent', maximumFractionDigits: 3 },
+								} ),
+							},
+						} ),
 						translate( 'High availability with automated scaling' ),
 					],
 				},

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/index.tsx
@@ -19,11 +19,21 @@ export function BundlePriceSelector( { options, value, onChange }: Props ) {
 			return (
 				{
 					1: '',
-					5: translate( '10%' ),
-					10: translate( '20%' ),
-					20: translate( '40%' ),
-					50: translate( '70%' ),
-					100: translate( '80%' ),
+					5: numberFormat( 0.1, {
+						numberFormatOptions: { style: 'percent' },
+					} ),
+					10: numberFormat( 0.2, {
+						numberFormatOptions: { style: 'percent' },
+					} ),
+					20: numberFormat( 0.4, {
+						numberFormatOptions: { style: 'percent' },
+					} ),
+					50: numberFormat( 0.7, {
+						numberFormatOptions: { style: 'percent' },
+					} ),
+					100: numberFormat( 0.8, {
+						numberFormatOptions: { style: 'percent' },
+					} ),
 				}[ bundleSize ] ?? ''
 			);
 		},

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-client-relationship/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-client-relationship/index.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import HostingBenefitsSection from 'calypso/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section';
 
 import './style.scss';
@@ -17,7 +17,14 @@ export default function MigrationsClientRelationship() {
 						"With over 15 years of experience running hundreds of millions of sites on WordPress.com, including the highest-trafficked sites globally, we've developed a platform we confidently put up against any cloud service."
 					),
 					benefits: [
-						translate( '99.999% Uptime' ),
+						translate( '%(uptimePercent)s Uptime', {
+							args: {
+								uptimePercent: numberFormat( 0.99999, {
+									numberFormatOptions: { style: 'percent', maximumFractionDigits: 3 },
+								} ),
+							},
+							comment: '99.999% uptime',
+						} ),
 						translate( 'High availability with automated scaling' ),
 					],
 				},

--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Button, FoldableCard, Gridicon } from '@automattic/components';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
@@ -22,7 +22,14 @@ const PressableOffering = () => {
 	const highlights = [
 		translate( 'Git integration, WP-CLI, SSH, and staging.' ),
 		translate( 'Lightning-fast performance.' ),
-		translate( '100% uptime SLA.' ),
+		translate( '%(uptimePercent)s uptime SLA.', {
+			args: {
+				uptimePercent: numberFormat( 1, {
+					numberFormatOptions: { style: 'percent' },
+				} ),
+			},
+			comment: '100% uptime SLA',
+		} ),
 		translate( 'Smart, managed plugin updates.' ),
 		translate( 'Comprehensive WP security & performance with Jetpack Complete included.' ),
 		translate( '24/7 support from WordPress experts.' ),
@@ -66,8 +73,8 @@ const PressableOffering = () => {
 				) }
 			</p>
 			<ul className="a4a-offering-item__card-list">
-				{ highlights.map( ( highlightItemText ) => (
-					<li className="a4a-offering-item__card-list-item" key={ highlightItemText }>
+				{ highlights.map( ( highlightItemText, index ) => (
+					<li className="a4a-offering-item__card-list-item" key={ index }>
 						<div className="a4a-offering-item__icon-container">
 							<Gridicon className="a4a-offering-item__gridicon" icon="checkmark" size={ 18 } />
 						</div>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -1,7 +1,7 @@
 import { Button, WooLogo } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { reusableBlock } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import {
@@ -141,7 +141,13 @@ export default function LayoutBodyContent( {
 			</div>
 			<div className="referrals-overview__section-heading">
 				{ translate( 'Recommend our products.' ) } <br />
-				{ translate( 'Earn up to a 50% commission.' ) }
+				{ translate( 'Earn up to a %(commissionPercent)s commission.', {
+					args: {
+						commissionPercent: numberFormat( 0.5, {
+							numberFormatOptions: { style: 'percent' },
+						} ),
+					},
+				} ) }
 			</div>
 
 			<div className="referrals-overview__section-subtitle">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Proposed Changes

Refactors a8c-for-agencies pages to use `numberFormat` for percentage values injected in strings. 

## Media

Before/After in EL:

- Marketplace & migrations

<img width="460" alt="Screenshot 2025-03-06 at 12 17 21 PM" src="https://github.com/user-attachments/assets/bcb1f9ba-82ec-4b50-961d-6a997198cbb8" />

- Overview Pressable card

<img width="906" alt="Screenshot 2025-03-06 at 12 23 34 PM" src="https://github.com/user-attachments/assets/80ed0a0a-4e61-45d2-8327-bd04bbf42645" />

- Products bundle-size selection

<img width="526" alt="Screenshot 2025-03-06 at 12 27 14 PM" src="https://github.com/user-attachments/assets/3675a5a2-ba5d-4bda-8fb8-a818c3738d6e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- try between AR/EN
- access the A4A live link
- go to `/marketplace/hosting/wpcom`
- go to `/migrations/overview`
- go to `/overview` - Pressable card
- go to `/marketplace/products` - "bundle size" selection

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
