### PR TITLE
Alert user that domain is being setup in congratulation modal. 

### DIFF
--- a/client/my-sites/checkout/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/purchase-modal/content.tsx
@@ -215,7 +215,7 @@ function PayButton( {
 	// translators: %s is the total to be paid in localized currency
 	const payText =
 		totalCost === 0
-			? translate( 'Complete Checkout 3' )
+			? translate( 'Complete Checkout' )
 			: sprintf( translate( 'Pay %s' ), totalCostDisplay );
 	const processingText = translate( 'Processing…' );
 

--- a/client/my-sites/checkout/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/purchase-modal/content.tsx
@@ -215,7 +215,7 @@ function PayButton( {
 	// translators: %s is the total to be paid in localized currency
 	const payText =
 		totalCost === 0
-			? translate( 'Complete Checkout' )
+			? translate( 'Complete Checkout 3' )
 			: sprintf( translate( 'Pay %s' ), totalCostDisplay );
 	const processingText = translate( 'Processing…' );
 

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -21,9 +21,9 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 	const transformedDomains = allDomains.map( createSiteDomainObject );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardButtonEl = useRef( null );
-	const hasCustomDomain = Boolean(
-		transformedDomains.find( ( domain ) => ! domain.isWPCOMDomain )
-	);
+	const customDomains = transformedDomains.filter( ( domain ) => ! domain.isWPCOMDomain );
+	const hasCustomDomain = Boolean( customDomains.length );
+
 	const hasEnTranslation = useHasEnTranslation();
 
 	useEffect( () => {
@@ -109,6 +109,43 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 		);
 	}
 
+	function renderPrimaryDomainContent() {
+		return (
+			<p>{ translate( 'Now you can head over to your site and share it with the world.' ) }</p>
+		);
+	}
+
+	function renderCustomDomainContent() {
+		if ( customDomains.some( ( domain ) => domain.isPrimary ) ) {
+			return renderPrimaryDomainContent();
+		}
+
+		const domainSetupString =
+			customDomains.length > 1
+				? translate( "We're setting up your domains." )
+				: translate( "We're setting up your domain, {{strong}}%(domain)s{{/strong}} now.", {
+						args: {
+							domain: customDomains[ 0 ]?.domain,
+						},
+						components: {
+							strong: <strong />,
+						},
+				  } );
+
+		return (
+			<>
+				<p>
+					{ domainSetupString } { translate( 'This usually takes 24-48 hours to complete.' ) }
+				</p>
+				<p>
+					{ translate(
+						'While you wait, you can explore your site and start creating content using this temporary address.'
+					) }
+				</p>
+			</>
+		);
+	}
+
 	return (
 		<Modal onRequestClose={ () => setModalIsOpen( false ) } className="launched__modal">
 			<ConfettiAnimation />
@@ -117,9 +154,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 					<h1 className="launched__modal-heading">
 						{ translate( 'Congrats, your site is live!' ) }
 					</h1>
-					<p className="launched__modal-body">
-						{ translate( 'Now you can head over to your site and share it with the world.' ) }
-					</p>
+					{ hasCustomDomain ? renderCustomDomainContent() : renderPrimaryDomainContent() }
 				</div>
 				<div className="launched__modal-actions">
 					<div className="launched__modal-site">

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -123,7 +123,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 		const domainSetupString =
 			customDomains.length > 1
 				? translate( "We're setting up your domains." )
-				: translate( "We're setting up your domain, {{strong}}%(domain)s{{/strong}} now.", {
+				: translate( "We're setting up your domain, {{strong}}%(domain)s{{/strong}}, now.", {
 						args: {
 							domain: customDomains[ 0 ]?.domain,
 						},

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -17,7 +17,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 		padding-bottom: 40px;
 		display: flex;
 		flex-direction: column;
-		gap: 32px;
+		gap: 16px;
 
 		@media (min-width: $breakpoint-mobile) {
 			min-width: 640px;
@@ -45,12 +45,16 @@ $breakpoint-mobile: 782px; //Mobile size.
 		}
 	}
 
-	&-body,
+	&-text > p,
 	&-domain-text {
 		margin: 0;
 		color: var(--studio-gray-80);
 		font-size: 1rem;
 		line-height: 24px;
+	}
+
+	&-text > p {
+		margin-bottom: 16px;
 	}
 
 	&-domain-text {

--- a/client/my-sites/customer-home/components/test/celebrate-launch-modal.tsx
+++ b/client/my-sites/customer-home/components/test/celebrate-launch-modal.tsx
@@ -50,7 +50,7 @@ describe( 'CelebrateLaunchModal', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'renders the custom domain content if custom domain is not primary yet', () => {
+	it( 'renders the custom domain content if a custom domain is not yet as primary', () => {
 		const allDomains = [
 			{ wpcom_domain: false, primary_domain: false, domain: 'example.com' },
 			{ wpcom_domain: true, primary_domain: true, domain: 'subdomain.wordpress.com' },
@@ -66,7 +66,7 @@ describe( 'CelebrateLaunchModal', () => {
 		expect( screen.getByText( /We're setting up your domain/i ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the multiple custom domain content', () => {
+	it( 'renders the multiple custom domain content if a custom domain is not yet as primary', () => {
 		const allDomains = [
 			{ wpcom_domain: false, primary_domain: false, domain: 'example.com' },
 			{ wpcom_domain: false, primary_domain: false, domain: 'exampletwo.com' },

--- a/client/my-sites/customer-home/components/test/celebrate-launch-modal.tsx
+++ b/client/my-sites/customer-home/components/test/celebrate-launch-modal.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import CelebrateLaunchModal from '../celebrate-launch-modal';
+
+jest.mock( 'react-redux', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/i18n-utils', () => ( {
+	...jest.requireActual( 'i18n-utils' ),
+	useHasEnTranslation: jest.fn( () => ( key ) => key ),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	useRtl: jest.fn(),
+	localize: ( x ) => x,
+} ) );
+
+describe( 'CelebrateLaunchModal', () => {
+	const setModalIsOpen = jest.fn();
+	const dispatch = jest.fn();
+	useDispatch.mockReturnValue( dispatch );
+
+	const site = {
+		slug: 'example-site',
+		URL: 'https://example.com',
+		plan: { is_free: false, product_slug: 'pro-monthly' },
+	};
+
+	it( 'renders the primary domain content if a custom domain is set', () => {
+		const allDomains = [
+			{ wpcom_domain: false, primary_domain: true, domain: 'example.com' },
+			{ wpcom_domain: true, primary_domain: false, domain: 'subdomain.wordpress.com' },
+		];
+
+		render(
+			<CelebrateLaunchModal
+				setModalIsOpen={ setModalIsOpen }
+				site={ site }
+				allDomains={ allDomains }
+			/>
+		);
+		expect(
+			screen.getByText( 'Now you can head over to your site and share it with the world.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the custom domain content if custom domain is not primary yet', () => {
+		const allDomains = [
+			{ wpcom_domain: false, primary_domain: false, domain: 'example.com' },
+			{ wpcom_domain: true, primary_domain: true, domain: 'subdomain.wordpress.com' },
+		];
+
+		render(
+			<CelebrateLaunchModal
+				setModalIsOpen={ setModalIsOpen }
+				site={ site }
+				allDomains={ allDomains }
+			/>
+		);
+		expect( screen.getByText( /We're setting up your domain/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the multiple custom domain content', () => {
+		const allDomains = [
+			{ wpcom_domain: false, primary_domain: false, domain: 'example.com' },
+			{ wpcom_domain: false, primary_domain: false, domain: 'exampletwo.com' },
+			{ wpcom_domain: true, primary_domain: true, domain: 'subdomain.wordpress.com' },
+		];
+
+		render(
+			<CelebrateLaunchModal
+				setModalIsOpen={ setModalIsOpen }
+				site={ site }
+				allDomains={ allDomains }
+			/>
+		);
+		expect( screen.getByText( /We're setting up your domains/i ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes: #98128

Related to: #74744

## Proposed Changes

When a domain is purchased, it's placed onto a domain move queue, which processes it and makes it the primary domain. The queue size affects how quickly this happens. While most users don't immediately launch a site (and therefore do not see the celebration modal), improved onboarding is making it more likely that they do immediately launch. If the domain has not been processed yet, don't see any mention of their domain and are presented with the underlying subdomain URL. 

This PR alerts users that their custom domain is being _provisioned_ and they can use their temporary site address in the meantime to handle that use case.

| Context | Screenshot |
|--------|--------|
| No domain | <img width="715" alt="Screenshot 2025-03-07 at 1 43 17 PM" src="https://github.com/user-attachments/assets/d0d5b2a1-970c-49bd-b631-df4ecb5632ac" /> |
| Domain, site ready | <img width="706" alt="Screenshot 2025-03-07 at 1 31 28 PM" src="https://github.com/user-attachments/assets/2f8c048e-f92c-4c4a-8cba-4093e2c9b11b" /> |
| One domain, not ready | <img width="718" alt="Screenshot 2025-03-07 at 1 30 23 PM" src="https://github.com/user-attachments/assets/0f584b83-3655-4aa2-a7a4-63ab6e09c059" /> | 
| Multiple domains, not ready | <img width="725" alt="Screenshot 2025-03-07 at 1 30 58 PM" src="https://github.com/user-attachments/assets/4ed52469-c2b6-4e00-9a34-f8e37ff48ddd" /> |


## Why are these changes being made?

Mentioned in #98128, when a user buys a package with a custom domain, the confirmation modal doesn't mention the custom domain and displays the site slug (which is typically {subdomain}.wordpress.com) as the website. This isn't great onboarding because when you choose a domain, you expect that to be your site. The subdomain URL is not expected unless you have not selected a domain.


## Testing Instructions

**Test one domain**
1. Purchase a domain with a plan
2. From "My Home" click "Launch site" 
3. Expect to see relevant copy about your domain.

**Test multiple domains**
1. Purchase multiple domains with a plan
2. From "My Home" click "Launch site" 
3. Expect to see relevant copy that speaks about "domains".

**Test no domain**
1. Choose any plan without a domain
2. From "My Home" click "Launch site" 
3. Expect to see relevant copy not mentioning domains.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
