### PR TITLE
Subscribers: Fix issue where the hash #add-subscribers does not trigger the Add Subscribers modal

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -5,7 +5,7 @@ import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
-import { ReactElement } from 'react';
+import { useEffect, ReactElement } from 'react';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import NavigationHeader from 'calypso/components/navigation-header';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -81,7 +81,28 @@ export const SubscribersHeader = ( {
 	);
 	const closeSubscriberModal = () => {
 		setShowSubscriberModal( SubscriberModalType.NONE );
+
+		if ( window.location.hash === '#add-subscribers' ) {
+			// Doing this instead of window.location.hash = '' because window.location.hash keeps the # symbol
+			// Also this makes the back button show the modal again, which is neat
+			history.pushState( '', document.title, window.location.pathname + window.location.search );
+		}
 	};
+
+	useEffect( () => {
+		const handleHashChange = () => {
+			if ( window.location.hash === '#add-subscribers' ) {
+				setShowSubscriberModal( SubscriberModalType.ADD );
+			}
+		};
+
+		window.addEventListener( 'hashchange', handleHashChange );
+		handleHashChange();
+
+		return () => {
+			window.removeEventListener( 'hashchange', handleHashChange );
+		};
+	}, [] );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100920

## Proposed Changes

The PR https://github.com/Automattic/wp-calypso/pull/99965 inadvertently removed the logic which showed the Add Subscribers modal when the URL contains the hash `#add-subscribers`.

![Screenshot 2025-03-06 at 2 10 34 PM](https://github.com/user-attachments/assets/5d94b6dd-b062-4951-ab06-fd5996f99ca6)

Unfortunately, this logic is still needed for the Subscribers page's launchpad:

![Screenshot 2025-03-06 at 2 11 41 PM](https://github.com/user-attachments/assets/49817da7-7766-4457-94e4-2fa86d3406c0)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /subscribers/:domain on a site that has no subscribers
* Click on the Import existing subscribers and ensure that the Add Subscribers modal appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
