### PR TITLE
Fix Actions column header text color

### DIFF
--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -82,7 +82,6 @@
 			font-size: rem( 11px );
 			font-weight: 500;
 			line-height: 20px;
-			color: var( --color-accent-80 );
 			text-transform: uppercase;
 		}
 


### PR DESCRIPTION
Update **Actions** column header to match non-hover text color of other columns (buttons).

Fixes https://github.com/Automattic/wp-calypso/issues/101067.

## Proposed Changes

* Utilize existing color override (`inherit`) applied to `.dataviews-view-table-header-button`.

## Why are these changes being made?

* Improves visual uniformity of column headers on the Billing History tab.

## Testing Instructions

* Go to `/me/purchases/billing` and inspect the **Actions** column header.
* The text should appear gray (`#1e1e1e` or `rgb(30, 30, 30)`), matching the other headers' non-hover color.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
