### PR TITLE
chore(deps): update dependency typescript to ^5.5.4

### DIFF
--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -52,7 +52,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.19.0",
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.19.0",
 		"copy-webpack-plugin": "^10.2.4",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -52,7 +52,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.19.0",
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.19.0",
 		"copy-webpack-plugin": "^10.2.4",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/apps/help-center/package.json
+++ b/apps/help-center/package.json
@@ -52,7 +52,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.19.0",
 		"@wordpress/readable-js-assets-webpack-plugin": "^3.19.0",
 		"copy-webpack-plugin": "^10.2.4",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/index.tsx
@@ -54,7 +54,11 @@ export function BundlePriceSelector( { options, value, onChange }: Props ) {
 			__nextHasNoMarginBottom
 			label={ translate( 'Bundle size' ) }
 			labelPosition="side"
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore -- value is a number, not a string
 			value={ value }
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore -- value is a number, not a string
 			onChange={ onChange }
 			options={ [
 				{

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -77,8 +77,8 @@ export const UnwrappedUpgradePlan: React.FunctionComponent< UpgradePlanProps > =
 	const introOfferAvailable =
 		isEnabled( 'migration-flow/introductory-offer' ) &&
 		pricing[ visiblePlan ]?.introOffer &&
-		pricing[ visiblePlan ]?.introOffer.rawPrice &&
-		! pricing[ visiblePlan ]?.introOffer.isOfferComplete &&
+		pricing[ visiblePlan ]?.introOffer?.rawPrice &&
+		! pricing[ visiblePlan ]?.introOffer?.isOfferComplete &&
 		pricing[ visiblePlan ]?.originalPrice &&
 		pricing[ visiblePlan ]?.originalPrice.monthly &&
 		pricing[ visiblePlan ]?.originalPrice.full &&

--- a/client/lib/analytics/ad-tracking/google-analytics-4.ts
+++ b/client/lib/analytics/ad-tracking/google-analytics-4.ts
@@ -1,3 +1,4 @@
+import { gtag } from 'ga-gtag'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';

--- a/client/lib/memoize-last/index.ts
+++ b/client/lib/memoize-last/index.ts
@@ -44,7 +44,7 @@ export default function memoizeLast< T extends ( ...args: any[] ) => any >( fn: 
  */
 export function once< T extends () => any >( fn: T ) {
 	// Runtime validation. Useful when static validation is unavailable.
-	if ( process.env.NODE_ENV !== 'production' && fn.length !== 0 ) {
+	if ( fn.length !== 0 ) {
 		throw new Error( 'memoize-last: The `once` method expects a function with no arguments.' );
 	}
 	return memoizeLast( fn );

--- a/client/my-sites/add-ons/components/storage-add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/storage-add-ons-card.tsx
@@ -248,6 +248,7 @@ export default function StorageAddOnCard( { siteId, actionPrimary }: Props ) {
 								__next40pxDefaultSize
 								hideLabelFromVision
 								options={ selectControlOptions || [] }
+								// @ts-expect-error ts complains about selectedOption possibly being null
 								value={ selectedOption }
 								onChange={ handleOnChange }
 								label=""

--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
 		"@testing-library/jest-dom": "^6.6.3",
 		"@types/chroma-js": "^2.4.5",
 		"@types/eslint": "^9.6.1",
+		"@types/ga-gtag": "^1.2.0",
 		"@types/gtag.js": "^0.0.20",
 		"@types/superagent": "^4.1.24",
 		"@types/wordpress__blocks": "^12.5.17",

--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
 		"stacktrace-gps": "^3.0.3",
 		"stylelint": "^16.13.2",
 		"tslib": "^2.3.0",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1",
 		"webpack-bundle-analyzer": "^4.10.2",
 		"webpack-cli": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
 		"stacktrace-gps": "^3.0.3",
 		"stylelint": "^16.13.2",
 		"tslib": "^2.3.0",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1",
 		"webpack-bundle-analyzer": "^4.10.2",
 		"webpack-cli": "^4.10.0",

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/accessible-focus/package.json
+++ b/packages/accessible-focus/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/block-renderer/package.json
+++ b/packages/block-renderer/package.json
@@ -42,7 +42,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/block-renderer/package.json
+++ b/packages/block-renderer/package.json
@@ -42,7 +42,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/block-renderer/package.json
+++ b/packages/block-renderer/package.json
@@ -42,7 +42,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -27,6 +27,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -27,6 +27,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -27,6 +27,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -60,7 +60,7 @@
 		"stream-browserify": "^3.0.0",
 		"terser-webpack-plugin": "^5.3.11",
 		"thread-loader": "^3.0.4",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack-cli": "^4.10.0",
 		"yargs": "^17.7.2"
 	},

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -60,7 +60,7 @@
 		"stream-browserify": "^3.0.0",
 		"terser-webpack-plugin": "^5.3.11",
 		"thread-loader": "^3.0.4",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack-cli": "^4.10.0",
 		"yargs": "^17.7.2"
 	},

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -60,7 +60,7 @@
 		"stream-browserify": "^3.0.0",
 		"terser-webpack-plugin": "^5.3.11",
 		"thread-loader": "^3.0.4",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack-cli": "^4.10.0",
 		"yargs": "^17.7.2"
 	},

--- a/packages/calypso-config/package.json
+++ b/packages/calypso-config/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/calypso-config/package.json
+++ b/packages/calypso-config/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/calypso-config/package.json
+++ b/packages/calypso-config/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -40,7 +40,7 @@
 		"@wordpress/i18n": "^5.19.0",
 		"asana-phrase": "^0.0.8",
 		"node-fetch": "^2.7.0",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -40,7 +40,7 @@
 		"@wordpress/i18n": "^5.19.0",
 		"asana-phrase": "^0.0.8",
 		"node-fetch": "^2.7.0",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -40,7 +40,7 @@
 		"@wordpress/i18n": "^5.19.0",
 		"asana-phrase": "^0.0.8",
 		"node-fetch": "^2.7.0",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",

--- a/packages/calypso-paypal/package.json
+++ b/packages/calypso-paypal/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"private": true
 }

--- a/packages/calypso-paypal/package.json
+++ b/packages/calypso-paypal/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"private": true
 }

--- a/packages/calypso-paypal/package.json
+++ b/packages/calypso-paypal/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"private": true
 }

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/data": "^10.19.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/data": "^10.19.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/data": "^10.19.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/calypso-razorpay/package.json
+++ b/packages/calypso-razorpay/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"private": true
 }

--- a/packages/calypso-razorpay/package.json
+++ b/packages/calypso-razorpay/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"private": true
 }

--- a/packages/calypso-razorpay/package.json
+++ b/packages/calypso-razorpay/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"private": true
 }

--- a/packages/calypso-sentry/package.json
+++ b/packages/calypso-sentry/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/calypso-sentry/package.json
+++ b/packages/calypso-sentry/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/calypso-sentry/package.json
+++ b/packages/calypso-sentry/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"private": true
 }

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"private": true
 }

