### PR TITLE
i18n: Update site-migration step components to use `numberFormat` for percentages in strings

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
@@ -69,7 +69,7 @@ const Authorization = ( { onShareCredentialsClick, onAuthorizationClick }: Autho
 								{
 									args: {
 										uptimePercent: numberFormat( 0.99999, {
-											numberFormatOptions: { style: 'percent' },
+											numberFormatOptions: { style: 'percent', maximumFractionDigits: 3 },
 										} ),
 									},
 									comment: '99.999% uptime',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
@@ -1,6 +1,6 @@
 import { NextButton } from '@automattic/onboarding';
 import { Icon, loop, backup, shield } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 
 interface AuthorizationBenefitsItem {
 	icon: React.ReactElement;
@@ -64,7 +64,17 @@ const Authorization = ( { onShareCredentialsClick, onAuthorizationClick }: Autho
 						},
 						{
 							icon: backup,
-							text: translate( 'Unmatched reliability with 99.999% uptime and unmetered traffic.' ),
+							text: translate(
+								'Unmatched reliability with %(uptimePercent)s uptime and unmetered traffic.',
+								{
+									args: {
+										uptimePercent: numberFormat( 0.99999, {
+											numberFormatOptions: { style: 'percent' },
+										} ),
+									},
+									comment: '99.999% uptime',
+								}
+							),
 						},
 						{
 							icon: shield,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/components/authorization.tsx
@@ -1,10 +1,10 @@
 import { NextButton } from '@automattic/onboarding';
 import { Icon, loop, backup, shield } from '@wordpress/icons';
-import { numberFormat, useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate, type TranslateResult } from 'i18n-calypso';
 
 interface AuthorizationBenefitsItem {
 	icon: React.ReactElement;
-	text: string;
+	text: TranslateResult;
 }
 
 interface AuthorizationBenefitsProps {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -6,7 +6,7 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { Icon, next, published, shield } from '@wordpress/icons';
-import { numberFormat, useTranslate } from 'i18n-calypso';
+import { numberFormat, TranslateResult, useTranslate } from 'i18n-calypso';
 import { type FC, ReactElement, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
 import ScanningStep from 'calypso/blocks/import/scanning';
@@ -25,7 +25,7 @@ import './style.scss';
 interface HostingDetailsWithIconsProps {
 	items: {
 		icon: ReactElement;
-		description: string;
+		description: TranslateResult;
 	}[];
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -6,7 +6,7 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { Icon, next, published, shield } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import { type FC, ReactElement, useEffect, useState, useCallback } from 'react';
 import CaptureInput from 'calypso/blocks/import/capture/capture-input';
 import ScanningStep from 'calypso/blocks/import/scanning';
@@ -101,7 +101,17 @@ export const Analyzer: FC< Props > = ( {
 		},
 		'unmatched-uptime': {
 			icon: published,
-			description: translate( 'Unmatched reliability with 99.999% uptime and unmetered traffic.' ),
+			description: translate(
+				'Unmatched reliability with %(uptimePercent)s uptime and unmetered traffic.',
+				{
+					args: {
+						uptimePercent: numberFormat( 0.99999, {
+							numberFormatOptions: { style: 'percent' },
+						} ),
+					},
+					comment: '99.999% uptime',
+				}
+			),
 		},
 		security: {
 			icon: shield,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -106,7 +106,7 @@ export const Analyzer: FC< Props > = ( {
 				{
 					args: {
 						uptimePercent: numberFormat( 0.99999, {
-							numberFormatOptions: { style: 'percent' },
+							numberFormatOptions: { style: 'percent', maximumFractionDigits: 3 },
 						} ),
 					},
 					comment: '99.999% uptime',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/migration-plan-feature-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/migration-plan-feature-list.tsx
@@ -4,7 +4,7 @@ import {
 	PLAN_BUSINESS_2_YEARS,
 } from '@automattic/calypso-products';
 import { JetpackLogo } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 import type { PlanSlug } from '@automattic/calypso-products';
 import type { PricingMetaForGridPlan } from '@automattic/data-stores';
 import type { ReactNode } from 'react';
@@ -25,11 +25,10 @@ export const MigrationPlanFeatureList = ( {
 
 	const selectedPlanPricing = pricing.originalPrice?.monthly;
 
-	let percentageString = '0%';
-	if ( fullMonthlyPrice && selectedPlanPricing ) {
-		percentageString =
-			Math.floor( ( ( fullMonthlyPrice - selectedPlanPricing ) / fullMonthlyPrice ) * 100 ) + '%';
-	}
+	const savingsDecimal =
+		fullMonthlyPrice && selectedPlanPricing
+			? ( fullMonthlyPrice - selectedPlanPricing ) / fullMonthlyPrice
+			: 0;
 
 	const jetpackFeatures = [
 		translate( 'In-depth site analytics dashboard' ),
@@ -48,7 +47,9 @@ export const MigrationPlanFeatureList = ( {
 		// translators: %(percentage)s is the percentage of annual savings formatted like '50%'
 		translate( '{{strong}}%(percentage)s{{/strong}} annual savings', {
 			args: {
-				percentage: percentageString,
+				percentage: numberFormat( savingsDecimal, {
+					numberFormatOptions: { style: 'percent' },
+				} ),
 			},
 			components: { strong: <strong /> },
 		} ),
@@ -69,7 +70,13 @@ export const MigrationPlanFeatureList = ( {
 	} = {
 		wpcomFeatures: {
 			[ PLAN_BUSINESS ]: [
-				translate( '{{strong}}50% off{{/strong}} your first year', {
+				translate( '{{strong}}%(percentage)s off{{/strong}} your first year', {
+					args: {
+						percentage: numberFormat( 0.5, {
+							numberFormatOptions: { style: 'percent' },
+						} ),
+						comment: 'percentage like 50% off',
+					},
 					components: { strong: <strong /> },
 				} ),
 				...commonDiscountedFeatures,
@@ -88,7 +95,13 @@ export const MigrationPlanFeatureList = ( {
 				...businessFeatures,
 			],
 			[ PLAN_BUSINESS_2_YEARS ]: [
-				translate( '{{strong}}50% off{{/strong}} your first two years', {
+				translate( '{{strong}}%(percentage)s off{{/strong}} your first two years', {
+					args: {
+						percentage: numberFormat( 0.5, {
+							numberFormatOptions: { style: 'percent' },
+						} ),
+						comment: 'percentage like 50% off',
+					},
 					components: { strong: <strong /> },
 				} ),
 				...commonDiscountedFeatures,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Proposed Changes

Refactors a few more cases in migration flow of injected percentages in strings

## Media

Before/after in EN:

<img width="515" alt="Screenshot 2025-03-06 at 5 49 37 PM" src="https://github.com/user-attachments/assets/0feb61e4-185a-4557-b2c2-4acd62b57ce1" />

<img width="1150" alt="Screenshot 2025-03-06 at 5 52 00 PM" src="https://github.com/user-attachments/assets/9c3ffb87-2c08-458d-87e1-9a112193b6b3" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- go to `/setup/site-migration`
- from authorization to plan selection, confirm the percentages render correctly - per media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
