### PR TITLE
Adjusting reader left nav proportions

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -519,9 +519,7 @@ $font-size: rem(14px);
 		}
 
 		.sidebar__menu.is-togglable .sidebar__heading {
-			padding: 12px 10px;
-			margin: 0 12px;
-			border-radius: 4px;
+			padding: 10px;
 
 			&:hover {
 				.sidebar__expandable-arrow {
@@ -948,6 +946,10 @@ $font-size: rem(14px);
 	// Reader specific styles
 	// client/reader/sidebar/style.scss
 	&.is-section-reader {
+		.sidebar__menu .components-button.has-icon {
+			padding: 0 0 0 6px;
+		}
+		
 		.sidebar__menu .count {
 			background: transparent;
 			color: var(--color-sidebar-menu-text);

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -519,7 +519,7 @@ $font-size: rem(14px);
 		}
 
 		.sidebar__menu.is-togglable .sidebar__heading {
-			padding: 10px;
+			box-sizing: border-box;
 
 			&:hover {
 				.sidebar__expandable-arrow {

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -254,7 +254,7 @@ export class ReaderSidebar extends Component {
 						label="A8C Conversations"
 						onNavigate={ this.handleReaderSidebarA8cConversationsClicked }
 						link="/reader/conversations/a8c"
-						customIcon={ <ReaderA8cConversationsIcon size={ 24 } viewBox="-5 0 24 24" /> }
+						customIcon={ <ReaderA8cConversationsIcon size={ 24 } viewBox="-5 -2 24 24" /> }
 					/>
 				) }
 

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -43,7 +43,7 @@ export class ReaderSidebarOrganizationsList extends Component {
 	renderIcon() {
 		const { organization } = this.props;
 		if ( organization.id === AUTOMATTIC_ORG_ID ) {
-			return <ReaderA8cIcon size={ 24 } viewBox="-5 0 24 24" />;
+			return <ReaderA8cIcon size={ 24 } viewBox="-5 -2 24 24" />;
 		}
 		return <ReaderP2Icon viewBox="-3 0 24 24" />;
 	}


### PR DESCRIPTION
## Description

Addresses https://github.com/Automattic/wp-calypso/issues/100346

In Reader, the collapsible buttons should not be taller:

## Before

![before](https://github.com/user-attachments/assets/f40c901b-3681-42f9-b740-c45e87afe382)

## After

Height should be the same, no matter whether it's collapsible.

![CleanShot 2025-03-10 at 07 13 00](https://github.com/user-attachments/assets/c5e84d8c-7185-4d24-818c-b9cc49f0442c)

## Testing

- Apply this PR
- Head to /reader
- Compare height of collapsible left nav buttons to regular buttons