--- a/packages/calypso-stripe/package.json
+++ b/packages/calypso-stripe/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"private": true
 }

--- a/packages/calypso-url/package.json
+++ b/packages/calypso-url/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/calypso-url/package.json
+++ b/packages/calypso-url/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/calypso-url/package.json
+++ b/packages/calypso-url/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/command-palette/package.json
+++ b/packages/command-palette/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"private": true
 }

--- a/packages/command-palette/package.json
+++ b/packages/command-palette/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"private": true
 }

--- a/packages/command-palette/package.json
+++ b/packages/command-palette/package.json
@@ -65,7 +65,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"private": true
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -82,7 +82,7 @@
 		"@types/react-slider": "^1.3.6",
 		"postcss": "^8.5.1",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"scripts": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -82,7 +82,7 @@
 		"@types/react-slider": "^1.3.6",
 		"postcss": "^8.5.1",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"scripts": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -82,7 +82,7 @@
 		"@types/react-slider": "^1.3.6",
 		"postcss": "^8.5.1",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"scripts": {

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -55,7 +55,7 @@
 		"@testing-library/user-event": "^14.6.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -55,7 +55,7 @@
 		"@testing-library/user-event": "^14.6.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -55,7 +55,7 @@
 		"@testing-library/user-event": "^14.6.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1",

--- a/packages/create-calypso-config/package.json
+++ b/packages/create-calypso-config/package.json
@@ -36,6 +36,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/create-calypso-config/package.json
+++ b/packages/create-calypso-config/package.json
@@ -36,6 +36,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/create-calypso-config/package.json
+++ b/packages/create-calypso-config/package.json
@@ -36,6 +36,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -74,7 +74,7 @@
 		"jest-fetch-mock": "^3.0.3",
 		"nock": "^13.5.6",
 		"node-fetch": "^2.7.0",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"wait-for-expect": "^3.0.2"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -74,7 +74,7 @@
 		"jest-fetch-mock": "^3.0.3",
 		"nock": "^13.5.6",
 		"node-fetch": "^2.7.0",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"wait-for-expect": "^3.0.2"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -74,7 +74,7 @@
 		"jest-fetch-mock": "^3.0.3",
 		"nock": "^13.5.6",
 		"node-fetch": "^2.7.0",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"wait-for-expect": "^3.0.2"
 	}
 }

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -57,7 +57,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -57,7 +57,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/design-picker/package.json
+++ b/packages/design-picker/package.json
@@ -57,7 +57,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/design-preview/package.json
+++ b/packages/design-preview/package.json
@@ -48,7 +48,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/design-preview/package.json
+++ b/packages/design-preview/package.json
@@ -48,7 +48,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/design-preview/package.json
+++ b/packages/design-preview/package.json
@@ -48,7 +48,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -53,7 +53,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -53,7 +53,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -53,7 +53,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -54,7 +54,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -54,7 +54,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/domains-table/package.json
+++ b/packages/domains-table/package.json
@@ -54,7 +54,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/eslint-plugin-package-json/package.json
+++ b/packages/eslint-plugin-package-json/package.json
@@ -21,7 +21,7 @@
 		"@wordpress/npm-package-json-lint-config": "^5.19.0",
 		"eslint-plugin-json-es": "^1.6.0",
 		"esquery": "^1.4.0",
-		"npm-package-json-lint": "^6.0.0"
+		"npm-package-json-lint": "^8.0.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -36,6 +36,6 @@
 		"@testing-library/react": "^16.2.0",
 		"jest": "^29.7.0",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -36,6 +36,6 @@
 		"@testing-library/react": "^16.2.0",
 		"jest": "^29.7.0",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -36,6 +36,6 @@
 		"@testing-library/react": "^16.2.0",
 		"jest": "^29.7.0",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -31,6 +31,6 @@
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"jest": "^29.7.0",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -31,6 +31,6 @@
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"jest": "^29.7.0",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -31,6 +31,6 @@
 		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"jest": "^29.7.0",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/fingerprintjs/package.json
+++ b/packages/fingerprintjs/package.json
@@ -84,7 +84,7 @@
 		"terser-webpack-plugin": "^5.3.11",
 		"ts-loader": "^9.4.2",
 		"ts-node": "^10.9.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"ua-parser-js": "^0.7.32",
 		"webpack": "^5.97.1",
 		"webpack-cli": "^5.1.4",

--- a/packages/fingerprintjs/package.json
+++ b/packages/fingerprintjs/package.json
@@ -84,7 +84,7 @@
 		"terser-webpack-plugin": "^5.3.11",
 		"ts-loader": "^9.4.2",
 		"ts-node": "^10.9.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"ua-parser-js": "^0.7.32",
 		"webpack": "^5.97.1",
 		"webpack-cli": "^5.1.4",

--- a/packages/fingerprintjs/package.json
+++ b/packages/fingerprintjs/package.json
@@ -84,7 +84,7 @@
 		"terser-webpack-plugin": "^5.3.11",
 		"ts-loader": "^9.4.2",
 		"ts-node": "^10.9.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"ua-parser-js": "^0.7.32",
 		"webpack": "^5.97.1",
 		"webpack-cli": "^5.1.4",

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"files": [
 		"dist",

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"files": [
 		"dist",

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"files": [
 		"dist",

--- a/packages/generate-password/package.json
+++ b/packages/generate-password/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/generate-password/package.json
+++ b/packages/generate-password/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/generate-password/package.json
+++ b/packages/generate-password/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/wordpress__block-library": "^2.6.3",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"private": true
 }

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/wordpress__block-library": "^2.6.3",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"private": true
 }

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/wordpress__block-library": "^2.6.3",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"private": true
 }

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -52,7 +52,7 @@
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/smooch": "^5.3.7",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@automattic/calypso-router": "workspace:^",

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -52,7 +52,7 @@
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/smooch": "^5.3.7",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@automattic/calypso-router": "workspace:^",

--- a/packages/help-center/package.json
+++ b/packages/help-center/package.json
@@ -52,7 +52,7 @@
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/smooch": "^5.3.7",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@automattic/calypso-router": "workspace:^",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -43,7 +43,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-test-renderer": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1"

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -43,7 +43,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-test-renderer": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1"

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -43,7 +43,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-test-renderer": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"react": "^18.3.1"

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -44,6 +44,6 @@
 		"@types/react": "^18.2.6",
 		"react-dom": "^18.3.1",
 		"react-test-renderer": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -44,6 +44,6 @@
 		"@types/react": "^18.2.6",
 		"react-dom": "^18.3.1",
 		"react-test-renderer": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -44,6 +44,6 @@
 		"@types/react": "^18.2.6",
 		"react-dom": "^18.3.1",
 		"react-test-renderer": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/jest-circus-allure-reporter/package.json
+++ b/packages/jest-circus-allure-reporter/package.json
@@ -28,7 +28,7 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/node": "^22.7.5",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",

