### PR TITLE
Revert "Try to make theme previews interactive in design picker"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -58,14 +58,8 @@ jest.mock( 'calypso/state/themes/hooks/use-is-theme-allowed-on-site', () => ( {
 	useIsThemeAllowedOnSite: () => false,
 } ) );
 
-jest.mock( 'calypso/state/themes/selectors/get-theme', () => ( {
+jest.mock( 'calypso/state/themes/selectors', () => ( {
 	getTheme: () => {
-		return;
-	},
-} ) );
-
-jest.mock( 'calypso/state/themes/selectors/get-theme-demo-url', () => ( {
-	getThemeDemoUrl: () => {
 		return;
 	},
 } ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -54,7 +54,7 @@ import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-sit
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
-import { getTheme, getThemeDemoUrl } from 'calypso/state/themes/selectors';
+import { getTheme } from 'calypso/state/themes/selectors';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
 import { useActivateDesign } from '../../../../hooks/use-activate-design';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
@@ -331,15 +331,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	// It should be removed when this property is ready on useQueryThemes
 	useQueryTheme( 'wpcom', selectedDesignThemeId );
 	const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedDesignThemeId ) );
-
-	const selectedDesignSlug = selectedDesign?.slug || '';
-
-	// Get theme URL for the design preview.
-	const themeDemoUrl = useSelector(
-		( state ) =>
-			getThemeDemoUrl( state, selectedDesignSlug, siteId + '' ) +
-			'?demo=true&iframe=true&theme_preview=true'
-	);
 	const screenshot = theme?.screenshots?.[ 0 ] ?? theme?.screenshot;
 	const fullLengthScreenshot = screenshot?.replace( /\?.*/, '' );
 
@@ -787,11 +778,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				<AsyncLoad
 					require="@automattic/design-preview"
 					placeholder={ null }
-					previewUrl={ themeDemoUrl || previewUrl }
-					siteInfo={ {
-						title: shouldCustomizeText ? site?.name : '',
-						tagline: shouldCustomizeText ? site?.description : '',
-					} }
+					previewUrl={ previewUrl }
 					splitDefaultVariation={
 						( isGlobalStylesOnPersonal &&
 							selectedDesign?.design_tier === THEME_TIER_FREE &&

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -15,10 +15,6 @@ interface Viewport {
 
 interface ThemePreviewProps {
 	url: string;
-	siteInfo?: {
-		title: string;
-		tagline: string;
-	};
 	inlineCss?: string;
 	viewportWidth?: number;
 	iframeScaleRatio?: number;
@@ -37,7 +33,6 @@ const isUrlWpcomApi = ( url: string ) =>
 
 const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	url,
-	siteInfo,
 	inlineCss,
 	viewportWidth,
 	iframeScaleRatio = 1,
@@ -52,12 +47,10 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const iframeRef = useRef< HTMLIFrameElement >( null );
 	const [ isLoaded, setIsLoaded ] = useState( ! isUrlWpcomApi( url ) );
 	const [ isFullyLoaded, setIsFullyLoaded ] = useState( ! isUrlWpcomApi( url ) );
-	const [ frameLocation, setFrameLocation ] = useState( '' );
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
 	const calypso_token = useMemo( () => iframeToken || uuid(), [ iframeToken ] );
 	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : iframeScaleRatio;
-	const { title, tagline } = siteInfo || {};
 
 	const wrapperHeight = useMemo( () => {
 		if ( ! viewport || iframeScaleRatio === 1 ) {
@@ -91,14 +84,6 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 						setViewport( data.payload );
 					}
 					return;
-				case 'location-change':
-					// We need to make sure location changes so it triggers the post message effects.
-					if ( data.payload.pathname === frameLocation ) {
-						setFrameLocation( '' );
-						return;
-					}
-					setFrameLocation( data.payload.pathname );
-					return;
 				default:
 					return;
 			}
@@ -109,7 +94,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 		return () => {
 			window.removeEventListener( 'message', handleMessage );
 		};
-	}, [ calypso_token, isFitHeight, setIsLoaded, setViewport, frameLocation ] );
+	}, [ setIsLoaded, setViewport ] );
 
 	// Ideally the iframe's document.body is already available on isLoaded = true.
 	// Unfortunately that's not always the case, so isFullyLoaded serves as another retry.
@@ -124,25 +109,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 				'*'
 			);
 		}
-	}, [ inlineCss, isLoaded, isFullyLoaded, frameLocation, calypso_token ] );
-
-	// Send site info to the iframe.
-	useEffect( () => {
-		// We only want to send info if it exists.
-		if ( ! title && ! tagline ) {
-			return;
-		}
-		if ( isLoaded || isFullyLoaded ) {
-			iframeRef.current?.contentWindow?.postMessage(
-				{
-					channel: `preview-${ calypso_token }`,
-					type: 'site-info',
-					site_info: { title, tagline },
-				},
-				'*'
-			);
-		}
-	}, [ title, tagline, calypso_token, isLoaded, isFullyLoaded, frameLocation ] );
+	}, [ inlineCss, isLoaded, isFullyLoaded ] );
 
 	return (
 		<DeviceSwitcher
@@ -174,7 +141,6 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 						width: viewportWidth,
 						height: viewport?.height,
 						transform: `scale(${ scale })`,
-						pointerEvents: 'all',
 					} }
 					src={ addQueryArgs( url, { calypso_token } ) }
 					tabIndex={ -1 }

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -11,10 +11,6 @@ import './style.scss';
 
 interface DesignPreviewProps {
 	previewUrl: string;
-	siteInfo?: {
-		title: string;
-		tagline: string;
-	};
 	title?: string;
 	author?: string;
 	categories?: Category[];
@@ -50,7 +46,6 @@ interface DesignPreviewProps {
 // @todo Get the style variations of theme, and then combine the selected one with colors & fonts for consistency
 const Preview: React.FC< DesignPreviewProps > = ( {
 	previewUrl,
-	siteInfo,
 	title,
 	author,
 	categories = [],
@@ -142,7 +137,6 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 			/>
 			<SitePreview
 				url={ previewUrl }
-				siteInfo={ siteInfo }
 				inlineCss={ inlineCss }
 				isFullscreen={ isFullscreen }
 				animated={ ! isDesktop && screens.length > 0 }

--- a/packages/design-preview/src/components/site-preview.tsx
+++ b/packages/design-preview/src/components/site-preview.tsx
@@ -6,10 +6,6 @@ import AnimatedFullscreen from './animated-fullscreen';
 
 interface SitePreviewProps {
 	url: string;
-	siteInfo?: {
-		title: string;
-		tagline: string;
-	};
 	inlineCss?: string;
 	isFullscreen?: boolean;
 	animated?: boolean;
@@ -21,7 +17,6 @@ interface SitePreviewProps {
 
 const SitePreview: React.FC< SitePreviewProps > = ( {
 	url,
-	siteInfo,
 	inlineCss = '',
 	isFullscreen,
 	animated,
@@ -68,7 +63,6 @@ const SitePreview: React.FC< SitePreviewProps > = ( {
 		>
 			<ThemePreview
 				url={ url }
-				siteInfo={ siteInfo }
 				inlineCss={ inlineCss }
 				isShowFrameBorder
 				isShowDeviceSwitcher


### PR DESCRIPTION
Reverts Automattic/wp-calypso#100915

The previous PR was merged without having rebased on trunk.