### PR TITLE
My Home: Add Manage Emails link to Quick Links

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -9,8 +9,6 @@ import { useDebouncedCallback } from 'use-debounce';
 import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
 import blazeIcon from 'calypso/assets/images/icons/blaze-icon.svg';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
-import { canCurrentUserAddEmail } from 'calypso/lib/domains';
-import { hasPaidEmailWithUs } from 'calypso/lib/emails';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -21,7 +19,6 @@ import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	getSiteFrontPage,
 	getCustomizerUrl,
@@ -45,7 +42,6 @@ export const QuickLinks = ( {
 	customizeUrl,
 	isWpcomStagingSite,
 	isStaticHomePage,
-	canAddEmail,
 	menusUrl,
 	trackEditHomepageAction,
 	trackWritePostAction,
@@ -57,9 +53,9 @@ export const QuickLinks = ( {
 	trackCustomizeThemeAction,
 	trackChangeThemeAction,
 	trackDesignLogoAction,
-	trackAddEmailAction,
 	trackAddDomainAction,
 	trackManageAllDomainsAction,
+	trackManageEmailsAction,
 	trackExplorePluginsAction,
 	isExpanded,
 	updateHomeQuickLinksToggleStatus,
@@ -178,25 +174,13 @@ export const QuickLinks = ( {
 				</>
 			) }
 			{ canManageSite && ! isWpcomStagingSite && (
-				<>
-					{ canAddEmail ? (
-						<ActionBox
-							href={ `/email/${ siteSlug }` }
-							hideLinkIndicator
-							onClick={ trackAddEmailAction }
-							label={ translate( 'Add email' ) }
-							materialIcon="email"
-						/>
-					) : (
-						<ActionBox
-							href={ `/domains/add/${ siteSlug }` }
-							hideLinkIndicator
-							onClick={ addNewDomain }
-							label={ translate( 'Add a domain' ) }
-							gridicon="add-outline"
-						/>
-					) }
-				</>
+				<ActionBox
+					href={ `/domains/add/${ siteSlug }` }
+					hideLinkIndicator
+					onClick={ addNewDomain }
+					label={ translate( 'Add a domain' ) }
+					gridicon="add-outline"
+				/>
 			) }
 			{ canManageSite && (
 				<ActionBox
@@ -205,6 +189,15 @@ export const QuickLinks = ( {
 					onClick={ trackManageAllDomainsAction }
 					label={ translate( 'Manage all domains' ) }
 					gridicon="domains"
+				/>
+			) }
+			{ canManageSite && ! isWpcomStagingSite && (
+				<ActionBox
+					href={ `/email/${ siteSlug }` }
+					hideLinkIndicator
+					onClick={ trackManageEmailsAction }
+					label={ translate( 'Manage emails' ) }
+					materialIcon="email"
 				/>
 			) }
 			{ siteAdminUrl && (
@@ -405,17 +398,6 @@ const trackAnchorPodcastAction = ( isStaticHomePage ) =>
 		bumpStat( 'calypso_customer_home', 'my_site_anchor_podcast' )
 	);
 
-const trackAddEmailAction = ( isStaticHomePage ) => ( dispatch ) => {
-	dispatch(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_customer_home_my_site_add_email_click', {
-				is_static_home_page: isStaticHomePage,
-			} ),
-			bumpStat( 'calypso_customer_home', 'my_site_add_email' )
-		)
-	);
-};
-
 const trackExplorePluginsAction = ( isStaticHomePage ) => ( dispatch ) => {
 	dispatch(
 		composeAnalytics(
@@ -449,27 +431,25 @@ export const trackManageAllDomainsAction = ( isStaticHomePage ) => ( dispatch ) 
 	);
 };
 
-/**
- * Select a list of domains that are eligible to add email to from a larger list.
- * WPCOM-specific domains like free and staging sub-domains are filtered from this list courtesy of `canCurrentUserAddEmail`
- * @param domains An array domains to filter
- */
-const getDomainsThatCanAddEmail = ( domains ) =>
-	domains.filter(
-		( domain ) => ! hasPaidEmailWithUs( domain ) && canCurrentUserAddEmail( domain )
+export const trackManageEmailsAction = ( isStaticHomePage ) => ( dispatch ) => {
+	dispatch(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_customer_home_my_site_manage_emails_click', {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', 'my_site_manage_emails' )
+		)
 	);
+};
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
-	const domains = getDomainsBySiteId( state, siteId );
 	const isStaticHomePage =
 		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
 	const siteSlug = getSelectedSiteSlug( state );
 	const staticHomePageId = getSiteFrontPage( state, siteId );
 	const editHomePageUrl = isStaticHomePage && `/page/${ siteSlug }/${ staticHomePageId }`;
-
-	const canAddEmail = getDomainsThatCanAddEmail( domains ).length > 0;
 
 	return {
 		siteId,
@@ -480,7 +460,6 @@ const mapStateToProps = ( state ) => {
 		customizeUrl: getCustomizerUrl( state, siteId ),
 		menusUrl: getCustomizerUrl( state, siteId, 'menus' ),
 		isNewlyCreatedSite: isNewSite( state, siteId ),
-		canAddEmail,
 		siteSlug,
 		isStaticHomePage,
 		editHomePageUrl,
@@ -505,9 +484,9 @@ const mapDispatchToProps = {
 	trackChangeThemeAction,
 	trackDesignLogoAction,
 	trackAnchorPodcastAction,
-	trackAddEmailAction,
 	trackAddDomainAction,
 	trackManageAllDomainsAction,
+	trackManageEmailsAction,
 	trackExplorePluginsAction,
 	updateHomeQuickLinksToggleStatus: ( status ) =>
 		savePreference( 'homeQuickLinksToggleStatus', status ),
@@ -528,10 +507,10 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		trackChangeThemeAction: () => dispatchProps.trackChangeThemeAction( isStaticHomePage ),
 		trackDesignLogoAction: () => dispatchProps.trackDesignLogoAction( isStaticHomePage ),
 		trackAnchorPodcastAction: () => dispatchProps.trackAnchorPodcastAction( isStaticHomePage ),
-		trackAddEmailAction: () => dispatchProps.trackAddEmailAction( isStaticHomePage ),
 		trackAddDomainAction: () => dispatchProps.trackAddDomainAction( isStaticHomePage ),
 		trackManageAllDomainsAction: () =>
 			dispatchProps.trackManageAllDomainsAction( isStaticHomePage ),
+		trackManageEmailsAction: () => dispatchProps.trackManageEmailsAction( isStaticHomePage ),
 		trackExplorePluginsAction: () => dispatchProps.trackExplorePluginsAction( isStaticHomePage ),
 		...ownProps,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100668

## Proposed Changes

This PR add a "Manage Emails" (string is already translated) item to Quick Links. 
![Screenshot 2025-03-06 at 3 59 23 PM](https://github.com/user-attachments/assets/bb6efbef-2605-4f0a-b202-0f8b01fe6c9f)

Note that there is an existing "Add email" that is only displayed when the site is eligible to purchase emails.

![Screenshot 2025-03-06 at 3 59 39 PM](https://github.com/user-attachments/assets/04b85aa0-0c73-498d-80d4-6186b5a51408)

With this PR, we simplify the logic and link to the Emails page for all non-staging sites.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Offer another entry point to the Emails page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to My Home
* Ensure that the Manage Emails item is available in the Quick Links section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
