### PR TITLE
Disabling goals first on wpcalypso so e2e tests will validate the production flow

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -144,8 +144,6 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
-		"onboarding/force-goals-first": false,
-
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"page/export": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -120,7 +120,6 @@
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
 		"onboarding/force-big-sky-before-plan": true,
-		"onboarding/force-goals-first": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"plans/hosting-trial": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10558

## Proposed Changes

* We're disabling Goals first on wpcalypso so e2e tests will work as expected
* We're also disabling them locally so we won't see goals first on our internal tests as well

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're rolling back goals first changes so we need to update the tests to run as they were before
