### PR TITLE
Retired themes: Show the theme details

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -912,44 +912,6 @@ class ThemeSheet extends Component {
 		return defaultOption.label;
 	};
 
-	renderRetired = () => {
-		const { translate, locale, isLoggedIn } = this.props;
-		return (
-			<div className="theme__sheet-content">
-				<Card className="theme__retired-theme-message">
-					<Gridicon icon="cross-circle" size={ 48 } />
-					<div className="theme__retired-theme-message-details">
-						<div className="theme__retired-theme-message-details-title">
-							{ this.props.translate( 'This theme is retired' ) }
-							<InlineSupportLink supportContext="themes-retired" showText={ false } />
-						</div>
-						<div>
-							{ this.props.translate(
-								'We invite you to try out a newer theme; start by browsing our WordPress theme directory.'
-							) }
-						</div>
-					</div>
-					<Button primary href={ localizeThemesPath( '/themes/', locale, ! isLoggedIn ) }>
-						{ translate( 'See all themes' ) }
-					</Button>
-				</Card>
-
-				{ this.isRemoved() && (
-					<Card>
-						<p>
-							{ this.props.translate(
-								'This theme has been renamed to reflect that support for it is now provided directly by WordPress.com. The theme will continue to work as before.'
-							) }
-						</p>
-					</Card>
-				) }
-				<div className="theme__sheet-footer-line">
-					<Gridicon icon="my-sites" />
-				</div>
-			</div>
-		);
-	};
-
 	renderButton = () => {
 		const { getUrl, key } = this.props.defaultOption;
 		const label = this.getDefaultOptionLabel();
@@ -1140,7 +1102,6 @@ class ThemeSheet extends Component {
 		const {
 			themeId,
 			siteId,
-			retired,
 			translate,
 			isLoggedIn,
 			isThemeActivationSyncStarted,
@@ -1256,16 +1217,7 @@ class ThemeSheet extends Component {
 						{ this.renderHeader() }
 						{ this.renderReviews() }
 					</div>
-					<div className="theme__sheet-column-left">
-						{ retired ? (
-							<>
-								{ this.renderRetired() }
-								{ this.renderSectionContent( section ) }
-							</>
-						) : (
-							this.renderSectionContent( section )
-						) }
-					</div>
+					<div className="theme__sheet-column-left">{ this.renderSectionContent( section ) }</div>
 					{ ! isRemoved && (
 						<div className="theme__sheet-column-right">
 							{ this.isWebPreviewAvailable() ? this.renderWebPreview() : this.renderScreenshot() }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1257,8 +1257,14 @@ class ThemeSheet extends Component {
 						{ this.renderReviews() }
 					</div>
 					<div className="theme__sheet-column-left">
-						{ ! retired && this.renderSectionContent( section ) }
-						{ retired && this.renderRetired() }
+						{ retired ? (
+							<>
+								{ this.renderRetired() }
+								{ this.renderSectionContent( section ) }
+							</>
+						) : (
+							this.renderSectionContent( section )
+						) }
 					</div>
 					{ ! isRemoved && (
 						<div className="theme__sheet-column-right">

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -230,7 +230,7 @@ $button-border: 4px;
 		display: flex;
 		flex-direction: column;
 	}
-	
+
 	.theme__sheet-main-info-title {
 		@include onboarding-font-recoleta;
 		display: flex;
@@ -239,13 +239,13 @@ $button-border: 4px;
 		line-height: 1.2;
 		margin: 0;
 	}
-	
+
 	.theme__sheet-main-info-type {
 		align-self: flex-start;
 		margin: 0;
 		margin-bottom: 8px;
 	}
-	
+
 	.theme__sheet-main-info-tag {
 		color: var(--color-neutral-60);
 		font-size: $font-body;
@@ -776,46 +776,6 @@ $button-border: 4px;
 	small {
 		display: block;
 		color: var(--color-neutral-light);
-	}
-}
-
-.theme__retired-theme-message {
-	display: flex;
-	align-items: center;
-	margin-bottom: 40px;
-
-	@include breakpoint-deprecated( "<960px" ) {
-		flex-wrap: wrap;
-	}
-
-	.gridicon {
-		color: var(--color-neutral-10);
-		flex: 0 0 auto;
-	}
-
-	.button {
-		flex: 0 0 auto;
-
-		@include breakpoint-deprecated( "<960px" ) {
-			flex: 1 1 100%;
-			margin-top: 20px;
-			text-align: center;
-		}
-	}
-}
-
-.theme__retired-theme-message-details {
-	flex: 1 1 20px;
-	padding: 0 20px;
-
-	.theme__retired-theme-message-details-title {
-		font-size: $font-title-small;
-	}
-
-	.inline-support-link .gridicon {
-		height: 18px;
-		width: 18px;
-		color: inherit;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/97048

## Proposed Changes

* Bring back theme details on retired themes, and also remove the retired theme notice.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There's no need to scare users with retired themes into trying new ones, and having the instructions removed on their active theme is bad UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On your sandbox, run the following command in order to activate a retired theme: `wp theme activate pub/verso --url=https://{SITE_SLUG}.wordpress.com/`
* Check that the command's output is `Success: Switched to 'Verso' theme.`
* Open the live preview
* Go to `/themes/{SITE_SLUG}.wordpress.com`
* Check that `Verso` is the active theme
* To the right of the theme's `Active` badge, click on the kebab menu, and then on `Info`
* Check that the theme details page actually contains the theme's details

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/7fc990c1-619b-429d-9ed1-2ab11f337849)|![image](https://github.com/user-attachments/assets/26701fbe-f683-4daf-8f81-40ba84fe7bf2)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
