### PR TITLE
Stepper: change submit function type away from multiple params

### DIFF
--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -70,7 +70,7 @@ const entrepreneurFlow: Flow = {
 			}
 		};
 
-		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
 				case SEGMENTATION_SURVEY_SLUG: {
 					setIsMigrationFlow( !! providedDependencies.isMigrationFlow );
@@ -102,7 +102,7 @@ const entrepreneurFlow: Flow = {
 				}
 
 				case STEPS.PROCESSING.slug: {
-					const processingResult = params[ 0 ] as ProcessingResult;
+					const processingResult = providedDependencies.processingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( STEPS.ERROR.slug );

--- a/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/entrepreneur-flow.ts
@@ -102,7 +102,7 @@ const entrepreneurFlow: Flow = {
 				}
 
 				case STEPS.PROCESSING.slug: {
-					const processingResult = providedDependencies.processingResult;
+					const processingResult = providedDependencies.processingResult as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( STEPS.ERROR.slug );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-starting-point/index.tsx
@@ -24,7 +24,7 @@ const StartingPointStep: Step = function StartingPointStep( { navigation } ) {
 	const submitIntent = ( startingPoint: string ) => {
 		const providedDependencies = { startingPoint };
 		recordTracksEvent( 'calypso_signup_starting_point_select', { starting_point: startingPoint } );
-		submit?.( providedDependencies, startingPoint );
+		submit?.( providedDependencies );
 	};
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/index.tsx
@@ -284,12 +284,10 @@ const BundleConfirm: Step = function BundleConfirm( { navigation } ) {
 								}
 
 								const providedDependencies = {
-									checkoutUrl: siteUpgrading.checkoutUrl,
+									checkoutUrl: siteUpgrading.required ? siteUpgrading.checkoutUrl : '',
 								};
-								submit?.(
-									providedDependencies,
-									siteUpgrading.required ? siteUpgrading.checkoutUrl : ''
-								);
+
+								submit?.( providedDependencies );
 							} }
 						>
 							{ __( 'Confirm' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intent-step/index.tsx
@@ -31,7 +31,7 @@ const IntentStep: Step = function IntentStep( { navigation } ) {
 		const providedDependencies = { intent };
 		recordTracksEvent( 'calypso_signup_intent_select', providedDependencies );
 		setIntent( intent );
-		submit?.( providedDependencies, intent );
+		submit?.( providedDependencies );
 	};
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/README.md
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/README.md
@@ -16,7 +16,7 @@ It works together with `ONBOARD_STORE` and some of its state:
 3. Configure your flow in a way that the `processing` step is called after submitting the main step, something like:
 
 ```
-function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+function submit( providedDependencies: ProvidedDependencies = {} ) {
 ...
 	switch ( currentStep ) {
 		case 'myMainStep':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -117,7 +117,11 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					console.error( 'ProcessingStep failed:', e );
 					captureFlowException( e );
 					setSiteSetupError( e.error || e.code, e.message );
-					submit?.( {}, ProcessingResult.FAILURE );
+					submit?.( {
+						...destinationState,
+						...props.data,
+						processingResult: ProcessingResult.FAILURE,
+					} );
 				}
 			} else {
 				setHasEmptyActionRun( true );
@@ -132,7 +136,11 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			// Let's ensure the submit function is called only once,
 			// but only for the onboarding flow to mitigate risks.
 			isSubmittedRef.current = flow === 'site-setup' ? true : false;
-			submit?.( {}, ProcessingResult.NO_ACTION );
+			submit?.( {
+				...destinationState,
+				...props.data,
+				processingResult: ProcessingResult.NO_ACTION,
+			} );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ hasEmptyActionRun ] );
@@ -150,7 +158,11 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {
-				submit?.( { ...destinationState, ...props.data }, ProcessingResult.SUCCESS );
+				submit?.( {
+					...destinationState,
+					...props.data,
+					processingResult: ProcessingResult.SUCCESS,
+				} );
 				return;
 			}
 
@@ -166,7 +178,11 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			isSubmittedRef.current = flow === 'site-setup' ? true : false;
 
 			// Default processing handler.
-			submit?.( destinationState, ProcessingResult.SUCCESS );
+			submit?.( {
+				...destinationState,
+				...props.data,
+				processingResult: ProcessingResult.SUCCESS,
+			} );
 		}
 		// A change in submit() doesn't cause this effect to rerun.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -118,8 +118,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					captureFlowException( e );
 					setSiteSetupError( e.error || e.code, e.message );
 					submit?.( {
-						...destinationState,
-						...props.data,
 						processingResult: ProcessingResult.FAILURE,
 					} );
 				}
@@ -137,8 +135,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			// but only for the onboarding flow to mitigate risks.
 			isSubmittedRef.current = flow === 'site-setup' ? true : false;
 			submit?.( {
-				...destinationState,
-				...props.data,
 				processingResult: ProcessingResult.NO_ACTION,
 			} );
 		}
@@ -180,7 +176,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 			// Default processing handler.
 			submit?.( {
 				...destinationState,
-				...props.data,
 				processingResult: ProcessingResult.SUCCESS,
 			} );
 		}

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -144,7 +144,7 @@ const pluginBundleFlow: FlowV1 = {
 			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction' ] );
 		};
 
-		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			let defaultExitDest = `/home/${ siteSlug }`;
 
 			if ( siteDetails?.options?.theme_slug ) {
@@ -171,7 +171,7 @@ const pluginBundleFlow: FlowV1 = {
 
 			switch ( currentStep ) {
 				case 'bundleConfirm': {
-					const [ checkoutUrl ] = params;
+					const checkoutUrl = providedDependencies.checkoutUrl as string;
 
 					if ( checkoutUrl ) {
 						window.location.replace( checkoutUrl.toString() );
@@ -180,7 +180,7 @@ const pluginBundleFlow: FlowV1 = {
 					return navigate( 'bundleTransfer' );
 				}
 				case 'processing': {
-					const processingResult = params[ 0 ] as ProcessingResult;
+					const processingResult = providedDependencies.processingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -327,7 +327,7 @@ const siteSetupFlow: FlowV1 = {
 				}
 
 				case 'bloggerStartingPoint': {
-					const intent = providedDependencies.intent;
+					const intent = providedDependencies.intent as string;
 					switch ( intent ) {
 						case 'firstPost': {
 							return exitFlow( `/post/${ siteSlug }` );
@@ -384,7 +384,7 @@ const siteSetupFlow: FlowV1 = {
 				}
 
 				case 'intent': {
-					const submittedIntent = params[ 0 ];
+					const submittedIntent = providedDependencies.intent as string;
 					switch ( submittedIntent ) {
 						case 'wpadmin': {
 							return exitFlow( `https://wordpress.com/home/${ siteId ?? siteSlug }` );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -273,7 +273,7 @@ const siteSetupFlow: FlowV1 = {
 
 		useRedirectDesignSetupOldSlug( currentStep, navigate );
 
-		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
 				case 'options': {
 					if ( intent === 'sell' ) {
@@ -292,7 +292,7 @@ const siteSetupFlow: FlowV1 = {
 				}
 
 				case 'processing': {
-					const processingResult = params[ 0 ] as ProcessingResult;
+					const processingResult = providedDependencies.processingResult as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
@@ -327,7 +327,7 @@ const siteSetupFlow: FlowV1 = {
 				}
 
 				case 'bloggerStartingPoint': {
-					const intent = params[ 0 ];
+					const intent = providedDependencies.intent;
 					switch ( intent ) {
 						case 'firstPost': {
 							return exitFlow( `/post/${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -327,7 +327,7 @@ const siteSetupFlow: FlowV1 = {
 				}
 
 				case 'bloggerStartingPoint': {
-					const intent = providedDependencies.intent as string;
+					const intent = providedDependencies.startingPoint as string;
 					switch ( intent ) {
 						case 'firstPost': {
 							return exitFlow( `/post/${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -46,10 +46,10 @@ const transferringHostedSite: Flow = {
 			return `/home/${ siteId }`;
 		};
 
-		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
 				case 'processing': {
-					const processingResult = params[ 0 ] as ProcessingResult;
+					const processingResult = providedDependencies.processingResult as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -58,15 +58,17 @@ const updateDesign: Flow = {
 
 		useRedirectDesignSetupOldSlug( currentStep, navigate );
 
-		function submit( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) {
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
-				case 'processing':
+				case 'processing': {
 					initializeLaunchpadState( {
 						siteId,
 						siteSlug: ( providedDependencies?.siteSlug ?? siteSlug ) as string,
 					} );
 
-					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
+					const processingResult = providedDependencies.processingResult as ProcessingResult;
+
+					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
 					}
 
@@ -81,7 +83,7 @@ const updateDesign: Flow = {
 							siteSlug: siteSlug as string,
 						} )
 					);
-
+				}
 				case 'design-setup':
 					if ( providedDependencies?.goToCheckout ) {
 						const destination = `/setup/${ flowToReturnTo }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -27,16 +27,19 @@ const updateOptions: Flow = {
 		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
 
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		function submit( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) {
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
-				case 'processing':
-					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
+				case 'processing': {
+					const processingResult = providedDependencies.processingResult as ProcessingResult;
+
+					if ( processingResult === ProcessingResult.FAILURE ) {
 						return navigate( 'error' );
 					}
 
 					return window.location.assign(
 						`/setup/${ flowToReturnTo }/launchpad?siteSlug=${ siteSlug }`
 					);
+				}
 				case 'options': {
 					return navigate( `processing?siteSlug=${ siteSlug }&flowToReturnTo=${ flowToReturnTo }` );
 				}


### PR DESCRIPTION
## Proposed Changes

This removes the few rare cases where Stepper's `submit` function was called with more than one parameter. The second parameter complicates things for no reason and makes typing the steps harder. This removes the second parameter and puts all the info in the first.

## Why are these changes being made?
To have a consistent signature for the function in all the steps and type it accurately.

## Testing Instructions

### Entrepreneur flow

1. Go to /setup/entrepreneur/
2. Select Migrate my site
3. Open DevTools > Network, filter by /new
4. Accept the trial rules. A site should be created. This takes a while (2 mins or so).
5. Block the /new request that you filtered out.
6. Repeat.
7. You should land at the error step.

cc @daledupreez would appreciate a smoke test of this flow.

### Site setup flow

1. Go to http://calypso.localhost:3000/setup/site-setup/bloggerStartingPoint?siteSlug=YOUR_SIMPLE_SITE
2. Pick the first option. 
3. It should take you to /post/SITE_SLUG

---

1. Go to http://calypso.localhost:3000/setup/site-setup/intent?siteSlug=YOUR_SIMPLE_SITE
2. Pick the first option
3. It should take you to /setup/site-setup/options

### Transferring hosted site

1. Go to /hosting
2. Make a site.
3. When you cross checkout, you should land add `/setup/transferring-hosted-site`.
5. You should see a processing step that takes ~1-2 minutes.
6. After that you should land at wp-admin.

### Update design flow

1. Go to http://calypso.localhost:3000/setup/update-design?siteSlug=YOUR_SIMPLE_SITE
2. Pick a design.
3. All should work and you should land at /start/free.

### Update options flow

1. Go to http://calypso.localhost:3000/setup/update-options?siteSlug=YOUR_SIMPLE_SITE
2. Change title. 
3. Submit. You should land at /start/free.

### Plugin bundle flow

I only changed `bundleConfirm` step and it's not used in the flow.


