### PR TITLE
Update WP Blaze translations

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -4,6 +4,7 @@ const BlazePressStrings = () => {
 	const translate = useTranslate();
 	translate( 'Calculating' );
 	translate( 'Cannot calculate' );
+	translate( '-' );
 	translate( 'Redirecting to my campaigns…' );
 	translate( 'Oops!' );
 	translate( 'The campaign cannot be created. Please {{a}}contact our support team{{/a}}.' );
@@ -103,6 +104,9 @@ const BlazePressStrings = () => {
 	translate( 'Click or drag an image here to upload.' );
 	translate( 'Upload an image file, or pick one from your media library.' );
 	translate( 'Audience' );
+	translate(
+		'Campaigns typically benefit from language targeting to avoid displaying ads to users who may not understand them. If the required language is unavailable, consider using geo-targeting as an alternative.'
+	);
 	translate( 'Language' );
 	translate( 'Location' );
 	translate( 'If you do not specify the location, the campaign will be displayed everywhere.' );
@@ -115,9 +119,6 @@ const BlazePressStrings = () => {
 	translate( 'Remove interests targeting' );
 	translate( 'Remove device targeting' );
 	translate( 'Your campaign has not set language targeting' );
-	translate(
-		'Campaigns typically benefit from language targeting to avoid displaying ads to users who may not understand them. If the required language is unavailable, consider using geo-targeting as an alternative.'
-	);
 	translate( 'All languages' );
 	translate(
 		'Based on the language of your site we suggest targeting %(lang)s speaking users to ensure the ad is seen by the right audience and to increase its effectiveness.'
@@ -164,6 +165,9 @@ const BlazePressStrings = () => {
 	translate( 'Estimated people reached' );
 	translate( 'Payment method' );
 	translate( 'Everywhere' );
+	translate(
+		"Campaigns typically benefit from language targeting to avoid displaying ads to users who may not understand them. To enhance your campaign's reach and impact, we may refine the language settings. If a particular language is crucial for your campaign, please update your settings accordingly."
+	);
 	translate( 'Languages' );
 	translate( 'Devices' );
 	translate( 'Destination' );
@@ -173,6 +177,9 @@ const BlazePressStrings = () => {
 	translate( 'Search for country, state or city' );
 	translate( 'You won’t be charged until the ad is approved and starts running.' );
 	translate( 'You can pause spending at any time.' );
+	translate(
+		'Your free credits cover up to %(creditsToBeUsed)s, and your card will only be charged once they’re used.'
+	);
 	translate( 'Could not retrieve countries. Please try again later.' );
 	translate( 'Could not connect to payment provider. Please try again later.' );
 	translate( 'Error setting up payment. Please try again later' );


### PR DESCRIPTION
Related to 3250-gh-Tumblr/a8c-dsp

## Proposed Changes
- Introduce update Blaze translations

## Why are these changes being made?
We need to notify translators about new strings to be translated.

Here are the screenshots for updated strings:
- `-`, We forecast the possible number of views for the promoted post. If we can't forecast the result, we just return this sign.
![Screenshot 2025-03-05 at 22 55 15](https://github.com/user-attachments/assets/3e2f3351-0899-4fec-8685-7bc0ae2ee61b)
(The sign highlights that there is no forecasting available)

- `Campaigns typically benefit from language targeting to avoid displaying ads to users who may not understand them. To enhance your campaign's reach and impact, we may refine the language settings. If a particular language is crucial for your campaign, please update your settings accordingly.`, we started a new format (TSP) for promoting posts. The new format implies showing ads a native posts on Tumblr, so we can't can't afford to show a post in an irrelevant language.

![Screenshot 2025-03-05 at 22 59 48](https://github.com/user-attachments/assets/0425a867-e17f-4180-a31e-24f42931bab7)

- `Your free credits cover up to %(creditsToBeUsed)s, and your card will only be charged once they’re used.`, we noticed that sometimes we were not clear about using Free Credits for Blaze. In order to make it clear to users we decided to append the text by saying that we want users to save their credit card data even if they have credits because the credits will be spent first, so we do need their credit cards data to be used as a backup.
 
![Screenshot 2025-03-05 at 23 13 22](https://github.com/user-attachments/assets/3fb102ea-7e78-40d3-a5fb-552c94734595)

## Testing Instructions
Code review is enough

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
