### PR TITLE
Fix spacing around Billing History DataViews component

### DIFF
--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -10,7 +10,7 @@
             display: flex;
             align-items: end;
             justify-content: center;
-            padding-top: 48px;
+            padding-top: 36px;
 
             .components-spinner {
                 width: 32px;

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -1,9 +1,10 @@
 #billing-history {
+    padding: 8px 0 0;
 
     .dataviews-wrapper {
         width: 100%;
-        margin-bottom: 1rem;
-        padding: 0 1rem;
+        margin-bottom: 0;
+        padding: 0;
 
         .dataviews-loading {
             display: flex;
@@ -59,6 +60,7 @@
 				button {
 					padding: 0;
 					text-transform: uppercase;
+                    margin-left: 0;
 				}
             }
 
@@ -81,6 +83,16 @@
                     color: var(--color-text-subtle);
                     margin-top: 0.25rem;
                 }
+            }
+
+            th:first-child,
+            td:first-child {
+                padding-left: 24px;
+            }
+
+            th:last-child,
+            td:last-child {
+                padding-right: 24px;
             }
 			
 			.dataviews-view-table__actions-column {
@@ -162,13 +174,15 @@
     }
 
     .dataviews__view-actions {
-        margin-top: 1em;
-		padding-left: 0;
-		padding-right: 0;
+        margin-top: 0;
+		padding-left: 24px;
+		padding-right: 24px;
     }
 
 	.dataviews-filters__container {
 		padding: 0;
+		padding-left: 24px;
+		padding-right: 24px;
 	}
 
     .section-nav {

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -18,6 +18,15 @@
             }
         }
 
+        .dataviews-no-results {
+            padding: 36px;
+
+            p {
+                margin: 0;
+            }
+
+        }
+
         .dataviews-view-table {
             width: 100%;
             border-collapse: collapse;

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -202,6 +202,10 @@
         border-bottom: 1px solid var(--color-neutral-5);
     }
 
+    .dataviews-footer {
+        padding: 12px;
+    }
+
     .card.billing-history__receipts {
         box-shadow: none;
     }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/99808

## Proposed Changes

* Remove padding around the `BillingHistoryListDataView` so that rows are full-width with padding to keep the content off of the edges.

## Why are these changes being made?

After deploying the new `BillingHistoryListDataView` component, it was noticed that the filter drop-down did not line up with the text in the `Add tax (VAT/GST/CT) details` text below the table.  This prompted a discussion on how to address that with removing the padding from the table so that the rows are full-width ended up being the preferred approach.

![alignment](https://github.com/user-attachments/assets/7902622e-b08c-4168-8179-09636a66e7b4)


## Testing Instructions

1. Before applying this patch, visit `http://calypso.localhost:3000/me/purchases/billing` and notice how the date filter's drop-down menu does not line up with the VAT link.  
2. Apply this patch and refresh the URL.  The drop-down should line up with the left most text in each row as well as with the VAT link.

## Screeshots
<img width="1547" alt="before" src="https://github.com/user-attachments/assets/031c1c57-4b36-4762-b4b5-e193d4a66f43" />
**Before**

<img width="1547" alt="after" src="https://github.com/user-attachments/assets/279009a4-c035-4baa-94b6-dc38507b1339" />
**After**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
