### PR TITLE
Fix: Skip page pattern modal end to end tests.

### DIFF
--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -99,7 +99,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		expect( publishedUrl.pathname ).toContain( `/${ customUrlSlug }` );
 	} );
 
-	// Test will be updated to test test equivalent core functionality.
+	// Test will be updated to test equivalent core functionality.
 	it.skip( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -57,6 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await pagesPage.addNewPage();
 	} );
 
+	// Test will be updated to test test equvalent core functionality.
 	it.skip( 'Select page template', async function () {
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.
@@ -98,6 +99,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		expect( publishedUrl.pathname ).toContain( `/${ customUrlSlug }` );
 	} );
 
+	// Test will be updated to test test equvalent core functionality.
 	it.skip( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -57,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await pagesPage.addNewPage();
 	} );
 
-	// Test will be updated to test test equivalent core functionality.
+	// Test will be updated to test equivalent core functionality.
 	it.skip( 'Select page template', async function () {
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -57,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await pagesPage.addNewPage();
 	} );
 
-	// Test will be updated to test test equvalent core functionality.
+	// Test will be updated to test test equivalent core functionality.
 	it.skip( 'Select page template', async function () {
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.
@@ -99,7 +99,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		expect( publishedUrl.pathname ).toContain( `/${ customUrlSlug }` );
 	} );
 
-	// Test will be updated to test test equvalent core functionality.
+	// Test will be updated to test test equivalent core functionality.
 	it.skip( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -57,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await pagesPage.addNewPage();
 	} );
 
-	it( 'Select page template', async function () {
+	it.skip( 'Select page template', async function () {
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.
 		await editorPage.selectTemplateCategory( 'About', { timeout: 20 * 1000 } );
@@ -98,7 +98,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		expect( publishedUrl.pathname ).toContain( `/${ customUrlSlug }` );
 	} );
 
-	it( 'Published page contains template content', async function () {
+	it.skip( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );
 		await publishedPagePage.validateTextInPost( pageTemplateToSelect );


### PR DESCRIPTION
We are removing the page patterns modal this PR skips the related end-to-end tests as now they are testing wpcom functionality which is being removed.
As a follow up these tests should be updated to test equivalent core offered functionality.