### PR TITLE
Jetpack Connect: Update copy on connection screen

### DIFF
--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useCallback } from 'react';
@@ -22,7 +21,6 @@ export default function JetpackConnectHelpButton( { label, url } ) {
 			rel="noopener noreferrer"
 			onClick={ recordClick }
 		>
-			<Gridicon icon="help-outline" size={ 18 } />{ ' ' }
 			{ label || translate( 'Get help setting up Jetpack' ) }
 		</LoggedOutFormLinkItem>
 	);

--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -63,7 +63,7 @@ class JetpackConnectMainHeader extends Component {
 		}
 
 		return {
-			title: translate( 'Set up Jetpack on your self-hosted WordPress' ),
+			title: translate( 'Set up Jetpack on your self-hosted WordPress site' ),
 			subtitle: translate(
 				"We'll be installing the Jetpack plugin so WordPress.com can communicate with " +
 					'your self-hosted WordPress site.'

--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -65,7 +65,7 @@ class JetpackConnectMainHeader extends Component {
 		return {
 			title: translate( 'Set up Jetpack on your self-hosted WordPress site' ),
 			subtitle: translate(
-				"We'll be installing the Jetpack plugin so WordPress.com can communicate with " +
+				'The Jetpack plugin will be installed so WordPress.com can communicate with ' +
 					'your self-hosted WordPress site.'
 			),
 		};

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -136,7 +136,7 @@ class JetpackConnectSiteUrlInput extends Component {
 
 		return (
 			<div>
-				<FormLabel htmlFor="siteUrl">{ translate( 'Site Address' ) }</FormLabel>
+				<FormLabel htmlFor="siteUrl">{ translate( 'Site address' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
 					<Gridicon size={ 24 } icon="globe" />
 					{ ! isSearch && (

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -139,6 +139,12 @@ $colophon-height: 50px;
 
 	.formatted-header {
 		text-align: center;
+
+		.formatted-header__title {
+			// To avoid wrapping of "self-hosted" in the title due
+			// to the behavior of text-wrap:balance with hyphens.
+			text-wrap: pretty;
+		}
 	}
 }
 

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -193,18 +193,6 @@ exports[`JetpackAuthorize renders as expected 1`] = `
             rel="noopener noreferrer"
             target="_blank"
           >
-            <svg
-              class="gridicon gridicons-help-outline needs-offset"
-              height="18"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <use
-                xlink:href="gridicons.svg#gridicons-help-outline"
-              />
-            </svg>
-             
             Get help setting up Jetpack
           </a>
         </div>

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -278,18 +278,6 @@ exports[`JetpackSignup should render 1`] = `
             rel="noopener noreferrer"
             target="_blank"
           >
-            <svg
-              class="gridicon gridicons-help-outline needs-offset"
-              height="18"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <use
-                xlink:href="gridicons.svg#gridicons-help-outline"
-              />
-            </svg>
-             
             Get help setting up Jetpack
           </a>
         </div>
@@ -577,18 +565,6 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
             rel="noopener noreferrer"
             target="_blank"
           >
-            <svg
-              class="gridicon gridicons-help-outline needs-offset"
-              height="18"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <use
-                xlink:href="gridicons.svg#gridicons-help-outline"
-              />
-            </svg>
-             
             Get help setting up Jetpack
           </a>
         </div>


### PR DESCRIPTION
Updates copy on Jetpack connection screen

Related to #100102


## Proposed Changes

* Add Missing "site" at the end of the title.
* Updates copy in jetpack subtitle so it's more assertive. From `We'll be installing the Jetpack plugin so WordPress.com can communicate with` to `The Jetpack plugin will be installed so WordPress.com can communicate with`.
* Removes help icon.
* Updates field label for site url to sentence casing,

### After

<img width="889" alt="image" src="https://github.com/user-attachments/assets/ee6609c1-28b0-420b-9e29-8ade885032d6" />


### Before

<img width="772" alt="image" src="https://github.com/user-attachments/assets/42e9eec3-cf0e-4788-bf4e-b47c6beca6e7" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Adds missing "site" at the end of the title to read "Set up Jetpack on your self-hosted WordPress site"
* Update the casing for the field label sot it maches the casing in title to be sentence casing.
 
Identified as necessary task in the context of p58i-kb4-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?