### PR TITLE
Sites dashboard: remove row actions that no longer make sense

### DIFF
--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -15,14 +15,6 @@ export const getDashboardUrl = ( slug: string ) => {
 	return `/home/${ slug }`;
 };
 
-export const getSettingsUrl = ( slug: string ) => {
-	return `/settings/general/${ slug }`;
-};
-
-export const getSiteMonitoringUrl = ( slug: string ) => {
-	return `/site-monitoring/${ slug }`;
-};
-
 export const getPluginsUrl = ( slug: string ) => {
 	return `/plugins/${ slug }`;
 };

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -1,4 +1,4 @@
-import { FEATURE_SFTP, getPlanPath, WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
+import { getPlanPath, WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
 import {
@@ -17,9 +17,7 @@ import useRestoreSiteMutation from 'calypso/sites/hooks/use-restore-site-mutatio
 import {
 	getAdminInterface,
 	getPluginsUrl,
-	getSettingsUrl,
 	getSiteAdminUrl,
-	getSiteMonitoringUrl,
 	isCustomDomain,
 	isDisconnectedJetpackAndNotAtomic,
 	isNotAtomicJetpack,
@@ -393,16 +391,6 @@ export function useActions( {
 			},
 
 			{
-				id: 'settings',
-				label: __( 'Site settings' ),
-				callback: ( sites ) => {
-					page( getSettingsUrl( sites[ 0 ].slug ) );
-					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_settings_click' ) );
-				},
-				isEligible: isActionEligible( 'settings', capabilities ),
-			},
-
-			{
 				id: 'general-settings',
 				label: __( 'General settings' ),
 				callback: ( sites ) => {
@@ -414,33 +402,6 @@ export function useActions( {
 					);
 				},
 				isEligible: isActionEligible( 'general-settings', capabilities ),
-			},
-
-			{
-				id: 'hosting',
-				label: __( 'Hosting' ),
-				callback: ( sites ) => {
-					const site = sites[ 0 ];
-					const hasHosting =
-						site.plan?.features.active.includes( FEATURE_SFTP ) && ! site?.plan?.expired;
-					page(
-						hasHosting ? `/hosting-config/${ site.slug }` : `/hosting-features/${ site.slug }`
-					);
-					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_hosting_click' ) );
-				},
-				isEligible: isActionEligible( 'hosting', capabilities ),
-			},
-
-			{
-				id: 'site-monitoring',
-				label: __( 'Monitoring' ),
-				callback: ( sites ) => {
-					page( getSiteMonitoringUrl( sites[ 0 ].slug ) );
-					dispatch(
-						recordTracksEvent( 'calypso_sites_dashboard_site_action_site_monitoring_click' )
-					);
-				},
-				isEligible: isActionEligible( 'site-monitoring', capabilities ),
 			},
 
 			{
@@ -476,26 +437,6 @@ export function useActions( {
 					dispatch( recordTracksEvent( 'calypso_sites_dashboard_site_action_copy_site_click' ) );
 				},
 				isEligible: isActionEligible( 'copy-site', capabilities ),
-			},
-
-			{
-				id: 'performance-settings',
-				label: __( 'Performance settings' ),
-				callback: ( sites ) => {
-					const site = sites[ 0 ];
-					const wpAdminUrl = getSiteAdminUrl( site );
-					const adminInterface = getAdminInterface( site );
-					const isWpAdminInterface = adminInterface === 'wp-admin';
-					if ( isWpAdminInterface ) {
-						window.location.href = `${ wpAdminUrl }options-general.php?page=page-optimize`;
-					} else {
-						page( `/settings/performance/${ site.slug }` );
-					}
-					dispatch(
-						recordTracksEvent( 'calypso_sites_dashboard_site_action_performance_settings_click' )
-					);
-				},
-				isEligible: isActionEligible( 'performance-settings', capabilities ),
 			},
 
 			{

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -440,19 +440,6 @@ export function useActions( {
 			},
 
 			{
-				id: 'privacy-settings',
-				label: __( 'Privacy settings' ),
-				callback: ( sites ) => {
-					const site = sites[ 0 ];
-					page( `/settings/general/${ site.slug }#site-privacy-settings` );
-					dispatch(
-						recordTracksEvent( 'calypso_sites_dashboard_site_action_privacy_settings_click' )
-					);
-				},
-				isEligible: isActionEligible( 'privacy-settings', capabilities ),
-			},
-
-			{
 				id: 'domains-and-dns',
 				label: __( 'Domains and DNS' ),
 				callback: ( sites ) => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100250

## Proposed Changes

This PR removes the following row quick actions from the sites dashboard, along with the rationales as follows.

> [!NOTE]  
> I believe, quick actions should be used for things that has complicated route / clicks to get there.

- **Site settings**
   - After https://github.com/Automattic/jetpack/pull/42230, the screen only contains a small number of options.
   - The number of clicks to reach the screen (click site row -> click Settings tab) is the same as with clicking the quick action (click three-dot -> click this action)
   - We are still surfacing General settings action (Settings -> General / `options-general.php`) which is much more relevant and still has link to WordPress.com Site Settings if needed.
- **Hosting**
   - The "Hosting Configuration" page is no longer relevant. We have split the config into multiple tabs and subtabs.
- **Monitoring**
   - Based on Tracks (`calypso_sites_dashboard_site_action_site_monitoring_click`), the number of unique clicks is < 20 a day on average 😱 
   -  The number of clicks to reach the screen (click site row -> click Monitoring tab) is the same as with clicking the quick action (click three-dot -> click this action)
   - It seems odd to just have this hosting feature in the quick actions. Why not also Logs, for example?
- **Performance settings**
   - The screen is no longer there: https://github.com/Automattic/wp-calypso/issues/98196

## Why are these changes being made?

Revisiting because some of them no longer make sense after we restructure the hosting dashboard.

## Testing Instructions

1. It's easier to review the code changes.
2. Go to /sites.
3. Click the three-dot menu for several sites and make sure the removed actions are no longer found.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
