### PR TITLE
A4A > WooPayments: Hide actions for disconnected sites

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -109,6 +109,9 @@ export default function SitesWithWooPayments() {
 					window.open( url, '_blank' );
 					dispatch( recordTracksEvent( 'calypso_a4a_woopayments_visit_wp_admin' ) );
 				},
+				isEligible( item: SitesWithWooPaymentsState ) {
+					return item.state !== 'disconnected';
+				},
 			},
 		],
 		[ translate, dispatch ]


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1914

## Proposed Changes

This PR hides the actions on the WooPayments Commissions table when the site is in a disconnected state.

## Why are these changes being made?

* To hide the actions menu for disconnected sites

## Testing Instructions

* Open the A4A live link or test locally if you don't see the `Disconnected` state on live links
* Go to WooPayments: Dashboard > Verify that the actions menu is hidden when the site is in a `Disconnected` state

<img width="1728" alt="Screenshot 2025-03-12 at 11 48 41 AM" src="https://github.com/user-attachments/assets/02e3d1fe-ef0a-45a9-b4f1-8b59b370067e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
