### PR TITLE
DIFM: fix post-checkout redirection for the goals flow

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -197,7 +197,7 @@ export default class SignupFlowController {
 		const hasStepThatProvidesSiteSlug = ( flowName: string ) => {
 			let foundStepThatProvidesSiteSlug = false;
 			const userLoggedIn = isUserLoggedIn( this._reduxStore.getState() );
-			forEach( pick( steps, flows.getFlow( flowName, userLoggedIn ).steps ), ( step ) => {
+			forEach( pick( steps, flows.getFlow( flowName, userLoggedIn )?.steps ), ( step ) => {
 				if ( ( step.providesDependencies || [] ).indexOf( 'siteSlug' ) > -1 ) {
 					foundStepThatProvidesSiteSlug = true;
 					return false;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -349,9 +349,12 @@ function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 	if ( step.lastKnownFlow === 'do-it-for-me-store' ) {
 		dependencies.isStoreFlow = true;
 	}
+
+	const selectedSiteId = siteId || getSiteId( reduxStore.getState(), siteSlug );
+
 	const extra = buildDIFMCartExtrasObject(
 		dependencies,
-		siteId,
+		selectedSiteId,
 		`step-actions-flow-${ step.lastKnownFlow || '' }`
 	);
 	const cartItem = {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -472,6 +472,7 @@ export function generateFlows( {
 			optionalDependenciesInQuery: [ 'siteSlug', 'back_to' ],
 			lastModified: '2025-03-04',
 			enabledHelpCenterGeos: [ 'US' ],
+			hideProgressIndicator: true,
 			get helpCenterButtonCopy() {
 				return translate( 'Questions?' );
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is a follow-up to #101014. This PR solves the same issue, but for the `website-design-services` flow.
* It also contains two small drive-by fixes
  * Fixes an uncaught error when redirecting from the `site-setup` flow to the `website-design-services` flow.
  * Hides the progress indicator for the `website-design-services` flow. (pdh1Xd-31k-p2#comment-3050)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>`.
* Proceed through the flow steps and complete checkout.
* After checkout, confirm that you are redirected to the content submission form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?