### PR TITLE
Update sections order on the Apps page

### DIFF
--- a/client/blocks/get-apps/index.tsx
+++ b/client/blocks/get-apps/index.tsx
@@ -21,16 +21,16 @@ export const GetApps = () => {
 		<>
 			<NavigationHeader title={ translate( 'Apps' ) } />
 			<div className="get-apps__wrapper">
-				<h2 className="get-apps__section-title">{ translate( 'Mobile' ) }</h2>
-				<div className="get-apps__section">
-					<MobileDownloadCard />
-				</div>
 				<h2 className="get-apps__section-title">{ translate( 'Desktop' ) }</h2>
 				<div className="get-apps__section">
 					{ ! isDesktopEnv &&
 						desktopApps.map( ( appConfig ) => (
 							<DesktopDownloadCard key={ appConfig.id } appConfig={ appConfig } />
 						) ) }
+				</div>
+				<h2 className="get-apps__section-title">{ translate( 'Mobile' ) }</h2>
+				<div className="get-apps__section">
+					<MobileDownloadCard />
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100387

## Proposed Changes

* Reorder the sections on the `/me/get-apps` page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Most users will likely visit this page from desktop, so we should show this section first.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me/get-apps`
* Check that the desktop section is shown on the top

| Trunk | This branch |
|--------|--------|
| ![CleanShot 2025-03-11 at 11 13 34@2x](https://github.com/user-attachments/assets/4da497df-1af5-4045-aeab-787ab6ec421a) | ![CleanShot 2025-03-11 at 11 04 18@2x](https://github.com/user-attachments/assets/4a81d73a-d8f6-4d65-8f9a-384c21720cec) |

