### PR TITLE
Add internal redirect check

### DIFF
--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -30,6 +30,23 @@ function isExternalUrl( url ) {
 	return true;
 }
 
+/**
+ * For internal urls check when parsed the origin
+ * @param {string} url URL to check
+ * @returns {boolean}
+ */
+function isUnsafeInternalUrl( url ) {
+	if ( ! url.startsWith( '/' ) ) {
+		return false;
+	}
+
+	try {
+		return new URL( url, window.location.origin ).origin !== window.location.origin;
+	} catch ( e ) {
+		return true;
+	}
+}
+
 export default function redirectLoggedIn( context, next ) {
 	const userLoggedIn = isUserLoggedIn( context.store.getState() );
 
@@ -37,7 +54,7 @@ export default function redirectLoggedIn( context, next ) {
 		// force full page reload to avoid SSR hydration issues.
 		// Redirect parameters should have higher priority.
 		let url = context?.query?.redirect_to;
-		if ( ! url || isExternalUrl( url ) ) {
+		if ( ! url || isUnsafeInternalUrl( url ) || isExternalUrl( url ) ) {
 			url = '/';
 		}
 		window.location = url;

--- a/client/login/test/redirect-to-login.js
+++ b/client/login/test/redirect-to-login.js
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import redirectLoggedIn from 'calypso/login/redirect-logged-in/index.web';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+const originalLocation = window.location;
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	isUserLoggedIn: jest.fn(),
+} ) );
+
+describe( 'redirectLoggedIn', () => {
+	let context;
+	let next;
+
+	describe( 'when user is logged in', () => {
+		beforeEach( () => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue( true );
+
+			context = {
+				store: {
+					getState: jest.fn(),
+				},
+				query: {},
+			};
+			next = jest.fn();
+
+			Object.defineProperty( window, 'location', {
+				value: { assign: jest.fn(), pathname: '', origin: 'https://wordpress.com' },
+				writable: true,
+			} );
+		} );
+
+		afterEach( () => {
+			Object.defineProperty( window, 'location', originalLocation );
+		} );
+
+		test( 'should redirect home when no redirect is passed', () => {
+			redirectLoggedIn( { ...context, query: {} }, next );
+			expect( window.location ).toBe( '/' );
+		} );
+
+		test( 'should redirect home when invalid internal url is passed', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn( { ...context, query: { redirect_to: '////test.com' } }, next );
+			expect( window.location ).toBe( '/' );
+		} );
+
+		test( 'should redirect according to valid internal redirect_to', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn( { ...context, query: { redirect_to: '/home' } }, next );
+			expect( window.location ).toBe( '/home' );
+		} );
+
+		test( 'should redirect home when invalid external url is provided', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn( { ...context, query: { redirect_to: 'invalid-external-url' } }, next );
+			expect( window.location ).toBe( '/' );
+		} );
+
+		test( 'should redirect according to allowed external url', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn(
+				{ ...context, query: { redirect_to: 'https://agencies.automattic.com' } },
+				next
+			);
+			expect( window.location ).toBe( 'https://agencies.automattic.com' );
+		} );
+
+		test( 'redirects to homepage when not allowed external url is provided', () => {
+			isUserLoggedIn.mockReturnValue( true );
+			redirectLoggedIn( { ...context, query: { redirect_to: 'https://test.com' } }, next );
+			expect( window.location ).toBe( '/' );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1741677495931879-slack-CRA4UEQQ3
We failed to do sanitisation for internal redirects when users are logged in and visit `login-in/link/use`.

## Proposed Changes

* Fix security issue by checking internal redirects

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix security issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Login to WordPress.com
* Visit: `/log-in/link/use/en-gb?token=${token_value}&email=${email_value}&client_id=39911&redirect_to=////nba.com`
* You should be redirected to the WordPress.com homepage
* Perform regression test to possibly find issues.
* The PR introduces unit tests for `redirectLoggedIn` they should be green 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?