### PR TITLE
Reader Editor: Fix styles for focus state

### DIFF
--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -73,9 +73,19 @@
 	}
 }
 
-.following-stream__quick-post-card.card.is-expanded {
-	.foldable-card__content {
-		overflow: visible;
+.following-stream__quick-post-card.card {
+
+	.foldable-card__action:focus {
+		outline: none;
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+		border-radius: 2px;
+	}
+
+	&.is-expanded {
+		.foldable-card__content {
+			overflow: visible;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/558

## Proposed Changes

Adds styles to fix the focus of the button to open the editor.

### Before

<img width="1225" alt="Image" src="https://github.com/user-attachments/assets/99f39f1b-54f0-4495-8bda-29472698f9dd" />

### After
<img width="792" alt="Screenshot 2025-03-11 at 16 11 01" src="https://github.com/user-attachments/assets/2b3bbd5e-ae21-48dd-9241-301c2cda0740" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Make styles consistent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/reader?flags=reader/quick-post`
- Navigate to the editor using the keyboard
- Ensure the focus style is a 2px solid blue outline

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
