### PR TITLE
Desktop: Fix release CI for windows and linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,19 @@ jobs:
       - run: *yarn-install
       - save_cache: *save-yarn-cache
       - run:
+          name: Set environment variables
+          command: |
+            if [[ $CIRCLE_TAG == desktop-v* ]]; then
+              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            # If this is not a release build, build all artifacts only when project config changes.
+            # Otherwise only build application executable required for end-to-end testing.
+            if [[ "$RELEASE_BUILD" != "true" ]]; then
+              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.mac.target=dir'" >> "$BASH_ENV"
+            fi
+      - run:
           name: Build Desktop Mac
           no_output_timeout: 45m
           environment:
@@ -196,17 +209,14 @@ jobs:
             source $HOME/.nvm/nvm.sh
             nvm use
 
+            echo RELEASE_BUILD=$RELEASE_BUILD
+            echo ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
+
             pushd desktop
 
             rbenv global $(cat .ruby-version) && rbenv rehash
-
             bundle install
-
             bundle exec fastlane configure_code_signing
-
-            # Build all artifacts only when project config changes.
-            # Otherwise only build application executable required for end-to-end testing.
-            ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && ELECTRON_BUILDER_ARGS='-c.mac.target=dir'
 
             ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS yarn run ci:build-mac
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,7 @@ jobs:
             # If this is not a release build, build all artifacts only when project config changes.
             # Otherwise only build application executable required for end-to-end testing.
             if [[ "$RELEASE_BUILD" != "true" ]]; then
-              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|desktop/yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
+              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
             fi
       - run:
           name: Build Desktop Linux
@@ -424,7 +424,7 @@ jobs:
 
             # Build all artifacts only when project config changes.
             # Otherwise only build application executable required for end-to-end testing.
-            If ( -Not $(git diff --name-only origin/trunk...HEAD | Select-String -Pattern desktop/package.json,desktop/yarn.lock) ) { $env:ARG2='-c.win.target=dir' }
+            If ( -Not $(git diff --name-only origin/trunk...HEAD | Select-String -Pattern desktop/package.json,yarn.lock) ) { $env:ARG2='-c.win.target=dir' }
             make -f desktop/Makefile package ELECTRON_BUILDER_ARGS=$($env:ARG1,$env:ARG2 -join " ")
       - run:
           name: Archive Unpacked Directories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,17 +173,22 @@ jobs:
     environment:
       CONFIG_ENV: release
       PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
+      # If, for testing purposes, you want to generate all artifacts in the CI of a PR, uncomment the following line,
+      # and push a commit to your branch. Make sure to remove the commit before merging to trunk!
+      #PR_DEBUG_RELEASE: 'true'
     steps:
       - checkout
       - attach_workspace:
           at: /Users/distiller/wp-calypso
-      - run: *update-node
-      - restore_cache: *restore-yarn-cache
-      - run: *yarn-install
-      - save_cache: *save-yarn-cache
       - run:
           name: Set environment variables
           command: |
+            if [[ "$PR_DEBUG_RELEASE" == "true" ]]; then
+              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
+              echo "export CSC_FOR_PULL_REQUEST=true" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
             if [[ $CIRCLE_TAG == desktop-v* ]]; then
               echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
               source "$BASH_ENV"
@@ -193,24 +198,25 @@ jobs:
             # Otherwise only build application executable required for end-to-end testing.
             if [[ "$RELEASE_BUILD" != "true" ]]; then
               ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.mac.target=dir'" >> "$BASH_ENV"
+              source "$BASH_ENV"
             fi
+
+            echo RELEASE_BUILD=$RELEASE_BUILD
+            echo CSC_FOR_PULL_REQUEST=$CSC_FOR_PULL_REQUEST
+            echo ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
+      - run: *update-node
+      - restore_cache: *restore-yarn-cache
+      - run: *yarn-install
+      - save_cache: *save-yarn-cache
       - run:
           name: Build Desktop Mac
           no_output_timeout: 45m
           environment:
             USE_HARD_LINKS: 'false'
-            # Code-signing does not normally run on PRs for security reasons.
-            # If you need to debug the code-signing process, you can temporarily uncomment the following line, and push
-            # a commit to your branch.
-            # Make sure to then remove the commit before merging to trunk!
-            # CSC_FOR_PULL_REQUEST: 'true'
           command: |
             set +e
             source $HOME/.nvm/nvm.sh
             nvm use
-
-            echo RELEASE_BUILD=$RELEASE_BUILD
-            echo ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
 
             pushd desktop
 
@@ -225,7 +231,6 @@ jobs:
             source $HOME/.nvm/nvm.sh
             nvm use
             npm install -g yarn
-
             cd desktop && yarn run test:e2e
       - run:
           when: always
@@ -269,10 +274,37 @@ jobs:
     environment:
       CONFIG_ENV: release
       PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
