### PR TITLE
Payment methods: tweak border styles to remove radius and border on inactive/disabled items

### DIFF
--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -23,11 +23,9 @@ const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
 const CheckoutPaymentMethodsWrapper = styled.div`
 	padding-top: 4px;
-
-	&
-		> div:has( > div:not( .is-checked )[disabled]:hover )
-		> div:not( .is-checked ):not( :hover )[disabled]::before {
-		border: none;
+	> div > div[disabled]:has( + div[disabled]:hover )::before,
+	> div > div[disabled]:has( + div.is-checked[disabled] )::before {
+		border-bottom: none;
 	}
 `;
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -23,7 +23,7 @@ const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
 const CheckoutPaymentMethodsWrapper = styled.div`
 	padding-top: 4px;
-	> div > div[disabled]:has( + div[disabled]:hover )::before,
+	> div > div:not( [disabled] ):has( + div:hover )::before,
 	> div > div[disabled]:has( + div.is-checked[disabled] )::before {
 		border-bottom: none;
 	}

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -23,6 +23,12 @@ const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
 const CheckoutPaymentMethodsWrapper = styled.div`
 	padding-top: 4px;
+
+	&
+		> div:has( > div:not( .is-checked )[disabled]:hover )
+		> div:not( .is-checked ):not( :hover )[disabled]::before {
+		border: none;
+	}
 `;
 
 export default function CheckoutPaymentMethods( {

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import * as React from 'react';
@@ -25,7 +26,7 @@ const RadioButtonWrapper = styled.div<
 		border: ${ ( props ) => ( props.checked ? '1px solid ' + getBorderColor( props ) : 'none' ) };
 		border-bottom: ${ ( props ) => '1px solid ' + getBorderColor( props ) };
 		box-sizing: border-box;
-		border-radius: 3px;
+		border-radius: ${ ( props ) => ( props.checked ? '3px' : 0 ) };
 
 		.rtl & {
 			right: 0;
@@ -209,6 +210,7 @@ export default function RadioButton( {
 			isFocused={ isFocused }
 			checked={ checked }
 			hidden={ hidden }
+			className={ clsx( { 'is-checked': checked } ) }
 		>
 			<Radio
 				type="radio"
@@ -266,7 +268,6 @@ function handleWrapperDisabled( { disabled }: { disabled?: boolean } ) {
 	}
 
 	return `
-		::before,
 		:hover::before {
 			border: 1px solid lightgray;
 		}

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -208,7 +208,7 @@ export default function RadioButton( {
 			isFocused={ isFocused }
 			checked={ checked }
 			hidden={ hidden }
-			className={ checked ? 'is-checked' : '' }
+			className={ `${ checked ? 'is-checked' : '' }` }
 		>
 			<Radio
 				type="radio"

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import * as React from 'react';
@@ -209,7 +208,7 @@ export default function RadioButton( {
 			isFocused={ isFocused }
 			checked={ checked }
 			hidden={ hidden }
-			className={ clsx( { 'is-checked': checked } ) }
+			className={ checked ? 'is-checked' : '' }
 		>
 			<Radio
 				type="radio"

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -268,7 +268,13 @@ function handleWrapperDisabled( { disabled }: { disabled?: boolean } ) {
 	}
 
 	return `
-		:hover::before {
+		:hover:not( :first-child )::before {
+			border: 1px solid lightgray;
+			border-radius: 3px;
+		}
+
+		:hover:first-child::before,
+		:hover:last-child::before {
 			border: 1px solid lightgray;
 		}
 

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -27,7 +27,6 @@ const RadioButtonWrapper = styled.div<
 		border-bottom: ${ ( props ) => '1px solid ' + getBorderColor( props ) };
 		box-sizing: border-box;
 		border-radius: ${ ( props ) => ( props.checked ? '3px' : 0 ) };
-
 		.rtl & {
 			right: 0;
 			left: auto;
@@ -36,6 +35,7 @@ const RadioButtonWrapper = styled.div<
 
 	:hover::before {
 		border: 3px solid ${ ( props ) => props.theme.colors.highlight };
+		border-radius: 3px;
 	}
 
 	.payment-logos {
@@ -203,7 +203,6 @@ export default function RadioButton( {
 	...otherProps
 }: RadioButtonProps ) {
 	const [ isFocused, changeFocus ] = useState( false );
-
 	return (
 		<RadioButtonWrapper
 			disabled={ disabled }
@@ -262,28 +261,36 @@ RadioButton.propTypes = {
 	ariaLabel: PropTypes.string,
 };
 
-function handleWrapperDisabled( { disabled }: { disabled?: boolean } ) {
+function handleWrapperDisabled( { disabled, checked }: { disabled?: boolean; checked?: boolean } ) {
 	if ( ! disabled ) {
 		return null;
 	}
 
-	return `
-		:hover:not( :first-child )::before {
-			border: 1px solid lightgray;
-			border-radius: 3px;
-		}
-
-		:hover:first-child::before,
-		:hover:last-child::before {
-			border: 1px solid lightgray;
-		}
-
+	const styles = `
 		svg,
 		:hover svg {
 			filter: grayscale( 100% );
 			opacity: 50%;
 		}
+		:hover::before {
+			border-width: 1px;
+		}
 	`;
+
+	if ( ! checked ) {
+		return (
+			styles +
+			`
+			:hover::before {
+				border: none;
+				border-bottom: 1px solid lightgray;
+				border-radius: 0;
+			}
+		`
+		);
+	}
+
+	return styles;
 }
 
 function handleLabelDisabled( { disabled }: { disabled?: boolean } ) {


### PR DESCRIPTION
(Maybe) fixes https://github.com/Automattic/wp-calypso/issues/100156


## Proposed Changes


This PR update the payment method radio button and payment method styling to:

- Add hover and disabled state styling for radio buttons
- Adjust border radius for checked radio buttons
- Prevent border on disabled payment method hover state

### Before

https://github.com/user-attachments/assets/e67e8090-17f8-4e19-8808-fc32ca6fc82d



### After

https://github.com/user-attachments/assets/98338580-ee99-4c2e-9319-c4fb40cc0fe4



## Why are these changes being made?

- To remove the border-radii on inactive list items
- To remove the border on disabled list items

## Testing Instructions

Head over to `/me/purchases/[YOUR_SITE.wordpress.com]` and click on a product.

You'll be taken to `/me/purchases/[YOUR_SITE.wordpress.com]/[PRODUCT_ID]`

Hover over the payment items to ensure there are no regressions. They should have blue borders.

Unchecked items will not have the border radius at the edges.

Update a setting or click "Use this card" if you have one registered. Ensure that all items do not receive full borders. The unchecked items should retain their bottoms. Ho!



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
