### PR TITLE
Log in: Move ToS to the bottom

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -762,7 +762,7 @@ class Login extends Component {
 		}
 
 		const tos = translate(
-			'Just a little reminder that by continuing with any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+			'Just a little reminder that by continuing with any of the options above, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 			{
 				components: {
 					tosLink: (
@@ -1031,11 +1031,11 @@ class Login extends Component {
 
 				{ this.renderNotice() }
 
-				{ this.renderToS() }
-
 				{ this.renderContent() }
 
 				{ this.renderFooter() }
+
+				{ this.renderToS() }
 			</div>
 		);
 	}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -624,7 +624,7 @@ $breakpoint-mobile: 782px; //Mobile size.
 		.login__form-subheader-terms {
 			display: block;
 			max-width: 450px;
-			margin: 0 auto;
+			margin: 32px auto 0;
 
 			color: var(--studio-gray-50, #646970);
 			text-align: center;


### PR DESCRIPTION
## Proposed Changes

* Moves the ToS on the log in screen to the bottom.
* Does a minor copy change to reflect the change: "any of the options below" => "any of the options above".

Fixes #100586.

## Why are these changes being made?

The ToS copy resembles what looks like a subtitle, so it's in the wrong place.

See #100586.

## Testing Instructions
* Go to `/log-in` as a logged-out user.
* Verify the ToS looks OK where it is. 

## Screenshots
|Before|After|
|---|---|
|![Screenshot 2025-03-11 at 17 23 32](https://github.com/user-attachments/assets/f1cb2536-6256-4816-9dc4-3c4f9cb1feeb)|![Screenshot 2025-03-11 at 17 23 12](https://github.com/user-attachments/assets/b69a7799-9307-405c-a447-cb6dc2da0d4d)|



