### PR TITLE
Plugins: Display progress bar when installing theme for the first time

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
@@ -17,19 +17,22 @@ body.is-section-marketplace.theme-default.color-scheme {
 	}
 }
 
-.marketplace-plugin-install__root {
-	display: flex;
-	justify-content: center;
-	height: 100vh;
-	align-items: center;
-	position: absolute;
-	top: 0;
-	right: 0;
-	left: 0;
+body.is-section-marketplace {
+	.layout__content {
+		padding-block: 0 !important;
+	}
 
-	> div {
-		width: 90%;
-		max-width: 509px;
+	.marketplace-plugin-install__root {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		width: 100%;
+		height: 100vh;
+
+		> div {
+			width: 90%;
+			max-width: 509px;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101068.

## Proposed Changes

The `.marketplace-plugin-install__root` element was absolutely positioned, and there were no other items on the page, causing the Layout container to have zero height. Therefore, nothing was showing up on the screen.

This PR makes that element statically positioned so it actually takes the real estate and displays properly.

## Testing Instructions

Install a plugin **for the first time** on your site and verify you see the progress bar. Verify that you see a blank screen on `trunk` when installing **a different plugin**.

I've only reproduced this in the first installation of a plugin, regardless of the site's state (Simple/Atomic).
