### PR TITLE
A4A: Update Sites page to use Core typography.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/a4a/site-error-preview/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .main.hosting-dashboard-layout.sites-dashboard .site-error-preview {
 	.hosting-dashboard-item-view__navigation.is-hidden {
@@ -21,12 +22,12 @@
 }
 
 .site-error-preview__title {
-	@include a4a-font-heading-lg;
+	@include heading-large;
 	margin-block-end: 16px;
 }
 
 .site-error-preview__description {
-	@include a4a-font-body-md;
+	@include body-medium;
 	margin-block-end: 16px;
 }
 
@@ -61,13 +62,13 @@
 		}
 
 		.formatted-header__title {
-			@include a4a-font-heading-md;
+			@include heading-medium;
 			margin-block-end: 4px;
 			color: var(--color-primary-100);
 		}
 
 		.formatted-header__subtitle {
-			@include a4a-font-body-md;
+			@include body-medium;
 			margin-block-end: 0;
 		}
 	}

--- a/client/a8c-for-agencies/sections/sites/features/hosting/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .hosting-dashboard-item-view__content .hosting__wrapper {
 	.hosting__card {
 		box-shadow: none;
@@ -5,7 +8,7 @@
 	}
 
 	.hosting__title {
-		@include a4a-font-heading-lg;
+		@include heading-large;
 		padding: 0 0 16px;
 	}
 

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .hosting-dashboard-item-view {
 
 	.hosting-dashboard-item-view__navigation {
@@ -35,7 +38,7 @@
 
 		.backup__header-title,
 		.activity-log-v2__header-title {
-			@include a4a-font-heading-lg;
+			@include heading-large;
 		}
 
 		.backup-getting-started {
@@ -57,7 +60,7 @@
 		}
 
 		.expanded-card__header {
-			@include a4a-font-heading-lg;
+			@include heading-large;
 		}
 
 		.site-expanded-content__card-content-score {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .sites-dataviews__site {
 	display: flex;
@@ -55,13 +56,13 @@
 	margin-inline-start: 32px;
 
 	li {
-		@include a4a-font-body-sm($font-weight: 500);
+		@include body-small;
 		text-align: start;
 	}
 }
 
 .sites-dataviews__site-error-popover-content {
-	@include a4a-font-body-sm($font-weight: 500);
+	@include body-small;
 	margin: 16px;
 }
 


### PR DESCRIPTION
This PR updates the Sites page to now use the Core's typography.

<img width="1450" alt="Screenshot 2025-03-10 at 10 31 06 PM" src="https://github.com/user-attachments/assets/f83ddd7f-4287-41ab-9730-3adfc0d8dfb9" />
<img width="1462" alt="Screenshot 2025-03-10 at 10 32 33 PM" src="https://github.com/user-attachments/assets/7c2b177f-5275-417a-9d06-4758f11de9de" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1909

## Proposed Changes

* Update the Sites page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/sites` page.
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
