### PR TITLE
Don't show fullscreen launchpad for sites with no intent

### DIFF
--- a/client/my-sites/customer-home/test/customer-home.tsx
+++ b/client/my-sites/customer-home/test/customer-home.tsx
@@ -76,10 +76,22 @@ describe( 'CustomerHome', () => {
 		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'should show HomeContent for unlaunched site with no intent created by onboarding flow, and launchpad is unskipped', async () => {
+		const testSite = makeTestSite( {
+			launch_status: 'unlaunched',
+			options: { launchpad_screen: false, site_intent: '', site_creation_flow: 'onboarding' },
+		} );
+
+		renderWithProvider( <CustomerHome site={ testSite } /> );
+
+		await waitFor( () => expect( screen.getByTestId( 'home-content' ) ).toBeInTheDocument() );
+		expect( screen.queryByTestId( 'launchpad-first' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'should show Launchpad when site is unlaunched, created by onboarding flow, and launchpad is unskipped', async () => {
 		const testSite = makeTestSite( {
 			launch_status: 'unlaunched',
-			options: { site_creation_flow: 'onboarding', launchpad_screen: false },
+			options: { site_creation_flow: 'onboarding', launchpad_screen: false, site_intent: 'sell' },
 		} );
 
 		renderWithProvider( <CustomerHome site={ testSite } /> );

--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -11,7 +11,8 @@ export const shouldShowLaunchpadFirst = ( site: SiteDetails ): boolean => {
 	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
 	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
 	// If we don't have a site intent, fall through to the next option.
-	const siteHasNoIntent = site && site.options && site.options.site_intent === '';
+	const siteHasNoIntent =
+		site && site.options && ( site.options.site_intent === '' || ! site.options.site_intent );
 
 	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || siteHasNoIntent ) {
 		return false;

--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -3,15 +3,17 @@ import { SiteDetails, Onboard } from '@automattic/data-stores';
 const SiteIntent = Onboard.SiteIntent;
 
 /**
- * Determines if the launchpad should be shown first based on site createion flow
+ * Determines if the launchpad should be shown first based on site creation flow.
  * @param site Site object
  * @returns Whether launchpad should be shown first
  */
 export const shouldShowLaunchpadFirst = ( site: SiteDetails ): boolean => {
 	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
 	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
+	// If we don't have a site intent, fall through to the next option.
+	const siteHasNoIntent = site && site.options && site.options.site_intent === '';
 
-	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow ) {
+	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || siteHasNoIntent ) {
 		return false;
 	}
 

--- a/client/state/selectors/test/should-show-launchpad-first.ts
+++ b/client/state/selectors/test/should-show-launchpad-first.ts
@@ -14,17 +14,46 @@ beforeEach( () => {
 } );
 
 describe( 'shouldShowLaunchpadFirst', () => {
-	it( 'should return true when site was created via onboarding flow and assigned to experiment', async () => {
+	it( 'should return true when site was created via onboarding flow, has an intent, and assigned to experiment', async () => {
 		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
 			variationName: 'treatment_cumulative',
 		} );
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
+				site_intent: 'sell',
 			},
 		} as SiteDetails;
 
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( true );
+	} );
+
+	it( 'should return false when site was created via onboarding flow, has the ai-assembler intent, and assigned to experiment', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'treatment_cumulative',
+		} );
+		const site = {
+			options: {
+				site_creation_flow: 'onboarding',
+				site_intent: 'ai-assembler',
+			},
+		} as SiteDetails;
+
+		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
+	} );
+
+	it( 'should return false when site was created via onboarding flow, has no intent, and assigned to experiment', async () => {
+		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
+			variationName: 'treatment_cumulative',
+		} );
+		const site = {
+			options: {
+				site_creation_flow: 'onboarding',
+				site_intent: '',
+			},
+		} as SiteDetails;
+
+		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 
 	it( 'should return false when site was not created via onboarding flow', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101219

Related to https://github.com/Automattic/wp-calypso/issues/101018 - it's possible this PR addresses that issue as well.

## Proposed Changes

* This change updates the `shouldShowLaunchpadFirst( site )` selector's internal logic so that it doesn't show the fullscreen launchpad when we have a site that doesn't have a site_intent option set, or has the `site_intent` option set to `''`. This should prevent us from showing a fullscreen launchpad with no tasks.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As reported in https://github.com/Automattic/wp-calypso/issues/101219, this is an awful UX for users who have somehow missed having a site intent set.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the code from this branch locally or via calypso.live
* Work through the onboarding flow at `/setup/onboarding`, and pick a paid plan on the plans step
* Wait for checkout to load, and not the site slug in the URL - do not complete checkout
* In a second window, load `/home/[site_slug]`
* Verify that you are redirected to My Home, and do not see the fullscreen launchpad

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [N/A] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
