### PR TITLE
Subscriber Import: add reset button

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -3,15 +3,13 @@ import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_UNLIMITED_SUBSCRIBERS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Gridicon, FlowQuestion } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { AddSubscriberForm, UploadSubscribersForm } from '@automattic/subscriber';
 import { useHasStaleImportJobs } from '@automattic/subscriber/src/hooks/use-has-stale-import-jobs';
 import { useInProgressState } from '@automattic/subscriber/src/hooks/use-in-progress-state';
-import { ExternalLink, Modal, __experimentalVStack as VStack } from '@wordpress/components';
+import { Modal, __experimentalVStack as VStack } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { copy, upload, reusableBlock } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
@@ -21,6 +19,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
+import { StaleImportJobsNotice } from './stale-job-notice';
 
 import './style.scss';
 
@@ -87,32 +86,6 @@ const AddSubscribersModal = ( {
 		} else {
 			page( `/import/newsletter/substack/${ site?.slug || site?.ID || '' }` );
 		}
-	};
-
-	const renderLearnMoreLink = ( isJetpack: boolean | null ) => {
-		// Jetpack sites
-		if ( isJetpack ) {
-			return (
-				<ExternalLink
-					href={ localizeUrl( 'https://jetpack.com/support/newsletter/import-subscribers/' ) }
-				>
-					{ translate( 'Learn more' ) }
-				</ExternalLink>
-			);
-		}
-
-		// WP.com sites
-		return (
-			<InlineSupportLink
-				showIcon={ false }
-				supportLink={ localizeUrl(
-					'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
-				) }
-				supportPostId={ 220199 }
-			>
-				{ translate( 'Learn more' ) }
-			</InlineSupportLink>
-		);
 	};
 
 	return (
@@ -191,21 +164,7 @@ const AddSubscribersModal = ( {
 						</Notice>
 					) }
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
-						<Notice
-							className="add-subscribers-modal__notice"
-							icon={ <Gridicon icon="notice" /> }
-							isCompact
-							theme="light"
-							status="is-warning"
-							showDismiss={ false }
-						>
-							<span className="add-subscribers-modal__notice-text">
-								{ translate(
-									'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.'
-								) }
-							</span>
-							{ renderLearnMoreLink( isJetpack ) }
-						</Notice>
+						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }
 					<label className="add-subscribers-modal__label">{ translate( 'Email' ) }</label>
 					<AddSubscriberForm
@@ -253,21 +212,7 @@ const AddSubscribersModal = ( {
 						</Notice>
 					) }
 					{ ! isUploading && isImportInProgress && hasStaleImportJobs && (
-						<Notice
-							className="add-subscribers-modal__notice"
-							icon={ <Gridicon icon="notice" /> }
-							isCompact
-							theme="light"
-							status="is-warning"
-							showDismiss={ false }
-						>
-							<span className="add-subscribers-modal__notice-text">
-								{ translate(
-									'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.'
-								) }
-							</span>
-							{ renderLearnMoreLink( isJetpack ) }
-						</Notice>
+						<StaleImportJobsNotice isJetpack={ isJetpack } siteId={ site?.ID || null } />
 					) }
 					<UploadSubscribersForm
 						siteId={ site?.ID || 0 }

