### PR TITLE
Site Selector: Add keyboard focus and styles to dropdown

### DIFF
--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -107,7 +107,7 @@ export class SitesDropdown extends PureComponent {
 					{ this.props.hasMultipleSites && this.state.open && (
 						<SiteSelector
 							// eslint-disable-next-line jsx-a11y/no-autofocus
-							autoFocus={ false }
+							autoFocus
 							onClose={ this.onClose }
 							onSiteSelect={ this.selectSite }
 							selected={ this.state.selectedSiteId }

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -74,6 +74,13 @@ export class SitesDropdown extends PureComponent {
 
 	handleKeyDown = ( event ) => {
 		if ( event.key === 'Enter' || event.keyCode === 13 ) {
+			// Without this event.preventDefault, this keydown event will
+			// somehow trigger the site selector to navigate to /me/?
+			// though it's unclear why. This seems related to the
+			// fact that pressing Enter while focused on a blank search input
+			// on the /me/account page will also cause navigation to happen.
+			// We can remove this once we find out how to prevent that
+			// erroneous navigation from happening with the search input.
 			if ( ! this.state.open ) {
 				event.preventDefault();
 			}

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -73,8 +73,10 @@ export class SitesDropdown extends PureComponent {
 	}
 
 	handleKeyDown = ( event ) => {
-		// Check if Enter key is pressed (key code 13)
 		if ( event.key === 'Enter' || event.keyCode === 13 ) {
+			if ( ! this.state.open ) {
+				event.preventDefault();
+			}
 			this.toggleOpen( event );
 		}
 	};

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -72,6 +72,13 @@ export class SitesDropdown extends PureComponent {
 		this.props.onClose && this.props.onClose( e );
 	}
 
+	handleKeyDown = ( event ) => {
+		// Check if Enter key is pressed (key code 13)
+		if ( event.key === 'Enter' || event.keyCode === 13 ) {
+			this.toggleOpen( event );
+		}
+	};
+
 	render() {
 		return (
 			<div
@@ -83,7 +90,13 @@ export class SitesDropdown extends PureComponent {
 			>
 				<div className="sites-dropdown__wrapper">
 					{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */ }
-					<div className="sites-dropdown__selected" onClick={ this.toggleOpen }>
+					<div
+						className="sites-dropdown__selected"
+						onClick={ this.toggleOpen }
+						onKeyDown={ this.handleKeyDown }
+						// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+						tabIndex={ 0 }
+					>
 						{ this.props.isPlaceholder ? (
 							<SitePlaceholder />
 						) : (
@@ -94,7 +107,7 @@ export class SitesDropdown extends PureComponent {
 					{ this.props.hasMultipleSites && this.state.open && (
 						<SiteSelector
 							// eslint-disable-next-line jsx-a11y/no-autofocus
-							autoFocus
+							autoFocus={ false }
 							onClose={ this.onClose }
 							onSiteSelect={ this.selectSite }
 							selected={ this.state.selectedSiteId }

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -63,12 +63,14 @@
 			color: var(--color-neutral-50);
 		}
 	}
+}
 
-	svg {
+.accessible-focus .sites-dropdown__selected {
+	svg.gridicons-chevron-down {
 		box-sizing: border-box;
 	}
 
-	&:focus svg {
+	&:focus svg.gridicons-chevron-down {
 		border: 2px solid var(--color-primary);
 		border-radius: 2px;
 	}

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -65,15 +65,10 @@
 	}
 }
 
-.accessible-focus .sites-dropdown__selected {
-	svg.gridicons-chevron-down {
-		box-sizing: border-box;
-	}
-
-	&:focus svg.gridicons-chevron-down {
-		border: 2px solid var(--color-primary);
-		border-radius: 2px;
-	}
+.accessible-focus .sites-dropdown__selected:focus svg.gridicons-chevron-down {
+	box-sizing: border-box;
+	border: 2px solid var(--color-primary);
+	border-radius: 2px;
 }
 
 .sites-dropdown .site-selector {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -63,6 +63,15 @@
 			color: var(--color-neutral-50);
 		}
 	}
+
+	svg {
+		box-sizing: border-box;
+	}
+
+	&:focus svg {
+		border: 2px solid var(--color-primary);
+		border-radius: 2px;
+	}
 }
 
 .sites-dropdown .site-selector {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/559

## Proposed Changes

- Adds `tabIndex` and a key event listener to the site selector dropdown
- Adds styles to the SVG when the dropdown has focus 

<img width="778" alt="Screenshot 2025-03-11 at 17 30 39" src="https://github.com/user-attachments/assets/0293e18f-fe9c-4fd4-af98-bb08a7993f59" />

<img width="1120" alt="Screenshot 2025-03-11 at 17 31 10" src="https://github.com/user-attachments/assets/8465154e-1fac-407d-a951-d4c6fa104fc6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- The Site Selector dropdown should be able to receive keyboard focus when opening

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure you can navigate to the selector dropdown by tabbing at the following URLs, selecting the chevron, and pressing Enter:
- Visit `/me/account`
- Visit `/reader?flags=reader/quick-post`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
