### PR TITLE
Line Chart: bigger toggle buttons and style fixes

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/chart-header.jsx
@@ -69,15 +69,15 @@ const ChartHeader = ( {
 				<ButtonGroup className="stats-chart-tabs__type-toggle">
 					<Button
 						icon={ <Icon icon={ trendingUp } /> }
-						isSmall
-						isPrimary={ chartType === 'line' }
+						size="compact"
+						variant={ chartType === 'line' ? 'primary' : 'secondary' }
 						onClick={ () => handleChartTypeChange( 'line' ) }
 						aria-label="Switch to line chart"
 					/>
 					<Button
 						icon={ <Icon icon={ chartBar } /> }
-						isSmall
-						isPrimary={ chartType === 'bar' }
+						size="compact"
+						variant={ chartType === 'bar' ? 'primary' : 'secondary' }
 						onClick={ () => handleChartTypeChange( 'bar' ) }
 						aria-label="Switch to bar chart"
 					/>

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -316,6 +316,12 @@ ul.module-tabs {
 		box-shadow: none;
 	}
 
+	.components-button.is-primary:is(:active, :hover, :focus):not(:disabled, [aria-disabled='true']) {
+		background-color: var(--color-accent);
+		border-color: var(--color-accent);
+		color: var(--color-text-inverted);
+	}
+
 	.components-button.is-compact.has-icon:not(.has-text) {
 		width: 44px;
 	}

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -307,9 +307,16 @@ ul.module-tabs {
 
 .stats-chart-tabs__type-toggle {
 	margin-left: 8px;
-	height: 24px;
 
 	&.components-button-group .components-button.is-primary {
 		z-index: 0;
+	}
+
+	.components-button.is-primary:focus:not(:disabled) {
+		box-shadow: none;
+	}
+
+	.components-button.is-compact.has-icon:not(.has-text) {
+		width: 44px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/348

## Proposed Changes

* Fixed a couple of deprecated properties
* Use `compact` instead of `small` to have 32px height buttons
* Set width of buttons to `44px`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Styling improvements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live on `/stats/day/yoursite.com`
* Ensure the chart type toggles look like the following (color depending on the activated theme)

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/bf83e014-8f04-4e9a-b9ba-8853248d1844" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
