### PR TITLE
Make copy on importerWordPress more clear

### DIFF
--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -20,6 +20,10 @@
 		align-items: center;
 		width: 100%;
 
+		.user:first-child {
+			width: 60%;
+		}
+
 		@include breakpoint-deprecated( "<480px" ) {
 			font-size: $font-body-extra-small;
 		}

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -144,9 +144,9 @@ class AuthorMappingPane extends PureComponent {
 			<div className="importer__mapping-pane">
 				<div className="importer__mapping-description">{ mappingDescription }</div>
 				<div className="importer__mapping-header">
-					<span className="importer__mapping-source-title">{ translate( 'Original Site' ) }</span>
+					<span className="importer__mapping-source-title">{ translate( 'Original site' ) }</span>
 					<span className="importer__mapping-target-title">
-						{ translate( 'This Site (%(siteDomain)s)', {
+						{ translate( 'This site', {
 							args: { siteDomain },
 						} ) }
 					</span>

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -3,10 +3,12 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import AuthorMapping from './author-mapping-item';
 
 import './author-mapping-pane.scss';
@@ -42,17 +44,17 @@ class AuthorMappingPane extends PureComponent {
 		);
 	};
 
-	getMappingDescription = ( numSourceUsers, numTargetUsers, targetTitle, sourceType ) => {
+	getMappingDescription = ( numSourceUsers, numTargetUsers, siteDomain, sourceType ) => {
 		if ( numTargetUsers === 1 && numSourceUsers === 1 ) {
 			return this.props.translate(
-				'There is one author on your %(sourceType)s site. ' +
-					"Because you're the only author on your new site, " +
+				'There is one author on your original %(sourceType)s site. ' +
+					"Because you're the only author on this site (%(siteDomain)s), " +
 					'all imported content will be assigned to you. ' +
 					'Click {{em}}Import{{/em}} to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
-						destinationSiteTitle: targetTitle,
+						siteDomain: siteDomain,
 					},
 					components: {
 						em: <em />,
@@ -61,14 +63,14 @@ class AuthorMappingPane extends PureComponent {
 			);
 		} else if ( numTargetUsers === 1 && numSourceUsers > 1 ) {
 			return this.props.translate(
-				'There are multiple authors on your %(sourceType)s site. ' +
-					"Because you're the only author on your new site, " +
+				'There are multiple authors on your original %(sourceType)s site. ' +
+					"Because you're the only author on this site (%(siteDomain)s), " +
 					'all imported content will be assigned to you. ' +
 					'Click {{em}}Import{{/em}} to proceed.',
 				{
 					args: {
 						sourceType: sourceType,
-						destinationSiteTitle: targetTitle,
+						siteDomain: siteDomain,
 					},
 					components: {
 						em: <em />,
@@ -79,11 +81,10 @@ class AuthorMappingPane extends PureComponent {
 			return this.props.translate(
 				'There are multiple authors on your site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on your new site, then click {{em}}Import{{/em}}.',
+					'user on this site, then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',
-						destinationSiteTitle: targetTitle,
 					},
 					components: {
 						em: <em />,
@@ -92,13 +93,13 @@ class AuthorMappingPane extends PureComponent {
 			);
 		} else if ( numTargetUsers > 1 && numSourceUsers > 1 ) {
 			return this.props.translate(
-				'There are multiple authors on your %(sourceType)s site. ' +
+				'There are multiple authors on your original %(sourceType)s site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on your new site, then click {{em}}Import{{/em}}.',
+					'user on this site (%(siteDomain)s), then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',
-						destinationSiteTitle: targetTitle,
+						siteDomain: siteDomain,
 					},
 					components: {
 						em: <em />,
@@ -115,7 +116,6 @@ class AuthorMappingPane extends PureComponent {
 	render() {
 		const {
 			sourceAuthors,
-			targetTitle,
 			onMap,
 			onStartImport,
 			siteId,
@@ -124,6 +124,7 @@ class AuthorMappingPane extends PureComponent {
 			site,
 			totalUsers,
 			translate,
+			siteDomain,
 		} = this.props;
 
 		const hasSingleAuthor = totalUsers === 1;
@@ -131,7 +132,7 @@ class AuthorMappingPane extends PureComponent {
 		const mappingDescription = this.getMappingDescription(
 			sourceAuthors.length,
 			totalUsers,
-			targetTitle,
+			siteDomain,
 			sourceType
 		);
 
@@ -139,10 +140,12 @@ class AuthorMappingPane extends PureComponent {
 			<div className="importer__mapping-pane">
 				<div className="importer__mapping-description">{ mappingDescription }</div>
 				<div className="importer__mapping-header">
-					<span className="importer__mapping-source-title">
-						{ translate( 'Original Site Users' ) }
+					<span className="importer__mapping-source-title">{ translate( 'Original Site' ) }</span>
+					<span className="importer__mapping-target-title">
+						{ translate( 'This Site (%(siteDomain)s)', {
+							args: { siteDomain },
+						} ) }
 					</span>
-					<span className="importer__mapping-target-title">{ translate( 'New Site Users' ) }</span>
 				</div>
 				{ sourceAuthors.map( ( author ) => {
 					return (
@@ -180,4 +183,6 @@ const withTotalUsers = createHigherOrderComponent(
 	'withTotalUsers'
 );
 
-export default localize( withTotalUsers( AuthorMappingPane ) );
+export default connect( ( state, ownProps ) => ( {
+	siteDomain: getSiteDomain( state, ownProps.siteId ),
+} ) )( localize( withTotalUsers( AuthorMappingPane ) ) );

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -46,6 +46,7 @@ class AuthorMappingPane extends PureComponent {
 
 	getMappingDescription = ( numSourceUsers, numTargetUsers, siteDomain, sourceType ) => {
 		if ( numTargetUsers === 1 && numSourceUsers === 1 ) {
+			// translators: Import is a call to action button.
 			return this.props.translate(
 				'There is one author on your original %(sourceType)s site. ' +
 					"Because you're the only author on this site (%(siteDomain)s), " +
@@ -62,6 +63,7 @@ class AuthorMappingPane extends PureComponent {
 				}
 			);
 		} else if ( numTargetUsers === 1 && numSourceUsers > 1 ) {
+			// translators: Import is a call to action button.
 			return this.props.translate(
 				'There are multiple authors on your original %(sourceType)s site. ' +
 					"Because you're the only author on this site (%(siteDomain)s), " +
@@ -78,6 +80,7 @@ class AuthorMappingPane extends PureComponent {
 				}
 			);
 		} else if ( numTargetUsers > 1 && numSourceUsers === 1 ) {
+			// translators: Import is a call to action button.
 			return this.props.translate(
 				'There are multiple authors on your site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
@@ -92,6 +95,7 @@ class AuthorMappingPane extends PureComponent {
 				}
 			);
 		} else if ( numTargetUsers > 1 && numSourceUsers > 1 ) {
+			// translators: Import is a call to action button.
 			return this.props.translate(
 				'There are multiple authors on your original %(sourceType)s site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
@@ -160,7 +164,10 @@ class AuthorMappingPane extends PureComponent {
 				} ) }
 				<ImporterActionButtonContainer>
 					<ImporterActionButton primary disabled={ ! canStartImport } onClick={ onStartImport }>
-						{ this.props.translate( 'Import' ) }
+						{ this.props.translate( 'Import', {
+							context:
+								'The user is told that authors are automatically mapped or they need to map them manually and then click Import.',
+						} ) }
 					</ImporterActionButton>
 					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
 				</ImporterActionButtonContainer>

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -44,69 +44,52 @@ class AuthorMappingPane extends PureComponent {
 		);
 	};
 
-	getMappingDescription = ( numSourceUsers, numTargetUsers, siteDomain, sourceType ) => {
+	getMappingDescription = ( numSourceUsers, numTargetUsers, siteDomain ) => {
 		if ( numTargetUsers === 1 && numSourceUsers === 1 ) {
-			// translators: Import is a call to action button.
 			return this.props.translate(
-				'There is one author on your original %(sourceType)s site. ' +
-					"Because you're the only author on this site (%(siteDomain)s), " +
-					'all imported content will be assigned to you. ' +
-					'Click {{em}}Import{{/em}} to proceed.',
+				"Your file is ready to be imported into {{strong}}%(siteDomain)s{{/strong}}. We'll assign you as the author of all imported content.",
 				{
 					args: {
-						sourceType: sourceType,
 						siteDomain: siteDomain,
 					},
 					components: {
-						em: <em />,
+						strong: <strong />,
 					},
 				}
 			);
 		} else if ( numTargetUsers === 1 && numSourceUsers > 1 ) {
-			// translators: Import is a call to action button.
 			return this.props.translate(
-				'There are multiple authors on your original %(sourceType)s site. ' +
-					"Because you're the only author on this site (%(siteDomain)s), " +
-					'all imported content will be assigned to you. ' +
-					'Click {{em}}Import{{/em}} to proceed.',
+				"Your file is ready to be imported into {{strong}}%(siteDomain)s{{/strong}}. As you're the only author on the new site, we'll assign all imported content to you.",
 				{
 					args: {
-						sourceType: sourceType,
 						siteDomain: siteDomain,
 					},
 					components: {
-						em: <em />,
+						strong: <strong />,
 					},
 				}
 			);
 		} else if ( numTargetUsers > 1 && numSourceUsers === 1 ) {
-			// translators: Import is a call to action button.
 			return this.props.translate(
-				'There are multiple authors on your site. ' +
-					'Please reassign the authors of the imported items to an existing ' +
-					'user on this site, then click {{em}}Import{{/em}}.',
+				"Your file is ready to be imported into {{strong}}%(siteDomain)s{{/strong}}. Please reassign content from your original site's author to a user on this site.",
 				{
 					args: {
-						sourceType: 'WordPress',
+						siteDomain: siteDomain,
 					},
 					components: {
-						em: <em />,
+						strong: <strong />,
 					},
 				}
 			);
 		} else if ( numTargetUsers > 1 && numSourceUsers > 1 ) {
-			// translators: Import is a call to action button.
 			return this.props.translate(
-				'There are multiple authors on your original %(sourceType)s site. ' +
-					'Please reassign the authors of the imported items to an existing ' +
-					'user on this site (%(siteDomain)s), then click {{em}}Import{{/em}}.',
+				"Your file is ready to be imported into {{strong}}%(siteDomain)s{{/strong}}. Please reassign content from your original site's authors to users on this site.",
 				{
 					args: {
-						sourceType: 'WordPress',
 						siteDomain: siteDomain,
 					},
 					components: {
-						em: <em />,
+						strong: <strong />,
 					},
 				}
 			);
@@ -123,7 +106,6 @@ class AuthorMappingPane extends PureComponent {
 			onMap,
 			onStartImport,
 			siteId,
-			sourceType,
 			importerStatus,
 			site,
 			totalUsers,
@@ -136,8 +118,7 @@ class AuthorMappingPane extends PureComponent {
 		const mappingDescription = this.getMappingDescription(
 			sourceAuthors.length,
 			totalUsers,
-			siteDomain,
-			sourceType
+			siteDomain
 		);
 
 		return (
@@ -145,11 +126,7 @@ class AuthorMappingPane extends PureComponent {
 				<div className="importer__mapping-description">{ mappingDescription }</div>
 				<div className="importer__mapping-header">
 					<span className="importer__mapping-source-title">{ translate( 'Original site' ) }</span>
-					<span className="importer__mapping-target-title">
-						{ translate( 'This site', {
-							args: { siteDomain },
-						} ) }
-					</span>
+					<span className="importer__mapping-target-title">{ translate( 'This site' ) }</span>
 				</div>
 				{ sourceAuthors.map( ( author ) => {
 					return (
@@ -164,10 +141,7 @@ class AuthorMappingPane extends PureComponent {
 				} ) }
 				<ImporterActionButtonContainer>
 					<ImporterActionButton primary disabled={ ! canStartImport } onClick={ onStartImport }>
-						{ this.props.translate( 'Import', {
-							context:
-								'The user is told that authors are automatically mapped or they need to map them manually and then click Import.',
-						} ) }
+						{ this.props.translate( 'Import' ) }
 					</ImporterActionButton>
 					<ImporterCloseButton importerStatus={ importerStatus } site={ site } isEnabled />
 				</ImporterActionButtonContainer>

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -46,7 +46,7 @@ class AuthorMappingPane extends PureComponent {
 		if ( numTargetUsers === 1 && numSourceUsers === 1 ) {
 			return this.props.translate(
 				'There is one author on your %(sourceType)s site. ' +
-					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
+					"Because you're the only author on your new site, " +
 					'all imported content will be assigned to you. ' +
 					'Click {{em}}Import{{/em}} to proceed.',
 				{
@@ -55,7 +55,6 @@ class AuthorMappingPane extends PureComponent {
 						destinationSiteTitle: targetTitle,
 					},
 					components: {
-						b: <strong />,
 						em: <em />,
 					},
 				}
@@ -63,7 +62,7 @@ class AuthorMappingPane extends PureComponent {
 		} else if ( numTargetUsers === 1 && numSourceUsers > 1 ) {
 			return this.props.translate(
 				'There are multiple authors on your %(sourceType)s site. ' +
-					"Because you're the only author on {{b}}%(destinationSiteTitle)s{{/b}}, " +
+					"Because you're the only author on your new site, " +
 					'all imported content will be assigned to you. ' +
 					'Click {{em}}Import{{/em}} to proceed.',
 				{
@@ -72,7 +71,6 @@ class AuthorMappingPane extends PureComponent {
 						destinationSiteTitle: targetTitle,
 					},
 					components: {
-						b: <strong />,
 						em: <em />,
 					},
 				}
@@ -81,14 +79,13 @@ class AuthorMappingPane extends PureComponent {
 			return this.props.translate(
 				'There are multiple authors on your site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Import{{/em}}.',
+					'user on your new site, then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',
 						destinationSiteTitle: targetTitle,
 					},
 					components: {
-						b: <strong />,
 						em: <em />,
 					},
 				}
@@ -97,14 +94,13 @@ class AuthorMappingPane extends PureComponent {
 			return this.props.translate(
 				'There are multiple authors on your %(sourceType)s site. ' +
 					'Please reassign the authors of the imported items to an existing ' +
-					'user on {{b}}%(destinationSiteTitle)s{{/b}}, then click {{em}}Import{{/em}}.',
+					'user on your new site, then click {{em}}Import{{/em}}.',
 				{
 					args: {
 						sourceType: 'WordPress',
 						destinationSiteTitle: targetTitle,
 					},
 					components: {
-						b: <strong />,
 						em: <em />,
 					},
 				}
@@ -119,7 +115,6 @@ class AuthorMappingPane extends PureComponent {
 	render() {
 		const {
 			sourceAuthors,
-			sourceTitle,
 			targetTitle,
 			onMap,
 			onStartImport,
@@ -128,6 +123,7 @@ class AuthorMappingPane extends PureComponent {
 			importerStatus,
 			site,
 			totalUsers,
+			translate,
 		} = this.props;
 
 		const hasSingleAuthor = totalUsers === 1;
@@ -143,8 +139,10 @@ class AuthorMappingPane extends PureComponent {
 			<div className="importer__mapping-pane">
 				<div className="importer__mapping-description">{ mappingDescription }</div>
 				<div className="importer__mapping-header">
-					<span className="importer__mapping-source-title">{ sourceTitle }</span>
-					<span className="importer__mapping-target-title">{ targetTitle }</span>
+					<span className="importer__mapping-source-title">
+						{ translate( 'Original Site Users' ) }
+					</span>
+					<span className="importer__mapping-target-title">{ translate( 'New Site Users' ) }</span>
 				</div>
 				{ sourceAuthors.map( ( author ) => {
 					return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100887

## Proposed Changes

If the site name is still the default "Site Title", we display 'your new site' instead to make things less technical for the user. If the site has a custom name, we display that instead.

We've also updated the user table heading to be more clear by including the word "Users" in each column heading.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are several different combinations that need to be tested. You'll want a test WordPress site that you can export from. Setting up a Jurassic Ninja site is probably easiest. I also recommend https://wordpress.org/plugins/fakerpress/ for creating multiple user accounts and dummy posts.

For each test, you'll go through the following process:

1. Begin with `/start`.
2. Select "Import or Migrate" from the goals step.
3. On "Let's find your site", click "pick your current platform from a list",
4. Select "WordPress".
5. Select "Import content only".
6. Upload a WordPress export file appropriate for the scenario you're testing.

There are two export files that could be used for the source site if you don't want to set up your own. You'll still need to create a test destination site with one user, then a second user.

Single user export file: Look for `226159` in OneBin
Multiple user export file: Look for `226160` in OneBin

**Scenario 1: A single user on the source and destination sites**
After uploading an export file, you should see something like the following:
![image](https://github.com/user-attachments/assets/2026ad04-0173-49c6-af88-a1bec9b15270)


**Scenario 2: Multiple users on the source site, a single user on the destination site**
After uploading an export file, you should see something like the following:
![image](https://github.com/user-attachments/assets/e7171af5-24f6-4e79-85f7-8abe357cc5c3)

**Scenario 3: Multiple users on the source and destination sites**
After uploading an export file, you should see something like the following:
![image](https://github.com/user-attachments/assets/02b5aef0-023b-45c5-bf9a-832fd7d51780)

**Scenario 4: Single user on the source, multiple users on the destination site**
After uploading an export file, you should see something like the following:
![image](https://github.com/user-attachments/assets/98fb7f24-c61c-4954-8dcf-8f4c881f9e85)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
