### PR TITLE
Jetpack Connect: Add back button on URL screen

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -1,5 +1,6 @@
 import { PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { Button, Gridicon } from '@automattic/components';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import { flowRight, get, omit } from 'lodash';
@@ -73,6 +74,17 @@ const jetpackConnection = ( WrappedComponent ) => {
 						{ translate( 'Install Jetpack manually' ) }
 					</LoggedOutFormLinkItem>
 					<HelpButton />
+					<div className="jetpack-connect__navigation">
+						<Button
+							compact
+							borderless
+							className="jetpack-connect__back-button"
+							onClick={ this.goBack }
+						>
+							<Gridicon icon="arrow-left" size={ 18 } />
+							{ translate( 'Back' ) }
+						</Button>
+					</div>
 				</LoggedOutFormLinks>
 			);
 		};

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -66,6 +66,15 @@ const jetpackConnection = ( WrappedComponent ) => {
 			}
 		}
 
+		/**
+		 * Check if there is a history of pages to go back to
+		 *
+		 * @returns {boolean}
+		 */
+		canGoBack = () => {
+			return page.len > 0 || window.history.length > 1;
+		};
+
 		renderFooter = () => {
 			const { translate } = this.props;
 			return (
@@ -74,17 +83,19 @@ const jetpackConnection = ( WrappedComponent ) => {
 						{ translate( 'Install Jetpack manually' ) }
 					</LoggedOutFormLinkItem>
 					<HelpButton />
-					<div className="jetpack-connect__navigation">
-						<Button
-							compact
-							borderless
-							className="jetpack-connect__back-button"
-							onClick={ this.goBack }
-						>
-							<Gridicon icon="arrow-left" size={ 18 } />
-							{ translate( 'Back' ) }
-						</Button>
-					</div>
+					{ this.canGoBack() && (
+						<div className="jetpack-connect__navigation">
+							<Button
+								compact
+								borderless
+								className="jetpack-connect__back-button"
+								onClick={ this.goBack }
+							>
+								<Gridicon icon="arrow-left" size={ 18 } />
+								{ translate( 'Back' ) }
+							</Button>
+						</div>
+					) }
 				</LoggedOutFormLinks>
 			);
 		};


### PR DESCRIPTION
Fixes #100303

## Proposed Changes

* Adds a back button **if there is browser history to go back to.**

### After 

<img width="895" alt="image" src="https://github.com/user-attachments/assets/220547fb-29a9-46dd-a6f8-7bee5ddd1717" />

### Before 

<img width="890" alt="image" src="https://github.com/user-attachments/assets/2eeaa839-1d93-48a2-89ce-c3902ecd7d5e" />

## Why are these changes being made?

* Identified as necessary task in the context of p58i-kb4-p2

## Testing Instructions

These are valid after the PR gets merged

For seeing the back button

* Open new tab
* Visit `https://wordpress.com/jetpack/connect`
* Expect to see the back button as usually there's a default page loaded on new tab

For confirming the button doesn't appear. 

* Click this link https://wordpress.com/jetpack/connect with the modifier key that triggers new tabs in your browser
* Confirm the back button is not present.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?