### PR TITLE
Jetpack Cloud: Fix style of the site search box

### DIFF
--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -8,6 +8,16 @@
 .jetpack-cloud-sidebar {
 	.jetpack-cloud-sidebar__site-selector {
 		background-color: var(--color-sidebar-background);
+		.components-button {
+			border: none;
+		}
+		form {
+			width: 100%;
+			flex: 1;
+			input {
+				width: 100%;
+			}
+		}
 	}
 
 

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -13,7 +13,7 @@
 		}
 		.search-component.is-open.has-focus {
 			box-sizing: border-box;
-			border: 2px solid var(--color-primary);
+			border: 2px solid var(--studio-jetpack-green-50);
 			box-shadow: none; // Use border instead of box-shadow to avoid hiding the shadow at 100% width
 		}
 		.search-component__input{

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -11,12 +11,13 @@
 		.components-button {
 			border: none;
 		}
-		form {
+		.search-component.is-open.has-focus {
+			box-sizing: border-box;
+			border: 2px solid var(--color-primary);
+			box-shadow: none; // Use border instead of box-shadow to avoid hiding the shadow at 100% width
+		}
+		.search-component__input{
 			width: 100%;
-			flex: 1;
-			input {
-				width: 100%;
-			}
 		}
 	}
 

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -7,6 +7,7 @@
 
 .theme-jetpack-cloud,
 .color-scheme.is-jetpack-cloud {
+	--color-primary: var(--studio-jetpack-green-50);
 	// Masterbar
 	@media only screen and (min-width: 782px) {
 		--masterbar-height: 46px;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -7,7 +7,6 @@
 
 .theme-jetpack-cloud,
 .color-scheme.is-jetpack-cloud {
-	--color-primary: var(--studio-jetpack-green-50);
 	// Masterbar
 	@media only screen and (min-width: 782px) {
 		--masterbar-height: 46px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/100753

## Proposed Changes

* Removes the predefined border for the left icon button
* Adds the theme color to the border
* Adds width to the input search component to avoid overflow

|Before | After|
|-------|------|
|![CleanShot 2025-03-06 at 20 58 10](https://github.com/user-attachments/assets/a01b82b5-2374-43e5-b4f7-768e721302bb)|![CleanShot 2025-03-06 at 20 57 50](https://github.com/user-attachments/assets/728debc1-ae7c-485f-8e63-4cfbe2c82c31)|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix they style issues

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Jetpack Cloud using the [links below](https://github.com/Automattic/wp-calypso/pull/100966#issuecomment-2704811921) or apply this branch to your local environment and run `yarn start-jetpack-cloud`
* On the left hand side, click on `All sites`
* Check the style of the Search box is fine and there is no overflows
* Check for different sizes and in mobile view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
