### PR TITLE
Refactor MigrationStartedDIFM to use individual components

### DIFF
--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -7,10 +7,8 @@ type MigrationStartedListProps = {
 	children: ReactElement< MigrationStartedItemProps > | ReactElement< MigrationStartedItemProps >[];
 };
 
-type IconType = Parameters< typeof Icon >[ 0 ][ 'icon' ];
-
 type MigrationStartedItemProps = {
-	icon: IconType;
+	icon: Parameters< typeof Icon >[ 0 ][ 'icon' ];
 	text: string;
 };
 

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -1,6 +1,31 @@
 import { globe, group, Icon, scheduled, envelope } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { ReactElement } from 'react';
 import { Container, Header } from './layout';
+
+type MigrationStartedListProps = {
+	children: ReactElement< MigrationStartedItemProps > | ReactElement< MigrationStartedItemProps >[];
+};
+
+type IconType = Parameters< typeof Icon >[ 0 ][ 'icon' ];
+
+type MigrationStartedItemProps = {
+	icon: IconType;
+	text: string;
+};
+
+const MigrationStartedList = ( { children }: MigrationStartedListProps ) => (
+	<ul className="migration-started-difm__list">{ children }</ul>
+);
+
+const MigrationStartedItem = ( { icon, text }: MigrationStartedItemProps ) => (
+	<li className="migration-started-difm__item">
+		<div className="migration-started-difm__icon-wrapper">
+			<Icon icon={ icon } className="migration-started-difm__icon" size={ 30 } />
+		</div>
+		<span>{ text }</span>
+	</li>
+);
 
 export const MigrationStartedDIFM = () => {
 	const translate = useTranslate();
@@ -15,48 +40,32 @@ export const MigrationStartedDIFM = () => {
 			<Header title={ title } subTitle={ subTitle } />
 			<div className="migration-started-difm">
 				<h2 className="migration-started-difm__title">{ translate( 'What to expect' ) }</h2>
-				<ul className="migration-started-difm__list">
-					<li className="migration-started-difm__item">
-						<div className="migration-started-difm__icon-wrapper">
-							<Icon icon={ envelope } className="migration-started-difm__icon" size={ 30 } />
-						</div>
-						<span>
-							{ translate(
-								"We'll send you an email with more details on the process and we'll let you know when we start the migration."
-							) }
-						</span>
-					</li>
-					<li className="migration-started-difm__item">
-						<div className="migration-started-difm__icon-wrapper">
-							<Icon icon={ group } className="migration-started-difm__icon" size={ 30 } />
-						</div>
-						<span>
-							{ translate(
-								"We'll bring over a copy of your site, without affecting the current live version."
-							) }
-						</span>
-					</li>
-					<li className="migration-started-difm__item">
-						<div className="migration-started-difm__icon-wrapper">
-							<Icon icon={ scheduled } className="migration-started-difm__icon" size={ 30 } />
-						</div>
-						<span>
-							{ translate(
-								"You'll get an update on the progress of your migration within 2-3 business days."
-							) }
-						</span>
-					</li>
-					<li className="migration-started-difm__item">
-						<div className="migration-started-difm__icon-wrapper">
-							<Icon icon={ globe } className="migration-started-difm__icon" size={ 30 } />
-						</div>
-						<span>
-							{ translate(
-								"We'll help you switch your domain over after the migration's completed."
-							) }
-						</span>
-					</li>
-				</ul>
+				<MigrationStartedList>
+					<MigrationStartedItem
+						icon={ envelope }
+						text={ translate(
+							"We'll send you an email with more details on the process and we'll let you know when we start the migration."
+						) }
+					/>
+					<MigrationStartedItem
+						icon={ group }
+						text={ translate(
+							"We'll bring over a copy of your site, without affecting the current live version."
+						) }
+					/>
+					<MigrationStartedItem
+						icon={ scheduled }
+						text={ translate(
+							"You'll get an update on the progress of your migration within 2-3 business days."
+						) }
+					/>
+					<MigrationStartedItem
+						icon={ globe }
+						text={ translate(
+							"We'll help you switch your domain over after the migration's completed."
+						) }
+					/>
+				</MigrationStartedList>
 			</div>
 		</Container>
 	);


### PR DESCRIPTION
We've moved the ul and li into MigrationStartedList and MigrationStartedItem, respectively.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100943
Related to #100786

## Proposed Changes

This refactors the previous `<ul>` and `<li>` code into local components.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This makes the markup cleaner and easier to modify. We may also be able to leverage these components in other places.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual inspection and no build errors should be sufficient.

If you do want to test manually, follow the instructions in https://github.com/Automattic/wp-calypso/pull/100786.

Once you get to `/sites/overview/:siteSlug`, it should still look like this:

![image](https://github.com/user-attachments/assets/4c4053bd-e4c8-4703-b5c7-ab78b490cb9c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
