### PR TITLE
Security Keys: Use better error messages on log in

### DIFF
--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { get as webauthn_auth } from '@github/webauthn-json';
+import { translate } from 'i18n-calypso';
 import { get } from 'lodash';
 import {
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
@@ -59,7 +60,34 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 				dispatch( updateNonce( twoFactorAuthType, twoStepNonce ) );
 			}
 
-			const error = getErrorFromHTTPError( httpError );
+			const errorMessages = {
+				'NotAllowedError:1': translate(
+					'It seems the page is not active for authentication. Please click anywhere on the page and try again while keeping the window open.'
+				),
+				NotAllowedError: translate(
+					'The security key interaction timed out or was canceled. Please try again.'
+				),
+				AbortError: translate( 'The security key interaction was canceled. Please try again.' ),
+				SecurityError: translate(
+					"There’s a security restriction preventing us from accessing your credentials. Please check your browser's settings or permissions."
+				),
+				TypeError: translate(
+					'There was an issue with the request. Please refresh the page and try again.'
+				),
+				default: translate( 'Oops! Something went wrong. Please try again.' ),
+			};
+
+			let error;
+			if ( httpError instanceof Error ) {
+				const field = 'global';
+				const errorKey = `${ httpError.name }${
+					httpError.message.includes( 'document is not focused' ) ? ':1' : ''
+				}`;
+				const message = errorMessages[ errorKey ] ?? errorMessages.default;
+				error = { code: httpError.name, message, field };
+			} else {
+				error = getErrorFromHTTPError( httpError );
+			}
 
 			dispatch( {
 				type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,

--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -61,7 +61,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 			}
 
 			const errorMessages = {
-				'NotAllowedError:1': translate(
+				NotFocusedError: translate(
 					'It seems the page is not active for authentication. Please click anywhere on the page and try again while keeping the window open.'
 				),
 				NotAllowedError: translate(
@@ -79,12 +79,11 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 
 			let error;
 			if ( httpError instanceof Error ) {
-				const field = 'global';
-				const errorKey = `${ httpError.name }${
-					httpError.message.includes( 'document is not focused' ) ? ':1' : ''
-				}`;
+				const errorKey = httpError.message.includes( 'document is not focused' )
+					? errorMessages.NotFocusedError
+					: httpError.name;
 				const message = errorMessages[ errorKey ] ?? errorMessages.default;
-				error = { code: httpError.name, message, field };
+				error = { code: httpError.name, message, field: 'global' };
 			} else {
 				error = getErrorFromHTTPError( httpError );
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Improve error handling by displaying more intuitive messages instead of browser-generated errors for client side errors.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in with a WP.com account with security key enabled
* Cancel the prompt for the security key

#### Before
Cancel the security key prompt
<img width="818" alt="Screenshot 2025-03-12 at 12 46 06" src="https://github.com/user-attachments/assets/939e4f38-0b8b-4ec8-8bb0-63f0df6f5d60" />

The browser tab/window is not active after entering the user password (Safari)
<img width="780" alt="Screenshot 2025-03-12 at 13 07 36" src="https://github.com/user-attachments/assets/d7186efd-fe07-4486-99e0-adfd2bcd896d" />

#### After
Cancel the security key prompt
<img width="805" alt="Screenshot 2025-03-12 at 12 46 35" src="https://github.com/user-attachments/assets/07c87c72-2a3b-44bb-b486-1a3738813d4d" />

The browser tab/window is not active after entering the user password (Safari)
<img width="803" alt="Screenshot 2025-03-12 at 13 06 39" src="https://github.com/user-attachments/assets/7a5bbdd2-c8e0-4d1f-a7a2-286c274312a4" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
