### PR TITLE
A4A: Update WooPayments missing payout setting notice message.

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
@@ -19,16 +19,20 @@ export const MissingPaymentSettingsNotice = () => {
 	return (
 		<LayoutBanner
 			level="warning"
-			title={ translate( 'Add your payment information to get paid' ) }
+			title={ translate( 'Add your payout information to get paid.' ) }
 			className="missing-payment-settings-notice"
 			hideCloseButton
 		>
-			<div>{ translate( 'To receive your revenue share, add your payment information.' ) }</div>
+			<div>
+				{ translate(
+					'Ensure you receive your share of revenue by providing your payout details in the Payout Settings screen.'
+				) }
+			</div>
 			<Button
 				className="missing-payment-settings-notice__button is-dark"
 				href={ A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK }
 			>
-				{ translate( 'Add your payment information' ) }
+				{ translate( 'Add payout information now' ) }
 			</Button>
 		</LayoutBanner>
 	);


### PR DESCRIPTION
This PR is a follow-up on https://github.com/Automattic/wp-calypso/pull/100993 and updates the correct copies for the missing payment notice.

| Before | After |
|--------|--------|
| <img width="1555" alt="420292757-13863315-c6a6-4dc4-9057-c0465ff86685" src="https://github.com/user-attachments/assets/6e96cfb5-279d-415e-b8a1-f1e20ba7ae19" /> | <img width="1541" alt="Screenshot 2025-03-11 at 6 55 31 PM" src="https://github.com/user-attachments/assets/283abf8e-9a7f-427b-9404-cd5d8c3549ff" /> | 



## Proposed Changes

* Update copies on the Missing payment details notice.

## Why are these changes being made?

* This is part of the WooPayments commission project.

## Testing Instructions

- Create a new agency account and add a site.
- Add a WooPayments license to the site and activate the WooPayments plugin.
- Go to the `/woopayments/dashboard` page.
- Confirm you see the banner with the updated copies.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
