### PR TITLE
Resolve file downloading using wpcom.js for Blaze

### DIFF
--- a/client/data/promote-post/use-promote-post-campaign-report-data-query.ts
+++ b/client/data/promote-post/use-promote-post-campaign-report-data-query.ts
@@ -16,7 +16,8 @@ const useCampaignReportDataQuery = (
 				`/stats/${ campaignId }/report/${ reportId }`,
 				'GET',
 				undefined,
-				'1.1'
+				'1.1',
+				true
 			);
 			return response;
 		},


### PR DESCRIPTION
Closes #100205

## Proposed Changes
* Introduce `responseType: 'blob'` for using `wpcom.js` while accessing DSP (Blaze) API

## Why are these changes being made?
We ended up using non-JSON response for stats downloading. Eventually we noticed that downloading stopped working, so users see infinite loading animation.

![image](https://github.com/user-attachments/assets/748447b9-2adf-4c46-bae4-dd8003ff7612)

Thankfully (in p1741353744526019-slack-C02DQP0FP) wise fellow suggested the solution.

## Testing Instructions
You need to have locally launched DSP and Calypso in order to test it locally. Otherwise, feel free to use a live link provided below.

If you're interested in having enough stats data to use locally, please consider testing instructions from `2793-gh-Tumblr/a8c-dsp`.

You need to find a finished campaign with insertions and try to download a report. It should work as it was engineered.

Short demo video

https://github.com/user-attachments/assets/39c7f931-1c56-4cc4-98b1-89d35de0e73f

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
