### PR TITLE
Site Migrations: Update Import link on add new site popover to point directly to import screen

### DIFF
--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -43,7 +43,7 @@ const importClick = () => {
 		action: 'import',
 	} );
 	page(
-		'/setup/hosted-site-migration/site-migration-identify?source=sites-dashboard&ref=new-site-popover&action=import'
+		'/setup/hosted-site-migration/create-site?source=sites-dashboard&ref=new-site-popover&action=import'
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -224,11 +224,12 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_CREATION_STEP.slug: {
-					if ( 'import' === actionQueryParam ) {
-						return navigate( addQueryArgs( { skipMigration: true }, STEPS.PROCESSING.slug ) );
-					}
+					const queryArgs = {
+						from: fromQueryParam,
+						skipMigration: 'import' === actionQueryParam ? true : undefined,
+					};
 
-					return navigate( addQueryArgs( { from: fromQueryParam }, STEPS.PROCESSING.slug ) );
+					return navigate( addQueryArgs( queryArgs, STEPS.PROCESSING.slug ) );
 				}
 
 				case STEPS.PROCESSING.slug: {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -110,6 +110,7 @@ const siteMigration: Flow = {
 		const siteSlugParam = useSiteSlugParam();
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
+		const actionQueryParam = urlQueryParams.get( 'action' );
 		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
 		const { data: urlData, isLoading: isLoadingFromData } = useAnalyzeUrlQuery(
 			fromQueryParam || '',
@@ -223,6 +224,10 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_CREATION_STEP.slug: {
+					if ( 'import' === actionQueryParam ) {
+						return navigate( addQueryArgs( { skipMigration: true }, STEPS.PROCESSING.slug ) );
+					}
+
 					return navigate( addQueryArgs( { from: fromQueryParam }, STEPS.PROCESSING.slug ) );
 				}
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -131,6 +131,27 @@ describe( 'Site Migration Flow', () => {
 					step: STEPS.PROCESSING,
 				} );
 			} );
+
+			it( 'redirects to PROCESSING and skips migration if the action is import', () => {
+				const destination = runNavigation( {
+					from: STEPS.SITE_CREATION_STEP,
+					dependencies: {
+						siteCreated: true,
+					},
+					query: {
+						action: 'import',
+						from: 'https://site-to-be-migrated.com',
+					},
+				} );
+
+				expect( destination ).toMatchDestination( {
+					step: STEPS.PROCESSING,
+					query: {
+						skipMigration: true,
+						from: 'https://site-to-be-migrated.com',
+					},
+				} );
+			} );
 		} );
 
 		describe( 'PROCESSING', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100883 

## Proposed Changes

* Update the link on the Add New Site popover for Imports to point directly to the create site step.
* At the create site step, check for the `action=import` query parameter. If we find it, create the site and skip the migration flow to go directly to the importer list. (We may want to make this check more specific, but I didn't see other instances of the action query parameter in use in Calypso.)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Removing the site identification step should hopefully reduce user confusion and enable them to get to their desired state more quickly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/sites`
* Click on "Add new site" and click Import
* You should be brought to the importers list with a new site having been created in the siteSlug parameter:

<img width="1411" alt="Screenshot 2025-03-10 at 1 54 55 PM" src="https://github.com/user-attachments/assets/a9395ce0-7313-4017-8439-187916d5709e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