--- a/packages/jest-circus-allure-reporter/package.json
+++ b/packages/jest-circus-allure-reporter/package.json
@@ -28,7 +28,7 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/node": "^22.7.5",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",

--- a/packages/jest-circus-allure-reporter/package.json
+++ b/packages/jest-circus-allure-reporter/package.json
@@ -28,7 +28,7 @@
 		"@automattic/calypso-eslint-overrides": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@types/node": "^22.7.5",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"scripts": {
 		"clean": "yarn build --clean && rm -rf dist",

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -51,7 +51,7 @@
 		"postcss": "^8.5.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -51,7 +51,7 @@
 		"postcss": "^8.5.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -51,7 +51,7 @@
 		"postcss": "^8.5.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -114,7 +114,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 				currentLimit - currentUsage < logoCost + promptCreationCost;
 
 			// If the site requires an upgrade, set the upgrade URL and show the upgrade screen immediately.
-			setNeedsFeature( ! feature?.hasFeature ?? true );
+			setNeedsFeature( ! feature?.hasFeature );
 			setNeedsMoreRequests( needsMoreRequests );
 
 			if ( ! feature?.hasFeature || needsMoreRequests ) {

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -32,6 +32,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -32,6 +32,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -32,6 +32,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -48,6 +48,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -48,6 +48,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/language-picker/package.json
+++ b/packages/language-picker/package.json
@@ -48,6 +48,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -39,7 +39,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	}
 }

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -39,7 +39,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	}
 }

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -39,7 +39,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	}
 }

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -60,7 +60,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -60,7 +60,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -60,7 +60,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -54,7 +54,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -54,7 +54,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -54,7 +54,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -53,6 +53,6 @@
 		"@types/autosize": "^4.0.3",
 		"@types/react": "^18.2.6",
 		"@types/smooch": "^5.3.7",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -53,6 +53,6 @@
 		"@types/autosize": "^4.0.3",
 		"@types/react": "^18.2.6",
 		"@types/smooch": "^5.3.7",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -53,6 +53,6 @@
 		"@types/autosize": "^4.0.3",
 		"@types/react": "^18.2.6",
 		"@types/smooch": "^5.3.7",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -55,7 +55,7 @@
 		"redux": "^5.0.1",
 		"sass-loader": "^13.1.0",
 		"style-loader": "^1.3.0",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -55,7 +55,7 @@
 		"redux": "^5.0.1",
 		"sass-loader": "^13.1.0",
 		"style-loader": "^1.3.0",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -55,7 +55,7 @@
 		"redux": "^5.0.1",
 		"sass-loader": "^13.1.0",
 		"style-loader": "^1.3.0",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -48,7 +48,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "1.5.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -48,7 +48,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "1.5.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/page-pattern-modal/package.json
+++ b/packages/page-pattern-modal/package.json
@@ -48,7 +48,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"resize-observer-polyfill": "1.5.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -43,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -74,7 +74,7 @@
 		"msw": "^2.2.14",
 		"msw-storybook-addon": "^2.0.2",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"msw": {

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -74,7 +74,7 @@
 		"msw": "^2.2.14",
 		"msw-storybook-addon": "^2.0.2",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"msw": {

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -74,7 +74,7 @@
 		"msw": "^2.2.14",
 		"msw-storybook-addon": "^2.0.2",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"msw": {

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -52,7 +52,7 @@
 		"@testing-library/react": "^16.2.0",
 		"postcss": "^8.5.1",
 		"require-from-string": "^2.0.2",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	}
 }

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -52,7 +52,7 @@
 		"@testing-library/react": "^16.2.0",
 		"postcss": "^8.5.1",
 		"require-from-string": "^2.0.2",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	}
 }

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -52,7 +52,7 @@
 		"@testing-library/react": "^16.2.0",
 		"postcss": "^8.5.1",
 		"require-from-string": "^2.0.2",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	}
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/is-shallow-equal": "^5.19.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"scripts": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/is-shallow-equal": "^5.19.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"scripts": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -59,7 +59,7 @@
 		"@wordpress/is-shallow-equal": "^5.19.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"scripts": {

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -46,6 +46,6 @@
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.2.0",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -46,6 +46,6 @@
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.2.0",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/shopping-cart/package.json
+++ b/packages/shopping-cart/package.json
@@ -46,6 +46,6 @@
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.2.0",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -53,7 +53,7 @@
 		"@storybook/react": "^7.6.20",
 		"copyfiles": "^2.4.1",
 		"postcss": "^8.4.5",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"dependencies": {

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -53,7 +53,7 @@
 		"@storybook/react": "^7.6.20",
 		"copyfiles": "^2.4.1",
 		"postcss": "^8.4.5",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"dependencies": {

--- a/packages/site-admin/package.json
+++ b/packages/site-admin/package.json
@@ -53,7 +53,7 @@
 		"@storybook/react": "^7.6.20",
 		"copyfiles": "^2.4.1",
 		"postcss": "^8.4.5",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"dependencies": {

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -37,7 +37,7 @@
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.2.0",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -37,7 +37,7 @@
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.2.0",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -37,7 +37,7 @@
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@testing-library/react": "^16.2.0",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -58,7 +58,7 @@
 		"postcss": "^8.5.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -58,7 +58,7 @@
 		"postcss": "^8.5.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -58,7 +58,7 @@
 		"postcss": "^8.5.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"webpack": "^5.97.1"
 	},
 	"peerDependencies": {

--- a/packages/state-utils/package.json
+++ b/packages/state-utils/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/state-utils/package.json
+++ b/packages/state-utils/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/state-utils/package.json
+++ b/packages/state-utils/package.json
@@ -39,6 +39,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/subscriber/package.json
+++ b/packages/subscriber/package.json
@@ -49,7 +49,7 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/subscriber/package.json
+++ b/packages/subscriber/package.json
@@ -49,7 +49,7 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/subscriber/package.json
+++ b/packages/subscriber/package.json
@@ -49,7 +49,7 @@
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -38,6 +38,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -38,6 +38,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -38,6 +38,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/verbum-block-editor/package.json
+++ b/packages/verbum-block-editor/package.json
@@ -63,7 +63,7 @@
 		"@wordpress/eslint-plugin": "^22.5.0",
 		"@wordpress/stylelint-config": "^23.11.0",
 		"node-fetch": "^2.7.0",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@babel/core": "*",

--- a/packages/verbum-block-editor/package.json
+++ b/packages/verbum-block-editor/package.json
@@ -63,7 +63,7 @@
 		"@wordpress/eslint-plugin": "^22.5.0",
 		"@wordpress/stylelint-config": "^23.11.0",
 		"node-fetch": "^2.7.0",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@babel/core": "*",

--- a/packages/verbum-block-editor/package.json
+++ b/packages/verbum-block-editor/package.json
@@ -63,7 +63,7 @@
 		"@wordpress/eslint-plugin": "^22.5.0",
 		"@wordpress/stylelint-config": "^23.11.0",
 		"node-fetch": "^2.7.0",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@babel/core": "*",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	}
 }

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	}
 }

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -31,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	}
 }

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/keycodes": "^4.19.0",
 		"@wordpress/react-i18n": "^4.19.0",
 		"clsx": "^2.1.1",