+      # If, for testing purposes, you want to generate all artifacts in the CI of a PR, uncomment the following line,
+      # and push a commit to your branch. Make sure to remove the commit before merging to trunk!
+      #PR_DEBUG_RELEASE: 'true'
     steps:
       - checkout
       - attach_workspace:
           at: ~/wp-calypso
+      - run:
+          name: Set environment variables
+          command: |
+            if [[ "$PR_DEBUG_RELEASE" == "true" ]]; then
+              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
+              echo "export CSC_FOR_PULL_REQUEST=true" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            if [[ $CIRCLE_TAG == desktop-v* ]]; then
+              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            # If this is not a release build, build all artifacts only when project config changes.
+            # Otherwise only build application executable required for end-to-end testing.
+            if [[ "$RELEASE_BUILD" != "true" ]]; then
+              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            echo RELEASE_BUILD=$RELEASE_BUILD
+            echo CSC_FOR_PULL_REQUEST=$CSC_FOR_PULL_REQUEST
+            echo ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
       - run:
           name: Install Linux deps
           command: |
@@ -286,19 +318,6 @@ jobs:
           command: yarn install --immutable --inline-builds
       - save_cache: *save-yarn-cache
       - run:
-          name: Set environment variables
-          command: |
-            if [[ $CIRCLE_TAG == desktop-v* ]]; then
-              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
-              source "$BASH_ENV"
-            fi
-
-            # If this is not a release build, build all artifacts only when project config changes.
-            # Otherwise only build application executable required for end-to-end testing.
-            if [[ "$RELEASE_BUILD" != "true" ]]; then
-              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
-            fi
-      - run:
           name: Build Desktop Linux
           environment:
             CSC_LINK: resource/certificates/win.p12
@@ -306,10 +325,6 @@ jobs:
           command: |
             set +e
             cd desktop
-
-            echo RELEASE_BUILD=$RELEASE_BUILD
-            echo ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
-
             ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS yarn run build
       - run:
           name: e2e Tests
@@ -350,6 +365,9 @@ jobs:
     environment:
       CONFIG_ENV: release
       PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
+      # If, for testing purposes, you want to generate all artifacts in the CI of a PR, uncomment the following line,
+      # and push a commit to your branch. Make sure to remove the commit before merging to trunk!
+      #PR_DEBUG_RELEASE: 'true'
     steps:
       - checkout
       - attach_workspace:
@@ -380,7 +398,7 @@ jobs:
           name: Install Desktop Dependencies
           command: yarn
       - when:
-          # Remove the condition on pipeline.git.tag on both steps to force a full artifact build for Windows.
+          # Set the condition to true on both steps to force a full artifact build for Windows.
           condition: << pipeline.git.tag >>
           steps:
             - run:
@@ -416,15 +434,24 @@ jobs:
       - run:
           name: Build NSIS
           command: |
+            If ( $env:CIRCLE_TAG -or $env:PR_DEBUG_RELEASE ) { $env:RELEASE_BUILD='true' }
+
+            # If this is not a release build, build all artifacts only when project config changes.
+            # Otherwise only build application executable required for end-to-end testing.
+            If ( -Not $env:RELEASE_BUILD ) {
+              If ( -Not $(git diff --name-only origin/trunk...HEAD | Select-String -Pattern desktop/package.json,yarn.lock) ) { $env:ARG2='-c.win.target=dir' }
+            }
+
             # Use make (not yarn/npm directly) for bash-like environment variable substitution
             make -f desktop/Makefile build-main
 
             # Codesign release (tagged) builds only
             If ( $env:CIRCLE_TAG ) { $env:ARG1='-c.win.certificateSubjectName="Automattic"' }
 
-            # Build all artifacts only when project config changes.
-            # Otherwise only build application executable required for end-to-end testing.
-            If ( -Not $(git diff --name-only origin/trunk...HEAD | Select-String -Pattern desktop/package.json,yarn.lock) ) { $env:ARG2='-c.win.target=dir' }
+            echo "RELEASE_BUILD=$env:RELEASE_BUILD"
+            echo "ARG1=$env:ARG1"
+            echo "ARG2=$env:ARG2"
+
             make -f desktop/Makefile package ELECTRON_BUILDER_ARGS=$($env:ARG1,$env:ARG2 -join " ")
       - run:
           name: Archive Unpacked Directories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,18 +286,30 @@ jobs:
           command: yarn install --immutable --inline-builds
       - save_cache: *save-yarn-cache
       - run:
+          name: Set environment variables
+          command: |
+            if [[ $CIRCLE_TAG == desktop-v* ]]; then
+              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            # If this is not a release build, build all artifacts only when project config changes.
+            # Otherwise only build application executable required for end-to-end testing.
+            if [[ "$RELEASE_BUILD" != "true" ]]; then
+              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|desktop/yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
+            fi
+      - run:
           name: Build Desktop Linux
           environment:
             CSC_LINK: resource/certificates/win.p12
             USE_HARD_LINKS: 'false'
           command: |
             set +e
