### PR TITLE
Theme Previewer: Update variation cards to match style editor

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/preview.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview.tsx
@@ -68,8 +68,12 @@ const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused, onFocusOut
 		'elements.h1.typography.fontWeight'
 	);
 	const [ textColor = 'black' ] = useGlobalStyle( 'color.text' );
-	const [ headingColor = textColor ] = useGlobalStyle( 'elements.h1.color.text' );
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
+	const [ headingColor = textColor ] = useGlobalStyle( 'elements.h1.color.text' );
+	const [ linkColor = headingColor ] = useGlobalStyle( 'elements.link.color.text' );
+	const [ buttonBackgroundColor = linkColor ] = useGlobalStyle(
+		'elements.button.color.background'
+	);
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
 	const disableMotion = useReducedMotion();
 	const [ coreColors ] = useGlobalSetting( 'color.palette.core' );
@@ -81,12 +85,23 @@ const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused, onFocusOut
 	const paletteColors = ( themeColors ?? [] )
 		.concat( customColors ?? [] )
 		.concat( coreColors ?? [] );
-	const highlightedColors = paletteColors
+	const textColorObject = paletteColors.filter(
+		( { color }: { color: Color } ) => color === textColor
+	);
+	const buttonBackgroundColorObject = paletteColors.filter(
+		( { color }: { color: Color } ) => color === buttonBackgroundColor
+	);
+
+	// Prefer the text & button background (or link) color, then look through the full palette.
+	const highlightedColors = textColorObject
+		.concat( buttonBackgroundColorObject )
+		.concat( paletteColors )
 		.filter(
-			// we exclude these two colors because they are already visible in the preview.
-			( { color }: { color: Color } ) => color !== backgroundColor && color !== headingColor
+			// we exclude these background color because it is already visible in the preview.
+			( { color }: { color: Color } ) => color !== backgroundColor
 		)
 		.slice( 0, 2 );
+
 	return (
 		<GlobalStylesVariationContainer
 			width={ width }
@@ -139,7 +154,7 @@ const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused, onFocusOut
 							{ highlightedColors.map(
 								( { slug, color }: { slug: string; color: string }, index: number ) => (
 									<motion.div
-										key={ slug }
+										key={ `${ slug }-${ index }` }
 										style={ {
 											height: normalizedColorSwatchSize * ratio,
 											width: normalizedColorSwatchSize * ratio,

--- a/packages/global-styles/src/components/global-styles-variations/preview.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview.tsx
@@ -97,7 +97,7 @@ const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused, onFocusOut
 		.concat( buttonBackgroundColorObject )
 		.concat( paletteColors )
 		.filter(
-			// we exclude these background color because it is already visible in the preview.
+			// we exclude this background color because it is already visible in the preview.
 			( { color }: { color: Color } ) => color !== backgroundColor
 		)
 		.slice( 0, 2 );


### PR DESCRIPTION
Fixes #100573.

## Proposed Changes

This PR updates the style variation cards in theme preview to better match the core cards, which also increases the contrast of the color-circles against the background.

| Theme | Before | After | Core site editor |
|---|---|---|---|
| Twenty Twenty-Five | ![tt5-prod](https://github.com/user-attachments/assets/e67a1480-9594-4c04-9cd2-588130b7be7a) | ![tt5-branch](https://github.com/user-attachments/assets/82d07fc6-5b12-458b-b870-9df312e2258c) | ![tt5-core](https://github.com/user-attachments/assets/1fae0c63-d2fd-42b4-9669-7ded4290d4f6) |
| Twenty Twenty-Two | ![tt2-prod](https://github.com/user-attachments/assets/00029354-7a77-4530-9e01-42730dd935ad) | ![tt2-branch](https://github.com/user-attachments/assets/0925c3a0-8c8c-497d-9296-44c126d75d33) | ![tt2-core](https://github.com/user-attachments/assets/c997b5a0-b4c8-40c5-882b-f5c2d31e115b) |
| Timestream | ![timestream-prod](https://github.com/user-attachments/assets/4a983de6-5d8b-4b03-b9b1-90df6a616b81) | ![timestream-branch](https://github.com/user-attachments/assets/aa151672-4614-4f12-9069-9d789bef02fc) | ![timestream-core](https://github.com/user-attachments/assets/32ac14c2-c179-4ab4-b43d-253f92a077ed) |
| Booknest | ![booknest-prod](https://github.com/user-attachments/assets/db5993e8-c03c-4d60-a430-ed67a354626f) | ![booknest-branch](https://github.com/user-attachments/assets/5321c183-759a-4946-9d5a-1cca0eb731ab) | ![booknest-core](https://github.com/user-attachments/assets/555027aa-652c-4a80-a676-48169edffb5e) |

In the onboarding flow, the same step that was screenshotted in the issue:

<img width="410" alt="Screenshot 2025-03-06 at 11 58 01 AM" src="https://github.com/user-attachments/assets/1108ad90-bd82-49e0-906d-0fcb79dff9ff" />

## Why are these changes being made?

To improve contrast and better match the core style cards.

## Testing Instructions

* Go to the theme showcase, either site-specific or /themes/
* View any theme with style variations
* The colors in variation cards should have decent contrast with the background
* The variations should match the core style variations in the site editor

You can also see the same cards by going through the onboarding site setup flow, it uses the same component.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
