### PR TITLE
Jetpack Connect: Update copy for error messages

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -69,7 +69,9 @@ export class JetpackConnectNotices extends Component {
 		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
-			text: translate( "That's not a valid url." ),
+			text: translate(
+				'The URL you entered appears to be invalid. Please enter a valid WordPress site address.'
+			),
 			showDismiss: false,
 		};
 
@@ -108,7 +110,9 @@ export class JetpackConnectNotices extends Component {
 
 			case NOT_WORDPRESS:
 				noticeValues.icon = 'block';
-				noticeValues.text = translate( "That's not a WordPress site." );
+				noticeValues.text = translate(
+					"The site doesn't appear to be running WordPress. Please verify you're using the correct URL."
+				);
 				return noticeValues;
 
 			case NOT_ACTIVE_JETPACK:
@@ -117,12 +121,16 @@ export class JetpackConnectNotices extends Component {
 
 			case OUTDATED_JETPACK:
 				noticeValues.icon = 'block';
-				noticeValues.text = translate( 'You must update Jetpack before connecting.' );
+				noticeValues.text = translate(
+					'Your Jetpack plugin is outdated. Please update Jetpack to the latest version before connecting.'
+				);
 				return noticeValues;
 
 			case JETPACK_IS_DISCONNECTED:
 				noticeValues.icon = 'link-break';
-				noticeValues.text = translate( 'Jetpack is currently disconnected.' );
+				noticeValues.text = translate(
+					'Jetpack is currently disconnected. Please reconnect it to continue.'
+				);
 				return noticeValues;
 
 			case JETPACK_IS_VALID:
@@ -136,7 +144,9 @@ export class JetpackConnectNotices extends Component {
 				return null;
 
 			case WORDPRESS_DOT_COM:
-				noticeValues.text = translate( "Oops, that's us." );
+				noticeValues.text = translate(
+					'This is a WordPress.com site, which already includes Jetpack features.'
+				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'status';
 				return noticeValues;
@@ -160,7 +170,9 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case SECRET_EXPIRED:
-				noticeValues.text = translate( "Oops, that took a while. You'll have to try again." );
+				noticeValues.text = translate(
+					'The connection request has expired. Please refresh the page and try connecting again.'
+				);
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
 				return noticeValues;
@@ -185,7 +197,7 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case ALREADY_CONNECTED:
-				noticeValues.text = translate( 'This site is already connected' );
+				noticeValues.text = translate( 'This site is already connected to WordPress.com.' );
 				noticeValues.status = 'is-info';
 				noticeValues.icon = 'notice';
 				return noticeValues;
@@ -209,12 +221,14 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case XMLRPC_ERROR:
-				noticeValues.text = translate( 'We had trouble connecting.' );
+				noticeValues.text = translate(
+					'We had trouble connecting to your site. Please check that your site is accessible and try again.'
+				);
 				return noticeValues;
 
 			case INVALID_CREDENTIALS:
 				noticeValues.text = translate(
-					'Oops, the credentials you entered were invalid. Please try again'
+					'The credentials you entered were invalid. Please double-check your username and password and try again.'
 				);
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100102

The current messages are a bit terse and they don't help a lot. 

## Proposed Changes

Updates error messages to 

* The URL you entered appears to be invalid. Please enter a valid WordPress site address. 
  * Before: _That's not a valid url._  
* The site doesn't appear to be running WordPress. Please verify you're using the correct URL. 
  * Before:  _That's not a WordPress site._
* Your Jetpack plugin is outdated. Please update Jetpack to the latest version before connecting.
  * Before: _You must update Jetpack before connecting._
* Jetpack is currently disconnected. Please reconnect it to continue.
  * Before: _Jetpack is currently disconnected._
* This is a WordPress.com site, which already includes Jetpack features.
  * Before:  _Oops, that's us._
* The connection request has expired. Please refresh the page and try connecting again.
  * Before:  _Oops, that took a while. You'll have to try again._
* This site is already connected to WordPress.com.
  * Before:  _ This site is already connected_
* We had trouble connecting to your site. Please check that your site is accessible and try again.
  * Before:  _ We had trouble connecting._
* The credentials you entered were invalid. Please double-check your username and password and try again.
  * Before:  _ Oops, the credentials you entered were invalid. Please try again_

#### After

<img width="884" alt="image" src="https://github.com/user-attachments/assets/e4e714cf-15ff-4dca-a217-6f5d6b0ff2e5" />

<img width="886" alt="image" src="https://github.com/user-attachments/assets/dd49c4a7-522e-4c88-959d-aa040e8cad10" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Identified as necessary task in the context of p58i-kb4-p2
 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?