### PR TITLE
Purchases: Use anchor tag for Help Center support chat button

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -54,7 +54,7 @@ export default function VatInfoPage() {
 	const taxSupportPageLinkTitle = translate( 'VAT, GST, and other taxes' );
 
 	const handleOpenCenterChat = useCallback(
-		async ( e: MouseEvent ) => {
+		async ( e: React.MouseEvent< HTMLAnchorElement > ) => {
 			e.preventDefault();
 			clearHelpCenterZendeskConversationStarted();
 			setNavigateToRoute( '/odie' );

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -54,7 +54,7 @@ export default function VatInfoPage() {
 	const taxSupportPageLinkTitle = translate( 'VAT, GST, and other taxes' );
 
 	const handleOpenCenterChat = useCallback(
-		async ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+		async ( e: MouseEvent ) => {
 			e.preventDefault();
 			clearHelpCenterZendeskConversationStarted();
 			setNavigateToRoute( '/odie' );

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -137,11 +137,8 @@ export default function VatInfoPage() {
 									ul: <ul />,
 									li: <li />,
 									contactSupportLink: (
-										// eslint-disable-next-line jsx-a11y/anchor-is-valid
 										<a
-											target="_blank"
-											href="#"
-											rel="noreferrer"
+											href="/help"
 											title={ contactSupportLinkTitle }
 											onClick={ handleOpenCenterChat }
 										/>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -4,7 +4,6 @@ import { useResetSupportInteraction } from '@automattic/help-center/src/hooks/us
 import { localizeUrl } from '@automattic/i18n-utils';
 import { clearHelpCenterZendeskConversationStarted } from '@automattic/odie-client/src/utils/storage-utils';
 import { CALYPSO_CONTACT } from '@automattic/urls';
-import { Button as WordPressButton } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
@@ -54,13 +53,17 @@ export default function VatInfoPage() {
 	/* This is the title of the support page from https://wordpress.com/support/vat-gst-other-taxes/ */
 	const taxSupportPageLinkTitle = translate( 'VAT, GST, and other taxes' );
 
-	const handleOpenCenterChat = useCallback( async () => {
-		clearHelpCenterZendeskConversationStarted();
-		setNavigateToRoute( '/odie' );
-		setShowHelpCenter( true );
-		await resetSupportInteraction();
-		reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
-	}, [ reduxDispatch, resetSupportInteraction, setNavigateToRoute, setShowHelpCenter ] );
+	const handleOpenCenterChat = useCallback(
+		async ( e: React.MouseEvent< HTMLAnchorElement > ) => {
+			e.preventDefault();
+			clearHelpCenterZendeskConversationStarted();
+			setNavigateToRoute( '/odie' );
+			setShowHelpCenter( true );
+			await resetSupportInteraction();
+			reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
+		},
+		[ reduxDispatch, resetSupportInteraction, setNavigateToRoute, setShowHelpCenter ]
+	);
 
 	useRecordVatEvents( { fetchError } );
 
@@ -134,10 +137,12 @@ export default function VatInfoPage() {
 									ul: <ul />,
 									li: <li />,
 									contactSupportLink: (
-										<WordPressButton
-											className="vat-info__open-help-center-support"
+										// eslint-disable-next-line jsx-a11y/anchor-is-valid
+										<a
+											target="_blank"
+											href="#"
+											rel="noreferrer"
 											title={ contactSupportLinkTitle }
-											variant="link"
 											onClick={ handleOpenCenterChat }
 										/>
 									),

--- a/client/me/purchases/vat-info/style.scss
+++ b/client/me/purchases/vat-info/style.scss
@@ -18,14 +18,6 @@
 .vat-info__sidebar-paragraph {
 	margin-bottom: 0;
 	font-size: 0.875rem;
-
-	.vat-info__open-help-center-support {
-		font-size: 0.875rem;
-		text-decoration: none;
-		&:hover, &:focus, &:active {
-			color: var( --color-link-dark );
-		}
-	}
 }
 
 .vat-info__sidebar-paragraph ul {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101024/files#r1987783676

## Proposed Changes

* Update to use anchor tag for contact support button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reduce CSS override in codebase

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/me/purchases/vat-details`.
* Verify the `Contact our Happiness Engineers.` link opens the Help Center to a new chat with AI.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
