### PR TITLE
Fix: Some issues on the current wpcom start page patterns skipping.

### DIFF
--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -59,11 +59,11 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		// Insert a random block to make the page dirty so it can be published and follow-up tests can be run.
 		// Temporary solution until we update tests to equivalent core functionality.
 		await editorPage.waitUntilLoaded();
-		const editorCanvas = await editorPage.getEditorParent();
-		if ( await editorCanvas.getByRole( 'button', { name: 'Close Block Inserter' } ).isVisible() ) {
-			await editorCanvas.getByRole( 'button', { name: 'Close Block Inserter' } ).click();
+		const editorParent = await editorPage.getEditorParent();
+		if ( await editorParent.getByRole( 'button', { name: 'Close Block Inserter' } ).isVisible() ) {
+			await editorParent.getByRole( 'button', { name: 'Close Block Inserter' } ).click();
 		}
-		await editorCanvas.getByRole( 'button', { name: 'Block Inserter' } ).first().click();
+		await editorParent.getByRole( 'button', { name: 'Block Inserter' } ).first().click();
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -98,7 +98,6 @@ describe.skip( DataHelper.createSuiteTitle( 'Editor: Basic Page Flow' ), functio
 		expect( publishedUrl.pathname ).toContain( `/${ customUrlSlug }` );
 	} );
 
-	// Test will be updated to test equivalent core functionality.
 	it( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -73,7 +73,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
 	} );
 
-	it( 'Template content loads into editor', async function () {
+	// Test will be updated to test equivalent core functionality.
+	it.skip( 'Template content loads into editor', async function () {
 		const editorCanvas = await editorPage.getEditorCanvas();
 		await editorCanvas.locator( `h1.wp-block:text-is('${ pageTemplateToSelect }')` ).waitFor();
 	} );

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -80,6 +80,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Open setting sidebar', async function () {
+		editorPage = new EditorPage( page );
 		await editorPage.openSettings();
 	} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -55,6 +55,18 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Start a new page', async function () {
 		await pagesPage.addNewPage();
+		editorPage = new EditorPage( page );
+		// Insert a random block to make the page dirty so it can be published and follow up tests can be run.
+		// Temporary solution we update tests to equivalent core functionality.
+		await editorPage.waitUntilLoaded();
+		const editorCanvas = await editorPage.getEditorParent();
+		if ( await editorCanvas.getByRole( 'button', { name: 'Close Block Inserter' } ).isVisible() ) {
+			await editorCanvas.getByRole( 'button', { name: 'Close Block Inserter' } ).click();
+		}
+		await editorCanvas.getByRole( 'button', { name: 'Block Inserter' } ).first().click();
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
 	} );
 
 	// Test will be updated to test equivalent core functionality.
@@ -80,7 +92,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Open setting sidebar', async function () {
-		editorPage = new EditorPage( page );
 		await editorPage.openSettings();
 	} );
 

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -56,8 +56,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	it( 'Start a new page', async function () {
 		await pagesPage.addNewPage();
 		editorPage = new EditorPage( page );
-		// Insert a random block to make the page dirty so it can be published and follow up tests can be run.
-		// Temporary solution we update tests to equivalent core functionality.
+		// Insert a random block to make the page dirty so it can be published and follow-up tests can be run.
+		// Temporary solution until we update tests to equivalent core functionality.
 		await editorPage.waitUntilLoaded();
 		const editorCanvas = await editorPage.getEditorParent();
 		if ( await editorCanvas.getByRole( 'button', { name: 'Close Block Inserter' } ).isVisible() ) {

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -22,7 +22,8 @@ const customUrlSlug = `about-${ DataHelper.getTimestamp() }-${ DataHelper.getRan
 	100
 ) }`;
 
-describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
+// Test will be updated to test equivalent core functionality.
+describe.skip( DataHelper.createSuiteTitle( 'Editor: Basic Page Flow' ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature(
 		features,
@@ -55,22 +56,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Start a new page', async function () {
 		await pagesPage.addNewPage();
-		editorPage = new EditorPage( page );
-		// Insert a random block to make the page dirty so it can be published and follow-up tests can be run.
-		// Temporary solution until we update tests to equivalent core functionality.
-		await editorPage.waitUntilLoaded();
-		const editorParent = await editorPage.getEditorParent();
-		if ( await editorParent.getByRole( 'button', { name: 'Close Block Inserter' } ).isVisible() ) {
-			await editorParent.getByRole( 'button', { name: 'Close Block Inserter' } ).click();
-		}
-		await editorParent.getByRole( 'button', { name: 'Block Inserter' } ).first().click();
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Enter' );
 	} );
 
-	// Test will be updated to test equivalent core functionality.
-	it.skip( 'Select page template', async function () {
+	it( 'Select page template', async function () {
 		editorPage = new EditorPage( page );
 		// Allow some time for CPU and/or network to catch up.
 		await editorPage.selectTemplateCategory( 'About', { timeout: 20 * 1000 } );
@@ -85,8 +73,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
 	} );
 
-	// Test will be updated to test equivalent core functionality.
-	it.skip( 'Template content loads into editor', async function () {
+	it( 'Template content loads into editor', async function () {
 		const editorCanvas = await editorPage.getEditorCanvas();
 		await editorCanvas.locator( `h1.wp-block:text-is('${ pageTemplateToSelect }')` ).waitFor();
 	} );
@@ -99,7 +86,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await editorPage.setURLSlug( customUrlSlug );
 	} );
 
-	// This step is required on mobile, but doesn't hurt anything on desktop, so avoiding conditional.
 	it( 'Close settings sidebar', async function () {
 		await editorPage.closeSettings();
 	} );
@@ -113,7 +99,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	// Test will be updated to test equivalent core functionality.
-	it.skip( 'Published page contains template content', async function () {
+	it( 'Published page contains template content', async function () {
 		// Not a typo, it's the POM page class for a WordPress page. :)
 		const publishedPagePage = new PublishedPostPage( page );
 		await publishedPagePage.validateTextInPost( pageTemplateToSelect );


### PR DESCRIPTION
Adds a skip I missed on https://github.com/Automattic/wp-calypso/pull/101253.
And adds a temporary solution that makes the post dirty by adding a random block so the publish test works.
We this change we are testing the page publish flow without the add pattern part which was removed.

On https://github.com/Automattic/wp-calypso/pull/101265 I'm working on an update to the start page patterns to test core functionality but while that PR is being worked on, the tests testing the wpcom functionality which now does not exist should be skipped.

## Testing

Tested locally with `yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
