### PR TITLE
Update plan label in sites dashboard to not use spaces if expired

### DIFF
--- a/client/sites-dashboard/components/sites-plan-renew-nag.tsx
+++ b/client/sites-dashboard/components/sites-plan-renew-nag.tsx
@@ -85,7 +85,7 @@ export const PlanRenewNag = ( {
 					<PlanRenewNoticeExpireText>
 						{ sprintf(
 							/* translators: %s - the plan's product name */
-							__( '%s - Expired' ),
+							__( '%s-Expired' ),
 							plan.product_name_short
 						) }
 					</PlanRenewNoticeExpireText>

--- a/client/sites-dashboard/components/test/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/test/sites-site-plan.tsx
@@ -84,7 +84,7 @@ describe( '<SitePlan>', () => {
 		const { getByText, queryAllByRole } = render(
 			<SitePlan site={ expiredBusinessSite } userId={ otherAdminId } />
 		);
-		expect( getByText( 'Creator - Expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Creator-Expired' ) ).toBeInTheDocument();
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 0 );
 	} );
 
@@ -92,7 +92,7 @@ describe( '<SitePlan>', () => {
 		const { getByText, queryAllByRole, getByRole } = render(
 			<SitePlan site={ expiredBusinessSite } userId={ siteOwnerId } />
 		);
-		expect( getByText( 'Creator - Expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Creator-Expired' ) ).toBeInTheDocument();
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 1 );
 		expect( getByRole( 'link', { name: 'Renew plan' } ) ).toHaveAttribute(
 			'href',
@@ -112,7 +112,7 @@ describe( '<SitePlan>', () => {
 		const { container, queryAllByRole } = render(
 			<SitePlan site={ expiredTrialSite } userId={ otherAdminId } />
 		);
-		expect( container.textContent ).toBe( 'Creator Trial - Expired' );
+		expect( container.textContent ).toBe( 'Creator Trial-Expired' );
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 0 );
 	} );
 
@@ -120,7 +120,7 @@ describe( '<SitePlan>', () => {
 		const { getByText, queryAllByRole, getByRole } = render(
 			<SitePlan site={ expiredTrialSite } userId={ siteOwnerId } />
 		);
-		expect( getByText( 'Creator Trial - Expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Creator Trial-Expired' ) ).toBeInTheDocument();
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 1 );
 		expect( getByRole( 'link', { name: 'Upgrade' } ) ).toHaveAttribute(
 			'href',


### PR DESCRIPTION
Fixes #100307

## Proposed Changes

* Removes whitespace around emdash from plan renew nag

### After

![image](https://github.com/user-attachments/assets/817e5e1e-25b1-4ee3-8ba0-edeca30c00ee)


### Before 
![image](https://github.com/user-attachments/assets/2fa76d2b-0b65-4c26-b5a4-71760820a7f0)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Identified as necessary task in the context of p58i-kb4-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?