### PR TITLE
Reader editor - connect site selector to calypso state.

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -9,17 +9,19 @@ import {
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
-import { useSelector, useDispatch, connect } from 'react-redux';
+import { connect } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { stripHTML } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
+import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receiveNewPost } from 'calypso/state/reader/streams/actions';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -40,11 +42,9 @@ interface PostItem {
 }
 
 function QuickPost( {
-	primarySiteId,
 	receivePosts,
 	successNotice,
 }: {
-	primarySiteId: number | null;
 	receivePosts: ( posts: PostItem[] ) => Promise< void >;
 	successNotice: ( message: string, options: object ) => void;
 } ) {
@@ -54,7 +54,7 @@ function QuickPost( {
 	const [ postContent, setPostContent ] = useState( '' );
 	const [ editorKey, setEditorKey ] = useState( 0 );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
-	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( primarySiteId ?? null );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const editorRef = useRef< HTMLDivElement >( null );
 	const dispatch = useDispatch();
 	const currentUser = useSelector( getCurrentUser );
@@ -126,7 +126,7 @@ function QuickPost( {
 	};
 
 	const handleSiteSelect = ( siteId: number ) => {
-		setSelectedSiteId( siteId );
+		dispatch( setSelectedSiteId( siteId ) );
 	};
 
 	const getButtonText = () => {
@@ -190,12 +190,7 @@ function QuickPost( {
 	);
 }
 
-export default connect(
-	( state: any ) => ( {
-		primarySiteId: getPrimarySiteId( state ),
-	} ),
-	{
-		successNotice: ( message: string, options: object ) => successNotice( message, options ),
-		receivePosts: ( posts: PostItem[] ) => receivePosts( posts ) as Promise< void >,
-	}
-)( QuickPost );
+export default connect( null, {
+	successNotice: ( message: string, options: object ) => successNotice( message, options ),
+	receivePosts: ( posts: PostItem[] ) => receivePosts( posts ) as Promise< void >,
+} )( QuickPost );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/100868 - an alternative solution than what was proposed in the issue.

## Proposed Changes

Testing the idea of potential alternative solution to linked issue above. Does this make more sense than the current state?

Connects the site selector in the reader editor to calypso state.
* The initial selection of the site selector in the reader will then be contextual to the site that the user is working with or coming from. This means if the user goes from wp-admin of a site and clicks "reader", the default site selected in the reader editor site selector will be the site they came from.
* This also connects the rest of calypso context to the site selection change. Its arguable unnecessary but is also consistent withe selection and I don't see it creating any downsides. That is, when you select a different site via the site selector in the reader editor, it will update calypso state and you will see the admin bar change its site selection as well.
   * If we don't want to do this part, we could look at only initializing the site selector here with calypso state, but then not change calypso state based on its usage. However, I lean towards the current behavior in this branch. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Keep the site selector contextual to what is being worked on, and bring consistency across the interface with changing site selection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a site that is not your primary blog in calypso. You can do this on the site dashboard.
* Go to the reader editor, verify the site selector defaults to the selected site instead of the primary blog.
* Change the selection via the site selector, notice the selection updates the adminbar as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
