### PR TITLE
Subscribers: fix envelope and body of useMigrateSubscribersCallback request

### DIFF
--- a/client/my-sites/subscribers/hooks/use-migrate-subscribers-callback.ts
+++ b/client/my-sites/subscribers/hooks/use-migrate-subscribers-callback.ts
@@ -9,10 +9,6 @@ type Response = {
 	message: string;
 };
 
-type ResponseWithBody = {
-	body: Response;
-};
-
 /**
  * This callback is used to initiate the migrate subscribers process.
  * @param siteId - The site ID of the current site.
@@ -33,16 +29,11 @@ export const useMigrateSubscribersCallback = ( siteId: number | null ) => {
 		}
 
 		try {
-			const response = await wpcom.req
-				.post(
-					`/jetpack-blogs/${ encodeURIComponent( siteId ) }/source/${ encodeURIComponent(
-						sourceSiteId
-					) }/migrate?http_envelope=1`
-				)
-				.then( ( data: ResponseWithBody & Response ) => {
-					// In Calypso green the response has body
-					return data.body ?? data;
-				} );
+			const response: Response = await wpcom.req.post(
+				`/jetpack-blogs/${ encodeURIComponent( siteId ) }/source/${ encodeURIComponent(
+					sourceSiteId
+				) }/migrate`
+			);
 
 			if ( response.success ) {
 				dispatch(


### PR DESCRIPTION
Fixes a confused `wpcom.req.post` request that manually adds a `http_envelope=1` query param (not needed) and is never sure whether the response has a `body` field or not.

This confusion was added in #84252 and #87684 because the authors were not aware of the following:
- the `wpcom.js` handler will automatically add `http_envelope=1` for v1 requests (`rest/v1.x`) and `_envelope=1` for v2 requests (`wp/v2`).
- passing `apiNamespace: 'rest/v1'` option is wrong, because when `apiNamespace` is present, the library assumes that the API version is v2. And will add `_envelope` instead of `http_envelope`.
- Jetpack Cloud in OAuth mode doesn't use the WP.com REST proxy, and its requests won't use the envelope. The response is directly in the response body, not in a `body` subfield of the envelope.

The above can lead to situations where Calypso Blue responses (WP.com proxy) won't have envelope although they should (because the `apiNamespace` option) confuses the library, and where Calypso Green responses (OAuth) will have envelope although they shouldn't (because `http_envelope` was specified manually).

This PR simply removes all the complications and makes the request straightforward.

**How to test:**
Not sure about this, I'm not very familiar with the subscriber migration feature.