### PR TITLE
Social | Update scheduled-actions endpoint usage

### DIFF
--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -24,7 +24,7 @@ export function fetchPostShareActionsScheduled( siteId, postId ) {
 			postId,
 		} );
 
-		const getScheduledPath = `/sites/${ siteId }/publicize/scheduled-actions/posts/${ postId }`;
+		const getScheduledPath = `/sites/${ siteId }/publicize/scheduled-actions?post_id=${ postId }`;
 		return wpcom.req.get(
 			{
 				path: getScheduledPath,
@@ -100,7 +100,7 @@ export function deletePostShareAction( siteId, postId, actionId ) {
 			actionId,
 		} );
 
-		const deleteActionPath = `/sites/${ siteId }/publicize/scheduled-actions/posts/${ postId }/${ actionId }`;
+		const deleteActionPath = `/sites/${ siteId }/publicize/scheduled-actions/${ actionId }`;
 		return wpcom.req.get(
 			{
 				path: deleteActionPath,
@@ -136,7 +136,7 @@ export function schedulePostShareAction( siteId, postId, message, share_date, co
 		return Promise.all(
 			connections.map( ( connection_id ) =>
 				wpcom.req.post( {
-					path: `/sites/${ siteId }/publicize/scheduled-actions/posts/${ postId }/`,
+					path: `/sites/${ siteId }/publicize/scheduled-actions?post_id=${ postId }`,
 					body: { message, share_date, connection_id },
 					apiNamespace: 'wpcom/v2',
 				} )


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/42283, we are updating the scheduled-actions enpoint to pass `post_id` as a query param instead of making it a route param to ease things when using it with `getEntityRecords` selectors.

## Proposed Changes

* Update the usage of scheduled-actions endpoint

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Goto `https://wordpress.com/posts/:site`
* Schedule a few shares for a post or two
* Apply https://github.com/Automattic/jetpack/pull/42283 to your sandbox
* Point the public API to your sandbox
* Goto `https://wordpress.com/posts/:site` again for backwards compatibility check for the endpoint
* Confirm that the shares load fine
* Try to create and delete shares
* Confirm that they work fine
* Checkout this branch or use the Calypso Live links below
* Goto `/posts/:site`
* Check the scheduled shares for the above post(s)
* Confirm that the shares and count is correct as before
* Try deleting a scheduled share
* Confirm that it works fine
* Schedule a few shares
* Confirm that it works fine
* Stop sandboxing the public API
* Goto `https://wordpress.com/posts/:site`
* Confirm that the shares scheduled above are visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
