### PR TITLE
Add New Site: Fix the heading color

### DIFF
--- a/client/components/sites-add-new-site/style.scss
+++ b/client/components/sites-add-new-site/style.scss
@@ -38,7 +38,7 @@
 }
 
 .sites-add-new-site__popover-column-heading {
-	color: var(--color-accent-40);
+	color: var(--color-neutral-40);
 	font-size: rem(12px);
 	font-weight: 500;
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/100910#issuecomment-2706221163

## Proposed Changes

This PR fixes the heading color on the Add New Site component on WordPress.com by using `var(--color-neutral-40)` for color instead of `var(--color-accent-40)`

## Why are these changes being made?

* To fix the heading color on the Add New Site component on WordPress.com

## Testing Instructions

* Open the A4A live link
* Click the `Add sites` dropdown button on the /overview page > Verify the heading color is not changed

<img width="897" alt="Screenshot 2025-03-10 at 3 14 14 PM" src="https://github.com/user-attachments/assets/8a8affc5-18bb-41e9-9cba-b5b8fd23033b" />

* Open the Calypso live link > Visit /sites > Click the `Add new site` dropdown button and verify the heading color is not gray instead of blue

| Before | After |
|--------|--------|
| <img width="899" alt="Screenshot 2025-03-10 at 3 14 00 PM" src="https://github.com/user-attachments/assets/8f1ecc22-277a-4897-825f-c857a98c6aea" /> | <img width="903" alt="Screenshot 2025-03-10 at 3 13 45 PM" src="https://github.com/user-attachments/assets/3d9bfdce-dbfd-4667-a50c-f652351fb388" /> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
