### PR TITLE
Fix formatting of use-site-logs-query.ts

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -6,14 +6,14 @@ interface SiteLogsAPIResponse {
 	message: string;
 	data: {
 		total_results: number | { value: number; relation: string };
-		logs: (PHPLogFromEndpoint | ServerLogFromEndpoint)[];
+		logs: ( PHPLogFromEndpoint | ServerLogFromEndpoint )[];
 		scroll_id: string | null;
 	};
 }
 
 interface SiteLogsData {
 	total_results: number;
-	logs: (ServerLog | PHPLog)[];
+	logs: ( ServerLog | PHPLog )[];
 	scroll_id: string | null;
 	has_more: boolean;
 }
@@ -55,7 +55,7 @@ interface PHPLogFromEndpoint {
 	atomic_site_id: number;
 }
 
-export interface PHPLog extends Omit<PHPLogFromEndpoint, 'atomic_site_id'> {
+export interface PHPLog extends Omit< PHPLogFromEndpoint, 'atomic_site_id' > {
 	id: string;
 }
 
@@ -77,7 +77,7 @@ export interface LogQueryParams {
 }
 
 export interface FilterType {
-	[key: string]: Array<string>;
+	[ key: string ]: Array< string >;
 }
 
 interface SiteLogsParams {
@@ -93,32 +93,35 @@ interface SiteLogsParams {
 export function useSiteLogsQuery(
 	siteId: number | null | undefined,
 	params: SiteLogsParams,
-	queryOptions: Omit<UseQueryOptions<SiteLogsAPIResponse, unknown, SiteLogsData>, 'queryKey'> = {}
+	queryOptions: Omit<
+		UseQueryOptions< SiteLogsAPIResponse, unknown, SiteLogsData >,
+		'queryKey'
+	> = {}
 ) {
 	const queryClient = useQueryClient();
-	const [scrollId, setScrollId] = useState<string | undefined>();
+	const [ scrollId, setScrollId ] = useState< string | undefined >();
 
 	// The scroll ID represents the state of a particular set of filtering arguments. If any of
 	// those filter arguments change we throw out the scroll ID so we can start over.
-	const [previousSiteId, setPreviousSiteId] = useState(siteId);
-	const [previousParams, setPreviousParams] = useState(params);
-	if (previousSiteId !== siteId || !areRequestParamsEqual(previousParams, params)) {
-		queryClient.removeQueries({
-			queryKey: buildPartialQueryKey(previousSiteId, previousParams),
-		});
+	const [ previousSiteId, setPreviousSiteId ] = useState( siteId );
+	const [ previousParams, setPreviousParams ] = useState( params );
+	if ( previousSiteId !== siteId || ! areRequestParamsEqual( previousParams, params ) ) {
+		queryClient.removeQueries( {
+			queryKey: buildPartialQueryKey( previousSiteId, previousParams ),
+		} );
 
 		// We're updating state directly in the render flow. This is preferable to using an effect.
 		// https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-		setPreviousSiteId(siteId);
-		setPreviousParams(params);
-		setScrollId(undefined);
+		setPreviousSiteId( siteId );
+		setPreviousParams( params );
+		setScrollId( undefined );
 	}
 
-	const queryResult = useQuery<SiteLogsAPIResponse, unknown, SiteLogsData>({
-		queryKey: buildQueryKey(siteId, params),
+	const queryResult = useQuery< SiteLogsAPIResponse, unknown, SiteLogsData >( {
+		queryKey: buildQueryKey( siteId, params ),
 		queryFn: () => {
 			const logTypeFragment = params.logType === LogType.PHP ? 'error-logs' : 'logs';
-			const path = `/sites/${siteId}/hosting/${logTypeFragment}`;
+			const path = `/sites/${ siteId }/hosting/${ logTypeFragment }`;
 			return wpcom.req.get(
 				{ path, apiNamespace: 'wpcom/v2' },
 				{
@@ -132,19 +135,19 @@ export function useSiteLogsQuery(
 			);
 		},
 		placeholderData: keepPreviousData,
-		enabled: !!siteId && params.start <= params.end,
+		enabled: !! siteId && params.start <= params.end,
 		staleTime: Infinity, // The logs within a specified time range never change.
-		select({ data }: SiteLogsAPIResponse): SiteLogsData {
+		select( { data }: SiteLogsAPIResponse ): SiteLogsData {
 			return {
-				has_more: !!data.scroll_id,
+				has_more: !! data.scroll_id,
 				total_results:
 					typeof data.total_results === 'number' ? data.total_results : data.total_results.value,
-				logs: data.logs.map(({ atomic_site_id, ...restLog }: any, key) => {
+				logs: data.logs.map( ( { atomic_site_id, ...restLog }: any, key ) => {
 					return {
 						...restLog,
-						id: String(key),
+						id: String( key ),
 					};
-				}),
+				} ),
 				scroll_id: data.scroll_id,
 			};
 		},
@@ -152,15 +155,15 @@ export function useSiteLogsQuery(
 			persist: false,
 		},
 		...queryOptions,
-	});
+	} );
 
 	const { data } = queryResult;
 
-	useEffect(() => {
-		if (data?.has_more && scrollId !== data.scroll_id) {
-			setScrollId(data.scroll_id ?? undefined);
+	useEffect( () => {
+		if ( data?.has_more && scrollId !== data.scroll_id ) {
+			setScrollId( data.scroll_id ?? undefined );
 		}
-	}, [data, scrollId]);
+	}, [ data, scrollId ] );
 
 	// The state represented by scroll ID will have already advanced to the next page, so we
 	// can't allow `refetch` to be used. Remember, the logs are fetched with a POST and the
@@ -172,13 +175,13 @@ export function useSiteLogsQuery(
 	};
 }
 
-function buildPartialQueryKey(siteId: number | null | undefined, params: SiteLogsParams) {
-	return [params.logType === LogType.PHP ? 'site-logs-php' : 'site-logs-web', siteId];
+function buildPartialQueryKey( siteId: number | null | undefined, params: SiteLogsParams ) {
+	return [ params.logType === LogType.PHP ? 'site-logs-php' : 'site-logs-web', siteId ];
 }
 
-function buildQueryKey(siteId: number | null | undefined, params: SiteLogsParams) {
+function buildQueryKey( siteId: number | null | undefined, params: SiteLogsParams ) {
 	return [
-		...buildPartialQueryKey(siteId, params),
+		...buildPartialQueryKey( siteId, params ),
 		params.start,
 		params.end,
 		params.filter,
@@ -190,34 +193,34 @@ function buildQueryKey(siteId: number | null | undefined, params: SiteLogsParams
 
 // Request params are equal if every field is the same _except_ for the page index.
 // The page index is not part of the request body, it is only part of the query key.
-function areRequestParamsEqual(a: SiteLogsParams, b: SiteLogsParams) {
+function areRequestParamsEqual( a: SiteLogsParams, b: SiteLogsParams ) {
 	return (
 		a.logType === b.logType &&
 		a.start === b.start &&
 		a.end === b.end &&
 		a.sortOrder === b.sortOrder &&
 		a.pageSize === b.pageSize &&
-		areFilterParamsEqual(a.filter, b.filter)
+		areFilterParamsEqual( a.filter, b.filter )
 	);
 }
 
-function areFilterParamsEqual(a: FilterType, b: FilterType) {
-	for (const filter in a) {
-		if (!b.hasOwnProperty(filter)) {
+function areFilterParamsEqual( a: FilterType, b: FilterType ) {
+	for ( const filter in a ) {
+		if ( ! b.hasOwnProperty( filter ) ) {
 			return false;
 		}
 
-		if (a[filter].toString() !== b[filter].toString()) {
+		if ( a[ filter ].toString() !== b[ filter ].toString() ) {
 			return false;
 		}
 	}
 
-	for (const filter in b) {
-		if (!a.hasOwnProperty(filter)) {
+	for ( const filter in b ) {
+		if ( ! a.hasOwnProperty( filter ) ) {
 			return false;
 		}
 
-		if (b[filter].toString() !== a[filter].toString()) {
+		if ( b[ filter ].toString() !== a[ filter ].toString() ) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Fixes incorrect Prettier formatting introduced in https://github.com/Automattic/wp-calypso/pull/100833