### PR TITLE
Subscriber Stats: Unify response field "is_owner_subscribed"

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -63,7 +63,7 @@ const selectSubscribers = ( payload: {
 	total: number;
 	total_email: number;
 	total_wpcom: number;
-	is_owner_subscribing: boolean;
+	is_owner_subscribed: boolean;
 	subscribers: {
 		label?: string;
 		date_subscribed: string;
@@ -77,7 +77,7 @@ const selectSubscribers = ( payload: {
 		total: payload.total,
 		total_email: payload.total_email,
 		total_wpcom: payload.total_wpcom,
-		is_owner_subscribing: payload.is_owner_subscribing,
+		is_owner_subscribed: payload.is_owner_subscribed,
 		subscribers: payload.subscribers?.map( ( item ) => {
 			return {
 				label: item.label ?? item.display_name,
@@ -167,7 +167,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 						? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
 						: null,
 				social_followers: results[ 1 ]?.data?.social_followers,
-				is_owner_subscribing: results[ 0 ]?.data?.is_owner_subscribing,
+				is_owner_subscribed: results[ 0 ]?.data?.is_owner_subscribed,
 				subscribers: ( results[ 0 ]?.data?.subscribers ?? [] ).sort( sortByDateDesc ),
 			},
 			isLoading: results.some( ( result ) => result.isPending ),
@@ -188,7 +188,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					? results[ 1 ].data.email_subscribers - results[ 1 ].data.paid_subscribers
 					: null,
 			social_followers: results[ 1 ]?.data?.social_followers,
-			is_owner_subscribing: results[ 2 ]?.data?.is_owner_subscribing,
+			is_owner_subscribed: results[ 2 ]?.data?.is_owner_subscribed,
 			// Merge email and wpcom subscribers and sort by date_subscribed, and only shows the most recent 10 subscribers.
 			subscribers: [
 				...( results[ 3 ]?.data?.subscribers ?? [] ),

--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -84,7 +84,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	const isSimple = useSelector( isSimpleSite );
 	const hasNoSubscriberOtherThanAdmin =
 		! subscribersTotals?.total ||
-		( subscribersTotals?.total === 1 && subscribersTotals?.is_owner_subscribing );
+		( subscribersTotals?.total === 1 && subscribersTotals?.is_owner_subscribed );
 	const showLaunchpad = ! isLoading && hasNoSubscriberOtherThanAdmin;
 
 	const emptyComponent = isSimple ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/99573

## Proposed Changes

* Use `is_owner_subscribed` instead of `is_owner_subscribing`.

#### /stats/followers
<img width="513" alt="截圖 2025-03-13 凌晨3 01 03" src="https://github.com/user-attachments/assets/327d8ba7-0178-4ef4-81a6-a3985adfcec6" />

#### /subscribers_by_user_type
<img width="437" alt="截圖 2025-03-13 凌晨3 00 53" src="https://github.com/user-attachments/assets/4897d2aa-46aa-40e8-b0fc-870c5a2ddbfd" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As there are two similar variable names that may cause confusion, I propose to replace the one I am familiar with with the other one to unify them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with Calypso Live branch.
* Navigate to Stats > Subscribers with a Simple site only the admin subscribes to.
* Ensure the page shows launch pad rather than the one subscriber chart.

<img width="1040" alt="截圖 2025-03-13 凌晨3 33 03" src="https://github.com/user-attachments/assets/c7f9764e-bfc4-4e07-98d5-066e9697044b" />

* Sandbox 176806-ghe-Automattic/wpcom.
* Spin this change up locally for a self-hosted site only the admin subscribes to: `cd /some-path-to/wp-calypso/apps/odyssey-stats && STATS_PACKAGE_PATH=/some-path-to/jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to Stats > Subscribers.
* Ensure the page shows steps to **Grow your subscribers** rather than the one subscriber chart.

<img width="1095" alt="截圖 2025-03-13 凌晨3 32 09" src="https://github.com/user-attachments/assets/28ce197d-d908-4253-93d0-7a024c685468" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?