### PR TITLE
Backup: Improve status transition handling to prevent incorrect failure states

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -1,6 +1,5 @@
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -46,8 +45,6 @@ const DailyBackupStatus = ( {
 	deltas,
 	refetch,
 } ) => {
-	const translate = useTranslate();
-
 	// Ref for interval ID of Activity Log fetching.
 	const activityLogIntervalRef = useRef( null );
 
@@ -174,7 +171,7 @@ const DailyBackupStatus = ( {
 		}
 
 		// Fallback: If we don't have definitive status information yet,
-		// show a "Finalizing backup..." message and continue polling for updates.
+		// show "Backup in progress" and continue polling for updates.
 		// This prevents showing a false failure message during state transitions.
 		return (
 			<>
@@ -184,7 +181,6 @@ const DailyBackupStatus = ( {
 					percent={ 99 }
 					inProgressDate={ inProgressDate }
 					lastBackupDate={ lastBackupDate }
-					statusText={ translate( 'Finalizing backup' ) }
 				/>
 			</>
 		);

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -1,5 +1,6 @@
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -7,6 +8,7 @@ import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
 import BackupWarnings from 'calypso/components/jetpack/backup-warnings/backup-warnings';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { Interval, EVERY_SECOND } from 'calypso/lib/interval';
 import {
 	isSuccessfulDailyBackup,
@@ -19,7 +21,7 @@ import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import {
 	getInProgressBackupForSite,
 	getRewindStorageUsageLevel,
-	getFinishedBackupForSiteById,
+	getBackupStatusById,
 } from 'calypso/state/rewind/selectors';
 import { StorageUsageLevels } from 'calypso/state/rewind/storage/types';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -44,6 +46,8 @@ const DailyBackupStatus = ( {
 	deltas,
 	refetch,
 } ) => {
+	const translate = useTranslate();
+
 	// Ref for interval ID of Activity Log fetching.
 	const activityLogIntervalRef = useRef( null );
 
@@ -84,12 +88,13 @@ const DailyBackupStatus = ( {
 		}
 	}, [ backupCurrentlyInProgress ] );
 
-	// Using the id from backupPreviouslyInProgress get the backup if it finished successfully.
-	const backupFinishedSuccessfully = useSelector( ( state ) => {
-		if ( backupPreviouslyInProgress.current ) {
-			return getFinishedBackupForSiteById( state, siteId, backupPreviouslyInProgress.current.id );
+	// Get the backup status for the backup that was in progress
+	const activeBackupStatus = useSelector( ( state ) => {
+		if ( ! backupPreviouslyInProgress.current ) {
+			return null;
 		}
-		return null;
+
+		return getBackupStatusById( state, siteId, backupPreviouslyInProgress.current.id );
 	} );
 
 	// The backup "period" property is represented by
@@ -113,7 +118,7 @@ const DailyBackupStatus = ( {
 		}
 
 		// Manages the interval for fetching Activity Log based on backup completion.
-		if ( backupFinishedSuccessfully && refetch ) {
+		if ( activeBackupStatus && activeBackupStatus.isFinished && refetch ) {
 			activityLogIntervalRef.current = setInterval( refetch, 5000 ); // Let's refetch every 5 seconds.
 		} else {
 			clearActivityLogInterval();
@@ -121,7 +126,7 @@ const DailyBackupStatus = ( {
 
 		// Ensures interval cleanup on component unmount or before effect reruns.
 		return () => clearActivityLogInterval();
-	}, [ backup, backupFinishedSuccessfully, clearActivityLogInterval, lastBackup, refetch ] );
+	}, [ backup, activeBackupStatus, clearActivityLogInterval, lastBackup, refetch ] );
 
 	// If we're looking at today and a backup is in progress,
 	// start tracking and showing progress
@@ -139,25 +144,50 @@ const DailyBackupStatus = ( {
 		);
 	}
 
-	// If we were previously tracking an active backup that's now
-	// completed (or otherwise not running), show that it just
-	// finished.
-	//
-	// NOTE: In the future it would be nice to switch back to the "success"
-	// state and show up-to-date details immediately after a backup finishes,
-	// but unfortunately there's a lag between the time a backup completes
-	// and when it becomes visible through the Activity Log API.
+	// Handle the case where a backup was previously in progress but is no longer running.
+	// We check the backup's status and show appropriate UI for each state:
+	// - If we know it finished successfully, show the success UI
+	// - If we know it failed, show the failure UI
+	// - Otherwise, show a "Finalizing backup..." message to avoid false failure states
 	if ( selectedDate.isSame( today, 'day' ) && backupPreviouslyInProgress.current ) {
-		if ( backupFinishedSuccessfully ) {
-			return (
-				<BackupJustCompleted
-					justCompletedBackupDate={ inProgressDate }
-					lastBackupDate={ lastBackupDate }
-				/>
-			);
+		// If we have backup status information
+		if ( activeBackupStatus ) {
+			// If the backup finished successfully
+			if ( activeBackupStatus.isFinished ) {
+				return (
+					<BackupJustCompleted
+						justCompletedBackupDate={ inProgressDate }
+						lastBackupDate={ lastBackupDate }
+					/>
+				);
+			}
+
+			// If the backup explicitly failed
+			if ( activeBackupStatus.hasFailed ) {
+				return (
+					<BackupFailed
+						backup={ { activityTs: Date.now() } }
+						status={ activeBackupStatus.status }
+					/>
+				);
+			}
 		}
-		// There was a backup in progress, but it failed.
-		return <BackupFailed backup={ { activityTs: Date.now() } } />;
+
+		// Fallback: If we don't have definitive status information yet,
+		// show a "Finalizing backup..." message and continue polling for updates.
+		// This prevents showing a false failure message during state transitions.
+		return (
+			<>
+				<TrackComponentView eventName="calypso_jetpack_backup_in_progress_unknown_state" />
+				<Interval onTick={ refreshBackupProgress } period={ EVERY_SECOND } />
+				<BackupInProgress
+					percent={ 99 }
+					inProgressDate={ inProgressDate }
+					lastBackupDate={ lastBackupDate }
+					statusText={ translate( 'Finalizing backup' ) }
+				/>
+			</>
+		);
 	}
 
 	if ( backup ) {

--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -16,7 +16,7 @@ import BackupSupportLinks from './backup-support-links';
 import cloudErrorIcon from './icons/cloud-error.svg';
 import './style.scss';
 
-const BackupFailed = ( { backup } ) => {
+const BackupFailed = ( { backup, status = null } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
@@ -42,8 +42,12 @@ const BackupFailed = ( { backup } ) => {
 	}, [ dispatch, mayBeBlockedByHost ] );
 
 	useEffect( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_failed_view' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_failed_view', {
+				backup_status: status,
+			} )
+		);
+	}, [ dispatch, backup.status, status ] );
 
 	return (
 		<>

--- a/client/state/rewind/selectors/get-backup-status-by-id.ts
+++ b/client/state/rewind/selectors/get-backup-status-by-id.ts
@@ -1,0 +1,33 @@
+import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
+import { AppState } from 'calypso/types';
+
+/**
+ * Returns comprehensive status information for a backup with the specified ID.
+ * @param {Object} state - Global state tree
+ * @param {number} siteId - The site ID
+ * @param {number} id - The backup ID to check
+ * @returns {Object|null} Backup status object or null if backup not found
+ */
+const getBackupStatusById = ( state: AppState, siteId: number, id: number ): object | null => {
+	const allBackups = getRewindBackups( state, siteId );
+	const backup = allBackups?.find( ( b ) => b.id === id );
+
+	return {
+		// Is this backup currently in progress?
+		isInProgress: backup?.status === 'started',
+
+		// Has this backup finished successfully?
+		isFinished: backup?.status === 'finished',
+
+		// Has this backup failed? (any status other than started/finished)
+		hasFailed: backup && backup.status !== 'started' && backup.status !== 'finished',
+
+		// The current status of the backup
+		status: backup?.status,
+
+		// The full backup object
+		backup: backup,
+	};
+};
+
+export default getBackupStatusById;

--- a/client/state/rewind/selectors/get-backup-status-by-id.ts
+++ b/client/state/rewind/selectors/get-backup-status-by-id.ts
@@ -12,6 +12,10 @@ const getBackupStatusById = ( state: AppState, siteId: number, id: number ): obj
 	const allBackups = getRewindBackups( state, siteId );
 	const backup = allBackups?.find( ( b ) => b.id === id );
 
+	if ( ! backup ) {
+		return null;
+	}
+
 	return {
 		// Is this backup currently in progress?
 		isInProgress: backup?.status === 'started',
@@ -20,7 +24,7 @@ const getBackupStatusById = ( state: AppState, siteId: number, id: number ): obj
 		isFinished: backup?.status === 'finished',
 
 		// Has this backup failed? (any status other than started/finished)
-		hasFailed: backup && backup.status !== 'started' && backup.status !== 'finished',
+		hasFailed: backup?.status !== 'started' && backup?.status !== 'finished',
 
 		// The current status of the backup
 		status: backup?.status,

--- a/client/state/rewind/selectors/get-finished-backup-for-site-by-id.ts
+++ b/client/state/rewind/selectors/get-finished-backup-for-site-by-id.ts
@@ -1,9 +1,0 @@
-import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
-import { AppState } from 'calypso/types';
-
-const getFinishedBackupForSiteById = ( state: AppState, siteId: number, id: number ) => {
-	const backups = getRewindBackups( state, siteId );
-	return backups?.find?.( ( b ) => b.id === id && 'finished' === b.status );
-};
-
-export default getFinishedBackupForSiteById;

--- a/client/state/rewind/selectors/index.ts
+++ b/client/state/rewind/selectors/index.ts
@@ -1,5 +1,4 @@
 export { default as getBackupStatusById } from './get-backup-status-by-id';
-export { default as getFinishedBackupForSiteById } from './get-finished-backup-for-site-by-id';
 export { default as getInProgressBackupForSite } from './get-in-progress-backup-for-site';
 export { default as getRewindBytesAvailable } from './get-rewind-bytes-available';
 export { default as getRewindBytesUsed } from './get-rewind-bytes-used';

--- a/client/state/rewind/selectors/index.ts
+++ b/client/state/rewind/selectors/index.ts
@@ -1,3 +1,4 @@
+export { default as getBackupStatusById } from './get-backup-status-by-id';
 export { default as getFinishedBackupForSiteById } from './get-finished-backup-for-site-by-id';
 export { default as getInProgressBackupForSite } from './get-in-progress-backup-for-site';
 export { default as getRewindBytesAvailable } from './get-rewind-bytes-available';

--- a/client/state/rewind/selectors/test/get-backup-status-by-id.ts
+++ b/client/state/rewind/selectors/test/get-backup-status-by-id.ts
@@ -1,0 +1,129 @@
+import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
+import getBackupStatusById from '../get-backup-status-by-id';
+
+jest.mock( 'calypso/state/selectors/get-rewind-backups' );
+
+describe( 'getBackupStatusById', () => {
+	const TEST_SITE_ID = 123;
+	const TEST_BACKUP_ID = 456;
+	const mockState = {};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should return null when no backups are found', () => {
+		( getRewindBackups as jest.Mock ).mockReturnValue( null );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( null );
+	} );
+
+	test( 'should return null when the backups array is empty', () => {
+		( getRewindBackups as jest.Mock ).mockReturnValue( [] );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( null );
+	} );
+
+	test( 'should return null when the requested backup ID does not exist', () => {
+		const mockBackups = [
+			{ id: 123, status: 'finished' },
+			{ id: 789, status: 'failed' },
+		];
+		( getRewindBackups as jest.Mock ).mockReturnValue( mockBackups );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( null );
+	} );
+
+	test( 'should correctly identify a backup in progress with status "started"', () => {
+		const mockBackup = { id: TEST_BACKUP_ID, status: 'started' };
+		( getRewindBackups as jest.Mock ).mockReturnValue( [ mockBackup ] );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( {
+			isInProgress: true,
+			isFinished: false,
+			hasFailed: false,
+			status: 'started',
+			backup: mockBackup,
+		} );
+	} );
+
+	test( 'should correctly identify a successfully completed backup with status "finished"', () => {
+		const mockBackup = { id: TEST_BACKUP_ID, status: 'finished' };
+		( getRewindBackups as jest.Mock ).mockReturnValue( [ mockBackup ] );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( {
+			isInProgress: false,
+			isFinished: true,
+			hasFailed: false,
+			status: 'finished',
+			backup: mockBackup,
+		} );
+	} );
+
+	test( 'should correctly identify a failed backup with status "error"', () => {
+		const mockBackup = { id: TEST_BACKUP_ID, status: 'error' };
+		( getRewindBackups as jest.Mock ).mockReturnValue( [ mockBackup ] );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( {
+			isInProgress: false,
+			isFinished: false,
+			hasFailed: true,
+			status: 'error',
+			backup: mockBackup,
+		} );
+	} );
+
+	test( 'should correctly identify a failed backup with status "not-accessible"', () => {
+		const mockBackup = { id: TEST_BACKUP_ID, status: 'not-accessible' };
+		( getRewindBackups as jest.Mock ).mockReturnValue( [ mockBackup ] );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( {
+			isInProgress: false,
+			isFinished: false,
+			hasFailed: true,
+			status: 'not-accessible',
+			backup: mockBackup,
+		} );
+	} );
+
+	test( 'should find the correct backup when multiple backups exist', () => {
+		const mockBackups = [
+			{ id: 123, status: 'finished' },
+			{ id: TEST_BACKUP_ID, status: 'started' },
+			{ id: 789, status: 'failed' },
+		];
+		( getRewindBackups as jest.Mock ).mockReturnValue( mockBackups );
+
+		const result = getBackupStatusById( mockState, TEST_SITE_ID, TEST_BACKUP_ID );
+
+		expect( getRewindBackups ).toHaveBeenCalledWith( mockState, TEST_SITE_ID );
+		expect( result ).toEqual( {
+			isInProgress: true,
+			isFinished: false,
+			hasFailed: false,
+			status: 'started',
+			backup: mockBackups[ 1 ],
+		} );
+	} );
+} );

--- a/client/state/rewind/test/selectors.js
+++ b/client/state/rewind/test/selectors.js
@@ -1,4 +1,3 @@
-import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
 import { BACKUP_RETENTION_UPDATE_REQUEST } from '../retention/constants';
 import {
 	getRewindStorageUsageLevel,
@@ -13,7 +12,6 @@ import {
 	getBackupStagingSiteInfo,
 	getBackupStagingSites,
 	getBackupStagingUpdateRequestStatus,
-	getFinishedBackupForSiteById,
 } from '../selectors';
 import { BACKUP_STAGING_UPDATE_REQUEST } from '../staging/constants';
 import { stagingSites } from '../staging/test/fixtures';
@@ -385,53 +383,5 @@ describe( 'Backup staging site info', () => {
 				staging: true,
 			} );
 		} );
-	} );
-} );
-
-jest.mock( 'calypso/state/selectors/get-rewind-backups' );
-
-describe( 'getFinishedBackupForSiteById()', () => {
-	const TEST_SITE_ID = 123;
-	const TEST_BACKUP_ID_1 = 1;
-	const TEST_BACKUP_ID_2 = 2;
-	const state = {};
-
-	beforeEach( () => {
-		getRewindBackups.mockReset();
-	} );
-
-	test( 'Should receive the finished backup.', () => {
-		getRewindBackups.mockReturnValue( [
-			{ id: TEST_BACKUP_ID_1, status: 'finished' },
-			{ id: TEST_BACKUP_ID_2, status: 'started' },
-		] );
-
-		const finishedBackup = getFinishedBackupForSiteById( state, TEST_SITE_ID, TEST_BACKUP_ID_1 );
-
-		expect( finishedBackup.id ).toEqual( TEST_BACKUP_ID_1 );
-	} );
-
-	test( 'Shouldnt receive backup since it is in progress.', () => {
-		getRewindBackups.mockReturnValue( [ { id: TEST_BACKUP_ID_1, status: 'started' } ] );
-
-		const finishedBackup = getFinishedBackupForSiteById( state, TEST_SITE_ID, TEST_BACKUP_ID_1 );
-
-		expect( finishedBackup ).toBeNull;
-	} );
-
-	test( 'Shouldnt receive backup since it failed.', () => {
-		getRewindBackups.mockReturnValue( [ { id: TEST_BACKUP_ID_1, status: 'not-accessible' } ] );
-
-		const finishedBackup = getFinishedBackupForSiteById( state, TEST_SITE_ID, TEST_BACKUP_ID_1 );
-
-		expect( finishedBackup ).toBeNull;
-	} );
-
-	test( 'Shouldnt receive backup if id doesnt match.', () => {
-		getRewindBackups.mockReturnValue( [ { id: TEST_BACKUP_ID_2, status: 'finished' } ] );
-
-		const finishedBackup = getFinishedBackupForSiteById( state, TEST_SITE_ID, TEST_BACKUP_ID_1 );
-
-		expect( finishedBackup ).toBeNull;
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/40984

## Proposed Changes

- Simplified checking of active backup status using a single selector (`getBackupStatusById`)
- Improved handling of backup status transitions to prevent false failure messages
- Added tracking to understand how common these unknown states are and if they are still occurring
  - `calypso_jetpack_backup_in_progress_unknown_state`
  - new `backup_status` event prop in `calypso_jetpack_backup_failed_view`
- Remove `getFinishedBackupForSiteById` selector and its tests

## Why are these changes being made?
We've identified an issue where users occasionally see a "Backup Failed" message immediately after a backup completes, even though the backup was actually successful. After refreshing the page, the correct "Backup Successful" message appears. The user needs to refresh the page because we stop fetching the rewind/backups API to update the status once the Backup Failed view is displayed.

This issue might be caused by a race condition in how the backup state is updated. When a backup completes, the `backupCurrentlyInProgress` selector becomes `null` (indicating no backup is in progress), but there's a brief delay before `backupFinishedSuccessfully` is updated to reflect the successful completion. During this brief window, the component incorrectly assumes the backup failed.

The changes in this PR fix this race condition by:
- Using a more comprehensive approach to check backup status
- Adding a "Finalizing backup..." state during transitions
- Continuing to poll for updates during the transition period
- Only showing the failure message when we're certain the backup actually failed

These changes ensure users see accurate status information even during state transitions, providing a better user experience and preventing confusion from false failure messages.

## Testing Instructions
> [!NOTE]
> Given that the original issue is hard to reproduce, you can simply navigate through the backup page and ensure you can see your backups in progress, when they fail, when they succeed, etc.

* Spin up a Calypso and Jetpack Cloud Live branch
* Navigate to the Jetpack Backup page
* Try initiating a new backup by either:
  * Clicking the Back up now button
  * Queuing a new backup from one of our internal tools
  * Spinning up a new site and triggering the initial backup
* Ensure you see the Backup in Progress view
* Ensure it completes (or fails) properly (you can force it to fail by shutting down your web server)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
