### PR TITLE
A4A: Update the Referrals page, the Teams page, and the Forms to use Core typography.

### DIFF
--- a/client/a8c-for-agencies/components/form/field/style.scss
+++ b/client/a8c-for-agencies/components/form/field/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .a4a-form__section-field {
 	display: flex;
 	flex-direction: column;
@@ -7,7 +10,7 @@
 .a4a-form__section-field-label,
 .a4a-form__section-field-sub,
 .a4a-form__section-field-description {
-	@include a4a-font-body-md;
+	@include body-medium;
 }
 
 .a4a-form__section-field-label {

--- a/client/a8c-for-agencies/components/form/section/style.scss
+++ b/client/a8c-for-agencies/components/form/section/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-form__section {
 	padding: 16px 24px;
@@ -5,11 +7,11 @@
 }
 
 .a4a-form__section-heading-title {
-	@include a4a-font-heading-lg($font-weight: 500);
+	@include heading-large;
 }
 
 .a4a-form__section-heading-description {
-	@include a4a-font-body-md;
+	@include body-medium;
 	color: var(--color-neutral-50);
 }
 

--- a/client/a8c-for-agencies/components/form/style.scss
+++ b/client/a8c-for-agencies/components/form/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .a4a-form {
 	display: flex;
 	flex-direction: column;
@@ -20,9 +23,9 @@
 }
 
 .a4a-form__heading-title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 }
 
 .a4a-form__heading-description {
-	@include a4a-font-body-lg;
+	@include body-large;
 }

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -46,6 +46,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				/>
 			) }
 			<ConsolidatedStatsCard
+				applyCoreStyles
 				value={ formatCurrency( expectedCommission, 'USD' ) }
 				footerText={ translate( 'Next estimated payout amount' ) }
 				popoverTitle={ translate( 'Estimated amount' ) }
@@ -69,6 +70,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				isLoading={ isFetching }
 			/>
 			<ConsolidatedStatsCard
+				applyCoreStyles
 				value={ nextPayoutDate + '*' }
 				footerText={ translate( 'Next estimated payout date' ) }
 				popoverTitle={ translate( 'Estimated date' ) }
@@ -85,6 +87,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				) }
 			/>
 			<ConsolidatedStatsCard
