### PR TITLE
Remove subtitle from Jetpack connection screen as it adds nothing to the heading when the setup is completing

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -245,7 +245,7 @@ export class AuthFormHeader extends Component {
 				return translate( 'Your new plan requires a connection to WordPress.com' );
 			case 'logged-in':
 			default:
-				return translate( 'Jetpack is finishing setup' );
+				return undefined;
 		}
 	}
 


### PR DESCRIPTION
Fixes #100105

### After

<img width="491" alt="image" src="https://github.com/user-attachments/assets/a65c7d15-e74e-4372-800e-6bcbd52c9f48" />


### Before

<img width="546" alt="image" src="https://github.com/user-attachments/assets/494de4d7-f184-4247-ab8e-58a89152b424" />


## Proposed Changes

* Removes subtitle from Jetpack connection screen as it adds nothing to the heading when the setup is completing. The subtitle repeats the copy in the main title and can be removed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Identified as necessary task in the context of p58i-kb4-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?