### PR TITLE
i18n: Update importer/upgrade-plan-details to use `numberFormat` for percent values in strings

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -13,7 +13,7 @@ import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NextButton, Title } from '@automattic/onboarding';
 import { Plans2023Tooltip, useManageTooltipToggle } from '@automattic/plans-grid-next';
 import clsx from 'clsx';
-import { type TranslateResult, useTranslate, formatCurrency } from 'i18n-calypso';
+import { type TranslateResult, useTranslate, formatCurrency, numberFormat } from 'i18n-calypso';
 import { useState, useEffect, type PropsWithChildren } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
 import { useSelectedPlanUpgradeMutation } from 'calypso/data/import-flow/use-selected-plan-upgrade';
@@ -182,9 +182,14 @@ const PlanPriceOffer = ( props: PlanPriceOfferProps ) => {
 		);
 	}
 
-	const badgeText = hasEnTranslation( '50% off your first year' )
-		? translate( '50% off your first year' )
-		: translate( 'One time offer' );
+	const badgeText = translate( '%(percentage)s off your first year', {
+		args: {
+			percentage: numberFormat( 0.5, {
+				numberFormatOptions: { style: 'percent' },
+			} ),
+			comment: 'percentage like 50% off',
+		},
+	} );
 
 	return (
 		<UpgradePlanPrice billingTimeFrame={ billingTimeFrame }>

--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-hosting-details.tsx
@@ -1,6 +1,6 @@
 import { useState } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { UpgradePlanHostingTestimonials } from './constants';
 import cwvtechReportJson from './cwvtech-report.json';
 import { UpgradePlanHostingDetailsTooltip } from './upgrade-plan-hosting-details-tooltip';
@@ -59,7 +59,16 @@ export const UpgradePlanHostingDetails: React.FC< Props > = ( {
 					<ul>{ hostingDetailsItems }</ul>
 				</div>
 				<div className="import__upgrade-plan-hosting-details-testimonials-container">
-					<p>{ translate( '100% loved by our best customers' ) }</p>
+					<p>
+						{ translate( '%(percentage)s loved by our best customers', {
+							args: {
+								percentage: numberFormat( 1, {
+									numberFormatOptions: { style: 'percent' },
+								} ),
+								comment: 'percentage like 100% loved',
+							},
+						} ) }
+					</p>
 					<div className="import__upgrade-plan-hosting-details-testimonials">
 						{ UpgradePlanHostingTestimonials.map(
 							( { customerName, customerTestimonial, customerInfo, customerImage }, i ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Proposed Changes

Updates the plan-upgrade details during site importer or plan upgrade to use placeholders with `numberFormat` parsing for percentages in translation strings

## Media 

`setup/import-focused?siteSlug=[site not on business]` - Before/after in EN:

<img width="855" alt="Screenshot 2025-03-07 at 11 45 22 AM" src="https://github.com/user-attachments/assets/cabc4182-ab71-4a1b-83c2-db8e0440d63f" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/949

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/setup/import-focused?siteSlug=[site not on business]`
- Confirm the percentages render correctly across different locales - we don't have translations yet, so the remaining strings won't be translated - per media above

props to @agrullon95 & @renatho for helping with testing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
