### PR TITLE
Reader getPostIcon: check site_icon for null or empty array

### DIFF
--- a/client/reader/get-helpers.ts
+++ b/client/reader/get-helpers.ts
@@ -92,8 +92,8 @@ export const getFeedUrl = ( { feed, site, post }: GetFeedUrlArgs = {} ) => {
  * Given a feed, site, or post: return the site icon. return false if one could not be found.
  */
 export function getPostIcon( post: Partial< ReaderPost > ): string | undefined {
-	if ( typeof post?.site_icon === 'object' ) {
-		return post.site_icon?.img;
+	if ( post?.site_icon && typeof post?.site_icon === 'object' && 'img' in post.site_icon ) {
+		return post.site_icon.img;
 	}
 
 	if ( typeof post?.site_icon === 'string' ) {

--- a/client/reader/get-helpers.ts
+++ b/client/reader/get-helpers.ts
@@ -92,7 +92,7 @@ export const getFeedUrl = ( { feed, site, post }: GetFeedUrlArgs = {} ) => {
  * Given a feed, site, or post: return the site icon. return false if one could not be found.
  */
 export function getPostIcon( post: Partial< ReaderPost > ): string | undefined {
-	if ( post?.site_icon && typeof post?.site_icon === 'object' && 'img' in post.site_icon ) {
+	if ( typeof post?.site_icon === 'object' && post?.site_icon?.img ) {
 		return post.site_icon.img;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* in `getPostIcon` it's possible that `post?.site_icon` is `null` or an empty array. In both of these cases, that passes the `post?.site_icon === 'object'` check causing `getPostIcon` to return `post.site_icon?.img` which is `undefined`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix a bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Subscribe to a site without a site icon and view the site in the Recent / dataview view. The user profile should be used for the site icon.
* Subscribe to https://old.reddit.com/r/Austin/.rss. The user profile should be an RSS icon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
