### PR TITLE
Site Migration: Removing ending slash

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -55,7 +55,15 @@ const isWPCOM = ( siteInfo?: UrlData ) => {
 };
 
 const removeEndingSlash = ( url: string ) => {
-	return url.endsWith( '/' ) ? url.slice( 0, -1 ) : url;
+	if ( ! globalThis.URL.canParse( url ) ) {
+		return url;
+	}
+	// Only remove the trailing slash if it's the only value in the path.
+	const urlObject = new globalThis.URL( url );
+	if ( urlObject.pathname === '/' && url.endsWith( '/' ) ) {
+		return url.slice( 0, -1 );
+	}
+	return url;
 };
 
 export const useCredentialsForm = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -55,14 +55,17 @@ const isWPCOM = ( siteInfo?: UrlData ) => {
 };
 
 const removeEndingSlash = ( url: string ) => {
-	if ( ! globalThis.URL.canParse( url ) ) {
-		return url;
+	try {
+		const urlObject = new globalThis.URL( url );
+		if ( urlObject.pathname === '/' && url.endsWith( '/' ) ) {
+			return url.slice( 0, -1 );
+		}
+	} catch {
+		if ( url.endsWith( '/' ) ) {
+			return url.slice( 0, -1 );
+		}
 	}
-	// Only remove the trailing slash if it's the only value in the path.
-	const urlObject = new globalThis.URL( url );
-	if ( urlObject.pathname === '/' && url.endsWith( '/' ) ) {
-		return url.slice( 0, -1 );
-	}
+
 	return url;
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -54,15 +54,8 @@ const isWPCOM = ( siteInfo?: UrlData ) => {
 	return !! siteInfo?.platform_data?.is_wpcom;
 };
 
-const getFormDefaultValues = ( fromUrl: string ): CredentialsFormData => {
-	return {
-		from_url: fromUrl,
-		username: '',
-		password: '',
-		backupFileLocation: '',
-		notes: '',
-		migrationType: 'credentials',
-	};
+const removeEndingSlash = ( url: string ) => {
+	return url.endsWith( '/' ) ? url.slice( 0, -1 ) : url;
 };
 
 export const useCredentialsForm = (
@@ -70,7 +63,7 @@ export const useCredentialsForm = (
 ) => {
 	const isApplicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
 	const siteSlug = useSiteSlugParam();
-	const importSiteQueryParam = useQuery().get( 'from' ) || '';
+	const fromUrl = useQuery().get( 'from' ) || '';
 	const [ siteInfo, setSiteInfo ] = useState< UrlData | undefined >( undefined );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const siteId = parseInt( useSiteIdParam() ?? '' );
@@ -96,7 +89,14 @@ export const useCredentialsForm = (
 		mode: 'onSubmit',
 		reValidateMode: 'onSubmit',
 		disabled: isBusy,
-		defaultValues: getFormDefaultValues( importSiteQueryParam ),
+		defaultValues: {
+			from_url: removeEndingSlash( fromUrl ),
+			username: '',
+			password: '',
+			backupFileLocation: '',
+			notes: '',
+			migrationType: 'credentials',
+		},
 		errors: serverSideError,
 	} );
 


### PR DESCRIPTION

Closes  [#100865](https://github.com/Automattic/wp-calypso/issues/100865)

## Proposed Changes
* Remove the existing ending slash


## Testing Instructions
* Go to /hosted-site-migration
* Set any WP site using an ending slash (E.g https://snowshoe-of-stags.jurassic.ninja/)
*  Follow the assisted migration steps
*  When you arrive on the `Tell us about your WordPress site` page, check if the input is not showing the ending `/`
* Select the input and type `/`
*  Check if the code is not blocking you to type `/` if needed. 

![Uploading CleanShot 2025-03-12 at 18.07.15@2x.png…]()


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
