### PR TITLE
Improve "Add new site" modal on site dashboard.

### DIFF
--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -59,7 +59,7 @@ export const Content = () => {
 	const hasEnTranslation = useHasEnTranslation();
 	return (
 		<>
-			<Column heading={ translate( 'Add a new site' ) }>
+			<Column heading={ translate( 'Add new site' ) }>
 				<MenuItem
 					icon={ <WordPressLogo /> }
 					heading={ translate( 'WordPress.com' ) }
@@ -81,10 +81,10 @@ export const Content = () => {
 					} }
 				/>
 			</Column>
-			<Column heading={ translate( 'Migrate & Import' ) }>
+			<Column heading={ translate( 'Migrate and Import' ) }>
 				<MenuItem
 					icon={ <Icon icon={ reusableBlock } size={ 18 } /> }
-					heading="Migrate"
+					heading={ translate( 'Migrate' ) }
 					description={ preventWidows(
 						hasEnTranslation( 'Bring your entire WordPress site to WordPress.com.' )
 							? translate( 'Bring your entire WordPress site to WordPress.com.' )
@@ -96,7 +96,7 @@ export const Content = () => {
 				/>
 				<MenuItem
 					icon={ <Icon icon={ download } size={ 18 } /> }
-					heading="Import"
+					heading={ translate( 'Import' ) }
 					description={ preventWidows(
 						hasEnTranslation( 'Use a backup to only import content from other platforms.' )
 							? translate( 'Use a backup to only import content from other platforms.' )

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import AddNewSiteButton from './button';
 import { AsyncContent } from './content/async';
 import './style.scss';

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Popover } from '@wordpress/components';
+import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback, PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import AddNewSiteButton from './button';
 import { AsyncContent } from './content/async';
 import './style.scss';
@@ -11,31 +11,31 @@ interface Props extends PropsWithChildren {
 }
 
 export const SitesAddNewSitePopover = ( { showCompact }: Props ) => {
-	const [ isOpen, setIsOpen ] = useState< boolean >( false );
 	const translate = useTranslate();
 
-	const toggleMenu = useCallback( () => {
-		if ( ! isOpen ) {
-			recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_open' );
-		}
-		setIsOpen( ( open ) => ! open );
-	}, [ isOpen ] );
-
 	return (
-		<AddNewSiteButton
-			showMainButtonLabel={ ! showCompact }
-			mainButtonLabelText={ translate( 'Add new site' ) }
-			isMenuVisible={ isOpen }
-			isPrimary={ ! showCompact }
-			toggleMenu={ toggleMenu }
-		>
-			{ isOpen && (
-				<Popover noArrow={ false } placement="bottom-end" offset={ 10 }>
-					<div className="sites-add-new-site__popover-content">
-						<AsyncContent />
-					</div>
-				</Popover>
+		<Dropdown
+			popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false } }
+			focusOnMount
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<AddNewSiteButton
+					showMainButtonLabel={ ! showCompact }
+					mainButtonLabelText={ translate( 'Add new site' ) }
+					isMenuVisible={ isOpen }
+					isPrimary={ ! showCompact }
+					toggleMenu={ onToggle }
+				/>
 			) }
-		</AddNewSiteButton>
+			renderContent={ () => (
+				<div className="sites-add-new-site__popover-content">
+					<AsyncContent />
+				</div>
+			) }
+			onToggle={ ( isOpen ) => {
+				if ( isOpen ) {
+					recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_open' );
+				}
+			} }
+		/>
 	);
 };

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,9 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import type { PropsWithChildren } from 'react';
 import AddNewSiteButton from './button';
 import { AsyncContent } from './content/async';
+import type { PropsWithChildren } from 'react';
 import './style.scss';
 
 interface Props extends PropsWithChildren {

--- a/client/components/sites-add-new-site/test/index.tsx
+++ b/client/components/sites-add-new-site/test/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { SitesAddNewSitePopover } from '../index';
+
+// Mock dependencies
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+	localize: ( x ) => x,
+} ) );
+
+// Mock the AsyncContent component to avoid loading issues in tests
+jest.mock( '../content/async', () => ( {
+	AsyncContent: () => <div data-testid="async-content">Async Content</div>,
+} ) );
+
+describe( 'SitesAddNewSitePopover', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders with full label when not in compact mode', () => {
+		render( <SitesAddNewSitePopover showCompact={ false } /> );
+		expect( screen.getByText( 'Add new site' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders without label in compact mode', () => {
+		render( <SitesAddNewSitePopover showCompact /> );
+		expect( screen.queryByText( 'Add new site' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'tracks event when dropdown is opened', () => {
+		render( <SitesAddNewSitePopover showCompact={ false } /> );
+		const button = screen.getByRole( 'button' );
+		fireEvent.click( button );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_sites_dashboard_new_site_action_click_open'
+		);
+	} );
+
+	it( 'closes popover when clicking the button again', () => {
+		render( <SitesAddNewSitePopover showCompact={ false } /> );
+		const button = screen.getByRole( 'button' );
+		fireEvent.click( button );
+		expect( screen.getByTestId( 'async-content' ) ).toBeInTheDocument();
+
+		// Click button again
+		fireEvent.click( button );
+		expect( screen.queryByTestId( 'async-content' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/components/sites-add-new-site/test/index.tsx
+++ b/client/components/sites-add-new-site/test/index.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { SitesAddNewSitePopover } from '../index';
 
@@ -45,7 +45,7 @@ describe( 'SitesAddNewSitePopover', () => {
 		);
 	} );
 
-	it( 'closes popover when clicking the button again', () => {
+	it( 'closes popover when clicking the button again', async () => {
 		render( <SitesAddNewSitePopover showCompact={ false } /> );
 		const button = screen.getByRole( 'button' );
 		fireEvent.click( button );
@@ -53,6 +53,8 @@ describe( 'SitesAddNewSitePopover', () => {
 
 		// Click button again
 		fireEvent.click( button );
-		expect( screen.queryByTestId( 'async-content' ) ).not.toBeInTheDocument();
+		await waitFor( () => {
+			expect( screen.queryByTestId( 'async-content' ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100292

Related: #98830.

## Proposed Changes

_Taken from #100292_

- [x] The "Add a new site" subtitle doesn't match the button copy. It should be "Add new site".
- [x] The ampersand in Migrate + Import hampers readability. It should be "Migrate and Import".
- [x] When you click outside the dropdown, it should close like all out other menus dropdown menus do.
   - [x] Users can't tab through dropdown menu .


| Before | After |
|--------|--------|
| <img width="1032" alt="Screenshot 2025-03-12 at 1 37 28 PM" src="https://github.com/user-attachments/assets/09b5fcc9-7fe8-4a7e-b0ee-a3b01d174473" /> | <img width="1031" alt="Screenshot 2025-03-12 at 1 38 20 PM" src="https://github.com/user-attachments/assets/3babe040-b8d2-4d93-a851-b7a899057c41" /> | 

## Why are these changes being made?

These changes bring the experience more aligned across the product.

## Testing Instructions

**Test tabbing**
1. Visit wp.com/sites
2. Tab into the "Add new site" button
3. Tab through items, close dropdown with `ESC` button
4. Expect modal to close

**Test clicking away**
1. Visit wp.com/sites
2. Click "Add new site" button
3. Click away from modal
4. Expect modal to close

**Test button**
1. Visit wp.com/sites
2. Click "Add new site" button
3. Click on button again
4. Expect modal to clear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
