### PR TITLE
Stats: Use page.redirect() for query update without history

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -317,7 +317,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 			if ( ! tab.loading && tab.attr !== chartTab ) {
 				dispatch( recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' ) );
 				// switch the tab by navigating to route with updated query string
-				page.show( getPathWithUpdatedQueryString( { tab: tab.attr } ) );
+				page.redirect( getPathWithUpdatedQueryString( { tab: tab.attr } ) );
 			}
 		},
 		[ chartTab, dispatch ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2183

## Proposed Changes

* Use `page.redirect()` for query update without history to avoid the `Return` action going through the chart tab route.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The chart tab changes should not be recorded for the chart `Return` action paths.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Choose the `Last 12 months` date range.
* Click on any of the months.
* Select the `Visitors` chart tab.
* Click on the `Return` action before the date range title.
* Ensure the chart goes back to the `Last 12 months` date range rather than the `Views` chart tab.

https://github.com/user-attachments/assets/4bb20963-b596-489a-b2b3-9a8f0beb10ca

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
