### PR TITLE
Update SitesDashboard transfer site card copy.

### DIFF
--- a/client/sites/settings/administration/tools/index.jsx
+++ b/client/sites/settings/administration/tools/index.jsx
@@ -1,5 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
-import { localize } from 'i18n-calypso';
+import { localize, fixMe } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
@@ -111,7 +111,13 @@ class SiteTools extends Component {
 		const startSiteTransferTitle = isUntangled
 			? translate( 'Transfer site' )
 			: translate( 'Transfer your site' );
-		const startSiteTransferText = translate( 'Transfer your site, plan and purchases.' );
+		const startSiteTransferText = fixMe( {
+			text: 'Transfer your site, plan and purchases to a new or existing site member.',
+			newCopy: translate(
+				'Transfer your site, plan and purchases to a new or existing site member.'
+			),
+			oldCopy: translate( 'Transfer your site, plan and purchases.' ),
+		} );
 
 		return (
 			<>

--- a/client/sites/settings/administration/tools/index.jsx
+++ b/client/sites/settings/administration/tools/index.jsx
@@ -112,9 +112,9 @@ class SiteTools extends Component {
 			? translate( 'Transfer site' )
 			: translate( 'Transfer your site' );
 		const startSiteTransferText = fixMe( {
-			text: 'Transfer your site, plan and purchases to a new or existing site member.',
+			text: 'Transfer your site, plan, and purchases to a new or existing site member.',
 			newCopy: translate(
-				'Transfer your site, plan and purchases to a new or existing site member.'
+				'Transfer your site, plan, and purchases to a new or existing site member.'
 			),
 			oldCopy: translate( 'Transfer your site, plan and purchases.' ),
 		} );


### PR DESCRIPTION
Fixes: #100283

## Proposed Changes

Improve the Site Overview Transfer Site tile copy from:

```
Transfer your site, plan and purchases.
```
to

```
Transfer your site, plan and purchases to a new or existing site member.
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="747" alt="Screenshot 2025-03-12 at 2 13 48 PM" src="https://github.com/user-attachments/assets/d78519db-68ef-42f9-bb46-9b31a2ff8b28" /> | <img width="739" alt="Screenshot 2025-03-12 at 2 13 58 PM" src="https://github.com/user-attachments/assets/1256d4e8-8c35-4306-bc0b-5e53482bc205" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The copy doesn't give enough information to the user to determine what transferring means.

## Testing Instructions

1. Visit `wp.com/overview/{site_url}`
2. Scroll down, observe new copy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
