### PR TITLE
Help Center - DIFM: Correct Help Center copy

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -72,11 +72,13 @@ export function DefaultMasterbarContact() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 
-	const { hasPremiumSupport, userFieldMessage, userFieldFlowName } = useProductsWithPremiumSupport(
-		responseCart.products,
-		'checkout'
-	);
-
+	const {
+		hasPremiumSupport,
+		userFieldMessage,
+		userFieldFlowName,
+		helpCenterButtonCopy,
+		helpCenterButtonLink,
+	} = useProductsWithPremiumSupport( responseCart.products, 'checkout' );
 	const helpCenterOptions = useProductsCustomOptions( responseCart.products );
 
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
@@ -113,10 +115,10 @@ export function DefaultMasterbarContact() {
 
 	return (
 		<ContactContainer>
-			<label>{ translate( 'Need extra help?' ) }</label>
+			<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) }</label>
 			<Button className="thank-you-help-center" variant="link" onClick={ toggleHelpCenter }>
 				<Gridicon icon="help-outline" />
-				<span>{ translate( 'Visit Help Center' ) }</span>
+				<span>{ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }</span>
 			</Button>
 		</ContactContainer>
 	);

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -430,7 +430,7 @@ export function generateFlows( {
 				return translate( 'Questions?' );
 			},
 			get helpCenterButtonLink() {
-				return translate( 'Contact our site building team' );
+				return translate( 'Contact our site-building team' );
 			},
 			providesDependenciesInQuery: [ 'coupon', 'back_to' ],
 			optionalDependenciesInQuery: [ 'coupon', 'back_to' ],
@@ -457,7 +457,7 @@ export function generateFlows( {
 				return translate( 'Questions?' );
 			},
 			get helpCenterButtonLink() {
-				return translate( 'Contact our site building team' );
+				return translate( 'Contact our site-building team' );
 			},
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
@@ -476,7 +476,7 @@ export function generateFlows( {
 				return translate( 'Questions?' );
 			},
 			get helpCenterButtonLink() {
-				return translate( 'Contact our site building team' );
+				return translate( 'Contact our site-building team' );
 			},
 		},
 

--- a/packages/help-center/src/hooks/use-products-with-premium-support.ts
+++ b/packages/help-center/src/hooks/use-products-with-premium-support.ts
@@ -5,6 +5,7 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 } from '@automattic/onboarding';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
+import { __ } from '@wordpress/i18n';
 import { FLOWS_ZENDESK_INITIAL_MESSAGES, FLOWS_ZENDESK_FLOWNAME } from '../constants';
 
 const getUserFieldMessage = ( flowName: string, url?: string ) => {
@@ -21,6 +22,8 @@ export function useProductsWithPremiumSupport( products: ResponseCartProduct[], 
 				userFieldFlowName:
 					FLOWS_ZENDESK_FLOWNAME[ DIFM_FLOW as keyof typeof FLOWS_ZENDESK_FLOWNAME ],
 				hasPremiumSupport: true,
+				helpCenterButtonCopy: __( 'Questions?', __i18n_text_domain__ ),
+				helpCenterButtonLink: __( 'Contact our site-building team', __i18n_text_domain__ ),
 			};
 		}
 		if ( product?.product_slug === PLAN_100_YEARS ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-31k-p2#comment-3043

## Proposed Changes

Changed the copy of the Help Center link in Checkout for the DIFMf low.

Changed to:
![Screenshot 2025-03-10 at 17 12 17](https://github.com/user-attachments/assets/9a9840ed-2de2-4842-ac6a-e9eb02531828)

From "Need extra help? Visit Help Center"


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the DIFM flow with the Help Center flag: `/start/do-it-for-me/new-or-existing-site?flags=signup/help-center-link`
* Reach Checkout
* Check the copy