### PR TITLE
Fixing e2e test after a component name change

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/post-carousel.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/post-carousel.ts
@@ -1,12 +1,12 @@
 import { BlockFlow } from '.';
 
-const blockParentSelector = '[aria-label="Block: Post Carousel"]';
+const blockParentSelector = '[aria-label="Block: Content Carousel"]';
 
 /**
  * Class representing the flow of using a Newspack Blog Posts block in the editor
  */
 export class PostCarouselBlockFlow implements BlockFlow {
-	blockSidebarName = 'Post Carousel';
+	blockSidebarName = 'Content Carousel';
 	blockEditorSelector = blockParentSelector;
 
 	// We are very limited in what we can safely smoke test with the Post Carousel block because it is dependent on other posts.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Gutenberg 20.0.4 release: p1741352097599229/1740665285.421309-slack-CBTN58FTJ

### How to test

Run the `specs/blocks/blocks__etk.ts` 2e2 test: `yarn workspace wp-e2e-tests test -- specs/blocks/blocks__etk.ts` and ensure it's passing.
