### PR TITLE
Stepper: Remove deprecated sync steps from Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/test/index.tsx
@@ -15,7 +15,12 @@ const mockFlow: Flow = {
 	name: 'some-flow',
 	isSignupFlow: false,
 	useSteps() {
-		return [ { slug: 'some-step', component: () => <div>Step 1</div> } ];
+		return [
+			{
+				slug: 'some-step',
+				asyncComponent: () => Promise.resolve( { default: () => <div>Step 1</div> } ),
+			},
+		];
 	},
 	useStepNavigation() {
 		return {};

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -40,16 +40,12 @@ function flowStepComponent( flowStep: StepperStep | undefined ) {
 		return null;
 	}
 
-	if ( 'asyncComponent' in flowStep ) {
-		let lazyComponent = lazyCache.get( flowStep.asyncComponent );
-		if ( ! lazyComponent ) {
-			lazyComponent = lazy( flowStep.asyncComponent );
-			lazyCache.set( flowStep.asyncComponent, lazyComponent );
-		}
-		return lazyComponent;
+	let lazyComponent = lazyCache.get( flowStep.asyncComponent );
+	if ( ! lazyComponent ) {
+		lazyComponent = lazy( flowStep.asyncComponent );
+		lazyCache.set( flowStep.asyncComponent, lazyComponent );
 	}
-
-	return flowStep.component;
+	return lazyComponent;
 }
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -42,23 +42,6 @@ export type NavigationControls = {
 	exitFlow?: ( to: string ) => void;
 };
 
-export type DeprecatedStepperStep = {
-	/**
-	 * The step slug is what appears as part of the pathname. Eg the intro in /setup/link-in-bio/intro
-	 */
-	slug: string;
-	/**
-	 * Does the step require a logged-in user?
-	 */
-	requiresLoggedInUser?: boolean;
-	/**
-	 * @deprecated Use asyncComponent instead. The component that will be rendered for this step. This variation is deprecated and will be removed in the future. Please use async loaded steps instead
-	 *
-	 * It should look like this: component: () => import( './internals/steps-repository/newsletter-setup' )
-	 */
-	component: React.FC< StepProps >;
-};
-
 export type AsyncStepperStep = {
 	/**
 	 * The step slug is what appears as part of the pathname. Eg the intro in /setup/link-in-bio/intro
@@ -83,7 +66,7 @@ export interface AsyncUserStep extends AsyncStepperStep {
 	slug: 'user';
 }
 
-export type StepperStep = DeprecatedStepperStep | AsyncStepperStep | AsyncUserStep;
+export type StepperStep = AsyncStepperStep | AsyncUserStep;
 
 /**
  * Navigates to a step in the current flow. Preserves the current query params.


### PR DESCRIPTION
Remove `DeprecatedStepperStep` since it's no longer used.