### PR TITLE
Newsletters: Show back button on signup

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -139,10 +139,6 @@ const newsletter: Flow = {
 			}
 		}
 
-		const goBack = () => {
-			return;
-		};
-
 		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
@@ -161,7 +157,7 @@ const newsletter: Flow = {
 			navigate( step );
 		};
 
-		return { goNext, goBack, goToStep, submit };
+		return { goNext, goToStep, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -2,7 +2,6 @@ import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
 import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -26,9 +25,6 @@ import type { Flow } from '../../internals/types';
 const newsletter: Flow = {
 	name: NEWSLETTER_FLOW,
 	__experimentalUseBuiltinAuth: true,
-	get title() {
-		return translate( 'Newsletter' );
-	},
 	isSignupFlow: true,
 	useSteps() {
 		const query = useQuery();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-goals/index.tsx
@@ -35,9 +35,9 @@ const NewsletterGoals: Step = ( { navigation } ) => {
 
 	return (
 		<StepContainer
+			goBack={ navigation.goBack }
 			stepName="newsletter-type"
 			isWideLayout
-			hideBack
 			flowName="newsletter"
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -95,9 +95,9 @@ const NewsletterSetup: Step< {
 
 	return (
 		<StepContainer
+			goBack={ navigation.goBack }
 			stepName="newsletter-setup"
 			isWideLayout
-			hideBack
 			flowName="newsletter"
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -97,6 +97,7 @@ const NewsletterSetup: Step< {
 		<StepContainer
 			stepName="newsletter-setup"
 			isWideLayout
+			hideBack
 			flowName="newsletter"
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -97,7 +97,6 @@ const NewsletterSetup: Step< {
 		<StepContainer
 			stepName="newsletter-setup"
 			isWideLayout
-			hideBack
 			flowName="newsletter"
 			formattedHeader={
 				<FormattedHeader


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100574

## Proposed Changes

* Add the back button and remove the custom header.
<img width="1773" alt="Screenshot 2025-03-13 at 11 15 51" src="https://github.com/user-attachments/assets/d78929b9-8862-4ceb-a6a8-98210fe269fe" />

<img width="1033" alt="Screenshot 2025-03-28 at 15 24 52" src="https://github.com/user-attachments/assets/6555071b-06e0-44a4-91ab-8b6c3aee9008" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For consistency with other flows

## Testing Instructions

* Go to http://calypso.localhost:3000/setup/newsletter/intro and click "Launch my newsletter". You'll be taken...
* ...to http://calypso.localhost:3000/setup/newsletter/newsletterSetup?ref=newsletter-lp. Confirm that the page title is replaced by the back button.... fill in some details and click continue
* The next screen should also contain a back button.

## Other considerations:

1. There are sure to be other flows that use this pattern. Rather than just fixing this one, should we address them all in a more wholistic manner?
2. The back button currently goes to https://wordpress.com/newsletter/. Is this always the behaviour we want?
3. The page title contains an H1. Removing this has an impact on the semantics of the page which probably has accessibility and SEO considerations also.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/newsletter/newsletterSetup?ref=newsletter-lp and confirm you no longer see the custom header on this signup flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
