### PR TITLE
Fix SitesDropdown and SiteSelector styling issues

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -29,6 +29,17 @@
 	&.is-large .site-selector__sites {
 		border-top: 1px solid var(--color-neutral-10);
 	}
+
+	.search-component {
+		.components-button {
+			border: none;
+			box-shadow: none;
+	
+			&:hover {
+				background: transparent;
+			}
+		}
+	}
 }
 
 // Styles for Site elements within the Selector

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -31,6 +31,10 @@
 	}
 
 	.search-component {
+		.search-component__input {
+			width: 100%;
+		}
+
 		.components-button {
 			border: none;
 			box-shadow: none;

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,27 +1,29 @@
-@import "../../assets/stylesheets/shared/mixins/breakpoints";
+@import '../../assets/stylesheets/shared/mixins/breakpoints';
 
 .sites-dropdown {
 	position: relative;
-	
+
 	&.is-open {
 		.gridicons-chevron-down {
-			transform: rotate(180deg);
+			transform: rotate( 180deg );
 		}
 	}
 
 	.gridicons-chevron-down {
 		align-self: center;
-		color: var(--color-neutral-20);
+		color: var( --color-neutral-20 );
 		flex-grow: 0;
 		flex-shrink: 0;
 		margin-right: 16px;
-		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+		transition:
+			transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ),
+			color 0.2s ease-in;
 	}
 }
 
 .sites-dropdown__wrapper {
-	background: var(--color-surface);
-	border: 1px solid var(--color-neutral-10);
+	background: var( --color-surface );
+	border: 1px solid var( --color-neutral-10 );
 	border-width: 1px;
 	border-radius: 2px;
 	margin: 0;
@@ -30,27 +32,24 @@
 	transition: border-color 0.2s ease-in;
 	z-index: 1;
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 
 	.has-multiple-sites &:hover {
-		border-color: var(--color-neutral-20);
+		border-color: var( --color-neutral-20 );
 
 		.site-selector {
-			border-color: var(--color-neutral-20);
+			border-color: var( --color-neutral-20 );
 		}
-	}
-
-	.is-open & {
-		border-radius: 2px 2px 0 0;
 	}
 }
 
 .sites-dropdown.is-open .sites-dropdown__wrapper {
 	position: relative;
-	z-index: z-index("root", ".sites-dropdown.is-open .sites-dropdown__wrapper");
+	z-index: z-index( 'root', '.sites-dropdown.is-open .sites-dropdown__wrapper' );
 	margin: 0;
+	border-radius: 2px 2px 0 0;
 }
 
 .sites-dropdown__selected {
@@ -62,13 +61,13 @@
 	}
 
 	.is-open & {
-		border-bottom-color: var(--color-neutral-0);
+		border-bottom-color: var( --color-neutral-0 );
 	}
 
 	&:hover {
 		.gridicons-chevron-down,
 		.gridicons-chevron-up {
-			color: var(--color-neutral-50);
+			color: var( --color-neutral-50 );
 		}
 	}
 }
@@ -80,8 +79,8 @@
 	left: -1px;
 	overflow-x: hidden;
 	overflow-y: auto;
-	background: var(--color-surface);
-	border: 1px solid var(--color-neutral-10);
+	background: var( --color-surface );
+	border: 1px solid var( --color-neutral-10 );
 	border-top: none;
 	border-radius: 0 0 2px 2px;
 	transition: border-color 0.2s ease-in;
