### PR TITLE
Sites Dashboard: Conditionally fetch and render sites list based on screen width

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -44,7 +44,8 @@ export const useSiteExcerptsQuery = (
 	sitesFilterFn?: ( site: SiteExcerptData ) => boolean,
 	site_visibility: SiteVisibility = 'all',
 	additional_fields: string[] = [],
-	additional_options: string[] = []
+	additional_options: string[] = [],
+	enabled = true
 ) => {
 	const store = useStore();
 
@@ -71,6 +72,7 @@ export const useSiteExcerptsQuery = (
 			const reduxData = getSites( store.getState() ).filter( notNullish );
 			return reduxData.length ? { sites: reduxData } : undefined;
 		},
+		enabled,
 	} );
 };
 

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -165,7 +165,9 @@ const SitesDashboard = ( {
 		sitesFilterCallback,
 		'all',
 		[ 'is_a4a_dev_site', 'site_migration' ],
-		[ 'theme_slug' ]
+		[ 'theme_slug' ],
+		// Don't fetch sites on narrow screens since it's not visible.
+		isWide
 	);
 
 	useShowSiteCreationNotice( allSites, newSiteID );
@@ -377,8 +379,10 @@ const SitesDashboard = ( {
 		return null;
 	}
 
+	// Hide the listing on narrow screens since it's not visible.
+	const hideListing = ! isWide;
+
 	// todo: temporary mock data
-	const hideListing = false;
 	const isNarrowView = false;
 
 	const dashboardTitle = siteType === 'p2' ? translate( 'P2s' ) : translate( 'Sites' );

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -167,7 +167,7 @@ const SitesDashboard = ( {
 		[ 'is_a4a_dev_site', 'site_migration' ],
 		[ 'theme_slug' ],
 		// Don't fetch sites on narrow screens since it's not visible.
-		isWide
+		! selectedSite || isWide
 	);
 
 	useShowSiteCreationNotice( allSites, newSiteID );
@@ -380,7 +380,7 @@ const SitesDashboard = ( {
 	}
 
 	// Hide the listing on narrow screens since it's not visible.
-	const hideListing = ! isWide;
+	const hideListing = selectedSite && ! isWide;
 
 	// todo: temporary mock data
 	const isNarrowView = false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100914

## Proposed Changes

This PR ensures that the sites list is neither fetched nor rendered on mobile devices.

---
Ideally, we should enhance performance across all devices, but that falls outside the scope of this PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On mobile (or low-CPU devices), switching tabs (Overview, Logs, Settings, etc) on the Site Overview page is noticeably slow. This update aims to improve performance by preventing unnecessary site list fetching and rendering.

## Testing Instructions

- Open Calypso Live 
- Go to /sites
- Pick a site 
- In Chrome DevTools,
	- Simulate any small device
	- Go to the Performance tab and set CPU throttling to 20x slower from ⚙️
- Try switching tabs

In my testing/profiling, the tab-switching time (from Overview to Settings) improved from >13,000ms to approximately 4-5,000ms.

### Regression testing

- Verify site selection and tab switching on devices larger than 1280px.
- Verify site selection and tab switching on devices with screen widths between 960px and 1280px.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
