### PR TITLE
AVLN-6 Partner Portal: Remove loading screen for the Partner Portal flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -40,7 +40,11 @@ import {
 	recordSignupPlanChange,
 	SIGNUP_DOMAIN_ORIGIN,
 } from 'calypso/lib/analytics/signup';
-import { isWooOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isWooOAuth2Client,
+	isGravatarOAuth2Client,
+	isPartnerPortalOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
@@ -428,8 +432,12 @@ class Signup extends Component {
 	};
 
 	updateShouldShowLoadingScreen = ( progress = this.props.progress ) => {
-		if ( isWooOAuth2Client( this.props.oauth2Client ) || this.props.isGravatar ) {
-			// We don't want to show the loading screen for the Woo signup, and Gravatar signup flow.
+		if (
+			isWooOAuth2Client( this.props.oauth2Client ) ||
+			this.props.isGravatar ||
+			isPartnerPortalOAuth2Client( this.props.oauth2Client )
+		) {
+			// We don't want to show the loading screen for the Woo signup, Automattic Partner Portal, and Gravatar signup flow.
 			return;
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -706,7 +706,11 @@ export class UserStep extends Component {
 	}
 
 	render() {
-		if ( this.userCreationComplete() && ! this.props.isWCCOM ) {
+		if (
+			this.userCreationComplete() &&
+			! this.props.isWCCOM &&
+			! isPartnerPortalOAuth2Client( this.props.oauth2Client )
+		) {
 			return null; // return nothing so that we don't see the completed signup form flash but skip for Woo because it need to keep the form until the user is redirected back to original page (e.g. WooCommerce.com).
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-avalon/issues/525

## Proposed Changes

* This PR removes the loading screen upon user creation for the Partner Portal

## Why are these changes being made?

*

## Testing Instructions

1. Start your Calypso local dev on this branch.
2. Open an incognito window and navigate to [https://hosts.automattic.com/wpcloud/](https://hosts.automattic.com/wpcloud/).
3. You should be presented with the generic WPCOM oAuth login.
4. In the URL bar of your browser, replace the `https://wordpress.com` part with `https://calypso.localhost:3000`.
5. Next, click on "Create a new account" at the bottom. 
6. No load screens ( e.g. `Building your site` ) should be presented.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
