### PR TITLE
Update security social login copy to avoid text orphan

### DIFF
--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -47,8 +47,7 @@ class SocialLogin extends Component {
 
 				<CompactCard>
 					{ translate(
-						'You’ll be able to log in faster by linking your WordPress.com account with the following ' +
-							'third-party services. We’ll never post without your permission.'
+						'Log in faster with the accounts you already use. We’ll never post without your permission.'
 					) }
 				</CompactCard>
 

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -45,7 +45,7 @@ class SocialLogin extends Component {
 					</Notice>
 				) }
 
-				<CompactCard>
+				<CompactCard className="social-login__description">
 					{ translate(
 						'Log in faster with the accounts you already use. We’ll never post without your permission.'
 					) }

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -46,9 +46,7 @@ class SocialLogin extends Component {
 				) }
 
 				<CompactCard className="social-login__description">
-					{ translate(
-						'Log in faster with the accounts you already use. We’ll never post without your permission.'
-					) }
+					{ translate( 'Log in faster with the accounts you already use.' ) }
 				</CompactCard>
 
 				<SocialLoginService service="google" icon={ <GoogleIcon /> } />

--- a/client/me/social-login/style.scss
+++ b/client/me/social-login/style.scss
@@ -49,3 +49,6 @@
 		max-width: 200px;
 	}
 }
+.social-login__description {
+	text-wrap: balance;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Fixes https://github.com/Automattic/wp-calypso/issues/100374

## Proposed Changes

* Update text in `/me/security/social-login` to avoid text orphan.
* It adds the CSS `text-wrap: balance;` to avoid making orphans in different resolutions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It was identified as code blue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn && yarn start` or try it in Calypso Live link
* Access `/me/security/social-login`
* Observe the new copy

<img width="620" alt="Screenshot 2025-03-07 at 18 28 30" src="https://github.com/user-attachments/assets/5e699a00-3626-44ec-8d8f-f1d9ef2cdf92" />
<img width="837" alt="Screenshot 2025-03-07 at 18 29 02" src="https://github.com/user-attachments/assets/b8d1d544-2c96-478b-a940-3c3a4f9d702a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
