### PR TITLE
Don't show upsell modal in the `site-migration` and `hosted-site-migration` flows

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -5,7 +5,6 @@ import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
-import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
@@ -111,12 +110,7 @@ const siteMigration: Flow = {
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
 		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
-		const { data: urlData, isLoading: isLoadingFromData } = useAnalyzeUrlQuery(
-			fromQueryParam || '',
-			true
-		);
 
-		const isFromSiteWordPress = ! isLoadingFromData && urlData?.platform === 'wordpress';
 		const { get, sessionId } = useFlowState();
 
 		const exitFlow = ( to: string ) => {
@@ -618,22 +612,11 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
-					if ( urlQueryParams.has( 'showModal' ) || ! isFromSiteWordPress ) {
+					if ( urlQueryParams.has( 'showModal' ) ) {
 						urlQueryParams.delete( 'showModal' );
-						return navigate( `${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }` );
 					}
 
-					// If the user selected the "Do it for me" option, we should take them back to the how to migrate step skipping
-					// the modal.
-					if ( urlQueryParams.get( 'how' ) === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
-						return navigate( `${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }` );
-					}
-
-					if ( isFromSiteWordPress ) {
-						urlQueryParams.set( 'showModal', 'true' );
-					}
-
-					return navigate( `site-migration-upgrade-plan?${ urlQueryParams.toString() }` );
+					return navigate( `${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }` );
 				}
 
 				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
 * https://github.com/Automattic/wp-calypso/issues/100864

## Proposed Changes

* This PR ensures that we no longer show the upsell modal in the `site-migration` and `hosted-site-migration` flows.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're not generating much revenue from this upsell, and we're also causing unnecessary friction for people in those flows, in addition to there being some visual issues with the modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* For a free site or a site with a Personal or Premium plan, navigate to _Tools_ -> _Import_ and select "WordPress" from the list
* On the "What do you want to do?" step, pick the "Migrate site" option
* On the "Let us migrate your site" click on "Get started"
* On the "There is a plan for you" step, click on the "Back" link
* Verify that you don't see a modal that blocks your navigation, and your are taken back to the "Let us migrate your site" step
* Click on the "I'll do it myself" link in the top right corner
* On the "There is a plan for you" step, click on the "Back" link
* Verify that you don't see a modal that blocks your navigation, and your are taken back to the "Let us migrate your site" step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [N/A] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
