### PR TITLE
Reader editor - use a11y focus on expandable dropdown

### DIFF
--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -40,18 +40,18 @@
 .following__view-toggle {
 	display: flex;
 	gap: 8px;
-	
+
 	.components-button {
 		height: 36px;
 		min-width: 36px;
 		padding: 6px;
 		color: var(--color-text);
-		
+
 		&.is-pressed {
 			background: var(--color-text);
 			color: var(--color-surface);
 		}
-		
+
 		&:hover {
 			background: var(--color-text);
 			color: var(--color-surface);
@@ -75,7 +75,7 @@
 
 .following-stream__quick-post-card.card {
 
-	.foldable-card__action:focus {
+	.accessible-focus & .foldable-card__action:focus {
 		outline: none;
 		border-color: var(--color-primary);
 		box-shadow: 0 0 0 2px var(--color-primary-light);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/101153

## Proposed Changes

Changes this focus style to only appear under accesible focus

BEFORE
![reader-dropdown-before](https://github.com/user-attachments/assets/7da54cf5-e64d-47c1-9a9b-1f2fd008229f)


AFTER
![reader-dropdown-after](https://github.com/user-attachments/assets/ec6b976d-1f23-45ae-93e3-ff28ba6ec556)




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistency of focus styles for a11y.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader.
* Click on the dropdown to expand the editor, click again to close it.
* Verify the dropdown does not how a focus outline.
* Now do the same with keyboard navigation, verify the focus outline is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
