### PR TITLE
Domains: Add translation for TLD filter "All"

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -583,7 +583,8 @@ class RegisterDomainStep extends Component {
 			return { key: `${ tld }`, text: `.${ tld }` };
 		} );
 
-		items.unshift( { key: 'all', text: 'All' } );
+		// translators: filter label displayed when all TLDs are enabled
+		items.unshift( { key: 'all', text: this.props.translate( 'All' ) } );
 
 		const handleClick = ( index ) => {
 			const option = items[ index ].key;


### PR DESCRIPTION
## Proposed Changes
Quick fix to add a translation to a button that was not translated:

![image](https://github.com/user-attachments/assets/c9ea3ba9-ae89-4d2b-b93e-34da0dfc3bd8)


## Why are these changes being made?
Because not only English must be supported 😬 

## Testing Instructions
Just load `/domains/add/{YOUR_SITE_SLUG}?domainAndPlanPackage=true&domain=true` and ensure everything looks fine.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [X] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
