### PR TITLE
Help Center: Add shadow for when it is opened

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -114,7 +114,7 @@
 		width: 410px;
 		height: 80vh;
 		max-height: 800px;
-		box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 1px 0 rgba(0, 0, 0, 0.04), 0 0px 0px 1px rgba(0, 0, 0, 0.04);
+		box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 1px 0 rgba(0, 0, 0, 0.04), 0 0 0 1px rgba(0, 0, 0, 0.04);
 		border-radius: 2px;
 
 		&.is-minimized {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -114,7 +114,7 @@
 		width: 410px;
 		height: 80vh;
 		max-height: 800px;
-		box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 1px 0 rgba(0, 0, 0, 0.04);
+		box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 1px 0 rgba(0, 0, 0, 0.04), 0 0px 0px 1px rgba(0, 0, 0, 0.04);
 		border-radius: 2px;
 
 		&.is-minimized {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes: https://github.com/Automattic/wp-calypso/issues/89577

## Proposed Changes

This PR adds shadow to the Help Center for when it is opened from the command palette:

| Before | After |
|---------|---------|
| <img src="https://github.com/user-attachments/assets/bcacd190-3255-45a7-a126-fc2fba031eff" width="400"/> | <img src="https://github.com/user-attachments/assets/02576ef5-8ef1-404e-9079-b3dada37299e" width="400"/> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or go to the Calypso link generated below
* Open the command palette ⌘+k
* Type 'help' and use the 'Get help' command
* Confirm that the Help Center has shadow around it 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
