### PR TITLE
Stepper: Fix store-address country field styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -260,6 +260,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 							} }
 							options={ countriesAsOptions }
 							className={ errors[ 'store_country' ] ? 'is-error' : '' }
+							__next40pxDefaultSize
 						/>
 						<ControlError error={ errors[ 'store_country' ] || '' } />
 					</FormFieldset>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -3,15 +3,24 @@
 .step-container.store-address {
 	.components-combobox-control__input {
 		padding: 7px 14px;
+		font-size: 1rem;
+		color: var(--color-neutral-70);
 	}
 	.components-combobox-control__suggestions-container {
 		width: unset;
-		border-color: var(--color-neutral-10);
+		border: 1px solid var(--color-neutral-10);
 		.components-flex {
-			padding-bottom: 5px;
+			padding: 0;
+			height: 38px;
 		}
 		.components-combobox-control__reset {
 			margin-top: 5px;
+		}
+		&:focus,
+		&:focus-within {
+			border-color: var(--color-primary);
+			outline: none;
+			box-shadow: 0 0 0 2px var(--color-primary-10);
 		}
 	}
 	.step-container__header {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/style.scss
@@ -2,20 +2,13 @@
 
 .step-container.store-address {
 	.components-combobox-control__input {
-		padding: 7px 14px;
+		padding-inline: 6px;
 		font-size: 1rem;
 		color: var(--color-neutral-70);
 	}
 	.components-combobox-control__suggestions-container {
-		width: unset;
 		border: 1px solid var(--color-neutral-10);
-		.components-flex {
-			padding: 0;
-			height: 38px;
-		}
-		.components-combobox-control__reset {
-			margin-top: 5px;
-		}
+
 		&:focus,
 		&:focus-within {
 			border-color: var(--color-primary);

--- a/client/signup/steps/woocommerce-install/step-store-address/style.scss
+++ b/client/signup/steps/woocommerce-install/step-store-address/style.scss
@@ -25,11 +25,6 @@ body.is-section-signup .is-woocommerce-install .signup__step.is-store-address {
 			width: min-content;
 		}
 
-		.components-combobox-control__reset.components-button {
-			// Height of 18 ensures combobox input matches height of text controls.
-			height: 18px;
-		}
-
 		.form-input-validation.is-error {
 			margin-bottom: $grid-unit-30;
 			padding-bottom: 0;


### PR DESCRIPTION
## Proposed Changes

Fixes the styles of the country field.

Not a perfect solution, since colors will still mismatch (button color vs focus border colors). Needs a broader solution if we're to address this properly.

Still, fixes the broken field, and applies consistency with the rest of the form.

Before:

![Screenshot 2025-03-10 at 19 49 10](https://github.com/user-attachments/assets/85b9c423-f5b2-4577-82b7-0a094469f7e7)


After:

![Screenshot 2025-03-10 at 19 48 57](https://github.com/user-attachments/assets/3e535cdc-63c1-4c70-9af5-05a3b67e3181)


## Why are these changes being made?

To resolve a bug reported in https://github.com/Automattic/wp-calypso/pull/100472#pullrequestreview-2645116827

## Testing Instructions

Follow Marco's instructions from https://github.com/Automattic/wp-calypso/pull/100472#pullrequestreview-2645116827