### PR TITLE
Reader: Update editor iframe styles

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -167,6 +167,11 @@ function QuickPost( {
 						onChange={ setPostContent }
 						isRTL={ isLocaleRtl( locale ) ?? false }
 						isDarkMode={ false }
+						customStyles={ `
+							div.is-root-container.block-editor-block-list__layout {
+								padding-bottom: 20px;
+							}
+						` }
 					/>
 				</div>
 			</div>

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -70,4 +70,9 @@
 			border-top-width: 0;
 		}
 	}
+
+	.verbum-editor-wrapper .editor__main,
+	.verbum-editor-wrapper .editor__main iframe {
+		min-height: 80px;
+	}
 }

--- a/packages/verbum-block-editor/src/editor/editor-types.ts
+++ b/packages/verbum-block-editor/src/editor/editor-types.ts
@@ -5,6 +5,7 @@ export interface EditorProps {
 	onChange: ( content: string ) => void;
 	isRTL: boolean;
 	isDarkMode: boolean;
+	customStyles?: string;
 }
 
 export interface StateWithUndoManager {

--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -35,6 +35,7 @@ export const Editor: FC< EditorProps > = ( {
 	onChange,
 	isRTL,
 	isDarkMode,
+	customStyles = '',
 } ) => {
 	// We keep the content in state so we can access the blocks in the editor.
 	const {
@@ -116,6 +117,11 @@ export const Editor: FC< EditorProps > = ( {
 					useSubRegistry
 					onInput={ handleContentUpdate }
 					onChange={ handleContentUpdate }
+					styles={ [
+						{
+							css: isDarkMode ? iframedCSS + darkModeCss + customStyles : iframedCSS + customStyles,
+						},
+					] }
 				>
 					<div className={ clsx( 'editor__header', { 'is-editing': isEditing } ) }>
 						<div className="editor__header-wrapper">
@@ -131,7 +137,13 @@ export const Editor: FC< EditorProps > = ( {
 						<Popover.Slot />
 						<BlockTools>
 							<BlockCanvas
-								styles={ [ { css: isDarkMode ? iframedCSS + darkModeCss : iframedCSS } ] }
+								styles={ [
+									{
+										css: isDarkMode
+											? iframedCSS + darkModeCss + customStyles
+											: iframedCSS + customStyles,
+									},
+								] }
 								height={ contentHeight }
 							>
 								{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */ }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/562

## Proposed Changes

- Adds styles for the editor in the Quick Edit component
- Creates a new `customStyles` prop that allows us to customize the styles for the iframe

### Before

<img width="775" alt="Screenshot 2025-03-11 at 20 01 24" src="https://github.com/user-attachments/assets/4f371982-94d6-4e53-ac0d-d855d581c125" />

### After

<img width="789" alt="Screenshot 2025-03-11 at 20 00 54" src="https://github.com/user-attachments/assets/4f21b16e-05b5-4a41-bee2-70ed04abf4cc" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Reduce height and improve appearance of the editor

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader?flags=reader/quick-post`
- Make sure the new styles are applied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
