### PR TITLE
My Profile: Update button copy in profile photo upload modal to "Update photo"

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -1,7 +1,7 @@
 import path from 'path';
 import { Dialog, Gridicon, Spinner, ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -120,6 +120,12 @@ export class EditGravatar extends Component {
 	};
 
 	renderImageEditor() {
+		const doneButtonText = i18n.fixMe( {
+			text: 'Upload photo',
+			newCopy: i18n.translate( 'Upload photo' ),
+			oldCopy: i18n.translate( 'Change My Photo' ),
+		} );
+
 		if ( this.state.isEditingImage ) {
 			return (
 				<Dialog additionalClassNames="edit-gravatar-modal" isVisible>
@@ -128,7 +134,7 @@ export class EditGravatar extends Component {
 						media={ { src: this.state.image } }
 						onDone={ this.onImageEditorDone }
 						onCancel={ this.hideImageEditor }
-						doneButtonText={ this.props.translate( 'Change My Photo' ) }
+						doneButtonText={ doneButtonText }
 					/>
 				</Dialog>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100251

## Proposed Changes

Copy change. See below for reference:

| Before | After |
| --- | --- |
| ![Screenshot 2025-03-12 at 4 26 38 PM](https://github.com/user-attachments/assets/98fc4a97-81fa-4346-9660-7963197a7e18) |  ![Screenshot 2025-03-12 at 4 26 26 PM](https://github.com/user-attachments/assets/27655d66-b7f3-44a3-b35a-5cdddb0a4eab) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /me
* Open the photo upload modal and ensure that the copy is updated as shown above 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
