### PR TITLE
Purchases: Move "Add VAT details" link to Billing History dataviews header

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { DataViews, View } from '@wordpress/dataviews';
@@ -35,7 +34,6 @@ export default function BillingHistoryListDataView( {
 	const isLoading = useSelector( isRequestingBillingTransactions );
 	const viewState = useViewStateUpdate();
 	const receiptActions = useReceiptActions( getReceiptUrlFor );
-
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
 	const { data: geoData } = useGeoLocationQuery();
@@ -78,11 +76,9 @@ export default function BillingHistoryListDataView( {
 		<DataViews
 			data={ paginatedItems }
 			header={
-				config.isEnabled( 'me/vat-details' ) && (
-					<Button className="dataviews__tax-details-notice" variant="link" href={ vatDetailsPath }>
-						{ vatText }
-					</Button>
-				)
+				<Button className="dataviews__tax-details-notice" variant="link" href={ vatDetailsPath }>
+					{ vatText }
+				</Button>
 			}
 			paginationInfo={ {
 				totalItems,

--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -1,7 +1,13 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { DataViews, View } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
+import { vatDetails as vatDetailsPath } from 'calypso/me/purchases/paths';
+import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
+import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
 import isRequestingBillingTransactions from 'calypso/state/selectors/is-requesting-billing-transactions';
 import { usePagination } from '../use-pagination';
@@ -11,7 +17,6 @@ import { useTransactionsFiltering } from './hooks/use-transactions-filtering';
 import { useTransactionsSorting } from './hooks/use-transactions-sorting';
 import { useViewStateUpdate } from './hooks/use-view-state-update';
 import type { ViewStateUpdate } from './data-views-types';
-
 import 'calypso/components/dataviews/style.scss';
 import './style-data-view.scss';
 
@@ -31,6 +36,26 @@ export default function BillingHistoryListDataView( {
 	const viewState = useViewStateUpdate();
 	const receiptActions = useReceiptActions( getReceiptUrlFor );
 
+	const translate = useTranslate();
+	const { vatDetails } = useVatDetails();
+	const { data: geoData } = useGeoLocationQuery();
+	const taxName = useTaxName( vatDetails.country ?? geoData?.country_short ?? 'GB' );
+
+	const genericTaxName =
+		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
+		translate( 'tax (VAT/GST/CT)' );
+	const fallbackTaxName = genericTaxName;
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const editVatText = translate( 'Edit %s details', {
+		textOnly: true,
+		args: [ taxName ?? fallbackTaxName ],
+	} );
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const addVatText = translate( 'Add %s details', {
+		textOnly: true,
+		args: [ taxName ?? fallbackTaxName ],
+	} );
+	const vatText = vatDetails.id ? editVatText : addVatText;
 	const actions = receiptActions.map( ( action ) => ( {
 		...action,
 		icon: <Gridicon icon={ action.iconName } />,
@@ -44,7 +69,7 @@ export default function BillingHistoryListDataView( {
 		viewState.view.page,
 		viewState.view.perPage
 	);
-	const translate = useTranslate();
+
 	const fields = useFieldDefinitions( transactions );
 
 	const handleViewChange = ( view: View ) => viewState.updateView( view as ViewStateUpdate );
@@ -52,6 +77,13 @@ export default function BillingHistoryListDataView( {
 	return (
 		<DataViews
 			data={ paginatedItems }
+			header={
+				config.isEnabled( 'me/vat-details' ) && (
+					<Button className="dataviews__tax-details-notice" variant="link" href={ vatDetailsPath }>
+						{ vatText }
+					</Button>
+				)
+			}
 			paginationInfo={ {
 				totalItems,
 				totalPages,

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,5 +1,4 @@
-import config from '@automattic/calypso-config';
-import { CompactCard, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
@@ -50,7 +49,6 @@ function BillingHistory() {
 			<QueryBillingTransactions transactionType="past" />
 			<PurchasesNavigation section="billingHistory" />
 			<BillingHistoryContent siteId={ null } getReceiptUrlFor={ billingHistoryReceipt } />
-			<CompactCard href={ vatDetailsPath }>{ vatText }</CompactCard>
 		</Main>
 	);
 }

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { CompactCard, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -5,14 +6,11 @@ import QueryBillingTransactions from 'calypso/components/data/query-billing-tran
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingHistoryListDataView from 'calypso/me/purchases/billing-history/billing-history-list-data-view';
-import { vatDetails as vatDetailsPath, billingHistoryReceipt } from 'calypso/me/purchases/paths';
+import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import titles from 'calypso/me/purchases/titles';
-import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
-import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 
 import './style.scss';
 
@@ -32,25 +30,6 @@ export function BillingHistoryContent( {
 
 function BillingHistory() {
 	const translate = useTranslate();
-	const { vatDetails } = useVatDetails();
-	const { data: geoData } = useGeoLocationQuery();
-	const taxName = useTaxName( vatDetails.country ?? geoData?.country_short ?? 'GB' );
-
-	const genericTaxName =
-		/* translators: This is a generic name for taxes to use when we do not know the user's country. */
-		translate( 'tax (VAT/GST/CT)' );
-	const fallbackTaxName = genericTaxName;
-	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-	const editVatText = translate( 'Edit %s details', {
-		textOnly: true,
-		args: [ taxName ?? fallbackTaxName ],
-	} );
-	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-	const addVatText = translate( 'Add %s details', {
-		textOnly: true,
-		args: [ taxName ?? fallbackTaxName ],
-	} );
-	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (
 		<Main id="purchases" wideLayout>

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -218,13 +218,14 @@
             white-space: normal;
             word-break: break-word;
             flex: 1 1 auto;
+            padding: 0.45rem;
         }
 
         @media (min-width: 370px) and (max-width: 900px) {
             & > div:not(.dataviews__search) {
                 flex-direction: column;
                 align-items: flex-end;
-                flex: 0 0 32px;
+                flex: 0 0 2rem;
                 flex-wrap: nowrap;
             }
 

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -182,45 +182,37 @@
         }
     }
 
-    .dataviews__search .dataviews-search {
-        min-width: 160px;
-
-        & .components-input-control__input {
-            font-size: 0.875rem; /* 13px equivalent */;
-        }
-    }
-
     .dataviews__view-actions {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
         margin-top: 1em;
-		padding-left: 0;
-		padding-right: 0;
-        row-gap: .5rem;
+		padding-inline: 1.5rem;
+        row-gap: 0.5rem;
+
+        & .dataviews__search {
+            display: flex;
+            flex: 0 1 auto;
+            gap: 0.5rem;
+
+            & .dataviews-search input {
+                font-size: 0.875rem;
+            }
+        }
 
         & .dataviews__tax-details-notice {
             text-decoration: none;
             order: -1;
         }
-      }
 
-      .dataviews__view-actions > * {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 100%; /* Default full width on narrow screens */
-      }
-
-      @media (min-width: 600px) {
-        .dataviews__view-actions {
-          flex-wrap: nowrap;
+        @media (max-width: 900px) {
+            & > * {
+                display: flex;
+                justify-content: space-between;
+                width: 100%;
+            }
         }
-
-        .dataviews__view-actions > * {
-          width: auto; /* Auto width when space allows */
-        }
-      }
+    }
 
 	.dataviews-filters__container {
 		padding: 0;

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -182,33 +182,70 @@
         }
     }
 
+    // TODO - This is temporary shim to handle moving the vat-details into the dataviews header.
+    // We can remove this once the page header is implemented
+    // as discussed in https://github.com/Automattic/wp-calypso/issues/100552#issuecomment-2706930102
     .dataviews__view-actions {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
-        margin-top: 1em;
-		padding-inline: 1.5rem;
+        padding-inline: 1.5rem;
         row-gap: 0.5rem;
 
         & .dataviews__search {
             display: flex;
-            flex: 0 1 auto;
+            flex: 1 1 auto;
             gap: 0.5rem;
+            min-width: 0; // Prevents flex from forcing unnecessary width
 
             & .dataviews-search input {
                 font-size: 0.875rem;
             }
         }
 
-        & .dataviews__tax-details-notice {
-            text-decoration: none;
-            order: -1;
+        // Second div containing the cog icon and tax details notice
+        & > div:not(.dataviews__search) {
+            display: flex;
+            flex-direction: row-reverse;
+            align-items: center;
+            gap: 1rem;
+            min-width: 0; // Prevents flex from forcing unnecessary width
+            width: auto;
         }
 
-        @media (max-width: 900px) {
-            & > * {
-                display: flex;
+        & .dataviews__tax-details-notice {
+            text-decoration: none;
+            white-space: normal;
+            word-break: break-word;
+            flex: 1 1 auto;
+        }
+
+        @media (min-width: 370px) and (max-width: 900px) {
+            & > div:not(.dataviews__search) {
+                flex-direction: column;
+                align-items: flex-end;
+                flex: 0 0 32px;
+                flex-wrap: nowrap;
+            }
+
+            & .dataviews__tax-details-notice {
+                white-space: nowrap;
+                text-align: start;
+                width: auto; // Only takes necessary space
+            }
+        }
+
+        // Handle fringe alignment issues on very small devices
+        @media (max-width: 369px) {
+            & > div {
                 justify-content: space-between;
+
+                & > .components-button.is-compact.has-icon:not(.has-text) {
+                    min-width: 32px;
+                }
+            }
+
+            & > div:not(.dataviews__search) {
                 width: 100%;
             }
         }

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -85,7 +85,7 @@
 					font-weight: 600;
 					margin-bottom: 0.25rem;
 				}
-	
+
 				small {
                     display: block;
                     font-size: 0.875rem;
@@ -103,7 +103,7 @@
             td:last-child {
                 padding-right: 24px;
             }
-			
+
 			.dataviews-view-table__actions-column {
 				text-align: right;
 			}
@@ -182,11 +182,45 @@
         }
     }
 
-    .dataviews__view-actions {
-        margin-top: 0;
-		padding-left: 24px;
-		padding-right: 24px;
+    .dataviews__search .dataviews-search {
+        min-width: 160px;
+
+        & .components-input-control__input {
+            font-size: 0.875rem; /* 13px equivalent */;
+        }
     }
+
+    .dataviews__view-actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        margin-top: 1em;
+		padding-left: 0;
+		padding-right: 0;
+        row-gap: .5rem;
+
+        & .dataviews__tax-details-notice {
+            text-decoration: none;
+            order: -1;
+        }
+      }
+
+      .dataviews__view-actions > * {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%; /* Default full width on narrow screens */
+      }
+
+      @media (min-width: 600px) {
+        .dataviews__view-actions {
+          flex-wrap: nowrap;
+        }
+
+        .dataviews__view-actions > * {
+          width: auto; /* Auto width when space allows */
+        }
+      }
 
 	.dataviews-filters__container {
 		padding: 0;


### PR DESCRIPTION
As noted in https://github.com/Automattic/wp-calypso/issues/100552#issuecomment-2706930102, we're moving the "Add Vat details" link from a Card component at the bottom of the me > Purchases > Billing History tab to an inline link within the `DataViews` component's header.

Fixes to #100552 

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/ca9d6920-b880-4da6-8562-56d63e16d254) | ![image](https://github.com/user-attachments/assets/f7f2dc1d-2ce8-47e1-b9c7-2abb2b09a277) |

There was also some interesting CSS magic done to have the header align somewhat reasonably on smaller devices:

Desktop >900px
<img width="1212" alt="image" src="https://github.com/user-attachments/assets/3ad4d698-1e1b-4a67-9722-ca815a3ef986" />

Tablet <899px w/ sidebar
<img width="898" alt="image" src="https://github.com/user-attachments/assets/f83bf888-8e6c-4081-8a7e-cda92a5cd956" />

Tablet <781px w/o sidebar
<img width="779" alt="image" src="https://github.com/user-attachments/assets/4124bb1d-af22-451b-967f-829fc6846600" />

Mobile < 375px 
<img width="375" alt="image" src="https://github.com/user-attachments/assets/2899d3d9-15a3-4b04-9337-3cc685ea5f79" />


> [!NOTE]
> Why 900px? That is roughly just above where the current English version of "Add VAT details" overflows onto the next line. 
> <img width="424" alt="image" src="https://github.com/user-attachments/assets/44b34c4e-497f-4c88-82e6-9d1925f31d28" />
> It doesn't look _bad_, but let me know in the comments which is preferable!


## Testing Instructions
* Go to `/me/purchases/billing-history` and adjust the window viewport width to see responsiveness
* Ensure dataviews component does not break or become obscured by the new header text
* Click on text to go to the vat details form