### PR TITLE
Site Migration: Remove Import/Migrate choice from flow if coming from Add New Site popover

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -256,9 +256,13 @@ const siteMigration: Flow = {
 							);
 						}
 
+						// If the action is migrate, navigate to the DIY/DIFM selector screen.
 						if ( 'migrate' === actionQueryParam ) {
 							return navigate(
-								addQueryArgs( { from: fromQueryParam }, STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug )
+								addQueryArgs(
+									{ siteId, siteSlug, from: fromQueryParam },
+									STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug
+								)
 							);
 						}
 

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -110,6 +110,7 @@ const siteMigration: Flow = {
 		const siteSlugParam = useSiteSlugParam();
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
+		const actionQueryParam = urlQueryParams.get( 'action' );
 		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
 		const { data: urlData, isLoading: isLoadingFromData } = useAnalyzeUrlQuery(
 			fromQueryParam || '',
@@ -208,6 +209,16 @@ const siteMigration: Flow = {
 						case 'select-site': {
 							const { ID: newSiteId, slug: newSiteSlug } =
 								providedDependencies.site as SiteExcerptData;
+
+							// If the action is migrate, navigate to the DIY/DIFM selector screen.
+							if ( 'migrate' === actionQueryParam ) {
+								return navigate(
+									addQueryArgs(
+										{ siteId: newSiteId, siteSlug: newSiteSlug, from: fromQueryParam },
+										STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug
+									)
+								);
+							}
 							return navigate(
 								addQueryArgs(
 									{ siteId: newSiteId, siteSlug: newSiteSlug, from: fromQueryParam },
@@ -244,6 +255,13 @@ const siteMigration: Flow = {
 								)
 							);
 						}
+
+						if ( 'migrate' === actionQueryParam ) {
+							return navigate(
+								addQueryArgs( { from: fromQueryParam }, STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug )
+							);
+						}
+
 						return navigate(
 							addQueryArgs(
 								{ siteId, siteSlug, from: fromQueryParam },

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -157,6 +157,30 @@ describe( 'Site Migration Flow', () => {
 				} );
 			} );
 
+			it( 'redirects to HOW_TO_MIGRATE step if there is a from parameter and the action is migrate', () => {
+				const destination = runNavigation( {
+					from: STEPS.PROCESSING,
+					dependencies: {
+						siteCreated: true,
+					},
+					query: {
+						from: 'https://site-to-be-migrated.com',
+						siteId: 123,
+						siteSlug: 'example.wordpress.com',
+						action: 'migrate',
+					},
+				} );
+
+				expect( destination ).toMatchDestination( {
+					step: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE,
+					query: {
+						sessionId: '123',
+						siteSlug: 'example.wordpress.com',
+						siteId: 123,
+					},
+				} );
+			} );
+
 			it( 'redirects to the import flow if there is no from query parameter', () => {
 				runNavigation( {
 					from: STEPS.PROCESSING,
@@ -388,6 +412,31 @@ describe( 'Site Migration Flow', () => {
 				expect( destination ).toMatchDestination( {
 					step: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
 					query: {
+						siteSlug: 'example.wordpress.com',
+						siteId: 123,
+					},
+				} );
+			} );
+
+			it( 'redirects to HOW_TO_MIGRATE step if a site is selected and the query action is migrate', () => {
+				const destination = runNavigation( {
+					from: STEPS.PICK_SITE,
+					query: {
+						action: 'migrate',
+					},
+					dependencies: {
+						action: 'select-site',
+						site: {
+							ID: 123,
+							slug: 'example.wordpress.com',
+						},
+					},
+				} );
+
+				expect( destination ).toMatchDestination( {
+					step: STEPS.SITE_MIGRATION_HOW_TO_MIGRATE,
+					query: {
+						sessionId: '123',
 						siteSlug: 'example.wordpress.com',
 						siteId: 123,
 					},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100874

## Proposed Changes

* When clicking the "Migrate" button from the Add New Site popover, don't show the Import/Migrate step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users have already chosen to migrate their site; they don't need to make that choice again and this removes an unnecessary step in the flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/sites`
* Click "Add New Site" and select "Migrate"
* You'll be brought to the identify step. Input the URL to your test site.
* You'll be brought to the site picker. Either choose an existing site or create a new one.
* You should be shown the DIY/DIFM screen:

<img width="1282" alt="Screenshot 2025-03-10 at 4 56 18 PM" src="https://github.com/user-attachments/assets/5e7246e9-f602-421f-aa9e-69cd81293e33" />

* Check that coming from a different source (like `/start`) still shows the Import/Migrate step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
