### PR TITLE
i18n: Update sites dashboard to use `numberFormat` for injected percentages

### DIFF
--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -4,7 +4,7 @@ import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { numberFormat, useTranslate } from 'i18n-calypso';
 // TODO: This will need to be updated to use whatever image we decide on.
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -111,10 +111,25 @@ export const Content = () => {
 				<MenuItem
 					isBanner
 					icon={ <img src={ devSiteBanner } alt="Get a Free Domain and Up to 55% off" /> }
-					heading={ translate( 'Get a Free Domain and Up to 55% off' ) }
+					heading={ translate( 'Get a Free Domain and Up to %(percentage)s off', {
+						args: {
+							percentage: numberFormat( 0.55, {
+								numberFormatOptions: { style: 'percent' },
+							} ),
+							comment: 'percentage like 55% off',
+						},
+					} ) }
 					description={ preventWidows(
 						translate(
-							'Save up to 55% on annual plans and get a free custom domain for a year. Your next site is just a step away.'
+							'Save up to %(percentage)s on annual plans and get a free custom domain for a year. Your next site is just a step away.',
+							{
+								args: {
+									percentage: numberFormat( 0.55, {
+										numberFormatOptions: { style: 'percent' },
+									} ),
+									comment: 'percentage like 55% off',
+								},
+							}
 						)
 					) }
 					buttonProps={ {

--- a/client/components/sites-add-new-site/content/layout/menu-item.tsx
+++ b/client/components/sites-add-new-site/content/layout/menu-item.tsx
@@ -11,7 +11,7 @@ type Props = {
 	children?: JSX.Element;
 	description: TranslateResult;
 	disabled?: boolean;
-	heading: string;
+	heading: TranslateResult;
 	icon: JSX.Element;
 	isBanner?: boolean;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Proposed Changes

Updates the sites dashboard to use placeholders with `numberFormat` parsing for percentages in translation strings

## Media

Before/After in EN (sites -> add new site):

<img width="953" alt="Screenshot 2025-03-06 at 6 34 18 PM" src="https://github.com/user-attachments/assets/37b759b5-3627-4d8e-a1d7-602015202245" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- go to `/sites` select to add new site
- confirm percentages in string render correctly - per media above (can check different locales - AR/EN - but the remaining string will be untranslated)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
