### PR TITLE
Subscribers Jetpack Empty State: Fix fixMe text

### DIFF
--- a/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
@@ -86,7 +86,9 @@ const JetpackEmptyListView = () => {
 			</h2>
 			<p className="jetpack-empty-list-view__description">
 				{ i18n.fixMe( {
-					text: translate( 'No subscribers yet? Turn your site visitors into subscribers.' ),
+					text: translate(
+						'No subscribers yet? {{howToTurnVisitorsLink}}Turn your site visitors into subscribers.{{/howToTurnVisitorsLink}}'
+					),
 					newCopy: translate(
 						'No subscribers yet? {{howToTurnVisitorsLink}}Turn your site visitors into subscribers.{{/howToTurnVisitorsLink}}',
 						{

--- a/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
@@ -86,9 +86,7 @@ const JetpackEmptyListView = () => {
 			</h2>
 			<p className="jetpack-empty-list-view__description">
 				{ i18n.fixMe( {
-					text: translate(
-						'No subscribers yet? {{howToTurnVisitorsLink}}Turn your site visitors into subscribers.{{/howToTurnVisitorsLink}}'
-					),
+					text: 'No subscribers yet? Turn your site visitors into subscribers.',
 					newCopy: translate(
 						'No subscribers yet? {{howToTurnVisitorsLink}}Turn your site visitors into subscribers.{{/howToTurnVisitorsLink}}',
 						{

--- a/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
@@ -86,7 +86,7 @@ const JetpackEmptyListView = () => {
 			</h2>
 			<p className="jetpack-empty-list-view__description">
 				{ i18n.fixMe( {
-					text: 'No subscribers yet? Turn your site visitors into subscribers.',
+					text: 'No subscribers yet? {{howToTurnVisitorsLink}}Turn your site visitors into subscribers.{{/howToTurnVisitorsLink}}',
 					newCopy: translate(
 						'No subscribers yet? {{howToTurnVisitorsLink}}Turn your site visitors into subscribers.{{/howToTurnVisitorsLink}}',
 						{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101008

## Proposed Changes

* Fix fixMe text

<img width="1628" alt="Screen Shot 2025-03-11 at 10 42 44 AM" src="https://github.com/user-attachments/assets/4996350d-39ab-4e6b-8bf5-00c5cf302f46" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix duplicate translation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
