### PR TITLE
Sites Dashboard: Sync checklist progress with the dashboard checklist

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad.ts
+++ b/client/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad.ts
@@ -13,27 +13,18 @@ import type { AppState } from 'calypso/types';
 interface UseLaunchpadProps {
 	checklistSlug: string;
 	launchpadContext: string;
-	siteId?: number;
 }
 
-export function useMyHomeCardLaunchpad( {
-	checklistSlug,
-	launchpadContext,
-	siteId: providedSiteId,
-}: UseLaunchpadProps ) {
+export function useMyHomeCardLaunchpad( { checklistSlug, launchpadContext }: UseLaunchpadProps ) {
 	const translate = useTranslate();
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const effectiveSiteId = providedSiteId || selectedSiteId;
-	const siteSlug = useSelector(
-		( state: AppState ) => getSiteSlug( state, effectiveSiteId ) || ''
-	);
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) || '' );
 
 	const { mutate: dismiss } = useLaunchpadDismisser( siteSlug, checklistSlug, launchpadContext );
 
 	const {
 		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
 		refetch,
-		isLoading,
 	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
 
 	const numberOfSteps = checklist?.length || 0;
@@ -60,6 +51,5 @@ export function useMyHomeCardLaunchpad( {
 		temporaryDismiss,
 		permanentDismiss,
 		refetch,
-		isLoading,
 	};
 }

--- a/client/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad.ts
+++ b/client/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad.ts
@@ -13,18 +13,27 @@ import type { AppState } from 'calypso/types';
 interface UseLaunchpadProps {
 	checklistSlug: string;
 	launchpadContext: string;
+	siteId?: number;
 }
 
-export function useMyHomeCardLaunchpad( { checklistSlug, launchpadContext }: UseLaunchpadProps ) {
+export function useMyHomeCardLaunchpad( {
+	checklistSlug,
+	launchpadContext,
+	siteId: providedSiteId,
+}: UseLaunchpadProps ) {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) || '' );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const effectiveSiteId = providedSiteId || selectedSiteId;
+	const siteSlug = useSelector(
+		( state: AppState ) => getSiteSlug( state, effectiveSiteId ) || ''
+	);
 
 	const { mutate: dismiss } = useLaunchpadDismisser( siteSlug, checklistSlug, launchpadContext );
 
 	const {
 		data: { checklist, is_dismissed: isDismissed, is_dismissible: isDismissible, title },
 		refetch,
+		isLoading,
 	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
 
 	const numberOfSteps = checklist?.length || 0;
@@ -51,5 +60,6 @@ export function useMyHomeCardLaunchpad( { checklistSlug, launchpadContext }: Use
 		temporaryDismiss,
 		permanentDismiss,
 		refetch,
+		isLoading,
 	};
 }

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -74,7 +74,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const {
 		data: { checklist },
 		isLoading,
-	} = useLaunchpad( site.ID, checklistSlug, undefined, 'sites-dashboard' );
+	} = useLaunchpad( site.slug, checklistSlug, undefined, 'sites-dashboard' );
 
 	if ( 'unlaunched' !== site.launch_status || ! checklist || isLoading ) {
 		return null;

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,9 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CircularProgressBar } from '@automattic/components';
+import { useLaunchpad } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useInView } from 'react-intersection-observer';
-import { useMyHomeCardLaunchpad } from 'calypso/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad';
 import { getDashboardUrl } from '../utils';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -71,15 +71,17 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 
 	const checklistSlug = site?.options?.site_intent || 'legacy-site-setup';
 
-	const { numberOfSteps, completedSteps, hasChecklist, isLoading } = useMyHomeCardLaunchpad( {
-		checklistSlug,
-		launchpadContext: 'sites-dashboard',
-		siteId: site.ID,
-	} );
+	const {
+		data: { checklist },
+		isLoading,
+	} = useLaunchpad( site.ID, checklistSlug, undefined, 'sites-dashboard' );
 
