### PR TITLE
A4A: Update Migrations page to use Core typography.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
@@ -69,6 +69,7 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 				{ isExpanded && (
 					<div className="a4a-migration-offer-v3__body">
 						<SimpleList
+							applyCoreStyles
 							items={ [
 								translate(
 									'{{b}}All migrations:{{/b}} Your first month of hosting will be free when you migrate twenty or more sites to us from any host.',

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-migration-offer-v3 {
 	display: flex;
@@ -39,10 +40,10 @@
 	flex-direction: row;
 	justify-content: space-between;
 
-	@include a4a-font-heading-md($font-weight: 400);
+	@include heading-large;
 
 	@include break-medium {
-		@include a4a-font-heading-lg($font-weight: 400);
+		@include heading-x-large;
 		margin-block-start: 10px;
 		margin-block-end: 8px;
 	}

--- a/client/a8c-for-agencies/components/task-steps/style.scss
+++ b/client/a8c-for-agencies/components/task-steps/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .task-steps {
 	a {
@@ -33,11 +34,11 @@
 }
 
 .task-steps__heading {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 }
 
 .task-steps__subheading {
-	@include a4a-font-body-lg;
+	@include body-large;
 	color: var(--color-accent-60);
 }
 
@@ -91,7 +92,7 @@
 }
 
 .task-step__title {
-	@include a4a-font-heading-md($font-size: 19px);
+	@include heading-medium;
 
 	@include break-large {
 		font-size: rem(20px)
@@ -99,7 +100,7 @@
 }
 
 .task-step__description {
-	@include a4a-font-body-lg;
+	@include body-large;
 	padding-block-end: 20px;
 }
 

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/style.scss
@@ -1,7 +1,10 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .migrations-commissions-list-mobile-view {
 	padding: 16px;
 }
 
 .migrations-commissions-list-mobile-view__column {
-	@include a4a-font-body-md;
+	@include body-medium;
 }

--- a/client/a8c-for-agencies/sections/migrations/consolidated-commissions/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/consolidated-commissions/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .migrations-commissions {
 	.consolidated-commissions {
 		display: flex;
@@ -11,14 +14,13 @@
 			padding: 24px;
 
 			.consolidated-commissions__value {
-				font-size: rem(24px);
+				@include heading-x-large;
 				color: var(--color-accent-100);
-				font-weight: 700;
 				margin-block-end: 8px;
 			}
 			.consolidated-commissions__label {
+				@include body-medium;
 				color: var(--color-accent);
-				font-size: rem(12px);
 				text-wrap: nowrap;
 			}
 		}

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
@@ -25,8 +25,12 @@ export default function MigrationsCommissionsEmptyState( {
 	const a4aPluginUrl = 'https://wordpress.org/plugins/automattic-for-agencies-client';
 
 	return (
-		<StepSection heading={ translate( 'View your migrated websites and commisions right here.' ) }>
+		<StepSection
+			applyCoreStyles
+			heading={ translate( 'View your migrated websites and commisions right here.' ) }
+		>
 			<StepSectionItem
+				applyCoreStyles
 				isNewLayout
 				heading={ translate( "We'll tag the sites we moved for you once they're transferred." ) }
 				description={ preventWidows(
@@ -37,6 +41,7 @@ export default function MigrationsCommissionsEmptyState( {
 			/>
 			<StepSectionItem
 				isNewLayout
+				applyCoreStyles
 				heading={ translate( 'Tag your transferred sites so we can pay you for them.' ) }
 				description={
 					<>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-banner/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .migrations-banner {
 	padding: 24px 32px;
@@ -27,7 +28,7 @@
 }
 
 .migrations-banner__title {
-	@include a4a-font-heading-lg;
+	@include heading-large;
 	display: flex;
 	flex-direction: row;
 	gap: 16px;

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-faqs/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 ul.migrations-faqs {
 	margin: 0;
 	padding: 0;
@@ -13,7 +16,7 @@ ul.migrations-faqs {
 	}
 
 	.foldable-faq__question-text {
-		@include a4a-font-heading-lg;
+		@include heading-large;
 	}
 
 	.gridicon {

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -24,7 +24,11 @@ function FeatureCard( {
 				<h2 className="migrations-hosting-features__card-title">{ title }</h2>
 			</div>
 
-			<SimpleList className="migrations-hosting-features__card-list" items={ items } />
+			<SimpleList
+				applyCoreStyles
+				className="migrations-hosting-features__card-list"
+				items={ items }
+			/>
 		</Card>
 	);
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .migrations-hosting-features {
 	overflow: hidden;
@@ -60,5 +61,5 @@
 }
 
 .migrations-hosting-features__card-title {
-	@include a4a-font-heading-lg;
+	@include heading-large;
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-options/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .migrations-hosting-options__container {
 	display: grid;
@@ -37,16 +38,16 @@
 }
 
 .migrations-hosting-options-card__title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 }
 
 .migrations-hosting-options-card__description {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin: 0;
 }
 
 .migrations-hosting-options-card__footnote {
-	@include a4a-font-body-lg($font-weight: 500);
+	@include body-large;
 	font-style: italic;
 	margin-block-end: 8px;
 }
@@ -67,7 +68,7 @@
 }
 
 .migrations-hosting-options__footnote {
-	@include a4a-font-body-lg;
+	@include body-large;
 
 	a,
 	a:hover,

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-process/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-process/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .migrations-process__cards {
 	display: grid;
@@ -36,9 +37,9 @@
 }
 
 .migrations-process__card-number {
-	@include a4a-font-heading-xxl;
+	@include heading-2x-large;
 }
 
 .migrations-process__card-text {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .migrations-overview-v2 {
 	.hosting-dashboard-layout__body {
@@ -13,12 +14,12 @@
 	}
 
 	.page-section__header-description {
-		@include a4a-font-heading-md;
+		@include heading-medium;
 		color: var(--color-neutral-70);
 		max-width: 600px;
 
 		@include break-medium {
-			@include a4a-font-heading-xl;
+			@include heading-x-large;
 		}
 
 		@include break-large {

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/style.scss
@@ -1,5 +1,8 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .migrations-tag-sites-modal__instruction {
-	@include a4a-font-body-sm;
+	@include body-small;
 	margin: 0;
 	color: var(--color-accent-60);
 


### PR DESCRIPTION
This PR updates the Migrations page to now use the Core's typography.

<img width="1481" alt="Screenshot 2025-03-11 at 7 58 23 PM" src="https://github.com/user-attachments/assets/b8a8afe9-2bff-4970-9ad3-50980ccc0b26" />
<img width="1721" alt="Screenshot 2025-03-12 at 11 12 41 PM" src="https://github.com/user-attachments/assets/43606584-2e76-4e45-9bc6-8170d702914e" />
<img width="1475" alt="Screenshot 2025-03-12 at 11 06 53 PM" src="https://github.com/user-attachments/assets/30d7cff9-d69f-451c-bace-740797894801" />



Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1911

## Proposed Changes

* Update all components in the Migrations page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/migrations` page.
* Use the A4A live link and go to the `/migrations/commissions` page.
* Use the A4A live link and go to the `/migrations/overview/migrate-to-wpcom` page.
* Use the A4A live link and go to the `/migrations/overview/migrate-to-pressable` page.
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
