### PR TITLE
Subscribers: Add list click tracking

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -167,38 +167,28 @@ const SubscriberDataViews = ( {
 	const shouldShowLaunchpad =
 		! isLoading && ! searchTerm && ( ! grandTotal || ( grandTotal === 1 && isOwnerSubscribed ) );
 
-	const handleSubscriberSelect = useCallback(
-		( items: string[] ) => {
-			if ( items.length === 0 ) {
-				setSelectedSubscriber( null );
-				return;
-			}
-			const selectedId = items[ 0 ];
-			const subscriber = subscribers.find(
-				( s: Subscriber ) => s.subscription_id.toString() === selectedId
-			);
-			if ( subscriber ) {
-				setSelectedSubscriber( subscriber );
+	const handleSubscriberSelection = useCallback(
+		( input: Subscriber | string[] ) => {
+			if ( Array.isArray( input ) ) {
+				const subscriber = subscribers.find( ( s ) => s.subscription_id.toString() === input[ 0 ] );
+				if ( subscriber ) {
+					recordSubscriberClicked( 'list', {
+						site_id: siteId,
+						subscription_id: subscriber.subscription_id,
+						user_id: subscriber.user_id,
+					} );
+					setSelectedSubscriber( subscriber );
+				}
+			} else {
+				recordSubscriberClicked( 'row', {
+					site_id: siteId,
+					subscription_id: input.subscription_id,
+					user_id: input.user_id,
+				} );
+				setSelectedSubscriber( input );
 			}
 		},
-		[ subscribers ]
-	);
-
-	const getSubscriberId = useCallback(
-		( subscriber: Subscriber ) => subscriber.subscription_id.toString(),
-		[]
-	);
-
-	const handleSubscriberOnClick = useCallback(
-		( subscriber: Subscriber ) => {
-			recordSubscriberClicked( 'row', {
-				site_id: siteId,
-				subscription_id: subscriber.subscription_id,
-				user_id: subscriber.user_id,
-			} );
-			handleSubscriberSelect( [ getSubscriberId( subscriber ) ] );
-		},
-		[ getSubscriberId, handleSubscriberSelect, recordSubscriberClicked, siteId ]
+		[ subscribers, recordSubscriberClicked, siteId ]
 	);
 
 	const fields = useMemo(
@@ -299,7 +289,7 @@ const SubscriberDataViews = ( {
 							subscription_id: items[ 0 ].subscription_id,
 							user_id: items[ 0 ].user_id,
 						} );
-						handleSubscriberSelect( [ getSubscriberId( items[ 0 ] ) ] );
+						handleSubscriberSelection( items[ 0 ] );
 					}
 				},
 				isPrimary: true,
@@ -328,11 +318,10 @@ const SubscriberDataViews = ( {
 		return baseActions;
 	}, [
 		selectedSubscriber,
-		handleSubscriberSelect,
+		handleSubscriberSelection,
 		handleUnsubscribe,
 		onGiftSubscription,
 		couponsAndGiftsEnabled,
-		getSubscriberId,
 		recordSubscriberClicked,
 		siteId,
 	] );
@@ -462,12 +451,12 @@ const SubscriberDataViews = ( {
 							data={ data }
 							fields={ fields }
 							view={ currentView }
-							onClickItem={ handleSubscriberOnClick }
+							onClickItem={ handleSubscriberSelection }
 							onChangeView={ handleViewChange }
 							selection={
 								selectedSubscriber ? [ selectedSubscriber.subscription_id.toString() ] : undefined
 							}
-							onChangeSelection={ handleSubscriberSelect }
+							onChangeSelection={ handleSubscriberSelection }
 							isLoading={ isLoading }
 							paginationInfo={ paginationInfo }
 							getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -170,6 +170,10 @@ const SubscriberDataViews = ( {
 	const handleSubscriberSelection = useCallback(
 		( input: Subscriber | string[] ) => {
 			if ( Array.isArray( input ) ) {
+				if ( input.length === 0 ) {
+					setSelectedSubscriber( null );
+					return;
+				}
 				const subscriber = subscribers.find( ( s ) => s.subscription_id.toString() === input[ 0 ] );
 				if ( subscriber ) {
 					recordSubscriberClicked( 'list', {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -288,11 +288,6 @@ const SubscriberDataViews = ( {
 				label: translate( 'View' ),
 				callback: ( items: Subscriber[] ) => {
 					if ( items[ 0 ] ) {
-						recordSubscriberClicked( 'row', {
-							site_id: siteId,
-							subscription_id: items[ 0 ].subscription_id,
-							user_id: items[ 0 ].user_id,
-						} );
 						handleSubscriberSelection( items[ 0 ] );
 					}
 				},

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
@@ -7,7 +7,6 @@ const useRecordSubscriberClicked = () => {
 		where: 'title' | 'icon' | 'row' | 'list',
 		tracksProps: { site_id?: number | null; subscription_id?: number; user_id?: number }
 	) => {
-		// Allows for calypso_subscribers_subscriber_title_clicked, calypso_subscribers_subscriber_icon_clicked, calypso_subscribers_subscriber_row_clicked,
 		recordSubscribersTracksEvent(
 			`calypso_subscribers_subscriber_${ where }_clicked`,
 			tracksProps

--- a/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
+++ b/client/my-sites/subscribers/tracks/use-record-subscriber-clicked.ts
@@ -4,10 +4,10 @@ const useRecordSubscriberClicked = () => {
 	const recordSubscribersTracksEvent = useRecordSubscriberTrackEvent();
 
 	return (
-		where: 'title' | 'icon' | 'row',
+		where: 'title' | 'icon' | 'row' | 'list',
 		tracksProps: { site_id?: number | null; subscription_id?: number; user_id?: number }
 	) => {
-		// Allows for calypso_subscribers_subscriber_title_clicked, calypso_subscribers_subscriber_icon_clicked & calypso_subscribers_subscriber_row_clicked
+		// Allows for calypso_subscribers_subscriber_title_clicked, calypso_subscribers_subscriber_icon_clicked, calypso_subscribers_subscriber_row_clicked,
 		recordSubscribersTracksEvent(
 			`calypso_subscribers_subscriber_${ where }_clicked`,
 			tracksProps


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/381

## Proposed Changes

* Add a Tracks event for Subscribers list clicks: `calypso_subscribers_subscriber_list_clicked`
* Refactor to combine subscriber selection methods.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To gain insight into how the new Subscribers is being used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* View tracks: PCYsg-nSS-p2
* Click on a subscriber. Check that you see the row Tracks event.
* While still in the list view, click on another subscriber in the list.
* Check that you see the list Tracks event, and no errors.
* Close the subscriber details pane and try clicking "View" in the three dots action menu in a row.
* Check that you see the row Tracks event, and no errors.

Note code style errors seem unrelated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
