### PR TITLE
For DomainsTable hide bulk action notices if DataViews is enabled

### DIFF
--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { DomainData } from '@automattic/data-stores';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
@@ -30,10 +31,13 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 				( domain ) => ! domain?.is_subdomain
 			).length > 1 );
 
+	const isDomainsDataViewsEnabled = config.isEnabled( 'calypso/domains-dataviews' );
+	const showBulkUpdateNotice = ! isDomainsDataViewsEnabled;
+
 	return (
 		<DomainsTableStateContext.Provider value={ state }>
 			<div className={ clsx( className, 'domains-table' ) }>
-				<DomainsTableBulkUpdateNotice />
+				{ showBulkUpdateNotice && <DomainsTableBulkUpdateNotice /> }
 				{ showDomainsToolbar && <DomainsTableToolbar /> }
 				{ useMobileCards ?? isMobile ? (
 					<DomainsTableMobileCards />


### PR DESCRIPTION
Considering how notifications work there, they might collect for DomainsTable that is still used for internal screens.

Context: p1741192183352019-slack-C02NWDZBL0H

## Proposed Changes

* Don't show bulk action notices for DomainsTable if Domains DataViews feature is enabled.

## Why are these changes being made?

* Part of the Domains Management Revamp project and addressing design feedback.

## Testing Instructions

* Go to http://calypso.localhost:3000/domains/manage
* Perform a bulk action (manage auto-renew) that triggers a notification.
* Don't dismiss notification!
* Go to the sites (http://calypso.localhost:3000/sites), then to the site to which the domain is connected you acted on.
* Make sure you don't see the notification above the domains connected to the site (Active domains).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?