### PR TITLE
Date Range: Replace Calypso Button with Core Button

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -89,13 +89,4 @@
 	ul.wp-submenu-wrap {
 		margin-left: 0;
 	}
-
-	&.wp-core-ui .popover.date-range__popover .button.is-secondary {
-		border-color: var(--color-neutral-20);
-		background-color: inherit;
-		&:hover {
-			color: var(--color-text-subtle);
-			border-color: var(--color-neutral-60);
-		}
-	}
 }

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -90,7 +90,7 @@
 		margin-left: 0;
 	}
 
-	&.wp-core-ui .button.is-secondary {
+	&.wp-core-ui .popover.date-range__popover .button.is-secondary {
 		border-color: var(--color-neutral-20);
 		background-color: inherit;
 		&:hover {

--- a/client/components/date-range/footer.tsx
+++ b/client/components/date-range/footer.tsx
@@ -26,7 +26,7 @@ const DateRangeFooter: FunctionComponent< Props > = ( {
 	return (
 		<div className="date-range__popover-footer">
 			<Button
-				className="date-range__cancel-btn is-secondary"
+				className="date-range__cancel-btn"
 				onClick={ onCancelClick }
 				variant="secondary"
 				size="compact"

--- a/client/components/date-range/footer.tsx
+++ b/client/components/date-range/footer.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 
@@ -28,7 +28,8 @@ const DateRangeFooter: FunctionComponent< Props > = ( {
 			<Button
 				className="date-range__cancel-btn is-secondary"
 				onClick={ onCancelClick }
-				compact
+				variant="secondary"
+				size="compact"
 				aria-label={ cancelText }
 			>
 				{ cancelText }
@@ -36,8 +37,8 @@ const DateRangeFooter: FunctionComponent< Props > = ( {
 			<Button
 				className="date-range__apply-btn"
 				onClick={ onApplyClick }
-				primary
-				compact
+				variant="primary"
+				size="compact"
 				aria-label={ applyText }
 			>
 				{ applyText }

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -112,11 +112,6 @@ $date-range-mobile-layout-switch: $break-small;
 
 	.components-button {
 		margin-left: 0.5em;
-		margin-right: 0;
-		&.is-compact {
-			height: 28px;
-			font-size: $font-body-extra-small;
-		}
 	}
 	margin-top: 10px;
 
@@ -125,8 +120,6 @@ $date-range-mobile-layout-switch: $break-small;
 		align-items: stretch;
 
 		.components-button {
-			height: 40px;
-			border: 0;
 			margin-top: 0.5em;
 			justify-content: center;
 		}

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -110,7 +110,7 @@ $date-range-mobile-layout-switch: $break-small;
 	justify-content: flex-end;
 	padding: 10px 0 0;
 
-	.button {
+	.components-button {
 		margin-left: 0.5em;
 		margin-right: 0;
 	}
@@ -120,7 +120,7 @@ $date-range-mobile-layout-switch: $break-small;
 		flex-direction: column-reverse;
 		align-items: stretch;
 
-		.button {
+		.components-button {
 			height: 40px;
 			border: 0;
 		}

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -113,6 +113,10 @@ $date-range-mobile-layout-switch: $break-small;
 	.components-button {
 		margin-left: 0.5em;
 		margin-right: 0;
+		&.is-compact {
+			height: 28px;
+			font-size: $font-body-extra-small;
+		}
 	}
 	margin-top: 10px;
 
@@ -123,6 +127,8 @@ $date-range-mobile-layout-switch: $break-small;
 		.components-button {
 			height: 40px;
 			border: 0;
+			margin-top: 0.5em;
+			justify-content: center;
 		}
 	}
 }
@@ -370,7 +376,7 @@ $date-range-mobile-layout-switch: $break-small;
 }
 
 .date-range-picker-shortcuts__shortcut {
-	border-radius: 4px;
+	border-radius: 2px;
 	min-width: $date-range-shortcut-min-width;
 
 

--- a/client/components/stats-interval-dropdown/style.scss
+++ b/client/components/stats-interval-dropdown/style.scss
@@ -47,7 +47,7 @@
 }
 
 .stats-interval-dropdown-listing__interval {
-	border-radius: 4px;
+	border-radius: 2px;
 	.components-button {
 		display: flex;
 		justify-content: space-between;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up for https://github.com/Automattic/wp-calypso/pull/101052

## Proposed Changes

* Replace Calypso Button with Core Button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Core Button is better isolated and the Calypso Button is deprecated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Odyssey Stats locally following instructions at `PCYsg-Pp7-p2`
* Open the traffic page, and click open the date range picker
* Ensure the `Cancel` and `Apply` buttons look good

<img width="163" alt="image" src="https://github.com/user-attachments/assets/5ee4deb0-a3b8-449f-9905-57d31cf07d3a" />

<img width="149" alt="image" src="https://github.com/user-attachments/assets/b9b0aa60-b0b7-4a0e-8224-afa88921cef2" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
