### PR TITLE
Add: Support for bulk subscriber management

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -2,6 +2,7 @@ import { Gravatar, TimeSince } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import { trash } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { useSubscribedNewsletterCategories } from 'calypso/data/newsletter-categories';
 import { useSelector } from 'calypso/state';
@@ -114,10 +115,10 @@ const SubscriberDataViews = ( {
 	} );
 
 	const {
-		currentSubscriber,
-		onClickUnsubscribe: handleUnsubscribe,
+		currentSubscribers,
+		onSetUnsubscribers: handleUnsubscribe,
 		onConfirmModal,
-		resetSubscriber,
+		resetSubscribers,
 	} = useUnsubscribeModal(
 		siteId ?? null,
 		{
@@ -294,8 +295,10 @@ const SubscriberDataViews = ( {
 			{
 				id: 'remove',
 				label: translate( 'Remove' ),
-				callback: ( items: Subscriber[] ) => handleUnsubscribe( items[ 0 ] ),
+				callback: handleUnsubscribe,
 				isPrimary: false,
+				supportsBulk: true,
+				icon: trash,
 			},
 		];
 
@@ -449,11 +452,14 @@ const SubscriberDataViews = ( {
 							fields={ fields }
 							view={ currentView }
 							onClickItem={ handleSubscriberSelection }
+							isItemClickable={ () => true }
 							onChangeView={ handleViewChange }
 							selection={
 								selectedSubscriber ? [ selectedSubscriber.subscription_id.toString() ] : undefined
 							}
-							onChangeSelection={ handleSubscriberSelection }
+							onChangeSelection={
+								currentView.type === 'list' ? handleSubscriberSelection : undefined
+							}
 							isLoading={ isLoading }
 							paginationInfo={ paginationInfo }
 							getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }
@@ -476,15 +482,15 @@ const SubscriberDataViews = ( {
 							siteId={ siteId }
 							subscriptionId={ selectedSubscriber.subscription_id }
 							onClose={ () => setSelectedSubscriber( null ) }
-							onUnsubscribe={ handleUnsubscribe }
+							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }
 							newsletterCategoriesEnabled={ subscribedNewsletterCategoriesData?.enabled }
 							newsletterCategories={ subscribedNewsletterCategoriesData?.newsletterCategories }
 						/>
 					</section>
 				) }
 			<UnsubscribeModal
-				subscriber={ currentSubscriber }
-				onCancel={ resetSubscriber }
+				subscribers={ currentSubscribers }
+				onCancel={ resetSubscribers }
 				onConfirm={ onConfirmModal }
 			/>
 		</div>

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -10,56 +10,80 @@ export enum UnsubscribeActionType {
 }
 
 type UnsubscribeModalProps = {
-	subscriber?: Subscriber;
+	subscribers?: Subscriber[];
 	onCancel: () => void;
 	onConfirm: ( action: UnsubscribeActionType, subscriber?: Subscriber ) => void;
 };
 
-const UnsubscribeModal = ( { subscriber, onCancel, onConfirm }: UnsubscribeModalProps ) => {
+const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModalProps ) => {
 	const translate = useTranslate();
-	const subscriberHasPlans = !! subscriber?.plans?.length;
+	const subscriber = subscribers?.[ 0 ];
+	const someSubscriberHasPlans = !! subscribers?.some( ( subscriber ) => subscriber.plans?.length );
+	const isSingleSubscriber = subscribers?.length === 1;
 	const recordRemoveModal = useRecordRemoveModal();
 
-	const freeSubscriberProps = {
-		action: UnsubscribeActionType.Unsubscribe,
-		confirmButtonLabel: translate( 'Remove subscriber' ),
-		text: translate(
-			'Are you sure you want to remove %s from your list? They will no longer receive new notifications from your site.',
-			{
-				args: [ subscriber?.display_name as string ],
-				comment: "%s is the subscriber's public display name",
-			}
-		),
-		title: translate( 'Remove free subscriber' ),
-	};
+	const freeSubscriberProps = isSingleSubscriber
+		? {
+				action: UnsubscribeActionType.Unsubscribe,
+				confirmButtonLabel: translate( 'Remove subscriber' ),
+				text: translate(
+					'Are you sure you want to remove %s from your list? They will no longer receive new notifications from your site.',
+					{
+						args: [ subscriber?.display_name as string ],
+						comment: "%s is the subscriber's public display name",
+					}
+				),
+				title: translate( 'Remove free subscriber' ),
+		  }
+		: {
+				action: UnsubscribeActionType.Unsubscribe,
+				confirmButtonLabel: translate( 'Remove subscribers' ),
+				text: translate(
+					'Are you sure you want to remove %d subscibers from your list? They will no longer receive new notifications from your site.',
+					{
+						args: [ subscribers?.length as number ],
+						comment: '%d is the number of subscribers',
+					}
+				),
+				title: translate( 'Remove free subscribers' ),
+		  };
 
-	const paidSubscriberProps = {
-		action: UnsubscribeActionType.Manage,
-		confirmButtonLabel: translate( 'Manage paid subscribers' ),
-		text: translate(
-			'To remove %s from your list, you’ll need to cancel their paid subscription first.',
-			{
-				args: [ subscriber?.display_name as string ],
-				comment: "%s is the subscriber's public display name",
-			}
-		),
-		title: translate( 'Remove paid subscriber' ),
-	};
+	const paidSubscriberProps = isSingleSubscriber
+		? {
+				action: UnsubscribeActionType.Manage,
+				confirmButtonLabel: translate( 'Manage paid subscribers' ),
+				text: translate(
+					'To remove %s from your list, you’ll need to cancel their paid subscription first.',
+					{
+						args: [ subscriber?.display_name as string ],
+						comment: "%s is the subscriber's public display name",
+					}
+				),
+				title: translate( 'Remove paid subscriber' ),
+		  }
+		: {
+				action: UnsubscribeActionType.Manage,
+				confirmButtonLabel: translate( 'Manage paid subscribers' ),
+				text: translate(
+					'Some subscribers have paid subscriptions. To remove them from your list, you’ll need to cancel their paid subscription first.'
+				),
+				title: translate( 'Remove paid subscribers' ),
+		  };
 
-	const { action, confirmButtonLabel, text, title } = subscriberHasPlans
+	const { action, confirmButtonLabel, text, title } = someSubscriberHasPlans
 		? paidSubscriberProps
 		: freeSubscriberProps;
 
 	useEffect( () => {
 		if ( subscriber ) {
-			recordRemoveModal( subscriberHasPlans, 'modal_showed' );
+			recordRemoveModal( someSubscriberHasPlans, 'modal_showed' );
 		}
-	}, [ recordRemoveModal, subscriberHasPlans, subscriber ] );
+	}, [ recordRemoveModal, someSubscriberHasPlans, subscriber ] );
 
 	const onCancelClick = useCallback( () => {
-		recordRemoveModal( subscriberHasPlans, 'modal_dismissed' );
+		recordRemoveModal( someSubscriberHasPlans, 'modal_dismissed' );
 		onCancel();
-	}, [ subscriberHasPlans, onCancel ] );
+	}, [ someSubscriberHasPlans, onCancel ] );
 
 	return (
 		<ConfirmModal

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -102,9 +102,9 @@ const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModa
 	return (
 		<ConfirmModal
 			isVisible={ !! subscriber }
-			confirmButtonLabel={ confirmButtonLabel || undefined }
+			confirmButtonLabel={ confirmButtonLabel || '' }
 			text={ text }
-			title={ title || undefined }
+			title={ title || '' }
 			onCancel={ onCancelClick }
 			onConfirm={ () => onConfirm( action, subscribers ) }
 		/>

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -12,7 +12,7 @@ export enum UnsubscribeActionType {
 type UnsubscribeModalProps = {
 	subscribers?: Subscriber[];
 	onCancel: () => void;
-	onConfirm: ( action: UnsubscribeActionType, subscriber?: Subscriber ) => void;
+	onConfirm: ( action: UnsubscribeActionType, subscribers: Subscriber[] | undefined ) => void;
 };
 
 const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModalProps ) => {

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -92,7 +92,7 @@ const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModa
 			text={ text }
 			title={ title }
 			onCancel={ onCancelClick }
-			onConfirm={ () => onConfirm( action, subscriber ) }
+			onConfirm={ () => onConfirm( action, subscribers ) }
 		/>
 	);
 };

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, fixMe } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import ConfirmModal from 'calypso/components/confirm-modal';
 import { useRecordRemoveModal } from '../../tracks';
