### PR TITLE
Plans: Update the CTA color of the Business plan and the Commerce plan

### DIFF
--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -51,10 +51,10 @@
 	}
 
 	&.is-business-plan {
-		background-color: var(--studio-woocommerce-purple-50);
+		background-color: var(--studio-woocommerce-purple-60);
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-50);
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-60);
 		}
 
 		&:hover {
@@ -64,11 +64,11 @@
 		+ .button.is-borderless {
 			background: transparent;
 			font-size: $font-body-small;
-			color: var(--studio-woocommerce-purple-50);
+			color: var(--studio-woocommerce-purple-60);
 			text-decoration: none;
 
 			&:focus {
-				box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-50);
+				box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-60);
 			}
 		}
 	}
@@ -101,14 +101,14 @@
 	}
 
 	&.is-ecommerce-plan {
-		background-color: var(--studio-woocommerce-purple-70);
+		background-color: var(--studio-woocommerce-purple-40);
 
 		&:focus {
-			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-70);
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-40);
 		}
 
 		&:hover {
-			background-color: var(--studio-woocommerce-purple-80);
+			background-color: var(--studio-woocommerce-purple-50);
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #99597

## Proposed Changes

This PR updates the Business plan CTA and Commerce plan CTA to the requested value as in https://github.com/Automattic/wp-calypso/issues/99597

| Before | After |
| -------| ------|
| ![CleanShot 2025-03-12 at 14 46 11@2x](https://github.com/user-attachments/assets/122ca01c-a9f6-4788-8b9e-ca5464d6b74d) | ![CleanShot 2025-03-12 at 14 45 41@2x](https://github.com/user-attachments/assets/29974c24-d95e-459f-a666-68379542772d) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The CTA colors of that two buttons are outdated. The latest version can be found in https://github.com/Automattic/wp-calypso/issues/99597#issuecomment-2666005961:

> For CTA's we use Woo40 #873EFF (for Woo) and the Business one could use Woo60 #6108CE

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch Storybook of plans-grid-next: yarn workspace @automattic/plans-grid-next storybook
* Confirm that the CTA color of the Business plan is #6108CE
* Confirm that the CTA color of the Commerce plan is #873EFF

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
