### PR TITLE
A4A: Show Missing Payment notice on WooPayments commission page.

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import { A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useGetTipaltiPayee from '../../referrals/hooks/use-get-tipalti-payee';
 
 import './style.scss';
@@ -25,7 +26,7 @@ export const MissingPaymentSettingsNotice = () => {
 			<div>{ translate( 'To receive your revenue share, add your payment information.' ) }</div>
 			<Button
 				className="missing-payment-settings-notice__button is-dark"
-				href="/woopayments/payment-settings"
+				href={ A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK }
 			>
 				{ translate( 'Add your payment information' ) }
 			</Button>

--- a/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import useGetTipaltiPayee from '../../referrals/hooks/use-get-tipalti-payee';
+
+import './style.scss';
+
+export const MissingPaymentSettingsNotice = () => {
+	const translate = useTranslate();
+
+	const { data: tipaltiData } = useGetTipaltiPayee();
+	const isPayable = tipaltiData?.IsPayable;
+
+	if ( isPayable ) {
+		return null;
+	}
+
+	return (
+		<LayoutBanner
+			level="warning"
+			title={ translate( 'Add your payment information to get paid' ) }
+			className="missing-payment-settings-notice"
+			hideCloseButton
+		>
+			<div>{ translate( 'To receive your revenue share, add your payment information.' ) }</div>
+			<Button
+				className="missing-payment-settings-notice__button is-dark"
+				href="/woopayments/payment-settings"
+			>
+				{ translate( 'Add your payment information' ) }
+			</Button>
+		</LayoutBanner>
+	);
+};
+
+export default MissingPaymentSettingsNotice;

--- a/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/style.scss
@@ -1,0 +1,5 @@
+.missing-payment-settings-notice {
+	.missing-payment-settings-notice__button {
+		margin-block-start: 1rem;
+	}
+}

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -22,6 +22,7 @@ import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 import { WooPaymentsProvider } from '../../context';
 import WooPaymentsDashboardContent from '../../dashboard-content';
 import useFetchWooPaymentsData from '../../hooks/use-fetch-woopayments-data';
+import MissingPaymentSettingsNotice from '../../missing-payment-settings-notice';
 import WooPaymentsDashboardEmptyState from './empty-state';
 import type { SitesWithWooPaymentsState, SitesWithWooPaymentsPlugins } from '../../types';
 import type { License } from 'calypso/state/partner-portal/types';
@@ -130,6 +131,7 @@ const WooPaymentsDashboard = () => {
 				} }
 			>
 				<LayoutTop>
+					{ !! sitesWithPluginsStates.length && <MissingPaymentSettingsNotice /> }
 					<LayoutHeader>
 						<Title>{ title }</Title>
 						<Actions>


### PR DESCRIPTION
This PR adds a notice banner on the WooPayments commission page when the payment details are missing.

<img width="1555" alt="Screenshot 2025-03-07 at 6 13 16 PM" src="https://github.com/user-attachments/assets/13863315-c6a6-4dc4-9057-c0465ff86685" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1869

## Proposed Changes

* Add the `MissingPaymentSettingsNotice` component in the commission page.

## Why are these changes being made?

* This is part of the WooPayments commission project.

## Testing Instructions

* Create a new agency account and add a site.
* Add a WooPayments license to the site and activate the WooPayments plugin.
* Go to the `/woopayments/dashboard` page.
* Confirm you see the banner.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
