### PR TITLE
Personal plan upsell in Stats page wrongly shows global styles is available

### DIFF
--- a/client/my-sites/stats/stats-upsell/insights-upsell.tsx
+++ b/client/my-sites/stats/stats-upsell/insights-upsell.tsx
@@ -1,3 +1,4 @@
+import { isGlobalStylesOnPersonalEnabled } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import statsFeaturesPNG from 'calypso/assets/images/stats/paid-features-2.png';
 import { STATS_FEATURE_PAGE_INSIGHTS } from '../constants';
@@ -20,8 +21,10 @@ const InsightsUpsell: React.FC = () => {
 				translate( 'Free domain for one year' ),
 				translate( 'Ad-free browsing experience for your visitors' ),
 				translate( 'Dozens of premium themes' ),
-				translate( 'Fast support from our expert team' ),
-				translate( 'Customize fonts and colors sitewide' ),
+				translate( 'Get support from our expert team' ),
+				...( isGlobalStylesOnPersonalEnabled()
+					? [ translate( 'Customize fonts and colors site wide' ) ]
+					: [] ),
 			] }
 			image={ statsFeaturesPNG }
 			expandableView

--- a/client/my-sites/stats/stats-upsell/insights-upsell.tsx
+++ b/client/my-sites/stats/stats-upsell/insights-upsell.tsx
@@ -1,4 +1,13 @@
-import { isGlobalStylesOnPersonalEnabled } from '@automattic/calypso-products';
+import {
+	isGlobalStylesOnPersonalEnabled,
+	getFeature,
+	FEATURE_UNLIMITED_ENTITIES,
+	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_AD_FREE_EXPERIENCE,
+	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
+	FEATURE_SUPPORT_FROM_EXPERTS,
+	FEATURE_STYLE_CUSTOMIZATION,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import statsFeaturesPNG from 'calypso/assets/images/stats/paid-features-2.png';
 import { STATS_FEATURE_PAGE_INSIGHTS } from '../constants';
@@ -17,13 +26,13 @@ const InsightsUpsell: React.FC = () => {
 				translate( 'Keep your data private and GDPR-compliant' ),
 				translate( '14-day money-back guarantee' ),
 				translate( '6 GB storage' ),
-				translate( 'Unlimited pages, posts, users, and visitors' ),
-				translate( 'Free domain for one year' ),
-				translate( 'Ad-free browsing experience for your visitors' ),
-				translate( 'Dozens of premium themes' ),
-				translate( 'Get support from our expert team' ),
+				getFeature( FEATURE_UNLIMITED_ENTITIES ).getTitle(),
+				getFeature( FEATURE_CUSTOM_DOMAIN ).getTitle(),
+				getFeature( FEATURE_AD_FREE_EXPERIENCE ).getTitle(),
+				getFeature( WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ).getTitle(),
+				getFeature( FEATURE_SUPPORT_FROM_EXPERTS ).getTitle(),
 				...( isGlobalStylesOnPersonalEnabled()
-					? [ translate( 'Customize fonts and colors site wide' ) ]
+					? [ getFeature( FEATURE_STYLE_CUSTOMIZATION ).getTitle() ]
 					: [] ),
 			] }
 			image={ statsFeaturesPNG }

--- a/client/my-sites/stats/stats-upsell/traffic-upsell.tsx
+++ b/client/my-sites/stats/stats-upsell/traffic-upsell.tsx
@@ -1,3 +1,4 @@
+import { isGlobalStylesOnPersonalEnabled } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import statsFeaturesPNG from 'calypso/assets/images/stats/paid-features.png';
 import { STATS_FEATURE_PAGE_TRAFFIC } from '../constants';
@@ -20,8 +21,10 @@ const TrafficUpsell: React.FC = () => {
 				translate( 'Free domain for one year' ),
 				translate( 'Ad-free browsing experience for your visitors' ),
 				translate( 'Dozens of premium themes' ),
-				translate( 'Fast support from our expert team' ),
-				translate( 'Customize fonts and colors sitewide' ),
+				translate( 'Get support from our expert team' ),
+				...( isGlobalStylesOnPersonalEnabled()
+					? [ translate( 'Customize fonts and colors site wide' ) ]
+					: [] ),
 			] }
 			image={ statsFeaturesPNG }
 			expandableView

