### PR TITLE
Jetpack Connect: Update title for licensing prompt dialog

### DIFF
--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -47,7 +47,7 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	}, [ dispatch ] );
 
 	let titleToRender = window.location.pathname.startsWith( JPC_PATH_PLANS )
-		? translate( 'Jetpack is successfully connected' )
+		? translate( 'Activate your license for this site' )
 		: '';
 
 	if ( ! titleToRender ) {


### PR DESCRIPTION
Fixes #100106

## Proposed Changes

* Updates copy in title to **Activate your license for this site** from _Jetpack is successfully connected_ so it's connected to the action proposed below


### After

<img width="829" alt="image" src="https://github.com/user-attachments/assets/707d6df1-0651-4d31-a42a-f717b798bc26" />

### Before

<img width="760" alt="image" src="https://github.com/user-attachments/assets/4deab041-91a0-46c8-b442-225be9799f9b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Identified as necessary task in the context of p58i-kb4-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?