+				applyCoreStyles
 				value={ pendingOrders }
 				footerText={ translate( 'Pending referral orders' ) }
 				popoverTitle={ translate( 'Pending orders' ) }

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -29,6 +29,7 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 		<ConsolidatedStatsGroup className="consolidated-view">
 			{ totalPayouts !== undefined && (
 				<ConsolidatedStatsCard
+					applyCoreStyles
 					value={ formatCurrency( totalPayouts, 'USD' ) }
 					footerText={ translate( 'All time referral payouts' ) }
 					popoverTitle={ translate( 'Total payouts' ) }

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 $iframe-background-color: #f7f7f7;
 
 .bank-details__iframe-container {
@@ -41,7 +41,7 @@ $iframe-background-color: #f7f7f7;
 }
 
 .bank-details__status {
-	@include a4a-font-label-button;
+	@include body-large;
 	color: var(--color-accent-80);
 
 	.badge {

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+
 $iframe-background-color: #f7f7f7;
 
 .bank-details__iframe-container {

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -99,7 +99,7 @@ export default function CommissionOverview( {
 					</>
 				) }
 				<div className="commission-overview__section-container">
-					<StepSection heading={ translate( 'How much can I earn?' ) }>
+					<StepSection applyCoreStyles heading={ translate( 'How much can I earn?' ) }>
 						<FoldableCard
 							header={
 								<>
@@ -181,7 +181,10 @@ export default function CommissionOverview( {
 						</FoldableCard>
 					</StepSection>
 
-					<StepSection heading={ translate( 'Eligibility requirements and terms of use?' ) }>
+					<StepSection
+						applyCoreStyles
+						heading={ translate( 'Eligibility requirements and terms of use?' ) }
+					>
 						<FoldableCard
 							header={ translate( 'Active referrals' ) }
 							expanded

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -213,6 +213,7 @@ export default function LayoutBodyContent( {
 					<>
 						{ ! isAutomatedReferral && <MigrationOffer /> }
 						<StepSection
+							applyCoreStyles
 							heading={
 								isAutomatedReferral
 									? translate( 'How do I start?' )
@@ -220,6 +221,7 @@ export default function LayoutBodyContent( {
 							}
 						>
 							<StepSectionItem
+								applyCoreStyles
 								isNewLayout={ isAutomatedReferral }
 								icon={ tipaltiLogo }
 								heading={
@@ -266,6 +268,7 @@ export default function LayoutBodyContent( {
 							/>
 							{ isAutomatedReferral ? (
 								<StepSectionItem
+									applyCoreStyles
 									iconClassName="referrals-overview__opacity-70-percent"
 									isNewLayout
 									icon={ reusableBlock }
@@ -282,6 +285,7 @@ export default function LayoutBodyContent( {
 								/>
 							) : (
 								<StepSectionItem
+									applyCoreStyles
 									iconClassName="referrals-overview__opacity-70-percent"
 									icon={ plugins }
 									heading={ translate( 'Verify your relationship with your clients' ) }
@@ -297,6 +301,7 @@ export default function LayoutBodyContent( {
 								/>
 							) }
 							<StepSectionItem
+								applyCoreStyles
 								isNewLayout={ isAutomatedReferral }
 								className="referrals-overview__step-section-woo-payments"
 								icon={ <WooLogo /> }
@@ -338,6 +343,7 @@ export default function LayoutBodyContent( {
 						</StepSection>
 						{ isAutomatedReferral && (
 							<StepSection
+								applyCoreStyles
 								className="referrals-overview__step-section-learn-more"
 								heading={ translate( 'Find out more' ) }
 							>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 $data-view-border-color: #f1f1f1;
 
@@ -11,12 +12,12 @@ $data-view-border-color: #f1f1f1;
 .referrals-overview__button-popover {
 	.a4a-popover__content {
 		.a4a-popover__title {
-			@include a4a-font-heading-md;
+			@include heading-medium;
 			color: var(--studio-gray-80);
 		}
 
 		.referrals-overview__button-popover-description {
-			@include a4a-font-body-md;
+			@include body-small;
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -58,8 +58,9 @@ export default function GetStarted() {
 					) }
 				</div>
 
-				<StepSection heading={ translate( 'How do I start?' ) }>
+				<StepSection applyCoreStyles heading={ translate( 'How do I start?' ) }>
 					<StepSectionItem
+						applyCoreStyles
 						isNewLayout
 						stepNumber={ 1 }
 						heading={ translate( 'Invite a team member' ) }
@@ -87,7 +88,7 @@ export default function GetStarted() {
 					/>
 				</StepSection>
 
-				<StepSection heading={ translate( 'Learn more about team members' ) }>
+				<StepSection applyCoreStyles heading={ translate( 'Learn more about team members' ) }>
 					<Button
 						className="team-list-get-started__learn-more-button"
 						variant="link"

--- a/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/style.scss
@@ -1,15 +1,18 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .team-list-get-started .hosting-dashboard-layout__body-wrapper {
 	max-width: 700px;
 }
 
 .team-list-get-started__heading {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	margin-block-start: 16px;
 	margin-block-end: 8px;
 }
 
 .team-list-get-started__subtitle {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin-block-end: 32px;
 }
 

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
@@ -51,7 +51,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 				) }
 			</div>
 
-			<StepSection heading={ translate( 'How to fix this:' ) }>
+			<StepSection applyCoreStyles heading={ translate( 'How to fix this:' ) }>
 				<StepSectionItem
 					isNewLayout
 					stepNumber={ 1 }
@@ -100,7 +100,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 				/>
 			</StepSection>
 
-			<StepSection heading={ translate( 'Learn more about Agency membership' ) }>
+			<StepSection applyCoreStyles heading={ translate( 'Learn more about Agency membership' ) }>
 				<Button
 					className="team-accept-invite__learn-more-button"
 					variant="link"

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 @mixin loading-effect {
 	animation: loading-fade 1.6s ease-in-out infinite;
 	background: var(--color-neutral-10);
@@ -8,14 +11,14 @@
 }
 
 .team-accept-invite__heading {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 
 	margin-block-start: 48px;
 	margin-block-end: 8px;
 }
 
 .team-accept-invite__subtitle {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin-block-end: 32px;
 	color: var(--color-neutral-60);
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .team-invite .hosting-dashboard-layout__body-wrapper {
 	max-width: 700px;
@@ -10,7 +11,7 @@
 }
 
 .team-invite-form__required-information {
-	@include a4a-font-body-md;
+	@include body-medium;
 	color: var(--color-neutral-50);
 	margin-block-start: -32px;
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-list/style.scss
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .team-list {
 	.hosting-dashboard-layout__body {
@@ -53,16 +54,16 @@
 }
 
 .team-list__member-column-details-name {
-	@include a4a-font-heading-md($font-size: rem(14px));
+	@include heading-medium;
 }
 
 .team-list__member-column-details-email {
-	@include a4a-font-body-sm;
+	@include body-small;
 	color: var(--color-neutral-70);
 }
 
 .team-list__status-badge {
-	@include a4a-font-body-sm;
+	@include body-small;
 
 	&.badge--warning {
 		color: var(--color-warning-50);


### PR DESCRIPTION
This PR updates the Referrals page, the Teams page, and the Forms to use Core typography.

**Referral page**
<img width="866" alt="Screenshot 2025-03-12 at 9 11 48 PM" src="https://github.com/user-attachments/assets/d1d28484-416a-41dc-8b8c-0c36a2b47177" />

**Teams page**
<img width="1728" alt="Screenshot 2025-03-12 at 9 03 01 PM" src="https://github.com/user-attachments/assets/9d775cb2-6059-41f1-8114-9577a7ce5dc7" />
<img width="1727" alt="Screenshot 2025-03-12 at 9 02 09 PM" src="https://github.com/user-attachments/assets/f1e71f1b-ead5-49db-bee3-92546a392968" />
<img width="1721" alt="Screenshot 2025-03-12 at 9 02 02 PM" src="https://github.com/user-attachments/assets/95ca5470-2fb1-4eed-bb10-7ed760e567ed" />

**Forms**
<img width="866" alt="Screenshot 2025-03-12 at 9 11 48 PM" src="https://github.com/user-attachments/assets/334927bb-71cc-4a93-8236-30616bbb9c76" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1912
Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1913

## Proposed Changes

* Update all components in the Referrals page to use the Core's typography.
* Update all components in the Teams page to use the Core's typography.
* Update all Form components to use the Core's typography.

## Why are these changes being made?
* This initiative aims to align with the Core library.

## Testing Instructions
* Use the A4A live link and go to the `/migrations` page.
* Use the A4A live link and go to the `/teams` page.
* Use the A4A live link and go to the `/partner-directory/agency-expertise` page.
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