@@ -19,60 +19,7 @@ const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModa
 	const translate = useTranslate();
 	const subscriber = subscribers?.[ 0 ];
 	const someSubscriberHasPlans = !! subscribers?.some( ( subscriber ) => subscriber.plans?.length );
-	const isSingleSubscriber = subscribers?.length === 1;
 	const recordRemoveModal = useRecordRemoveModal();
-
-	const freeSubscriberProps = isSingleSubscriber
-		? {
-				action: UnsubscribeActionType.Unsubscribe,
-				confirmButtonLabel: translate( 'Remove subscriber' ),
-				text: translate(
-					'Are you sure you want to remove %s from your list? They will no longer receive new notifications from your site.',
-					{
-						args: [ subscriber?.display_name as string ],
-						comment: "%s is the subscriber's public display name",
-					}
-				),
-				title: translate( 'Remove free subscriber' ),
-		  }
-		: {
-				action: UnsubscribeActionType.Unsubscribe,
-				confirmButtonLabel: translate( 'Remove subscribers' ),
-				text: translate(
-					'Are you sure you want to remove %d subscibers from your list? They will no longer receive new notifications from your site.',
-					{
-						args: [ subscribers?.length as number ],
-						comment: '%d is the number of subscribers',
-					}
-				),
-				title: translate( 'Remove free subscribers' ),
-		  };
-
-	const paidSubscriberProps = isSingleSubscriber
-		? {
-				action: UnsubscribeActionType.Manage,
-				confirmButtonLabel: translate( 'Manage paid subscribers' ),
-				text: translate(
-					'To remove %s from your list, you’ll need to cancel their paid subscription first.',
-					{
-						args: [ subscriber?.display_name as string ],
-						comment: "%s is the subscriber's public display name",
-					}
-				),
-				title: translate( 'Remove paid subscriber' ),
-		  }
-		: {
-				action: UnsubscribeActionType.Manage,
-				confirmButtonLabel: translate( 'Manage paid subscribers' ),
-				text: translate(
-					'Some subscribers have paid subscriptions. To remove them from your list, you’ll need to cancel their paid subscription first.'
-				),
-				title: translate( 'Remove paid subscribers' ),
-		  };
-
-	const { action, confirmButtonLabel, text, title } = someSubscriberHasPlans
-		? paidSubscriberProps
-		: freeSubscriberProps;
 
 	useEffect( () => {
 		if ( subscriber ) {
@@ -85,12 +32,79 @@ const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModa
 		onCancel();
 	}, [ someSubscriberHasPlans, onCancel ] );
 
+	if ( ! subscribers || ! subscribers.length ) {
+		return null;
+	}
+
+	const freeSubscriberProps = {
+		action: UnsubscribeActionType.Unsubscribe,
+		confirmButtonLabel: fixMe( {
+			text: 'Remove subscribers',
+			newCopy: translate( 'Remove subscriber', 'Remove subscribers', {
+				count: subscribers.length,
+			} ),
+			oldCopy: translate( 'Remove subscriber' ),
+		} ),
+		text: translate(
+			'Are you sure you want to remove %(displayName)s from your list? They will no longer receive new notifications from your site.',
+			'Are you sure you want to remove %(numberOfSubscribers)d subscibers from your list? They will no longer receive new notifications from your site.',
+			{
+				count: subscribers.length,
+				args: {
+					displayName: subscriber?.display_name || '',
+					numberOfSubscribers: subscribers.length,
+				},
+			}
+		),
+		title: fixMe( {
+			text: 'Remove free subscribers',
+			newCopy: translate( 'Remove free subscriber', 'Remove free subscribers', {
+				count: subscribers.length,
+			} ),
+			oldCopy: translate( 'Remove free subscriber' ),
+		} ),
+	};
+
+	const paidSubscriberProps = {
+		action: UnsubscribeActionType.Manage,
+		confirmButtonLabel: fixMe( {
+			text: 'Manage paid subscribers',
+			newCopy: translate( 'Manage paid subscriber', 'Manage paid subscribers', {
+				count: subscribers.length,
+			} ),
+			oldCopy: translate( 'Manage paid subscriber' ),
+		} ),
+		// eslint-disable-next-line wpcalypso/i18n-mismatched-placeholders
+		text: translate(
+			'To remove %s from your list, you’ll need to cancel their paid subscription first.',
+			'Some subscribers have paid subscriptions. To remove them from your list, you’ll need to cancel their paid subscription first.',
+			{
+				count: subscribers.length,
+				args: {
+					displayName: subscriber?.display_name || '',
+					numberOfSubscribers: subscribers.length,
+				},
+			}
+		),
+		title: fixMe( {
+			text: 'Remove paid subscribers',
+			newCopy: translate( 'Remove paid subscriber', 'Remove paid subscribers', {
+				count: subscribers.length,
+			} ),
+			oldCopy: translate( 'Remove paid subscriber' ),
+		} ),
+	};
+
+	const { action, confirmButtonLabel, text, title } = someSubscriberHasPlans
+		? paidSubscriberProps
+		: freeSubscriberProps;
+
 	return (
 		<ConfirmModal
 			isVisible={ !! subscriber }
-			confirmButtonLabel={ confirmButtonLabel }
+			confirmButtonLabel={ confirmButtonLabel || undefined }
 			text={ text }
-			title={ title }
+			title={ title || undefined }
 			onCancel={ onCancelClick }
 			onConfirm={ () => onConfirm( action, subscribers ) }
 		/>

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -76,13 +76,12 @@ const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModa
 		} ),
 		// eslint-disable-next-line wpcalypso/i18n-mismatched-placeholders
 		text: translate(
-			'To remove %s from your list, you’ll need to cancel their paid subscription first.',
+			'To remove %(displayName)s from your list, you’ll need to cancel their paid subscription first.',
 			'Some subscribers have paid subscriptions. To remove them from your list, you’ll need to cancel their paid subscription first.',
 			{
 				count: subscribers.length,
 				args: {
 					displayName: subscriber?.display_name || '',
-					numberOfSubscribers: subscribers.length,
 				},
 			}
 		),

