### PR TITLE
Newsletter Widget: link to add subscribers modal

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -1,9 +1,10 @@
+import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
@@ -82,6 +83,16 @@ export const SubscribersHeader = ( {
 	const closeSubscriberModal = () => {
 		setShowSubscriberModal( SubscriberModalType.NONE );
 	};
+
+	// Open the add subscribers modal on mount if the URL hash is #add-subscribers
+	useEffect( () => {
+		if ( window.location.hash === '#add-subscribers' ) {
+			setShowSubscriberModal( SubscriberModalType.ADD );
+
+			// Remove the hash from the URL and the entry from the browser history to clean up
+			page.redirect( window.location.pathname + window.location.search );
+		}
+	}, [] );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/loop#552 Automattic/jetpack#42239

## Proposed Changes

* When `<SubscribersHeader/>` mounts, it will check for a url hash of `add-subscribers` and if present, will open the add subscribers modal

https://github.com/user-attachments/assets/bca2c1c5-7c0e-4a93-bbc6-24936c6f880c

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So we can "deep link" to the add subscribers UI/flow from the Newsletter Widget

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/subscribers/:domain#add-subscribers`
* The add subscribers modal should open
* The url should no longer have the hash (i.e. cleaned up)
* Hitting back in your browser should take you to the first page before visiting `/subscribers/:domain#add-subscribers`, not the url with the hash
* There should be no console errors
* Test in JP Cloud as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
