### PR TITLE
Try to make theme previews interactive in design picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -64,6 +64,12 @@ jest.mock( 'calypso/state/themes/selectors', () => ( {
 	},
 } ) );
 
+jest.mock( 'calypso/state/themes/selectors', () => ( {
+	getThemeDemoUrl: () => {
+		return;
+	},
+} ) );
+
 jest.mock( '../../../../../hooks/use-marketplace-theme-products', () => ( {
 	useMarketplaceThemeProducts: () => ( {
 		isLoading: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -58,13 +58,13 @@ jest.mock( 'calypso/state/themes/hooks/use-is-theme-allowed-on-site', () => ( {
 	useIsThemeAllowedOnSite: () => false,
 } ) );
 
-jest.mock( 'calypso/state/themes/selectors', () => ( {
+jest.mock( 'calypso/state/themes/selectors/get-theme', () => ( {
 	getTheme: () => {
 		return;
 	},
 } ) );
 
-jest.mock( 'calypso/state/themes/selectors', () => ( {
+jest.mock( 'calypso/state/themes/selectors/get-theme-demo-url', () => ( {
 	getThemeDemoUrl: () => {
 		return;
 	},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -335,8 +335,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const selectedDesignSlug = selectedDesign?.slug || '';
 
 	// Get theme URL for the design preview.
-	const themeDemoUrl = useSelector( ( state ) =>
-		getThemeDemoUrl( state, selectedDesignSlug, siteId + '' )
+	const themeDemoUrl = useSelector(
+		( state ) =>
+			getThemeDemoUrl( state, selectedDesignSlug, siteId + '' ) +
+			'?demo=true&iframe=true&theme_preview=true'
 	);
 	const screenshot = theme?.screenshots?.[ 0 ] ?? theme?.screenshot;
 	const fullLengthScreenshot = screenshot?.replace( /\?.*/, '' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -54,7 +54,7 @@ import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-sit
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
-import { getTheme } from 'calypso/state/themes/selectors';
+import { getTheme, getThemeDemoUrl } from 'calypso/state/themes/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useActivateDesign } from '../../../../hooks/use-activate-design';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
@@ -331,6 +331,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	// It should be removed when this property is ready on useQueryThemes
 	useQueryTheme( 'wpcom', selectedDesignThemeId );
 	const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedDesignThemeId ) );
+
+	const selectedDesignSlug = selectedDesign?.slug || '';
+
+	// Get theme URL for the design preview.
+	const themeDemoUrl = useSelector( ( state ) =>
+		getThemeDemoUrl( state, selectedDesignSlug, siteId + '' )
+	);
 	const screenshot = theme?.screenshots?.[ 0 ] ?? theme?.screenshot;
 	const fullLengthScreenshot = screenshot?.replace( /\?.*/, '' );
 
@@ -778,7 +785,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				<AsyncLoad
 					require="@automattic/design-preview"
 					placeholder={ null }
-					previewUrl={ previewUrl }
+					previewUrl={ themeDemoUrl || previewUrl }
 					splitDefaultVariation={
 						( isGlobalStylesOnPersonal &&
 							selectedDesign?.design_tier === THEME_TIER_FREE &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -788,6 +788,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					require="@automattic/design-preview"
 					placeholder={ null }
 					previewUrl={ themeDemoUrl || previewUrl }
+					siteInfo={ {
+						title: shouldCustomizeText ? site?.name : '',
+						tagline: shouldCustomizeText ? site?.description : '',
+					} }
 					splitDefaultVariation={
 						( isGlobalStylesOnPersonal &&
 							selectedDesign?.design_tier === THEME_TIER_FREE &&

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -141,6 +141,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 						width: viewportWidth,
 						height: viewport?.height,
 						transform: `scale(${ scale })`,
+						pointerEvents: 'all',
 					} }
 					src={ addQueryArgs( url, { calypso_token } ) }
 					tabIndex={ -1 }

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -47,6 +47,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const iframeRef = useRef< HTMLIFrameElement >( null );
 	const [ isLoaded, setIsLoaded ] = useState( ! isUrlWpcomApi( url ) );
 	const [ isFullyLoaded, setIsFullyLoaded ] = useState( ! isUrlWpcomApi( url ) );
+	const [ frameLocation, setFrameLocation ] = useState( '' );
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
 	const calypso_token = useMemo( () => iframeToken || uuid(), [ iframeToken ] );
@@ -84,6 +85,14 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 						setViewport( data.payload );
 					}
 					return;
+				case 'location-change':
+					// We need to make sure location changes so it triggers the effect to send inline CSS.
+					if ( data.payload.pathname === frameLocation ) {
+						setFrameLocation( '' );
+						return;
+					}
+					setFrameLocation( data.payload.pathname );
+					return;
 				default:
 					return;
 			}
@@ -94,7 +103,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 		return () => {
 			window.removeEventListener( 'message', handleMessage );
 		};
-	}, [ setIsLoaded, setViewport ] );
+	}, [ calypso_token, isFitHeight, setIsLoaded, setViewport, frameLocation ] );
 
 	// Ideally the iframe's document.body is already available on isLoaded = true.
 	// Unfortunately that's not always the case, so isFullyLoaded serves as another retry.
@@ -109,7 +118,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 				'*'
 			);
 		}
-	}, [ inlineCss, isLoaded, isFullyLoaded ] );
+	}, [ inlineCss, isLoaded, isFullyLoaded, frameLocation, calypso_token ] );
 
 	return (
 		<DeviceSwitcher

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -15,6 +15,10 @@ interface Viewport {
 
 interface ThemePreviewProps {
 	url: string;
+	siteInfo?: {
+		title: string;
+		tagline: string;
+	};
 	inlineCss?: string;
 	viewportWidth?: number;
 	iframeScaleRatio?: number;
@@ -33,6 +37,7 @@ const isUrlWpcomApi = ( url: string ) =>
 
 const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	url,
+	siteInfo,
 	inlineCss,
 	viewportWidth,
 	iframeScaleRatio = 1,
@@ -52,6 +57,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
 	const calypso_token = useMemo( () => iframeToken || uuid(), [ iframeToken ] );
 	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : iframeScaleRatio;
+	const { title, tagline } = siteInfo || {};
 
 	const wrapperHeight = useMemo( () => {
 		if ( ! viewport || iframeScaleRatio === 1 ) {
@@ -86,7 +92,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 					}
 					return;
 				case 'location-change':
-					// We need to make sure location changes so it triggers the effect to send inline CSS.
+					// We need to make sure location changes so it triggers the post message effects.
 					if ( data.payload.pathname === frameLocation ) {
 						setFrameLocation( '' );
 						return;
@@ -119,6 +125,24 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 			);
 		}
 	}, [ inlineCss, isLoaded, isFullyLoaded, frameLocation, calypso_token ] );
+
+	// Send site info to the iframe.
+	useEffect( () => {
+		// We only want to send info if it exists.
+		if ( ! title && ! tagline ) {
+			return;
+		}
+		if ( isLoaded || isFullyLoaded ) {
+			iframeRef.current?.contentWindow?.postMessage(
+				{
+					channel: `preview-${ calypso_token }`,
+					type: 'site-info',
+					site_info: { title, tagline },
+				},
+				'*'
+			);
+		}
+	}, [ title, tagline, calypso_token, isLoaded, isFullyLoaded, frameLocation ] );
 
 	return (
 		<DeviceSwitcher

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -11,6 +11,10 @@ import './style.scss';
 
 interface DesignPreviewProps {
 	previewUrl: string;
+	siteInfo?: {
+		title: string;
+		tagline: string;
+	};
 	title?: string;
 	author?: string;
 	categories?: Category[];
@@ -46,6 +50,7 @@ interface DesignPreviewProps {
 // @todo Get the style variations of theme, and then combine the selected one with colors & fonts for consistency
 const Preview: React.FC< DesignPreviewProps > = ( {
 	previewUrl,
+	siteInfo,
 	title,
 	author,
 	categories = [],
@@ -137,6 +142,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 			/>
 			<SitePreview
 				url={ previewUrl }
+				siteInfo={ siteInfo }
 				inlineCss={ inlineCss }
 				isFullscreen={ isFullscreen }
 				animated={ ! isDesktop && screens.length > 0 }

--- a/packages/design-preview/src/components/site-preview.tsx
+++ b/packages/design-preview/src/components/site-preview.tsx
@@ -6,6 +6,10 @@ import AnimatedFullscreen from './animated-fullscreen';
 
 interface SitePreviewProps {
 	url: string;
+	siteInfo?: {
+		title: string;
+		tagline: string;
+	};
 	inlineCss?: string;
 	isFullscreen?: boolean;
 	animated?: boolean;
@@ -17,6 +21,7 @@ interface SitePreviewProps {
 
 const SitePreview: React.FC< SitePreviewProps > = ( {
 	url,
+	siteInfo,
 	inlineCss = '',
 	isFullscreen,
 	animated,
@@ -63,6 +68,7 @@ const SitePreview: React.FC< SitePreviewProps > = ( {
 		>
 			<ThemePreview
 				url={ url }
+				siteInfo={ siteInfo }
 				inlineCss={ inlineCss }
 				isShowFrameBorder
 				isShowDeviceSwitcher


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100298

This is a very tentative POC to address #100298.

Basically it tries to render the dynamic theme preview that we get on the themes page at `https://wordpress.com/themes/[yoursitename]` when we select a theme.

That preview is an actual wordpress.com site, e.g. for the Pomme theme it's `https://pommedemo.wordpress.com/`. whereas what we currently have in the design picker is a call to an API endpoint that delivers a preview of the theme's homepage only, with non-functional links, such as `https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fpomme`.

I'd love some early feedback on the viability of this approach! Is there any reason _not_ to do it this way?


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and step through to theme selection
* Pick a theme and verify that links in the theme preview are clickable.


I probably need to add some parameter to get rid of the header banner 😅 

<img width="1190" alt="Screenshot 2025-03-06 at 4 14 23 pm" src="https://github.com/user-attachments/assets/68fa1419-6c37-49d7-907d-97aa7e8795e3" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
