### PR TITLE
A4A: Update WooPayments commission page to pre-fetch all licenses.

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-all-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-all-licenses.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { LICENSES_PER_PAGE } from 'calypso/a8c-for-agencies/sections/purchases/lib/constants';
 import {
 	LicenseFilter,
 	LicenseSortDirection,
@@ -19,6 +18,8 @@ export const getFetchLicensesQueryKey = (
 ) => {
 	return [ 'a4a-all-licenses', filter, search, sortField, sortDirection, agencyId ];
 };
+
+const FETCH_SIZE = 100;
 
 export default function useFetchAllLicenses(
 	filter: LicenseFilter,
@@ -48,7 +49,7 @@ export default function useFetchAllLicenses(
 						page: currentPage,
 						sort_field: sortField,
 						sort_direction: sortDirection,
-						per_page: LICENSES_PER_PAGE,
+						per_page: FETCH_SIZE,
 					}
 				);
 

--- a/client/a8c-for-agencies/data/purchases/use-fetch-all-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-all-licenses.ts
@@ -1,0 +1,69 @@
+import { useQuery } from '@tanstack/react-query';
+import { LICENSES_PER_PAGE } from 'calypso/a8c-for-agencies/sections/purchases/lib/constants';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import formatLicenses from './lib/format-licenses';
+
+export const getFetchLicensesQueryKey = (
+	filter: LicenseFilter,
+	search: string,
+	sortField: LicenseSortField,
+	sortDirection: LicenseSortDirection,
+	agencyId?: number
+) => {
+	return [ 'a4a-all-licenses', filter, search, sortField, sortDirection, agencyId ];
+};
+
+export default function useFetchAllLicenses(
+	filter: LicenseFilter,
+	search: string,
+	sortField: LicenseSortField,
+	sortDirection: LicenseSortDirection
+) {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useQuery( {
+		queryKey: getFetchLicensesQueryKey( filter, search, sortField, sortDirection, agencyId ),
+		queryFn: async () => {
+			let currentPage = 1;
+			let hasMorePages = true;
+			const licenses = [];
+
+			while ( hasMorePages ) {
+				const response = await wpcom.req.get(
+					{
+						apiNamespace: 'wpcom/v2',
+						path: '/jetpack-licensing/licenses',
+					},
+					{
+						...( agencyId && { agency_id: agencyId } ),
+						...( search && { search: search } ),
+						filter: filter,
+						page: currentPage,
+						sort_field: sortField,
+						sort_direction: sortDirection,
+						per_page: LICENSES_PER_PAGE,
+					}
+				);
+
+				licenses.push( ...response.items );
+
+				hasMorePages = currentPage < response.total_pages;
+				currentPage++;
+			}
+
+			return {
+				items: formatLicenses( licenses ),
+				total: licenses.length,
+			};
+		},
+		enabled: !! agencyId,
+		refetchOnWindowFocus: false,
+	} );
+}

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -4,9 +4,8 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import useFetchAllLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-all-licenses';
 import useFetchSitesWithPlugins from 'calypso/a8c-for-agencies/data/sites/use-fetch-sites-with-plugins';
-import { LICENSES_PER_PAGE } from 'calypso/a8c-for-agencies/sections/purchases/lib/constants';
 import {
 	LicenseFilter,
 	LicenseSortField,
@@ -49,13 +48,11 @@ const WooPaymentsDashboard = () => {
 	const [ isWooPaymentsDataLoading, setIsWooPaymentsDataLoading ] = useState( false );
 
 	const { data: licensesWithWooPayments, isLoading: isLoadingLicensesWithWooPayments } =
-		useFetchLicenses(
+		useFetchAllLicenses(
 			LicenseFilter.Attached,
 			'woopayments',
 			LicenseSortField.IssuedAt,
-			LicenseSortDirection.Descending,
-			1,
-			LICENSES_PER_PAGE
+			LicenseSortDirection.Descending
 		);
 
 	const { isLoading: isLoadingSitesWithPlugins, data: sitesWithPlugins } = useFetchSitesWithPlugins(


### PR DESCRIPTION
At present, we retrieve only the first 50 WooPayments licenses while displaying the WooPayments page. This PR resolves that limitation by ensuring that all licenses are pre-fetched.

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1889

## Proposed Changes

* Add a `fetchAllLicenses` hook to manage bulk fetching. This new hook will be used to prefetch all licenses.

## Why are these changes being made?

* This is part of the WooPayments commission project.

## Testing Instructions

* To easily test if the pre-fetched is functioning and fetching the licenses in bulk, run this branch locally and [update this line so the page fetch size is 1.](https://github.com/Automattic/wp-calypso/pull/100987/files#diff-3d8387b4274367038f9929735abadbcac5a9532822f70595ae7fa85bfe802198R51)
  ```
     per_page: 1,
  ```
* Then go to the `/woopayments/dashboard` page.
* Inspect the network request and confirm you see multiple requests going to the `/jetpack-licensing/licenses` endpoint.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
