### PR TITLE
Reader Editor: Focus Editor on FoldableCard open

### DIFF
--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -60,6 +60,14 @@
 	}
 
 	.verbum-editor-wrapper {
+		.editor__main iframe {
+			min-height: none;
+		}
+
+		.is-root-container.block-editor-block-list__layout {
+			padding: 10px 20px;
+		}
+
 		.editor__header {
 			border-color: var( --color-border-subtle );
 			border-style: solid;

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -60,14 +60,6 @@
 	}
 
 	.verbum-editor-wrapper {
-		.editor__main iframe {
-			min-height: none;
-		}
-
-		.is-root-container.block-editor-block-list__layout {
-			padding: 10px 20px;
-		}
-
 		.editor__header {
 			border-color: var( --color-border-subtle );
 			border-style: solid;

--- a/client/reader/components/quick-post/utils.tsx
+++ b/client/reader/components/quick-post/utils.tsx
@@ -25,6 +25,10 @@ export const isEditorIframeFocused = (): boolean => {
  * @returns {void}
  */
 export const focusEditor = (): void => {
+	if ( isEditorIframeFocused() ) {
+		return;
+	}
+
 	const attemptFocus = () => {
 		const editorIframe = getEditorIframe();
 		const editable = editorIframe?.contentDocument?.querySelector< HTMLElement >(

--- a/client/reader/components/quick-post/utils.tsx
+++ b/client/reader/components/quick-post/utils.tsx
@@ -1,12 +1,48 @@
 /**
+ * Returns the contenteditable element inside the editor iframe, or null if not found.
+ * @returns {HTMLElement | null}
+ */
+const getEditableElement = (): HTMLElement | null => {
+	const iframe = document.querySelector< HTMLIFrameElement >( 'iframe[name="editor-canvas"]' );
+	const doc = iframe?.contentDocument;
+	return doc?.querySelector< HTMLElement >( '[contenteditable="true"]' ) || null;
+};
+
+/**
  * Check if the Editor iframe is focused.
- * @returns {boolean} Whether the editor iframe has focus
+ * @returns {boolean} Whether the editor iframe has focus.
  */
 export const isEditorIframeFocused = (): boolean => {
-	const editorIframe = document.querySelector< HTMLIFrameElement >(
-		'iframe[name="editor-canvas"]'
-	);
-	const iframeFocused =
-		editorIframe?.contentDocument?.activeElement?.getAttribute( 'contenteditable' ) === 'true';
-	return !! iframeFocused;
+	const editable = getEditableElement();
+	return editable !== null && editable.ownerDocument?.activeElement === editable;
+};
+
+/**
+ * Focus the Editor iframe if possible.
+ * @returns {void}
+ */
+export const focusEditor = (): void => {
+	const attemptFocus = () => {
+		const editable = getEditableElement();
+		if ( ! editable ) {
+			return false;
+		}
+		editable.focus();
+		editable.dispatchEvent( new MouseEvent( 'click' ) );
+		return true;
+	};
+
+	// If immediate focus attempt fails, watch for DOM changes until
+	// the editor becomes available, then focus and auto-disconnect.
+	if ( ! attemptFocus() ) {
+		const observer = new MutationObserver( ( _, obs ) => {
+			if ( attemptFocus() ) {
+				obs.disconnect();
+			}
+		} );
+		observer.observe( document.body, { childList: true, subtree: true } );
+
+		// Failsafe disconnect and give up after 30 seconds.
+		setTimeout( () => observer.disconnect(), 30000 );
+	}
 };

--- a/client/reader/components/quick-post/utils.tsx
+++ b/client/reader/components/quick-post/utils.tsx
@@ -1,11 +1,12 @@
 /**
- * Returns the contenteditable element inside the editor iframe, or null if not found.
+ * Returns the editor iframe element, or null if not found.
  * @returns {HTMLElement | null}
  */
-const getEditableElement = (): HTMLElement | null => {
-	const iframe = document.querySelector< HTMLIFrameElement >( 'iframe[name="editor-canvas"]' );
-	const doc = iframe?.contentDocument;
-	return doc?.querySelector< HTMLElement >( '[contenteditable="true"]' ) || null;
+const getEditorIframe = (): HTMLIFrameElement | null => {
+	const editorIframe = document.querySelector< HTMLIFrameElement >(
+		'iframe[name="editor-canvas"]'
+	);
+	return editorIframe || null;
 };
 
 /**
@@ -13,8 +14,10 @@ const getEditableElement = (): HTMLElement | null => {
  * @returns {boolean} Whether the editor iframe has focus.
  */
 export const isEditorIframeFocused = (): boolean => {
-	const editable = getEditableElement();
-	return editable !== null && editable.ownerDocument?.activeElement === editable;
+	const editorIframe = getEditorIframe();
+	const iframeFocused =
+		editorIframe?.contentDocument?.activeElement?.getAttribute( 'contenteditable' ) === 'true';
+	return !! iframeFocused;
 };
 
 /**
@@ -23,12 +26,15 @@ export const isEditorIframeFocused = (): boolean => {
  */
 export const focusEditor = (): void => {
 	const attemptFocus = () => {
-		const editable = getEditableElement();
+		const editorIframe = getEditorIframe();
+		const editable = editorIframe?.contentDocument?.querySelector< HTMLElement >(
+			'[contenteditable="true"]'
+		);
+
 		if ( ! editable ) {
 			return false;
 		}
 		editable.focus();
-		editable.dispatchEvent( new MouseEvent( 'click' ) );
 		return true;
 	};
 

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -8,6 +8,7 @@ import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import withDimensions from 'calypso/lib/with-dimensions';
 import QuickPost from 'calypso/reader/components/quick-post';
+import { focusEditor } from 'calypso/reader/components/quick-post/utils';
 import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import ReaderStream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
@@ -81,6 +82,9 @@ function FollowingStream( { ...props } ) {
 							className="following-stream__quick-post-card"
 							smooth
 							contentExpandedStyle={ { maxHeight: '800px' } }
+							onOpen={ () => {
+								focusEditor();
+							} }
 						>
 							<QuickPost />
 						</FoldableCard>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/514

## Proposed Changes

* Introduce a `focusEditor` function.
* Call `focusEditor` when the `FoldableCard` component is opened.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We can assume the user's intent to write once they've clicked the "Write a new post" FoldableCard CTA. Giving the Editor focus makes the toolbar appear, and there is one less click to start writing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Calypso Live go to /reader
* Click "Write a new post"
* You should see the Editor toolbar, and it should be focused.
* Ensure you can type the letters `j` and `k` in the Editor.
* Click outside of the Editor so it loses focus and press the `j` and `k` keys. They should act as keyboard shortcuts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
