### PR TITLE
Newsletter: Improve subscription status.

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -248,13 +248,13 @@ const SubscriberDataViews = ( {
 					</div>
 				),
 				elements: [
-					{ label: translate( 'Subscribed' ), value: SubscribersFilterBy.EmailSubscriber },
+					{ label: SubscribersStatus.Subscribed, value: SubscribersFilterBy.EmailSubscriber },
 					{
-						label: translate( 'Not confirmed' ),
+						label: SubscribersStatus.NotConfirmed,
 						value: SubscribersFilterBy.UnconfirmedSubscriber,
 					},
-					{ label: translate( 'Not subscribed' ), value: SubscribersFilterBy.ReaderSubscriber },
-					{ label: translate( 'Not sending' ), value: SubscribersFilterBy.BlockedSubscriber },
+					{ label: SubscribersStatus.NotSubscribed, value: SubscribersFilterBy.ReaderSubscriber },
+					{ label: SubscribersStatus.NotSending, value: SubscribersFilterBy.BlockedSubscriber },
 				],
 				filterBy: {
 					operators: [ 'is' as Operator ],

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,6 +1,5 @@
 import { Gravatar, TimeSince } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { Tooltip } from '@wordpress/components';
 import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
@@ -59,13 +58,13 @@ const defaultView: View = {
 	mediaField: 'media',
 	showTitle: true,
 	showMedia: true,
-	fields: [ 'plan', 'is_email_subscriber', 'date_subscribed' ],
+	fields: [ 'plan', 'subscription_status', 'date_subscribed' ],
 	layout: {
 		styles: {
 			media: { width: '60px' },
 			name: { width: '55%', minWidth: '195px' },
 			plan: { width: '15%' },
-			is_email_subscriber: { width: '15%' },
+			subscription_status: { width: '15%' },
 			date_subscribed: { width: '15%' },
 		},
 	},
@@ -239,24 +238,19 @@ const SubscriberDataViews = ( {
 				enableSorting: true,
 			},
 			{
-				id: 'is_email_subscriber',
-				label: translate( 'Email subscriber' ),
-				getValue: ( { item }: { item: Subscriber } ) => ( item.is_email_subscriber ? 'yes' : 'no' ),
+				id: 'subscription_status',
+				label: translate( 'Email subscription' ),
+				getValue: ( { item }: { item: Subscriber } ) => item.subscription_status,
 				render: ( { item }: { item: Subscriber } ) => {
-					const noTooltip = (
-						<Tooltip text={ translate( 'Reader only subscriber' ) }>
-							<span className="subscriber-data-views__tooltip-text">{ translate( 'No' ) }</span>
-						</Tooltip>
-					);
-
-					return <div>{ item.is_email_subscriber ? translate( 'Yes' ) : noTooltip }</div>;
+					return <div>{ item.subscription_status }</div>;
 				},
 				elements: [
-					{ label: translate( 'True' ), value: SubscribersFilterBy.EmailSubscriber },
+					{ label: translate( 'Subscribed' ), value: SubscribersFilterBy.EmailSubscriber },
 					{
-						label: translate( 'False' ),
-						value: SubscribersFilterBy.ReaderSubscriber,
+						label: translate( 'Unconfirmed' ),
+						value: SubscribersFilterBy.UnconfirmedSubscriber,
 					},
+					{ label: translate( 'Not subscribed' ), value: SubscribersFilterBy.ReaderSubscriber },
 				],
 				filterBy: {
 					operators: [ 'is' as Operator ],

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -247,7 +247,7 @@ const SubscriberDataViews = ( {
 				elements: [
 					{ label: translate( 'Subscribed' ), value: SubscribersFilterBy.EmailSubscriber },
 					{
-						label: translate( 'Unconfirmed' ),
+						label: translate( 'Not confirmed' ),
 						value: SubscribersFilterBy.UnconfirmedSubscriber,
 					},
 					{ label: translate( 'Not subscribed' ), value: SubscribersFilterBy.ReaderSubscriber },

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -9,7 +9,7 @@ import { getCouponsAndGiftsEnabledForSiteId } from 'calypso/state/memberships/se
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
-import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
+import { SubscribersFilterBy, SubscribersSortBy, SubscribersStatus } from '../../constants';
 import { useSubscriptionPlans, useUnsubscribeModal } from '../../hooks';
 import {
 	useSubscribersQuery,
@@ -241,9 +241,12 @@ const SubscriberDataViews = ( {
 				id: 'subscription_status',
 				label: translate( 'Email subscription' ),
 				getValue: ( { item }: { item: Subscriber } ) => item.subscription_status,
-				render: ( { item }: { item: Subscriber } ) => {
-					return <div>{ item.subscription_status }</div>;
-				},
+				render: ( { item }: { item: Subscriber } ) => (
+					<div>
+						{ SubscribersStatus[ item.subscription_status as keyof typeof SubscribersStatus ] ??
+							item.subscription_status }
+					</div>
+				),
 				elements: [
 					{ label: translate( 'Subscribed' ), value: SubscribersFilterBy.EmailSubscriber },
 					{

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -251,6 +251,7 @@ const SubscriberDataViews = ( {
 						value: SubscribersFilterBy.UnconfirmedSubscriber,
 					},
 					{ label: translate( 'Not subscribed' ), value: SubscribersFilterBy.ReaderSubscriber },
+					{ label: translate( 'Not sending' ), value: SubscribersFilterBy.BlockedSubscriber },
 				],
 				filterBy: {
 					operators: [ 'is' as Operator ],

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -89,51 +89,10 @@ const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
 	const isFilteredByUnconfirmed = filters.includes( SubscribersFilterBy.UnconfirmedSubscriber );
 	const filterLabel = getFilterLabel( filters, filteredCount );
 
-	if ( isFilteredByUnconfirmed ) {
+	// Handle unfiltered case. This is the default case where we show the total subscribers count.
+	if ( ! isFiltered ) {
 		return (
 			<div className="subscriber-totals">
-				<span className="subscriber-totals__total-count">
-					{ translate(
-						'%(count)d unconfirmed subscriber',
-						'%(count)d unconfirmed subscribers',
-						{
-							count: filteredCount,
-							args: { count: filteredCount },
-						}
-					) }
-				</span>
-			</div>
-		);
-	}
-
-	return (
-		<div className="subscriber-totals">
-			{ isFiltered ? (
-				<>
-					<span className="subscriber-totals__filtered-count">
-						{ searchTerm
-							? translate(
-									'%(matchingSubscriberCount)s matching result',
-									'%(matchingSubscriberCount)s matching results',
-									{
-										count: filteredCount,
-										args: { matchingSubscriberCount: numberFormat( filteredCount ) },
-									}
-							  )
-							: translate( '%(filteredSubscriberCount)s %(filterLabel)s', {
-									args: {
-										filteredSubscriberCount: numberFormat( filteredCount ),
-										filterLabel,
-									},
-							  } ) }
-					</span>
-					<span className="subscriber-totals__total">
-						{ translate( 'out of %(totalSubscriberCount)s total subscribers', {
-							args: { totalSubscriberCount: numberFormat( totalSubscribers ) },
-						} ) }
-					</span>
-				</>
-			) : (
 				<span className="subscriber-totals__total-count">
 					{ translate(
 						'%(subscriberCount)s total subscriber',
@@ -144,7 +103,49 @@ const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
 						}
 					) }
 				</span>
-			) }
+			</div>
+		);
+	}
+
+	// Handle unconfirmed subscribers case. This is a special case where we don't want to show the total subscribers count since unconfirmed subscribers are not part of the total.
+	if ( isFilteredByUnconfirmed ) {
+		return (
+			<div className="subscriber-totals">
+				<span className="subscriber-totals__total-count">
+					{ translate( '%(count)d unconfirmed subscriber', '%(count)d unconfirmed subscribers', {
+						count: filteredCount,
+						args: { count: filteredCount },
+					} ) }
+				</span>
+			</div>
+		);
+	}
+
+	// Handle filtered case. This is the case where we show the filtered subscribers count.
+	return (
+		<div className="subscriber-totals">
+			<span className="subscriber-totals__filtered-count">
+				{ searchTerm
+					? translate(
+							'%(matchingSubscriberCount)s matching result',
+							'%(matchingSubscriberCount)s matching results',
+							{
+								count: filteredCount,
+								args: { matchingSubscriberCount: numberFormat( filteredCount ) },
+							}
+					  )
+					: translate( '%(filteredSubscriberCount)s %(filterLabel)s', {
+							args: {
+								filteredSubscriberCount: numberFormat( filteredCount ),
+								filterLabel,
+							},
+					  } ) }
+			</span>
+			<span className="subscriber-totals__total">
+				{ translate( 'out of %(totalSubscriberCount)s total subscribers', {
+					args: { totalSubscriberCount: numberFormat( totalSubscribers ) },
+				} ) }
+			</span>
 		</div>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-totals/index.tsx
+++ b/client/my-sites/subscribers/components/subscriber-totals/index.tsx
@@ -86,7 +86,25 @@ const SubscriberTotals: React.FC< SubscriberTotalsProps > = ( {
 	}
 
 	const isFiltered = ! filters.includes( SubscribersFilterBy.All ) || !! searchTerm;
+	const isFilteredByUnconfirmed = filters.includes( SubscribersFilterBy.UnconfirmedSubscriber );
 	const filterLabel = getFilterLabel( filters, filteredCount );
+
+	if ( isFilteredByUnconfirmed ) {
+		return (
+			<div className="subscriber-totals">
+				<span className="subscriber-totals__total-count">
+					{ translate(
+						'%(count)d unconfirmed subscriber',
+						'%(count)d unconfirmed subscribers',
+						{
+							count: filteredCount,
+							args: { count: filteredCount },
+						}
+					) }
+				</span>
+			</div>
+		);
+	}
 
 	return (
 		<div className="subscriber-totals">

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -2,7 +2,7 @@ export enum SubscribersSortBy {
 	Name = 'name',
 	DateSubscribed = 'date_subscribed',
 	Plan = 'plan',
-	EmailSubscriber = 'is_email_subscriber',
+	SubscriptionStatus = 'subscription_status',
 }
 
 export enum SubscribersFilterBy {
@@ -11,8 +11,9 @@ export enum SubscribersFilterBy {
 	WPCOM = 'wpcom',
 	Free = 'free',
 	Paid = 'paid',
-	EmailSubscriber = 'email_subscriber',
 	ReaderSubscriber = 'reader_subscriber',
+	UnconfirmedSubscriber = 'unconfirmed_subscriber',
+	EmailSubscriber = 'email_subscriber',
 }
 
 export const DEFAULT_PER_PAGE = 10;

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -17,4 +17,10 @@ export enum SubscribersFilterBy {
 	BlockedSubscriber = 'blocked_subscriber',
 }
 
+export enum SubscribersStatus {
+	Subscribed = 'Subscribed',
+	NotConfirmed = 'Not confirmed',
+	NotSubscribed = 'Not subscribed',
+	NotSending = 'Not sending',
+}
 export const DEFAULT_PER_PAGE = 10;

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -1,3 +1,5 @@
+import { translate } from 'i18n-calypso';
+
 export enum SubscribersSortBy {
 	Name = 'name',
 	DateSubscribed = 'date_subscribed',
@@ -17,10 +19,11 @@ export enum SubscribersFilterBy {
 	BlockedSubscriber = 'blocked_subscriber',
 }
 
-export enum SubscribersStatus {
-	Subscribed = 'Subscribed',
-	NotConfirmed = 'Not confirmed',
-	NotSubscribed = 'Not subscribed',
-	NotSending = 'Not sending',
-}
+export const SubscribersStatus = {
+	Subscribed: translate( 'Subscribed' ),
+	NotConfirmed: translate( 'Not confirmed' ),
+	NotSubscribed: translate( 'Not subscribed' ),
+	NotSending: translate( 'Not sending' ),
+} as const;
+
 export const DEFAULT_PER_PAGE = 10;

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -14,6 +14,7 @@ export enum SubscribersFilterBy {
 	ReaderSubscriber = 'reader_subscriber',
 	UnconfirmedSubscriber = 'unconfirmed_subscriber',
 	EmailSubscriber = 'email_subscriber',
+	BlockedSubscriber = 'blocked_subscriber',
 }
 
 export const DEFAULT_PER_PAGE = 10;

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -28,7 +28,7 @@ export type Subscriber = {
 	user_id: number;
 	subscription_id: number;
 	date_subscribed: string;
-	is_email_subscriber: boolean;
+	subscription_status: string;
 	email_address: string;
 	avatar: string;
 	display_name: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/546

## Proposed Changes

* Switch to using the `subscription_status` instead of `is_email_subscriber`
* Filter by 'Subscribed', 'Not sending', 'Not confirmed', 'Not subscribed'


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Related to https://github.com/Automattic/loop/issues/546


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With the backend PR sandboxed:
*  Setup a site with paid, subscribed, unconfirmed and reader only subscribers. 
* Filter for the different types of subscribers on the subscribers dashboard.
*  Now, as one of the subscribers go to your reader subscription settings and pause the email notifications. 
*  Come back to your subscribers page, refresh the list and search for the subscriber who just paused the emai notification. The subscription status will be 'Not sending'. 
* Test the sorting of the different fields. 


https://github.com/user-attachments/assets/bf8ffcff-127f-4a60-ae1a-bd64c83918bd



Screenshots for translation:


<img width="1707" alt="Screenshot 2025-03-12 at 4 07 50 PM" src="https://github.com/user-attachments/assets/e3d366fa-1056-4ecd-8c72-c8eda857cda2" />

<img width="1739" alt="Screenshot 2025-03-12 at 4 07 56 PM" src="https://github.com/user-attachments/assets/44fdfd15-bfbc-40b4-b8b9-7f81b29738f3" />


<img width="1663" alt="Screenshot 2025-03-12 at 4 08 03 PM" src="https://github.com/user-attachments/assets/2c3690bc-0fed-43ae-9e0c-39c0adf797c1" />

<img width="433" alt="Screenshot 2025-03-13 at 2 47 18 PM" src="https://github.com/user-attachments/assets/0fa8ea18-37fa-47e1-a4c6-b44b38d64af2" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
