### PR TITLE
Help Center: Enable Help center to be opened with search term

### DIFF
--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -6,7 +6,7 @@ import { GeneratorReturnType } from '../mapped-types';
 import { SiteDetails } from '../site';
 import { wpcomRequest } from '../wpcom-request-controls';
 import { isE2ETest } from '.';
-import type { APIFetchOptions, HelpCenterOptions } from './types';
+import type { APIFetchOptions, HelpCenterOptions, HelpCenterShowOptions } from './types';
 import type { SupportInteraction } from '@automattic/odie-client/src/types';
 
 export const receiveHasSeenWhatsNewModal = ( value: boolean | undefined ) =>
@@ -127,7 +127,7 @@ export const setHelpCenterOptions = ( options: HelpCenterOptions ) => ( {
 export const setShowHelpCenter = function* (
 	show: boolean,
 	allowPremiumSupport = false,
-	options = { hideBackButton: false, searchTerm: '' }
+	options: HelpCenterShowOptions = { hideBackButton: false, searchTerm: '' }
 ) {
 	if ( ! isE2ETest() ) {
 		try {

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -107,6 +107,12 @@ export const setShowMessagingWidget = ( show: boolean ) =>
 		show,
 	} ) as const;
 
+export const setMessage = ( message: string ) =>
+	( {
+		type: 'HELP_CENTER_SET_MESSAGE',
+		message,
+	} ) as const;
+
 export const setAllowPremiumSupport = ( allow: boolean ) =>
 	( {
 		type: 'HELP_CENTER_SET_ALLOW_PREMIUM_SUPPORT',
@@ -121,7 +127,7 @@ export const setHelpCenterOptions = ( options: HelpCenterOptions ) => ( {
 export const setShowHelpCenter = function* (
 	show: boolean,
 	allowPremiumSupport = false,
-	options = { hideBackButton: false }
+	options = { hideBackButton: false, searchTerm: '' }
 ) {
 	if ( ! isE2ETest() ) {
 		try {
@@ -153,7 +159,9 @@ export const setShowHelpCenter = function* (
 		yield setShowMessagingWidget( false );
 	}
 
+	yield setMessage( options.searchTerm );
 	yield setIsMinimized( false );
+
 	if ( allowPremiumSupport ) {
 		yield setAllowPremiumSupport( true );
 	}
@@ -172,12 +180,6 @@ export const setSubject = ( subject: string ) =>
 	( {
 		type: 'HELP_CENTER_SET_SUBJECT',
 		subject,
-	} ) as const;
-
-export const setMessage = ( message: string ) =>
-	( {
-		type: 'HELP_CENTER_SET_MESSAGE',
-		message,
 	} ) as const;
 
 export const setUserDeclaredSiteUrl = ( url: string ) =>

--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -9,7 +9,10 @@ export type Location = {
 	state?: unknown;
 	key?: string;
 };
-
+export interface HelpCenterShowOptions {
+	hideBackButton: boolean;
+	searchTerm: string;
+}
 export interface SiteLogo {
 	id: number;
 	sizes: never[];

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -58,11 +58,10 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 	// we need to keep the query param up-to-date with that
 	// Search term is used to set a search term before opening help center
 	useEffect( () => {
-		const hasSearchQuery = query || searchTerm;
-		if ( hasSearchQuery ) {
+		if ( query ) {
 			navigate( '/?query=' + searchQuery );
 		}
-	}, [ searchTerm, searchQuery, query, navigate ] );
+	}, [ searchQuery, query, navigate ] );
 
 	const redirectToArticle = useCallback(
 		( event: React.MouseEvent< HTMLAnchorElement, MouseEvent >, result: SearchResult ) => {

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -56,7 +56,6 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 
 	// Search query can be a query param, if the user searches or clears the search field
 	// we need to keep the query param up-to-date with that
-	// Search term is used to set a search term before opening help center
 	useEffect( () => {
 		if ( query ) {
 			navigate( '/?query=' + searchQuery );

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -56,8 +56,10 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 
 	// Search query can be a query param, if the user searches or clears the search field
 	// we need to keep the query param up-to-date with that
+	// Search term is used to set a search term before opening help center
 	useEffect( () => {
-		if ( query || searchTerm ) {
+		const hasSearchQuery = query || searchTerm;
+		if ( hasSearchQuery ) {
 			navigate( '/?query=' + searchQuery );
 		}
 	}, [ searchTerm, searchQuery, query, navigate ] );

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { NewThirdPartyCookiesNotice } from '@automattic/odie-client';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
@@ -14,6 +14,7 @@ import { SearchResult } from '../types';
 import { HelpCenterLaunchpad } from './help-center-launchpad';
 import { HelpCenterMoreResources } from './help-center-more-resources';
 import HelpCenterSearchResults from './help-center-search-results';
+import type { HelpCenterSelect } from '@automattic/data-stores';
 import './help-center-search.scss';
 import './help-center-launchpad.scss';
 
@@ -26,10 +27,15 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 	const navigate = useNavigate();
 	const { search } = useLocation();
 	const params = new URLSearchParams( search );
-	const query = params.get( 'query' );
 	const { sectionName, site, canConnectToZendesk } = useHelpCenterContext();
-
-	const [ searchQuery, setSearchQuery ] = useState( query || '' );
+	const { searchTerm } = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return {
+			searchTerm: helpCenterSelect.getMessage(),
+		};
+	}, [] );
+	const query = params.get( 'query' );
+	const [ searchQuery, setSearchQuery ] = useState( query || searchTerm || '' );
 	const { setSubject, setMessage } = useDispatch( HELP_CENTER_STORE );
 
 	// when the user sets the search query, let's also populate the email subject and body
@@ -51,10 +57,10 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 	// Search query can be a query param, if the user searches or clears the search field
 	// we need to keep the query param up-to-date with that
 	useEffect( () => {
-		if ( query ) {
+		if ( query || searchTerm ) {
 			navigate( '/?query=' + searchQuery );
 		}
-	}, [ searchQuery, query, navigate ] );
+	}, [ searchTerm, searchQuery, query, navigate ] );
 
 	const redirectToArticle = useCallback(
 		( event: React.MouseEvent< HTMLAnchorElement, MouseEvent >, result: SearchResult ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9821
Fixes https://github.com/Automattic/dotcom-forge/issues/9821

## Proposed Changes

* This PR adds the capability of setting a search term when setting the Help Center visibility. For instance, in a checkout page if the Help Center is opened, we can load it with checkout articles by default, since it might be what the user is looking for. More details p7DVsv-lGw-p2#comment-51682

**This PR does not yet make the Help Center open with any search term; it only introduces this capability. More PRs implementing this feature will follow.**

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In some pages, it makes sense to open the Help Center in a specific context to help the user better. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull this branch and run calypso locally
* In this [file (masterbar)](https://github.com/Automattic/wp-calypso/blob/trunk/client/layout/masterbar/masterbar-help-center/index.jsx#L36) you can change the `setShowHelpCenter` call to use this feature by adding `setShowHelpCenter( ! helpCenterVisible, false, { searchTerm: 'site theme' } );`
* Once done that, open the Help Center using the "?" icon from the Masterbar , when opened you should noticed that the search term set before, should be applied on the search field and the search results should be related to the search term.
