### PR TITLE
Magic login: Hide Jetpack Mobile App promo on desktop / non-mobile UAs

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -28,6 +28,7 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
+import userAgent from 'calypso/lib/user-agent';
 import wpcom from 'calypso/lib/wp';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
@@ -242,13 +243,17 @@ class MagicLogin extends Component {
 		const { isJetpackLogin, locale, showCheckYourEmail, translate, isWCCOM, query } = this.props;
 
 		const isA4A = query?.redirect_to?.includes( 'agencies.automattic.com/client' ) ?? false;
+		const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
+		const isMobile = isiPad || isiPod || isiPhone || isAndroid;
+
+		const hideAppPromo = isA4A || ! isMobile;
 
 		if ( isWCCOM ) {
 			return null;
 		}
 
 		if ( showCheckYourEmail ) {
-			if ( isA4A ) {
+			if ( hideAppPromo ) {
 				return null;
 			}
 			return (
@@ -288,7 +293,7 @@ class MagicLogin extends Component {
 						{ linkBack }
 					</a>
 				</div>
-				{ ! isA4A && (
+				{ ! hideAppPromo && (
 					<AppPromo
 						title={ translate( 'Stay logged in with the Jetpack Mobile App' ) }
 						campaign="calypso-login-link"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100434

## Proposed Changes

* On the magic login link page (https://wordpress.com/log-in/link) hide the Jetpack Mobile App promo on desktop (the version that includes the QR code).
* When that page is accessed via a mobile device (or for example, Chrome running in device preview mode), continue to display the AppPromo, so that its app variant continues to be displayed.
* The check uses the same logic as [that used by the AppPromo component](https://github.com/Automattic/wp-calypso/blob/d2f640d00a8f4b4782dca1b9153454ed3fc30c43/client/blocks/app-promo/index.tsx#L36-L37), for consistency.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For context, see the discussion (and linked discussions) in #100434. TL;DR: for the clarity of this screen, on desktop its preferable to not include the mobile app promo. However on mobile devices there's a ~5% click through rate, so for now retain the AppPromo for those devices

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With this PR applied go to https://wordpress.com/log-in/link (e.g. http://calypso.localhost:3000/log-in/link) while not logged in, and check that on desktop, the AppPromo component does not get rendered
* Open up dev tools and a mobile device preview mode and reload the page — the AppPromo should be rendered (or access the page from a mobile device). Note if you were already testing on desktop you will need to reload the page while in device preview so that the user agent is updated.
* Submit a username or email and ensure the next state of the screen (that a link has been sent) conforms to the expected behaviour above

## Screenshots

| Desktop | Mobile |
| --- | --- |
| <img width="1208" alt="image" src="https://github.com/user-attachments/assets/b89180b8-53e8-4d41-8160-981cf1e4b1bf" /> | <img width="1206" alt="image" src="https://github.com/user-attachments/assets/806eed51-7e2c-43bf-97f0-ea300c5c3093" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
