### PR TITLE
Test case: only spawn `MAX_PARALLEL_BATCHES`

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -625,8 +625,8 @@ object CheckCodeStyleBranch : BuildType({
 					#
 					# CAVEAT: ASSUMES NO SPACES IN FILENAMES.
 
-					BATCH_SIZE=15 # Number of files handled by each ESLint process
-					MAX_PARALLEL_BATCHES=15 # Number of concurrent ESLint processes
+					BATCH_SIZE=1 # Number of files handled by each ESLint process
+					MAX_PARALLEL_BATCHES=5 # Number of concurrent ESLint processes
 
 					_find_files_to_lint \
 						| awk -v"n=${'$'}BATCH_SIZE" '{printf "%%s%%s", $0, (NR%%n?"\t":"\n")}' \


### PR DESCRIPTION
**NOT TO MERGE**

This PR is a test case for https://github.com/Automattic/wp-calypso/pull/100986

## What

This PR tests that TeamCity won't spawn more than `MAX_PARALLEL_BATCHES`, which is set to 15.

## How

- It's built on top of the existing test case https://github.com/Automattic/wp-calypso/pull/101074. 
- The files to lint by process are set to 1, so it needs to create more than the limit (15).

## Test

The "check code style" task should fail and run in two batches.

- Go to the "Code style (web app)" check and navigate to the "Build log" tab. The expected result is that it failed.
- Look at how it was run. After spawning the 15th process, it should have waited before spawning more processes.

<img width="1356" alt="Screenshot 2025-03-10 at 14 05 45" src="https://github.com/user-attachments/assets/6c65d1b0-eb39-4213-991e-567f9a6a04e9" />
