### PR TITLE
Stats: Refactor views per visitor calculation

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/utility.js
+++ b/client/my-sites/stats/stats-chart-tabs/utility.js
@@ -160,6 +160,8 @@ function addTooltipData( chartTab, item, period, customRange = {} ) {
 		value: null,
 	} );
 
+	const viewsPerVisitor = item.data.views / item.data.visitors;
+
 	switch ( chartTab ) {
 		case 'comments':
 			tooltipData.push( {
@@ -196,11 +198,10 @@ function addTooltipData( chartTab, item, period, customRange = {} ) {
 				} );
 			}
 
-			// Ensure the Views/Visitors ratio number is finite.
-			if ( item.data.visitors > 0 ) {
+			if ( Number.isFinite( viewsPerVisitor ) ) {
 				tooltipData.push( {
 					label: translate( 'Views Per Visitor' ),
-					value: numberFormat( item.data.views / item.data.visitors, { decimals: 2 } ),
+					value: numberFormat( viewsPerVisitor, { decimals: 2 } ),
 					className: 'is-views-per-visitor',
 					icon: <Icon className="gridicon" icon={ chevronRight } />,
 				} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101007#discussion_r1989033037

## Proposed Changes

* Refactor views per visitor calculation for display on the Traffic page chart.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Refactor the condition without extra comment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Ensure the chart tooltip works well without `NaN` **Views Per Visitor** item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
