### PR TITLE
Help Center: Fix messages shown time

### DIFF
--- a/packages/help-center/src/components/help-center-support-chat-message.tsx
+++ b/packages/help-center/src/components/help-center-support-chat-message.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gravatar, TimeSince } from '@automattic/components';
-import { getNumericDateString, useLocale } from '@automattic/i18n-utils';
+import { getNumericDateTimeString, useLocale } from '@automattic/i18n-utils';
 import { HumanAvatar } from '@automattic/odie-client/src/assets';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { chevronRight, Icon } from '@wordpress/icons';
@@ -108,7 +108,7 @@ export const HelpCenterSupportChatMessage = ( {
 						}
 					/>
 					<span>
-						<TimeSince date={ getNumericDateString( received * 1000, locale ) } />
+						<TimeSince date={ getNumericDateTimeString( received * 1000, locale ) } />
 					</span>
 				</div>
 			</div>

--- a/packages/i18n-utils/src/date-utils.ts
+++ b/packages/i18n-utils/src/date-utils.ts
@@ -103,3 +103,25 @@ export const getNumericDateString = ( timestamp: number, locale = 'en' ) => {
 		return getISODateString( timestamp );
 	}
 };
+
+/**
+ * Get localized full date and time format for timestamp including hours and minutes.
+ * @param {number} timestamp Web timestamp (milliseconds since Epoch)
+ * @param {string} locale Locale slug
+ * @returns {string} Formatted localized date and time, e.g. '12/20/2021, 3:30 PM' for US English
+ *   Falls back to ISO date string if anything goes wrong.
+ */
+export const getNumericDateTimeString = ( timestamp: number, locale = 'en' ) => {
+	try {
+		const formatter = new Intl.DateTimeFormat( locale, {
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: 'numeric',
+		} );
+		return formatter.format( new Date( timestamp ) );
+	} catch ( error ) {
+		return getISODateString( timestamp );
+	}
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* The date used was missing the time, only had the date, so if I sent a message at 8 AM it would calculate it as being sent 8 hours ago.

This fixes this

![image](https://github.com/user-attachments/assets/c72dfcf4-7078-4c3d-8d9f-b15154214ac3)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Help Center
* Send message and check the date in History
