### PR TITLE
Untangling: completely remove untangling/hosting-menu code

### DIFF
--- a/client/components/panel/style.scss
+++ b/client/components/panel/style.scss
@@ -21,12 +21,6 @@
 	.upsell-nudge {
 		width: 100%;
 	}
-
-	// TODO: remove after the untangling/hosting-menu flag is enabled
-	#primary > & {
-		margin-left: auto;
-		margin-right: auto;
-	}
 }
 
 .panel-card {

--- a/client/hosting/performance/index.tsx
+++ b/client/hosting/performance/index.tsx
@@ -5,7 +5,7 @@ import {
 	redirectToHostingPromoIfNotAtomic,
 } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
-import { DOTCOM_SITE_PERFORMANCE } from 'calypso/sites/components/site-preview-pane/constants';
+import { PERFORMANCE } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
 import { sitePerformance } from './controller';
 
@@ -18,7 +18,7 @@ export default function () {
 		redirectToHostingPromoIfNotAtomic,
 		navigation,
 		sitePerformance,
-		siteDashboard( DOTCOM_SITE_PERFORMANCE ),
+		siteDashboard( PERFORMANCE ),
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
@@ -61,9 +60,7 @@ import './style.scss';
 const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
 
 function getGeneralTabUrl( slug ) {
-	return isEnabled( 'untangling/hosting-menu' )
-		? `/sites/settings/site/${ slug }`
-		: `/settings/general/${ slug }`;
+	return `/sites/settings/site/${ slug }`;
 }
 
 export class SiteSettingsFormSEO extends Component {

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -1,14 +1,13 @@
-export const DOTCOM_OVERVIEW = 'dotcom-hosting';
-export const DOTCOM_MONITORING = 'dotcom-site-monitoring';
-export const DOTCOM_LOGS_PHP = 'dotcom-site-logs-php';
-export const DOTCOM_LOGS_WEB = 'dotcom-site-logs-web';
-export const DOTCOM_GITHUB_DEPLOYMENTS = 'dotcom-github-deployments';
-export const DOTCOM_HOSTING_CONFIG = 'dotcom-hosting-config';
-export const DOTCOM_HOSTING_FEATURES = 'dotcom-hosting-features';
-export const DOTCOM_STAGING_SITE = 'dotcom-staging-site';
-export const DOTCOM_SITE_PERFORMANCE = 'dotcom-site-performance';
+export const OVERVIEW = 'overview';
+export const MONITORING = 'monitoring';
+export const LOGS_PHP = 'logs-php';
+export const LOGS_WEB = 'logs-web';
+export const DEPLOYMENTS = 'deployments';
+export const HOSTING_CONFIG = 'hosting-config';
+export const HOSTING_FEATURES = 'hosting-features';
+export const STAGING_SITE = 'staging-site';
+export const PERFORMANCE = 'performance';
 export const SETTINGS_SITE = 'settings-site';
-export const SETTINGS_ADMINISTRATION = 'settings-administration';
 export const SETTINGS_ADMINISTRATION_RESET_SITE = 'settings-administration-reset-site';
 export const SETTINGS_ADMINISTRATION_TRANSFER_SITE = 'settings-administration-transfer-site';
 export const SETTINGS_ADMINISTRATION_DELETE_SITE = 'settings-administration-delete-site';
@@ -18,15 +17,15 @@ export const SETTINGS_DATABASE = 'settings-database';
 export const SETTINGS_PERFORMANCE = 'settings-performance';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
-	[ DOTCOM_OVERVIEW ]: 'overview/:site',
-	[ DOTCOM_MONITORING ]: 'site-monitoring/:site',
-	[ DOTCOM_LOGS_PHP ]: 'site-logs/:site/php',
-	[ DOTCOM_LOGS_WEB ]: 'site-logs/:site/web',
-	[ DOTCOM_GITHUB_DEPLOYMENTS ]: 'github-deployments/:site',
-	[ DOTCOM_HOSTING_CONFIG ]: 'hosting-config/:site',
-	[ DOTCOM_HOSTING_FEATURES ]: 'hosting-features/:site',
-	[ DOTCOM_STAGING_SITE ]: 'staging-site/:site',
-	[ DOTCOM_SITE_PERFORMANCE ]: 'sites/performance/:site',
+	[ OVERVIEW ]: 'overview/:site',
+	[ MONITORING ]: 'site-monitoring/:site',
+	[ LOGS_PHP ]: 'site-logs/:site/php',
+	[ LOGS_WEB ]: 'site-logs/:site/web',
+	[ DEPLOYMENTS ]: 'github-deployments/:site',
+	[ HOSTING_CONFIG ]: 'hosting-config/:site',
+	[ HOSTING_FEATURES ]: 'hosting-features/:site',
+	[ STAGING_SITE ]: 'staging-site/:site',
+	[ PERFORMANCE ]: 'sites/performance/:site',
 	[ SETTINGS_SITE ]: 'sites/settings/site/:site',
 	[ SETTINGS_ADMINISTRATION_RESET_SITE ]: 'sites/settings/site/:site/reset-site',
 	[ SETTINGS_ADMINISTRATION_TRANSFER_SITE ]: 'sites/settings/site/:site/transfer-site',

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { SiteExcerptData } from '@automattic/sites';
 import { useI18n } from '@wordpress/react-i18n';
@@ -17,15 +16,15 @@ import { showSitesPage } from '../sites-dashboard';
 import { SiteStatus } from '../sites-dataviews/sites-site-status';
 import {
 	FEATURE_TO_ROUTE_MAP,
-	DOTCOM_HOSTING_CONFIG,
-	DOTCOM_OVERVIEW,
-	DOTCOM_MONITORING,
-	DOTCOM_SITE_PERFORMANCE,
-	DOTCOM_LOGS_PHP,
-	DOTCOM_LOGS_WEB,
-	DOTCOM_GITHUB_DEPLOYMENTS,
-	DOTCOM_HOSTING_FEATURES,
-	DOTCOM_STAGING_SITE,
+	HOSTING_CONFIG,
+	OVERVIEW,
+	MONITORING,
+	PERFORMANCE,
+	LOGS_PHP,
+	LOGS_WEB,
+	DEPLOYMENTS,
+	HOSTING_FEATURES,
+	STAGING_SITE,
 	SETTINGS_SITE,
 	SETTINGS_ADMINISTRATION_RESET_SITE,
 	SETTINGS_ADMINISTRATION_TRANSFER_SITE,
@@ -72,8 +71,8 @@ const DotcomPreviewPane = ( {
 		const siteFeatures = [
 			{
 				label: __( 'Overview' ),
-				enabled: ! config.isEnabled( 'untangling/hosting-menu' ),
-				featureIds: [ DOTCOM_OVERVIEW ],
+				enabled: true,
+				featureIds: [ OVERVIEW ],
 			},
 			{
 				label: (
@@ -82,34 +81,33 @@ const DotcomPreviewPane = ( {
 						<HostingFeaturesIcon />
 					</span>
 				),
-				enabled:
-					( isSimpleSite || isPlanExpired ) && ! config.isEnabled( 'untangling/hosting-menu' ),
-				featureIds: [ DOTCOM_HOSTING_FEATURES ],
+				enabled: isSimpleSite || isPlanExpired,
+				featureIds: [ HOSTING_FEATURES ],
 			},
 			{
 				label: __( 'Deployments' ),
-				enabled: isActiveAtomicSite && ! config.isEnabled( 'untangling/hosting-menu' ),
-				featureIds: [ DOTCOM_GITHUB_DEPLOYMENTS ],
+				enabled: isActiveAtomicSite,
+				featureIds: [ DEPLOYMENTS ],
 			},
 			{
 				label: __( 'Monitoring' ),
-				enabled: isActiveAtomicSite && ! config.isEnabled( 'untangling/hosting-menu' ),
-				featureIds: [ DOTCOM_MONITORING ],
+				enabled: isActiveAtomicSite,
+				featureIds: [ MONITORING ],
 			},
 			{
 				label: __( 'Performance' ),
 				enabled: isActiveAtomicSite,
-				featureIds: [ DOTCOM_SITE_PERFORMANCE ],
+				featureIds: [ PERFORMANCE ],
 			},
 			{
 				label: __( 'Logs' ),
-				enabled: isActiveAtomicSite && ! config.isEnabled( 'untangling/hosting-menu' ),
-				featureIds: [ DOTCOM_LOGS_PHP, DOTCOM_LOGS_WEB ],
+				enabled: isActiveAtomicSite,
+				featureIds: [ LOGS_PHP, LOGS_WEB ],
 			},
 			{
 				label: __( 'Staging Site' ),
-				enabled: isActiveAtomicSite && ! config.isEnabled( 'untangling/hosting-menu' ),
-				featureIds: [ DOTCOM_STAGING_SITE ],
+				enabled: isActiveAtomicSite,
+				featureIds: [ STAGING_SITE ],
 			},
 			{
 				label: __( 'Settings' ),
@@ -130,7 +128,7 @@ const DotcomPreviewPane = ( {
 					? __( 'Server Settings' )
 					: __( 'Server Config' ),
 				enabled: ! isRemoveDuplicateViewsExperimentEnabled && isActiveAtomicSite,
-				featureIds: [ DOTCOM_HOSTING_CONFIG ],
+				featureIds: [ HOSTING_CONFIG ],
 			},
 		];
 

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -42,7 +42,7 @@ import {
 	CALYPSO_ONBOARDING_TOURS_EVENT_NAMES,
 	useOnboardingTours,
 } from '../onboarding-tours';
-import { DOTCOM_OVERVIEW, FEATURE_TO_ROUTE_MAP } from './site-preview-pane/constants';
+import { OVERVIEW, FEATURE_TO_ROUTE_MAP } from './site-preview-pane/constants';
 import DotcomPreviewPane from './site-preview-pane/dotcom-preview-pane';
 import SitesDashboardBannersManager from './sites-dashboard-banners-manager';
 import SitesDashboardHeader from './sites-dashboard-header';
@@ -126,7 +126,7 @@ const SitesDashboard = ( {
 		status,
 		siteType = DEFAULT_SITE_TYPE,
 	},
-	initialSiteFeature = DOTCOM_OVERVIEW,
+	initialSiteFeature = OVERVIEW,
 	selectedSiteFeaturePreview = undefined,
 	isOnlyLayoutView = undefined,
 }: SitesDashboardProps ) => {

--- a/client/sites/deployments/index.tsx
+++ b/client/sites/deployments/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import { DOTCOM_GITHUB_DEPLOYMENTS } from 'calypso/sites/components/site-preview-pane/constants';
+import { DEPLOYMENTS } from 'calypso/sites/components/site-preview-pane/constants';
 import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
 import {
 	deploymentCreation,
@@ -19,7 +19,7 @@ export default function () {
 		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentsList,
-		siteDashboard( DOTCOM_GITHUB_DEPLOYMENTS ),
+		siteDashboard( DEPLOYMENTS ),
 		makeLayout,
 		clientRender
 	);
@@ -30,7 +30,7 @@ export default function () {
 		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentCreation,
-		siteDashboard( DOTCOM_GITHUB_DEPLOYMENTS ),
+		siteDashboard( DEPLOYMENTS ),
 		makeLayout,
 		clientRender
 	);
@@ -41,7 +41,7 @@ export default function () {
 		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentManagement,
-		siteDashboard( DOTCOM_GITHUB_DEPLOYMENTS ),
+		siteDashboard( DEPLOYMENTS ),
 		makeLayout,
 		clientRender
 	);
@@ -52,7 +52,7 @@ export default function () {
 		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		deploymentRunLogs,
-		siteDashboard( DOTCOM_GITHUB_DEPLOYMENTS ),
+		siteDashboard( DEPLOYMENTS ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SFTP, getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
@@ -55,11 +54,7 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 
 	let redirectUrl = redirectToRef.current as string;
 	if ( ! redirectUrl ) {
-		if ( isEnabled( 'untangling/hosting-menu' ) ) {
-			redirectUrl = `/sites/tools/${ siteId }`;
-		} else {
-			redirectUrl = hasSftpFeature ? `/hosting-config/${ siteSlug }` : `/overview/${ siteId }`;
-		}
+		redirectUrl = hasSftpFeature ? `/hosting-config/${ siteSlug }` : `/overview/${ siteId }`;
 	}
 
 	const hasEnTranslation = useHasEnTranslation();

--- a/client/sites/hosting/index.tsx
+++ b/client/sites/hosting/index.tsx
@@ -13,8 +13,8 @@ import {
 import { handleHostingPanelRedirect } from 'calypso/hosting/server-settings/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
-	DOTCOM_HOSTING_CONFIG,
-	DOTCOM_HOSTING_FEATURES,
+	HOSTING_CONFIG,
+	HOSTING_FEATURES,
 } from 'calypso/sites/components/site-preview-pane/constants';
 import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -42,7 +42,7 @@ export default function () {
 		redirectToServerSettingsIfDuplicatedView,
 		handleHostingPanelRedirect,
 		hostingConfiguration,
-		siteDashboard( DOTCOM_HOSTING_CONFIG ),
+		siteDashboard( HOSTING_CONFIG ),
 		makeLayout,
 		clientRender
 	);
@@ -55,7 +55,7 @@ export default function () {
 		redirectForNonSimpleSite,
 		redirectIfP2,
 		hostingFeatures,
-		siteDashboard( DOTCOM_HOSTING_FEATURES ),
+		siteDashboard( HOSTING_FEATURES ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites/logs/index.tsx
+++ b/client/sites/logs/index.tsx
@@ -1,10 +1,7 @@
 import page, { type Callback, type Context } from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
-import {
-	DOTCOM_LOGS_PHP,
-	DOTCOM_LOGS_WEB,
-} from 'calypso/sites/components/site-preview-pane/constants';
+import { LOGS_PHP, LOGS_WEB } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard, redirectToHostingFeaturesIfNotAtomic } from 'calypso/sites/controller';
 import { phpErrorLogs, webServerLogs } from './controller';
 
@@ -22,7 +19,7 @@ export default function () {
 		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		phpErrorLogs,
-		siteDashboard( DOTCOM_LOGS_PHP ),
+		siteDashboard( LOGS_PHP ),
 		makeLayout,
 		clientRender
 	);
@@ -32,7 +29,7 @@ export default function () {
 		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		webServerLogs,
-		siteDashboard( DOTCOM_LOGS_WEB ),
+		siteDashboard( LOGS_WEB ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites/monitoring/index.tsx
+++ b/client/sites/monitoring/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites, navigation } from 'calypso/my-sites/controller';
-import { DOTCOM_MONITORING } from 'calypso/sites/components/site-preview-pane/constants';
+import { MONITORING } from 'calypso/sites/components/site-preview-pane/constants';
 import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
 import { siteMonitoring } from './controller';
 
@@ -14,7 +14,7 @@ export default function () {
 		redirectToHostingFeaturesIfNotAtomic,
 		navigation,
 		siteMonitoring,
-		siteDashboard( DOTCOM_MONITORING ),
+		siteDashboard( MONITORING ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites/overview/index.tsx
+++ b/client/sites/overview/index.tsx
@@ -22,7 +22,7 @@ import {
 	EDIT_CONTACT_INFO,
 } from 'calypso/my-sites/domains/domain-management/subpage-wrapper/subpages';
 import emailController from 'calypso/my-sites/email/controller';
-import { DOTCOM_OVERVIEW } from 'calypso/sites/components/site-preview-pane/constants';
+import { OVERVIEW } from 'calypso/sites/components/site-preview-pane/constants';
 import { siteDashboard } from 'calypso/sites/controller';
 import { overview } from './controller';
 
@@ -55,7 +55,7 @@ export default function () {
 		redirectIfJetpackNonAtomic,
 		navigation,
 		overview,
-		siteDashboard( DOTCOM_OVERVIEW ),
+		siteDashboard( OVERVIEW ),
 		makeLayout,
 		clientRender
 	);

--- a/client/sites/staging-site/index.tsx
+++ b/client/sites/staging-site/index.tsx
@@ -6,7 +6,7 @@ import {
 } from 'calypso/controller';
 import { handleHostingPanelRedirect } from 'calypso/hosting/server-settings/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import { DOTCOM_STAGING_SITE } from 'calypso/sites/components/site-preview-pane/constants';
+import { STAGING_SITE } from 'calypso/sites/components/site-preview-pane/constants';
 import { redirectToHostingFeaturesIfNotAtomic, siteDashboard } from 'calypso/sites/controller';
 import { stagingSite } from './controller';
 
@@ -21,7 +21,7 @@ export default function () {
 		redirectIfCurrentUserCannot( 'manage_options' ),
 		handleHostingPanelRedirect,
 		stagingSite,
-		siteDashboard( DOTCOM_STAGING_SITE ),
+		siteDashboard( STAGING_SITE ),
 		makeLayout,
 		clientRender
 	);

--- a/config/development.json
+++ b/config/development.json
@@ -202,7 +202,6 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"untangling/hosting-menu": false,
 		"user-management-revamp": true,
 		"wpcom-user-bootstrap": false,
 		"yolo/command-palette": true

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -172,7 +172,6 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"untangling/hosting-menu": false,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"wpcom-user-bootstrap": true,


### PR DESCRIPTION
## Proposed Changes

This PR cleans up the remaining `untangling/hosting-menu` logic in the codebase.

This PR also renames the constants `DOTCOM_*` by removing the prefix, so that all constants for the tabs/subtabs in the hosting dashboard are consistent.

## Why are these changes being made?

Removing dead code.

## Testing Instructions

1. Go to /sites
2. Click Simple and Atomic sites and verify the tabs are still working.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