-		"typescript": "5.5.4",
+		"typescript": "^5.5.4",
 		"wpcom": "workspace:^",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/keycodes": "^4.19.0",
 		"@wordpress/react-i18n": "^4.19.0",
 		"clsx": "^2.1.1",
-		"typescript": "5.4.5",
+		"typescript": "5.5.4",
 		"wpcom": "workspace:^",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/packages/whats-new/package.json
+++ b/packages/whats-new/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/keycodes": "^4.19.0",
 		"@wordpress/react-i18n": "^4.19.0",
 		"clsx": "^2.1.1",
-		"typescript": "^5.3.3",
+		"typescript": "5.4.5",
 		"wpcom": "workspace:^",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -58,7 +58,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -58,7 +58,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -58,7 +58,7 @@
 		"@testing-library/react": "^16.2.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.4.1",

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.19.0",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.5.4"
+		"typescript": "^5.5.4"
 	},
 	"license": "GPL-2.0-or-later"
 }

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "5.4.5"
+		"typescript": "5.5.4"
 	},
 	"license": "GPL-2.0-or-later"
 }

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^5.3.3"
+		"typescript": "5.4.5"
 	},
 	"license": "GPL-2.0-or-later"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,7 +985,7 @@ __metadata:
     "@wordpress/npm-package-json-lint-config": "npm:^5.19.0"
     eslint-plugin-json-es: "npm:^1.6.0"
     esquery: "npm:^1.4.0"
-    npm-package-json-lint: "npm:^6.0.0"
+    npm-package-json-lint: "npm:^8.0.0"
   peerDependencies:
     eslint: ">=8.57.1"
   languageName: unknown
@@ -13477,15 +13477,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builtins@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "builtins@npm:5.0.1"
-  dependencies:
-    semver: "npm:^7.0.0"
-  checksum: 9390a51a9abbc0233dac79c66715f927508b9d0c62cb7a42448fe8c52def60c707e6e9eb2cc4c9b7aba11601899935bca4e4064ae5e19c04c7e1bb9309e69134
-  languageName: node
-  linkType: hard
-
 "bunyan@npm:^1.8.15":
   version: 1.8.15
   resolution: "bunyan@npm:1.8.15"
@@ -15337,7 +15328,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^8.0.0":
+"cosmiconfig@npm:^8.3.6":
   version: 8.3.6
   resolution: "cosmiconfig@npm:8.3.6"
   dependencies:
@@ -21364,7 +21355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.1, ignore@npm:^5.1.8, ignore@npm:^5.2.0, ignore@npm:^5.2.4":
+"ignore@npm:^5.1.1, ignore@npm:^5.1.8, ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.1":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -23543,10 +23534,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "jsonc-parser@npm:3.2.0"
-  checksum: 5a12d4d04dad381852476872a29dcee03a57439574e4181d91dca71904fcdcc5e8e4706c0a68a2c61ad9810e1e1c5806b5100d52d3e727b78f5cdc595401045b
+"jsonc-parser@npm:^3.2.1":
+  version: 3.3.1
+  resolution: "jsonc-parser@npm:3.3.1"
+  checksum: 269c3ae0a0e4f907a914bf334306c384aabb9929bd8c99f909275ebd5c2d3bc70b9bcd119ad794f339dec9f24b6a4ee9cd5a8ab2e6435e730ad4075388fc2ab6
   languageName: node
   linkType: hard
 
@@ -26622,30 +26613,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-package-json-lint@npm:^6.0.0":
-  version: 6.4.0
-  resolution: "npm-package-json-lint@npm:6.4.0"
+"npm-package-json-lint@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "npm-package-json-lint@npm:8.0.0"
   dependencies:
     ajv: "npm:^6.12.6"
     ajv-errors: "npm:^1.0.1"
     chalk: "npm:^4.1.2"
-    cosmiconfig: "npm:^8.0.0"
+    cosmiconfig: "npm:^8.3.6"
     debug: "npm:^4.3.4"
     globby: "npm:^11.1.0"
-    ignore: "npm:^5.2.0"
+    ignore: "npm:^5.3.1"
     is-plain-obj: "npm:^3.0.0"
-    jsonc-parser: "npm:^3.2.0"
+    jsonc-parser: "npm:^3.2.1"
     log-symbols: "npm:^4.1.0"
     meow: "npm:^9.0.0"
     plur: "npm:^4.0.0"
-    semver: "npm:^7.3.8"
+    semver: "npm:^7.6.2"
     slash: "npm:^3.0.0"
     strip-json-comments: "npm:^3.1.1"
-    type-fest: "npm:^3.2.0"
-    validate-npm-package-name: "npm:^5.0.0"
+    type-fest: "npm:^4.20.0"
+    validate-npm-package-name: "npm:^5.0.1"
   bin:
     npmPkgJsonLint: dist/cli.js
-  checksum: 3258a8a67a2251fe40198320cd97412a0d41994273f7c53da7caf039a1df521458aa5f512ff43be860d433aaeab28f29e437022bd34b71f524dccb0bc5b2acde
+  checksum: 39943ae726dc2ca1483897bdcbf6eb8d4cbd68501f42a08a73fe35b024c8c7d3adbb489b244ec719856513d51a4e3243ec5d531b62112d99f5c74b5eb60dc88f
   languageName: node
   linkType: hard
 
@@ -31544,7 +31535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.0.0, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.2":
   version: 7.7.1
   resolution: "semver@npm:7.7.1"
   bin:
@@ -34128,10 +34119,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^3.2.0":
-  version: 3.13.1
-  resolution: "type-fest@npm:3.13.1"
-  checksum: 547d22186f73a8c04590b70dcf63baff390078c75ea8acd366bbd510fd0646e348bd1970e47ecf795b7cff0b41d26e9c475c1fedd6ef5c45c82075fbf916b629
+"type-fest@npm:^4.20.0":
+  version: 4.37.0
+  resolution: "type-fest@npm:4.37.0"
+  checksum: 5bad189f66fbe3431e5d36befa08cab6010e56be68b7467530b7ef94c3cf81ef775a8ac3047c8bbda4dd3159929285870357498d7bc1df062714f9c5c3a84926
   languageName: node
   linkType: hard
 
