### PR TITLE
Code Blue: Fix active theme opening customizer instead of theme details page

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -7,7 +7,7 @@ import {
 	isLockedStyleVariation,
 } from '@automattic/design-picker';
 import { localize } from 'i18n-calypso';
-import { isEmpty, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import photon from 'photon';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
@@ -296,18 +296,11 @@ export class Theme extends Component {
 	renderMoreButton = () => {
 		const { active, buttonContents, index, theme, siteId } = this.props;
 
-		let moreOptions;
-		if ( active && buttonContents.info ) {
-			moreOptions = { info: buttonContents.info };
-		} else if ( buttonContents.deleteTheme ) {
-			moreOptions = { deleteTheme: buttonContents.deleteTheme };
-		} else {
-			moreOptions = {};
-		}
-
-		if ( isEmpty( moreOptions ) ) {
+		if ( ! buttonContents.deleteTheme ) {
 			return null;
 		}
+
+		const moreOptions = { deleteTheme: buttonContents.deleteTheme };
 
 		return (
 			<ThemeMoreButton

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -7,11 +7,9 @@ import SingleSiteThemeShowcaseJetpack from './single-site-jetpack';
 import SingleSiteThemeShowcaseWpcom from './single-site-wpcom';
 
 const SingleSiteThemeShowcaseWithOptions = ( props ) => {
-	const { activeTheme, isJetpack, siteId, translate } = props;
+	const { isJetpack, siteId, translate } = props;
 
-	const getScreenshotOption = ( themeId ) => {
-		return activeTheme === themeId ? 'customize' : 'info';
-	};
+	const getScreenshotOption = () => 'info';
 
 	if ( isJetpack ) {
 		return (


### PR DESCRIPTION
Related to:
- https://github.com/Automattic/wp-calypso/issues/100230

## Proposed Changes
We've removed the condition that checks if the theme is active and assigns a different action. Also, since clicking on the theme now navigates to the info action, we no longer need the three-dot menu with the info action. This change also makes the theme showcase items more consistent, as there are no longer special cases depending on whether the theme is active or not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This issue is part of the code blue effort to improve the quality of WordPress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link.
* Navigate to the theme showcase.
* Clicking on the active theme takes you to the theme's details page instead of the customizer.
* Test on the LoTS for regressions.
* Test on an Atomic site for regressions.
* Test on the siteless LiTS for regressions.

| Before | After |
| ------- | ------| 
|![Screenshot 2025-03-12 at 16 38 31](https://github.com/user-attachments/assets/0f20f60d-af15-4695-8363-80601d19441a)|![Screenshot 2025-03-12 at 16 38 37](https://github.com/user-attachments/assets/68c01e33-54a4-4b52-9dbd-6c25d69ad30f)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
