### PR TITLE
A4A: check connection status for woopayments

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -7,6 +7,7 @@ import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/s
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useFetchTestConnection } from '../../sites/hooks/use-fetch-test-connection';
 
 export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
@@ -24,6 +25,8 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const jetpackConnectionStatus = useFetchTestConnection( true, true, siteId );
+
 	if ( ! state ) {
 		return (
 			<Button
@@ -39,18 +42,19 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 	}
 
 	const getStatusProps = () => {
-		switch ( state ) {
-			case 'active':
-				return {
-					statusText: translate( 'Active' ),
-					statusType: 'success',
-				};
-			default:
-				return {
-					statusText: translate( 'Disconnected' ),
-					statusType: 'warning',
-				};
+		const isActive = jetpackConnectionStatus?.data?.connected && state === 'active';
+
+		if ( isActive ) {
+			return {
+				statusText: translate( 'Active' ),
+				statusType: 'success',
+			};
 		}
+
+		return {
+			statusText: translate( 'Disconnected' ),
+			statusType: 'warning',
+		};
 	};
 
 	const statusProps = getStatusProps();

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -7,7 +7,6 @@ import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/s
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { useFetchTestConnection } from '../../sites/hooks/use-fetch-test-connection';
 
 export const SiteColumn = ( { site }: { site: string } ) => {
 	return urlToSlug( site );
@@ -25,8 +24,6 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const jetpackConnectionStatus = useFetchTestConnection( true, true, siteId );
-
 	if ( ! state ) {
 		return (
 			<Button
@@ -42,19 +39,20 @@ export const WooPaymentsStatusColumn = ( { state, siteId }: { state: string; sit
 	}
 
 	const getStatusProps = () => {
-		const isActive = jetpackConnectionStatus?.data?.connected && state === 'active';
-
-		if ( isActive ) {
-			return {
-				statusText: translate( 'Active' ),
-				statusType: 'success',
-			};
+		switch ( state ) {
+			case 'active':
+				return {
+					statusText: translate( 'Active' ),
+					statusType: 'success',
+				};
+			case 'disconnected':
+				return {
+					statusText: translate( 'Disconnected' ),
+					statusType: 'error',
+				};
+			default:
+				return null;
 		}
-
-		return {
-			statusText: translate( 'Disconnected' ),
-			statusType: 'warning',
-		};
 	};
 
 	const statusProps = getStatusProps();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1901

## Proposed Changes

We need to check connection status (Jetpack or A4A plugin) when determining if woopayments are properly connected.

<img width="682" alt="Screenshot 2025-03-11 at 10 43 35 AM" src="https://github.com/user-attachments/assets/23c44f6d-42e9-41df-8b6d-8ed7589467aa" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- You need a new JN site connected with A4A plugin.
- Navigate to `/woopayments/dashboard` and add woopayments to it.
- Verify status as active for the site.
- If you have a stale JN site verify.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
