### PR TITLE
Help Center: Add chat to account closure

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -2,11 +2,11 @@ import page from '@automattic/calypso-router';
 import { Button as LegacyButton, Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
-import { dispatch as dataStoreDispatch } from '@wordpress/data';
+import { dispatch as useDataStoreDispatch } from '@wordpress/data';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
-import { Component, Fragment } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { connect } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
@@ -33,235 +33,215 @@ import './style.scss';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-class AccountSettingsClose extends Component {
-	state = {
-		showConfirmDialog: false,
-		showSiteDropdown: true,
-	};
+const AccountSettingsClose = ( {
+	translate,
+	hasAtomicSites,
+	hasCancelablePurchases,
+	isLoading,
+	purchasedPremiumThemes,
+	sitesToBeDeleted,
+	isAccountAlreadyClosed,
+	handleRedirectToLogout,
+} ) => {
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+	const [ showSiteDropdown, setShowSiteDropdown ] = useState( true );
+	const { setNewMessagingChat } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	componentDidUpdate() {
-		// If the account is closed, logout
-		if ( this.props.isAccountClosed === true ) {
-			this.props.redirectToLogout();
+	useEffect( () => {
+		if ( isAccountAlreadyClosed ) {
+			handleRedirectToLogout();
 		}
-	}
+	}, [ isAccountAlreadyClosed, handleRedirectToLogout ] );
 
-	goBack = () => {
-		page( '/me/account' );
-	};
-
-	handleDeleteClick = ( event ) => {
-		event.preventDefault();
-
-		// Check if purchases and sites have loaded
-		if ( this.props.isLoading ) {
-			return false;
-		}
-
-		this.setState( { showConfirmDialog: true } );
-	};
-
-	closeConfirmDialog = () => {
-		this.setState( { showConfirmDialog: false } );
-	};
-
-	handleSiteDropdown = () => {
-		this.setState( ( state ) => ( {
-			showSiteDropdown: ! state.showSiteDropdown,
-		} ) );
-	};
-
-	render() {
-		const { translate, hasAtomicSites, hasCancelablePurchases, isLoading, purchasedPremiumThemes } =
-			this.props;
-		const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasCancelablePurchases;
-		const containerClasses = clsx( 'account-close', 'main', 'is-wide-layout', {
-			'is-loading': isLoading,
-			'is-hiding-other-sites': this.state.showSiteDropdown,
+	const handleContactSupport = () => {
+		setNewMessagingChat( {
+			initialMessage: 'User is contacting us requesting information about account deletion',
+			section: 'account-deletion',
 		} );
+	};
+	const goBack = () => page( '/me/account' );
+	const handleDeleteClick = ( event ) => {
+		event.preventDefault();
+		if ( ! isLoading ) {
+			setShowConfirmDialog( true );
+		}
+	};
+	const closeConfirmDialog = () => setShowConfirmDialog( false );
+	const toggleSiteDropdown = () => setShowSiteDropdown( ( prev ) => ! prev );
 
-		return (
-			<div className={ containerClasses } role="main">
-				<QueryUserPurchases />
-				<NavigationHeader navigationItems={ [] } title={ translate( 'Account Settings' ) } />
+	const isDeletePossible = ! isLoading && ! hasAtomicSites && ! hasCancelablePurchases;
+	const containerClasses = clsx( 'account-close', 'main', 'is-wide-layout', {
+		'is-loading': isLoading,
+		'is-hiding-other-sites': showSiteDropdown,
+	} );
 
-				<HeaderCake onClick={ this.goBack }>
-					<h1>{ translate( 'Delete account' ) }</h1>
-				</HeaderCake>
-				<ActionPanel>
-					<ActionPanelBody>
-						{ isDeletePossible && (
-							<ActionPanelFigure>
-								<ActionPanelFigureHeader>
-									{ translate( 'These items will be deleted' ) }
-								</ActionPanelFigureHeader>
-								<ActionPanelFigureList>
-									<ActionPanelFigureListItem>
-										{ translate( 'Personal details' ) }
-									</ActionPanelFigureListItem>
-									{ this.props.sitesToBeDeleted.length > 0 && (
-										<Fragment>
-											<ActionPanelFigureListItem className="account-close__sites-item">
-												{ translate( 'Sites' ) }
-												<Gridicon
-													size={ 18 }
-													onClick={ this.handleSiteDropdown }
-													icon="chevron-down"
-												/>
-												{ this.state.showSiteDropdown && (
-													<ul className="account-close__sites-list">
-														{ this.props.sitesToBeDeleted.map( ( sitesToBeDeleted ) => (
-															<li key={ sitesToBeDeleted.slug }>
-																{ [ sitesToBeDeleted.name ] }
-																<span>{ [ sitesToBeDeleted.slug ] }</span>
-															</li>
-														) ) }
-													</ul>
-												) }
-											</ActionPanelFigureListItem>
-											<ActionPanelFigureListItem>
-												{ translate( 'Posts' ) }
-											</ActionPanelFigureListItem>
-											<ActionPanelFigureListItem>
-												{ translate( 'Pages' ) }
-											</ActionPanelFigureListItem>
-											<ActionPanelFigureListItem>
-												{ translate( 'Media' ) }
-											</ActionPanelFigureListItem>
-											<ActionPanelFigureListItem>
-												{ translate( 'Domains' ) }
-											</ActionPanelFigureListItem>
-										</Fragment>
-									) }
-									{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
-										<ActionPanelFigureListItem>
-											{ translate( 'Premium themes' ) }
-										</ActionPanelFigureListItem>
-									) }
-									<ActionPanelFigureListItem>Gravatar</ActionPanelFigureListItem>
-								</ActionPanelFigureList>
-							</ActionPanelFigure>
-						) }
-						{ ! isLoading && hasCancelablePurchases && (
-							<Fragment>
-								<p className="account-close__body-copy">
-									{ translate( 'You still have active purchases on your account.' ) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate(
-										"To delete your account, you'll need to cancel any active purchases " +
-											'in {{a}}Manage Purchases{{/a}} before proceeding.',
-										{
-											components: {
-												a: <ActionPanelLink href="/me/purchases" />,
-											},
-										}
-									) }
-								</p>
-							</Fragment>
-						) }
-						{ ! isLoading && hasAtomicSites && ! hasCancelablePurchases && (
-							<Fragment>
-								<p className="account-close__body-copy">
-									{ translate(
-										'We are still in the process of removing one or more of your sites. This process normally takes 15-20 minutes. Once removal is completed, you should be able to close your account from this page.'
-									) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
-										components: {
-											a: <Button onClick={ this.props.handleContactSupport } variant="link" />,
-										},
-									} ) }
-								</p>
-							</Fragment>
-						) }
+	return (
+		<div className={ containerClasses } role="main">
+			<QueryUserPurchases />
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Account Settings' ) } />
 
-						{ ( isLoading || isDeletePossible ) && (
-							<Fragment>
-								<p className="account-close__body-copy">
-									<strong>
-										{ translate(
-											'Deleting your account will also delete all your sites and their content.'
-										) }
-									</strong>
-								</p>
-								{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
+			<HeaderCake onClick={ goBack }>
+				<h1>{ translate( 'Delete account' ) }</h1>
+			</HeaderCake>
+			<ActionPanel>
+				<ActionPanelBody>
+					{ isDeletePossible && (
+						<ActionPanelFigure>
+							<ActionPanelFigureHeader>
+								{ translate( 'These items will be deleted' ) }
+							</ActionPanelFigureHeader>
+							<ActionPanelFigureList>
+								<ActionPanelFigureListItem>
+									{ translate( 'Personal details' ) }
+								</ActionPanelFigureListItem>
+								{ sitesToBeDeleted.length > 0 && (
 									<Fragment>
-										{ translate(
-											'You will also lose access to the following premium themes you have purchased:'
-										) }
-										<ul className="account-close__theme-list">
-											{ map( purchasedPremiumThemes, ( purchasedPremiumTheme ) => {
-												return (
-													<li key={ purchasedPremiumTheme.id }>
-														{ purchasedPremiumTheme.productName }
-													</li>
-												);
-											} ) }
-										</ul>
+										<ActionPanelFigureListItem className="account-close__sites-item">
+											{ translate( 'Sites' ) }
+											<Gridicon size={ 18 } onClick={ toggleSiteDropdown } icon="chevron-down" />
+											{ showSiteDropdown && (
+												<ul className="account-close__sites-list">
+													{ sitesToBeDeleted.map( ( siteToBeDeleted ) => (
+														<li key={ siteToBeDeleted.slug }>
+															{ [ siteToBeDeleted.name ] }
+															<span>{ [ siteToBeDeleted.slug ] }</span>
+														</li>
+													) ) }
+												</ul>
+											) }
+										</ActionPanelFigureListItem>
+										<ActionPanelFigureListItem>{ translate( 'Posts' ) }</ActionPanelFigureListItem>
+										<ActionPanelFigureListItem>{ translate( 'Pages' ) }</ActionPanelFigureListItem>
+										<ActionPanelFigureListItem>{ translate( 'Media' ) }</ActionPanelFigureListItem>
+										<ActionPanelFigureListItem>
+											{ translate( 'Domains' ) }
+										</ActionPanelFigureListItem>
 									</Fragment>
 								) }
-								<p className="account-close__body-copy">
+								{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
+									<ActionPanelFigureListItem>
+										{ translate( 'Premium themes' ) }
+									</ActionPanelFigureListItem>
+								) }
+								<ActionPanelFigureListItem>Gravatar</ActionPanelFigureListItem>
+							</ActionPanelFigureList>
+						</ActionPanelFigure>
+					) }
+					{ ! isLoading && hasCancelablePurchases && (
+						<Fragment>
+							<p className="account-close__body-copy">
+								{ translate( 'You still have active purchases on your account.' ) }
+							</p>
+							<p className="account-close__body-copy">
+								{ translate(
+									"To delete your account, you'll need to cancel any active purchases " +
+										'in {{a}}Manage Purchases{{/a}} before proceeding.',
+									{
+										components: {
+											a: <ActionPanelLink href="/me/purchases" />,
+										},
+									}
+								) }
+							</p>
+						</Fragment>
+					) }
+					{ ! isLoading && hasAtomicSites && ! hasCancelablePurchases && (
+						<Fragment>
+							<p className="account-close__body-copy">
+								{ translate(
+									'We are still in the process of removing one or more of your sites. This process normally takes 15-20 minutes. Once removal is completed, you should be able to close your account from this page.'
+								) }
+							</p>
+							<p className="account-close__body-copy">
+								{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
+									components: {
+										a: <Button onClick={ handleContactSupport } variant="link" />,
+									},
+								} ) }
+							</p>
+						</Fragment>
+					) }
+
+					{ ( isLoading || isDeletePossible ) && (
+						<Fragment>
+							<p className="account-close__body-copy">
+								<strong>
 									{ translate(
-										'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
+										'Deleting your account will also delete all your sites and their content.'
 									) }
-								</p>
-								<p className="account-close__body-copy">
+								</strong>
+							</p>
+							{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
+								<Fragment>
 									{ translate(
-										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com, and Gravatar.com. Once your WordPress.com account is deleted, these services will also be deleted and you will lose access to any orders or support history you may have.'
+										'You will also lose access to the following premium themes you have purchased:'
 									) }
-								</p>
-								<p className="account-close__body-copy">
-									{ translate(
-										'If you have any questions at all about what happens when you delete an account, ' +
-											'please {{a}}contact someone from our support team{{/a}} first. ' +
-											"They'll explain the ramifications and help you explore alternatives. ",
-										{
-											components: {
-												a: <Button onClick={ this.props.handleContactSupport } variant="link" />,
-											},
-										}
-									) }
-								</p>
-							</Fragment>
-						) }
-					</ActionPanelBody>
-					<ActionPanelFooter>
-						{ ( isLoading || isDeletePossible ) && (
-							<LegacyButton
-								scary
-								onClick={ this.handleDeleteClick }
-								data-testid="close-account-button"
-							>
-								<Gridicon icon="trash" />
-								{ translate( 'Delete account', { context: 'button label' } ) }
-							</LegacyButton>
-						) }
-						{ hasAtomicSites && ! hasCancelablePurchases && (
-							<LegacyButton
-								primary
-								onClick={ this.props.handleContactSupport }
-								data-testid="contact-support-button"
-							>
-								{ translate( 'Contact support' ) }
-							</LegacyButton>
-						) }
-						{ hasCancelablePurchases && (
-							<LegacyButton primary href="/me/purchases" data-testid="manage-purchases-button">
-								{ translate( 'Manage purchases', { context: 'button label' } ) }
-							</LegacyButton>
-						) }
-					</ActionPanelFooter>
-					<AccountCloseConfirmDialog
-						isVisible={ this.state.showConfirmDialog }
-						closeConfirmDialog={ this.closeConfirmDialog }
-					/>
-				</ActionPanel>
-			</div>
-		);
-	}
-}
+									<ul className="account-close__theme-list">
+										{ map( purchasedPremiumThemes, ( purchasedPremiumTheme ) => {
+											return (
+												<li key={ purchasedPremiumTheme.id }>
+													{ purchasedPremiumTheme.productName }
+												</li>
+											);
+										} ) }
+									</ul>
+								</Fragment>
+							) }
+							<p className="account-close__body-copy">
+								{ translate(
+									'You will not be able to open a new WordPress.com account using the same email address for 30 days.'
+								) }
+							</p>
+							<p className="account-close__body-copy">
+								{ translate(
+									'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com, and Gravatar.com. Once your WordPress.com account is deleted, these services will also be deleted and you will lose access to any orders or support history you may have.'
+								) }
+							</p>
+							<p className="account-close__body-copy">
+								{ translate(
+									'If you have any questions at all about what happens when you delete an account, ' +
+										'please {{a}}contact someone from our support team{{/a}} first. ' +
+										"They'll explain the ramifications and help you explore alternatives. ",
+									{
+										components: {
+											a: <Button onClick={ handleContactSupport } variant="link" />,
+										},
+									}
+								) }
+							</p>
+						</Fragment>
+					) }
+				</ActionPanelBody>
+				<ActionPanelFooter>
+					{ ( isLoading || isDeletePossible ) && (
+						<LegacyButton scary onClick={ handleDeleteClick } data-testid="close-account-button">
+							<Gridicon icon="trash" />
+							{ translate( 'Delete account', { context: 'button label' } ) }
+						</LegacyButton>
+					) }
+					{ hasAtomicSites && ! hasCancelablePurchases && (
+						<LegacyButton
+							primary
+							onClick={ handleContactSupport }
+							data-testid="contact-support-button"
+						>
+							{ translate( 'Contact support' ) }
+						</LegacyButton>
+					) }
+					{ hasCancelablePurchases && (
+						<LegacyButton primary href="/me/purchases" data-testid="manage-purchases-button">
+							{ translate( 'Manage purchases', { context: 'button label' } ) }
+						</LegacyButton>
+					) }
+				</ActionPanelFooter>
+				<AccountCloseConfirmDialog
+					isVisible={ showConfirmDialog }
+					closeConfirmDialog={ closeConfirmDialog }
+				/>
+			</ActionPanel>
+		</div>
+	);
+};
 
 export default connect(
 	( state ) => {
@@ -276,17 +256,11 @@ export default connect(
 			hasCancelablePurchases: hasCancelableUserPurchases( state ),
 			purchasedPremiumThemes,
 			hasAtomicSites: userHasAnyAtomicSites( state ),
-			isAccountClosed: isAccountClosed( state ),
+			isAccountAlreadyClosed: isAccountClosed( state ),
 			sitesToBeDeleted: getAccountClosureSites( state ),
 		};
 	},
 	{
-		redirectToLogout,
-		handleContactSupport: () => {
-			dataStoreDispatch( HELP_CENTER_STORE ).setNewMessagingChat( {
-				initialMessage: 'User is contacting us requesting information about account deletion',
-				section: 'account-deletion',
-			} );
-		},
+		handleRedirectToLogout: redirectToLogout,
 	}
 )( localize( AccountSettingsClose ) );

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -154,7 +154,7 @@ const AccountSettingsClose = ( {
 									'We are still in the process of removing one or more of your sites. This process normally takes 15-20 minutes. Once removal is completed, you should be able to close your account from this page.'
 								) }
 							</p>
