### PR TITLE
Help Center: Fix Odie chat for free users

### DIFF
--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -125,6 +125,14 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 
 		setMainChatState( ( prevChat ) => {
 			if ( ! prevChat.supportInteractionId ) {
+				if ( ! odieId && ! conversationId ) {
+					return {
+						...emptyChat,
+						supportInteractionId: currentSupportInteraction!.uuid,
+						status: 'loaded',
+					};
+				}
+
 				return {
 					...prevChat,
 					supportInteractionId: currentSupportInteraction!.uuid,
@@ -142,7 +150,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 
 			return { ...prevChat };
 		} );
-	}, [ currentSupportInteraction?.uuid ] );
+	}, [ currentSupportInteraction?.uuid, odieId, conversationId ] );
 
 	return { mainChatState, setMainChatState };
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101218

## Proposed Changes

* This PR fixes a bug for free users, in which the users were stuck in a loop when requesting a chat with AI for the first time.

![image](https://github.com/user-attachments/assets/70a51595-ba69-4210-806b-8cdd74324562)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Live Link 
* Create a new user and open the Help Center. Click on "Still need help?"
* Odie should appear. Interact with it and check that it is working.
* Try your normal, paid, user and verify that you can access chat with Happiness Engineers.