### PR TITLE
fix back button behaviour when coming from wp-admin

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -612,12 +612,12 @@ const siteMigration: Flow = {
 					}
 
 					if ( entryPoint === 'wp-admin' ) {
-						const siteId = getSiteIdBySlug( siteSlug );
-						// Prevent redirect if the site does not belong to the current user
-						if ( undefined !== siteId ) {
-							window.location.replace( `https://${ siteSlug }/wp-admin/import.php` );
+						if ( null !== siteAdminUrl ) {
+							window.location.replace( `${ siteAdminUrl }import.php` );
 							return;
 						}
+						// Unexpected behavior probably caused by the user tinkering with the URL. Redirect to /start.
+						return exitFlow( '/start' );
 					}
 
 					return navigate(

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -611,6 +611,15 @@ const siteMigration: Flow = {
 						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/import/${ siteSlug }` ) );
 					}
 
+					if ( entryPoint === 'wp-admin' ) {
+						const siteId = getSiteIdBySlug( siteSlug );
+						// Prevent redirect if the site does not belong to the current user
+						if ( undefined !== siteId ) {
+							window.location.replace( `https://${ siteSlug }/wp-admin/import.php` );
+							return;
+						}
+					}
+
 					return navigate(
 						addQueryArgs( { siteSlug, siteId }, STEPS.SITE_MIGRATION_IDENTIFY.slug )
 					);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100896

## Proposed Changes
If pressing the `< Back` button on the `Migrate vs Import` step check the referrer, if it's `wp-admin` then redirect to `https://{SITE_SLUG}/wp-admin/import.php`.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As part of fixing the related issue we need to make sure we redirect to correct place when coming from wp-admin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply this PR to your local env or navigate to the Calypso Live link below
2. Set up an AT site for testing
1. Navigate to `http://calypso.localhost:3000/setup/site-migration/site-migration-import-or-migrate?siteId=[YOUR_AT_TESTING_SITE_ID]&ref=wp-admin`
3. Press the back button
4. Verify you are redirected to `[YOUR_AT_TESTING_SITE]/wp-admin/import.php`
5. Change the url to a non-existing site
6. Verify you land on the enter your URL step. This is the default behaviour as we should not redirect to a site that does not belong to the user.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