@@ -35108,12 +35099,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-npm-package-name@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "validate-npm-package-name@npm:5.0.0"
-  dependencies:
-    builtins: "npm:^5.0.0"
-  checksum: 36a9067650f5b90c573a0d394b89ddffb08fe58a60507d7938ad7c38f25055cc5c6bf4a10fbd604abe1f4a31062cbe0dfa8e7ccad37b249da32e7b71889c079e
+"validate-npm-package-name@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "validate-npm-package-name@npm:5.0.1"
+  checksum: 903e738f7387404bb72f7ac34e45d7010c877abd2803dc2d614612527927a40a6d024420033132e667b1bade94544b8a1f65c9431a4eb30d0ce0d80093cd1f74
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -34119,17 +34119,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.20.0":
+"type-fest@npm:^4.20.0, type-fest@npm:^4.9.0":
   version: 4.37.0
   resolution: "type-fest@npm:4.37.0"
   checksum: 5bad189f66fbe3431e5d36befa08cab6010e56be68b7467530b7ef94c3cf81ef775a8ac3047c8bbda4dd3159929285870357498d7bc1df062714f9c5c3a84926
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^4.9.0":
-  version: 4.26.1
-  resolution: "type-fest@npm:4.26.1"
-  checksum: d2719ff8d380befe8a3c61068f37f28d6fa2849fd140c5d2f0f143099e371da6856aad7c97e56b83329d45bfe504afe9fd936a7cff600cc0d46aa9ffb008d6c6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@ __metadata:
   resolution: "@automattic/accessible-focus@workspace:packages/accessible-focus"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -190,7 +190,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     utility-types: "npm:^3.10.0"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -208,7 +208,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -223,7 +223,7 @@ __metadata:
     debug: "npm:^4.3.3"
     hash.js: "npm:^1.1.7"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
@@ -303,7 +303,7 @@ __metadata:
     stream-browserify: "npm:^3.0.0"
     terser-webpack-plugin: "npm:^5.3.11"
     thread-loader: "npm:^3.0.4"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack-cli: "npm:^4.10.0"
     yargs: "npm:^17.7.2"
   peerDependencies:
@@ -341,7 +341,7 @@ __metadata:
     "@types/node": "npm:^22.7.5"
     cookie: "npm:^0.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -382,7 +382,7 @@ __metadata:
     node-fetch: "npm:^2.7.0"
     playwright: "npm:1.48.2"
     totp-generator: "npm:^0.0.12"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -443,7 +443,7 @@ __metadata:
     "@wordpress/i18n": "npm:^5.19.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -471,7 +471,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -486,7 +486,7 @@ __metadata:
     debug: "npm:^4.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -506,7 +506,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -545,7 +545,7 @@ __metadata:
     debug: "npm:^4.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -561,7 +561,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     photon: "workspace:^"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -654,7 +654,7 @@ __metadata:
     "@wordpress/url": "npm:^4.19.0"
     clsx: "npm:^2.1.1"
     cmdk: "npm:^0.2.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     utility-types: "npm:^3.10.0"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -714,7 +714,7 @@ __metadata:
     react-router-dom: "npm:^6.23.1"
     react-slider: "npm:^2.0.5"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     utility-types: "npm:^3.10.0"
     uuid: "npm:^9.0.1"
     webpack: "npm:^5.97.1"
@@ -746,7 +746,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -760,7 +760,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     cookie: "npm:^0.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -799,7 +799,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     use-debounce: "npm:^3.1.0"
     utility-types: "npm:^3.10.0"
     validator: "npm:^13.5.2"
@@ -841,7 +841,7 @@ __metadata:
     react-router-dom: "npm:^6.23.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.97.1"
   peerDependencies:
@@ -876,7 +876,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     "@wordpress/element": ^6.19.0
@@ -912,7 +912,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     use-debounce: "npm:^3.1.0"
     uuid: "npm:^9.0.1"
   peerDependencies:
@@ -951,7 +951,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
@@ -1004,7 +1004,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:>=2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1016,7 +1016,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     jest: "npm:^29.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1059,7 +1059,7 @@ __metadata:
     ts-loader: "npm:^9.4.2"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     ua-parser-js: "npm:^0.7.32"
     webpack: "npm:^5.97.1"
     webpack-cli: "npm:^5.1.4"
@@ -1073,7 +1073,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1082,7 +1082,7 @@ __metadata:
   resolution: "@automattic/generate-password@workspace:packages/generate-password"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1112,7 +1112,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -1145,7 +1145,7 @@ __metadata:
     "@wordpress/router": "npm:^1.19.0"
     copy-webpack-plugin: "npm:^10.2.4"
     postcss-prefix-selector: "npm:^1.16.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
@@ -1183,7 +1183,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-draggable: "npm:^4.4.4"
     smooch: "npm:5.6.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.19.0
@@ -1212,7 +1212,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1240,7 +1240,7 @@ __metadata:
     "@types/allure-js-commons": "npm:^0.0.1"
     "@types/node": "npm:^22.7.5"
     allure-js-commons: "npm:2.0.0-beta.9"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1262,7 +1262,7 @@ __metadata:
     postcss: "npm:^8.5.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@babel/runtime": ^7.26.9
@@ -1280,7 +1280,7 @@ __metadata:
   resolution: "@automattic/js-utils@workspace:packages/js-utils"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1296,7 +1296,7 @@ __metadata:
     "@wordpress/components": "npm:^29.5.0"
     "@wordpress/i18n": "npm:^5.19.0"
     "@wordpress/react-i18n": "npm:^4.19.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1318,7 +1318,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   languageName: unknown
   linkType: soft
@@ -1363,7 +1363,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.97.1"
     wpcom-proxy-request: "workspace:^"
@@ -1415,7 +1415,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^5.0.1
@@ -1528,7 +1528,7 @@ __metadata:
     react-markdown: "npm:^9.0.1"
     react-redux: "npm:^9.2.0"
     smooch: "npm:5.6.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     wpcom-proxy-request: "npm:^7.0.5"
   languageName: unknown
   linkType: soft
@@ -1612,7 +1612,7 @@ __metadata:
     sass-loader: "npm:^13.1.0"
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.5.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -1644,7 +1644,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     resize-observer-polyfill: "npm:1.5.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1687,7 +1687,7 @@ __metadata:
     react-intersection-observer: "npm:^9.4.3"
     react-transition-group: "npm:^4.3.0"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@wordpress/i18n": ^5.19.0
@@ -1723,7 +1723,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     postcss: "npm:^8.5.1"
     require-from-string: "npm:^2.0.2"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     react: ^18.3.1
@@ -1785,7 +1785,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     react: ^18.3.1
@@ -1802,7 +1802,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.2.0"
     debug: "npm:^4.3.3"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -1826,7 +1826,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     copyfiles: "npm:^2.4.1"
     postcss: "npm:^8.4.5"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -1845,7 +1845,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.2.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1873,7 +1873,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@babel/runtime": ^7.26.9
@@ -1896,7 +1896,7 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1922,7 +1922,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     debug: "npm:^4.3.4"
     react-popper: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1954,7 +1954,7 @@ __metadata:
   resolution: "@automattic/urls@workspace:packages/urls"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1990,7 +1990,7 @@ __metadata:
     "@wordpress/stylelint-config": "npm:^23.11.0"
     "@wordpress/url": "npm:^4.19.0"
     node-fetch: "npm:^2.7.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@babel/core": "*"
     "@wordpress/data": ^10.19.0