-	if ( 'unlaunched' !== site.launch_status || ! hasChecklist || isLoading ) {
+	if ( 'unlaunched' !== site.launch_status || ! checklist || isLoading ) {
 		return null;
 	}
+
+	const numberOfSteps = checklist.length || 0;
+	const completedSteps = ( checklist.filter( ( task ) => task.completed ) || [] ).length;
 
 	const link = getDashboardUrl( site.slug );
 	const text = __( 'Checklist' );

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -17,7 +17,6 @@ const SiteLaunchDonutContainer = styled.div( {
 	alignItems: 'center',
 	justifyContent: 'center',
 	flexShrink: 0,
-	height: '25px',
 	width: '25px',
 	zIndex: 0,
 } );

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -63,18 +63,34 @@ const recordNagView = () => {
 	recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_inview' );
 };
 
+const getChecklistSlug = ( site: SiteExcerptData ) => {
+	const intent = site.options?.site_intent;
+	const flow = site.options?.site_creation_flow;
+
+	if ( ! intent ) {
+		return 'legacy-site-setup';
+	}
+
+	const isHostedSite =
+		'host-site' === intent || 'new-hosted-site' === flow || 'import-hosted-site' === flow;
+
+	if ( isHostedSite && ! site?.is_wpcom_atomic ) {
+		return 'legacy-site-setup';
+	}
+
+	return intent;
+};
+
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const { __ } = useI18n();
 	const { ref } = useInView( {
 		onChange: ( inView ) => inView && recordNagView(),
 	} );
 
-	const checklistSlug = site?.options?.site_intent || 'legacy-site-setup';
-
 	const {
 		data: { checklist },
 		isLoading,
-	} = useLaunchpad( site.slug, checklistSlug, undefined, 'sites-dashboard' );
+	} = useLaunchpad( site.slug, getChecklistSlug( site ), undefined, 'sites-dashboard' );
 
 	if ( 'unlaunched' !== site.launch_status || ! checklist || isLoading ) {
 		return null;

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,7 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { CircularProgressBar } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useInView } from 'react-intersection-observer';
+import { useMyHomeCardLaunchpad } from 'calypso/my-sites/customer-home/cards/launchpad/use-my-home-card-launchpad';
 import { getDashboardUrl } from '../utils';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -9,29 +11,20 @@ interface SiteLaunchNagProps {
 	site: SiteExcerptData;
 }
 
-const SiteLaunchDonutBase = styled.svg( {
-	position: 'absolute',
-	top: 0,
-	left: 0,
-	bottom: 0,
-	right: 0,
-} );
-
-const SiteLaunchDonutProgress = styled( SiteLaunchDonutBase )( {
-	zIndex: 1,
-} );
-
 const SiteLaunchDonutContainer = styled.div( {
 	position: 'relative',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
 	flexShrink: 0,
 	height: '25px',
+	width: '25px',
 	zIndex: 0,
 } );
 
 const SiteLaunchNagLink = styled.a( {
 	display: 'flex',
 	alignItems: 'center',
-	gap: '25px',
 	marginLeft: '-5px',
 	fontSize: '12px',
 	lineHeight: '16px',
@@ -45,35 +38,23 @@ const SiteLaunchNagText = styled.span( {
 	textOverflow: 'ellipsis',
 } );
 
-const SiteLaunchDonut = () => {
+const SiteLaunchDonut = ( {
+	numberOfSteps,
+	completedSteps,
+}: {
+	numberOfSteps: number;
+	completedSteps: number;
+} ) => {
 	return (
 		<SiteLaunchDonutContainer>
-			<SiteLaunchDonutProgress
-				width="25"
-				height="25"
-				viewBox="0 0 27 27"
-				version="1.1"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<circle
-					r="7"
-					cx="13.5"
-					cy="13.5"
-					fill="transparent"
-					stroke="#DCDCDE"
-					strokeWidth="3"
-				></circle>
-				<circle
-					r="7"
-					cx="13.5"
-					cy="13.5"
-					fill="transparent"
-					strokeDashoffset="-32.9823"
-					strokeDasharray="43.9823 11"
-					stroke="currentColor"
-					strokeWidth="3"
-				></circle>
-			</SiteLaunchDonutProgress>
+			<CircularProgressBar
+				size={ 16 }
+				strokeWidth={ 3 }
+				enableDesktopScaling={ false }
+				showProgressText={ false }
+				numberOfSteps={ numberOfSteps }
+				currentStep={ completedSteps }
+			/>
 		</SiteLaunchDonutContainer>
 	);
 };
@@ -88,10 +69,15 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 		onChange: ( inView ) => inView && recordNagView(),
 	} );
 
-	// Don't show nag to all Coming Soon sites, only those that are "unlaunched"
-	// That's because sites that have been previously launched before going back to
-	// Coming Soon mode don't have a launch checklist.
-	if ( 'unlaunched' !== site.launch_status ) {
+	const checklistSlug = site?.options?.site_intent || 'legacy-site-setup';
+
+	const { numberOfSteps, completedSteps, hasChecklist, isLoading } = useMyHomeCardLaunchpad( {
+		checklistSlug,
+		launchpadContext: 'sites-dashboard',
+		siteId: site.ID,
+	} );
+
+	if ( 'unlaunched' !== site.launch_status || ! hasChecklist || isLoading ) {
 		return null;
 	}
 
@@ -106,7 +92,8 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 				recordTracksEvent( 'calypso_sites_dashboard_site_launch_nag_click' );
 			} }
 		>
