### PR TITLE
Staging Sites: Update modal size and `Cancel` button styling

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -116,6 +116,7 @@ export const ManageStagingSiteCardContent = ( {
 					modalMessage={ translate(
 						'Are you sure you want to delete the staging site? This action cannot be undone.'
 					) }
+					modalSize="medium"
 					confirmLabel={ translate( 'Delete staging site' ) }
 					cancelLabel={ translate( 'Cancel' ) }
 				>

--- a/client/sites/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/staging-sync-card.tsx
@@ -328,6 +328,7 @@ const ProductionToStagingSync = ( {
 				modalMessage={ translate(
 					'Synchronizing your staging site will replace the contents of the staging site with those of your production site.'
 				) }
+				modalSize="medium"
 				confirmLabel={ translate( 'Synchronize' ) }
 				cancelLabel={ translate( 'Cancel' ) }
 			>

--- a/client/sites/staging-site/components/staging-site-card/confirmation-modal.tsx
+++ b/client/sites/staging-site/components/staging-site-card/confirmation-modal.tsx
@@ -83,6 +83,7 @@ export function ConfirmationModal( {
 								onCancel?.();
 								closeModal();
 							} }
+							borderless
 						>
 							{ cancelLabel }
 						</Button>

--- a/client/sites/staging-site/components/staging-site-card/confirmation-modal.tsx
+++ b/client/sites/staging-site/components/staging-site-card/confirmation-modal.tsx
@@ -24,6 +24,7 @@ type ConfirmationModalButtonProps = {
 	children: React.ReactNode;
 	modalTitle: string;
 	modalMessage?: string;
+	modalSize?: 'small' | 'medium' | 'large' | 'fill';
 	extraModalContent?: React.ReactNode;
 	confirmLabel: string;
 	cancelLabel: string;
@@ -44,6 +45,7 @@ export function ConfirmationModal( {
 	children,
 	modalTitle,
 	modalMessage,
+	modalSize,
 	extraModalContent,
 	confirmLabel,
 	cancelLabel,
@@ -68,7 +70,11 @@ export function ConfirmationModal( {
 				{ children }
 			</Button>
 			{ isOpen && (
-				<Modal title={ modalTitle } onRequestClose={ closeModal }>
+				<Modal
+					title={ modalTitle }
+					onRequestClose={ closeModal }
+					{ ...( modalSize && { size: modalSize } ) }
+				>
 					{ modalMessage && <p>{ modalMessage }</p> }
 					{ extraModalContent }
 					<ActionButtons>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/99322.
Resolves https://github.com/Automattic/wp-calypso/issues/99323.

## Proposed Changes

* make some of the staging sites` confirmation modals narrower:
  * "delete staging site" modal
  * "sync staging site to production" modal
* use borderless `Cancel` button on all staging sites` confirmation modals

| Before | After |
|--------|--------|
| ![Markup on 2025-03-10 at 16:33:00](https://github.com/user-attachments/assets/91fa14e0-985b-43de-822c-7a5b57edfab2) | ![Markup on 2025-03-10 at 16:33:32](https://github.com/user-attachments/assets/b696eefc-bd54-4aac-a5d6-0e4591eacc0e) (smaller modal, borderless button) |
| ![Markup on 2025-03-10 at 16:38:21](https://github.com/user-attachments/assets/c5d9d61d-9390-4e4c-9bad-46f783a3ac3f) | ![Markup on 2025-03-10 at 16:34:09](https://github.com/user-attachments/assets/23022152-6784-4b6f-ba38-8cb1979a1709) (smaller modal, borderless button) | 
| ![Markup on 2025-03-10 at 16:35:30](https://github.com/user-attachments/assets/b6ee39fe-88ad-4e4b-83b4-fc5f16780964) | ![Markup on 2025-03-10 at 16:34:53](https://github.com/user-attachments/assets/96bca9d6-10a1-4b28-b49c-7359e0fb583e) (keeping the modal size, borderless button) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/99322
* https://github.com/Automattic/wp-calypso/issues/99323

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start`.
2. Head over to `http://calypso.localhost:3000/staging-site/{atomic-site-slug}` of an existing Atomic test site.
3. Create a staging site (if it does not exist yet).
4. Try out opening the modals by:
  - clicking on the `Delete staging site` button
  - trying to synchronize staging to production
  - trying to production staging to synchronize
5. Review all modals and the `Cancel` buttons

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
