### PR TITLE
Add trailing periods to descriptions in Add new site menu for the a4a version

### DIFF
--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -65,7 +65,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					icon={ <WordPressLogo /> }
 					heading={ translate( 'Via WordPress.com connection' ) }
 					description={ preventWidows(
-						translate( 'Import connected WordPress.com or Jetpack sites' )
+						translate( 'Import connected WordPress.com or Jetpack sites.' )
 					) }
 					buttonProps={ {
 						onClick: () => {
@@ -77,7 +77,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					icon={ <A4ALogo /> }
 					heading={ translate( 'Via the Automattic plugin' ) }
 					description={ preventWidows(
-						translate( 'Connect with the Automattic for Agencies plugin' )
+						translate( 'Connect with the Automattic for Agencies plugin.' )
 					) }
 					buttonProps={ {
 						onClick: () => {
@@ -89,7 +89,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 					icon={ <JetpackLogo /> }
 					heading={ translate( 'Via the Jetpack plugin' ) }
 					description={ preventWidows(
-						translate( 'Install the Jetpack plugin on an existing site' )
+						translate( 'Install the Jetpack plugin on an existing site.' )
 					) }
 					buttonProps={ {
 						onClick: () => {


### PR DESCRIPTION
Fixes #100101
### After
<img width="924" alt="image" src="https://github.com/user-attachments/assets/e0591e44-3b55-4c98-9ab6-693c619b46c8" />


### Before
<img width="920" alt="image" src="https://github.com/user-attachments/assets/86d3a9ea-1ae9-4be9-90b7-cdc93b80cbac" />




## Proposed Changes

* Adds trailing period to item descriptions. Related to #101010

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Identified as necessary task in the context of p58i-kb4-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?