### PR TITLE
Stats: Improve styling of linechart empty state notice

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,7 +1,7 @@
 import { LineChart, ThemeProvider, jetpackTheme } from '@automattic/charts';
 import { DataPointDate } from '@automattic/charts/src/types';
 import clsx from 'clsx';
-import { numberFormat, useTranslate } from 'i18n-calypso';
+import { numberFormat, translate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import { useCallback, useMemo } from 'react';
 import ChartBarTooltip from 'calypso/components/chart/bar-tooltip';
@@ -17,7 +17,12 @@ function StatsLineChart( {
 	className,
 	onClick,
 	height = 400,
-	EmptyState = StatsEmptyState,
+	emptyState = (
+		<StatsEmptyState
+			headingText={ translate( 'No data available' ) }
+			infoText={ translate( 'Try selecting a different time frame.' ) }
+		/>
+	),
 	zeroBaseline = true,
 	fixedDomain = false,
 }: {
@@ -31,12 +36,11 @@ function StatsLineChart( {
 	className?: string;
 	height?: number;
 	moment: Moment;
-	EmptyState: typeof StatsEmptyState;
+	emptyState: JSX.Element;
 	zeroBaseline?: boolean;
 	fixedDomain?: boolean;
 	onClick?: ( item: { data: { period: string } } ) => void;
 } ) {
-	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
 	const formatTime = formatTimeTick
@@ -158,12 +162,7 @@ function StatsLineChart( {
 
 	return (
 		<div className={ clsx( 'stats-line-chart', className ) }>
-			{ isEmpty && (
-				<EmptyState
-					headingText={ translate( 'No data available' ) }
-					infoText={ translate( 'Try selecting a different time frame.' ) }
-				/>
-			) }
+			{ isEmpty && emptyState }
 			{ ! isEmpty && (
 				<ThemeProvider theme={ jetpackTheme }>
 					<LineChart

--- a/client/my-sites/stats/components/line-chart/styles.scss
+++ b/client/my-sites/stats/components/line-chart/styles.scss
@@ -95,3 +95,18 @@
 	}
 
 }
+
+.stats-line-chart {
+	position: relative;
+	box-sizing: border-box;
+
+	.stats__empty-state {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		max-width: 75%;
+		z-index: 1;
+		margin: 0;
+	}
+}

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -197,6 +197,15 @@ class StatModuleChartTabs extends Component {
 			gmtOffset
 		);
 
+		const emptyState = (
+			<StatsEmptyState
+				headingText={ selectedPeriod === 'hour' ? translate( 'No hourly data available' ) : null }
+				infoText={
+					selectedPeriod === 'hour' ? translate( 'Try selecting a different time frame.' ) : null
+				}
+			/>
+		);
+
 		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return (
 			<div className={ clsx( ...classes ) } ref={ chartContainerRef }>
@@ -213,37 +222,26 @@ class StatModuleChartTabs extends Component {
 					chartType={ chartType }
 					onChartTypeChange={ this.handleChartTypeChange }
 				/>
-
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
-
-				{ chartType === 'bar' || chartData.length === 0 ? (
-					<Chart barClick={ this.props.barClick } data={ chartData } minBarWidth={ 35 }>
-						<StatsEmptyState
-							headingText={
-								selectedPeriod === 'hour' ? translate( 'No hourly data available' ) : null
-							}
-							infoText={
-								selectedPeriod === 'hour'
-									? translate( 'Try selecting a different time frame.' )
-									: null
-							}
-						/>
+				{ chartType === 'bar' || lineChartData.length === 0 ? (
+					<Chart barClick={ this.props.barClick } data={ chartData } minBarWidth={ 20 }>
+						{ emptyState }
 					</Chart>
 				) : (
 					<AsyncLoad
 						require="calypso/my-sites/stats/components/line-chart"
 						className="stats-chart-tabs__line-chart"
 						chartData={ lineChartData }
-						height={ 200 }
+						height={ 224 }
 						moment={ moment }
 						onClick={ this.props.barClick }
 						formatTimeTick={ this.formatLineChartTimeTick }
 						placeholder={
 							<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 						}
+						emptyState={ emptyState }
 					/>
 				) }
-
 				<StatTabs
 					data={ this.props.counts }
 					previousData={ countsComp }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* This PR improves the styling and location of the empty state notice 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Navigate to `/stats/hour/{URL}?chartStart=2025-03-04&chartEnd=2025-03-04&tab=visitors`
* Check that the empty state notice is now centered and looks right. 

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/b45c5b3f-4d39-41f2-9eb5-f3fe5eafa800)  | ![image](https://github.com/user-attachments/assets/37b43727-a6ac-4b58-babf-d78fa996ae11)  |




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
