### PR TITLE
Magic Link Page: Align header, spacings and text

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -58,7 +58,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 			: translate( 'We just emailed you a link.' );
 
 		return (
-			<div>
+			<div className="magic-login__form">
 				<RedirectWhenLoggedIn
 					redirectTo="/help"
 					replaceCurrentLocation
@@ -71,11 +71,10 @@ class EmailedLoginLinkSuccessfully extends Component {
 					<div className="magic-login__form-text">
 						<p>{ preventWidows( successMessage ) }</p>
 					</div>
+					<div className="magic-login__emails-list">
+						<MagicLoginEmailWrapper emailAddress={ emailAddress } />
+					</div>
 				</Card>
-				<div className="magic-login__emails-list">
-					<MagicLoginEmailWrapper emailAddress={ emailAddress } />
-				</div>
-
 				<div className="magic-login__footer">
 					<p>
 						{ translate(

--- a/client/login/magic-login/magic-login-email/magic-login-email-wrapper.tsx
+++ b/client/login/magic-login/magic-login-email/magic-login-email-wrapper.tsx
@@ -35,7 +35,7 @@ export function MagicLoginEmailWrapper( { emailAddress }: MagicLoginEmailWrapper
 
 	const filteredDomains = getEmailDomain( emailAddress );
 
-	if ( filteredDomains ) {
+	if ( filteredDomains?.length > 0 ) {
 		return (
 			<ul>
 				{ filteredDomains.map( ( item: MagicEmailDomainInfo, key: number ) => (

--- a/client/login/magic-login/magic-login-email/style.scss
+++ b/client/login/magic-login/magic-login-email/style.scss
@@ -1,8 +1,9 @@
 @import "@automattic/typography/styles/variables";
 .magic-login__emails-list {
+	
 	ul {
 		list-style: none;
-		margin: 0;
+		margin: 48px 0 0;
 
 		li {
 			height: 48px;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -96,7 +96,7 @@
 
 .magic-login__form {
 	margin-bottom: 0;
-	padding: 4px 0 48px 0;
+	padding-top: 4px;
 
 	.magic-login__form-text {
 		text-align: center;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -96,6 +96,7 @@
 
 .magic-login__form {
 	margin-bottom: 0;
+	padding: 4px 0 48px 0;
 
 	.magic-login__form-text {
 		text-align: center;
@@ -153,6 +154,7 @@
 
 .magic-login__footer {
 	margin: 4px 0 48px 0;
+	text-align: center;
 
 	a {
 		border-bottom: 1px solid #c8d7e1;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100435

## Proposed Changes

* Align spacing and text centralization on magic login page. [More details](https://github.com/Automattic/wp-calypso/issues/100435)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To keep pages consistent avoid content jump

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link and navigate to `/log-in/link`
* Type a valid email using `gmail` and make sure that the alignment on the magic link page is matching the page before or check this screenshot.

<img width="1830" alt="image" src="https://github.com/user-attachments/assets/72c42d4b-db14-4ab6-9a08-e8aed3773e80" />



