### PR TITLE
Enable JPOP chat on /pricing page

### DIFF
--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -32,8 +32,8 @@ function getConfigName( keyType: KeyType ): ZendeskConfigName {
 		case 'jpAgency':
 			return 'zendesk_presales_chat_key_jp_agency_dashboard';
 		case 'jpCheckout':
-			return 'zendesk_presales_chat_key_jp_checkout';
 		case 'jpGeneral':
+			return 'zendesk_presales_chat_key_jp_checkout';
 		case 'wpcom':
 		default:
 			return 'zendesk_presales_chat_key';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/jpop-issues#9607

## Proposed Changes

This PR changes the behavior of the presales chat widget for specific environment (JPOP), enabling it on /pricing page.

## Why are these changes being made?
We're reviving live support to our direct support work as a way to increase our customer satisfaction and improve our response times to those inquiries.

## Testing Instructions

* When testing locally make sure you copy proper code to the [shared](https://github.com/Automattic/wp-calypso/blob/trunk/config/_shared.json#L42) config and restart your local environment before testing
* On Jetpack Cloud environment, go to /pricing page.
* Override line https://github.com/Automattic/wp-calypso/blob/update/jpop-chat-on-pricing/client/lib/presales-chat/index.ts#L70 to be true (force chat availability)
* Chat should be displayed in the bottom right corner.