### PR TITLE
Desktop: Fix release CI and bump version to 8.1.0-beta5

### DIFF
--- a/desktop/bin/build-mac-ci.js
+++ b/desktop/bin/build-mac-ci.js
@@ -9,14 +9,13 @@ const PROJECT_DIR = path.join( __dirname, '..' );
 const BUILD_DIR = path.join( PROJECT_DIR, 'release' );
 
 const circleTag = process.env.CIRCLE_TAG;
-// Set this value to true in conjunction with `ELECTRON_BUILDER_ARGS` above
-// to force a full-artifact build on macOS.
 const isReleaseBuild =
 	process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'desktop-v' );
 
-// Set this value to an empty string ('') in conjunction with `isReleaseBuild`
-// below to force a full-artifact build on macOS.
-const ELECTRON_BUILDER_ARGS = process.env.ELECTRON_BUILDER_ARGS || '';
+// In certain conditions, .circle/config.yml sets ELECTRON_BUILDER_ARGS to -c.mac.target=dir.
+// However, when building a release, that flag must not be set, otherwise the latest-mac.yml file will not be created,
+// and that file is needed below when isReleaseBuild is true.
+const ELECTRON_BUILDER_ARGS = isReleaseBuild ? '' : process.env.ELECTRON_BUILDER_ARGS || '';
 
 // Build Apple Silicon binaries only unless tagged for release.
 const arches = isReleaseBuild ? [ 'x64', 'arm64' ] : [ 'arm64' ];

--- a/desktop/bin/build-mac-ci.js
+++ b/desktop/bin/build-mac-ci.js
@@ -7,15 +7,16 @@ const yaml = require( 'js-yaml' );
 
 const PROJECT_DIR = path.join( __dirname, '..' );
 const BUILD_DIR = path.join( PROJECT_DIR, 'release' );
-// Set this value to an empty string ('') in conjunction with `isReleaseBuild`
-// below to force a full-artifact build on macOS.
-const ELECTRON_BUILDER_ARGS = process.env.ELECTRON_BUILDER_ARGS || '';
 
 const circleTag = process.env.CIRCLE_TAG;
 // Set this value to true in conjunction with `ELECTRON_BUILDER_ARGS` above
 // to force a full-artifact build on macOS.
 const isReleaseBuild =
 	process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'desktop-v' );
+
+// Set this value to an empty string ('') in conjunction with `isReleaseBuild`
+// below to force a full-artifact build on macOS.
+const ELECTRON_BUILDER_ARGS = process.env.ELECTRON_BUILDER_ARGS || '';
 
 // Build Apple Silicon binaries only unless tagged for release.
 const arches = isReleaseBuild ? [ 'x64', 'arm64' ] : [ 'arm64' ];

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.1.0-beta4",
+	"version": "8.1.0-beta5",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",


### PR DESCRIPTION
The Desktop app release CI for beta4 [failed](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/263435/workflows/b3f6091d-4728-40b0-adde-5571c052e929/jobs/1177501) with the following error:

```
mv: rename latest-mac.yml to latest-mac-x64.yml: No such file or directory
Build error:  Error: Command failed: mv latest-mac.yml latest-mac-x64.yml
mv: rename latest-mac.yml to latest-mac-x64.yml: No such file or directory
```

After considerable debugging, I identified the cause to be the `-c.mac.target=dir` that is passed in certain conditions. When that flag is passed, the `latest-mac.yml` file is not created by `electron-builder`. This PR fixes it by unsetting that flag when it's a release build.

That flag is set [here](https://github.com/Automattic/wp-calypso/blob/trunk/.circleci/config.yml#L209). I'm not sure how the release CI ever passed, it would mean that `-c.mac.target=dir` was not set, which I think would only be the case when:

- There are new commits in origin/trunk compared to the release branch
- Those commits modify `desktop/package.json` or `yarn.lock`

To be honest, I'm not sure I understand what [that command](https://github.com/Automattic/wp-calypso/blob/trunk/.circleci/config.yml#L209) is doing, but I didn't want to change things here, I just want the build to pass.