-			<SiteLaunchDonut /> <SiteLaunchNagText>{ text }</SiteLaunchNagText>
+			<SiteLaunchDonut numberOfSteps={ numberOfSteps } completedSteps={ completedSteps } />
+			<SiteLaunchNagText>{ text }</SiteLaunchNagText>
 		</SiteLaunchNagLink>
 	);
 };

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -4,6 +4,7 @@ import { useLaunchpad } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useInView } from 'react-intersection-observer';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { getDashboardUrl } from '../utils';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -79,8 +80,18 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 		return null;
 	}
 
-	const numberOfSteps = checklist.length || 0;
-	const completedSteps = ( checklist.filter( ( task ) => task.completed ) || [] ).length;
+	let numberOfSteps = checklist.length || 0;
+	let completedSteps = ( checklist.filter( ( task ) => task.completed ) || [] ).length;
+
+	if ( shouldShowLaunchpadFirst( site ) ) {
+		// The focused launchpad on My Home doesn't include the launch site task in the count.
+		// In which case, we want this donut to match the one on the focused launchpad.
+		const launchSiteTask = checklist?.find( ( task ) => task.isLaunchTask );
+		const isLaunchSiteTaskComplete = launchSiteTask?.completed;
+
+		numberOfSteps = numberOfSteps - ( launchSiteTask ? 1 : 0 );
+		completedSteps = completedSteps - ( isLaunchSiteTaskComplete ? 1 : 0 );
+	}
 
 	const link = getDashboardUrl( site.slug );
 	const text = __( 'Checklist' );

--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -1,4 +1,5 @@
-import { SiteDetails, Onboard } from '@automattic/data-stores';
+import { Onboard } from '@automattic/data-stores';
+import type { SiteExcerptData } from '@automattic/sites';
 
 const SiteIntent = Onboard.SiteIntent;
 
@@ -7,7 +8,7 @@ const SiteIntent = Onboard.SiteIntent;
  * @param site Site object
  * @returns Whether launchpad should be shown first
  */
-export const shouldShowLaunchpadFirst = ( site: SiteDetails ): boolean => {
+export const shouldShowLaunchpadFirst = ( site: SiteExcerptData ): boolean => {
 	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
 	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
 

--- a/packages/sites/src/site-excerpt-constants.ts
+++ b/packages/sites/src/site-excerpt-constants.ts
@@ -31,6 +31,7 @@ export const SITE_EXCERPT_REQUEST_OPTIONS = [
 	'is_redirect',
 	'is_wpforteams_site',
 	'launchpad_screen',
+	'site_creation_flow',
 	'site_intent',
 	'unmapped_url',
 	'updated_at',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/100260

## Proposed Changes

- Update `useMyHomeCardLaunchpad` hook to support optional site ID
- Replace custom SVG donut progress with CircularProgressBar component
- Improve site launch nag rendering with dynamic progress tracking
- Adjust site nag height so that all rows on the dashboard have the same height
  - Prevents layout shift as site nags are dynamically loaded
- Ensure donut is sync'd, regardless of whether the site has the focused launchpad or not

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of code blue issues to improve platform overall consistency 

The site nag and status label have less padding between each other now. This is how the rows are able to be all the same height. It does look a bit more cramped. But on the other hand, the site title and site URL are also sort of cramped, and this allows the text to line up better, like so:

![CleanShot 2025-03-12 at 21 23 14@2x](https://github.com/user-attachments/assets/cd11842b-d10a-41c9-8bed-3fdaed3d50dc)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites/dashboard`
* Verify the checklist progress is the same as the checklist progress shown in the launchpad
* Clear your cache and reload the dashboard to confirm there's no vertical shift as the data view loads
* Use the dashboard appearance controls to try different "densities" and confirm there's still no layout shift while loading
* Test different sorts of launchpads, e.g.
  * Launchpad of atomic site
    * Create site with `/setup/new-hosted-site`
    * Complete purchase
    * Go through the launchpad tasks on `/home`, comparing with the donut on `/sites` in another tab
  * That has been reverted
    * Create site with `/setup/new-hosted-site`
    * Either bail from the checkout so the site doesn't go atomic, or complete purchase and then revert the site to simple
    * Go through the launchpad tasks on `/home`, comparing with the donut on `/sites` in another tab
  * With focused launchpad
    * Create site with `/setup/onboarding`
    * Choose a sell goal
    * Go through the launchpad tasks, comparing with the donut on `/sites` in another tab
  * With legacy onboarding launchpad
    * Create site with `/start/free`
    * Go through the legacy onboarding screen style launchpad, comparing with the donut on `/sites` in another tab

| Before | After |
|--------|-------|
|  ![image](https://github.com/user-attachments/assets/8990aaac-7171-46c4-a0e5-0a6361d4c345) | ![image](https://github.com/user-attachments/assets/afe66191-ba6d-48c3-a861-fdaf50f51021)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
