### PR TITLE
Update plugin page copy

### DIFF
--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -88,7 +88,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	paid: {
 		menu: __( 'Premium plugins' ),
 		title: __( 'Must-have premium plugins' ),
-		description: __( 'Add the best-loved plugins on WordPress.com' ),
+		description: __( 'Take your site further with these premium plugins' ),
 		slug: 'paid',
 		tags: [],
 		preview: [],

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -88,7 +88,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	paid: {
 		menu: __( 'Premium plugins' ),
 		title: __( 'Must-have premium plugins' ),
-		description: __( 'Take your site further with these premium plugins' ),
+		description: __( 'Take your site further with these premium plugins.' ),
 		slug: 'paid',
 		tags: [],
 		preview: [],
@@ -96,7 +96,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	popular: {
 		menu: __( 'Popular plugins' ),
 		title: __( 'Popular plugins' ),
-		description: __( 'Add and install the most popular free plugins' ),
+		description: __( 'Add and install the most popular free plugins.' ),
 		slug: 'popular',
 		tags: [],
 		preview: [],
@@ -104,14 +104,14 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	featured: {
 		menu: __( 'Developer favorites' ),
 		title: __( 'Our developers’ favorites' ),
-		description: __( 'Start fast with these WordPress.com team picks' ),
+		description: __( 'Start fast with these WordPress.com team picks.' ),
 		slug: 'featured',
 		tags: [],
 		preview: [],
 	},
 	seo: {
 		menu: __( 'Search Engine Optimization' ),
-		title: __( 'Search Engine Optimization' ),
+		title: __( 'Search engine optimization' ),
 		description: __( 'Fine-tune your site’s content and metadata for search engine success.' ),
 		icon: 'grid',
 		slug: 'seo',
@@ -124,7 +124,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 		icon: 'grid',
 		slug: 'ecommerce',
 		tags: [ 'ecommerce', 'e-commerce', 'woocommerce', 'payments' ],
-		description: __( 'Tools that will set you up to optimize your online business' ),
+		description: __( 'Tools that will set you up to optimize your online business.' ),
 		preview: [
 			{
 				slug: 'woocommerce-subscriptions',
@@ -166,7 +166,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	booking: {
 		menu: __( 'Booking & Scheduling' ),
-		title: __( 'Booking & Scheduling' ),
+		title: __( 'Booking & scheduling' ),
 		description: __( 'Take bookings and manage your availability right from your site.' ),
 		icon: 'grid',
 		slug: 'booking',
@@ -175,7 +175,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	events: {
 		menu: __( 'Events Calendar' ),
-		title: __( 'Events Calendar' ),
+		title: __( 'Events calendar' ),
 		description: __( 'Build buzz and set the scene with an on-site events calendar.' ),
 		icon: 'grid',
 		slug: 'events',
@@ -211,7 +211,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	finance: {
 		menu: __( 'Finance & Payments' ),
-		title: __( 'Finance & Payments' ),
+		title: __( 'Finance & payments' ),
 		description: __(
 			'Sell products, subscriptions, and services while keeping on top of every transaction.'
 		),
@@ -222,7 +222,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	shipping: {
 		menu: __( 'Shipping & Delivery' ),
-		title: __( 'Shipping & Delivery' ),
+		title: __( 'Shipping & delivery' ),
 		description: __( 'Create a seamless shipping experience with advanced delivery integrations.' ),
 		icon: 'grid',
 		slug: 'shipping',
@@ -267,7 +267,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	photo: {
 		menu: __( 'Photo & Video' ),
-		title: __( 'Photo & Video' ),
+		title: __( 'Photo & video' ),
 		description: __(
 			'Create, share, edit, and manage beautiful images and video {with added precision and flexibility.'
 		),
@@ -278,7 +278,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	customer: {
 		menu: __( 'CRM & Live Chat' ),
-		title: __( 'CRM & Live Chat' ),
+		title: __( 'CRM & live chat' ),
 		description: __( 'Create stand-out customer service experiences for your site visitors.' ),
 		icon: 'grid',
 		slug: 'customer',
@@ -305,7 +305,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	education: {
 		menu: __( 'Learning Management Systems' ),
-		title: __( 'Learning Management Systems' ),
+		title: __( 'Learning management systems' ),
 		description: __( 'Create, run, and manage interactive courses and learning experiences.' ),
 		icon: 'grid',
 		slug: 'education',
@@ -323,7 +323,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	posts: {
 		menu: __( 'Posts & Posting' ),
-		title: __( 'Posts & Posting' ),
+		title: __( 'Posts & posting' ),
 		description: __( 'Unlock advanced content planning, publishing, and scheduling features.' ),
 		icon: 'grid',
 		slug: 'posts',
@@ -334,7 +334,9 @@ export const getCategories: () => Record< string, Category > = () => ( {
 		menu: __( 'Monetization' ),
 		title: __( 'Supercharging and monetizing your blog' ),
 		slug: 'monetization',
-		description: __( 'Building a money-making blog doesn’t have to be as hard as you might think' ),
+		description: __(
+			'Building a money-making blog doesn’t have to be as hard as you might think.'
+		),
 		tags: [ 'affiliate-marketing', 'advertising', 'adwords' ],
 		preview: [
 			{
@@ -379,7 +381,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 		menu: _x( 'Business', 'category name' ),
 		title: __( 'Setting up your local business' ),
 		slug: 'business',
-		description: __( 'These plugins are here to keep your business on track' ),
+		description: __( 'These plugins are here to keep your business on track.' ),
 		tags: [ 'google', 'testimonials', 'crm', 'business-directory' ],
 		preview: [
 			{
@@ -436,7 +438,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	landingpage: {
 		menu: __( 'Landing Page' ),
-		title: __( 'Landing Page' ),
+		title: __( 'Landing page' ),
 		slug: 'landingpage',
 		tags: [ 'landing page', 'page builder', 'landing-page' ],
 		preview: [],
@@ -492,7 +494,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	comments: {
 		menu: __( 'Comment' ),
-		title: __( 'Comments & Commenting' ),
+		title: __( 'Comments & commenting' ),
 		slug: 'comments',
 		tags: [ 'comment', 'comments', 'comment fields', 'delete comments' ],
 		preview: [],
@@ -513,7 +515,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	realestate: {
 		menu: __( 'Real Estate' ),
-		title: __( 'Real Estate' ),
+		title: __( 'Real estate' ),
 		slug: 'realestate',
 		tags: [
 			'real estate',
@@ -543,14 +545,14 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	projectmanagement: {
 		menu: __( 'Project Management' ),
-		title: __( 'Project Management' ),
+		title: __( 'Project management' ),
 		slug: 'projectmanagement',
 		tags: [ 'gantt charts', 'kanban', 'project', 'project management', 'tasks', 'task management' ],
 		preview: [],
 	},
 	jobboards: {
 		menu: __( 'Job Boards' ),
-		title: __( 'Job Boards' ),
+		title: __( 'Job boards' ),
 		slug: 'jobboards',
 		tags: [ 'career', 'job board', 'job listing' ],
 		preview: [],
@@ -584,14 +586,14 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	knowledgebase: {
 		menu: __( 'Knowledge Base' ),
-		title: __( 'Knowledge Base' ),
+		title: __( 'Knowledge base' ),
 		slug: 'knowledgebase',
 		tags: [ 'faq', 'faqs', 'frequently asked questions', 'knowledge base' ],
 		preview: [],
 	},
 	storelocator: {
 		menu: __( 'Store Locator' ),
-		title: __( 'Store Locator' ),
+		title: __( 'Store locator' ),
 		slug: 'storelocator',
 		tags: [ 'business locations', 'geocoding', 'locators', 'dealer locator', 'directions' ],
 		preview: [],
@@ -680,7 +682,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	restaurantmenu: {
 		menu: __( 'Restaurant Menu' ),
-		title: __( 'Restaurant Menu' ),
+		title: __( 'Restaurant menu' ),
 		slug: 'restaurantmenu',
 		tags: [
 			'food ordering',
@@ -712,7 +714,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	leadgeneration: {
 		menu: __( 'Lead Generation' ),
-		title: __( 'Lead Generation' ),
+		title: __( 'Lead generation' ),
 		slug: 'leadgeneration',
 		tags: [ 'lead gen', 'lead generation' ],
 		preview: [],
@@ -755,7 +757,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	wpbeginner: {
 		menu: __( 'WPBeginner' ),
 		title: __( 'Must-have plugins from WPBeginner' ),
-		description: __( 'Add the best-loved plugins on WordPress.com' ),
+		description: __( 'Add the best-loved plugins on WordPress.com.' ),
 		slug: 'wpbeginner',
 		tags: [ 'wpbeginner', 'Awesome Motive' ],
 		preview: [],

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -182,7 +182,7 @@ const EducationFooter = () => {
 		<EducationFooterContainer>
 			<PluginsResultsHeader
 				title={ __( 'Get started with plugins' ) }
-				subtitle={ __( 'Our favorite how-to guides to get you started with plugins' ) }
+				subtitle={ __( 'Our favorite how-to guides to get you started with plugins.' ) }
 			/>
 			<ThreeColumnContainer className="plugin-how-to-guides">
 				<LinkCard

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -131,12 +131,11 @@ const UpgradeNudge = ( {
 		);
 	}
 
-	const title = translate(
-		'You need to upgrade to a %(businessPlanName)s Plan to install plugins',
-		{ args: { businessPlanName: getPlan( plan )?.getTitle() } }
-	);
+	const title = translate( 'Access thousands of plugins with the %(businessPlanName)s Plan', {
+		args: { businessPlanName: getPlan( plan )?.getTitle() },
+	} );
 
-	const description = translate( 'Get a free domain with an annual plan.' );
+	const description = translate( 'Free domain included.' );
 	// This banner upsells the ability to install free and paid plugins on a Business plan.
 	return (
 		<UpsellNudge

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -172,7 +172,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			className="plugins-navigation-header"
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }
-			title={ translate( 'Plugins {{wbr}}{{/wbr}}Marketplace', {
+			title={ translate( 'Plugins {{wbr}}{{/wbr}}marketplace', {
 				components: { wbr: <wbr /> },
 			} ) }
 			loggedIn={ isLoggedIn }

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -50,7 +50,7 @@ export default function PluginsResultsHeader( {
 								} );
 							} }
 						>
-							{ __( 'Browse All' ) }
+							{ __( 'Browse all' ) }
 						</a>
 					) }
 					{ resultCount && <span className="plugins-results-header__action">{ resultCount }</span> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #100449 

## Proposed Changes

* Updates the copy in the premium plugins section header
* Updates the copy in the upgrade nudge banner
* Updates the copy in all buttons and titles to use sentence case with no punctuation 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The updates make the copy more inviting and consistent style-wise. From the ticket:
* The upgrade banner needs to be reworded. We could make this more inviting and less punitive in tone. The second line is verging on non-sequitur. Let’s see if we can connect the clauses a little more elegantly.
* All titles and buttons need to be updated to Sentence case
* "Must-have premium plugins" subtitle's "Add" language is awkward in this context. Should be activate "Activate the best-loved plugins on WordPress.com."
* Fix punctuation. Titles shouldn't have periods, descriptions and subtitles should.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Screenshots (includes changes from 176844-ghe-Automattic/wpcom)

| Before | After |
|-|-|
| ![Screenshot 2025-03-13 at 4 00 01 PM](https://github.com/user-attachments/assets/b222612f-a5b0-4013-8412-8b049c55ee74) | ![Screenshot 2025-03-13 at 4 01 07 PM](https://github.com/user-attachments/assets/9c547dae-6d07-4896-b129-9352a3bdcbb6) |

* Visit the plugins page for one of your sites, eg. https://wordpress.com/plugins/your-site.wordpress.com
* Observe that all titles and buttons use sentence case with no punctuation
* Observe updated copy for the premium plugin header and upgrade nudge banner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?