### PR TITLE
Update copy when removing a payment method to consistently use "Remove" terminology

### DIFF
--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -24,7 +24,7 @@ function PaymentMethods() {
 				navigationItems={ [] }
 				title={ titles.sectionTitle }
 				subtitle={ translate(
-					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					'Add or remove payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
 						components: {
 							learnMoreLink: (

--- a/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete-dialog.tsx
@@ -42,7 +42,7 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 				{ action: 'cancel', label: translate( 'Cancel' ), onClick: onClose },
 				{
 					action: 'confirm',
-					label: translate( 'Delete' ),
+					label: translate( 'Remove' ),
 					isPrimary: true,
 					additionalClassNames: 'is-scary',
 					onClick: onConfirm,

--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { isPaymentAgreement, PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
+import { PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -32,12 +32,7 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 		closeDialog();
 		deletePaymentMethod( card.stored_details_id )
 			.then( () => {
-				if ( isPaymentAgreement( card ) ) {
-					reduxDispatch( successNotice( translate( 'Payment method deleted successfully' ) ) );
-				} else {
-					reduxDispatch( successNotice( translate( 'Card deleted successfully' ) ) );
-				}
-
+				reduxDispatch( successNotice( translate( 'Payment method removed' ) ) );
 				recordTracksEvent( 'calypso_purchases_delete_payment_method' );
 			} )
 			.catch( ( error: Error ) => {
@@ -46,14 +41,14 @@ const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	}, [ deletePaymentMethod, closeDialog, card, translate, reduxDispatch ] );
 
 	/* translators: %s is the name of the payment method (usually the last 4 digits of the card but could be a proper name for PayPal). */
-	const deleteText = translate( 'Delete the "%s" payment method', {
+	const deleteText = translate( 'Remove the "%s" payment method', {
 		textOnly: true,
 		args: [ 'card_last_4' in card ? card.card_last_4 : card.name ],
 	} );
 
 	const renderDeleteButton = () => {
-		const text = isDeleting ? translate( 'Deleting…' ) : translate( 'Delete this payment method' );
-		const ariaText = isDeleting ? translate( 'Deleting…' ) : deleteText;
+		const text = isDeleting ? translate( 'Removing…' ) : translate( 'Remove payment method' );
+		const ariaText = isDeleting ? translate( 'Removing…' ) : deleteText;
 
 		return (
 			<Button

--- a/client/me/purchases/payment-methods/test/payment-method.tsx
+++ b/client/me/purchases/payment-methods/test/payment-method.tsx
@@ -152,7 +152,7 @@ describe( 'PaymentMethod', () => {
 			</ReduxProvider>
 		);
 		await user.click(
-			await screen.findByLabelText( `Delete the "${ card.card_last_4 }" payment method` )
+			await screen.findByLabelText( `Remove the "${ card.card_last_4 }" payment method` )
 		);
 
 		expect( await screen.findByText( 'Associated subscriptions' ) ).toBeInTheDocument();
@@ -174,7 +174,7 @@ describe( 'PaymentMethod', () => {
 			</ReduxProvider>
 		);
 		await user.click(
-			await screen.findByLabelText( `Delete the "${ card.card_last_4 }" payment method` )
+			await screen.findByLabelText( `Remove the "${ card.card_last_4 }" payment method` )
 		);
 
 		expect( await screen.queryByText( 'Associated subscriptions' ) ).not.toBeInTheDocument();
@@ -195,10 +195,10 @@ describe( 'PaymentMethod', () => {
 			</ReduxProvider>
 		);
 		await user.click(
-			await screen.findByLabelText( `Delete the "${ card.card_last_4 }" payment method` )
+			await screen.findByLabelText( `Remove the "${ card.card_last_4 }" payment method` )
 		);
 		// Click confimation.
-		await user.click( await screen.findByText( 'Delete' ) );
+		await user.click( await screen.findByText( 'Remove' ) );
 		await waitForElementToBeRemoved( () => screen.queryByText( card.name ) );
 		expect( screen.queryByText( `Mastercard ****${ card.card_last_4 }` ) ).not.toBeInTheDocument();
 		expect( await screen.findByText( payPalAgreement.name ) ).toBeInTheDocument();
@@ -217,10 +217,10 @@ describe( 'PaymentMethod', () => {
 		);
 		expect( await screen.findByText( `Mastercard ****${ card.card_last_4 }` ) ).toBeInTheDocument();
 		await user.click(
-			await screen.findByLabelText( `Delete the "${ payPalAgreement.name }" payment method` )
+			await screen.findByLabelText( `Remove the "${ payPalAgreement.name }" payment method` )
 		);
 		// Click confimation.
-		await user.click( await screen.findByText( 'Delete' ) );
+		await user.click( await screen.findByText( 'Remove' ) );
 		await waitForElementToBeRemoved( () => screen.queryByText( payPalAgreement.name ) );
 		expect( screen.queryByText( payPalAgreement.name ) ).not.toBeInTheDocument();
 		expect( await screen.findByText( `Mastercard ****${ card.card_last_4 }` ) ).toBeInTheDocument();

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -60,7 +60,7 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 				<NavigationHeader
 					title={ titles.sectionTitle }
 					subtitle={ translate(
-						'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'Add or remove payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
 								learnMoreLink: (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100154

## Proposed Changes

When removing a payment method, we sometimes use "Remove" terminology but other times use "Delete".  This pull request standardizes on "Remove".

### Before:
![list-before](https://github.com/user-attachments/assets/f6559bcd-ce44-47fe-b683-f3df266d0df6)
![modal-before](https://github.com/user-attachments/assets/6c2d175a-cca7-4806-bf7a-e7d502243fca)

### After:
![list-after](https://github.com/user-attachments/assets/1b4c9d47-9013-405c-a3be-cd4a0e3f594a)
![modal-after](https://github.com/user-attachments/assets/6e60518d-99c3-435c-9306-6bdd5edfae91)

## Testing Instructions

Visit `me/purchases/payment-methods` (or the site-specific version thereof) and remove a payment method.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