--- a/client/my-sites/subscribers/components/add-subscribers-modal/stale-job-notice.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/stale-job-notice.tsx
@@ -1,0 +1,88 @@
+import { Gridicon } from '@automattic/components';
+import { Subscriber } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { useSubscriberImportStatusReset } from '../../mutations';
+
+const LearnMoreLink = ( { isJetpack }: { isJetpack: boolean | null } ) => {
+	const translate = useTranslate();
+	const learnMoreText = translate( 'Learn more' );
+
+	return (
+		<>
+			{ isJetpack ? (
+				<ExternalLink
+					href={ localizeUrl( 'https://jetpack.com/support/newsletter/import-subscribers/' ) }
+				>
+					{ learnMoreText }
+				</ExternalLink>
+			) : (
+				<InlineSupportLink
+					showIcon={ false }
+					supportLink={ localizeUrl(
+						'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
+					) }
+					supportPostId={ 220199 }
+				>
+					{ learnMoreText }
+				</InlineSupportLink>
+			) }
+		</>
+	);
+};
+
+export const StaleImportJobsNotice = ( {
+	isJetpack,
+	siteId,
+}: {
+	isJetpack: boolean | null;
+	siteId: number | null;
+} ) => {
+	const translate = useTranslate();
+	const imports =
+		useSelect( ( select ) => select( Subscriber.store ).getImportJobsSelector(), [] ) || [];
+	const lastImportWasCancelled = imports[ imports.length - 1 ]?.status === 'cancelled';
+	const { mutate: resetImportStatus } = useSubscriberImportStatusReset( siteId );
+
+	return (
+		<Notice
+			className="add-subscribers-modal__notice"
+			icon={ <Gridicon icon="notice" /> }
+			isCompact
+			theme="light"
+			status="is-warning"
+			showDismiss={ false }
+		>
+			{ lastImportWasCancelled ? (
+				<>
+					<span className="add-subscribers-modal__notice-text">
+						{ translate(
+							'Your recent import is taking longer than expected to complete. If this issue persists, please contact our support team for assistance.'
+						) }
+					</span>
+					<LearnMoreLink isJetpack={ isJetpack } />
+				</>
+			) : (
+				<>
+					<span className="add-subscribers-modal__notice-text">
+						{ translate(
+							'Your recent import is taking longer than expected to complete. Please cancel your import and try again.'
+						) }
+					</span>
+					<NoticeAction
+						onClick={ () => {
+							resetImportStatus();
+						} }
+					>
+						{ translate( 'Cancel import' ) }
+					</NoticeAction>
+				</>
+			) }
+		</Notice>
+	);
+};

--- a/client/my-sites/subscribers/components/add-subscribers-modal/stale-job-notice.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/stale-job-notice.tsx
@@ -3,6 +3,7 @@ import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
@@ -43,10 +44,11 @@ export const StaleImportJobsNotice = ( {
 	isJetpack: boolean | null;
 	siteId: number | null;
 } ) => {
+	const [ isCancelling, setIsCancelling ] = useState( false );
 	const translate = useTranslate();
 	const imports =
 		useSelect( ( select ) => select( Subscriber.store ).getImportJobsSelector(), [] ) || [];
-	const lastImportWasCancelled = imports[ imports.length - 1 ]?.status === 'cancelled';
+	const lastImportWasCancelled = imports[ 1 ]?.status === 'cancelled';
 	const { mutate: resetImportStatus } = useSubscriberImportStatusReset( siteId );
 
 	return (
@@ -76,10 +78,11 @@ export const StaleImportJobsNotice = ( {
 					</span>
 					<NoticeAction
 						onClick={ () => {
+							setIsCancelling( true );
 							resetImportStatus();
 						} }
 					>
-						{ translate( 'Cancel import' ) }
+						{ isCancelling ? translate( 'Cancelling import…' ) : translate( 'Cancel import' ) }
 					</NoticeAction>
 				</>
 			) }

--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -68,6 +68,7 @@
 			+ a.notice__action {
 				margin: 0;
 				padding: 0;
+				cursor: pointer;
 			}
 		}
 	}

--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -64,6 +64,11 @@
 
 		.add-subscribers-modal__notice-text {
 			margin-right: 6px;
+
+			+ a.notice__action {
+				margin: 0;
+				padding: 0;
+			}
 		}
 	}
 

