### PR TITLE
A4A > WooPayments: Add track events and apply Core Typography

### DIFF
--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -82,6 +82,7 @@ interface ConsolidatedStatsCardProps {
 	popoverTitle?: string;
 	popoverContent: React.ReactNode;
 	isLoading?: boolean;
+	applyCoreStyles?: boolean;
 }
 
 export function ConsolidatedStatsCard( {
@@ -90,16 +91,27 @@ export function ConsolidatedStatsCard( {
 	popoverTitle,
 	popoverContent,
 	isLoading = false,
+	applyCoreStyles = false,
 }: ConsolidatedStatsCardProps ) {
 	const cardRef = useRef< HTMLDivElement | null >( null );
 
 	return (
-		<Card compact ref={ cardRef }>
+		<Card
+			compact
+			ref={ cardRef }
+			className={ clsx( 'consolidated-stats-card', { 'is-core-styles': applyCoreStyles } ) }
+		>
 			<div className="consolidated-stats-card__value">
 				{ isLoading ? <TextPlaceholder /> : value }
 			</div>
 			<CardInfo title={ popoverTitle } wrapperRef={ cardRef } footerText={ footerText }>
-				<div className="consolidated-stats-card__popover-content">{ popoverContent }</div>
+				<div
+					className={ clsx( 'consolidated-stats-card__popover-content', {
+						'is-core-styles': applyCoreStyles,
+					} ) }
+				>
+					{ popoverContent }
+				</div>
 			</CardInfo>
 		</Card>
 	);

--- a/client/a8c-for-agencies/components/consolidated-stats-card/style.scss
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .consolidated-stats-group {
 	display: flex;
@@ -52,9 +53,10 @@
 		align-items: flex-start;
 
 		.consolidated-stats-card__info-mobile {
+			@include body-small;
+
 			margin: 0;
 			padding: 0;
-			font-size: rem(12px);
 			color: var(--color-neutral-50);
 			text-decoration: underline;
 			display: flex;
@@ -107,3 +109,21 @@
 		outline: none;
 	}
 }
+
+// Core styles
+
+.consolidated-stats-card.is-core-styles {
+	.consolidated-stats-card__value {
+		@include heading-x-large;
+	}
+
+	.consolidated-stats-card__label {
+		@include body-medium;
+	}
+}
+
+.consolidated-stats-card__popover-content.is-core-styles {
+	@include body-medium;
+}
+
+// End of core styles

--- a/client/a8c-for-agencies/components/copy-to-clipboard-button/index.tsx
+++ b/client/a8c-for-agencies/components/copy-to-clipboard-button/index.tsx
@@ -7,7 +7,13 @@ import { useState } from 'react';
 
 import './style.scss';
 
-const CopyToClipboardButton = ( { textToCopy }: { textToCopy: string } ) => {
+const CopyToClipboardButton = ( {
+	textToCopy,
+	onClick,
+}: {
+	textToCopy: string;
+	onClick?: () => void;
+} ) => {
 	const translate = useTranslate();
 	const isNarrowView = useBreakpoint( '<960px' );
 
@@ -21,6 +27,7 @@ const CopyToClipboardButton = ( { textToCopy }: { textToCopy: string } ) => {
 	};
 
 	const copyToClipboard = () => {
+		onClick?.();
 		navigator.clipboard
 			.writeText( textToCopy )
 			.then( () => {

--- a/client/a8c-for-agencies/components/simple-list/index.tsx
+++ b/client/a8c-for-agencies/components/simple-list/index.tsx
@@ -6,12 +6,18 @@ import './style.scss';
 export default function SimpleList( {
 	items,
 	className,
+	applyCoreStyles = false,
 }: {
 	items: ReactNode[];
 	className?: string;
+	applyCoreStyles?: boolean;
 } ) {
 	return (
-		<ul className={ clsx( 'simple-list', className ) }>
+		<ul
+			className={ clsx( 'simple-list', className, {
+				'is-core-styles': applyCoreStyles,
+			} ) }
+		>
 			{ items.map( ( item, index ) => (
 				<li key={ `item-${ index }` }>
 					<Icon className="simple-list-icon" icon={ check } size={ 24 } />

--- a/client/a8c-for-agencies/components/simple-list/style.scss
+++ b/client/a8c-for-agencies/components/simple-list/style.scss
@@ -1,3 +1,7 @@
+
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .simple-list {
 	display: flex;
 	flex-direction: column;
@@ -11,6 +15,12 @@
 		display: flex;
 		flex-direction: row;
 		@include a4a-font-body-lg($line-height: 1.625);
+	}
+
+	&.is-core-styles {
+		li {
+			@include body-large;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/components/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/index.tsx
@@ -19,6 +19,7 @@ interface StepSectionItemProps {
 	iconClassName?: string;
 	isNewLayout?: boolean;
 	stepNumber?: number;
+	applyCoreStyles?: boolean;
 }
 
 export default function StepSectionItem( {
@@ -31,6 +32,7 @@ export default function StepSectionItem( {
 	iconClassName,
 	isNewLayout = false,
 	stepNumber,
+	applyCoreStyles = false,
 }: StepSectionItemProps ) {
 	const status = <StatusBadge statusProps={ statusProps } />;
 
@@ -45,7 +47,9 @@ export default function StepSectionItem( {
 	);
 
 	return (
-		<div className={ clsx( 'step-section-item', className ) }>
+		<div
+			className={ clsx( 'step-section-item', className, { 'is-core-styles': applyCoreStyles } ) }
+		>
 			{ icon && (
 				<div className={ clsx( 'step-section-item__icon', iconClassName ) }>
 					<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />

--- a/client/a8c-for-agencies/components/step-section-item/style.scss
+++ b/client/a8c-for-agencies/components/step-section-item/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 .step-section-item {
 	margin-block-end: 16px;
 	border-radius: 4px;
@@ -46,6 +46,16 @@
 				width: auto;
 				height: inherit;
 			}
+		}
+	}
+
+	&.is-core-styles {
+		.step-section-item__heading {
+			@include heading-medium;
+		}
+
+		.step-section-item__description {
+			@include body-medium;
 		}
 	}
 }

--- a/client/a8c-for-agencies/components/step-section/index.tsx
+++ b/client/a8c-for-agencies/components/step-section/index.tsx
@@ -8,6 +8,7 @@ interface StepSectionProps {
 	stepCount?: number;
 	children: React.ReactNode;
 	className?: string;
+	applyCoreStyles?: boolean;
 }
 
 export default function StepSection( {
@@ -15,9 +16,10 @@ export default function StepSection( {
 	heading,
 	children,
 	className,
+	applyCoreStyles = false,
 }: StepSectionProps ) {
 	return (
-		<div className={ clsx( 'step-section', className ) }>
+		<div className={ clsx( 'step-section', className, { 'is-core-styles': applyCoreStyles } ) }>
 			<div className="step-section__header">
 				{ !! stepCount && <div className="step-section__step-count">{ stepCount }</div> }
 				<div className="step-section__step-heading">{ heading }</div>

--- a/client/a8c-for-agencies/components/step-section/style.scss
+++ b/client/a8c-for-agencies/components/step-section/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 .step-section {
 	.step-section__header {
 		display: flex;
@@ -31,6 +31,12 @@
 			text-wrap: pretty;
 		}
 	}
+
+	&.is-core-styles {
+		.step-section__step-heading {
+			@include heading-large;
+		}
+	}
 }
 
 .referrals-layout--automated,
@@ -39,3 +45,4 @@
 		font-size: rem(16px);
 	}
 }
+

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -5,10 +5,13 @@ import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
 import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSiteTable, { type WooPaymentsSiteItem } from './add-site-table';
 
 const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const [ selectedSite, setSelectedSite ] = useState< WooPaymentsSiteItem | null >( null );
 
@@ -23,6 +26,7 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 
 	const handleAddSite = () => {
 		if ( selectedSite ) {
+			dispatch( recordTracksEvent( 'calypso_a4a_woopayments_add_site_button_click' ) );
 			issueAndAssignLicenses( [
 				{
 					slug: 'woocommerce-woopayments',

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
@@ -21,6 +21,7 @@ const WooPaymentsConsolidatedViews = () => {
 	return (
 		<ConsolidatedStatsGroup className="consolidated-view">
 			<ConsolidatedStatsCard
+				applyCoreStyles
 				value={ formatCurrency( totalCommission, 'USD' ) }
 				footerText={ translate( 'Total WooPayments commissions paid' ) }
 				popoverTitle={ translate( 'Total WooPayments commissions paid' ) }
@@ -37,6 +38,7 @@ const WooPaymentsConsolidatedViews = () => {
 				isLoading={ isLoadingWooPaymentsData }
 			/>
 			<ConsolidatedStatsCard
+				applyCoreStyles
 				value={ formatCurrency( expectedCommission, 'USD' ) }
 				footerText={ translate( 'Next estimated payout amount' ) }
 				popoverTitle={ translate( 'Estimated amount' ) }
@@ -60,6 +62,7 @@ const WooPaymentsConsolidatedViews = () => {
 				isLoading={ isLoadingWooPaymentsData }
 			/>
 			<ConsolidatedStatsCard
+				applyCoreStyles
 				value={ nextPayoutDate + '*' }
 				footerText={ translate( 'Next estimated payout date' ) }
 				popoverTitle={ translate( 'Estimated date' ) }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -4,6 +4,8 @@ import { useTranslate, formatCurrency } from 'i18n-calypso';
 import { memo } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
@@ -25,10 +27,14 @@ export const WooPaymentsStatusColumn = ( {
 	siteUrl: string;
 } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	if ( ! state ) {
 		return (
 			<Button
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_a4a_woopayments_setup_in_wp_admin' ) );
+				} }
 				variant="tertiary"
 				href={ `${ siteUrl }/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` }
 				target="_blank"

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -9,10 +9,13 @@ import cartImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cart.p
 import ccImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cc-image.png';
 import demoImage from 'calypso/assets/images/a8c-for-agencies/woopayments/demo.png';
 import wooPaymentsLogo from 'calypso/assets/images/a8c-for-agencies/woopayments/logo.svg';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 
 const WooPaymentsDashboardEmptyState = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const isNarrowView = useBreakpoint( '<960px' );
 
@@ -91,6 +94,11 @@ const WooPaymentsDashboardEmptyState = () => {
 													href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
 													target="_blank"
 													rel="noopener noreferrer"
+													onClick={ () => {
+														dispatch(
+															recordTracksEvent( 'calypso_a4a_woopayments_learn_more_button_click' )
+														);
+													} }
 												/>
 											),
 										},
@@ -107,6 +115,11 @@ const WooPaymentsDashboardEmptyState = () => {
 													href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
 													target="_blank"
 													rel="noopener noreferrer"
+													onClick={ () => {
+														dispatch(
+															recordTracksEvent( 'calypso_a4a_woopayments_view_terms_button_click' )
+														);
+													} }
 												/>
 											),
 										},
@@ -118,6 +131,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							__next40pxDefaultSize
 							href="/marketplace/products?show_license_modal=woocommerce-woopayments"
 							className="woopayments-dashboard-empty-state__button"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_view_details_button_click' )
+								);
+							} }
 						>
 							{ translate( 'View details and start earning ↗' ) }
 						</Button>
@@ -155,6 +173,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							textToCopy={ [ ...listItems1, ...listItems2 ]
 								.map( ( item ) => `• ${ item }` )
 								.join( '\n' ) }
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_copy_benefits_button_click' )
+								);
+							} }
 						/>
 					</>
 				}
@@ -186,6 +209,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/products/woopayments/"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_explore_woocommerce_button_click' )
+								);
+							} }
 						>
 							{ translate( 'Explore WooPayments on WooCommerce.com ↗' ) }
 						</Button>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -186,10 +186,10 @@ const WooPaymentsDashboardEmptyState = () => {
 				} }
 			>
 				<PageSectionColumns.Column>
-					<SimpleList items={ listItems1 } />
+					<SimpleList applyCoreStyles items={ listItems1 } />
 				</PageSectionColumns.Column>
 				<PageSectionColumns.Column>
-					<SimpleList items={ listItems2 } />
+					<SimpleList applyCoreStyles items={ listItems2 } />
 				</PageSectionColumns.Column>
 			</PageSectionColumns>
 

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -51,6 +51,8 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_woopayments_site_setup_install_plugin_click', {
 				status: isInstalled ? 'installed' : 'not_installed',
+				isWooPaymentsActive,
+				isWooCommerceActive,
 			} )
 		);
 
@@ -142,8 +144,9 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 								'Follow the steps below to complete the process so you can earn commissions.'
 							) }
 						</div>
-						<StepSection heading={ translate( 'Next steps' ) }>
+						<StepSection applyCoreStyles heading={ translate( 'Next steps' ) }>
 							<StepSectionItem
+								applyCoreStyles
 								isNewLayout
 								heading={ translate( 'Install and activate the plugin on WP-Admin' ) }
 								description={
@@ -192,6 +195,7 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 								}
 							/>
 							<StepSectionItem
+								applyCoreStyles
 								isNewLayout
 								heading={ translate( 'Earn commissions' ) }
 								description={

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/style.scss
@@ -5,10 +5,6 @@
 	max-width: 900px;
 	padding-block-start: calc(24px + 48px);
 
-	.step-section .step-section__header .step-section__step-heading {
-		@include heading-large;
-	}
-
 	.step-section-item__description {
 		.components-button {
 			margin-block-start: 16px;

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -613,6 +613,20 @@ html {
 		overflow-y: auto;
 		margin-block: 24px;
 
+		&::-webkit-scrollbar {
+			width: 4px;
+		}
+
+		&::-webkit-scrollbar-track {
+			background: transparent;
+		}
+
+		&::-webkit-scrollbar-thumb {
+			background-color: rgba(155, 155, 155, 0.5);
+			border-radius: 4px;
+			border: transparent;
+		}
+
 		&::after {
 			content: "";
 			position: absolute;


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1847
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1904

## Proposed Changes

- Add all the event tracking: https://github.com/Automattic/wp-calypso/pull/101055/commits/73eb9583b0ad805da964c103cc4e4e671aa22bb8
- Minor UI enhancements to the table overlay: https://github.com/Automattic/wp-calypso/pull/101055/commits/0bb88912efc2e9104c5cd92b933ec95c4e9ce305
- Apply Core Typography: https://github.com/Automattic/wp-calypso/pull/101055/commits/ab37e1d6b9fc1308c8ebbfd45567bf664c2a3905

## Why are these changes being made?

* UI enhancements and tracking events

## Testing Instructions

* Open the A4A live link
* Go to WooPayments: Verify all below pages match the design: iyNspimFpNJSlBxaatQEoC-fi-6480_23310

1) Empty page
2) Sites list view
3) `Add WooPayments to site` popup
4) Site setup page

* Also, ensure the events are being tracked for the following:

1) All the buttons on the empty state view, including the `Copy to clipboard` button on the empty page
2) Clicking on the `Add WooPayments to site` button
3) Clicking the `Setup in WP-Admin ↗` link on the table column
4) Clicking on the CTAs on the site setup page

Screenshots:

Empty page

![screencapture-agencies-localhost-3000-woopayments-dashboard-2025-03-10-11_27_55](https://github.com/user-attachments/assets/6743580f-dc97-466e-834d-caac4acdcb37)

Sites list view

<img width="955" alt="Screenshot 2025-03-10 at 11 30 43 AM" src="https://github.com/user-attachments/assets/5317d3e0-0f35-4e4d-a9cc-028545b412bc" />

`Add WooPayments to site` popup

<img width="959" alt="Screenshot 2025-03-10 at 11 31 09 AM" src="https://github.com/user-attachments/assets/63522b06-88ca-4bae-aa9b-0a01d70bd608" />

Site setup page

<img width="960" alt="Screenshot 2025-03-10 at 11 31 43 AM" src="https://github.com/user-attachments/assets/b76c29e5-62df-4df4-9214-df3dc9160343" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?