@@ -2025,7 +2025,7 @@ __metadata:
   resolution: "@automattic/viewport@workspace:packages/viewport"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2130,7 +2130,7 @@ __metadata:
     "@wordpress/keycodes": "npm:^4.19.0"
     "@wordpress/react-i18n": "npm:^4.19.0"
     clsx: "npm:^2.1.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -2237,7 +2237,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^5.0.1
@@ -2254,7 +2254,7 @@ __metadata:
     "@wordpress/url": "npm:^4.19.0"
     i18n-calypso: "workspace:^"
     social-logos: "npm:^3.1.16"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -2273,7 +2273,7 @@ __metadata:
     "@wordpress/element": "npm:^6.19.0"
     "@wordpress/url": "npm:^4.19.0"
     react: "npm:^18.3.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -21281,7 +21281,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tannin: "npm:^1.1.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     use-subscription: "npm:1.6.0"
   peerDependencies:
     react: ^18.3.1
@@ -27682,7 +27682,7 @@ __metadata:
     debug: "npm:^4.3.3"
     seed-random: "npm:^2.2.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -34205,23 +34205,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
+  checksum: 422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=e012d7"
+"typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9cf4c053893bcf327d101b6c024a55baf05430dc30263f9adb1bf354aeffc11306fe1f23ba2f9a0209674359f16219b5b7d229e923477b94831d07d5a33a4217
+  checksum: 10dd9881baba22763de859e8050d6cb6e2db854197495c6f1929b08d1eb2b2b00d0b5d9b0bcee8472f1c3f4a7ef6a5d7ebe0cfd703f853aa5ae465b8404bc1ba
   languageName: node
   linkType: hard
 
@@ -36006,7 +36006,7 @@ __metadata:
     stylelint: "npm:^16.13.2"
     swiper: "npm:^10.1.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:5.5.4"
     webpack: "npm:^5.97.1"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-cli: "npm:^4.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8480,6 +8480,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ga-gtag@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@types/ga-gtag@npm:1.2.0"
+  dependencies:
+    "@types/gtag.js": "npm:^0.0"
+  checksum: 154080cfd240da068b8e4339c0781d46d522680ca1b27e61b27d71fa95f10f6afad8d3d26c4e78b6dfb03451ce7844c09c805f36c31b35b133eeba1d76ae888d
+  languageName: node
+  linkType: hard
+
 "@types/geojson@npm:*":
   version: 7946.0.16
   resolution: "@types/geojson@npm:7946.0.16"
@@ -8523,7 +8532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/gtag.js@npm:^0.0.20":
+"@types/gtag.js@npm:^0.0, @types/gtag.js@npm:^0.0.20":
   version: 0.0.20
   resolution: "@types/gtag.js@npm:0.0.20"
   checksum: eb878aa3cfab6b98f5e69ef3383e9788aaea6a4d0611c72078678374dcbb4731f533ff2bf479a865536f1626a57887b1198279ff35a65d223fe4f93d9c76dbdd
@@ -35898,6 +35907,7 @@ __metadata:
     "@types/debug": "npm:^4.1.7"
     "@types/eslint": "npm:^9.6.1"
     "@types/fast-json-stable-stringify": "npm:^2.0.0"
+    "@types/ga-gtag": "npm:^1.2.0"
     "@types/gtag.js": "npm:^0.0.20"
     "@types/jest": "npm:^29.5.14"
     "@types/lodash": "npm:^4.14.199"

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@ __metadata:
   resolution: "@automattic/accessible-focus@workspace:packages/accessible-focus"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -190,7 +190,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     utility-types: "npm:^3.10.0"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -208,7 +208,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -223,7 +223,7 @@ __metadata:
     debug: "npm:^4.3.3"
     hash.js: "npm:^1.1.7"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
@@ -303,7 +303,7 @@ __metadata:
     stream-browserify: "npm:^3.0.0"
     terser-webpack-plugin: "npm:^5.3.11"
     thread-loader: "npm:^3.0.4"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack-cli: "npm:^4.10.0"
     yargs: "npm:^17.7.2"
   peerDependencies:
@@ -341,7 +341,7 @@ __metadata:
     "@types/node": "npm:^22.7.5"
     cookie: "npm:^0.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -382,7 +382,7 @@ __metadata:
     node-fetch: "npm:^2.7.0"
     playwright: "npm:1.48.2"
     totp-generator: "npm:^0.0.12"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -443,7 +443,7 @@ __metadata:
     "@wordpress/i18n": "npm:^5.19.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -471,7 +471,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -486,7 +486,7 @@ __metadata:
     debug: "npm:^4.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -506,7 +506,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -545,7 +545,7 @@ __metadata:
     debug: "npm:^4.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -561,7 +561,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     photon: "workspace:^"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -654,7 +654,7 @@ __metadata:
     "@wordpress/url": "npm:^4.19.0"
     clsx: "npm:^2.1.1"
     cmdk: "npm:^0.2.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     utility-types: "npm:^3.10.0"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -714,7 +714,7 @@ __metadata:
     react-router-dom: "npm:^6.23.1"
     react-slider: "npm:^2.0.5"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     utility-types: "npm:^3.10.0"
     uuid: "npm:^9.0.1"
     webpack: "npm:^5.97.1"
@@ -746,7 +746,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -760,7 +760,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     cookie: "npm:^0.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -799,7 +799,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     use-debounce: "npm:^3.1.0"
     utility-types: "npm:^3.10.0"
     validator: "npm:^13.5.2"
@@ -841,7 +841,7 @@ __metadata:
     react-router-dom: "npm:^6.23.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.97.1"
   peerDependencies:
@@ -876,7 +876,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     "@wordpress/element": ^6.19.0
@@ -912,7 +912,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     use-debounce: "npm:^3.1.0"
     uuid: "npm:^9.0.1"
   peerDependencies:
@@ -951,7 +951,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
@@ -1004,7 +1004,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:>=2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1016,7 +1016,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     jest: "npm:^29.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1059,7 +1059,7 @@ __metadata:
     ts-loader: "npm:^9.4.2"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     ua-parser-js: "npm:^0.7.32"
     webpack: "npm:^5.97.1"
     webpack-cli: "npm:^5.1.4"
@@ -1073,7 +1073,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1082,7 +1082,7 @@ __metadata:
   resolution: "@automattic/generate-password@workspace:packages/generate-password"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1112,7 +1112,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -1145,7 +1145,7 @@ __metadata:
     "@wordpress/router": "npm:^1.19.0"
     copy-webpack-plugin: "npm:^10.2.4"
     postcss-prefix-selector: "npm:^1.16.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
@@ -1183,7 +1183,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-draggable: "npm:^4.4.4"
     smooch: "npm:5.6.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.19.0
