### PR TITLE
Sites Dashboard: Removes hover color from disabled reset button

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -11,9 +11,7 @@
 	border-color: var(--color-accent);
 	color: var(--color-text-inverted);
 
-	&:active:not(:disabled),
-	&:hover:not(:disabled),
-	&:focus:not(:disabled) {
+	&:is(:active, :hover, :focus):not(:disabled, [aria-disabled="true"]) {
 		background-color: var(--color-accent-60);
 		border-color: var(--color-accent-60);
 		color: var(--color-text-inverted);
@@ -33,8 +31,7 @@
 	color: var(--color-neutral-70);
 	box-shadow: inset 0 0 0 1px var(--color-neutral-10);
 
-	&:active:not(:disabled),
-	&:hover:not(:disabled) {
+	&:is(:active, :hover):not(:disabled, [aria-disabled="true"]) {
 		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
 		color: var(--color-neutral-70);
 	}
@@ -55,8 +52,7 @@
 .components-button.is-tertiary {
 	color: var(--color-accent);
 
-	&:active:not(:disabled),
-	&:hover:not(:disabled) {
+	&:is(:active, :hover):not(:disabled, [aria-disabled="true"]) {
 		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
 		color: var(--color-accent-60);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix https://github.com/Automattic/wp-calypso/issues/100373

## Proposed Changes

This PR removes hover color from disabled reset button in DataViews. 

- Updated button styles to prevent hover effects when buttons have `aria-disabled="true"` attribute
- _Kept `aria-disabled` on DataViews component instead of using `disabled` attribute, as this follows Gutenberg's Button component design_: https://github.com/WordPress/gutenberg/blob/e4649fe6896123231de35da0875e93ac2920c23a/packages/components/src/button/types.ts#L28-L40

Before:

https://github.com/user-attachments/assets/6865da4a-cedd-4fc8-b28f-4da781751a4a

After: Removes a color change on hover.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- As it diverges from Core. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/sites`
2. Apply all the filters
3. Hover over the "Add filter" button
4. Verify that the disabled button no longer shows hover effects (text color should not change to blue)
5. Verify that button colors on hover still works on any screens in Calypso

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
