### PR TITLE
A4A: Update Agency Tier page to use Core typography.

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .agency-tier-download-badge__button {
 	display: flex;
@@ -34,15 +35,15 @@
 		flex-direction: column;
 
 		.agency-tier-download-badges-modal__title {
-			@include a4a-font-heading-xl;
+			@include heading-x-large;
 		}
 
 		.agency-tier-download-badges-modal__description {
-			@include a4a-font-body-md;
+			@include body-medium;
 		}
 
 		.agency-tier-download-badges-modal__list-heading {
-			@include a4a-font-heading-md($font-weight: 700);
+			@include heading-medium;
 		}
 
 		.agency-tier-download-badges-modal__list {
@@ -52,7 +53,7 @@
 			gap: 4px;
 
 			a.components-button {
-				@include a4a-font-body-lg;
+				@include body-large;
 				display: flex;
 				justify-content: flex-start;
 				gap: 8px;

--- a/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/primary/agency-tier-overview/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 $color-pink: #f4b1ff;
 $dark-blue: #022836;
@@ -103,31 +104,31 @@ $light-green: #53dc81;
 		}
 
 		.agency-tier-overview__current-agency-tier-label {
-			@include a4a-font-body-sm($font-weight: 600);
+			@include body-small;
 			text-transform: uppercase;
 			opacity: 0.7;
 			text-wrap: balance;
 
 			@include break-xlarge {
-				@include a4a-font-heading-md($font-weight: 600);
+				@include heading-medium;
 			}
 		}
 
 		.agency-tier-overview__current-agency-tier-title {
-			@include a4a-font-heading-xl;
+			@include heading-x-large;
 
 			@include break-xlarge {
-				@include a4a-font-heading-xxl;
+				@include heading-2x-large;
 			}
 		}
 
 		&.is-default {
 			.agency-tier-overview__current-agency-tier-title {
-				@include a4a-font-body-sm($font-weight: 800);
+				@include body-small;
 				text-transform: uppercase;
 
 				@include break-xlarge {
-					@include a4a-font-heading-md($font-weight: 800);
+					@include heading-medium;
 				}
 				opacity: 0.7;
 			}
@@ -193,12 +194,12 @@ $light-green: #53dc81;
 		}
 
 		div {
-			@include a4a-font-body-lg;
+			@include body-large;
 			margin-block-end: 8px;
 		}
 
 		a {
-			@include a4a-font-body-lg;
+			@include body-large;
 			padding: 0;
 			text-decoration: underline;
 			color: var(--color-text-black);
@@ -221,11 +222,11 @@ $light-green: #53dc81;
 }
 
 .agency-tier-overview__bottom-content-subheading {
-	@include a4a-font-body-md;
+	@include body-medium;
 }
 
 .agency-tier-overview__bottom-content-heading {
-	@include a4a-font-heading-xxl;
+	@include heading-2x-large;
 }
 
 .agency-tier-overview__bottom-content-cards {
@@ -268,12 +269,12 @@ $light-green: #53dc81;
 }
 
 .agency-tier-overview__benefit-card-title {
-	@include a4a-font-heading-lg;
+	@include heading-large;
 	padding-block-end: 4px;
 }
 
 .agency-tier-overview__benefit-card-desciption {
-	@include a4a-font-body-md;
+	@include body-medium;
 	padding-block-end: 24px;
 }
 
@@ -284,7 +285,7 @@ $light-green: #53dc81;
 	list-style-image: url(calypso/assets/images/a8c-for-agencies/agency-tier/list-icon.svg);
 
 	li {
-		@include a4a-font-body-sm;
+		@include body-small;
 		padding-inline-start: 8px;
 	}
 }
@@ -296,7 +297,7 @@ $light-green: #53dc81;
 	width: 100%;
 
 	.badge {
-		@include a4a-font-body-sm;
+		@include body-small;
 		display: flex;
 		align-items: center;
 	}
@@ -376,7 +377,7 @@ $light-green: #53dc81;
 		}
 
 		.agency-tier-overview__benefit-card-item-title {
-			@include a4a-font-heading-md($font-weight: 600);
+			@include heading-medium;
 			position: relative;
 			top: -6px;
 			left: 24px;

--- a/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/tier-permission-error/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .agency-tier-permission-error__layout {
 	.hosting-dashboard-layout__container {
@@ -69,11 +70,11 @@
 	}
 
 	.agency-tier-permission-error__content-heading {
-		@include a4a-font-heading-xl;
+		@include heading-x-large;
 	}
 
 	.agency-tier-permission-error__content-description {
-		@include a4a-font-body-md;
+		@include body-medium;
 	}
 
 	a.components-button {


### PR DESCRIPTION
This PR updates the Agency Tier page to now use the Core's typography.
<img width="1720" alt="Screenshot 2025-03-12 at 9 41 53 PM" src="https://github.com/user-attachments/assets/2fff1284-831f-4d77-89bb-10b731f1fe74" />
<img width="834" alt="Screenshot 2025-03-12 at 9 43 24 PM" src="https://github.com/user-attachments/assets/286879a6-8588-4fc3-b8aa-fc225db3090b" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1917

## Proposed Changes

* Update all components in the Agency Tier page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/agency-tier` page.
* Use the A4A live link and go to the `/partner-directory` page. **(Set your agency to non-pro to see the access required message)**
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