@@ -1212,7 +1212,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1240,7 +1240,7 @@ __metadata:
     "@types/allure-js-commons": "npm:^0.0.1"
     "@types/node": "npm:^22.7.5"
     allure-js-commons: "npm:2.0.0-beta.9"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1262,7 +1262,7 @@ __metadata:
     postcss: "npm:^8.5.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@babel/runtime": ^7.26.9
@@ -1280,7 +1280,7 @@ __metadata:
   resolution: "@automattic/js-utils@workspace:packages/js-utils"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1296,7 +1296,7 @@ __metadata:
     "@wordpress/components": "npm:^29.5.0"
     "@wordpress/i18n": "npm:^5.19.0"
     "@wordpress/react-i18n": "npm:^4.19.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1318,7 +1318,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   languageName: unknown
   linkType: soft
@@ -1363,7 +1363,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.97.1"
     wpcom-proxy-request: "workspace:^"
@@ -1415,7 +1415,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^5.0.1
@@ -1528,7 +1528,7 @@ __metadata:
     react-markdown: "npm:^9.0.1"
     react-redux: "npm:^9.2.0"
     smooch: "npm:5.6.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     wpcom-proxy-request: "npm:^7.0.5"
   languageName: unknown
   linkType: soft
@@ -1612,7 +1612,7 @@ __metadata:
     sass-loader: "npm:^13.1.0"
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.5.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -1644,7 +1644,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     resize-observer-polyfill: "npm:1.5.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1687,7 +1687,7 @@ __metadata:
     react-intersection-observer: "npm:^9.4.3"
     react-transition-group: "npm:^4.3.0"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@wordpress/i18n": ^5.19.0
@@ -1723,7 +1723,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     postcss: "npm:^8.5.1"
     require-from-string: "npm:^2.0.2"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     react: ^18.3.1
@@ -1785,7 +1785,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     react: ^18.3.1
@@ -1802,7 +1802,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.2.0"
     debug: "npm:^4.3.3"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -1826,7 +1826,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     copyfiles: "npm:^2.4.1"
     postcss: "npm:^8.4.5"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -1845,7 +1845,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.2.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1873,7 +1873,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@babel/runtime": ^7.26.9
@@ -1896,7 +1896,7 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1922,7 +1922,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     debug: "npm:^4.3.4"
     react-popper: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1954,7 +1954,7 @@ __metadata:
   resolution: "@automattic/urls@workspace:packages/urls"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -1990,7 +1990,7 @@ __metadata:
     "@wordpress/stylelint-config": "npm:^23.11.0"
     "@wordpress/url": "npm:^4.19.0"
     node-fetch: "npm:^2.7.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@babel/core": "*"
     "@wordpress/data": ^10.19.0
@@ -2025,7 +2025,7 @@ __metadata:
   resolution: "@automattic/viewport@workspace:packages/viewport"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -2130,7 +2130,7 @@ __metadata:
     "@wordpress/keycodes": "npm:^4.19.0"
     "@wordpress/react-i18n": "npm:^4.19.0"
     clsx: "npm:^2.1.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -2237,7 +2237,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^5.0.1
@@ -2254,7 +2254,7 @@ __metadata:
     "@wordpress/url": "npm:^4.19.0"
     i18n-calypso: "workspace:^"
     social-logos: "npm:^3.1.16"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -2273,7 +2273,7 @@ __metadata:
     "@wordpress/element": "npm:^6.19.0"
     "@wordpress/url": "npm:^4.19.0"
     react: "npm:^18.3.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -21281,7 +21281,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tannin: "npm:^1.1.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     use-subscription: "npm:1.6.0"
   peerDependencies:
     react: ^18.3.1
@@ -27682,7 +27682,7 @@ __metadata:
     debug: "npm:^4.3.3"
     seed-random: "npm:^2.2.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -34212,23 +34212,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.3.3":
-  version: 5.3.3
-  resolution: "typescript@npm:5.3.3"
+"typescript@npm:5.4.5":
+  version: 5.4.5
+  resolution: "typescript@npm:5.4.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: e33cef99d82573624fc0f854a2980322714986bc35b9cb4d1ce736ed182aeab78e2cb32b385efa493b2a976ef52c53e20d6c6918312353a91850e2b76f1ea44f
+  checksum: 2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
-  version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
+"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
+  version: 5.4.5
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1d0a5f4ce496c42caa9a30e659c467c5686eae15d54b027ee7866744952547f1be1262f2d40de911618c242b510029d51d43ff605dba8fb740ec85ca2d3f9500
+  checksum: 9cf4c053893bcf327d101b6c024a55baf05430dc30263f9adb1bf354aeffc11306fe1f23ba2f9a0209674359f16219b5b7d229e923477b94831d07d5a33a4217
   languageName: node
   linkType: hard
 
@@ -36014,7 +36014,7 @@ __metadata:
     stylelint: "npm:^16.13.2"
     swiper: "npm:^10.1.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:5.4.5"
     webpack: "npm:^5.97.1"
     webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-cli: "npm:^4.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@ __metadata:
   resolution: "@automattic/accessible-focus@workspace:packages/accessible-focus"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -190,7 +190,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     utility-types: "npm:^3.10.0"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -208,7 +208,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -223,7 +223,7 @@ __metadata:
     debug: "npm:^4.3.3"
     hash.js: "npm:^1.1.7"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
@@ -303,7 +303,7 @@ __metadata:
     stream-browserify: "npm:^3.0.0"
     terser-webpack-plugin: "npm:^5.3.11"
     thread-loader: "npm:^3.0.4"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack-cli: "npm:^4.10.0"
     yargs: "npm:^17.7.2"
   peerDependencies:
@@ -341,7 +341,7 @@ __metadata:
     "@types/node": "npm:^22.7.5"
     cookie: "npm:^0.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -382,7 +382,7 @@ __metadata:
     node-fetch: "npm:^2.7.0"
     playwright: "npm:1.48.2"
     totp-generator: "npm:^0.0.12"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -443,7 +443,7 @@ __metadata:
     "@wordpress/i18n": "npm:^5.19.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -471,7 +471,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -486,7 +486,7 @@ __metadata:
     debug: "npm:^4.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -506,7 +506,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -545,7 +545,7 @@ __metadata:
     debug: "npm:^4.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -561,7 +561,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     photon: "workspace:^"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -654,7 +654,7 @@ __metadata:
     "@wordpress/url": "npm:^4.19.0"
     clsx: "npm:^2.1.1"
     cmdk: "npm:^0.2.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     utility-types: "npm:^3.10.0"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -714,7 +714,7 @@ __metadata:
     react-router-dom: "npm:^6.23.1"
     react-slider: "npm:^2.0.5"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     utility-types: "npm:^3.10.0"
     uuid: "npm:^9.0.1"
     webpack: "npm:^5.97.1"
@@ -746,7 +746,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -760,7 +760,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     cookie: "npm:^0.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -799,7 +799,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     use-debounce: "npm:^3.1.0"
     utility-types: "npm:^3.10.0"
     validator: "npm:^13.5.2"
