### PR TITLE
Reader: Remove top margin on full posts missing a title

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -439,8 +439,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 // For posts without a title
 .reader-full-post__header.is-missing-title {
-	margin-top: 60px;
-
 	.reader-full-post__header-meta {
 		margin-bottom: 20px;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove margin on full post pages with a missing title.

Before | After
--|--
<img width="444" alt="Screenshot 2025-03-06 at 2 52 58 PM" src="https://github.com/user-attachments/assets/420a3376-4d4c-4179-ab6e-da609068ab03" /> | <img width="437" alt="Screenshot 2025-03-06 at 2 53 54 PM" src="https://github.com/user-attachments/assets/f8e1dd9c-50e8-4aa0-8088-8c88058cfca2" />


Before | After
--|--
<img width="1718" alt="Screenshot 2025-03-06 at 2 51 22 PM" src="https://github.com/user-attachments/assets/f5917a66-3f1d-4cfb-aac8-b8a1a0dca626" />  | <img width="1725" alt="Screenshot 2025-03-06 at 2 51 42 PM" src="https://github.com/user-attachments/assets/52784689-12d5-4331-81f8-8d958507e92a" />

Before | After
--|--
<img width="1719" alt="Screenshot 2025-03-06 at 2 50 40 PM" src="https://github.com/user-attachments/assets/1364b3ca-00a2-40d3-bcaa-3b0b26d29563" /> |  <img width="1720" alt="Screenshot 2025-03-06 at 2 51 00 PM" src="https://github.com/user-attachments/assets/7993b7ce-7b33-40c2-b8b1-f645b739ddce" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This extra top margin added to full post pages with a missing title seems to no longer be applicable. It's causing extra white space at the top of the page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* View a "Full post" page that's missing a title via the Recent stream and directly via the full post view.
* Make sure it looks ok on desktop and mobile.
* Make sure there are no regressions on posts that include a title.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
