### PR TITLE
Stats: override secondary button style for date range picker

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -89,4 +89,13 @@
 	ul.wp-submenu-wrap {
 		margin-left: 0;
 	}
+
+	&.wp-core-ui .button.is-secondary {
+		border-color: var(--color-neutral-20);
+		background-color: inherit;
+		&:hover {
+			color: var(--color-text-subtle);
+			border-color: var(--color-neutral-60);
+		}
+	}
 }

--- a/client/components/date-range/footer.tsx
+++ b/client/components/date-range/footer.tsx
@@ -26,7 +26,7 @@ const DateRangeFooter: FunctionComponent< Props > = ( {
 	return (
 		<div className="date-range__popover-footer">
 			<Button
-				className="date-range__cancel-btn"
+				className="date-range__cancel-btn is-secondary"
 				onClick={ onCancelClick }
 				compact
 				aria-label={ cancelText }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100509

## Proposed Changes

* Fix gray background for the cancel button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Odyssey Stats locally following instructions at `PCYsg-Pp7-p2`
* Open the traffic page, and click open the date range picker


| Before | After |
|-------|-------|
| <img width="237" alt="image" src="https://github.com/user-attachments/assets/77f908cb-8eb2-4c8c-a092-2ebce880ba78" />  | <img width="206" alt="image" src="https://github.com/user-attachments/assets/f3901c4a-bd40-48e9-b46b-cf6a36436c34" />  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?