### PR TITLE
Remove close button from sites and domains dashboard panels

### DIFF
--- a/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/index.tsx
@@ -55,7 +55,6 @@ export function showDomainManagementPage( route: string ) {
 type BtnProps = {
 	focusRef: React.RefObject< HTMLButtonElement >;
 	itemData: ItemData;
-	closeSitePreviewPane?: () => void;
 };
 
 // This is the tabbed preview pane that is used for the domain management pages.
@@ -83,14 +82,11 @@ const DomainOverviewPane = ( {
 	const translate = useTranslate();
 	const { adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 
-	const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane }: BtnProps ) => {
+	const PreviewPaneHeaderButtons = ( { focusRef }: BtnProps ) => {
 		const adminButtonRef = useRef< HTMLButtonElement | null >( null );
 		const mergedRef = useMergeRefs( [ adminButtonRef, focusRef ] );
 		return (
 			<>
-				<Button onClick={ closeSitePreviewPane } className="button item-view__close-button">
-					{ __( 'Close' ) }
-				</Button>
 				{ ! site.options?.is_domain_only && (
 					<Button
 						primary

--- a/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
@@ -144,12 +144,6 @@ describe( 'DomainOverviewPane', () => {
 			'/domains/manage/all/email/example.com/example.wordpress.com'
 		);
 	} );
-
-	it( 'handles close button click', () => {
-		renderComponent();
-		fireEvent.click( screen.getByText( 'Close' ) );
-		expect( page.show ).toHaveBeenCalledWith( '/domains/manage' );
-	} );
 } );
 
 describe( 'showDomainManagementPage', () => {

--- a/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
+++ b/client/sites/components/site-preview-pane/preview-pane-header-buttons.tsx
@@ -10,19 +10,15 @@ import type { ItemData } from 'calypso/layout/hosting-dashboard/item-view/types'
 type Props = {
 	focusRef: React.RefObject< HTMLButtonElement >;
 	itemData: ItemData;
-	closeSitePreviewPane?: () => void;
 };
 
-const PreviewPaneHeaderButtons = ( { focusRef, closeSitePreviewPane, itemData }: Props ) => {
+const PreviewPaneHeaderButtons = ( { focusRef, itemData }: Props ) => {
 	const adminButtonRef = useRef< HTMLButtonElement | null >( null );
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( itemData.blogId );
 	const { __ } = useI18n();
 
 	return (
 		<>
-			<Button onClick={ closeSitePreviewPane } className="item-view__close-button">
-				{ __( 'Close' ) }
-			</Button>
 			<Button
 				primary
 				className="item-preview__admin-button"


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100368

## Proposed Changes

This PR removes the close buttons from the sites/domains dashboard as follows:

|Before|After|
|-|-|
|<img width="913" alt="image" src="https://github.com/user-attachments/assets/69ba1ecb-356f-4072-b35c-4ee8b97bba82" />|<img width="910" alt="image" src="https://github.com/user-attachments/assets/7b7b1613-3bb7-4cba-ba8b-e1ee4d229cff" />|
|<img width="913" alt="image" src="https://github.com/user-attachments/assets/b9395e5b-9e18-487f-ba33-dc00b20ce3e7" />|<img width="913" alt="image" src="https://github.com/user-attachments/assets/42765812-c58d-4501-a58a-9a7e2bb963f8" />|

## Why are these changes being made?

The placement does not make sense, and it's not Core pattern.

## Testing Instructions

1. Go to /sites, click a site, verify there is no close button anymore
1. Go to /domains/manage, click a domain, verify there is no close button anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
