### PR TITLE
My Account: fix race condition when updating default landing page

### DIFF
--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -1,6 +1,5 @@
 import { RadioControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -17,19 +16,16 @@ function ToggleLandingPageSettings() {
 		readerAsLandingPage: getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage,
 	} ) );
 
-	let preference = 'default';
+	let selectedOption = 'default';
 	if ( sitesAsLandingPage ) {
-		preference = 'my-sites';
+		selectedOption = 'my-sites';
 	} else if ( readerAsLandingPage ) {
-		preference = 'reader';
+		selectedOption = 'reader';
 	}
 
-	// Local state to handle selected option
-	const [ selectedOption, setSelectedOption ] = useState( preference );
 	const isSaving = useSelector( isSavingPreference );
 
 	async function handlePreferenceChange( selectedOption: string ) {
-		setSelectedOption( selectedOption );
 		try {
 			const updatedAt = Date.now();
 			await dispatch(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100333

## Proposed Changes

This PR fixes a logic error when rendering the Default Landing Page option in `/me/account`.

In the existing codebase, `sitesAsLandingPage` and/or `readerAsLandingPage` can be undefined while the preferences are being fetched. However, we then call `useState()` with the undefined value as the initial state, which won't be updated when the preferences are later set,  causing the bug, which is always showing `My primary site` (the default option).

## Why are these changes being made?

Fixed a bug.

## Testing Instructions

1. Verify that you can't repro the steps in https://github.com/Automattic/wp-calypso/issues/100333 anymore.
2. Test updating the values and the primary site and make sure there's no bug.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