-
-            # Build all artifacts only when project config changes.
-            # Otherwise only build application executable required for end-to-end testing.
-            ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|desktop/yarn.lock' && ELECTRON_BUILDER_ARGS='-c.linux.target=dir'
-
             cd desktop
+
+            echo RELEASE_BUILD=$RELEASE_BUILD
+            echo ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
+
             ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS yarn run build
       - run:
           name: e2e Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,10 +194,9 @@ jobs:
               source "$BASH_ENV"
             fi
 
-            # If this is not a release build, build all artifacts only when project config changes.
-            # Otherwise only build application executable required for end-to-end testing.
+            # If this is not a release build, only build the executable required for end-to-end testing.
             if [[ "$RELEASE_BUILD" != "true" ]]; then
-              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.mac.target=dir'" >> "$BASH_ENV"
+              echo "export ELECTRON_BUILDER_ARGS='-c.mac.target=dir'" >> "$BASH_ENV"
               source "$BASH_ENV"
             fi
 
@@ -295,10 +294,9 @@ jobs:
               source "$BASH_ENV"
             fi
 
-            # If this is not a release build, build all artifacts only when project config changes.
-            # Otherwise only build application executable required for end-to-end testing.
+            # If this is not a release build, only build the executable required for end-to-end testing.
             if [[ "$RELEASE_BUILD" != "true" ]]; then
-              ! git diff --name-only origin/trunk...HEAD | grep -E -q 'desktop/package.json|yarn.lock' && echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
+              echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
               source "$BASH_ENV"
             fi
 
@@ -436,10 +434,9 @@ jobs:
           command: |
             If ( $env:CIRCLE_TAG -or $env:PR_DEBUG_RELEASE ) { $env:RELEASE_BUILD='true' }
 
-            # If this is not a release build, build all artifacts only when project config changes.
-            # Otherwise only build application executable required for end-to-end testing.
+            # If this is not a release build, only build the executable required for end-to-end testing.
             If ( -Not $env:RELEASE_BUILD ) {
-              If ( -Not $(git diff --name-only origin/trunk...HEAD | Select-String -Pattern desktop/package.json,yarn.lock) ) { $env:ARG2='-c.win.target=dir' }
+              $env:ARG2='-c.win.target=dir'
             }
 
             # Use make (not yarn/npm directly) for bash-like environment variable substitution

--- a/desktop/bin/build-mac-ci.js
+++ b/desktop/bin/build-mac-ci.js
@@ -7,15 +7,8 @@ const yaml = require( 'js-yaml' );
 
 const PROJECT_DIR = path.join( __dirname, '..' );
 const BUILD_DIR = path.join( PROJECT_DIR, 'release' );
-
-const circleTag = process.env.CIRCLE_TAG;
-const isReleaseBuild =
-	process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'desktop-v' );
-
-// In certain conditions, .circle/config.yml sets ELECTRON_BUILDER_ARGS to -c.mac.target=dir.
-// However, when building a release, that flag must not be set, otherwise the latest-mac.yml file will not be created,
-// and that file is needed below when isReleaseBuild is true.
-const ELECTRON_BUILDER_ARGS = isReleaseBuild ? '' : process.env.ELECTRON_BUILDER_ARGS || '';
+const ELECTRON_BUILDER_ARGS = process.env.ELECTRON_BUILDER_ARGS || '';
+const isReleaseBuild = process.env.RELEASE_BUILD === 'true';
 
 // Build Apple Silicon binaries only unless tagged for release.
 const arches = isReleaseBuild ? [ 'x64', 'arm64' ] : [ 'arm64' ];

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "8.1.0-beta5",
+	"version": "8.1.0-beta6",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/",


### PR DESCRIPTION
[Windows](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/263922/workflows/ff9d3c2b-a2ac-410f-abea-7c3b8251e65f/jobs/1177806/artifacts) and [Linux](https://href.li/?https://app.circleci.com/pipelines/github/Automattic/wp-calypso/263922/workflows/ff9d3c2b-a2ac-410f-abea-7c3b8251e65f/jobs/1177805/artifacts) installers were not being produced by the release CI (more info at p8Qyks-9kJ-p2#comment-3962).

The issue here was similar to the issue with mac builds that was fixed in https://github.com/Automattic/wp-calypso/pull/100998: the `-c.linux.target=dir` or `-c.win.target=dir` flags cannot be passed for builds that generate the artifacts.

This PR makes it so that those flags are not passed for release builds, on all platforms.

Additionally, for non-release builds, the flags are now always passed, regardless of whether `desktop/package.json` or `yarn.lock` are modified or not. Previously, the flags would only be passed when those files were modified compared to trunk. I'm not sure why that was the case, that behavior has now been removed.

These changes result in the following:

1. If it's the CI of a PR, only build the artifacts needed for e2e testing 
2. If the developer wants to build all artifacts in the CI of a PR, they can set the `PR_DEBUG_RELEASE=true` env variable
3. If it's the CI of a release tag, build all artifacts

