### PR TITLE
Purchases: Update VAT tax info support contact link

### DIFF
--- a/client/me/purchases/vat-info/style.scss
+++ b/client/me/purchases/vat-info/style.scss
@@ -18,6 +18,14 @@
 .vat-info__sidebar-paragraph {
 	margin-bottom: 0;
 	font-size: 0.875rem;
+
+	.vat-info__open-help-center-support {
+		font-size: 0.875rem;
+		text-decoration: none;
+		&:hover, &:focus, &:active {
+			color: var( --color-link-dark );
+		}
+	}
 }
 
 .vat-info__sidebar-paragraph ul {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/wp-calypso/issues/100553

## Proposed Changes

* Update contact support link to open chat in the Help Center.

![CleanShot 2025-03-10 at 12 14 49@2x](https://github.com/user-attachments/assets/9e8a9b05-05ea-4d6a-8318-07f0b43c3ee1)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve support contact links behavior consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/me/purchases/vat-details` 
* Verify the `[Contact our Happiness Engineers](http://calypso.localhost:3000/help/contact).` button on the right side bar opens a new chat in the Help Center.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
