### PR TITLE
Hosting Logs: increase `name` max width and let it overflow to the next line

### DIFF
--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -54,6 +54,7 @@
 
 // Long fields in PHP Errors.
 .site-logs-table__file,
+.site-logs-table__name,
 // Long fields in Web Errors.
 .site-logs-table__request-url,
 .site-logs-table__http-referer {

--- a/client/sites/logs/hooks/use-fields.tsx
+++ b/client/sites/logs/hooks/use-fields.tsx
@@ -98,6 +98,9 @@ const useFields = ( { logType }: { logType: LogType } ): Field< ServerLog | PHPL
 					id: 'name',
 					type: 'text',
 					label: translate( 'Source' ),
+					render: ( { item }: { item: PHPLog } ) => {
+						return <span className="site-logs-table__name">{ item.name }</span>;
+					},
 					enableSorting: false,
 				},
 				{

--- a/client/sites/logs/hooks/use-view.ts
+++ b/client/sites/logs/hooks/use-view.ts
@@ -95,7 +95,8 @@ const useView = ( { logType, query }: { logType: LogType; query: LogQueryParams 
 						maxWidth: '150px',
 					},
 					name: {
-						maxWidth: '150px',
+						maxWidth: '200px',
+						minWidth: '75px',
 					},
 					message: {
 						maxWidth: '30vw',


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/99056

## Proposed Changes

- Increase max-width for name to `200px`.
- Let it overflow to the next line if the contents are larger than the available space.

## Why

We don't want contents to overlap.

## How to test

This is a bit difficult to test since it requires plugins with long names in your test site. This is what I've done to test it:

- Open the devtools and modify one of the cell's content to have a longer text.
- Verify that it works as expected.

| Before | After |
| --- | --- |
| <img width="1085" alt="Screenshot 2025-03-10 at 11 30 21" src="https://github.com/user-attachments/assets/4bced362-0170-4679-bd81-ff46748d19f9" /> | <img width="1085" alt="Screenshot 2025-03-10 at 11 29 51" src="https://github.com/user-attachments/assets/995da436-8ac5-43e4-9780-9824b1e6855b" /> |


