### PR TITLE
Hosting Logs: update field name copy

### DIFF
--- a/client/sites/logs/components/details-modal-server.tsx
+++ b/client/sites/logs/components/details-modal-server.tsx
@@ -40,7 +40,7 @@ const DetailsModalServer = ( { item }: DetailsModalServerProps ) => {
 			<div>
 				<Badge className={ `badge--${ item.request_type }` }>{ item.request_type }</Badge>
 			</div>
-			<div className="site-logs-details-modal__field-title">{ translate( 'HTTP Status' ) }</div>
+			<div className="site-logs-details-modal__field-title">{ translate( 'Status' ) }</div>
 			<div>{ item.status }</div>
 			<div className="site-logs-details-modal__field-title">{ translate( 'Request URL' ) }</div>
 			<div>{ item.request_url }</div>

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -186,13 +186,13 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 			{
 				id: 'http2',
 				type: 'text',
-				label: translate( 'HTTP2' ),
+				label: translate( 'HTTP/2' ),
 				enableSorting: false,
 			},
 			{
 				id: 'http_user_agent',
 				type: 'text',
-				label: translate( 'HTTP User Agent' ),
+				label: translate( 'User Agent' ),
 				enableSorting: false,
 			},
 			{
@@ -204,7 +204,7 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 			{
 				id: 'http_x_forwarded_for',
 				type: 'text',
-				label: translate( 'HTTP X Forwarded Port' ),
+				label: translate( 'X-Forwarded-For' ),
 				enableSorting: false,
 			},
 			{


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/99056

## Proposed Changes

Updates the field name copy for clarity.

<img width="860" alt="Screenshot 2025-03-06 at 10 32 38" src="https://github.com/user-attachments/assets/129ae241-5a6c-48bf-b634-e9a184fb11d7" />