--- a/client/my-sites/stats/stats-upsell/traffic-upsell.tsx
+++ b/client/my-sites/stats/stats-upsell/traffic-upsell.tsx
@@ -1,4 +1,13 @@
-import { isGlobalStylesOnPersonalEnabled } from '@automattic/calypso-products';
+import {
+	isGlobalStylesOnPersonalEnabled,
+	getFeature,
+	FEATURE_UNLIMITED_ENTITIES,
+	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_AD_FREE_EXPERIENCE,
+	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
+	FEATURE_SUPPORT_FROM_EXPERTS,
+	FEATURE_STYLE_CUSTOMIZATION,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import statsFeaturesPNG from 'calypso/assets/images/stats/paid-features.png';
 import { STATS_FEATURE_PAGE_TRAFFIC } from '../constants';
@@ -17,13 +26,13 @@ const TrafficUpsell: React.FC = () => {
 				translate( 'Keep your data private and GDPR-compliant' ),
 				translate( '14-day money-back guarantee' ),
 				translate( '6 GB storage' ),
-				translate( 'Unlimited pages, posts, users, and visitors' ),
-				translate( 'Free domain for one year' ),
-				translate( 'Ad-free browsing experience for your visitors' ),
-				translate( 'Dozens of premium themes' ),
-				translate( 'Get support from our expert team' ),
+				getFeature( FEATURE_UNLIMITED_ENTITIES ).getTitle(),
+				getFeature( FEATURE_CUSTOM_DOMAIN ).getTitle(),
+				getFeature( FEATURE_AD_FREE_EXPERIENCE ).getTitle(),
+				getFeature( WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ).getTitle(),
+				getFeature( FEATURE_SUPPORT_FROM_EXPERTS ).getTitle(),
 				...( isGlobalStylesOnPersonalEnabled()
-					? [ translate( 'Customize fonts and colors site wide' ) ]
+					? [ getFeature( FEATURE_STYLE_CUSTOMIZATION ).getTitle() ]
 					: [] ),
 			] }
 			image={ statsFeaturesPNG }

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -336,7 +336,7 @@ import {
 	FEATURE_SUPPORT_FROM_EXPERTS,
 	FEATURE_AI_ASSISTANT,
 } from './constants';
-import type { FeatureList } from './types';
+import type { FeatureList, FeatureObject } from './types';
 
 const getTransactionFeeCopy = ( commission = 0, variation = '' ) => {
 	switch ( variation ) {
@@ -2795,6 +2795,10 @@ const FEATURES_LIST: FeatureList = {
 		getDescription: () =>
 			i18n.translate( 'Keep an administrative eye on activity across your site.' ),
 	},
+};
+
+export const getFeature = ( featureName: string ): FeatureObject => {
+	return FEATURES_LIST[ featureName ];
 };
 
 export { FEATURES_LIST };

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -150,3 +150,4 @@ export * from './translations';
 export { findProductKeys } from './find-product-keys';
 export { isRenewable } from './is-renewable';
 export { isSenseiProduct } from './is-sensei-product';
+export { isGlobalStylesOnPersonalEnabled } from './is-global-styles-on-personal-enabled';

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -151,3 +151,4 @@ export { findProductKeys } from './find-product-keys';
 export { isRenewable } from './is-renewable';
 export { isSenseiProduct } from './is-sensei-product';
 export { isGlobalStylesOnPersonalEnabled } from './is-global-styles-on-personal-enabled';
+export { getFeature } from './features-list';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

The Personal plan upsell in the stats pages shows global styles as available, even when it's not enabled for the Personal plan. This is because the feature is hardcoded in the upsell message. This PR removes the hardcoding and adds a conditional to show the feature only if global styles is enabled.

This PR also removes the claim of "Fast support". We are not promising fast support for Personal plan users, and we recently made changes for these in the pricing grid too (pcNC1U-1vN-p2#comment-1937)

This upsell is hardcoded in two places:

* `/stats/day/:siteSlug` 
* `/stats/insights/:siteSlug` 

#### BEFORE

<img width="50%" alt="Screenshot 2025-03-12 at 12 48 22 PM" src="https://github.com/user-attachments/assets/72937b4b-c94c-45ed-88e9-823cb1c24680" />



#### AFTER

<img width="50%" alt="Screenshot 2025-03-12 at 1 20 01 PM" src="https://github.com/user-attachments/assets/0c7ac125-8ea4-40a3-a8f4-36490409b303" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed this issue on the Stats page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In `/stats/day:siteSlug` page, verify that the Personal plan upsell does not show the Global styles feature. Also verify that the support feature says "Get support from our expert team" instead of "Fast support from our expert team".
* Assign yourself to treatment groups in the global styles experiment (pbxNRc-4My-p2#comment-6587) and verify that you can see the feature under the Personal plan.