### PR TITLE
A4A: Update Partner directory pages to use Core's typography.

### DIFF
--- a/client/a8c-for-agencies/components/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/index.tsx
@@ -2,6 +2,7 @@ import { Button, Badge } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import React from 'react';
+import { preventWidows } from 'calypso/lib/formatting';
 import StatusBadge from './status-badge';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -63,7 +64,7 @@ export default function StepSectionItem( {
 				<div className="step-section-item__heading">
 					{ heading } { isNewLayout && statusContent }
 				</div>
-				<div className="step-section-item__description">{ description }</div>
+				<div className="step-section-item__description">{ preventWidows( description ) }</div>
 				{ ! isNewLayout && buttonContent }
 			</div>
 			{ isNewLayout ? buttonContent : statusContent }

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/style.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 .partner-directory-agency-expertise__directory-client-sites {
 	display: grid;
@@ -25,18 +27,15 @@
 }
 
 h3.partner-directory-agency-expertise__client-samples-label {
-	font-size: rem(14px);
-	line-height: 1.5;
-	font-weight: 500;
+	@include body-medium;
 	margin-block-end: 8px;
 }
 
 .partner-directory-agency-expertise__error {
 	margin-block-start: 0.25rem;
 	color: var(--color-scary-40);
+	@include body-small;
 	font-style: italic;
-	font-size: 0.875rem;
-	line-height: 14px;
 
 	&.hidden {
 		display: none;

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -1,5 +1,6 @@
-import { BadgeType, Button } from '@automattic/components';
-import { Icon, external, check } from '@wordpress/icons';
+import { BadgeType } from '@automattic/components';
+import { Button, ExternalLink } from '@wordpress/components';
+import { check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -211,28 +212,17 @@ const PartnerDirectoryDashboard = () => {
 
 	const programLinks = (
 		<StepSection
+			applyCoreStyles
 			className="partner-directory-dashboard__learn-more-section"
 			heading={ translate( 'Learn more about the program' ) }
 		>
-			<Button
-				className="a8c-blue-link"
-				borderless
-				target="_blank"
-				href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings"
-			>
+			<ExternalLink href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings">
 				{ translate( 'How does the approval process work?' ) }
-				<Icon icon={ external } size={ 18 } />
-			</Button>
+			</ExternalLink>
 			<br />
-			<Button
-				className="a8c-blue-link"
-				borderless
-				target="_blank"
-				href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content"
-			>
+			<ExternalLink href="https://agencieshelp.automattic.com/knowledge-base/agency-directory-listings/#profile-content">
 				{ translate( 'What can I put on my public profile?' ) }
-				<Icon icon={ external } size={ 18 } />
-			</Button>
+			</ExternalLink>
 		</StepSection>
 	);
 
@@ -249,22 +239,15 @@ const PartnerDirectoryDashboard = () => {
 				// Application approved and visible in the directory
 				return (
 					<>
-						<Button className="a8c-blue-link" borderless href={ brandMeta.url } target="_blank">
+						<ExternalLink href={ brandMeta.url }>
 							{ translate( '%(brand)s Partner Directory', {
 								args: { brand: brandMeta.brand },
 							} ) }
-							<Icon icon={ external } size={ 18 } />
-						</Button>
+						</ExternalLink>
 						<br />
-						<Button
-							className="a8c-blue-link"
-							borderless
-							href={ brandMeta.urlProfile }
-							target="_blank"
-						>
+						<ExternalLink href={ brandMeta.urlProfile }>
 							{ translate( "Your agency's profile" ) }
-							<Icon icon={ external } size={ 18 } />
-						</Button>
+						</ExternalLink>
 					</>
 				);
 			}
@@ -308,6 +291,7 @@ const PartnerDirectoryDashboard = () => {
 
 						return (
 							<StepSectionItem
+								applyCoreStyles
 								key={ application.brand }
 								isNewLayout
 								iconClassName={ clsx( brandMeta.className ) }
@@ -318,6 +302,7 @@ const PartnerDirectoryDashboard = () => {
 						);
 					} ) }
 				<StepSection
+					applyCoreStyles
 					className="partner-directory-dashboard__edit-section"
 					heading={ translate( "Edit your agency's information" ) }
 				>
@@ -326,18 +311,18 @@ const PartnerDirectoryDashboard = () => {
 							"Expand to more Automattic directories by adding products or updating your agency's profile."
 						) }
 					</div>
-					<div>
+					<div className="partner-directory-dashboard__button-container">
 						<Button
 							onClick={ onEditExpertiseClick }
 							href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_EXPERTISE_SLUG }` }
-							compact
+							variant="secondary"
 						>
 							{ translate( 'Edit expertise' ) }
 						</Button>
 						<Button
 							onClick={ onEditProfileClick }
 							href={ `${ A4A_PARTNER_DIRECTORY_LINK }/${ PARTNER_DIRECTORY_AGENCY_DETAILS_SLUG }` }
-							compact
+							variant="secondary"
 						>
 							{ translate( 'Edit profile' ) }
 						</Button>
@@ -359,8 +344,9 @@ const PartnerDirectoryDashboard = () => {
 					'List your agency in our partner directories. Showcase your skills, attract clients, and grow your business.'
 				) }
 			</div>
-			<StepSection heading={ translate( 'How do I start?' ) }>
+			<StepSection applyCoreStyles heading={ translate( 'How do I start?' ) }>
 				<StepSectionItem
+					applyCoreStyles
 					isNewLayout
 					className={
 						currentApplicationStep > 0 ? 'partner-directory-dashboard__checked-step' : ''
@@ -406,6 +392,7 @@ const PartnerDirectoryDashboard = () => {
 					} }
 				/>
 				<StepSectionItem
+					applyCoreStyles
 					isNewLayout
 					className={
 						currentApplicationStep > 1 ? 'partner-directory-dashboard__checked-step' : ''
@@ -426,6 +413,7 @@ const PartnerDirectoryDashboard = () => {
 					} }
 				/>
 				<StepSectionItem
+					applyCoreStyles
 					isNewLayout
 					stepNumber={ currentApplicationStep > 2 ? undefined : 3 }
 					icon={ currentApplicationStep > 2 ? check : undefined }

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
 .partner-directory__dashboard {
 	.hosting-dashboard-layout__body-wrapper {
 		max-width: 700px;
@@ -15,16 +18,14 @@
 
 .partner-directory-dashboard__heading {
 	margin-block-start: 32px;
-	font-size: rem(24px);
+	@include heading-x-large;
 	margin-block-end: 8px;
-	font-weight: 600;
 }
 .partner-directory-dashboard__subtitle {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
-	font-size: rem(14px);
-	font-weight: 400;
+	@include body-medium;
 	margin-block-end: 48px;
 	color: var(--color-neutral-50);
 }
@@ -113,7 +114,6 @@
 	}
 
 	.partner-directory-dashboard__popover-content-title {
-		font-size: rem(14px);
 		color: var(--color-accent-60);
 	}
 }
@@ -122,4 +122,10 @@
 	.components-popover__content {
 		padding: 16px;
 	}
+}
+
+.partner-directory-dashboard__button-container {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
 }

--- a/client/a8c-for-agencies/sections/partner-directory/style.scss
+++ b/client/a8c-for-agencies/sections/partner-directory/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
 .partner-directory-agency-cta__footer {
 	display: flex;
 	flex-direction: row;
@@ -20,16 +23,16 @@
 
 .partner-directory__body {
 	.searchable-dropdown input.components-combobox-control__input[type="text"] {
-		font-size: rem(14px);
+		@include body-medium;
 	}
 
 	.searchable-dropdown .components-form-token-field__suggestions-list li {
-		font-size: rem(14px);
+		@include body-medium;
 	}
 }
 
 .partner-directory-agency-cta__required-information {
-	font-size: rem(14px);
+	@include body-medium;
 	color: var(--color-neutral-50);
 	margin-block-start: -32px;
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -184,6 +184,10 @@
 		}
 	}
 
+	.components-external-link {
+		color: var(--color-primary-50);
+	}
+
 	.components-button.is-destructive,
 	.button.is-scary {
 		color: var(--color-scary-50);


### PR DESCRIPTION
This PR updates the Partner directory pages to now use the Core's typography.
<img width="2150" alt="Screenshot 2025-03-13 at 1 50 06 AM" src="https://github.com/user-attachments/assets/b60c6b20-cee3-4d23-b3fd-54851437bb86" />
<img width="1919" alt="Screenshot 2025-03-13 at 1 50 23 AM" src="https://github.com/user-attachments/assets/65c8c1c5-ca30-4901-90f7-0ccaf33545b5" />
<img width="1717" alt="Screenshot 2025-03-13 at 1 51 20 AM" src="https://github.com/user-attachments/assets/879cf07a-ae36-4742-9b7e-177bea579c7b" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1918

## Proposed Changes

* Update all components in the Migrations page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/partner-directory` page.
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
