### PR TITLE
A4A > WooPayments: Display WooPayments transactions on sites and async loading indicator

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
@@ -10,8 +10,8 @@ const WooPaymentsConsolidatedViews = () => {
 	const translate = useTranslate();
 
 	const { woopaymentsData, isLoadingWooPaymentsData } = useWooPaymentsContext();
-	const totalCommission = woopaymentsData?.total?.payout ?? 0;
-	const expectedCommission = woopaymentsData?.estimated?.payout ?? 0;
+	const totalCommission = woopaymentsData?.data?.total?.payout ?? 0;
+	const expectedCommission = woopaymentsData?.data?.estimated?.payout ?? 0;
 
 	const { nextPayoutActivityWindow, nextPayoutDate } = useGetPayoutData();
 

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -29,7 +29,7 @@ export const WooPaymentsStatusColumn = ( {
 	if ( ! state ) {
 		return (
 			<Button
-				variant="secondary"
+				variant="tertiary"
 				href={ `${ siteUrl }/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` }
 				target="_blank"
 				rel="noopener noreferrer"

--- a/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
+++ b/client/a8c-for-agencies/sections/woopayments/lib/site-data.ts
@@ -9,6 +9,6 @@ export const getSiteData = (
 	woopaymentsData: WooPaymentsData,
 	siteId: number
 ): WooPaymentsSiteData => ( {
-	transactions: woopaymentsData?.total?.sites?.[ siteId ]?.tpv ?? 0,
-	payout: woopaymentsData?.total?.sites?.[ siteId ]?.payout ?? 0,
+	transactions: woopaymentsData?.data?.total?.sites?.[ siteId ]?.transactions ?? 0,
+	payout: woopaymentsData?.data?.total?.sites?.[ siteId ]?.payout ?? 0,
 } );

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
@@ -123,7 +124,14 @@ const WooPaymentsDashboard = () => {
 						<Title>{ title }</Title>
 						<Actions>
 							<MobileSidebarNavigation />
-							<AddWooPaymentsToSite />
+							<div className="woopayments-dashboard__actions">
+								{ isInProgress && (
+									<div className="woopayments-dashboard__spinner">
+										<Spinner /> { translate( 'Loading and refreshing data' ) }
+									</div>
+								) }
+								<AddWooPaymentsToSite />
+							</div>
 						</Actions>
 					</LayoutHeader>
 				</LayoutTop>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
@@ -1,8 +1,33 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .woopayments-dashboard {
 	.hosting-dashboard-layout__header-actions {
 		display: flex;
 		flex-direction: column;
 		align-items: normal;
 		justify-content: normal;
+	}
+}
+
+.woopayments-dashboard__actions {
+	@include body-small;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	@include break-xlarge {
+		flex-direction: row;
+		align-items: center;
+	}
+}
+
+.woopayments-dashboard__spinner {
+	display: flex;
+	gap: 8px;
+
+	svg {
+		margin: 0
 	}
 }

--- a/client/a8c-for-agencies/sections/woopayments/types.ts
+++ b/client/a8c-for-agencies/sections/woopayments/types.ts
@@ -18,18 +18,24 @@ export interface SitesWithWooPaymentsState {
 }
 
 export interface WooPaymentsData {
-	total?: {
-		payout: number;
-		tpv: number;
-		sites?: {
-			[ key: number ]: {
-				tpv?: number;
-				payout?: number;
+	data: {
+		total?: {
+			payout: number;
+			tpv: number;
+			transactions: number;
+			sites?: {
+				[ key: number ]: {
+					tpv?: number;
+					payout?: number;
+					transactions?: number;
+				};
 			};
 		};
+		estimated?: {
+			payout: number;
+			tpv: number;
+			transactions: number;
+		};
 	};
-	estimated?: {
-		payout: number;
-		tpv: number;
-	};
+	status: string;
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1896

## Proposed Changes

This PR:
- Shows a loading indicator when the WooPayments data is async-loading (in_progress)
- Implements transactions based on the API endpoint changes.
- Updated the `Setup in WP-Admin ↗` button variant to tertiary

## Why are these changes being made?

*To show a loading indicator when the updated data is fetching and display the transactions instead of TPV for sites

## Testing Instructions

* Switch to this branch locally for better testing
* Patch and follow testing instructions here: 175910-ghe-Automattic/wpcom. Do not change the agency ID, keep yours as of now
* Visit WooPayments: Dashboard: Verify you can see a loading indicator as displayed below.
* Open the file: client/a8c-for-agencies/sections/woopayments/hooks/use-fetch-woopayments-data.ts and set the agencyId to the one mentioned on the ticket linked
* Open the file: client/a8c-for-agencies/sections/woopayments/dashboard-content/index.tsx and change the blogId to the one mentioned on the ticket linked in the createInitialSiteState method
* Refresh the page, it should look like something like this. We also updated the `Setup in WP-Admin ↗` button variant to tertiary

<img width="1920" alt="Screenshot 2025-03-06 at 1 15 03 PM" src="https://github.com/user-attachments/assets/10d3ae4b-bb21-4ec9-aeb8-4de16e5482fd" />

Loading indicators

| Large | Tablet | Mobile |
|--------|--------|--------|
| <img width="576" alt="Screenshot 2025-03-06 at 12 55 43 PM" src="https://github.com/user-attachments/assets/86868af9-8906-46e4-91be-fe385dd18aa5" /> | <img width="766" alt="Screenshot 2025-03-06 at 1 02 32 PM" src="https://github.com/user-attachments/assets/fd218471-d7bf-4b6b-b5a4-def1f149fc77" /> | <img width="376" alt="Screenshot 2025-03-06 at 1 02 18 PM" src="https://github.com/user-attachments/assets/ad1b7d00-e3a4-4cd5-a7eb-61fc81b9bdcd" /> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?