### PR TITLE
Notifications: Remove default horizontal margin from buttons

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -13,7 +13,6 @@
 		color: var(--color-neutral-70);
 		cursor: pointer;
 		display: block;
-		margin: 0 24px;
 		outline: 0;
 		overflow: hidden;
 		font-weight: 500;


### PR DESCRIPTION
Fixes #100422

Reverts the margin change introduced in #56146


## Proposed Changes

* Removes horizontal margin from `wpnc__button` class for notifications.

### After

<img width="440" alt="Screenshot 2025-03-08 at 9 42 22 AM" src="https://github.com/user-attachments/assets/daa174d5-2bd3-4350-af5d-7d4d16ab7900" />

### Before

<img width="440" alt="Screenshot 2025-03-08 at 9 42 22 AM" src="https://github.com/user-attachments/assets/00a117aa-b8c0-4806-83e0-890cebefd642" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Identified as necessary task in the context of p58i-kb4-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?