### PR TITLE
[Calendar]: remove events functionality from Calendar component

### DIFF
--- a/packages/components/src/calendar/README.md
+++ b/packages/components/src/calendar/README.md
@@ -66,24 +66,6 @@ A callback invoked when selecting the previous/next month in the date picker. Th
 -   Required: No
 -   Default: `undefined`
 
-### events
-
-List of events to show in the date picker. Each event will appear as a dot on the day of the event.
-
--   Type: `Array<{ date: Date }>`
--   Required: No
--   Default: `[]`
-
-```jsx
-// Example: Show events on specific dates
-<Calendar
-	events={ [
-		{ date: new Date(2023, 0, 1) }, // January 1, 2023
-		{ date: new Date(2023, 0, 15) }, // January 15, 2023
-	] }
-/>
-```
-
 ### startOfWeek
 
 The day that the week should start on. 0 for Sunday, 1 for Monday, etc.
@@ -96,7 +78,6 @@ The day that the week should start on. 0 for Sunday, 1 for Monday, etc.
 
 - Month navigation with previous/next buttons
 - Keyboard navigation support for accessibility
-- Event indicators for dates with events
 - Support for marking specific dates as invalid
 - Customizable week start day
 - Internationalization support via WordPress i18n

--- a/packages/components/src/calendar/calendar.tsx
+++ b/packages/components/src/calendar/calendar.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/components';
 import { dateI18n, getSettings } from '@wordpress/date';
 import { useState, useRef, useEffect } from '@wordpress/element';
