### PR TITLE
Untangling: render skeleton Plans page in the sites dashboard under feature flag

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -90,6 +90,7 @@ const renderHelpBubble = ( item: Item ) => {
 };
 
 export type Item = {
+	id?: string;
 	label: string;
 	href?: string;
 	helpBubble?: React.ReactElement;

--- a/client/lib/plans/untangling-plans-experiment.ts
+++ b/client/lib/plans/untangling-plans-experiment.ts
@@ -1,0 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
+import type { AppState } from 'calypso/types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function isPlansPageUntangled( state: AppState ) {
+	return isEnabled( 'untangling/plans' );
+}

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,5 +1,6 @@
 import { PLAN_100_YEARS, isValidFeatureKey } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
 import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-header';
 import { PLAN } from 'calypso/sites/components/site-preview-pane/constants';
@@ -62,8 +63,7 @@ export function plans( context, next ) {
 		/>
 	);
 
-	const isUntangled = true;
-	if ( isUntangled ) {
+	if ( isPlansPageUntangled( context.store.getState() ) ) {
 		siteDashboard( PLAN )( context, next );
 	} else {
 		next();

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -2,6 +2,8 @@ import { PLAN_100_YEARS, isValidFeatureKey } from '@automattic/calypso-products'
 import page from '@automattic/calypso-router';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
 import setJetpackPlansHeader from 'calypso/my-sites/plans/jetpack-plans/plans-header';
+import { PLAN } from 'calypso/sites/components/site-preview-pane/constants';
+import { siteDashboard } from 'calypso/sites/controller';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Plans from './main';
@@ -59,7 +61,13 @@ export function plans( context, next ) {
 			jetpackAppPlans={ context.query.jetpackAppPlans === 'true' }
 		/>
 	);
-	next();
+
+	const isUntangled = true;
+	if ( isUntangled ) {
+		siteDashboard( PLAN )( context, next );
+	} else {
+		next();
+	}
 }
 
 export function features( context ) {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -437,10 +437,7 @@ class PlansComponent extends Component {
 
 		return (
 			<div>
-				{ isUntangled && (
-					<FeatureBreadcrumb siteId={ selectedSite.ID } title={ translate( 'Plan' ) } />
-				) }
-				{ ! isJetpackNotAtomic && <ModernizedLayout /> }
+				{ ! isUntangled && ! isJetpackNotAtomic && <ModernizedLayout /> }
 				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />
@@ -458,7 +455,10 @@ class PlansComponent extends Component {
 				) }
 				{ canAccessPlans && (
 					<div>
-						{ ! isDomainAndPlanPackageFlow && (
+						{ isUntangled && (
+							<FeatureBreadcrumb siteId={ selectedSite.ID } title={ translate( 'Plan' ) } />
+						) }
+						{ ! isUntangled && ! isDomainAndPlanPackageFlow && (
 							<PlansHeader
 								domainFromHomeUpsellFlow={ domainFromHomeUpsellFlow }
 								subHeaderText={ subHeaderText }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -37,6 +37,7 @@ import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import { FeatureBreadcrumb } from 'calypso/sites/hooks/breadcrumbs/use-set-feature-breadcrumb';
 import { useSelector } from 'calypso/state';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -428,12 +429,17 @@ class PlansComponent extends Component {
 				? translate( 'Get your domain’s first year for free' )
 				: translate( 'Choose the perfect plan' );
 
+		const isUntangled = true;
+
 		// Hide for WooExpress plans and Entrepreneur trials that are not WooExpress trials
 		const isEntrepreneurTrial = isEcommerceTrial && ! purchase?.isWooExpressTrial;
-		const showPlansNavigation = ! ( isWooExpressPlan || isEntrepreneurTrial );
+		const showPlansNavigation = ! isUntangled && ! ( isWooExpressPlan || isEntrepreneurTrial );
 
 		return (
 			<div>
+				{ isUntangled && (
+					<FeatureBreadcrumb siteId={ selectedSite.ID } title={ translate( 'Plan' ) } />
+				) }
 				{ ! isJetpackNotAtomic && <ModernizedLayout /> }
 				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -34,6 +34,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
+import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
@@ -365,6 +366,7 @@ class PlansComponent extends Component {
 			selectedSite,
 			translate,
 			canAccessPlans,
+			isUntangled,
 			currentPlan,
 			domainAndPlanPackage,
 			isDomainAndPlanPackageFlow,
@@ -428,8 +430,6 @@ class PlansComponent extends Component {
 			currentPlanIntervalType === 'monthly'
 				? translate( 'Get your domain’s first year for free' )
 				: translate( 'Choose the perfect plan' );
-
-		const isUntangled = true;
 
 		// Hide for WooExpress plans and Entrepreneur trials that are not WooExpress trials
 		const isEntrepreneurTrial = isEcommerceTrial && ! purchase?.isWooExpressTrial;
@@ -522,6 +522,7 @@ const ConnectedPlans = connect(
 			purchase: currentPlan ? getByPurchaseId( state, currentPlan.purchaseId ) : null,
 			selectedSite: getSelectedSite( state ),
 			canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
+			isUntangled: isPlansPageUntangled( state ),
 			isWPForTeamsSite: isSiteWPForTeams( state, selectedSiteId ),
 			isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 			isDomainAndPlanPackageFlow: !! getCurrentQueryArguments( state )?.domainAndPlanPackage,

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -60,7 +60,7 @@ body.is-section-plans {
 		}
 	}
 
-	.layout:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
+	.layout:not(.has-no-sidebar):not(.has-no-masterbar):not(.is-global-sidebar-visible) .layout__content {
 		@media (min-width: $break-small) {
 			padding-top: 79px !important;
 		}

--- a/client/sites/components/site-preview-pane/constants.ts
+++ b/client/sites/components/site-preview-pane/constants.ts
@@ -15,6 +15,7 @@ export const SETTINGS_SERVER = 'settings-server';
 export const SETTINGS_SFTP_SSH = 'settings-sftp-ssh';
 export const SETTINGS_DATABASE = 'settings-database';
 export const SETTINGS_PERFORMANCE = 'settings-performance';
+export const PLAN = 'plan';
 
 export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ OVERVIEW ]: 'overview/:site',
@@ -34,4 +35,5 @@ export const FEATURE_TO_ROUTE_MAP: { [ feature: string ]: string } = {
 	[ SETTINGS_SFTP_SSH ]: 'sites/settings/sftp-ssh/:site',
 	[ SETTINGS_DATABASE ]: 'sites/settings/database/:site',
 	[ SETTINGS_PERFORMANCE ]: 'sites/settings/performance/:site',
+	[ PLAN ]: 'plans/:site',
 };

--- a/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
+++ b/client/sites/components/site-preview-pane/dotcom-preview-pane.tsx
@@ -33,6 +33,7 @@ import {
 	SETTINGS_SFTP_SSH,
 	SETTINGS_DATABASE,
 	SETTINGS_PERFORMANCE,
+	PLAN,
 } from './constants';
 import PreviewPaneHeaderButtons from './preview-pane-header-buttons';
 import SiteEnvironmentSwitcher from './site-environment-switcher';
@@ -130,9 +131,14 @@ const DotcomPreviewPane = ( {
 				enabled: ! isRemoveDuplicateViewsExperimentEnabled && isActiveAtomicSite,
 				featureIds: [ HOSTING_CONFIG ],
 			},
+			{
+				enabled: true,
+				visible: false,
+				featureIds: [ PLAN ],
+			},
 		];
 
-		return siteFeatures.map( ( { label, enabled, featureIds } ) => {
+		return siteFeatures.map( ( { label, enabled, visible, featureIds } ) => {
 			const selected = enabled && featureIds.includes( selectedSiteFeature );
 			const defaultFeatureId = featureIds[ 0 ] as string;
 			const defaultRoute = `/${ FEATURE_TO_ROUTE_MAP[ defaultFeatureId ].replace(
@@ -145,7 +151,7 @@ const DotcomPreviewPane = ( {
 				tab: {
 					label,
 					href: defaultRoute,
-					visible: enabled,
+					visible: enabled && visible !== false,
 					selected,
 					onTabClick: () => {
 						if ( enabled && ! selected ) {

--- a/client/sites/hooks/breadcrumbs/use-breadcrumbs.ts
+++ b/client/sites/hooks/breadcrumbs/use-breadcrumbs.ts
@@ -1,3 +1,4 @@
+import { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import { useSelector } from 'calypso/state';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
@@ -6,7 +7,9 @@ export function useBreadcrumbs() {
 	const breadcrumbs = useSelector( getBreadcrumbs );
 	const isRemoveDuplicateViewsExperimentEnabled = useRemoveDuplicateViewsExperimentEnabled();
 
-	const shouldShowBreadcrumbs = isRemoveDuplicateViewsExperimentEnabled && breadcrumbs.length >= 3;
+	const shouldShowBreadcrumbs =
+		isRemoveDuplicateViewsExperimentEnabled &&
+		breadcrumbs.some( ( item: BreadcrumbItem ) => item.id === 'feature' );
 
 	return {
 		// In sites dashboard, the components are rendered from the innermost level,

--- a/client/sites/hooks/breadcrumbs/use-set-tab-breadcrumb.tsx
+++ b/client/sites/hooks/breadcrumbs/use-set-tab-breadcrumb.tsx
@@ -25,19 +25,22 @@ export function useSetTabBreadcrumb( {
 			return;
 		}
 
-		const breadcrumb = {
-			id: 'tab',
-			label: tab.label,
-			href: tab.href,
-		};
-		if ( tabId === selectedFeatureId ) {
-			// This is the default feature of the tab, so no feature breadcrumb will be added.
-			// Replace the entire breadcrumbs with the tab breadcrumb.
-			dispatch( updateBreadcrumbs( [ breadcrumb ] ) );
-		} else {
-			// The feature breadcrumb has been added, so we append the tab breadcrumb.
-			dispatch( appendBreadcrumb( breadcrumb ) );
+		if ( tab.visible ) {
+			const breadcrumb = {
+				id: 'tab',
+				label: tab.label,
+				href: tab.href,
+			};
+			if ( tabId === selectedFeatureId ) {
+				// This is the default feature of the tab, so no feature breadcrumb will be added.
+				// Replace the entire breadcrumbs with the tab breadcrumb.
+				dispatch( updateBreadcrumbs( [ breadcrumb ] ) );
+			} else {
+				// The feature breadcrumb has been added, so we append the tab breadcrumb.
+				dispatch( appendBreadcrumb( breadcrumb ) );
+			}
 		}
+
 		dispatch(
 			appendBreadcrumb( {
 				id: 'site',

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -8,36 +8,50 @@ import type { AppState } from 'calypso/types';
 // Calypso routes for which we show the Site Dashboard.
 // Calypso routes not listed here will be shown in nav unification instead.
 // See: pfsHM7-Dn-p2.
-const SITE_DASHBOARD_ROUTES = [
-	'/overview/',
-	'/hosting-config/',
-	'/github-deployments/',
-	'/site-monitoring/',
-	'/sites/performance/',
-	'/site-logs/',
-	'/hosting-features/',
-	'/staging-site/',
-	'/sites/settings',
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getSiteDashboardRoutes( state: AppState ) {
+	const isPlanUntangled = true;
 
-	// Domain Management
-	'/domains/manage/all/overview',
-	'/domains/manage/all/email',
-	'/domains/manage/all/contact-info',
+	return [
+		'/overview/',
+		'/hosting-config/',
+		'/github-deployments/',
+		'/site-monitoring/',
+		'/sites/performance/',
+		'/site-logs/',
+		'/hosting-features/',
+		'/staging-site/',
+		'/sites/settings',
+		...( isPlanUntangled ? [ '/plans' ] : [] ),
 
-	// Bulk Plugins management
-	'/plugins/manage/sites',
-];
+		// Domain Management
+		'/domains/manage/all/overview',
+		'/domains/manage/all/email',
+		'/domains/manage/all/contact-info',
+
+		// Bulk Plugins management
+		'/plugins/manage/sites',
+	];
+}
 
 function isInRoute( state: AppState, routes: string[] ) {
 	return routes.some( ( route ) => state.route.path?.current?.startsWith( route ) );
 }
 
 function shouldShowSitesDashboard( state: AppState ) {
-	return isInRoute( state, [ '/sites', '/p2s', '/setup', '/start', ...SITE_DASHBOARD_ROUTES ] );
+	return isInRoute( state, [
+		'/sites',
+		'/p2s',
+		'/setup',
+		'/start',
+		...getSiteDashboardRoutes( state ),
+	] );
 }
 
 export function shouldShowSiteDashboard( state: AppState, siteId: number | null ) {
-	return !! siteId && isInRoute( state, [ '/setup', '/start', ...SITE_DASHBOARD_ROUTES ] );
+	return (
+		!! siteId && isInRoute( state, [ '/setup', '/start', ...getSiteDashboardRoutes( state ) ] )
+	);
 }
 
 export const getShouldShowGlobalSidebar = (

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,3 +1,4 @@
+import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
 import isScheduledUpdatesMultisiteRoute, {
 	isScheduledUpdatesMultisiteCreateRoute,
 	isScheduledUpdatesMultisiteEditRoute,
@@ -8,10 +9,7 @@ import type { AppState } from 'calypso/types';
 // Calypso routes for which we show the Site Dashboard.
 // Calypso routes not listed here will be shown in nav unification instead.
 // See: pfsHM7-Dn-p2.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getSiteDashboardRoutes( state: AppState ) {
-	const isPlanUntangled = true;
-
 	return [
 		'/overview/',
 		'/hosting-config/',
@@ -22,7 +20,7 @@ function getSiteDashboardRoutes( state: AppState ) {
 		'/hosting-features/',
 		'/staging-site/',
 		'/sites/settings',
-		...( isPlanUntangled ? [ '/plans' ] : [] ),
+		...( isPlansPageUntangled( state ) ? [ '/plans' ] : [] ),
 
 		// Domain Management
 		'/domains/manage/all/overview',


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/10607

## Proposed Changes

This PR renders the Plan (`/plans/:site`) routes in the sites dashboard, under the `untangling/plans` feature flag.

This is the simplest way to do that that touches as little code as possible from the plan-related codebase without risky refactoring.

Note that this new Plans page is not fully functional yet; it's to unblock further implementations. We intend to polish the page in follow-up PRs.

|Before|After|
|-|-|
|<img width="1445" alt="image" src="https://github.com/user-attachments/assets/10db521e-2347-48c1-b8cf-c82c63120a87" />|<img width="1465" alt="image" src="https://github.com/user-attachments/assets/003c974d-7425-465a-ab95-10c22519675c" />|


## Why are these changes being made?

We want to move the Plans page from site-specific nav-unification, to the sites dashboard layer.

## Testing Instructions

1. Go to `/plans/:site?flags=untangling/plans`.
2. Verify that all interactions / links in the screen still works.
1. Go to `/plans/:site`.
2. Verify that the old Plans page still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
