### PR TITLE
Performance: Guard incorrect url being saved

### DIFF
--- a/client/hosting/performance/hooks/usePerformanceReport.ts
+++ b/client/hosting/performance/hooks/usePerformanceReport.ts
@@ -2,13 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { useUrlBasicMetricsQuery } from 'calypso/data/site-profiler/use-url-basic-metrics-query';
 import { useUrlPerformanceInsightsQuery } from 'calypso/data/site-profiler/use-url-performance-insights';
 import { TabType } from 'calypso/performance-profiler/components/header';
-
-function isValidURL( url: string ) {
-	if ( 'canParse' in URL ) {
-		return URL.canParse( url );
-	}
-	return /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test( url );
-}
+import { isValidURL } from '../utils';
 
 export const usePerformanceReport = (
 	setIsSavingPerformanceReportUrl: ( isSaving: boolean ) => void,

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -7,6 +7,7 @@ import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/
 import { useDispatch, useSelector } from 'calypso/state';
 import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isValidURL } from '../utils';
 
 interface SitePage {
 	id: number;
@@ -147,6 +148,10 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 			}
 
 			const performanceReportUrl = toPerformanceReportUrl( performanceReport );
+
+			if ( ! isValidURL( performanceReportUrl ) ) {
+				return;
+			}
 
 			if ( pageId === HOME_PAGE_ID ) {
 				return await dispatch(

--- a/client/hosting/performance/utils.ts
+++ b/client/hosting/performance/utils.ts
@@ -1,0 +1,8 @@
+export function isValidURL( url: string ) {
+	if ( 'canParse' in URL ) {
+		return URL.canParse( url );
+	}
+	return /^(https?:\/\/)?((?!false\.)([a-z0-9-]+\.)+)[a-z]{2,}(:[0-9]{1,5})?(\/[^\s]*)?$/i.test(
+		url
+	);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97206 (it fixes it, but continue reading to see about keeping the issue open)

## Proposed Changes

In this [PR](https://github.com/Automattic/wp-calypso/pull/98295) we added a guard to prevent invalid urls from being saved when the performance test failed. However if the user clicks `Test again` and it also fail again then the invalid url is now saved as there was no guard around the `testAgain` function. 

* add the url guard inside the save function itself so that an invalid url will never be saved.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Janitorial work to help avoid support being contacted to clear the invalid url from the users sites option.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
_The invalid url is edge case and it's hard to consistently reproduce as it's hard to tell if the performance report will fail or now._

* Go to `/sites/performance` and ensure feature keeps working

We will merge this guard but keep the issue open for some time to see if there are any new reports.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
