### PR TITLE
Login page: Better copy

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -139,7 +139,7 @@ class RequestLoginEmailForm extends Component {
 
 		if ( siteName ) {
 			return translate(
-				'We’ll send you an email with a login link that will log you in right away to %(siteName)s.',
+				'We’ll send you an email with a link that will log you in right away to %(siteName)s.',
 				{
 					args: {
 						siteName,
@@ -148,9 +148,7 @@ class RequestLoginEmailForm extends Component {
 			);
 		}
 
-		return translate(
-			'We’ll send you an email with a login link that will log you in right away.'
-		);
+		return translate( 'We’ll send you an email with a link that will log you in right away.' );
 	}
 
 	render() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100433

## Proposed Changes

The sub copy on the login link page has some akward copy. Awkward wording ‘...a login link that will log you in’.
Rephrase it to "We'll send you an email with a link that will log you in right away."

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /log-in/link
