### PR TITLE
Disable onboarding/create-course feature flag on dev envs

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -130,7 +130,7 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"oauth": false,
-		"onboarding/create-course": true,
+		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,7 +86,7 @@
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
-		"onboarding/create-course": true,
+		"onboarding/create-course": false,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"plans/hosting-trial": true,

--- a/config/test.json
+++ b/config/test.json
@@ -82,7 +82,7 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
-		"onboarding/create-course": true,
+		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,7 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"onboarding/enable-write-goal-features": true,
-		"onboarding/create-course": true,
+		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,


### PR DESCRIPTION


## Proposed Changes
* Turn off the `onboarding/create-course` feature flag on all dev envs

## Why are these changes being made?
* The project which was planning use this flag is in HOLD

## Testing Instructions
* Run `yarn feature-search onboarding/create-course` and check if all states are OFF on unset

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
