### PR TITLE
Theme Details page: Make entire theme preview clickable

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -541,18 +541,39 @@ class ThemeSheet extends Component {
 			iframeToken.concat( '-', getTracksAnonymousUserId() ?? siteSlug );
 		}
 
+		if ( ! this.shouldRenderPreviewButton() ) {
+			return (
+				<div className="theme__sheet-web-preview">
+					<ThemeWebPreview
+						url={ url }
+						inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
+						iframeScaleRatio={ 0.5 }
+						iframeToken={ iframeToken }
+						isShowFrameBorder={ false }
+						isShowDeviceSwitcher={ false }
+						isFitHeight
+					/>
+				</div>
+			);
+		}
+
 		return (
-			<div className="theme__sheet-web-preview">
-				{ this.shouldRenderPreviewButton() && (
-					<Button
-						className="theme__sheet-preview-demo-site"
-						onClick={ ( e ) => {
-							this.previewAction( e, 'link', 'preview' );
-						} }
-					>
-						{ translate( 'Preview demo site' ) }
-					</Button>
-				) }
+			<div
+				className="theme__sheet-web-preview is-clickable"
+				role="button"
+				tabIndex="0"
+				onClick={ ( e ) => {
+					this.previewAction( e, 'link', 'preview' );
+				} }
+				onKeyDown={ ( e ) => {
+					if ( e.key === 'Enter' ) {
+						this.previewAction( e, 'link', 'preview' );
+					}
+				} }
+			>
+				<Button className="theme__sheet-preview-demo-site">
+					{ translate( 'Preview demo site' ) }
+				</Button>
 				<ThemeWebPreview
 					url={ url }
 					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -365,12 +365,17 @@ $button-border: 4px;
 			}
 		}
 	}
-	&:hover,
-	&:focus {
-		.theme-preview__frame-wrapper {
-			opacity: 0.8;
-		}
-	}
+
+    &.is-clickable {
+      cursor: pointer;
+
+      &:hover,
+      &:focus {
+          .theme-preview__frame-wrapper {
+              opacity: 0.8;
+          }
+      }
+    }
 
 	.theme-preview__container {
 		position: relative;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100256

## Proposed Changes

This PR makes the entire theme preview clickable.

Before:

https://github.com/user-attachments/assets/baa4de20-0a9f-4a29-b5b5-9818b31adc2d

After:

https://github.com/user-attachments/assets/2ac66cbf-fd10-495c-8d66-577bd4ce136e




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /themes
* Click any theme
* Ensure that the entire theme preview is clickable

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