-							{ isEligibleForChat && (
+							{ ! isLoading && isEligibleForChat && (
 								<p className="account-close__body-copy">
 									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
 										components: {
@@ -201,7 +201,7 @@ const AccountSettingsClose = ( {
 									'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com, and Gravatar.com. Once your WordPress.com account is deleted, these services will also be deleted and you will lose access to any orders or support history you may have.'
 								) }
 							</p>
-							{ isEligibleForChat && (
+							{ ! isLoading && isEligibleForChat && (
 								<p className="account-close__body-copy">
 									{ translate(
 										'If you have any questions at all about what happens when you delete an account, ' +

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -1,5 +1,8 @@
 import page from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
+import { Button as LegacyButton, Gridicon } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
+import { dispatch as dataStoreDispatch } from '@wordpress/data';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
@@ -27,6 +30,8 @@ import userHasAnyAtomicSites from 'calypso/state/selectors/user-has-any-atomic-s
 import AccountCloseConfirmDialog from './confirm-dialog';
 
 import './style.scss';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 class AccountSettingsClose extends Component {
 	state = {
@@ -165,7 +170,7 @@ class AccountSettingsClose extends Component {
 								<p className="account-close__body-copy">
 									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
 										components: {
-											a: <ActionPanelLink href="/help/contact" />,
+											a: <Button onClick={ this.props.handleContactSupport } variant="link" />,
 										},
 									} ) }
 								</p>
@@ -214,7 +219,7 @@ class AccountSettingsClose extends Component {
 											"They'll explain the ramifications and help you explore alternatives. ",
 										{
 											components: {
-												a: <ActionPanelLink href="/help/contact" />,
+												a: <Button onClick={ this.props.handleContactSupport } variant="link" />,
 											},
 										}
 									) }
@@ -224,20 +229,28 @@ class AccountSettingsClose extends Component {
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						{ ( isLoading || isDeletePossible ) && (
-							<Button scary onClick={ this.handleDeleteClick } data-testid="close-account-button">
+							<LegacyButton
+								scary
+								onClick={ this.handleDeleteClick }
+								data-testid="close-account-button"
+							>
 								<Gridicon icon="trash" />
 								{ translate( 'Delete account', { context: 'button label' } ) }
-							</Button>
+							</LegacyButton>
 						) }
 						{ hasAtomicSites && ! hasCancelablePurchases && (
-							<Button primary href="/help/contact" data-testid="contact-support-button">
+							<LegacyButton
+								primary
+								onClick={ this.props.handleContactSupport }
+								data-testid="contact-support-button"
+							>
 								{ translate( 'Contact support' ) }
-							</Button>
+							</LegacyButton>
 						) }
 						{ hasCancelablePurchases && (
-							<Button primary href="/me/purchases" data-testid="manage-purchases-button">
+							<LegacyButton primary href="/me/purchases" data-testid="manage-purchases-button">
 								{ translate( 'Manage purchases', { context: 'button label' } ) }
-							</Button>
+							</LegacyButton>
 						) }
 					</ActionPanelFooter>
 					<AccountCloseConfirmDialog
@@ -269,5 +282,11 @@ export default connect(
 	},
 	{
 		redirectToLogout,
+		handleContactSupport: () => {
+			dataStoreDispatch( HELP_CENTER_STORE ).setNewMessagingChat( {
+				initialMessage: 'User is contacting us requesting information about account deletion',
+				section: 'account-deletion',
+			} );
+		},
 	}
 )( localize( AccountSettingsClose ) );

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Button as LegacyButton, Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
+import { useChatStatus } from '@automattic/help-center/src/hooks';
 import { Button } from '@wordpress/components';
 import { dispatch as useDataStoreDispatch } from '@wordpress/data';
 import clsx from 'clsx';
@@ -46,6 +47,7 @@ const AccountSettingsClose = ( {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 	const [ showSiteDropdown, setShowSiteDropdown ] = useState( true );
 	const { setNewMessagingChat } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { isEligibleForChat } = useChatStatus();
 
 	useEffect( () => {
 		if ( isAccountAlreadyClosed ) {
@@ -152,13 +154,15 @@ const AccountSettingsClose = ( {
 									'We are still in the process of removing one or more of your sites. This process normally takes 15-20 minutes. Once removal is completed, you should be able to close your account from this page.'
 								) }
 							</p>
-							<p className="account-close__body-copy">
-								{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
-									components: {
-										a: <Button onClick={ handleContactSupport } variant="link" />,
-									},
-								} ) }
-							</p>
+							{ isEligibleForChat && (
+								<p className="account-close__body-copy">
+									{ translate( 'To close this account now, {{a}}contact our support team{{/a}}.', {
+										components: {
+											a: <Button onClick={ handleContactSupport } variant="link" />,
+										},
+									} ) }
+								</p>
+							) }
 						</Fragment>
 					) }
 
@@ -197,18 +201,20 @@ const AccountSettingsClose = ( {
 									'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com, and Gravatar.com. Once your WordPress.com account is deleted, these services will also be deleted and you will lose access to any orders or support history you may have.'
 								) }
 							</p>
-							<p className="account-close__body-copy">
-								{ translate(
-									'If you have any questions at all about what happens when you delete an account, ' +
-										'please {{a}}contact someone from our support team{{/a}} first. ' +
-										"They'll explain the ramifications and help you explore alternatives. ",
-									{
-										components: {
-											a: <Button onClick={ handleContactSupport } variant="link" />,
-										},
-									}
-								) }
-							</p>
+							{ isEligibleForChat && (
+								<p className="account-close__body-copy">
+									{ translate(
+										'If you have any questions at all about what happens when you delete an account, ' +
+											'please {{a}}contact someone from our support team{{/a}} first. ' +
+											"They'll explain the ramifications and help you explore alternatives. ",
+										{
+											components: {
+												a: <Button onClick={ handleContactSupport } variant="link" />,
+											},
+										}
+									) }
+								</p>
+							) }
 						</Fragment>
 					) }
 				</ActionPanelBody>

--- a/client/me/account-close/test/main.js
+++ b/client/me/account-close/test/main.js
@@ -5,7 +5,15 @@ import { render, screen } from '@testing-library/react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import AccountSettingsClose from '../main';
-
+jest.mock( '@automattic/help-center/src/hooks', () => {
+	return {
+		useChatStatus: () => {
+			return {
+				isEligibleForChat: true,
+			};
+		},
+	};
+} );
 describe( 'AccountSettingsClose', () => {
 	it( 'Shows Manage purchases button when refundable purchases exist', () => {
 		render(

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -219,6 +219,25 @@ export const setNewMessagingChat = function* ( {
 	yield setShowHelpCenter( true );
 };
 
+export const setNewMessagingChat = function* ( {
+	initialMessage,
+	section,
+	siteUrl,
+	siteId,
+}: {
+	initialMessage: string;
+	section?: string;
+	siteUrl?: string;
+	siteId?: string;
+} ) {
+	yield setNavigateToRoute(
+		`/odie?provider=zendesk&userFieldMessage=${ initialMessage ?? '' }&section=${
+			section ?? ''
+		}&siteUrl=${ siteUrl ?? '' }&siteId=${ siteId ?? '' }`
+	);
+	yield setShowHelpCenter( true );
+};
+
 export const setShowSupportDoc = function* ( link: string, postId?: number, blogId?: number ) {
 	const params = new URLSearchParams( {
 		link,
@@ -253,4 +272,6 @@ export type HelpCenterAction =
 			| typeof setAllowPremiumSupport
 			| typeof setHelpCenterOptions
 	  >
-	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;
+	| GeneratorReturnType<
+			typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal | typeof setNewMessagingChat
+	  >;

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -219,25 +219,6 @@ export const setNewMessagingChat = function* ( {
 	yield setShowHelpCenter( true );
 };
 
-export const setNewMessagingChat = function* ( {
-	initialMessage,
-	section,
-	siteUrl,
-	siteId,
-}: {
-	initialMessage: string;
-	section?: string;
-	siteUrl?: string;
-	siteId?: string;
-} ) {
-	yield setNavigateToRoute(
-		`/odie?provider=zendesk&userFieldMessage=${ initialMessage }&section=${
-			section ?? ''
-		}&siteUrl=${ siteUrl ?? '' }&siteId=${ siteId ?? '' }`
-	);
-	yield setShowHelpCenter( true );
-};
-
 export const setShowSupportDoc = function* ( link: string, postId?: number, blogId?: number ) {
 	const params = new URLSearchParams( {
 		link,

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -231,7 +231,7 @@ export const setNewMessagingChat = function* ( {
 	siteId?: string;
 } ) {
 	yield setNavigateToRoute(
-		`/odie?provider=zendesk&userFieldMessage=${ initialMessage ?? '' }&section=${
+		`/odie?provider=zendesk&userFieldMessage=${ initialMessage }&section=${
 			section ?? ''
 		}&siteUrl=${ siteUrl ?? '' }&siteId=${ siteId ?? '' }`
 	);

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -272,6 +272,4 @@ export type HelpCenterAction =
 			| typeof setAllowPremiumSupport
 			| typeof setHelpCenterOptions
 	  >
-	| GeneratorReturnType<
-			typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal | typeof setNewMessagingChat
-	  >;
+	| GeneratorReturnType< typeof setShowHelpCenter | typeof setHasSeenWhatsNewModal >;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99804

## Proposed Changes

* Hide contact links for ineligible users
* For eligible users connect to zd directly when the button is clicked

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the account closure form

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Using a free user visit `/me/account/close`. There should be no links for contacting support in the content.
* Using a paid user visit `/me/account/close`. There should be a link to contact support in the content. By clicking on it you should be connected via zd direct chat.


