### PR TITLE
Newsletter importer: Fix blank screen when going back to change URL

### DIFF
--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -67,6 +67,15 @@ export default function NewsletterImporter( {
 	const [ validFromSite, setValidFromSite ] = useState( false );
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
 	const [ shouldResetImport, setShouldResetImport ] = useState( step === 'reset' );
+	const previousFromSite = useRef( fromSite );
+
+	// Reset validFromSite when fromSite changes or is removed
+	useEffect( () => {
+		if ( fromSite !== previousFromSite.current ) {
+			setValidFromSite( false );
+			previousFromSite.current = fromSite;
+		}
+	}, [ fromSite ] );
 
 	if ( step === 'reset' ) {
 		step = 'content';

--- a/client/my-sites/importer/newsletter/utils.tsx
+++ b/client/my-sites/importer/newsletter/utils.tsx
@@ -108,6 +108,9 @@ export function getImporterStatus(
 }
 
 export function normalizeFromSite( fromSite: string ) {
+	if ( ! fromSite ) {
+		return '';
+	}
 	const result = fromSite.match( /\/@(?<slug>\w+)$/ );
 	if ( result?.groups?.slug ) {
 		return result.groups.slug + '.substack.com';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Prevent .match console error.
* Reset `fromSite` so that users can get back.

Before | After
---- | ----
![Screen Shot 2025-03-05 at 2 13 01 PM](https://github.com/user-attachments/assets/3ea27625-1336-4ffb-83c8-8e04c0f90217) | ![Screen Shot 2025-03-05 at 2 12 27 PM](https://github.com/user-attachments/assets/ba874d45-8b4d-4687-b540-f8c8d31c9a72)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix a bug I noticed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /import/newsletter/substack/{site url}
* Enter a url and hit enter.
* Go back in your browser.
* You should be able to enter a new url.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
