### PR TITLE
Reader Editor: Add overflow visible for site dropdown

### DIFF
--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -73,6 +73,12 @@
 	}
 }
 
+.following-stream__quick-post-card.card.is-expanded {
+	.foldable-card__content {
+		overflow: visible;
+	}
+}
+
 .following-stream__quick-post-card.card.is-compact {
 	margin-bottom: 20px !important;
 	border-radius: 6px; /* stylelint-disable-line scales/radii */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/560

## Proposed Changes

* Add overflow visible style to the Reader Editor foldable-card when it's expanded.

Before | After
--|--
<img width="581" alt="Screenshot 2025-03-07 at 10 01 55 AM" src="https://github.com/user-attachments/assets/b19d98ff-c23d-4825-8b89-d70f6ea508fb" />  | <img width="594" alt="Screenshot 2025-03-07 at 10 01 06 AM" src="https://github.com/user-attachments/assets/0f274ee6-c5f9-4e20-8916-2a182ef51c7b" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /reader and open the Reader Editor
* Click to select a site. The drop-down should not be cut off.
  * Note: The select a site drop-down height is relative to your browser window's height. So make sure your browser window is full screen to ensure you see the cutoff in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