@@ -841,7 +841,7 @@ __metadata:
     react-router-dom: "npm:^6.23.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.97.1"
   peerDependencies:
@@ -876,7 +876,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     "@wordpress/element": ^6.19.0
@@ -912,7 +912,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     use-debounce: "npm:^3.1.0"
     uuid: "npm:^9.0.1"
   peerDependencies:
@@ -951,7 +951,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
@@ -1004,7 +1004,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:>=2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1016,7 +1016,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     jest: "npm:^29.7.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1059,7 +1059,7 @@ __metadata:
     ts-loader: "npm:^9.4.2"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     ua-parser-js: "npm:^0.7.32"
     webpack: "npm:^5.97.1"
     webpack-cli: "npm:^5.1.4"
@@ -1073,7 +1073,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1082,7 +1082,7 @@ __metadata:
   resolution: "@automattic/generate-password@workspace:packages/generate-password"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1112,7 +1112,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -1145,7 +1145,7 @@ __metadata:
     "@wordpress/router": "npm:^1.19.0"
     copy-webpack-plugin: "npm:^10.2.4"
     postcss-prefix-selector: "npm:^1.16.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
@@ -1183,7 +1183,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-draggable: "npm:^4.4.4"
     smooch: "npm:5.6.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@automattic/calypso-router": "workspace:^"
     "@wordpress/data": ^10.19.0
@@ -1212,7 +1212,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1240,7 +1240,7 @@ __metadata:
     "@types/allure-js-commons": "npm:^0.0.1"
     "@types/node": "npm:^22.7.5"
     allure-js-commons: "npm:2.0.0-beta.9"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1262,7 +1262,7 @@ __metadata:
     postcss: "npm:^8.5.1"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@babel/runtime": ^7.26.9
@@ -1280,7 +1280,7 @@ __metadata:
   resolution: "@automattic/js-utils@workspace:packages/js-utils"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1296,7 +1296,7 @@ __metadata:
     "@wordpress/components": "npm:^29.5.0"
     "@wordpress/i18n": "npm:^5.19.0"
     "@wordpress/react-i18n": "npm:^4.19.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1318,7 +1318,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   languageName: unknown
   linkType: soft
@@ -1363,7 +1363,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.97.1"
     wpcom-proxy-request: "workspace:^"
@@ -1415,7 +1415,7 @@ __metadata:
     i18n-calypso: "workspace:^"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^5.0.1
@@ -1528,7 +1528,7 @@ __metadata:
     react-markdown: "npm:^9.0.1"
     react-redux: "npm:^9.2.0"
     smooch: "npm:5.6.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     wpcom-proxy-request: "npm:^7.0.5"
   languageName: unknown
   linkType: soft
@@ -1612,7 +1612,7 @@ __metadata:
     sass-loader: "npm:^13.1.0"
     style-loader: "npm:^1.3.0"
     tslib: "npm:^2.5.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -1644,7 +1644,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     resize-observer-polyfill: "npm:1.5.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1687,7 +1687,7 @@ __metadata:
     react-intersection-observer: "npm:^9.4.3"
     react-transition-group: "npm:^4.3.0"
     resize-observer-polyfill: "npm:^1.5.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@wordpress/i18n": ^5.19.0
@@ -1723,7 +1723,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     postcss: "npm:^8.5.1"
     require-from-string: "npm:^2.0.2"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     react: ^18.3.1
@@ -1785,7 +1785,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     react: ^18.3.1
@@ -1802,7 +1802,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.2.0"
     debug: "npm:^4.3.3"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -1826,7 +1826,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     copyfiles: "npm:^2.4.1"
     postcss: "npm:^8.4.5"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@wordpress/data": ^10.19.0
@@ -1845,7 +1845,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.2.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1873,7 +1873,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@babel/runtime": ^7.26.9
@@ -1896,7 +1896,7 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1922,7 +1922,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     debug: "npm:^4.3.4"
     react-popper: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1954,7 +1954,7 @@ __metadata:
   resolution: "@automattic/urls@workspace:packages/urls"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -1990,7 +1990,7 @@ __metadata:
     "@wordpress/stylelint-config": "npm:^23.11.0"
     "@wordpress/url": "npm:^4.19.0"
     node-fetch: "npm:^2.7.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@babel/core": "*"
     "@wordpress/data": ^10.19.0
@@ -2025,7 +2025,7 @@ __metadata:
   resolution: "@automattic/viewport@workspace:packages/viewport"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -2130,7 +2130,7 @@ __metadata:
     "@wordpress/keycodes": "npm:^4.19.0"
     "@wordpress/react-i18n": "npm:^4.19.0"
     clsx: "npm:^2.1.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
@@ -2237,7 +2237,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@emotion/react": ^11.4.1
     redux: ^5.0.1
@@ -2254,7 +2254,7 @@ __metadata:
     "@wordpress/url": "npm:^4.19.0"
     i18n-calypso: "workspace:^"
     social-logos: "npm:^3.1.16"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   peerDependencies:
     "@wordpress/data": ^10.19.0
     react: ^18.3.1
@@ -2273,7 +2273,7 @@ __metadata:
     "@wordpress/element": "npm:^6.19.0"
     "@wordpress/url": "npm:^4.19.0"
     react: "npm:^18.3.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
@@ -21281,7 +21281,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tannin: "npm:^1.1.1"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
     use-subscription: "npm:1.6.0"
   peerDependencies:
     react: ^18.3.1
@@ -27682,7 +27682,7 @@ __metadata:
     debug: "npm:^4.3.3"
     seed-random: "npm:^2.2.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:5.5.4"
+    typescript: "npm:^5.5.4"
   languageName: unknown
   linkType: soft
 
@@ -34215,6 +34215,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.5.4":
+  version: 5.8.2
+  resolution: "typescript@npm:5.8.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 5c4f6fbf1c6389b6928fe7b8fcd5dc73bb2d58cd4e3883f1d774ed5bd83b151cbac6b7ecf11723de56d4676daeba8713894b1e9af56174f2f9780ae7848ec3c6
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>":
   version: 5.5.4
   resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=e012d7"
@@ -34222,6 +34232,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10dd9881baba22763de859e8050d6cb6e2db854197495c6f1929b08d1eb2b2b00d0b5d9b0bcee8472f1c3f4a7ef6a5d7ebe0cfd703f853aa5ae465b8404bc1ba
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.5.4#optional!builtin<compat/typescript>":
+  version: 5.8.2
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=e012d7"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 8a6cd29dfb59bd5a978407b93ae0edb530ee9376a5b95a42ad057a6f80ffb0c410489ccd6fe48d1d0dfad6e8adf5d62d3874bbd251f488ae30e11a1ce6dabd28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Extracted from https://github.com/Automattic/wp-calypso/pull/88826, more recent ts versions have more errors, but at least this is a step forward.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