@@ -101,7 +100,7 @@
 
 .sites-dropdown .site-selector .search input {
 	margin: 0;
-	background-color: var(--color-surface);
+	background-color: var( --color-surface );
 }
 
 .sites-dropdown .site-selector .site {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -25,7 +25,6 @@
 	border-width: 1px;
 	border-radius: 2px;
 	margin: 0;
-	overflow: visible;
 	position: relative;
 	width: 300px;
 	transition: all 0.2s ease-in;
@@ -69,17 +68,13 @@
 .sites-dropdown .site-selector {
 	padding: 0;
 	position: absolute;
-	top: 100%;
-	left: 0;
-	width: calc(100% + 2px);
-	margin-left: -1px;
-	z-index: 10;
+	width: 100%;
+	left: -1px;
 	overflow-y: auto;
 	background: var(--color-surface);
 	border: 1px solid var(--color-neutral-10);
 	border-top: none;
 	border-radius: 0 0 2px 2px;
-	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .sites-dropdown .site-selector__sites {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -86,8 +86,16 @@
 
 	.search-component {
 		.components-button {
-			right: 8px;
-			position: relative;
+			border: none;
+			box-shadow: none;
+
+			&:hover {
+				background: transparent;
+			}
+		}
+
+		.search-component__input {
+			width: 100%;
 		}
 	}
 }

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,8 +1,9 @@
 @import "../../assets/stylesheets/shared/mixins/breakpoints";
 
 .sites-dropdown {
+	position: relative;
+	
 	&.is-open {
-		height: 69px;
 		.gridicons-chevron-down {
 			transform: rotate(180deg);
 		}
@@ -24,7 +25,7 @@
 	border-width: 1px;
 	border-radius: 2px;
 	margin: 0;
-	overflow: hidden;
+	overflow: visible;
 	position: relative;
 	width: 300px;
 	transition: all 0.2s ease-in;
@@ -48,6 +49,7 @@
 
 .sites-dropdown__selected {
 	display: flex;
+	min-height: 54px;
 
 	.has-multiple-sites & {
 		cursor: pointer;
@@ -67,8 +69,18 @@
 
 .sites-dropdown .site-selector {
 	padding: 0;
-	position: static;
+	position: absolute;
+	top: 100%;
+	left: 0;
+	width: calc(100% + 2px);
+	margin-left: -1px;
+	z-index: 10;
 	overflow-y: auto;
+	background: var(--color-surface);
+	border: 1px solid var(--color-neutral-10);
+	border-top: none;
+	border-radius: 0 0 2px 2px;
+	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .sites-dropdown .site-selector__sites {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -36,7 +36,14 @@
 
 	.has-multiple-sites &:hover {
 		border-color: var(--color-neutral-20);
-		box-shadow: 0 1px var(--color-neutral-20);
+
+		.site-selector {
+			border-color: var(--color-neutral-20);
+		}
+	}
+
+	.is-open & {
+		border-radius: 2px 2px 0 0;
 	}
 }
 
@@ -77,7 +84,8 @@
 	border: 1px solid var(--color-neutral-10);
 	border-top: none;
 	border-radius: 0 0 2px 2px;
-	
+	transition: all 0.2s ease-in;
+
 	.search-component {
 		.components-button {
 			right: 8px;

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,29 +1,27 @@
-@import '../../assets/stylesheets/shared/mixins/breakpoints';
+@import "../../assets/stylesheets/shared/mixins/breakpoints";
 
 .sites-dropdown {
 	position: relative;
 
 	&.is-open {
 		.gridicons-chevron-down {
-			transform: rotate( 180deg );
+			transform: rotate(180deg);
 		}
 	}
 
 	.gridicons-chevron-down {
 		align-self: center;
-		color: var( --color-neutral-20 );
+		color: var(--color-neutral-20);
 		flex-grow: 0;
 		flex-shrink: 0;
 		margin-right: 16px;
-		transition:
-			transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ),
-			color 0.2s ease-in;
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
 }
 
 .sites-dropdown__wrapper {
-	background: var( --color-surface );
-	border: 1px solid var( --color-neutral-10 );
+	background: var(--color-surface);
+	border: 1px solid var(--color-neutral-10);
 	border-width: 1px;
 	border-radius: 2px;
 	margin: 0;
@@ -32,22 +30,22 @@
 	transition: border-color 0.2s ease-in;
 	z-index: 1;
 
-	@include breakpoint-deprecated( '<660px' ) {
+	@include breakpoint-deprecated( "<660px" ) {
 		width: 100%;
 	}
 
 	.has-multiple-sites &:hover {
-		border-color: var( --color-neutral-20 );
+		border-color: var(--color-neutral-20);
 
 		.site-selector {
-			border-color: var( --color-neutral-20 );
+			border-color: var(--color-neutral-20);
 		}
 	}
 }
 
 .sites-dropdown.is-open .sites-dropdown__wrapper {
 	position: relative;
-	z-index: z-index( 'root', '.sites-dropdown.is-open .sites-dropdown__wrapper' );
+	z-index: z-index("root", ".sites-dropdown.is-open .sites-dropdown__wrapper");
 	margin: 0;
 	border-radius: 2px 2px 0 0;
 }
@@ -61,13 +59,13 @@
 	}
 
 	.is-open & {
-		border-bottom-color: var( --color-neutral-0 );
+		border-bottom-color: var(--color-neutral-0);
 	}
 
 	&:hover {
 		.gridicons-chevron-down,
 		.gridicons-chevron-up {
-			color: var( --color-neutral-50 );
+			color: var(--color-neutral-50);
 		}
 	}
 }
@@ -75,15 +73,16 @@
 .sites-dropdown .site-selector {
 	padding: 0;
 	position: absolute;
+	overflow-y: auto;
 	width: 100%;
 	left: -1px;
 	overflow-x: hidden;
-	overflow-y: auto;
 	background: var( --color-surface );
 	border: 1px solid var( --color-neutral-10 );
 	border-top: none;
 	border-radius: 0 0 2px 2px;
 	transition: border-color 0.2s ease-in;
+	box-sizing: initial;
 
 	.search-component {
 		.components-button {
@@ -100,7 +99,7 @@
 
 .sites-dropdown .site-selector .search input {
 	margin: 0;
-	background-color: var( --color-surface );
+	background-color: var(--color-surface);
 }
 
 .sites-dropdown .site-selector .site {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -71,11 +71,19 @@
 	position: absolute;
 	width: 100%;
 	left: -1px;
+	overflow-x: hidden;
 	overflow-y: auto;
 	background: var(--color-surface);
 	border: 1px solid var(--color-neutral-10);
 	border-top: none;
 	border-radius: 0 0 2px 2px;
+	
+	.search-component {
+		.components-button {
+			right: 8px;
+			position: relative;
+		}
+	}
 }
 
 .sites-dropdown .site-selector__sites {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -83,6 +83,10 @@
 	border-radius: 0 0 2px 2px;
 	transition: border-color 0.2s ease-in;
 	box-sizing: initial;
+
+	.search-component {
+		box-sizing: border-box;
+	}
 }
 
 .sites-dropdown .site-selector__sites {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -85,15 +85,6 @@
 	box-sizing: initial;
 
 	.search-component {
-		.components-button {
-			border: none;
-			box-shadow: none;
-
-			&:hover {
-				background: transparent;
-			}
-		}
-
 		.search-component__input {
 			width: 100%;
 		}

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -83,12 +83,6 @@
 	border-radius: 0 0 2px 2px;
 	transition: border-color 0.2s ease-in;
 	box-sizing: initial;
-
-	.search-component {
-		.search-component__input {
-			width: 100%;
-		}
-	}
 }
 
 .sites-dropdown .site-selector__sites {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -27,7 +27,7 @@
 	margin: 0;
 	position: relative;
 	width: 300px;
-	transition: all 0.2s ease-in;
+	transition: border-color 0.2s ease-in;
 	z-index: 1;
 
 	@include breakpoint-deprecated( "<660px" ) {
@@ -84,7 +84,7 @@
 	border: 1px solid var(--color-neutral-10);
 	border-top: none;
 	border-radius: 0 0 2px 2px;
-	transition: all 0.2s ease-in;
+	transition: border-color 0.2s ease-in;
 
 	.search-component {
 		.components-button {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -48,13 +48,14 @@
 
 .sites-dropdown__selected {
 	display: flex;
+	border-bottom: 1px solid transparent;
 
 	.has-multiple-sites & {
 		cursor: pointer;
 	}
 
 	.is-open & {
-		border-bottom: 1px solid var(--color-neutral-0);
+		border-bottom-color: var(--color-neutral-0);
 	}
 
 	&:hover {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -49,7 +49,6 @@
 
 .sites-dropdown__selected {
 	display: flex;
-	min-height: 54px;
 
 	.has-multiple-sites & {
 		cursor: pointer;

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -16,9 +16,16 @@
 
 		.sites-dropdown__wrapper {
 			border-color: var( --color-border-subtle );
-			border-style: solid;
 			border-radius: 6px;
-			border-width: 1px;
+		}
+
+		.site-selector {
+			border-color: var( --color-border-subtle );
+			border-radius: 0 0 6px 6px;
+		}
+
+		.sites-dropdown.is-open .sites-dropdown__wrapper {
+			border-radius: 6px 6px 0 0;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/571

## Proposed Changes

* Fix the styling of the SitesDropdown component so that it no longer shifts elements beneath it when opened.
* Adjust the width of the Search component inside SitesDropdown to prevent horizontal scrolling and avoid a clipped close button.
* Declare Search component buttons inside SiteSelector have no border or background color on hover. (This was an issue on cloud.jetpack.com.)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These improvements enhance the user interface of the SiteSelector and SitesDropdown by making them more stable and visually consistent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test cloud.jetpack.com

You can test cloud.jetpack.com using the [live link in the comment below](https://github.com/Automattic/wp-calypso/pull/101103#issuecomment-2711882428).

* Test the front page site selector. (https://cloud.jetpack.com/ with no site selected.) There should be no borders around the search button components and it should otherwise work as expected.

Before | After
--|--
<img width="1042" alt="Screenshot 2025-03-11 at 1 49 02 PM" src="https://github.com/user-attachments/assets/675bfa9a-8870-4073-a3b9-aa119fa71b77" /> | <img width="1041" alt="Screenshot 2025-03-11 at 1 48 54 PM" src="https://github.com/user-attachments/assets/0d10b434-cceb-4ada-9c15-17308fc02f5a" />

* Test the SiteDropdown in the migrate subscribers modal popup found at: https://cloud.jetpack.com/subscribers/{siteSlug} AND at https://wordpress.com/subscribers/{siteSlug}. The layout should not shift underneath the site selector dropdown and the search box should fit properly in the dropdown.

Before | After
--|--
<video src="https://github.com/user-attachments/assets/5cf8467f-cfe7-4e31-a6ec-3ba3ce1119ae" /> | <video src="https://github.com/user-attachments/assets/6e12f35d-9eac-4e67-989f-45ee9e987afa" />


* Test the site selector in the main menu on https://cloud.jetpack.com/. The search buttons should not have a background color on hover and it should otherwise work as expected.

Before | After
--|--
<video src="https://github.com/user-attachments/assets/3174e8f0-827b-47b4-9a32-a3a668615fef" /> | <video src="https://github.com/user-attachments/assets/ceedd324-45bf-4aa4-978c-3de38367c815" />


### Test /me/account

* Test the SiteDropdown at https://wordpress.com/me/account. The layout should not shift underneath the site selector dropdown, and the search box should fit properly in it. The X close button should not be cut off, and there should be no horizontal scrolling in the drop-down.

Before | After
--|--
<video src="https://github.com/user-attachments/assets/df8416ff-5717-4211-8845-5951e5297450" /> | <video src="https://github.com/user-attachments/assets/3a9629f3-b0d4-46c0-96d6-0333c3a30bf0" />


### Test the Reader Editor

* Similar to the test above. Test the SiteDropdown in the Reader Editor at https://wordpress.com/reader. The layout should not shift underneath the site selector dropdown, and the search box should fit properly in it. The X close button should not be cut off, and there should be no horizontal scrolling in the drop-down. The SiteDropdown in the Reader Editor has slightly rounder corners and a lighter border than the stock component. It should look good.

### Test /home
* Go to /home on Calypso Live and ensure there are no regressions. Nothing should have changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