--- a/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
+++ b/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
@@ -29,29 +29,43 @@ export const useAddSubscribersCallback = ( siteId: number | null ) => {
 	const addSubscribersCallback = () => {
 		if ( ! importError ) {
 			if ( completedJob ) {
-				const { email_count, subscribed_count, already_subscribed_count, failed_subscribed_count } =
-					completedJob;
-				dispatch(
-					successNotice(
-						translate(
-							'Import completed. %(added)d subscribed, %(skipped)d already subscribed, and %(failed)d failed out of %(total)d %(totalLabel)s.',
-							{
-								args: {
-									added: subscribed_count,
-									skipped: already_subscribed_count,
-									failed: failed_subscribed_count,
-									total: email_count,
-									totalLabel: translate( 'subscriber', 'subscribers', {
-										count: email_count,
-									} ),
-								},
-							}
+				const {
+					email_count,
+					subscribed_count,
+					already_subscribed_count,
+					failed_subscribed_count,
+					status,
+				} = completedJob;
+				if ( status === 'cancelled' ) {
+					// Handle when the import is cancelled.
+					dispatch(
+						successNotice(
+							translate( 'Import has been successfully cancelled. Please try again.' )
 						)
-					)
-				);
+					);
+				} else {
+					dispatch(
+						successNotice(
+							translate(
+								'Import completed. %(added)d subscribed, %(skipped)d already subscribed, and %(failed)d failed out of %(total)d %(totalLabel)s.',
+								{
+									args: {
+										added: subscribed_count,
+										skipped: already_subscribed_count,
+										failed: failed_subscribed_count,
+										total: email_count,
+										totalLabel: translate( 'subscriber', 'subscribers', {
+											count: email_count,
+										} ),
+									},
+								}
+							)
+						)
+					);
 
-				// Invalidate the subscribers query to ensure the new subscribers are fetched
-				queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
+					// Invalidate the subscribers query to ensure the new subscribers are fetched
+					queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
+				}
 			} else {
 				dispatch(
 					successNotice(

--- a/client/my-sites/subscribers/mutations/index.ts
+++ b/client/my-sites/subscribers/mutations/index.ts
@@ -1,1 +1,2 @@
 export { default as useSubscriberRemoveMutation } from './use-subscriber-remove-mutation';
+export { default as useSubscriberImportStatusReset } from './use-subscriber-import-status-reset';

--- a/client/my-sites/subscribers/mutations/use-subscriber-import-status-reset.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-import-status-reset.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+const useSubscriberImportStatusReset = ( siteId: number | null ) => {
+	return useMutation( {
+		mutationFn: () => {
+			if ( ! siteId ) {
+				return Promise.resolve();
+			}
+
+			return wpcom.req.post( {
+				path: `/sites/${ siteId }/subscribers/import/reset_state`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+	} );
+};
+
+export default useSubscriberImportStatusReset;

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -31,7 +31,7 @@ export type ImportJob = {
 
 export type CompletedImportJob = {
 	id: number;
-	status: 'imported';
+	status: 'imported' | 'cancelled';
 	email_count: number;
 	subscribed_count: number;
 	already_subscribed_count: number;

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -14,7 +14,7 @@ export interface SubscriberState {
 	hydrated?: boolean;
 }
 
-export type ImportJobStatus = 'pending' | 'importing' | 'imported' | 'failed';
+export type ImportJobStatus = 'pending' | 'importing' | 'imported' | 'failed' | 'cancelled';
 
 export type ImportJob = {
 	id: number;

--- a/packages/subscriber/src/hooks/use-active-job-recognition.ts
+++ b/packages/subscriber/src/hooks/use-active-job-recognition.ts
@@ -16,7 +16,7 @@ export function useActiveJobRecognition( siteId: number ) {
 	const { imports, completedJob } = useSelect( ( select ) => {
 		const latestJob = select( Subscriber.store ).getLatestImportJobSelector();
 		const isCompletedJob = ( job: ImportJob ): job is CompletedImportJob =>
-			job?.status === 'imported';
+			job?.status === 'imported' || job?.status === 'cancelled';
 
 		return {
 			imports: select( Subscriber.store ).getImportJobsSelector() || [],


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack/issues/40615
Related to https://github.com/Automattic/loop/issues/507
Context p1741175534451789-slack-C083ZPVVDTK

## Proposed Changes

* Move stale-state component to its own home
* Add hook to POST to reset endpoint

## Why are these changes being made?

Currently there is a bug that causes imports to stall in the pending state. The only way to resolve this is by manually reseting the state from BlogRC. Adding this ability to the import modal allows users to resolve the issue themselves.

To prevent there being an endless loop of resetting we allow the users to reset once, then if it ends with another pending stall we give them the previous "Ask for help" message.

## Testing Instructions

*You first need to create a stalled job to be able to cancel it.*

### Create a pending stall
1. Sandbox public-api
2. Sandbox your import jobs from `0-sandbox.php`

```
function sandbox_jobs( $sandboxed, $type ) {
    return in_array( $type, array(
        'import_subscribers',
    ) );
}
 
add_filter( 'sandbox_async_job', 'sandbox_jobs', 10, 2 );
```

3. DO NOT start the job watcher. This seems to cause the job to stall.
4. Attempt to import an email address. You should get no notice in the UI and see the job as `pending` from your blog RC.

*Once the job is stalled now you need to force some checks to be true to be able to see the notice without waiting 24 hrs.*

### Testing UI changes
1. [Pull this branch](https://github.com/Automattic/wp-calypso/pull/100941)
2. [Force this line](https://github.com/Automattic/wp-calypso/blob/subscribers/add-import-reset/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx#L166) to be `true` so you can see the reset.
5. Go to `/subscribers/YOUR_SITE#add-subscribers` choose "manually"
6. Click the "Cancel import" button
7. State should reset and user should be free to import again.
8. Your blog RC should show the state as `cancelled`
9. Repeat the pending stall and you should now see the "Learn more" link