### PR TITLE
Make locale suggestions notice at login/signup less obtrusive

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -96,7 +96,7 @@ export class LocaleSuggestions extends Component {
 
 		return (
 			<div className="locale-suggestions">
-				<Notice icon="globe" showDismiss onDismissClick={ this.dismiss }>
+				<Notice icon="globe" showDismiss onDismissClick={ this.dismiss } isCompact theme="light">
 					<div className="locale-suggestions__list">{ localeMarkup }</div>
 				</Notice>
 			</div>

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -96,7 +96,14 @@ export class LocaleSuggestions extends Component {
 
 		return (
 			<div className="locale-suggestions">
-				<Notice icon="globe" showDismiss onDismissClick={ this.dismiss } isCompact theme="light">
+				<Notice
+					icon="globe"
+					showDismiss
+					onDismissClick={ this.dismiss }
+					isCompact
+					theme="light"
+					status="is-info"
+				>
 					<div className="locale-suggestions__list">{ localeMarkup }</div>
 				</Notice>
 			</div>

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -97,6 +97,7 @@ export class LocaleSuggestions extends Component {
 		return (
 			<div className="locale-suggestions">
 				<Notice
+					className="locale-suggestions__notice"
 					icon="globe"
 					showDismiss
 					onDismissClick={ this.dismiss }

--- a/client/components/locale-suggestions/style.scss
+++ b/client/components/locale-suggestions/style.scss
@@ -17,7 +17,6 @@
 .locale-suggestions__notice {
 	&.notice.is-compact.is-light.is-info {
 		margin: 20px auto;
-		// width: 100%;
 
 		a.locale-suggestions__locale-link {
 			margin: 0 5px;

--- a/client/components/locale-suggestions/style.scss
+++ b/client/components/locale-suggestions/style.scss
@@ -1,6 +1,8 @@
 .locale-suggestions {
 	margin: 20px auto 0;
 	max-width: 500px;
+	display: flex;
+	justify-content: center;
 }
 
 .locale-suggestions__list-item {

--- a/client/components/locale-suggestions/style.scss
+++ b/client/components/locale-suggestions/style.scss
@@ -3,6 +3,15 @@
 	max-width: 500px;
 	display: flex;
 	justify-content: center;
+
+	.notice.is-light {
+		.notice__icon-wrapper {
+			color: var(--color-neutral-20);
+			.notice__icon-wrapper-drop {
+				background: var(--color-text-inverted);
+			}
+		}
+	}
 }
 
 .locale-suggestions__list-item {

--- a/client/components/locale-suggestions/style.scss
+++ b/client/components/locale-suggestions/style.scss
@@ -25,8 +25,7 @@
 			text-underline-offset: unset;
 		}
 
-		.wp-login__main.is-vip-auth &,
-		.wp-login__main.is-crowdsignal-auth & {
+		.wp-login__main.is-generic-oauth & {
 			background: var(--color-text-inverted);
 		}
 
@@ -37,8 +36,7 @@
 				background: var(--color-text-inverted);
 			}
 
-			.wp-login__main.is-vip-auth &,
-			.wp-login__main.is-crowdsignal-auth & {
+			.wp-login__main.is-generic-oauth & {
 				background: var(--color-text-inverted);
 			}
 		}

--- a/client/components/locale-suggestions/style.scss
+++ b/client/components/locale-suggestions/style.scss
@@ -4,14 +4,6 @@
 	display: flex;
 	justify-content: center;
 
-	.notice.is-light {
-		.notice__icon-wrapper {
-			color: var(--color-neutral-20);
-			.notice__icon-wrapper-drop {
-				background: var(--color-text-inverted);
-			}
-		}
-	}
 }
 
 .locale-suggestions__list-item {
@@ -22,6 +14,33 @@
 	}
 }
 
-.locale-suggestions__locale-link {
-	margin: 0 5px;
+.locale-suggestions__notice {
+	&.notice.is-compact.is-light.is-info {
+		margin: 20px auto;
+		// width: 100%;
+
+		a.locale-suggestions__locale-link {
+			margin: 0 5px;
+			font-size: inherit;
+			text-underline-offset: unset;
+		}
+
+		.wp-login__main.is-vip-auth &,
+		.wp-login__main.is-crowdsignal-auth & {
+			background: var(--color-text-inverted);
+		}
+
+		.notice__icon-wrapper {
+			color: var(--color-neutral-20);
+
+			.notice__icon-wrapper-drop {
+				background: var(--color-text-inverted);
+			}
+
+			.wp-login__main.is-vip-auth &,
+			.wp-login__main.is-crowdsignal-auth & {
+				background: var(--color-text-inverted);
+			}
+		}
+	}
 }

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -54,3 +54,7 @@ export const isStudioAppOAuth2Client = ( oauth2Client ) => {
 export const isPartnerPortalOAuth2Client = ( oauth2Client ) => {
 	return oauth2Client && [ 102832, 103914 ].includes( oauth2Client.id );
 };
+
+export const isVIPOAuth2Client = ( oauth2Client ) => {
+	return oauth2Client?.id === 76596;
+};

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -23,7 +23,8 @@ import {
 	isGravatarFlowOAuth2Client,
 	isGravatarOAuth2Client,
 	isGravPoweredOAuth2Client,
-	isVIPOAuth2Client,
+	isBlazeProOAuth2Client,
+	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -576,12 +577,11 @@ export class Login extends Component {
 			locale,
 			translate,
 			isFromMigrationPlugin,
+			isGenericOauth,
 			isGravPoweredClient,
 			isWoo,
 			isBlazePro,
-			isVIPOAuth,
 			isWhiteLogin,
-			isCrowdsignalOAuth,
 		} = this.props;
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 		const isSocialFirst =
@@ -598,8 +598,7 @@ export class Login extends Component {
 					className={ clsx( 'wp-login__main', {
 						'is-wpcom-migration': isFromMigrationPlugin,
 						'is-social-first': isSocialFirst,
-						'is-vip-auth': isVIPOAuth,
-						'is-crowdsignal-auth': isCrowdsignalOAuth,
+						'is-generic-oauth': isGenericOauth,
 					} ) }
 				>
 					{ this.renderI18nSuggestions() }
@@ -653,8 +652,13 @@ export default connect(
 			isWCCOM: getIsWCCOM( state ),
 			isWoo: getIsWoo( state ),
 			isBlazePro: getIsBlazePro( state ),
-			isVIPOAuth: isVIPOAuth2Client( oauth2Client ),
-			isCrowdsignalOAuth: isCrowdsignalOAuth2Client( oauth2Client ),
+			// This applies to all oauth screens except for A4A, Blaze Pro, Jetpack, Woo.
+			isGenericOauth:
+				oauth2Client &&
+				! isA4AOAuth2Client( oauth2Client ) &&
+				! isBlazeProOAuth2Client( oauth2Client ) &&
+				! isJetpackCloudOAuth2Client( oauth2Client ) &&
+				! isWooOAuth2Client( oauth2Client ),
 			currentRoute,
 			currentQuery,
 			redirectTo: getRedirectToOriginal( state ),

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -23,6 +23,7 @@ import {
 	isGravatarFlowOAuth2Client,
 	isGravatarOAuth2Client,
 	isGravPoweredOAuth2Client,
+	isVIPOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -578,7 +579,9 @@ export class Login extends Component {
 			isGravPoweredClient,
 			isWoo,
 			isBlazePro,
+			isVIPOAuth,
 			isWhiteLogin,
+			isCrowdsignalOAuth,
 		} = this.props;
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 		const isSocialFirst =
@@ -595,6 +598,8 @@ export class Login extends Component {
 					className={ clsx( 'wp-login__main', {
 						'is-wpcom-migration': isFromMigrationPlugin,
 						'is-social-first': isSocialFirst,
+						'is-vip-auth': isVIPOAuth,
+						'is-crowdsignal-auth': isCrowdsignalOAuth,
 					} ) }
 				>
 					{ this.renderI18nSuggestions() }
@@ -648,6 +653,8 @@ export default connect(
 			isWCCOM: getIsWCCOM( state ),
 			isWoo: getIsWoo( state ),
 			isBlazePro: getIsBlazePro( state ),
+			isVIPOAuth: isVIPOAuth2Client( oauth2Client ),
+			isCrowdsignalOAuth: isCrowdsignalOAuth2Client( oauth2Client ),
 			currentRoute,
 			currentQuery,
 			redirectTo: getRedirectToOriginal( state ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100426

## Proposed Changes

Make the locale suggestions notice a little less profound on signup/login pages.

## Media

| WPCOM Before | WPCOM After |
|--------|--------|
| <img width="500" alt="Screenshot 2025-03-12 at 6 53 50 PM" src="https://github.com/user-attachments/assets/b36f5809-82b3-455e-be15-5a9e7314ace0" /> | <img width="500" alt="Screenshot 2025-03-12 at 6 53 27 PM" src="https://github.com/user-attachments/assets/06ecff50-b2fb-4a7c-816f-02cfbcd07c1f" /> | 

| Crowdsignal | VIP | Woo |
|--------|--------|--------|
| <img width="400" alt="Screenshot 2025-03-13 at 6 49 46 PM" src="https://github.com/user-attachments/assets/32ac66fc-59bf-48d3-ba6e-f0488f2ffbcb" /> | <img width="400" alt="Screenshot 2025-03-13 at 7 00 40 PM" src="https://github.com/user-attachments/assets/398414bd-3cd4-4385-aee3-2d097a168c2a" /> | <img width="400" alt="Screenshot 2025-03-13 at 6 50 21 PM" src="https://github.com/user-attachments/assets/953a486e-d9fd-43c0-8ff2-59220db4ac4d" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Addresses https://github.com/Automattic/wp-calypso/issues/100426

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/el` and observe the notice shown at the top
* There are several login screens and variations. See comment below for a run down of all of them along with caveats: https://github.com/Automattic/wp-calypso/pull/101254#issuecomment-2718683901
* For instructions and direct local links to access these screens, see https://github.com/Automattic/wp-calypso/pull/100807

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
