### PR TITLE
Revert "ESLint: disallow backticks unless there is interpolation (#100942)"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,7 +112,7 @@ module.exports = {
 					'no-unused-vars': 'off',
 					'no-use-before-define': 'off',
 					'no-useless-constructor': 'off',
-					quotes: [ 'error', 'single', 'avoid-escape' ],
+					quotes: 'off',
 					'require-await': 'off',
 					'return-await': 'off',
 					semi: 'off',


### PR DESCRIPTION
This reverts #100942.

Context: p1741318199376559-slack-C02DQP0FP

The reverted change would fail all builds that have > 16 changed files. It's because such build will run eslint on all files in the codebase, which already has violation to the added rule.