### PR TITLE
Reader - fix tracking for new recent routes.

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -41,7 +41,7 @@ function getLocation( path ) {
 	if ( path === undefined || path === '' ) {
 		return 'unknown';
 	}
-	if ( path === '/reader' ) {
+	if ( path === '/reader' || path.indexOf( '/reader/recent/' ) === 0 ) {
 		return 'following';
 	}
 	if ( path.indexOf( '/reader/a8c' ) === 0 ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/100775 

last week we added specific routes for selected items in recent. This means the tracking helpers that updates the `ui_algo` prop for reader tracking events was returning "unknown" for these new routes where they previously added "following"

## Proposed Changes

Updates the new reader/recent/:feed_id routes to return 'following' instead of 'unknown' for the readers tracking `getLocation` helper.
* Adds an `||` condition with the check that returns 'following'.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I overlooked the tracking nuance with last weeks change

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the /reader
* Click to view a specific site in the recent feed.
* Verify `calypso_reader_post_display` tracking events have `ui_algo` property of value `following` (this was preivously `unknown`.
* Click a card to view the full post, you should also see this property on `calypso_reader_article_opened`.
* Verify no regressions with this properties values on other streams.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
