### PR TITLE
Stats: Add steady title info icon to empty state of modules

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -395,6 +395,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 					title={ title }
 					isEmpty
 					emptyMessage={ emptyMessage }
+					titleNodes={ titleTooltip }
 					footerAction={
 						summaryUrl
 							? {

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -61,6 +61,27 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 		? ! hasData && ! presentLoadingUI
 		: ! isRequestingData && ! hasData && ! shouldGateStatsModule;
 
+	const titleInfoNode = (
+		<StatsInfoArea>
+			{ translate(
+				'Websites {{link}}referring visitors{{/link}} sorted by most clicked. Learn about where your audience comes from.',
+				{
+					comment: '{{link}} links to support documentation.',
+					components: {
+						link: (
+							<a
+								target="_blank"
+								rel="noreferrer"
+								href={ localizeUrl( `${ supportUrl }#referrers` ) }
+							/>
+						),
+					},
+					context: 'Stats: Link in a popover for the Referrers when the module has data',
+				}
+			) }
+		</StatsInfoArea>
+	);
+
 	return (
 		<>
 			{ ! shouldGateStatsModule && siteId && statType && (
@@ -78,26 +99,7 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 				// show data or an overlay
 				<StatsModule
 					path="referrers"
-					titleNodes={
-						<StatsInfoArea>
-							{ translate(
-								'Websites {{link}}referring visitors{{/link}} sorted by most clicked. Learn about where your audience comes from.',
-								{
-									comment: '{{link}} links to support documentation.',
-									components: {
-										link: (
-											<a
-												target="_blank"
-												rel="noreferrer"
-												href={ localizeUrl( `${ supportUrl }#referrers` ) }
-											/>
-										),
-									},
-									context: 'Stats: Link in a popover for the Referrers when the module has data',
-								}
-							) }
-						</StatsInfoArea>
-					}
+					titleNodes={ titleInfoNode }
 					moduleStrings={ moduleStrings }
 					period={ period }
 					query={ query }
@@ -116,6 +118,7 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 					className={ clsx( 'stats-card--empty-variant', className ) } // when removing stats/empty-module-traffic add this to the root of the card
 					title={ moduleStrings.title }
 					isEmpty
+					titleNodes={ titleInfoNode }
 					emptyMessage={
 						<EmptyModuleCard
 							icon={ megaphone }

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -61,6 +61,21 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 		? ! hasData && ! presentLoadingUI
 		: ! isRequestingData && ! hasData && ! shouldGateStatsModule;
 
+	const titleInfoNode = (
+		<StatsInfoArea>
+			{ translate(
+				'{{link}}Posts and pages{{/link}} sorted by most visited. Learn about what content resonates the most.',
+				{
+					comment: '{{link}} links to support documentation.',
+					components: {
+						link: <a target="_blank" rel="noreferrer" href={ localizeUrl( supportUrl ) } />,
+					},
+					context: 'Stats: Link in a popover for the Posts & Pages when the module has data',
+				}
+			) }
+		</StatsInfoArea>
+	);
+
 	return (
 		<>
 			{ ! shouldGateStatsModule && siteId && statType && (
@@ -78,21 +93,7 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 				// show data or an overlay
 				<StatsModule
 					path="posts"
-					titleNodes={
-						<StatsInfoArea>
-							{ translate(
-								'{{link}}Posts and pages{{/link}} sorted by most visited. Learn about what content resonates the most.',
-								{
-									comment: '{{link}} links to support documentation.',
-									components: {
-										link: <a target="_blank" rel="noreferrer" href={ localizeUrl( supportUrl ) } />,
-									},
-									context:
-										'Stats: Link in a popover for the Posts & Pages when the module has data',
-								}
-							) }
-						</StatsInfoArea>
-					}
+					titleNodes={ titleInfoNode }
 					moduleStrings={ moduleStrings }
 					period={ period }
 					query={ query }
@@ -111,6 +112,7 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 					className={ clsx( 'stats-card--empty-variant', className ) } // when removing stats/empty-module-traffic add this to the root of the card
 					title={ moduleStrings.title }
 					isEmpty
+					titleNodes={ titleInfoNode }
 					emptyMessage={
 						<EmptyModuleCard
 							icon={ postList }

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-overlay.tsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-overlay.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import StatsCardUpsell from 'calypso/my-sites/stats/stats-card-upsell';
 import { STATS_FEATURE_UTM_STATS } from '../../../constants';
 import StatsListCard from '../../../stats-list/stats-list-card';
+import useUTMSupportURL from './utm-support-url';
+import UTMTitleInfoNode from './utm-title-info-node';
 
 import './stats-module-utm-overlay.scss';
 
@@ -17,6 +19,8 @@ const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( {
 	className,
 	overlay,
 } ) => {
+	const supportUrl = useUTMSupportURL( siteId );
+
 	const fakeData = [
 		{
 			label: 'google / cpc',
@@ -57,6 +61,7 @@ const StatsModuleUTMOverlay: React.FC< StatsModuleUTMOverlayProps > = ( {
 			data={ fakeData }
 			mainItemLabel="Posts by Source / Medium"
 			splitHeader
+			titleNodes={ <UTMTitleInfoNode supportUrl={ supportUrl } /> }
 			showMore={ {
 				label: 'View all',
 			} }

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -1,16 +1,13 @@
 import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { trendingUp } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
 import { useSelector } from 'calypso/state';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
-import { JETPACK_SUPPORT_URL_TRAFFIC, SUPPORT_URL } from '../../../const';
 import useUTMMetricsQuery from '../../../hooks/use-utm-metrics-query';
 import ErrorPanel from '../../../stats-error';
 import StatsListCard from '../../../stats-list/stats-list-card';
@@ -20,6 +17,8 @@ import { StatsEmptyActionUTMBuilder } from '../shared';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import UTMDropdown from './stats-module-utm-dropdown';
 import UTMExportButton from './utm-export-button';
+import useUTMSupportURL from './utm-support-url';
+import UTMTitleInfoNode from './utm-title-info-node';
 
 import '../../../stats-module/style.scss';
 import '../../../stats-list/style.scss';
@@ -129,28 +128,8 @@ const StatsModuleUTM = ( {
 		? generateFileNameForDownload( siteSlug, period )
 		: '';
 
-	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
-		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
-	);
-
-	const supportUrl = isSiteJetpackNotAtomic
-		? localizeUrl( `${ JETPACK_SUPPORT_URL_TRAFFIC }#harnessing-utm-stats-for-precision-tracking` )
-		: localizeUrl( `${ SUPPORT_URL }#utm` );
-
-	const titleNodes = (
-		<StatsInfoArea isNew>
-			{ translate(
-				'Track your campaign {{link}}UTM performance data{{/link}}. Generate URL codes with our builder.',
-				{
-					comment: '{{link}} links to support documentation.',
-					components: {
-						link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
-					},
-					context: 'Stats: Popover information when the UTM module has data',
-				}
-			) }
-		</StatsInfoArea>
-	);
+	const supportUrl = useUTMSupportURL( siteId );
+	const titleInfoNode = <UTMTitleInfoNode supportUrl={ supportUrl } />;
 
 	return (
 		<>
@@ -169,7 +148,7 @@ const StatsModuleUTM = ( {
 							<StatsCard
 								className={ clsx( 'stats-card--empty-variant', className ) }
 								title={ moduleStrings.title }
-								titleNodes={ <StatsInfoArea isNew /> }
+								titleNodes={ titleInfoNode }
 								isEmpty
 								emptyMessage={
 									<EmptyModuleCard
@@ -206,7 +185,7 @@ const StatsModuleUTM = ( {
 									data={ data }
 									useShortLabel={ useShortLabel }
 									title={ moduleStrings?.title }
-									titleNodes={ titleNodes }
+									titleNodes={ titleInfoNode }
 									emptyMessage={ <div>{ moduleStrings.empty }</div> }
 									metricLabel={ metricLabel }
 									showMore={
@@ -250,6 +229,7 @@ const StatsModuleUTM = ( {
 						) }
 				</>
 			) }
+			{ /* TODO: Refactor later */ }
 			{ ! isNewEmptyStateEnabled && (
 				<>
 					<StatsListCard

--- a/client/my-sites/stats/features/modules/stats-utm/utm-support-url.tsx
+++ b/client/my-sites/stats/features/modules/stats-utm/utm-support-url.tsx
@@ -1,0 +1,19 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { JETPACK_SUPPORT_URL_TRAFFIC, SUPPORT_URL } from '../../../const';
+
+const useUTMSupportURL = ( siteId: number ) => {
+	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
+
+	// TODO: Should it be aligned with getUpsellCopy?
+	const supportUrl = isSiteJetpackNotAtomic
+		? localizeUrl( `${ JETPACK_SUPPORT_URL_TRAFFIC }#harnessing-utm-stats-for-precision-tracking` )
+		: localizeUrl( `${ SUPPORT_URL }#utm` );
+
+	return supportUrl;
+};
+
+export default useUTMSupportURL;

--- a/client/my-sites/stats/features/modules/stats-utm/utm-title-info-node.tsx
+++ b/client/my-sites/stats/features/modules/stats-utm/utm-title-info-node.tsx
@@ -1,0 +1,23 @@
+import { useTranslate } from 'i18n-calypso';
+import StatsInfoArea from 'calypso/my-sites/stats/features/modules/shared/stats-info-area';
+
+const UTMTitleInfoNode = ( { supportUrl }: { supportUrl: string } ) => {
+	const translate = useTranslate();
+
+	return (
+		<StatsInfoArea isNew>
+			{ translate(
+				'Track your campaign {{link}}UTM performance data{{/link}}. Generate URL codes with our builder.',
+				{
+					comment: '{{link}} links to support documentation.',
+					components: {
+						link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
+					},
+					context: 'Stats: Popover information when the UTM module has data',
+				}
+			) }
+		</StatsInfoArea>
+	);
+};
+
+export default UTMTitleInfoNode;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100504

## Proposed Changes

* Add steady title info icon to empty state of Stats modules.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

|Before|After|
|-|-|
|<img width="635" alt="截圖 2025-03-10 晚上11 09 36" src="https://github.com/user-attachments/assets/775f1bd7-b559-41bf-a0f6-0def90c6e4b6" />|<img width="675" alt="截圖 2025-03-10 晚上11 11 41" src="https://github.com/user-attachments/assets/1fe9f0b2-6af2-4cd8-9771-2e81cd863cba" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
