### PR TITLE
Help Center: Better manage solved interactions

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -248,14 +248,16 @@ export const HelpCenterContactButton: FC = () => {
 	const { __ } = useI18n();
 	const { data: supportInteractionsResolved } = useGetSupportInteractions(
 		'zendesk',
-		100,
+		1,
 		'resolved'
 	);
-	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 10, 'open' );
+	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 1, 'open' );
+	const { data: supportInteractionsSolved } = useGetSupportInteractions( 'zendesk', 1, 'solved' );
 
 	const supportInteractions = [
 		...( supportInteractionsResolved || [] ),
 		...( supportInteractionsOpen || [] ),
+		...( supportInteractionsSolved || [] ),
 	];
 
 	return canConnectToZendesk && supportInteractions && supportInteractions?.length > 0 ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The History button was showed only if the user had 'open' or 'closed' conversations, but not 'solved'. This fixes it.