### PR TITLE
Update /settings/general to /domains/manage/select-site in delete account flow

### DIFF
--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -73,7 +73,7 @@ class AccountCloseConfirmDialog extends Component {
 						{
 							englishText: "Change your site's address",
 							text: translate( "Change your site's address" ),
-							href: '/settings/general',
+							href: '/domains/manage',
 							supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
 							supportPostId: 11280,
 						},

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -73,7 +73,7 @@ class AccountCloseConfirmDialog extends Component {
 						{
 							englishText: "Change your site's address",
 							text: translate( "Change your site's address" ),
-							href: '/domains/manage',
+							href: '/domains/manage/select-site',
 							supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
 							supportPostId: 11280,
 						},

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -9,6 +9,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { onboardingUrl } from 'calypso/lib/paths';
 import { clearStore, disablePersistence } from 'calypso/lib/user/store';
+import { domainManagementSelectSite } from 'calypso/my-sites/domains/paths';
 import { closeAccount } from 'calypso/state/account/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
@@ -73,7 +74,7 @@ class AccountCloseConfirmDialog extends Component {
 						{
 							englishText: "Change your site's address",
 							text: translate( "Change your site's address" ),
-							href: '/domains/manage/select-site',
+							href: domainManagementSelectSite(),
 							supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
 							supportPostId: 11280,
 						},

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -9,6 +9,7 @@ import {
 	stagingSiteNotSupportedRedirect,
 	noSite,
 } from 'calypso/my-sites/controller';
+import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
 import emailController from '../email/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -160,6 +161,24 @@ export default function () {
 		paths.domainManagementTransferToOtherSite,
 		domainManagementController.domainManagementTransferToOtherSite
 	);
+
+	// /domains/manage/select-site
+	// Allows the user to select a site to manage domains for.
+	// Workaround for not listing wordpress.com subdomains on the global /domains/manage.
+	// This is **not** a workaround for /domains/manage omitting to render a site selector.
+	// See https://github.com/Automattic/wp-calypso/issues/100339
+	page( paths.domainManagementSelectSite(), siteSelection, sites, makeLayout, clientRender );
+
+	// /domains/manage/select-site/:site
+	// Redirects to the selected site to /domains/manage/:site
+	page( paths.domainManagementSelectSite( ':site' ), siteSelection, ( context ) => {
+		const state = context.store.getState();
+		const slug = getSelectedSiteSlug( state );
+		if ( slug ) {
+			return page.redirect( paths.domainManagementList( slug ) );
+		}
+		return page.redirect( paths.domainManagementRoot() );
+	} );
 
 	page(
 		paths.domainManagementRoot(),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -166,7 +166,9 @@ export default function () {
 	// Allows the user to select a site to manage domains for.
 	// Workaround for not listing wordpress.com subdomains on the global /domains/manage.
 	// This is **not** a workaround for /domains/manage omitting to render a site selector.
-	// See https://github.com/Automattic/wp-calypso/issues/100339
+	// This and the below route will need to be removed if we ever add wordpress.com subdomains
+	// to the global domain management pages and remove site specific domain management.
+	// See https://github.com/Automattic/wp-calypso/issues/100339 for more details.
 	page( paths.domainManagementSelectSite(), siteSelection, sites, makeLayout, clientRender );
 
 	// /domains/manage/select-site/:site

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -113,6 +113,10 @@ export function domainManagementRoot() {
 	return '/domains/manage';
 }
 
+export function domainManagementSelectSite( siteName = '' ) {
+	return '/domains/manage/select-site/' + siteName;
+}
+
 /**
  * @param {string|undefined} siteName
  * @param {string|undefined} relativeTo


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100339

## Proposed Changes

* Replaces /settings/general route with /domains/manage

## Why are these changes being made?

* The /settings/general route doesn't make sense for a "Change site address nudge"

## Testing Instructions

* With a new account + site (or account with no purchases)
* Attempt to delete site
* See confirm dialog
* Click link going to "Change your site address"
* [ ] Be taken to /domains/manage