-import { __, _n, sprintf, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import {
@@ -58,7 +58,6 @@ import './styles.scss';
 export function Calendar( {
 	currentDate,
 	onChange,
-	events = [],
 	isInvalidDate,
 	onMonthPreviewed,
 	startOfWeek: weekStartsOn = 0,
@@ -155,7 +154,6 @@ export function Calendar( {
 								isFocusAllowed={ isFocusWithinCalendar }
 								isToday={ isSameDay( day, new Date() ) }
 								isInvalid={ isInvalidDate ? isInvalidDate( day ) : false }
-								numEvents={ events.filter( ( event ) => isSameDay( event.date, day ) ).length }
 								onClick={ () => {
 									setSelected( [ day ] );
 									setFocusable( day );
@@ -226,7 +224,6 @@ type DayProps = {
 	isFocusable: boolean;
 	isFocusAllowed: boolean;
 	isToday: boolean;
-	numEvents: number;
 	isInvalid: boolean;
 	onClick: () => void;
 	onKeyDown: KeyboardEventHandler;
@@ -240,7 +237,6 @@ function Day( {
 	isFocusAllowed,
 	isToday,
 	isInvalid,
-	numEvents,
 	onClick,
 	onKeyDown,
 }: DayProps ) {
@@ -265,11 +261,10 @@ function Day( {
 				'is-selected': isSelected,
 				'is-today': isToday,
 				'is-invalid': isInvalid,
-				'has-events': numEvents > 0,
 			} ) }
 			disabled={ isInvalid }
 			tabIndex={ isFocusable ? 0 : -1 }
-			aria-label={ getDayLabel( day, isSelected, numEvents ) }
+			aria-label={ getDayLabel( day, isSelected ) }
 			onClick={ onClick }
 			onKeyDown={ onKeyDown }
 		>
@@ -278,34 +273,17 @@ function Day( {
 	);
 }
 
-function getDayLabel( date: Date, isSelected: boolean, numEvents: number ) {
+function getDayLabel( date: Date, isSelected: boolean ) {
 	const { formats } = getSettings();
 	const localizedDate = dateI18n( formats.date, date, -date.getTimezoneOffset() );
-	if ( isSelected && numEvents > 0 ) {
-		return sprintf(
-			// translators: 1: The calendar date. 2: Number of events on the calendar date.
-			_n(
-				'%1$s. Selected. There is %2$d event',
-				'%1$s. Selected. There are %2$d events',
-				numEvents
-			),
-			localizedDate,
-			numEvents
-		);
-	} else if ( isSelected ) {
+	if ( isSelected ) {
 		return sprintf(
 			// translators: %s: The calendar date.
 			__( '%1$s. Selected' ),
 			localizedDate
 		);
-	} else if ( numEvents > 0 ) {
-		return sprintf(
-			// translators: 1: The calendar date. 2: Number of events on the calendar date.
-			_n( '%1$s. There is %2$d event', '%1$s. There are %2$d events', numEvents ),
-			localizedDate,
-			numEvents
-		);
 	}
+
 	return localizedDate;
 }
 

--- a/packages/components/src/calendar/stories/date.stories.tsx
+++ b/packages/components/src/calendar/stories/date.stories.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import Calendar from '../calendar';
-import { daysFromNow, isWeekend } from './utils';
+import { isWeekend } from './utils';
 /**
  * Types
  */
@@ -47,17 +47,6 @@ const Template: StoryFn< typeof Calendar > = ( { currentDate, onChange, ...args 
 export const Default: StoryFn< typeof Calendar > = Template.bind( {} );
 Default.args = {
 	currentDate: new Date(),
-};
-
-export const WithEvents: StoryFn< typeof Calendar > = Template.bind( {} );
-WithEvents.args = {
-	currentDate: new Date(),
-	events: [
-		{ date: daysFromNow( 2 ) },
-		{ date: daysFromNow( 4 ) },
-		{ date: daysFromNow( 6 ) },
-		{ date: daysFromNow( 8 ) },
-	],
 };
 
 export const WithInvalidDates: StoryFn< typeof Calendar > = Template.bind( {} );

--- a/packages/components/src/calendar/styles.scss
+++ b/packages/components/src/calendar/styles.scss
@@ -119,20 +119,5 @@ $accent-inverted: $gray-900;
 		&.is-today:not(.is-selected) {
 			background: $gray-200;
 		}
-	
-		&.has-events {
-			&::before {
-				content: " ";
-				position: absolute;
-				left: 50%;
-				transform: translate(-50%, 9px);
-				border-radius: 50%;
-				border: 2px solid #3858e9;
-			}
-	
-			&.is-selected::before {
-				border-color: $white;
-			}
-		}
 	}	
 }

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -1,10 +1,3 @@
-export type CalendarEvent = {
-	/**
-	 * The date of the event.
-	 */
-	date: Date;
-};
-
 export type CalendarProps = {
 	/**
 	 * The current date and time at initialization. Optionally pass in a `null`
@@ -31,12 +24,6 @@ export type CalendarProps = {
 	 * argument.
 	 */
 	onMonthPreviewed?: ( date: string ) => void;
-
-	/**
-	 * List of events to show in the date picker. Each event will appear as a
-	 * dot on the day of the event.
-	 */
-	events?: CalendarEvent[];
 
 	/**
 	 * The day that the week should start on. 0 for Sunday, 1 for Monday, etc.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/100856

## Proposed Changes

This PR removes the events functionality from the Calendar component as part of our effort to simplify the component for the MVP version. The changes include:

* Removing the events prop and related code from the Calendar component
* Removing the CalendarEvent type definition
* Removing event indicators from the styles
* Updating the documentation to remove references to events
* Removing event-related stories from Storybook

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because events for Calendar are not required for the MVP.

## Testing Instructions

This is primarily a janitorial PR that streamlines the component by removing unused functionality. Testing is straightforward—simply verify that the Calendar component continues to function normally without the events feature by using Storybook to interact with it.

1. Run Site Admin Storybook app
```
yarn workspace @automattic/components run storybook
```
2. Go to the Calendar stories
3. Confirm the stories work as expected

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/8a15c47f-fc6c-4611-a5d5-0376a5241a5c" />

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
