### PR TITLE
A4A > WooPayments: Implement search for Add WooPayments to site popup and UI enhancements

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
@@ -61,7 +61,7 @@ const AddWooPaymentsToSiteTable = ( {
 		const siteColumn = {
 			id: 'site',
 			label: translate( 'Site' ),
-			getValue: () => '-',
+			getValue: ( { item }: { item: WooPaymentsSiteItem } ) => item.site,
 			render: ( { item }: { item: WooPaymentsSiteItem } ) => (
 				<div>
 					<FormRadio
@@ -73,6 +73,7 @@ const AddWooPaymentsToSiteTable = ( {
 					/>
 				</div>
 			),
+			enableGlobalSearch: true,
 			enableHiding: false,
 			enableSorting: false,
 		};
@@ -85,7 +86,7 @@ const AddWooPaymentsToSiteTable = ( {
 	}, [ availableSites, dataViewsState, fields ] );
 
 	return (
-		<div className="redesigned-a8c-table show-overflow-overlay hide-actions">
+		<div className="redesigned-a8c-table show-overflow-overlay search-enabled">
 			{ isLoading ? (
 				<A4ATablePlaceholder />
 			) : (
@@ -95,7 +96,7 @@ const AddWooPaymentsToSiteTable = ( {
 						fields,
 						getItemId: ( item ) => `${ item.id }`,
 						pagination: paginationInfo,
-						enableSearch: false,
+						enableSearch: true,
 						actions: [],
 						dataViewsState: dataViewsState,
 						setDataViewsState: setDataViewsState,

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/mobile-view.tsx
@@ -61,7 +61,7 @@ export default function SitesWithWooPaymentsMobileView( {
 							</div>
 						</ListItemCardContent>
 						<ListItemCardContent title={ translate( 'Review status' ) }>
-							<WooPaymentsStatusColumn state={ item.state } siteUrl={ item.siteUrl } />
+							<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
 						</ListItemCardContent>
 					</ListItemCard>
 				) ) }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -2,6 +2,7 @@ import { BadgeType, Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate, formatCurrency } from 'i18n-calypso';
 import { memo } from 'react';
+import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
@@ -19,13 +20,7 @@ export const CommissionsPaidColumn = memo( ( { payout }: { payout: number | null
 	return payout ? formatCurrency( payout, 'USD', { stripZeros: true } ) : <Gridicon icon="minus" />;
 } );
 
-export const WooPaymentsStatusColumn = ( {
-	state,
-	siteUrl,
-}: {
-	state: string;
-	siteUrl: string;
-} ) => {
+export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; siteId: number } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -36,11 +31,9 @@ export const WooPaymentsStatusColumn = ( {
 					dispatch( recordTracksEvent( 'calypso_a4a_woopayments_setup_in_wp_admin' ) );
 				} }
 				variant="tertiary"
-				href={ `${ siteUrl }/wp-admin/plugin-install.php?s=woopayments&tab=search&type=term` }
-				target="_blank"
-				rel="noopener noreferrer"
+				href={ `${ A4A_WOOPAYMENTS_SITE_SETUP_LINK }/?site_id=${ siteId }` }
 			>
-				{ translate( 'Setup in WP-Admin ↗' ) }
+				{ translate( 'Continue setup' ) }
 			</Button>
 		);
 	}

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -81,7 +81,7 @@ export default function SitesWithWooPayments() {
 				label: translate( 'WooPayments Status' ).toUpperCase(),
 				getValue: () => '-',
 				render: ( { item } ) => (
-					<WooPaymentsStatusColumn state={ item.state } siteUrl={ item.siteUrl } />
+					<WooPaymentsStatusColumn state={ item.state } siteId={ item.blogId } />
 				),
 				enableHiding: false,
 				enableSorting: false,

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -609,10 +609,10 @@ html {
 		}
 	}
 
-	// TODO: Remove this once we have support to hide actions in the DataViews component
-	&.hide-actions {
+
+	&.search-enabled {
 		.dataviews__view-actions {
-			display: none;
+			padding: 1px;
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1890

## Proposed Changes

- Implement search on the `Add WooPayments to site` popup
- Update the site column status column to redirect to the site setup page since we install/activate based on the plugin's current status instead of redirecting to WP-Admin

## Why are these changes being made?

* To improve the installation flow and add search to the `Add WooPayments to site` popup

## Testing Instructions

* Open the A4A live link
* Go to WooPayments: Dashboard > Click the `Add WooPayments to site`  button > Verify you can now see the search and it works as expected.

<img width="820" alt="Screenshot 2025-03-11 at 2 49 02 PM" src="https://github.com/user-attachments/assets/ad77595c-2725-4ab3-8b31-596cc5b6b1ad" />

* Verify the button on the table now shows `Continue setup` when the WooPayment plugin is not active for a site > Click the button and verify it takes you to the site setup page where you can continue the installation. 

<img width="1596" alt="Screenshot 2025-03-11 at 2 53 19 PM" src="https://github.com/user-attachments/assets/e52b6e3e-7690-4569-972f-1fa03758ace2" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
