### PR TITLE
A4A: Update Overview page to use Core typography.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/intro-cards/style.scss
@@ -1,12 +1,15 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .intro-cards {
 	.dot-pager__page {
 		p,
 		li {
-			@include a4a-font-body-lg;
+			@include body-large;
 		}
 
 		h1 {
-			@include a4a-font-heading-xxl;
+			@include heading-2x-large;
 			margin-bottom: 16px;
 		}
 

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .next-steps {
 
 	&__header {
@@ -7,7 +10,7 @@
 		margin-bottom: 16px;
 
 		h2 {
-			@include a4a-font-heading-md;
+			@include heading-large;
 			color: var(--color-neutral-100);
 		}
 		.circular__progress-bar {
@@ -26,7 +29,7 @@
 
 	p,
 	button {
-		@include a4a-font-body-md;
+		@include body-medium;
 		color: var(--color-neutral-80);
 	}
 
@@ -42,7 +45,7 @@
 	.checklist-item__task {
 
 		.checklist-item__text {
-			@include a4a-font-body-md;
+			@include body-medium;
 			color: var(--color-neutral-80);
 		}
 

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -17,7 +17,7 @@
 			margin-right: 8px;
 
 			.circular__progress-bar-text {
-				@include a4a-font-label-button($font-size: rem(10px));
+				@include body-small;
 				color: var(--color-neutral-100);
 			}
 

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -17,7 +17,7 @@
 			margin-right: 8px;
 
 			.circular__progress-bar-text {
-				@include heading-x-small;
+				@include heading-small;
 				color: var(--color-neutral-100);
 			}
 

--- a/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
+++ b/client/a8c-for-agencies/sections/overview/body/next-steps/style.scss
@@ -17,7 +17,7 @@
 			margin-right: 8px;
 
 			.circular__progress-bar-text {
-				@include body-small;
+				@include heading-x-small;
 				color: var(--color-neutral-100);
 			}
 

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/celebration-modal/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 $video-pink: #f5baff;
 $video-blue: #002d3e;
 $video-green: #0e5837;
@@ -121,13 +124,13 @@ $announcement-blue: #032836;
 }
 
 .agency-tier-celebration-modal__title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	text-wrap: balance;
 }
 
 .agency-tier-celebration-modal__description,
 .agency-tier-celebration-modal__extra-description {
-	@include a4a-font-body-md;
+	@include body-medium;
 }
 
 .agency-tier-celebration-modal__benefits {
@@ -137,7 +140,7 @@ $announcement-blue: #032836;
 	list-style-image: url(calypso/assets/images/a8c-for-agencies/agency-tier/check-icon.svg);
 
 	li {
-		@include a4a-font-body-md;
+		@include body-medium;
 		padding-inline-start: 8px;
 		margin-inline-start: 4px;
 	}

--- a/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/agency-tier/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .agency-tier__card {
 	padding: 8px;
 	border-radius: 4px;
@@ -29,7 +32,7 @@
 		}
 
 		.agency-tier__current-agency-tier-title {
-			@include a4a-font-heading-lg;
+			@include heading-large;
 		}
 
 		&.is-default {
@@ -48,19 +51,19 @@
 			}
 
 			.agency-tier__current-agency-tier-title {
-				@include a4a-font-body-lg;
+				@include body-large;
 			}
 		}
 	}
 
 	.agency-tier__current-agency-tier-description {
-		@include a4a-font-body-md;
+		@include body-medium;
 		padding-block-end: 8px;
 	}
 }
 
 .foldable-nav.foldable-card.card .foldable-card__content .agency-tier__bottom-content a.components-button {
-	@include a4a-font-body-md;
+	@include body-medium;
 	padding: 0;
 	color: var(--color-gray-40);
 

--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/style.scss
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .overview__growth-accelerator {
 	display: flex;
 	flex-direction: column;
@@ -12,11 +15,11 @@
 }
 
 .overview__growth-accelerator-header {
-	@include a4a-font-heading-md;
+	@include heading-large;
 }
 
 .overview__growth-accelerator-body {
-	@include a4a-font-body-md;
+	@include body-medium;
 	margin: 0;
 }
 


### PR DESCRIPTION
This PR updates the Overview page to now use the Core's typography.

<img width="1424" alt="Screenshot 2025-03-10 at 10 12 13 PM" src="https://github.com/user-attachments/assets/6a393f40-97e0-4b87-a3d3-0aa5eea7e8cb" />
<img width="1365" alt="Screenshot 2025-03-10 at 10 12 21 PM" src="https://github.com/user-attachments/assets/5be5eb25-d8af-4913-aed0-fa20ca94459b" />
<img width="1405" alt="Screenshot 2025-03-10 at 10 12 32 PM" src="https://github.com/user-attachments/assets/25f72925-b1df-4cfb-ab9e-f82a5a36227f" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1906

## Proposed Changes

* Update all cards in the Overview page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/overview` page.
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
