### PR TITLE
Fix: Domains step: Update UI alignment on Your domains section.

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -187,6 +187,7 @@ body.is-section-stepper .domains__step-content,
 				min-width: 50px;
 				margin-right: 10px;
 				text-align: left;
+				text-decoration: underline;
 			}
 
 			.domain-product-price__price {
@@ -242,6 +243,7 @@ body.is-section-stepper .domains__step-content,
 			height: 40px;
 			color: var(--studio-gray-100);
 			text-decoration: underline;
+			text-align: left;
 			margin-top: 5px;
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/100294

This PR underlines the remove link and left aligns the "Choose my domain later' link on the domains checkout page.

## Screenshot
<img width="1477" alt="Screenshot 2025-03-11 at 19 13 31" src="https://github.com/user-attachments/assets/dbd6f7e2-dc6c-4be3-a110-030e206b99ec" />


## Testing Instructions

- Create a site starting from wordpress.com/setup/onboarding
- Make your way to the domains screen
- Pick a domain
- Verify the UI matches the screen above namely:
	- The remove link should be underlined.
	- The "Choose my domain later' link should be left aligned.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