--- a/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
+++ b/client/my-sites/subscribers/components/unsubscribe-modal/unsubscribe-modal.tsx
@@ -104,7 +104,7 @@ const UnsubscribeModal = ( { subscribers, onCancel, onConfirm }: UnsubscribeModa
 			isVisible={ !! subscriber }
 			confirmButtonLabel={ confirmButtonLabel || '' }
 			text={ text }
-			title={ title || '' }
+			title={ ( title || '' ) as string }
 			onCancel={ onCancelClick }
 			onConfirm={ () => onConfirm( action, subscribers ) }
 		/>

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -27,15 +27,19 @@ const useUnsubscribeModal = (
 		setCurrentSubscribers( undefined );
 	};
 
-	const onConfirmModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
+	const onConfirmModal = ( action: UnsubscribeActionType, subscribers?: Subscriber[] ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
 			recordRemoveModal( true, 'manage_button_clicked' );
 			const link = isJetpackCloud()
 				? `/monetize/supporters/${ selectedSiteSlug }`
 				: `/earn/supporters/${ selectedSiteSlug }`;
 			navigate( link ?? '' );
-		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
-			mutate( currentSubscribers, {
+		} else if (
+			action === UnsubscribeActionType.Unsubscribe &&
+			subscribers &&
+			subscribers.length
+		) {
+			mutate( subscribers, {
 				onSuccess: () => {
 					resetSubscribers();
 					onSuccess?.();

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -35,7 +35,7 @@ const useUnsubscribeModal = (
 				: `/earn/supporters/${ selectedSiteSlug }`;
 			navigate( link ?? '' );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
-			mutate( subscriber, {
+			mutate( currentSubscribers, {
 				onSuccess: () => {
 					resetSubscribers();
 					onSuccess?.();

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -14,17 +14,17 @@ const useUnsubscribeModal = (
 	detailsView = false,
 	onSuccess?: () => void
 ) => {
-	const [ currentSubscriber, setCurrentSubscriber ] = useState< Subscriber >();
+	const [ currentSubscribers, setCurrentSubscribers ] = useState< Subscriber[] >();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const recordRemoveModal = useRecordRemoveModal();
 	const { mutate } = useSubscriberRemoveMutation( siteId, subscriberQueryParams, detailsView );
 
-	const onClickUnsubscribe = ( subscriber: Subscriber ) => {
-		setCurrentSubscriber( subscriber );
+	const onSetUnsubscribers = ( subscribers: Subscriber[] ) => {
+		setCurrentSubscribers( subscribers );
 	};
 
-	const resetSubscriber = () => {
-		setCurrentSubscriber( undefined );
+	const resetSubscribers = () => {
+		setCurrentSubscribers( undefined );
 	};
 
 	const onConfirmModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
@@ -37,25 +37,25 @@ const useUnsubscribeModal = (
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
 			mutate( subscriber, {
 				onSuccess: () => {
-					resetSubscriber();
+					resetSubscribers();
 					onSuccess?.();
 				},
 			} );
 		}
 
-		resetSubscriber();
+		resetSubscribers();
 	};
 
 	// Reset current subscriber on unmount
 	useEffect( () => {
-		return resetSubscriber;
+		return resetSubscribers;
 	}, [] );
 
 	return {
-		currentSubscriber,
-		onClickUnsubscribe,
+		currentSubscribers,
+		onSetUnsubscribers,
 		onConfirmModal,
-		resetSubscriber,
+		resetSubscribers,
 	};
 };
 

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -44,6 +44,13 @@ const useSubscriberRemoveMutation = (
 				);
 			}
 
+			if ( subscribers.length > 100 ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'The maximum number of subscribers you can remove at once is 100.'
+				);
+			}
+
 			const subscriberPromises = subscribers.map( async ( subscriber ) => {
 				if ( subscriber.plans?.length ) {
 					// unsubscribe this user from all plans

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -36,61 +36,81 @@ const useSubscriberRemoveMutation = (
 	} );
 
 	return useMutation( {
-		mutationFn: async ( subscriber: Subscriber ) => {
-			if ( ! siteId || ! subscriber ) {
+		mutationFn: async ( subscribers: Subscriber[] ) => {
+			if ( ! siteId || ! subscribers || ! subscribers.length ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
 					'Something went wrong while unsubscribing.'
 				);
 			}
 
-			if ( subscriber.plans?.length ) {
-				// unsubscribe this user from all plans
-				const promises = subscriber.plans.map( ( plan ) =>
-					wpcom.req.post(
-						`/sites/${ siteId }/memberships/subscriptions/${ plan.paid_subscription_id }/cancel`,
-						{
-							user_id: subscriber.user_id,
-						}
-					)
-				);
-
-				await Promise.all( promises );
-			}
-
-			let wasRemoved = false;
-
-			// Remove the subscriber from the followers and email followers because they may be both of them.
-			if ( subscriber.user_id ) {
-				try {
-					await wpcom.req.post( `/sites/${ siteId }/followers/${ subscriber.user_id }/delete` );
-					wasRemoved = true;
-				} catch ( e ) {
-					// Only throw if subscription_id is empty.
-					if ( ( e as ApiResponseError )?.error === 'not_found' && ! subscriber.subscription_id ) {
-						throw new Error( ( e as ApiResponseError )?.message );
-					}
-				}
-			}
-
-			// Always try to remove as email follower if they have a subscription_id.
-			if ( subscriber.subscription_id ) {
-				try {
-					await wpcom.req.post(
-						`/sites/${ siteId }/email-followers/${ subscriber.subscription_id }/delete`
+			const subscriberPromises = subscribers.map( async ( subscriber ) => {
+				if ( subscriber.plans?.length ) {
+					// unsubscribe this user from all plans
+					const promises = subscriber.plans.map( ( plan ) =>
+						wpcom.req.post(
+							`/sites/${ siteId }/memberships/subscriptions/${ plan.paid_subscription_id }/cancel`,
+							{
+								user_id: subscriber.user_id,
+							}
+						)
 					);
-					wasRemoved = true;
-				} catch ( e ) {
-					// Only throw if we haven't successfully removed them through any other method.
-					if ( ! wasRemoved ) {
-						throw new Error( ( e as ApiResponseError )?.message );
+
+					await Promise.all( promises );
+				}
+
+				let wasRemoved = false;
+
+				// Remove the subscriber from the followers and email followers because they may be both of them.
+				if ( subscriber.user_id ) {
+					try {
+						await wpcom.req.post( `/sites/${ siteId }/followers/${ subscriber.user_id }/delete` );
+						wasRemoved = true;
+					} catch ( e ) {
+						// Only throw if subscription_id is empty.
+						if (
+							( e as ApiResponseError )?.error === 'not_found' &&
+							! subscriber.subscription_id
+						) {
+							throw new Error( ( e as ApiResponseError )?.message );
+						}
 					}
 				}
-			}
 
-			return wasRemoved;
+				// Always try to remove as email follower if they have a subscription_id.
+				if ( subscriber.subscription_id ) {
+					try {
+						await wpcom.req.post(
+							`/sites/${ siteId }/email-followers/${ subscriber.subscription_id }/delete`
+						);
+						wasRemoved = true;
+					} catch ( e ) {
+						// Only throw if we haven't successfully removed them through any other method.
+						if ( ! wasRemoved ) {
+							throw new Error( ( e as ApiResponseError )?.message );
+						}
+					}
+				}
+
+				return wasRemoved;
+			} );
+			const promiseResults = await Promise.allSettled( subscriberPromises );
+			if (
+				promiseResults.every( ( promiseResults ) => {
+					return promiseResults.status === 'fulfilled' && promiseResults.value === true;
+				} )
+			) {
+				return true;
+			}
+			const errorPromise = promiseResults.find( ( promiseResult ) => {
+				return promiseResult.status === 'rejected';
+			} );
+			if ( errorPromise ) {
+				throw new Error( errorPromise.reason );
+			}
+			return false;
 		},
-		onMutate: async ( subscriber ) => {
+		onMutate: async ( subscribers ) => {
 			// Cancel any outgoing refetches
 			await queryClient.cancelQueries( { queryKey: [ 'subscribers', siteId ] } );
 
@@ -102,9 +122,11 @@ const useSubscriberRemoveMutation = (
 				// Update the current page data
 				const updatedData = {
 					...previousData,
-					subscribers: previousData.subscribers.filter(
-						( s ) => s.subscription_id !== subscriber.subscription_id
-					),
+					subscribers: previousData.subscribers.filter( ( s ) => {
+						return ! subscribers.some(
+							( subscriber ) => s.subscription_id === subscriber.subscription_id
+						);
+					} ),
 					total: previousData.total - 1,
 					pages: Math.ceil( ( previousData.total - 1 ) / previousData.per_page ),
 				};
@@ -130,14 +152,16 @@ const useSubscriberRemoveMutation = (
 			// Handle subscriber details cache if needed
 			let previousDetailsData;
 			if ( invalidateDetailsCache ) {
-				const detailsCacheKey = getSubscriberDetailsCacheKey(
-					siteId,
-					subscriber.subscription_id,
-					subscriber.user_id,
-					getSubscriberDetailsType( subscriber.user_id )
-				);
-				await queryClient.cancelQueries( { queryKey: detailsCacheKey } );
-				previousDetailsData = queryClient.getQueryData< Subscriber >( detailsCacheKey );
+				for ( const subscriber of subscribers ) {
+					const detailsCacheKey = getSubscriberDetailsCacheKey(
+						siteId,
+						subscriber.subscription_id,
+						subscriber.user_id,
+						getSubscriberDetailsType( subscriber.user_id )
+					);
+					await queryClient.cancelQueries( { queryKey: detailsCacheKey } );
+					previousDetailsData = queryClient.getQueryData< Subscriber >( detailsCacheKey );
+				}
 			}
 
 			return {
@@ -161,25 +185,29 @@ const useSubscriberRemoveMutation = (
 				queryClient.setQueryData( detailsCacheKey, context.previousDetailsData );
 			}
 		},
-		onSuccess: ( data, subscriber ) => {
-			recordSubscriberRemoved( {
-				site_id: siteId,
-				subscription_id: subscriber.subscription_id,
-				user_id: subscriber.user_id,
-			} );
+		onSuccess: ( data, subscribers ) => {
+			for ( const subscriber of subscribers ) {
+				recordSubscriberRemoved( {
+					site_id: siteId,
+					subscription_id: subscriber.subscription_id,
+					user_id: subscriber.user_id,
+				} );
+			}
 		},
-		onSettled: ( data, error, subscriber ) => {
-			// Invalidate all subscriber queries to ensure consistency
-			queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
+		onSettled: ( data, error, subscribers ) => {
+			for ( const subscriber of subscribers ) {
+				// Invalidate all subscriber queries to ensure consistency
+				queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
 
-			if ( invalidateDetailsCache ) {
-				const detailsCacheKey = getSubscriberDetailsCacheKey(
-					siteId,
-					subscriber.subscription_id,
-					subscriber.user_id,
-					getSubscriberDetailsType( subscriber.user_id )
-				);
-				queryClient.invalidateQueries( { queryKey: detailsCacheKey } );
+				if ( invalidateDetailsCache ) {
+					const detailsCacheKey = getSubscriberDetailsCacheKey(
+						siteId,
+						subscriber.subscription_id,
+						subscriber.user_id,
+						getSubscriberDetailsType( subscriber.user_id )
+					);
+					queryClient.invalidateQueries( { queryKey: detailsCacheKey } );
+				}
 			}
 		},
 	} );


### PR DESCRIPTION
This PR adds support for bulk subscriber management.
For now, only the remove subscriber action has bulk support but we can expand that later.
This change makes the subscribers list more consistent with what happens with other data-views e.g.: the core ones, that support bulk actions.

It also opens the door for some nice user interactions, e.g.: I can easily apply a filter for example free subscribers, and then select all records to apply an action (remove) instead of going one by one.

## Screenshots

<img width="1382" alt="Screenshot 2025-03-07 at 14 48 17" src="https://github.com/user-attachments/assets/74fb76dd-755c-4f30-bcdc-448aff455a28" />
<img width="1376" alt="Screenshot 2025-03-07 at 14 48 08" src="https://github.com/user-attachments/assets/8a7833ea-ea29-4ce3-8c72-3739dbf09f75" />


## Testing Instructions

Go to http://calypso.localhost:3000/subscribers/site.
Select multiple subscribers and verify they can all be removed at once.
Use the select all checkbox and verify it works.
Verify it is still possible to switch to the details view and navigate the records there.
Verify removing subscribers from the details view still works as expected.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
