### PR TITLE
A4A: Update Marketplace page to use Core typography.

### DIFF
--- a/client/a8c-for-agencies/components/page-section/style.scss
+++ b/client/a8c-for-agencies/components/page-section/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 .page-section-wrapper {
 	margin-inline: 0;
 	background-repeat: no-repeat;
@@ -29,7 +29,7 @@
 }
 
 .page-section__sub-header-title {
-	@include a4a-font-body-md;
+	@include body-medium;
 }
 
 
@@ -45,18 +45,18 @@
 }
 
 .page-section__header-title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 
 	@include break-medium {
-		@include a4a-font-heading-xxl;
+		@include heading-2x-large;
 	}
 }
 
 .page-section__header-description {
-	@include a4a-font-body-md;
+	@include body-medium;
 	margin: 0;
 
 	@include break-medium {
-		@include a4a-font-body-lg;
+		@include body-large;
 	}
 }

--- a/client/a8c-for-agencies/components/simple-list/style.scss
+++ b/client/a8c-for-agencies/components/simple-list/style.scss
@@ -1,4 +1,3 @@
-
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
@@ -14,7 +13,7 @@
 	li {
 		display: flex;
 		flex-direction: row;
-		@include a4a-font-body-lg($line-height: 1.625);
+		@include body-large;
 	}
 
 	&.is-core-styles {

--- a/client/a8c-for-agencies/components/simple-list/style.scss
+++ b/client/a8c-for-agencies/components/simple-list/style.scss
@@ -13,7 +13,7 @@
 	li {
 		display: flex;
 		flex-direction: row;
-		@include body-large;
+		@include a4a-font-body-lg($line-height: 1.625);
 	}
 
 	&.is-core-styles {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 @mixin loading-effect {
 	animation: loading-fade 1.6s ease-in-out infinite;
@@ -63,7 +64,7 @@
 .checkout__main-title {
 	margin-block-end: 64px;
 	margin-block-start: 32px;
-	@include a4a-font-heading-xxl;
+	@include heading-x-large;
 
 	@include breakpoint-deprecated( ">960px" ) {
 		margin-block-start: 0;
@@ -123,23 +124,23 @@
 	}
 
 	.checkout__summary-pricing-discounted {
-		@include a4a-font-heading-lg;
+		@include heading-large;
 		color: var(--color-neutral-80);
 
 		@include break-xlarge {
-			@include a4a-font-heading-xl;
+			@include heading-x-large;
 			color: var(--color-black);
 		}
 	}
 
 	.checkout__summary-pricing-original {
-		@include a4a-font-body-lg;
+		@include body-large;
 		text-decoration: line-through;
 		margin-inline-start: 8px;
 	}
 
 	.checkout__summary-pricing-interval {
-		@include a4a-font-body-sm;
+		@include body-small;
 		color: var(--color-neutral-60);
 		line-height: 2;
 	}
@@ -153,12 +154,12 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	@include a4a-font-heading-md;
+	@include heading-medium;
 }
 
 
 .checkout__summary-notice {
-	@include a4a-font-body-sm;
+	@include body-small;
 	margin-block-end: 16px;
 	color: var(--color-neutral-50);
 
@@ -243,7 +244,7 @@
 	}
 
 	.product-info__label {
-		@include a4a-font-heading-md;
+		@include heading-medium;
 	}
 
 	.product-info__count {
@@ -255,13 +256,13 @@
 	}
 
 	.product-info__description {
-		@include a4a-font-body-lg;
+		@include body-large;
 		margin-block: 4px 0;
 		color: var(--color-neutral-70);
 	}
 
 	.product-info__site-url {
-		@include a4a-font-body-md;
+		@include body-medium;
 		margin-block: 4px 0;
 		color: var(--color-neutral-40);
 	}
@@ -354,12 +355,12 @@
 		width: 100%;
 
 		.a4a-popover__title {
-			@include a4a-font-heading-md;
+			@include heading-medium;
 			color: var(--studio-gray-80);
 		}
 
 		.checkout__button-popover-description {
-			@include a4a-font-body-md;
+			@include body-medium;
 		}
 	}
 }
@@ -373,5 +374,5 @@
 
 .product-info__pressable-limit-warning {
 	margin-block-start: 8px;
-	@include a4a-font-body-sm;
+	@include body-small;
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-additional-features-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-additional-features-section/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 ul.hosting-additional-features {
 	display: grid;
@@ -29,7 +30,7 @@ ul.hosting-additional-features {
 	}
 
 	li {
-		@include a4a-font-body-lg;
+		@include body-large;
 		display: flex;
 		align-content: center;
 		gap: 4px;

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-benefits-section/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .hosting-benefits {
 	display: grid;
@@ -33,12 +34,12 @@
 }
 
 .hosting-benefits-card__title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	margin-block-end: 24px;
 }
 
 .hosting-benefits-card__description {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin: 0;
 }
 
@@ -52,7 +53,7 @@
 	padding: 0;
 
 	li {
-		@include a4a-font-body-lg;
+		@include body-large;
 
 		display: flex;
 		flex-direction: row;

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
@@ -30,7 +30,11 @@ function FeatureCard( {
 				<h2 className="hosting-features-section-v2__card-title">{ title }</h2>
 			</div>
 
-			<SimpleList className="hosting-features-section-v2__card-list" items={ items } />
+			<SimpleList
+				applyCoreStyles
+				className="hosting-features-section-v2__card-list"
+				items={ items }
+			/>
 		</Card>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .hosting-features-section-v2 {
 	overflow: hidden;
@@ -63,5 +64,5 @@
 }
 
 .hosting-features-section-v2__card-title {
-	@include a4a-font-heading-lg;
+	@include heading-large;
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-testimonials-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-testimonials-section/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .hosting-testimonials {
 	display: grid;
@@ -30,7 +31,7 @@
 }
 
 .hosting-testimonials__item-message {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin: 0;
 }
 
@@ -53,15 +54,15 @@
 }
 
 .hosting-testimonials__item-profile-name {
-	@include a4a-font-heading-md;
+	@include heading-medium;
 }
 
 .hosting-testimonials__item-profile-title {
-	@include a4a-font-body-lg;
+	@include body-large;
 }
 
 .hosting-testimonials__item-profile-link {
-	@include a4a-font-body-lg;
+	@include body-large;
 
 	a {
 		color: var(--color-text);

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .a4a-marketplace__toggle-marketplace-type {
 	display: flex;
 	align-items: center;
@@ -16,11 +19,11 @@
 
 .referral-toggle__notice {
 	.a4a-popover__title {
-		@include a4a-font-heading-md;
+		@include heading-medium;
 		color: var(--studio-gray-80);
 	}
 
 	.referral-toggle__notice-description {
-		@include a4a-font-body-md;
+		@include body-medium;
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 $tab-background: linear-gradient( #EBF4FA, #DAE9F3);
 $tab-background-selected: var(--color-surface);
@@ -67,12 +68,12 @@ $tab-background-selected: var(--color-surface);
 
 
 .hosting-v3-hero-section__heading {
-	@include a4a-font-heading-lg;
+	@include heading-2x-large;
 	color: var( --color-text-inverted );
 	margin-block-start: 0;
 
 	@include break-medium {
-		@include a4a-font-heading-xxl;
+		@include heading-x-large;
 	}
 }
 
@@ -134,16 +135,16 @@ $tab-background-selected: var(--color-surface);
 }
 
 .hosting-v3__nav-item-label {
-	@include a4a-font-body-md($font-weight: 500);
+	@include body-medium;
 	color: var( --color-text );
 	text-align: center;
 
 	@include break-medium {
-		@include a4a-font-heading-lg;
+		@include heading-x-large;
 	}
 }
 
 .hosting-v3__nav-item-subtitle {
-	@include a4a-font-body-md;
+	@include body-medium;
 	color: var( --color-text );
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
@@ -68,12 +68,12 @@ $tab-background-selected: var(--color-surface);
 
 
 .hosting-v3-hero-section__heading {
-	@include heading-2x-large;
+	@include heading-x-large;
 	color: var( --color-text-inverted );
 	margin-block-start: 0;
 
 	@include break-medium {
-		@include heading-x-large;
+		@include heading-2x-large;
 	}
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hero-section/style.scss
@@ -63,7 +63,7 @@ $tab-background-selected: var(--color-surface);
 		position: absolute;
 	}
 
-	height: 55px;
+	height: 74px;
 }
 
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-plan-section/style.scss
@@ -1,10 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .hosting-plan-section {
 	padding-block: 32px;
 
 	.page-section__header-title {
-		@include a4a-font-heading-lg;
+		@include heading-x-large;
 		text-align: center;
 	}
 
@@ -99,7 +101,7 @@
 
 .hosting-plan-section__details-heading,
 .hosting-plan-section__aside-heading {
-	@include a4a-font-heading-lg;
+	@include heading-x-large;
 }
 
 .hosting-plan-section__details-content,
@@ -110,7 +112,7 @@
 	margin-block: 16px;
 
 	> * {
-		@include a4a-font-body-md;
+		@include body-medium;
 		margin: 0;
 		padding: 0;
 	}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/index.tsx
@@ -93,6 +93,7 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 					) }
 
 					<SimpleList
+						applyCoreStyles
 						items={ [
 							translate( 'Unmatched flexibility to build a customized web experience' ),
 							translate( 'Tools to increase customer engagement' ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 
 .enterprise-agency-hosting-v3 {
 	.hosting-plan-section__main {
@@ -28,14 +28,14 @@
 }
 
 .enterprise-agency-hosting__top-heading {
-	@include a4a-font-heading-lg;
+	@include heading-large;
 	display: flex;
 	align-items: center;
 	margin-block-end: 16px;
 }
 
 .enterprise-agency-hosting__top-subheading {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 }
 
 .theme-a8c-for-agencies .enterprise-agency-hosting-v3__cta-button.enterprise-agency-hosting-v3__cta-button.enterprise-agency-hosting-v3__cta-button.is-primary {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -164,6 +164,7 @@ export default function PressablePlanSection( {
 
 				{ isCustomPlan ? (
 					<SimpleList
+						applyCoreStyles
 						items={ [
 							translate( 'Custom WordPress installs' ),
 							translate( '{{b}}%(count)s{{/b}} visits per month*', {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .pressable-plan-card-content {
 	display: flex;
@@ -16,12 +17,12 @@
 }
 
 .pressable-plan-card-content__price-actual-value{
-	@include a4a-font-heading-lg;
+	@include heading-large;
 	color: var(--color-text);
 }
 
 .pressable-plan-card-content__price-interval {
-	@include a4a-font-body-sm;
+	@include body-small;
 }
 
 // We need to do this specifically to override the white-space.

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-usage-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-usage-section/style.scss
@@ -1,10 +1,13 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .pressable-usage-section {
 	border-block-end: 1px solid var( --color-neutral-5 );
 	padding-block: 32px;
 
 
 	.page-section__header-title {
-		@include a4a-font-heading-lg;
+		@include heading-x-large;
 		text-align: center;
 	}
 }
@@ -18,7 +21,7 @@
 }
 
 .pressable-usage-card__heading {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -26,7 +29,7 @@
 	align-items: center;
 
 	.badge.badge--info {
-		@include a4a-font-body-sm;
+		@include body-small;
 		background-color: var( --color-neutral-0 );
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .premier-agency-hosting ul.hosting-additional-features {
 	.gridicon {
@@ -56,7 +57,7 @@
 	justify-content: center;
 
 	.pressable-overview-plan-selection__filter-label {
-		@include a4a-font-heading-md($font-size: rem(14px));
+		@include heading-medium;
 		margin: 0;
 
 	}
@@ -114,6 +115,6 @@
 }
 
 .pressable-plan-section__details-footnote {
-	@include a4a-font-body-sm;
+	@include body-small;
 	color: var(--color-neutral-80);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -132,6 +132,7 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 					</p>
 
 					<SimpleList
+						applyCoreStyles
 						items={ [
 							translate( '{{b}}50GB{{/b}} of storage', { components: { b: <b /> } } ),
 							translate( '{{b}}Free{{/b}} staging site', { components: { b: <b /> } } ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 
 .wpcom-plan-section .a4a-slider {
 	position: relative;
@@ -29,7 +29,7 @@
 
 .wpcom-plan-selector__price-actual-value,
 .wpcom-plan-selector__price-original-value {
-	@include a4a-font-heading-lg;
+	@include heading-large;
 	color: var(--color-text);
 }
 
@@ -40,13 +40,13 @@
 }
 
 .wpcom-plan-selector__price-discount {
-	@include a4a-font-body-md;
+	@include body-medium;
 	color: var(--color-success);
 	text-wrap: nowrap;
 }
 
 .wpcom-plan-selector__price-interval {
-	@include a4a-font-body-sm;
+	@include body-small;
 }
 
 .wpcom-plan-selector__cta {
@@ -58,7 +58,7 @@
 }
 
 .wpcom-plan-selector__owned-plan {
-	@include a4a-font-heading-md;
+	@include heading-medium;
 
 	display: inline-block;
 	border: 1px solid var(--color-neutral-5);

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -111,6 +111,7 @@ export default function PlanSelectionDetails( {
 
 				{ ! isRegularOwnership && ! isReferMode && (
 					<SimpleList
+						applyCoreStyles
 						items={ [
 							info?.install
 								? translate(

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .pressable-overview-plan-selection {
 	width: 100%;
@@ -37,7 +38,7 @@
 }
 
 .pressable-overview-plan-selection__details-hint {
-	@include a4a-font-body-md;
+	@include body-medium;
 }
 
 .pressable-overview-plan-selection__details-card {
@@ -63,18 +64,18 @@
 }
 
 .pressable-overview-plan-selection__details-card-header-coming-soon {
-	@include a4a-font-heading-md($font-weight: 400);
+	@include heading-medium;
 }
 
 .pressable-overview-plan-selection__details-card-header-subtitle {
-	@include a4a-font-body-md;
+	@include body-medium;
 
 	&.is-regular-ownership {
 		padding-block-start: 32px;
 	}
 
 	&.is-refer-mode {
-		@include a4a-font-body-sm;
+		@include body-small;
 		padding-block-end: 16px;
 	}
 
@@ -136,7 +137,7 @@
 	justify-content: center;
 
 	.pressable-overview-plan-selection__filter-label {
-		@include a4a-font-heading-md($font-size: rem(14px));
+		@include heading-medium;
 		margin: 0;
 
 	}
@@ -293,11 +294,11 @@
 	}
 
 	.pressable-overview-plan-selection__details-card-header-title {
-		@include a4a-font-heading-lg;
+		@include heading-large;
 
 		&.plan-name {
 			margin-block-end: 8px;
-			@include a4a-font-heading-xl;
+			@include heading-x-large;
 		}
 	}
 
@@ -306,7 +307,7 @@
 	}
 
 	.pressable-overview-plan-selection__details-card-header-price-value {
-		@include a4a-font-heading-xl;
+		@include heading-x-large;
 	}
 
 	.pressable-overview-plan-selection__details > * {

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/bundle-price-selector/style.scss
@@ -1,6 +1,7 @@
 
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .bundle-price-selector {
 	display: flex;
@@ -10,7 +11,7 @@
 }
 
 .bundle-price-selector__label {
-	@include a4a-font-heading-sm;
+	@include heading-small;
 	text-transform: uppercase;
 	display: none;
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
@@ -141,7 +141,7 @@ $woocommerce-purple-50: #720EEC;
 }
 
 .product-card__title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	color: var(--color-neutral-80);
 
 	@include product-card-block__title;
@@ -164,7 +164,7 @@ $woocommerce-purple-50: #720EEC;
 }
 
 .product-card__description {
-	@include a4a-font-body-lg;
+	@include body-large;
 	color: var(--color-neutral-60);
 	margin: 8px 0;
 }


### PR DESCRIPTION
This PR updates the Marketplace page to now use the Core's typography.

<img width="1726" alt="Screenshot 2025-03-10 at 11 47 47 PM" src="https://github.com/user-attachments/assets/56d924a0-6f9d-4c51-b76f-af2c117eff92" />
<img width="1727" alt="Screenshot 2025-03-10 at 11 47 53 PM" src="https://github.com/user-attachments/assets/d8d5bf4e-524a-4210-8eda-e5672d30020f" />
<img width="865" alt="Screenshot 2025-03-10 at 11 48 08 PM" src="https://github.com/user-attachments/assets/f7c1bc90-736d-4979-9f2c-4f4c362d4976" />

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1910

## Proposed Changes

* Update the Marketplace page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/marketplace` page.
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
