### PR TITLE
Updated onboarding focused launchpad test to support the new Blog actions

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
+++ b/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
@@ -1,0 +1,186 @@
+/**
+ * @group calypso-release
+ */
+import {
+	DataHelper,
+	TestAccount,
+	envVariables,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	BrowserManager,
+	SignupDomainPage,
+	SignupPickPlanPage,
+	NewSiteResponse,
+	StartSiteFlow,
+	MyHomePage,
+	EditorPage,
+	RestAPIClient,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiDeleteSite } from '../shared';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
+	let page: Page;
+	let newSiteDetails: NewSiteResponse;
+	let siteCreatedFlag = false;
+	let testAccount: TestAccount;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+		const testUser = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+			{
+				gutenberg: 'stable',
+				siteType: 'simple',
+				accountName: 'defaultUser',
+			},
+		] );
+		testAccount = new TestAccount( testUser );
+		await testAccount.authenticate( page );
+	} );
+
+	describe( 'Log in, select a goal and theme', function () {
+		const themeName = 'Retrospect';
+		let startSiteFlow: StartSiteFlow;
+
+		beforeAll( async function () {
+			await BrowserManager.setStoreCookie( page, { currency: 'GBP' } );
+			startSiteFlow = new StartSiteFlow( page );
+		} );
+
+		it( 'Visit onboarding page', async function () {
+			await page.goto( DataHelper.getCalypsoURL( '/setup/onboarding' ) );
+		} );
+
+		it( 'Skip domain selection', async function () {
+			const signupDomainPage = new SignupDomainPage( page );
+			await signupDomainPage.searchForFooDomains();
+			await signupDomainPage.skipDomainSelection();
+		} );
+
+		it( 'Select WordPress.com Free plan', async function () {
+			const signupPickPlanPage = new SignupPickPlanPage( page );
+			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
+
+			siteCreatedFlag = true;
+		} );
+
+		it( 'Select "Publish a blog" goal', async function () {
+			await startSiteFlow.selectGoal( 'Publish a blog' );
+			await startSiteFlow.clickButton( 'Next' );
+		} );
+
+		it( 'Select theme', async function () {
+			await startSiteFlow.selectTheme( themeName );
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+	} );
+
+	describe( 'Launch the site', function () {
+		let editorPage: EditorPage;
+
+		it( 'Visit Focused Launchpad page', async function () {
+			const title = await page.getByText( "Let's get started!" );
+			await title.waitFor( { timeout: 30 * 1000 } );
+		} );
+
+		it( 'Start building your audience', async function () {
+			const addSubscribersButton = await page.getByText( 'Start building your audience' );
+			await addSubscribersButton.waitFor();
+			await addSubscribersButton.click();
+			await new Promise( ( r ) => setTimeout( r, 1000 ) );
+
+			await page.goto(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
+		} );
+
+		it( 'Complete your profile', async function () {
+			const completeProfileButton = await page.getByText( 'Complete your profile' );
+			await completeProfileButton.waitFor();
+			await completeProfileButton.click();
+			await new Promise( ( r ) => setTimeout( r, 1000 ) );
+
+			await page.goto(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
+		} );
+
+		it( 'Give your site a name', async function () {
+			const giveSiteNameButton = await page.getByText( 'Give your site a name' );
+			await giveSiteNameButton.waitFor();
+			await giveSiteNameButton.click();
+		} );
+
+		it( 'Once at the /wp-admin settings page, update site name', async function () {
+			await page.fill( 'input[name="blogname"]', 'my first site' );
+			const saveChangesButton = await page.getByRole( 'button', { name: 'Save Changes' } );
+			await saveChangesButton.click();
+
+			// The first time we save, we need to wait for the page to reload because it redirects to Calypo's settings page
+			// before loading /wp-admin settings page again, so we'd lose the settings updated notice
+			await new Promise( ( r ) => setTimeout( r, 2000 ) );
+			await saveChangesButton.click();
+			// Wait for the success notice that appears after saving
+			await page.waitForSelector( '#setting-error-settings_updated' );
+			await page.goto(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
+		} );
+
+		it( "It will write the user's first post", async function () {
+			const writeFirstPostButton = await page.getByText( 'Write your first post' );
+			await writeFirstPostButton.waitFor();
+			await writeFirstPostButton.click();
+		} );
+
+		it( 'Editor loads', async function () {
+			editorPage = new EditorPage( page );
+			await editorPage.waitUntilLoaded();
+			await new Promise( ( r ) => setTimeout( r, 2000 ) );
+			await editorPage.closeWelcomeGuideIfNeeded();
+		} );
+
+		it( 'Enter blog title', async function () {
+			await editorPage.enterTitle( 'my first post' );
+		} );
+
+		it( 'Publish post', async function () {
+			await editorPage.publish();
+			await page.goto(
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+			);
+		} );
+
+		it( 'Should show Launch Site button and update title', async function () {
+			const header = await page.getByText( "You're all set!" );
+			await header.waitFor();
+			const launchSiteButton = await page.getByText( 'Launch your site' );
+			await launchSiteButton.waitFor();
+			await launchSiteButton.click();
+		} );
+
+		it( 'Make sure launch modal shows', async function () {
+			const myHomePage = new MyHomePage( page );
+			await myHomePage.validateTaskHeadingMessage( 'Congrats, your site is live!' );
+		} );
+	} );
+
+	afterAll( async function () {
+		if ( ! siteCreatedFlag ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient( {
+			username: testAccount.credentials.username,
+			password: testAccount.credentials.password,
+		} );
+
+		await apiDeleteSite( restAPIClient, {
+			url: newSiteDetails.blog_details.url,
+			id: newSiteDetails.blog_details.blogid,
+			name: newSiteDetails.blog_details.blogname,
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

After [we changed the Blog onboarding items](https://github.com/Automattic/jetpack/pull/42272), we need to update the Onboarding Focused Launchpad e2e tests.

We removed it [in this PR](https://github.com/Automattic/wp-calypso/pull/101129) because it wasn't working due to [the previous changes](https://github.com/Automattic/jetpack/pull/42272).

## Proposed Changes

* Reenabled Focused Onboarding e2e tests
* Added treatment to the new items of the Blog onboarding flow
* Added blog removal after it runs, even if it fails, so user won’t get marked as spam

Test working with network throttle:

https://github.com/user-attachments/assets/363dad06-6d77-477d-a696-6dbe5bc614ba



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
