### PR TITLE
Stepper: Query eligibility while loading

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/index.tsx
@@ -277,6 +277,7 @@ const BundleConfirm: Step = function BundleConfirm( { navigation } ) {
 	if ( site === null || ! site.ID || ! isDataReady || isReadyToStart ) {
 		return (
 			<div className="bundle-confirm__loading-container">
+				<QueryEligibility siteId={ siteId } />
 				<LoadingEllipsis />
 			</div>
 		);


### PR DESCRIPTION
## Proposed Changes

Fixing https://github.com/Automattic/wp-calypso/pull/100472#issuecomment-2711388374

## Why are these changes being made?

We intended to land this as part of #100472, but it was left out during a rebase.

## Testing Instructions

Follow these instructions and verify it doesn't get stuck while loading: https://github.com/Automattic/wp-calypso/pull/100472#pullrequestreview-2645116827