### PR TITLE
Profile: Make User management screen headers consistent.

### DIFF
--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -6,7 +6,6 @@ import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import useUserQuery from 'calypso/data/users/use-user-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useProtectForm } from 'calypso/lib/protect-form';
@@ -60,16 +59,7 @@ export const EditTeamMemberForm = ( {
 	return (
 		<Main className="edit-team-member-form">
 			<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
-			{ isEnabled( 'user-management-revamp' ) && (
-				<NavigationHeader
-					navigationItems={ [] }
-					title={ translate( 'Users' ) }
-					subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
-				/>
-			) }
-			<HeaderCake onClick={ goBack } isCompact>
-				{ translate( 'User Details' ) }
-			</HeaderCake>
+			<HeaderCake onClick={ goBack }>{ translate( 'User Details' ) }</HeaderCake>
 			<Card className="edit-team-member-form__user-profile">
 				<PeopleProfile siteId={ siteId } user={ user } />
 				{ user && (

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -11,7 +11,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import InviteStatus from 'calypso/my-sites/people/invite-status';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
@@ -202,17 +201,7 @@ export class PeopleInviteDetails extends PureComponent {
 				<PageViewTracker path="/people/invites/:site/:invite" title="People > User Details" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 
-				{ isEnabled( 'user-management-revamp' ) && (
-					<NavigationHeader
-						navigationItems={ [] }
-						title={ translate( 'Users' ) }
-						subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
-					/>
-				) }
-
-				<HeaderCake isCompact onClick={ this.goBack }>
-					{ translate( 'User Details' ) }
-				</HeaderCake>
+				<HeaderCake onClick={ this.goBack }>{ translate( 'User Details' ) }</HeaderCake>
 
 				{ this.renderInvite() }
 			</Main>

--- a/client/my-sites/people/people-invites-pending/index.tsx
+++ b/client/my-sites/people/people-invites-pending/index.tsx
@@ -1,12 +1,9 @@
 import page from '@automattic/calypso-router';
 import { SiteDetails } from '@automattic/data-stores';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TeamInvites from 'calypso/my-sites/people/team-invites';
 import { useSelector } from 'calypso/state';
@@ -32,23 +29,6 @@ export default function PeopleInvitesPending( props: Props ) {
 			<PageViewTracker
 				path="/people/pending-invites/:site"
 				title="People > Pending Invite People"
-			/>
-			<NavigationHeader
-				navigationItems={ [] }
-				title={ translate( 'Users' ) }
-				subtitle={ translate(
-					'Invite subscribers and team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
-					{
-						components: {
-							learnMore: (
-								<InlineSupportLink
-									showIcon={ false }
-									supportLink={ localizeUrl( 'https://wordpress.com/support/invite-people/' ) }
-								/>
-							),
-						},
-					}
-				) }
 			/>
 			<HeaderCake onClick={ goBack }>{ translate( 'Pending invites' ) }</HeaderCake>
 			<TeamInvites />


### PR DESCRIPTION
Fixes: #100411

## Proposed Changes

This PR removes the Header and Subtitle from interior `/people` pages as requested in #100411. It also restores the spacing between the Title bar and the card. 

### Screenshots

| URL | Screenshot |
|--------|--------|
| **No Change:** `/people/team/{site_url}` | <img width="1073" alt="Screenshot 2025-03-13 at 9 56 07 AM" src="https://github.com/user-attachments/assets/a5c36e8d-f96f-4fa1-95ee-aaff85941d84" /> |
| `/people/new/{site_url}` | <img width="1072" alt="Screenshot 2025-03-13 at 9 56 31 AM" src="https://github.com/user-attachments/assets/b1c0787d-7ec4-4ad3-b776-b58f065d19fe" /> |
| `/people/edit/{site_url}/{user_name}` | <img width="536" alt="Screenshot 2025-03-13 at 9 56 19 AM" src="https://github.com/user-attachments/assets/d1254326-917d-4fc9-bdcb-65575b1d218d" /> | 
| `/people/pending-invites/{site_url}` | <img width="536" alt="Screenshot 2025-03-13 at 9 57 33 AM" src="https://github.com/user-attachments/assets/ffbea1a1-40f0-4635-ab75-c9f22df9f8e9" /> |
| `/people/invites/{site_url}/{hash}` | <img width="1073" alt="Screenshot 2025-03-13 at 10 08 51 AM" src="https://github.com/user-attachments/assets/6134cdcf-d539-457b-a966-a599d7b18d35" /> |


## Why are these changes being made?

To make the views more consistent.


## Considerations

I decided to re-add the spacing between the title bar and the card because the default page's navigation bar has a space. 

Read #100411.

## Testing Instructions

Verify that only the "All Users" page has a header and subtitle and that all title bars have a space above the card.

1.  Go to `/people/team/{site_url}`
3. Click "Add a team member"
4. Invite someone
5. Click on pending user profile
6. Invite someone else
7. Click on "View all" under pending user list
8. Click on one of the pending users
9. Navigate back to "All users"
10. Click on team member

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
