### PR TITLE
Sites: Update link from command palette to use hosted-site-migration flow

### DIFF
--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -490,7 +490,7 @@ export function useCommands() {
 			importSite: {
 				name: 'importSite',
 				label: __( 'Import site to WordPress.com', __i18n_text_domain__ ),
-				callback: commandNavigation( '/start/import?ref=command-palette' ),
+				callback: commandNavigation( '/setup/hosted-site-migration?ref=command-palette' ),
 				searchLabel: [
 					_x(
 						'Import site to WordPress.com',

--- a/packages/command-palette/test/commands.tsx
+++ b/packages/command-palette/test/commands.tsx
@@ -52,7 +52,7 @@ const expectedCommandsResults = {
 	openJetpackSettings: [ '/wp-admin/admin.php?page=jetpack#/dashboard', siteFilters.adminJetpack ],
 	addJetpack: [ '/jetpack/connect?cta_from=command-palette' ],
 	manageJetpackModules: [ '/wp-admin/admin.php?page=jetpack_modules', siteFilters.adminJetpack ],
-	importSite: [ '/start/import?ref=command-palette' ],
+	importSite: [ '/setup/hosted-site-migration?ref=command-palette' ],
 	addNewSite: [ '/start?source=command-palette' ],
 	openAccountSettings: [ '/me/account' ],
 	accessPurchases: [ '/me/purchases' ],


### PR DESCRIPTION


## Proposed Changes
* Update the /sites command palette to use the hosted-site-migration flow

## Why are these changes being made?
* We want to centralize all import/migration flows over the use the `hosted-site-migration.

## Testing Instructions
* `Go to /sites` 
* Type `cmd + k` 
* Type "Import"
* Select "Import site to WordPress.com"
* Check if you have been redirected to the `/setup/hosted-site-migration`


![CleanShot 2025-03-11 at 16 34 42@2x](https://github.com/user-attachments/assets/63b142ba-8f30-4052-9bb8-afb2c7093194)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
