### PR TITLE
Fix the "Add Sites" card for mobile version

### DIFF
--- a/client/components/sites-add-new-site/style.scss
+++ b/client/components/sites-add-new-site/style.scss
@@ -22,11 +22,13 @@
 .sites-add-new-site__popover-content {
 	display: flex;
 	flex-direction: column;
-	padding: 28px 32px;
-	gap: 32px;
+	padding: 1em;
+	gap: 1em;
 
 	@include break-large {
 		flex-direction: row;
+		padding: 28px 32px;
+		gap: 32px;
 	}
 
 	.sites-add-new-site__popover-column {
@@ -41,11 +43,15 @@
 	color: var(--color-neutral-40);
 	font-size: rem(12px);
 	font-weight: 500;
+	padding: 0 1em;
+
+	@include break-large {
+		padding: 0;
+	}
 }
 
 
 .components-button.sites-add-new-site__popover-button {
-	padding: 8px;
 	white-space: unset;
 	text-align: unset;
 	margin-block: 0;
@@ -53,6 +59,7 @@
 	border-radius: 4px;
 	height: auto;
 	color: var(--color-text-black);
+	padding: 1em;
 
 	&:hover {
 		color: var(--color-text-black);
@@ -65,6 +72,7 @@
 	}
 
 	@include break-large {
+		padding: 8px;
 		display: flex;
 		gap: 8px;
 		align-items: unset;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #100910

## Proposed Changes

* Fixes the spacings on the "Add Site" popover to align the titles and CTA for the discount.
* I also ensured we used the `em` unit instead of pixels.

#### Before

![Captura de Tela 2025-03-12 às 15 02 40](https://github.com/user-attachments/assets/c721ca18-9d6a-4b91-a6d7-52c845070972)

#### After

![Captura de Tela 2025-03-12 às 15 03 42](https://github.com/user-attachments/assets/f0bad565-c1ea-44e4-8eee-7277800db108)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We noticed that the "Add Site" card on the `/sites` page was not looking good for the mobile version. We had too much spacing between the items and the card boundaries, and the tiles were not correctly aligned with the items it included and the CTA box.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local environment or use the Calypso Live link below
* Navigate to `/sites` and ensure you are viewing the mobile version.
* Please note the new spacings and alignment

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
