### PR TITLE
Skip E2E tests for Social Previews for private WoA sites

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -114,12 +114,13 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		);
 
-		it( 'Open social preview', async function () {
+		// Social Previews is not available on private WoA sites and needs to be fixed.
+		it.skip( 'Open social preview', async function () {
 			await editorPage.expandSection( 'Social Previews' );
 			await editorPage.clickSidebarButton( 'Open Social Previews' );
 		} );
 
-		it( 'Show social preview for Tumblr', async function () {
+		it.skip( 'Show social preview for Tumblr', async function () {
 			// Action implemented as "raw" calls for now (2023-09).
 			const editorParent = await editorPage.getEditorParent();
 			const dialog = editorParent.getByRole( 'dialog' );
@@ -136,7 +137,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 				.waitFor();
 		} );
 
-		it( 'Dismiss social preview', async function () {
+		it.skip( 'Dismiss social preview', async function () {
 			await page.keyboard.press( 'Escape' );
 		} );
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -114,31 +114,32 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			}
 		);
 
-		// Social Previews is not available on private WoA sites and needs to be fixed.
-		it.skip( 'Open social preview', async function () {
-			await editorPage.expandSection( 'Social Previews' );
-			await editorPage.clickSidebarButton( 'Open Social Previews' );
-		} );
+		skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'Social Previews', function () {
+			it( 'Open social preview', async function () {
+				await editorPage.expandSection( 'Social Previews' );
+				await editorPage.clickSidebarButton( 'Open Social Previews' );
+			} );
 
-		it.skip( 'Show social preview for Tumblr', async function () {
-			// Action implemented as "raw" calls for now (2023-09).
-			const editorParent = await editorPage.getEditorParent();
-			const dialog = editorParent.getByRole( 'dialog' );
+			it( 'Show social preview for Tumblr', async function () {
+				// Action implemented as "raw" calls for now (2023-09).
+				const editorParent = await editorPage.getEditorParent();
+				const dialog = editorParent.getByRole( 'dialog' );
 
-			await dialog.getByRole( 'tab', { name: 'Tumblr' } ).click();
-			await dialog.getByRole( 'tabpanel', { name: 'Tumblr' } ).waitFor();
-			await dialog
-				.filter( {
-					// Look for either the SEO title, or the post title,
-					// depending on whether the platform had SEO options
-					// two steps previously.
-					hasText: new RegExp( `${ seoTitle }|${ title }` ),
-				} )
-				.waitFor();
-		} );
+				await dialog.getByRole( 'tab', { name: 'Tumblr' } ).click();
+				await dialog.getByRole( 'tabpanel', { name: 'Tumblr' } ).waitFor();
+				await dialog
+					.filter( {
+						// Look for either the SEO title, or the post title,
+						// depending on whether the platform had SEO options
+						// two steps previously.
+						hasText: new RegExp( `${ seoTitle }|${ title }` ),
+					} )
+					.waitFor();
+			} );
 
-		it.skip( 'Dismiss social preview', async function () {
-			await page.keyboard.press( 'Escape' );
+			it( 'Dismiss social preview', async function () {
+				await page.keyboard.press( 'Escape' );
+			} );
 		} );
 
 		afterAll( async function () {


### PR DESCRIPTION
Social Previews is not available on private WoA sites because publicize is not available on private sites. The E2E tests are failing for private WoA sites on Jetpack deployment. So, we are skipping them for private WoA sites.

Slack discussion: p1741607833677579-slack-C034JEXD1RD


## Proposed Changes

* Skip E2E tests for Social Previews for private WoA sites

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should be happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?