### PR TITLE
Updating e2e tests to prevent test user being marked as spam

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
+++ b/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
@@ -114,7 +114,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 		} );
 
 		it( 'Once at the /wp-admin settings page, update site name', async function () {
-			await page.fill( 'input[name="blogname"]', 'my first site' );
+			await page.fill( 'input[name="blogname"]', DataHelper.getRandomPhrase() );
 			const saveChangesButton = await page.getByRole( 'button', { name: 'Save Changes' } );
 			await saveChangesButton.click();
 

--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.ts
@@ -41,7 +41,7 @@ describe( 'Signup: Tailored Start Writing Flow', () => {
 		const editorPage = new EditorPage( page );
 		await editorPage.waitUntilLoaded();
 		await editorPage.closeWelcomeGuideIfNeeded();
-		await editorPage.enterTitle( 'my first post title' );
+		await editorPage.enterTitle( DataHelper.getRandomPhrase() );
 		await editorPage.publish();
 		await page.getByText( "Your blog's almost ready!" ).waitFor();
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pet6gk-26G-p2

## Proposed Changes

* We're creating random posts names to avoid test user being marked as spam


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?