### PR TITLE
Hosting Features: Update upgrade link to use plan and feature params

### DIFF
--- a/client/sites/hosting-features/components/hosting-features.tsx
+++ b/client/sites/hosting-features/components/hosting-features.tsx
@@ -1,5 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	FEATURE_HOSTING,
+	FEATURE_SFTP,
+	getPlan,
+	PLAN_BUSINESS,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
@@ -78,7 +83,7 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 		}
 	}, [ isSiteAtomic, isPlanExpired, redirectUrl ] );
 
-	const upgradeLink = `https://wordpress.com/checkout/${ encodeURIComponent( siteSlug ) }/business`;
+	const upgradeLink = `/plans/${ siteSlug }?feature=${ FEATURE_HOSTING }&plan=${ PLAN_BUSINESS }`;
 	const promoCards = [
 		{
 			title: translate( 'Deployments' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix https://github.com/Automattic/wp-calypso/issues/100276
Related to https://github.com/Automattic/wp-calypso/pull/90246

## Proposed Changes

- Redirects the "Upgrade now" button under the Hosting Features tab to the Plans page in Site Admin instead of directly leading to the checkout page.
- Ensures that users have the opportunity to compare plans before making a purchase decision.

<img width="945" alt="Screenshot 2025-03-06 at 14 57 19" src="https://github.com/user-attachments/assets/282e27af-bb02-40c9-9809-1b2cb98e842d" />

<img width="1437" alt="Screenshot 2025-03-06 at 15 00 24" src="https://github.com/user-attachments/assets/7079e618-04e1-4110-a8fe-36f43572a769" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, clicking "Upgrade now" takes users directly to the checkout page without allowing them to see available plan options. This behavior feels broken as there is no comparison stage in between.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Prepare a site on a plan lower than Premium 
- Go to wordpress.com/overview/[site-url]
- Click on the Hosting Features tab.
- Click on the "Upgrade now" button.
- Confirm that the link now leads to the Plans page instead of the checkout page.
- Verify that you can proceed to/complete the checkout. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
