### PR TITLE
Fix copy on users screens to specify "users" instead of "team members"

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -223,7 +223,7 @@ function renderSingleTeamMember( context, next ) {
 	const SingleTeamMemberTitle = () => {
 		const translate = useTranslate();
 
-		return <DocumentHead title={ translate( 'View Team Member', { textOnly: true } ) } />;
+		return <DocumentHead title={ translate( 'View User', { textOnly: true } ) } />;
 	};
 
 	context.primary = (
@@ -239,7 +239,7 @@ function renderViewerTeamMember( context, next ) {
 	const SingleTeamMemberTitle = () => {
 		const translate = useTranslate();
 
-		return <DocumentHead title={ translate( 'View Team Member', { textOnly: true } ) } />;
+		return <DocumentHead title={ translate( 'View User', { textOnly: true } ) } />;
 	};
 
 	context.primary = (

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -172,7 +172,7 @@ function renderTeamMembers( context, next ) {
 	const TeamMembersTitle = () => {
 		const translate = useTranslate();
 
-		return <DocumentHead title={ translate( 'Team Members', { textOnly: true } ) } />;
+		return <DocumentHead title={ translate( 'Users', { textOnly: true } ) } />;
 	};
 
 	context.primary = (

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -58,7 +58,7 @@ export const EditTeamMemberForm = ( {
 
 	return (
 		<Main className="edit-team-member-form">
-			<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
+			<PageViewTracker path="people/edit/:site/:user" title="People > View User" />
 			<HeaderCake onClick={ goBack }>{ translate( 'User Details' ) }</HeaderCake>
 			<Card className="edit-team-member-form__user-profile">
 				<PeopleProfile siteId={ siteId } user={ user } />

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -709,7 +709,7 @@ class InvitePeople extends Component {
 				<EmailVerificationGate>
 					<div className="invite-people__link-instructions">
 						{ translate(
-							'Use this link to onboard your team members without having to invite them one by one. {{strong}}Anybody visiting this URL will be able to sign up to your organization,{{/strong}} even if they received the link from somebody else, so make sure that you share it with trusted people.',
+							'Use this link to onboard your users without having to invite them one by one. {{strong}}Anybody visiting this URL will be able to sign up to your organization,{{/strong}} even if they received the link from somebody else, so make sure that you share it with trusted people.',
 							{
 								components: {
 									strong: <strong />,

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -20,7 +20,7 @@ function PeopleSectionNavCompact( props: Props ) {
 	const filters = [
 		{
 			id: 'team',
-			title: translate( 'Team' ),
+			title: translate( 'Users' ),
 			path: '/people/team/' + site?.slug,
 		},
 	];

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -123,7 +123,7 @@ export default function SubscriberDetails( props: Props ) {
 			<NavigationHeader
 				navigationItems={ [] }
 				title={ translate( 'Users' ) }
-				subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
+				subtitle={ translate( 'People who have subscribed to your site and users.' ) }
 			/>
 
 			<HeaderCake isCompact onClick={ onBackClick }>

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -62,7 +62,7 @@ function SubscribersTeam( props: Props ) {
 				navigationItems={ [] }
 				title={ translate( 'Users' ) }
 				subtitle={ translate(
-					'Invite team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}',
+					'Invite users to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}',
 					{
 						components: {
 							learnMore: (

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -105,10 +105,7 @@ function SubscribersTeam( props: Props ) {
 						case 'team':
 							return (
 								<>
-									<PageViewTracker
-										path="/people/team/:site"
-										title="People > Team Members / Invites"
-									/>
+									<PageViewTracker path="/people/team/:site" title="People > Users / Invites" />
 
 									<TeamInvites singleInviteView />
 									<TeamMembers

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -54,7 +54,7 @@ function TeamInvite( props: Props ) {
 			<Main>
 				<PageViewTracker path="/people/new/:site" title="People > Invite People" />
 				<HeaderCake onClick={ goBack }>
-					{ translate( 'Add team members to %(sitename)s', {
+					{ translate( 'Add users to %(sitename)s', {
 						args: { sitename: site.name ?? translate( 'this site' ) },
 					} ) }
 				</HeaderCake>
@@ -73,7 +73,7 @@ function TeamInvite( props: Props ) {
 			{ siteId && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 			<HeaderCake onClick={ goBack }>
-				{ translate( 'Add team members to %(sitename)s', {
+				{ translate( 'Add users to %(sitename)s', {
 					args: { sitename: site.name ?? translate( 'this site' ) },
 				} ) }
 			</HeaderCake>

--- a/client/my-sites/people/team-invite/invite-link-form.tsx
+++ b/client/my-sites/people/team-invite/invite-link-form.tsx
@@ -83,7 +83,7 @@ export function InviteLinkForm( props: Props ) {
 		<>
 			<div className="invite-people__link-instructions">
 				{ translate(
-					'Use this link to onboard your team members without having to invite them one by one. ' +
+					'Use this link to onboard your users without having to invite them one by one. ' +
 						'{{strong}}Anybody visiting this URL will be able to sign up to your organization,{{/strong}} ' +
 						'even if they received the link from somebody else, so make sure that you share it with trusted people.',
 					{ components: { strong: <strong /> } }

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -56,7 +56,7 @@ function TeamInvites( props: Props ) {
 					>
 						{ singleInviteView && (
 							<Button compact primary href={ addTeamMemberLink }>
-								{ translate( 'Add a team member' ) }
+								{ translate( 'Add a user' ) }
 							</Button>
 						) }
 					</PeopleListSectionHeader>

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -75,7 +75,7 @@ function TeamMembers( props: Props ) {
 			);
 		}
 
-		return translate( 'You have %(number)d team member', 'You have %(number)d team members', {
+		return translate( 'You have %(number)d user', 'You have %(number)d users', {
 			args: { number: membersTotal as number, searchTerm: search as string },
 			count: membersTotal as number,
 		} );
@@ -146,7 +146,7 @@ function TeamMembers( props: Props ) {
 						<PeopleListSectionHeader isPlaceholder={ isLoading } label={ getHeaderLabel() }>
 							{ showAddTeamMembersBtn && (
 								<Button compact primary href={ addTeamMemberLink }>
-									{ translate( 'Add a team member' ) }
+									{ translate( 'Add a user' ) }
 								</Button>
 							) }
 						</PeopleListSectionHeader>

--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -117,11 +117,7 @@ export default function ViewerDetails( props: Props ) {
 			<PageViewTracker path="/people/viewers/:site/:id" title="People > User Details" />
 			{ site?.ID && <QuerySiteInvites siteId={ site?.ID } /> }
 
-			<NavigationHeader
-				navigationItems={ [] }
-				title={ translate( 'Users' ) }
-				subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
-			/>
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Users' ) } />
 
 			<HeaderCake isCompact onClick={ onBackClick }>
 				{ translate( 'User Details' ) }

--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -7,7 +7,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import useRemoveViewer from 'calypso/data/viewers/use-remove-viewer-mutation';
 import useViewerQuery from 'calypso/data/viewers/use-viewer-query';
 import accept from 'calypso/lib/accept';
@@ -116,8 +115,6 @@ export default function ViewerDetails( props: Props ) {
 		<Main className="people-member-details">
 			<PageViewTracker path="/people/viewers/:site/:id" title="People > User Details" />
 			{ site?.ID && <QuerySiteInvites siteId={ site?.ID } /> }
-
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Users' ) } />
 
 			<HeaderCake isCompact onClick={ onBackClick }>
 				{ translate( 'User Details' ) }

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -16,7 +16,7 @@ const selectors = {
 	deleteConfirmBanner: ':text("Successfully deleted")',
 
 	// Header
-	addPeopleButton: 'a:text("Add a team member")',
+	addPeopleButton: 'a:text("Add a user")',
 	invitePeopleButton: '.people-list-section-header__add-button',
 
 	// Invites


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100388

## Proposed Changes

* As specified in the issue, replace all instances of "team members" with "users" in the users screens.
* I also tried deleting the "People who have subscribed to your site and team members" subtitle as mentioned [here](https://github.com/Automattic/wp-calypso/issues/100388#issuecomment-2712606982).


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/people/team/siteid` and check that copy is updated. 
* Check the edit user screen by clicking through any of the users in the list.
* Check the `/people/new/siteid` screen by clicking the "Add a user" button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
