### PR TITLE
Reader - Recent / dataView - fix pagination footer placement.

### DIFF
--- a/client/reader/recent/style.scss
+++ b/client/reader/recent/style.scss
@@ -32,7 +32,7 @@ body.is-reader-full-post {
 		box-shadow: 0 0 17.4px 0 rgba( 0, 0, 0, 0.05 );
 	}
 
-	&__list-column {
+	.recent-feed__list-column {
 		$feed-list-header-height: 70px;
 		$feed-list-actions-height: 65px;
 		$feed-list-footer-height: 57px;
@@ -58,7 +58,7 @@ body.is-reader-full-post {
 			max-width: 320px;
 		}
 
-		&-header {
+		.recent-feed__list-column-header {
 			padding: 16px $recent-feed-spacing;
 			border-bottom: 1px solid var( --studio-gray-0 );
 
@@ -66,7 +66,7 @@ body.is-reader-full-post {
 				align-items: center;
 			}
 
-			header {
+			header.navigation-header {
 				margin: 0;
 				padding: 0;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Fixes the placement of the pagination footer in dataViews recent view.
* There was very little specificity for the `display: none` on the after pseudo element for the header used in this panel. [Recent changes from a few weeks](https://github.com/Automattic/wp-calypso/pull/99959) ago overwrote that with highly specific navigation-header styles. This caused the header to be larger than expected and the calculated height of the posts list to then be too long to show the pagination footer. Here we apply more specificity for this specific navigation-header. Less specificity is good when we have general component usage, more specificity is good when we have special cases that need to ensure their own specific styles. This is the latter.

BEFORE
![Screenshot 2025-03-11 at 3 58 52 PM](https://github.com/user-attachments/assets/baa0d3a3-910b-4088-9690-f88827a2ed56)

AFTER
![Screenshot 2025-03-11 at 3 59 15 PM](https://github.com/user-attachments/assets/6bf4816b-7244-407a-8cf9-9420fe0e4fab)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Boken pagination in recent dataview.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader
* verify the pagination footer in recent dataView is visible again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
