### PR TITLE
DIFM: adds the help center link to the difmStartingPoint step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -6,6 +6,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
 import HelpCenterStepButton from 'calypso/signup/help-center-step-button';
+import useShouldRenderHelpCenterButton from 'calypso/signup/help-center-step-button/use-should-render-help-center-button';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import type { Step } from '../../types';
 import type { AppState } from 'calypso/types';
@@ -21,6 +22,8 @@ const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 	const queryParams = new URLSearchParams( window?.location.search );
 	const flags = queryParams.get( 'flags' )?.split( ',' );
 	const isHelpCenterLinkEnabled = flags?.includes( 'signup/help-center-link' );
+
+	const shouldRenderHelpCenterLink = useShouldRenderHelpCenterButton( { enabledGeos: [ 'US' ] } );
 
 	const onSubmit = ( value: string ) => {
 		submit?.( {
@@ -38,7 +41,10 @@ const DIFMStartingPoint: Step = function ( { navigation, flow } ) {
 				isHorizontalLayout
 				isWideLayout
 				isLargeSkipLayout={ false }
-				skipLabelText={ translate( 'No Thanks, I’ll Build It' ) }
+				skipLabelText={
+					shouldRenderHelpCenterLink ? undefined : translate( 'No Thanks, I’ll Build It' )
+				}
+				hideSkip={ shouldRenderHelpCenterLink }
 				customizedActionButtons={
 					isHelpCenterLinkEnabled ? (
 						<HelpCenterStepButton

--- a/client/signup/help-center-step-button/index.tsx
+++ b/client/signup/help-center-step-button/index.tsx
@@ -1,6 +1,6 @@
 import { HelpCenterInlineButton } from '@automattic/help-center';
 import { useTranslate } from 'i18n-calypso';
-import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
+import useShouldRenderHelpCenterButton from './use-should-render-help-center-button';
 import type { FC } from 'react';
 
 interface HelpCenterStepButtonProps {
@@ -18,9 +18,9 @@ const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const { data: geoData } = useGeoLocationQuery();
+	const shouldRenderHelpCenterButton = useShouldRenderHelpCenterButton( { enabledGeos } );
 
-	if ( ! geoData?.country_short || ! enabledGeos?.includes( geoData.country_short ) ) {
+	if ( ! shouldRenderHelpCenterButton ) {
 		return null;
 	}
 

--- a/client/signup/help-center-step-button/use-should-render-help-center-button.ts
+++ b/client/signup/help-center-step-button/use-should-render-help-center-button.ts
@@ -1,0 +1,15 @@
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
+
+export default function useShouldRenderHelpCenterButton( {
+	enabledGeos,
+}: {
+	enabledGeos?: string[];
+} ) {
+	const { data: geoData } = useGeoLocationQuery();
+
+	if ( ! geoData?.country_short || ! enabledGeos?.includes( geoData.country_short ) ) {
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-31k-p2#comment-3022

## Proposed Changes

* If the help center is enabled, replaces the "No Thanks, I’ll Build It" skip link with the Help Center link.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pdh1Xd-31k-p2#comment-3022

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a US geo and go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>&flags=signup/help-center-link`.
* Confirm that you see the help center link.
<img width="1875" alt="image" src="https://github.com/user-attachments/assets/2e56cc58-e37b-4de7-89c8-5053d445f656" />

* Switch to a non-US geo and go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>&flags=signup/help-center-link`.
* Confirm that you see the "No Thanks, I’ll Build It" skip link.
<img width="1731" alt="image" src="https://github.com/user-attachments/assets/d0ade89b-e0e5-4215-aaf8-36a00728568a" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?