### PR TITLE
Actions: add a new workflow to enforce use of Type labels on PRs

### DIFF
--- a/.github/workflows/enforce-pr-type.yml
+++ b/.github/workflows/enforce-pr-type.yml
@@ -1,0 +1,43 @@
+name: PR type
+
+on:
+  pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
+    types: [opened, reopened, synchronize, edited, labeled, closed]
+
+jobs:
+  check-pr-type:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Ensure that you have added a [Type] label to your PR"
+        uses: actions/github-script@v7
+        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+        with:
+          script: |
+            const {
+              repo: {
+                owner,
+                repo
+              },
+              issue: {
+                number
+              }
+            } = context;
+
+            core.debug( 'check-pr-type: Get the list of labels on the PR.' );
+            const prLabels = [];
+            for await ( const response of github.paginate.iterator( github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number: +number,
+              per_page: 100,
+            } ) ) {
+              for ( const label of response.data ) {
+                prLabels.push( label.name );
+              }
+            }
+
+            // If the PR has no [Type] label, set the status to failure.
+            if ( ! prLabels.some( label => label.match( /^\[Type\]/ ) ) ) {
+              core.setFailed( 'Your PR has no [Type] label.' );
+            }
+


### PR DESCRIPTION
## Proposed Changes

This new workflow will fail whenever a "[Type]" label is not found on the PR. We can make the workflow required for merges to trunk once this has been merged.

Of note, this requirement is also enforced in the Jetpack repo (although via the Repo Gardening action instead of a custom workflow):

- https://github.com/Automattic/jetpack/pull/40428
- https://github.com/Automattic/jetpack/pull/42260

## Why are these changes being made?

In our Quality reports, we want to be able to know what percentage of our PRs are bug fixes vs. enhancements vs. new features.
We can rely on the existing [Type] labels for that, but for reporting to be accurate we want each and every PR to use such a label from now on.

## Testing Instructions

This can only be tested in a fork, where you will have merged this branch into `trunk` and pushed `trunk` to your remote.

* Open a new PR against `trunk`.
* Do not add a [Type] label
    * Notice the workflow failing
* Add a label
    * Notice the workflow running again, and passing.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
