### PR TITLE
TeamCity CodeStyle: lint the modified files in batches

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -609,7 +609,7 @@ object CheckCodeStyleBranch : BuildType({
 					#
 					# where -n3 is the batch size and -P5 the number of parallel runs. However, we
 					# want to know which batch we are currently in -- a concept that I don't think
-					# xargs has.
+					# xargs has -- so that each ESLint run can write to a separate file.
 					#
 					# So we resort to a little bit of AWK magic to reshape our list of files into
 					# rows of BATCH_SIZE. Then, we use `nl` to prepend each row with an index.
@@ -638,6 +638,16 @@ object CheckCodeStyleBranch : BuildType({
 								--format checkstyle \
 								--output-file "${'$'}RESULTS_DIR/batch_${'$'}{BATCH_NUM}.xml" \
 								${'$'}BATCH_FILES
+
+							# xargs will return 123 if any run returns a non-zero value. Ensure we
+							# only catch relevant issues. ESLint's exit codes seem to be:
+							# - 0 for no errors
+							# - 1 for linting errors (let's ignore)
+							# - 2 for other errors (let's propagate)
+							status=${'$'}?
+							if [ ${'$'}status -gt 1 ]; then
+								exit ${'$'}status
+							fi
 						' yarn-batch # Arbitrary name to be used as each batch's progname
 				fi
 			"""

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -570,66 +570,65 @@ object CheckCodeStyleBranch : BuildType({
 		bashNodeScript {
 			name = "Run eslint"
 			scriptContent = """
-				set -x
 				export NODE_ENV="test"
 
-				# Find files to lint
-				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -cE '(\.[jt]sx?|\.json|\.md)${'$'}' || true)
-				FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.json|\.md)${'$'}' || echo "")
+				# Find lintable files touched in this branch, except those deleted
+				function _find_files_to_lint() {
+					git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD \
+						| grep -E '(\.[jt]sx?|\.json|\.md)$$'
+				}
 
-				# Create temporary output directory
-				mkdir -p "./checkstyle_results/eslint"
+				# Use with `grep -c .` to prevent miscounts due to newlines
+				FILE_COUNT=$$(_find_files_to_lint | grep -c .)
 
-				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" == "0" ]; then
+				# Create temporary output directory. Export the variable so that it is
+				# available in the batch runs.
+				export RESULTS_DIR=checkstyle_results/eslint
+				mkdir -p "$$RESULTS_DIR"
+
+				if [ "%run_full_eslint%" = true ] || [ "$$FILE_COUNT" -eq 0 ]; then
 					echo "Linting all files"
-					yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" .
+					yarn run eslint --format checkstyle --output-file "$$RESULTS_DIR/results.xml" .
 				else
-					# When linting the files we have to cover for two issues:
+					echo "Linting affected files"
+
+					# In an ideal scenario, we'd simply pipe the list of target files to `xargs`:
 					#
-					# - ENAMETOOLONG: we cannot pass to eslint too many files as input because we can exceed the maximum command line length.
-					# - OOM (Out Of Memory): we cannot spawn too many processes in parallel.
+					# _find_files | xargs -n3 -P5 yarn run eslint...
 					#
-					# To prevent running into any of these issues, we process the files in batches.
+					# where -n3 is the batch size and -P5 the number of parallel runs. However, we
+					# want to know which batch we are currently in -- a concept that I don't think
+					# xargs has.
 					#
-					# - BATCH_SIZE is the number of files each eslint process will take.
-					# - MAX_PARALLEL_BATCHES is the maximum number of eslint processes to execute in parallel.
+					# So we resort to a little bit of shell magic:
+					# - `rs` reshapes our list of files into rows of "$$BATCH_SIZE"
+					# - `nl` prepends each row with an index (1-based)
+					#
+					# The output of the `rs | nl` chain now looks like:
+					#
+					#     1 file1 file2 file3
+					#     2 file4 file5 file6
+					#     3 file7
+					#
+					# - `xargs` must now use the `-L1` option to process one line at a time
+					# - instead of calling `yarn` directly, we use `bash` to split the arguments
+					#
+					# CAVEAT: ASSUMES NO SPACES IN FILENAMES.
 
-					BATCH_SIZE=15
-					MAX_PARALLEL_BATCHES=15
+					BATCH_SIZE=15 # Number of files handled by each ESLint process
+					MAX_PARALLEL_BATCHES=15 # Number of concurrent ESLint processes
 
-					# This rounds up the division (total files / batch size) to the next integer.
-					TOTAL_BATCHES=$(( (${'$'}TOTAL_FILES_TO_LINT + ${'$'}BATCH_SIZE - 1) / ${'$'}BATCH_SIZE ))
-					echo "Linting ${'$'}TOTAL_FILES_TO_LINT files in ${'$'}TOTAL_BATCHES batches"
-
-					# Create a temporary file with all files to process.
-					TMP_FILE_LIST=$(mktemp)
-					echo "${'$'}FILES_TO_LINT" > "${'$'}TMP_FILE_LIST"
-
-					# Process them in batches
-					for BATCH_NUM in $(seq 1 ${'$'}TOTAL_BATCHES); do
-						BATCH_START=$(( (${'$'}BATCH_NUM - 1) * ${'$'}BATCH_SIZE + 1 ))
-						BATCH_END=$(( ${'$'}BATCH_NUM * ${'$'}BATCH_SIZE ))
-
-						# Extract batch of filenames
-						BATCH_FILES=$(sed -n "${'$'}{BATCH_START},${'$'}{BATCH_END}p" "${'$'}TMP_FILE_LIST" | tr '\n' ' ')
-
-						if [ -n "${'$'}BATCH_FILES" ]; then
-							echo "Linting batch ${'$'}BATCH_NUM of ${'$'}TOTAL_BATCHES"
-							yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/batch_${'$'}{BATCH_NUM}.xml" ${'$'}BATCH_FILES &
-
-							# Limit concurrent processes to avoid OutOfMemory errors
-							if [ $(( ${'$'}BATCH_NUM % ${'$'}MAX_PARALLEL_BATCHES )) -eq 0 ]; then
-								echo "Waiting for batch ${'$'}BATCH_NUM to complete"
-								wait
-							fi
-						fi
-					done
-
-					# Wait for any remaining processes
-					wait
-
-					# Clean up
-					rm "${'$'}TMP_FILE_LIST"
+					_find_files_to_lint \
+						| rs 0 "$$BATCH_SIZE" \
+						| nl \
+						| xargs -L1 -P"$$MAX_PARALLEL_BATCHES" bash -c '
+							BATCH_NUM="$$1"; shift
+							BATCH_FILES="$$@"
+							yarn run eslint \
+								--format checkstyle \
+								--output-file "$$RESULTS_DIR/batch_$${BATCH_NUM}.xml" \
+								$$BATCH_FILES
+						' yarn-batch # Arbitrary name to be used as each batch's progname
 				fi
 			"""
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -603,11 +603,10 @@ object CheckCodeStyleBranch : BuildType({
 					# want to know which batch we are currently in -- a concept that I don't think
 					# xargs has.
 					#
-					# So we resort to a little bit of shell magic:
-					# - `rs` reshapes our list of files into rows of "${'$'}BATCH_SIZE"
-					# - `nl` prepends each row with an index (1-based)
+					# So we resort to a little bit of AWK magic to reshape our list of files into
+					# rows of BATCH_SIZE. Then, we use `nl` to prepend each row with an index.
 					#
-					# The output of the `rs | nl` chain now looks like:
+					# The output of the `awk | nl` chain now looks like:
 					#
 					#     1 file1 file2 file3
 					#     2 file4 file5 file6
@@ -622,7 +621,7 @@ object CheckCodeStyleBranch : BuildType({
 					MAX_PARALLEL_BATCHES=15 # Number of concurrent ESLint processes
 
 					_find_files_to_lint \
-						| rs 0 "${'$'}BATCH_SIZE" \
+						| awk -v"n=${'$'}BATCH_SIZE" '{printf "%s%s", $0, (NR%n?"\t":"\n")}' \
 						| nl \
 						| xargs -L1 -P"${'$'}MAX_PARALLEL_BATCHES" bash -c '
 							BATCH_NUM="${'$'}1"; shift

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -577,11 +577,12 @@ object CheckCodeStyleBranch : BuildType({
 				# Find lintable files touched in this branch, except those deleted
 				function _find_files_to_lint() {
 					git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD \
-						| grep -E '(\.[jt]sx?|\.json|\.md)${'$'}'
+						| grep -E '(\.[jt]sx?|\.json|\.md)${'$'}' \
+						|| true
 				}
 
 				# Use with `grep -c .` to prevent miscounts due to newlines
-				FILE_COUNT=${'$'}(_find_files_to_lint | grep -c .)
+				FILE_COUNT=${'$'}(_find_files_to_lint | grep -c . || true)
 
 				# Create temporary output directory. Export the variable so that it is
 				# available in the batch runs.

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -575,19 +575,61 @@ object CheckCodeStyleBranch : BuildType({
 
 				# Find files to lint
 				TOTAL_FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -cE '(\.[jt]sx?|\.json|\.md)${'$'}' || true)
+				FILES_TO_LINT=$(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.json|\.md)${'$'}' || echo "")
 
-				# Avoid running more than 16 parallel eslint tasks as it could OOM
-				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" -gt 16 ] || [ "${'$'}TOTAL_FILES_TO_LINT" == "0" ]; then
+				# Create temporary output directory
+				mkdir -p "./checkstyle_results/eslint"
+
+				if [ "%run_full_eslint%" = "true" ] || [ "${'$'}TOTAL_FILES_TO_LINT" == "0" ]; then
 					echo "Linting all files"
 					yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/results.xml" .
 				else
-					# To avoid `ENAMETOOLONG` errors linting files, we have to lint them one by one,
-					# instead of passing the full list of files to eslint directly.
-					for file in ${'$'}(git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.json|\.md)${'$'}' || true); do
-						( echo "Linting ${'$'}file"
-						yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/${'$'}{file//\//_}.xml" "${'$'}file" ) &
+					# When linting the files we have to cover for two issues:
+					#
+					# - ENAMETOOLONG: we cannot pass to eslint too many files as input because we can exceed the maximum command line length.
+					# - OOM (Out Of Memory): we cannot spawn too many processes in parallel.
+					#
+					# To prevent running into any of these issues, we process the files in batches.
+					#
+					# - BATCH_SIZE is the number of files each eslint process will take.
+					# - MAX_PARALLEL_BATCHES is the maximum number of eslint processes to execute in parallel.
+
+					BATCH_SIZE=15
+					MAX_PARALLEL_BATCHES=15
+
+					# This rounds up the division (total files / batch size) to the next integer.
+					TOTAL_BATCHES=$(( (${'$'}TOTAL_FILES_TO_LINT + ${'$'}BATCH_SIZE - 1) / ${'$'}BATCH_SIZE ))
+					echo "Linting ${'$'}TOTAL_FILES_TO_LINT files in ${'$'}TOTAL_BATCHES batches"
+
+					# Create a temporary file with all files to process.
+					TMP_FILE_LIST=$(mktemp)
+					echo "${'$'}FILES_TO_LINT" > "${'$'}TMP_FILE_LIST"
+
+					# Process them in batches
+					for BATCH_NUM in $(seq 1 ${'$'}TOTAL_BATCHES); do
+						BATCH_START=$(( (${'$'}BATCH_NUM - 1) * ${'$'}BATCH_SIZE + 1 ))
+						BATCH_END=$(( ${'$'}BATCH_NUM * ${'$'}BATCH_SIZE ))
+
+						# Extract batch of filenames
+						BATCH_FILES=$(sed -n "${'$'}{BATCH_START},${'$'}{BATCH_END}p" "${'$'}TMP_FILE_LIST" | tr '\n' ' ')
+
+						if [ -n "${'$'}BATCH_FILES" ]; then
+							echo "Linting batch ${'$'}BATCH_NUM of ${'$'}TOTAL_BATCHES"
+							yarn run eslint --format checkstyle --output-file "./checkstyle_results/eslint/batch_${'$'}{BATCH_NUM}.xml" ${'$'}BATCH_FILES &
+
+							# Limit concurrent processes to avoid OutOfMemory errors
+							if [ $(( ${'$'}BATCH_NUM % ${'$'}MAX_PARALLEL_BATCHES )) -eq 0 ]; then
+								echo "Waiting for batch ${'$'}BATCH_NUM to complete"
+								wait
+							fi
+						fi
 					done
+
+					# Wait for any remaining processes
 					wait
+
+					# Clean up
+					rm "${'$'}TMP_FILE_LIST"
 				fi
 			"""
 		}
@@ -1058,4 +1100,3 @@ object QuarantinedE2ETests: E2EBuildType(
 	buildTriggers = {
 	}
 )
-

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -595,6 +595,14 @@ object CheckCodeStyleBranch : BuildType({
 				else
 					echo "Linting affected files"
 
+					# When linting a large set of files we have to guard against two errors:
+					#
+					# - ENAMETOOLONG: we cannot pass ESLint too many files as arguments, lest we exceed
+					# the maximum command line length.
+					# - OOM (Out Of Memory): we cannot spawn too many processes in parallel.
+					#
+					# Thus, we'll process the files in batches.
+					#
 					# In an ideal scenario, we'd simply pipe the list of target files to `xargs`:
 					#
 					# _find_files | xargs -n3 -P5 yarn run eslint...

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -575,20 +575,20 @@ object CheckCodeStyleBranch : BuildType({
 				# Find lintable files touched in this branch, except those deleted
 				function _find_files_to_lint() {
 					git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD \
-						| grep -E '(\.[jt]sx?|\.json|\.md)$$'
+						| grep -E '(\.[jt]sx?|\.json|\.md)${'$'}'
 				}
 
 				# Use with `grep -c .` to prevent miscounts due to newlines
-				FILE_COUNT=$$(_find_files_to_lint | grep -c .)
+				FILE_COUNT=${'$'}(_find_files_to_lint | grep -c .)
 
 				# Create temporary output directory. Export the variable so that it is
 				# available in the batch runs.
 				export RESULTS_DIR=checkstyle_results/eslint
-				mkdir -p "$$RESULTS_DIR"
+				mkdir -p "${'$'}RESULTS_DIR"
 
-				if [ "%run_full_eslint%" = true ] || [ "$$FILE_COUNT" -eq 0 ]; then
+				if [ "%run_full_eslint%" = true ] || [ "${'$'}FILE_COUNT" -eq 0 ]; then
 					echo "Linting all files"
-					yarn run eslint --format checkstyle --output-file "$$RESULTS_DIR/results.xml" .
+					yarn run eslint --format checkstyle --output-file "${'$'}RESULTS_DIR/results.xml" .
 				else
 					echo "Linting affected files"
 
@@ -601,7 +601,7 @@ object CheckCodeStyleBranch : BuildType({
 					# xargs has.
 					#
 					# So we resort to a little bit of shell magic:
-					# - `rs` reshapes our list of files into rows of "$$BATCH_SIZE"
+					# - `rs` reshapes our list of files into rows of "${'$'}BATCH_SIZE"
 					# - `nl` prepends each row with an index (1-based)
 					#
 					# The output of the `rs | nl` chain now looks like:
@@ -619,15 +619,15 @@ object CheckCodeStyleBranch : BuildType({
 					MAX_PARALLEL_BATCHES=15 # Number of concurrent ESLint processes
 
 					_find_files_to_lint \
-						| rs 0 "$$BATCH_SIZE" \
+						| rs 0 "${'$'}BATCH_SIZE" \
 						| nl \
-						| xargs -L1 -P"$$MAX_PARALLEL_BATCHES" bash -c '
-							BATCH_NUM="$$1"; shift
-							BATCH_FILES="$$@"
+						| xargs -L1 -P"${'$'}MAX_PARALLEL_BATCHES" bash -c '
+							BATCH_NUM="${'$'}1"; shift
+							BATCH_FILES="${'$'}@"
 							yarn run eslint \
 								--format checkstyle \
-								--output-file "$$RESULTS_DIR/batch_$${BATCH_NUM}.xml" \
-								$$BATCH_FILES
+								--output-file "${'$'}RESULTS_DIR/batch_${'$'}{BATCH_NUM}.xml" \
+								${'$'}BATCH_FILES
 						' yarn-batch # Arbitrary name to be used as each batch's progname
 				fi
 			"""

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -570,6 +570,8 @@ object CheckCodeStyleBranch : BuildType({
 		bashNodeScript {
 			name = "Run eslint"
 			scriptContent = """
+				set -x
+
 				export NODE_ENV="test"
 
 				# Find lintable files touched in this branch, except those deleted

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -640,10 +640,10 @@ object CheckCodeStyleBranch : BuildType({
 								${'$'}BATCH_FILES
 
 							# xargs will return 123 if any run returns a non-zero value. Ensure we
-							# only catch relevant issues. ESLint's exit codes seem to be:
+							# only catch relevant issues. ESLint exit codes seem to be:
 							# - 0 for no errors
-							# - 1 for linting errors (let's ignore)
-							# - 2 for other errors (let's propagate)
+							# - 1 for linting errors (should ignore)
+							# - 2 for other errors (should propagate)
 							status=${'$'}?
 							if [ ${'$'}status -gt 1 ]; then
 								exit ${'$'}status

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -629,7 +629,7 @@ object CheckCodeStyleBranch : BuildType({
 					MAX_PARALLEL_BATCHES=15 # Number of concurrent ESLint processes
 
 					_find_files_to_lint \
-						| awk -v"n=${'$'}BATCH_SIZE" '{printf "%s%s", $0, (NR%n?"\t":"\n")}' \
+						| awk -v"n=${'$'}BATCH_SIZE" '{printf "%%s%%s", $0, (NR%%n?"\t":"\n")}' \
 						| nl \
 						| xargs -L1 -P"${'$'}MAX_PARALLEL_BATCHES" bash -c '
 							BATCH_NUM="${'$'}1"; shift


### PR DESCRIPTION
## Proposed Changes

For linting the files modified, we have to cover for two issues:

- ENAMETOOLONG: we cannot pass to the ESLint process too many files as input because we can exceed the maximum command line length.
- OOM: we cannot spawn too many processes in parallel, otherwise TeamCity may run Out Of Memory.

To prevent running into any of these issues, this PR processes the files in batches:

- `BATCH_SIZE` is the number of files each ESLint process will take.
- `MAX_PARALLEL_BATCHES` is the maximum number of ESLint processes to execute in parallel.

## Why are these changes being made?

To cover for the above issues, right now we use the following strategy:

1. If there are more than 16 files to lint, lint the whole codebase.

This prevents both ENAMETOOLONG and OOM issues. It comes at the cost of impacting big PRs by requiring them to lint files they didn't modify. This is opaque to the PR authors (they need to dig into this job to understand) and creates friction.

2. If there are less than 16 files to lint, spawn a ESLint process for each file.

This takes advantage of parallelism, but only in a limited way (ESLint only process 1 file per process). It aims to control ENAMETOOLONG by only linting 1 file, and OOM by only spawning 16 processes.

By spawning `MAX_PARALLEL_BATCHES` (15) we take advantage of parallelism, and by limiting each ESLint process to only lint `BATCH_SIZE` (15) we cover against ENAMETOOLONG issues. These numbers can be tweaked.

## Tests

- [x] 0 files to lint (this PR as it is). Tests linting the whole codebase.
- [x] [101074](https://github.com/Automattic/wp-calypso/pull/101074). Tests that it will only lint the modified files, and that it does it in batches.
- [x] [101077](https://github.com/Automattic/wp-calypso/pull/101077) Tests that it won't spawn more than `MAX_PARALLEL_BATCHES` batches.
