### PR TITLE
Onboarding: Bypass all goals-first onboarding logic

### DIFF
--- a/client/data/experiment/use-goals-first-cumulative-experience.ts
+++ b/client/data/experiment/use-goals-first-cumulative-experience.ts
@@ -1,47 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { useMemo } from 'react';
-import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
-import { useExperiment } from 'calypso/lib/explat';
-import { useSelector } from 'calypso/state';
-import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
-import type { AppState } from 'calypso/types';
-
-export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
-
 /**
  * Check whether the user should have the cumulative improvements to the "goals first" onboarding experience.
+ *
+ * This experiment has been disabled, but we are keeping the project code for now.
  *
  * Returns [ isLoading, isCumulativeExperience ]
  */
 export function useGoalsFirstCumulativeExperience(): [ boolean, boolean ] {
-	const flow = useMemo( () => getFlowFromURL(), [] );
-
-	const inOnboardingFlow = flow === ONBOARDING_FLOW;
-
-	const selectedSite = useSelector( ( state: AppState ) => getSelectedSite( state ) );
-	const isSelectedSiteEligible =
-		selectedSite?.options?.site_creation_flow === ONBOARDING_FLOW &&
-		( selectedSite.options.created_at ?? '' ) > '2025-02-03T10:22:45+00:00'; // If created_at is null then this expression is false
-
-	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible:
-			( inOnboardingFlow || isSelectedSiteEligible ) &&
-			! isEnabled( 'onboarding/force-goals-first' ),
-	} );
-
-	if ( isEnabled( 'onboarding/force-goals-first' ) ) {
-		return [ false, true ];
-	}
-
-	/**
-	 * If the user is not eligible, we'll treat them as if they were in the
-	 * holdout/control group so we can provide the existing experience.
-	 *
-	 * This fallback is necessary because experimentAssignment returns null when the user
-	 * is not eligible, and we're using this hook within steps that are used by other flows.
-	 */
-	const variationName = experimentAssignment?.variationName ?? 'control';
-
-	return [ isLoading, variationName === 'treatment_cumulative' ];
+	return [ false, false ];
 }

--- a/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-bigsky-before-plans-experiment.ts
@@ -1,47 +1,10 @@
-import configApi from '@automattic/calypso-config';
-import { setPlansListExperiment } from '@automattic/calypso-products';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { useMemo, useRef } from 'react';
-import { useExperiment } from 'calypso/lib/explat';
-import { getFlowFromURL } from '../../utils/get-flow-from-url';
-import { useGoalsFirstExperiment } from './use-goals-first-experiment';
-
-export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_bigsky_202501_v1';
-
 /**
  * Check whether the user should have the "Big Sky before plans" onboarding experience.
+ *
+ * This experiment has been disabled, but we are keeping the project code for now.
  *
  * Returns [ isLoading, isBigSkyBeforePlans ]
  */
 export function useBigSkyBeforePlans(): [ boolean, boolean ] {
-	const flow = useMemo( () => getFlowFromURL(), [] );
-	const forceBigSkyEligibility =
-		useRef(
-			new URLSearchParams( window.location.search ).get( 'isBigSkyBeforePlansFlow' ) === 'true'
-		).current || configApi.isEnabled( 'onboarding/force-big-sky-before-plan' );
-
-	const [ isLoadingGoalsFirst, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
-
-	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible:
-			! isLoadingGoalsFirst &&
-			isGoalsFirstExperiment &&
-			flow === ONBOARDING_FLOW &&
-			! forceBigSkyEligibility,
-	} );
-
-	if ( forceBigSkyEligibility ) {
-		setPlansListExperiment( EXPERIMENT_NAME, 'treatment' );
-		return [ false, true ];
-	}
-
-	/**
-	 * This fallback is necessary because experimentAssignment returns null when the user
-	 * is not eligible, and we're using this hook within steps that are used by other flows.
-	 */
-	const variationName = experimentAssignment?.variationName ?? 'control';
-
-	setPlansListExperiment( EXPERIMENT_NAME, variationName );
-
-	return [ isLoading, variationName === 'treatment' ];
+	return [ false, false ];
 }

--- a/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-goals-first-experiment.ts
@@ -1,41 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { useMemo } from 'react';
-import { useExperiment } from 'calypso/lib/explat';
-import { getFlowFromURL } from '../../utils/get-flow-from-url';
-
-export const EXPERIMENT_NAME = 'calypso_signup_onboarding_goals_first_flow_holdout_v2_20250131';
-
 /**
  * Check whether the user should have the "goals first" onboarding experience.
+ *
+ * This experiment has been disabled, but we are keeping the project code for now.
  *
  * Returns [ isLoading, isGoalsAtFrontExperiment ]
  */
 export function useGoalsFirstExperiment(): [ boolean, boolean ] {
-	const flow = useMemo( () => getFlowFromURL(), [] );
-
-	const [ isLoading, experimentAssignment ] = useExperiment( EXPERIMENT_NAME, {
-		isEligible: flow === ONBOARDING_FLOW && ! isEnabled( 'onboarding/force-goals-first' ),
-	} );
-
-	if ( isEnabled( 'onboarding/force-goals-first' ) ) {
-		return [ false, true ];
-	}
-
-	/**
-	 * If the user is not eligible, we'll treat them as if they were in the
-	 * holdout/control group so we can provide the existing experience.
-	 *
-	 * This fallback is necessary because experimentAssignment returns null when the user
-	 * is not eligible, and we're using this hook within steps that are used by other flows.
-	 */
-	const variationName = experimentAssignment?.variationName ?? 'control';
-
-	// There's a separate cohort for holdout reasons. But in terms of the "goals-first" experience,
-	// both treatment cohorts see it.
-	const isGoalsAtFrontExperiment = [ 'treatment_cumulative', 'treatment_frozen' ].includes(
-		variationName
-	);
-
-	return [ isLoading, isGoalsAtFrontExperiment ];
+	return [ false, false ];
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,6 @@
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/user-on-stepper-hosting": true,
-		"onboarding/force-big-sky-before-plan": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"plans/hosting-trial": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The goals-first and big-sky-before-plans experiment have been disabled p1740371895971309-slack-C085HCWCEDN. This means that all _new_ users are given the user-first experience. However there are existing users who are seeing the goals-first experience. 90% were assigned to that cohort. So there's probably a lot of a12s seeing goals-first too.

Plus it adds confusion with e2e testing because depending on the environment the test steps are different.

This PR bypasses the code for checking whether the user is assigned to the goals-first experience. This means all users get the user-first onboarding, regardless of what cohort they've been assigned to in the past.

This doesn't remove any of the actual goals-first code. That would still be easy to resurrect by changing the logic of the `useGoalsFirstExperiment()`, and related, hooks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run through onboarding.
* Feel free to assign yourself to a specific cohort 22180-explat-experiment
* You always see the user-first onboarding flow. That is:
  * Optionally signup/signin
  * Domains
  * Plans
  * Optionally checkout
  * Goals
  * Design
  * Launchpad in My Home

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?