### PR TITLE
A4A: Only render Referral checkout not match notice when checkout is ready.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -255,7 +255,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 					<div className="checkout__main">
 						<h1 className="checkout__main-title">{ title }</h1>
 
-						{ isClient && isDoNotMatchReferralClientEmail && (
+						{ isClient && !! checkoutItems?.length && isDoNotMatchReferralClientEmail && (
 							<LayoutBanner level="error" hideCloseButton>
 								{ translate(
 									'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',


### PR DESCRIPTION
The referral checkout error message identified for a mismatch account tends to appear during the loading state of the checkout page. This PR resolves the issue.

https://github.com/user-attachments/assets/bfc51e86-cfc9-45c9-8c8b-bab6e9fa883a



## Proposed Changes

* Add some additional condition to check if the checkout is ready.

## Why are these changes being made?

* This makes our UI more polished when we fix these small UI glitches.

## Testing Instructions

* Spin up this branch on your local machine.
* Create a referral order.
* Open the magic link via your local server.
* Ensure that the error message no longer appears during the checkout process.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
