### PR TITLE
Stats: Display the chart bar ratio number only when it is finite

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -194,6 +194,10 @@ function addTooltipData( chartTab, item, period, customRange = {} ) {
 					className: 'is-visitors',
 					icon: <Icon className="gridicon" icon={ people } />,
 				} );
+			}
+
+			// Ensure the Views/Visitors ratio number is finite.
+			if ( item.data.visitors > 0 ) {
 				tooltipData.push( {
 					label: translate( 'Views Per Visitor' ),
 					value: numberFormat( item.data.views / item.data.visitors, { decimals: 2 } ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Ensure the `Views/Visitors` ratio number is finite before displaying it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `NaN` value should not display on the chart tooltip.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure the chart bars do not display `NaN` on the tooltip.

|Before|After|
|-|-|
|<img width="496" alt="截圖 2025-03-08 凌晨1 06 09" src="https://github.com/user-attachments/assets/7744faa0-52e9-4685-b6a9-bd59a455816f" />|<img width="496" alt="截圖 2025-03-08 凌晨1 10 02" src="https://github.com/user-attachments/assets/7dbb4964-e653-435e-b9a9-07dc52b07ec7" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
