### PR TITLE
Update AddNewSiteButton to used secondary style when compact.

### DIFF
--- a/client/components/sites-add-new-site/button.tsx
+++ b/client/components/sites-add-new-site/button.tsx
@@ -22,7 +22,11 @@ const AddNewSiteButton: React.FC< Props > = ( {
 	const mainButtonLabel = mainButtonLabelText || translate( 'Add sites' );
 
 	return (
-		<Button variant="primary" className="sites-add-new-site__button" onClick={ toggleMenu }>
+		<Button
+			variant={ showMainButtonLabel ? 'primary' : 'secondary' }
+			className="sites-add-new-site__button"
+			onClick={ toggleMenu }
+		>
 			<>
 				{ showMainButtonLabel ? mainButtonLabel : null }
 				<Gridicon

--- a/client/components/sites-add-new-site/button.tsx
+++ b/client/components/sites-add-new-site/button.tsx
@@ -9,6 +9,7 @@ interface Props extends PropsWithChildren {
 	mainButtonLabelText?: string;
 	isMenuVisible: boolean;
 	toggleMenu: () => void;
+	isPrimary?: boolean;
 }
 
 const AddNewSiteButton: React.FC< Props > = ( {
@@ -16,6 +17,7 @@ const AddNewSiteButton: React.FC< Props > = ( {
 	mainButtonLabelText,
 	isMenuVisible,
 	toggleMenu,
+	isPrimary = true,
 	children,
 } ) => {
 	const translate = useTranslate();
@@ -23,7 +25,7 @@ const AddNewSiteButton: React.FC< Props > = ( {
 
 	return (
 		<Button
-			variant={ showMainButtonLabel ? 'primary' : 'secondary' }
+			variant={ isPrimary ? 'primary' : 'secondary' }
 			className="sites-add-new-site__button"
 			onClick={ toggleMenu }
 		>

--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -26,6 +26,7 @@ export const SitesAddNewSitePopover = ( { showCompact }: Props ) => {
 			showMainButtonLabel={ ! showCompact }
 			mainButtonLabelText={ translate( 'Add new site' ) }
 			isMenuVisible={ isOpen }
+			isPrimary={ ! showCompact }
 			toggleMenu={ toggleMenu }
 		>
 			{ isOpen && (


### PR DESCRIPTION
Fixes #100356

## Proposed Changes

When the right panel is opened, the `<AddNewSiteButton>` becomes compact since it's not the primary action. This PR updates it so it switches to `secondary` button styles when it's compact.

| Before | After |
|--------|--------|
| <img width="1333" alt="Screenshot 2025-03-12 at 2 35 18 PM" src="https://github.com/user-attachments/assets/b382d849-52b4-4b5b-8a81-e09ac5b893fd" /> | <img width="1328" alt="Screenshot 2025-03-12 at 2 34 56 PM" src="https://github.com/user-attachments/assets/050114fe-c662-42df-a626-eb80e01c8ff7" /> | 

## Why are these changes being made?

It's no longer primary action so it shouldn't demand visual attention.

## Testing Instructions

While on desktop....

1. Go to wp.com/sites
2. Click on any site
3. Look at the `<AddNewSiteButton>` in the site list and verify that's its the secondary styles.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
