### PR TITLE
Apps: Command Palette/Odyssey Stats: fix createRoot warning

### DIFF
--- a/apps/command-palette-wp-admin/src/index.js
+++ b/apps/command-palette-wp-admin/src/index.js
@@ -1,7 +1,7 @@
 import CommandPalette from '@automattic/command-palette';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import domReady from '@wordpress/dom-ready';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import setLocale from './set-locale';
 import { useCommandsWpAdmin } from './use-commands';
 import { useSites } from './use-sites';
@@ -50,7 +50,8 @@ function wpcomInitCommandPalette() {
 	const commandPaletteContainer = document.createElement( 'div' );
 	document.body.appendChild( commandPaletteContainer );
 
-	render( <CommandPaletteApp />, commandPaletteContainer );
+	const root = createRoot( commandPaletteContainer );
+	root.render( <CommandPaletteApp /> );
 }
 
 domReady( wpcomInitCommandPalette );

--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -1,7 +1,7 @@
 import '@automattic/calypso-polyfills';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import config from '../lib/config-api';
 import getSiteAdminUrl from '../lib/selectors/get-site-admin-url';
@@ -26,8 +26,13 @@ export function init() {
 	const queryClient = new QueryClient();
 
 	// Ensure locale files are loaded before rendering.
-	setLocale( localeSlug ).then( () =>
-		render(
+	setLocale( localeSlug ).then( () => {
+		const statsWidgetEl = document.getElementById( 'dashboard_stats' );
+		if ( ! statsWidgetEl ) {
+			return;
+		}
+		const root = createRoot( statsWidgetEl );
+		root.render(
 			<QueryClientProvider client={ queryClient }>
 				<div id="stats-widget-content" className="stats-widget-content">
 					<MiniChart
@@ -57,8 +62,7 @@ export function init() {
 						</div>
 					</div>
 				</div>
-			</QueryClientProvider>,
-			document.getElementById( 'dashboard_stats' )
-		)
-	);
+			</QueryClientProvider>
+		);
+	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Trying to eliminate red console logs. This one appears everywhere in wp-admin.

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/30ed5ade-41d2-4a9b-aa68-0ccf004a7980" />


## Proposed Changes

* Update to createRoot

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Get rid of "errors"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure `define( 'SCRIPT_DEBUG', true );`
* Run:
  * `bin/install-plugin.sh odyssey-stats fix/react-create-root`
  * `bin/install-plugin.sh command-palette fix/react-create-root`
* Go to classic wp-admin post list, there should be no red warning. Cmd+K should show the command palette.
* Go to the Dashboard. The two related createRoot warnings should be gone. Jetpack stats widget mounts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
