### PR TITLE
Reader: Add unit tests for User Profile

### DIFF
--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -64,12 +64,18 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 	return (
 		<div className="user-profile-header">
 			<header className="user-profile-header__main">
-				<div className="user-profile-header__avatar user-profile-header__avatar-desktop">
+				<div
+					className="user-profile-header__avatar user-profile-header__avatar-desktop"
+					data-testid="desktop-avatar"
+				>
 					{ avatarElement }
 				</div>
 				<div className="user-profile-header__details">
 					<div className="user-profile-header__display-name">
-						<div className="user-profile-header__avatar user-profile-header__avatar-mobile">
+						<div
+							className="user-profile-header__avatar user-profile-header__avatar-mobile"
+							data-testid="mobile-avatar"
+						>
 							{ avatarElement }
 						</div>
 						{ user.display_name }

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -76,7 +76,7 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 					</div>
 					{ user.bio && (
 						<div className="user-profile-header__bio">
-							<p className="user-profile-header__bio-desc">
+							<div className="user-profile-header__bio-desc">
 								<span ref={ bioRef } className="user-profile-header__bio-desc-text">
 									{ user.bio }
 								</span>
@@ -89,7 +89,7 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 										</a>
 									</>
 								) }
-							</p>
+							</div>
 						</div>
 					) }
 				</div>

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -76,20 +76,20 @@ const UserProfileHeader = ( { user }: UserProfileHeaderProps ): JSX.Element => {
 					</div>
 					{ user.bio && (
 						<div className="user-profile-header__bio">
-							<div className="user-profile-header__bio-desc">
+							<p className="user-profile-header__bio-desc">
 								<span ref={ bioRef } className="user-profile-header__bio-desc-text">
 									{ user.bio }
 								</span>
 								{ isClamped && user.profile_URL && (
 									<>
-										<div className="user-profile-header__bio-desc-fader"></div>
+										<span className="user-profile-header__bio-desc-fader"></span>
 										<a className="user-profile-header__bio-desc-link" href={ user.profile_URL }>
 											{ translate( 'Read More' ) }{ ' ' }
 											<Icon width={ 18 } height={ 18 } icon={ external } />
 										</a>
 									</>
 								) }
-							</div>
+							</p>
 						</div>
 					) }
 				</div>

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -100,11 +100,6 @@ describe( 'UserProfileHeader', () => {
 		const displayNameEl = screen.getByText( defaultUser.display_name ?? '' );
 		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( displayNameEl ).toBeInTheDocument();
-
-		expect(
-			displayNameEl.closest( '[class*="user-profile-header__display-name"]' )
-			// @ts-expect-error -- jest-dom matchers are available globally
-		).toBeInTheDocument();
 	} );
 
 	/**
@@ -166,8 +161,6 @@ describe( 'UserProfileHeader', () => {
 		const bioText = screen.getByText( userWithBio.bio );
 		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( bioText ).toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
-		expect( bioText.closest( '[class*="user-profile-header__bio"]' ) ).toBeInTheDocument();
 	} );
 
 	/**

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import UserProfileHeader from '../index';
+
+// Mock external icon
+jest.mock( '@wordpress/icons', () => ( {
+	external: 'mock-external-icon',
+	Icon: ( { icon } ) => <span data-testid="icon">{ icon }</span>,
+} ) );
+
+// Mock ReaderAvatar component
+jest.mock( 'calypso/blocks/reader-avatar', () => ( {
+	__esModule: true,
+	default: ( { author, iconSize } ) => (
+		<div data-testid="reader-avatar" data-author-id={ author.ID } data-icon-size={ iconSize }>
+			{ author.avatar_URL && (
+				<img src={ author.avatar_URL } alt="avatar" data-testid="avatar-img" />
+			) }
+		</div>
+	),
+} ) );
+
+// Mock SectionNav components
+jest.mock( 'calypso/components/section-nav', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div data-testid="section-nav">{ children }</div>,
+} ) );
+
+// Mock SectionNav/Tabs component
+jest.mock( 'calypso/components/section-nav/tabs', () => ( {
+	__esModule: true,
+	default: ( { children } ) => <div data-testid="nav-tabs">{ children }</div>,
+} ) );
+
+// Mock SectionNav/Item component
+jest.mock( 'calypso/components/section-nav/item', () => ( {
+	__esModule: true,
+	default: ( { children, path, selected } ) => (
+		<a href={ path } data-testid="nav-item" data-selected={ selected ? 'true' : 'false' }>
+			{ children }
+		</a>
+	),
+} ) );
+
+describe( 'UserProfileHeader', () => {
+	const defaultUser = {
+		ID: 123,
+		user_login: 'testuser',
+		display_name: 'Test User',
+		avatar_URL: 'https://example.com/avatar.jpg',
+		profile_URL: 'https://wordpress.com/testuser',
+		bio: undefined,
+	};
+
+	/**
+	 * Test: Avatar rendering
+	 *
+	 * Verifies that:
+	 * 1. The avatar component is rendered with correct props
+	 * 2. The correct user data is passed to the avatar component
+	 */
+	test( 'should render the avatar with correct user information', () => {
+		render( <UserProfileHeader user={ defaultUser } /> );
+
+		const avatars = screen.getAllByTestId( 'reader-avatar' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( avatars[ 0 ] ).toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( avatars[ 0 ] ).toHaveAttribute( 'data-author-id', defaultUser.ID.toString() );
+
+		// Test that desktop and mobile versions are properly rendered
+		const desktopAvatar = document.querySelector(
+			'.user-profile-header__avatar-desktop [data-testid="reader-avatar"]'
+		);
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( desktopAvatar ).toBeInTheDocument();
+
+		const mobileAvatar = document.querySelector(
+			'.user-profile-header__avatar-mobile [data-testid="reader-avatar"]'
+		);
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( mobileAvatar ).toBeInTheDocument();
+	} );
+
+	/**
+	 * Test: Display name rendering
+	 *
+	 * Verifies that:
+	 * 1. The user's display name is shown in the header
+	 */
+	test( 'should render the user display name', () => {
+		render( <UserProfileHeader user={ defaultUser } /> );
+
+		// Check if display name is rendered
+		const displayNameEl = screen.getByText( defaultUser.display_name );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( displayNameEl ).toBeInTheDocument();
+
+		expect(
+			displayNameEl.closest( '[class*="user-profile-header__display-name"]' )
+			// @ts-expect-error -- jest-dom matchers are available globally
+		).toBeInTheDocument();
+	} );
+
+	/**
+	 * Test: Navigation rendering
+	 *
+	 * Verifies that:
+	 * 1. The navigation tabs are rendered with Posts and Lists options
+	 */
+	test( 'should render navigation tabs with Posts and Lists options', () => {
+		render( <UserProfileHeader user={ defaultUser } /> );
+
+		// Check if navigation section is rendered
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'section-nav' ) ).toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'nav-tabs' ) ).toBeInTheDocument();
+
+		// Check for navigation items
+		const navItems = screen.getAllByTestId( 'nav-item' );
+		expect( navItems.length ).toBe( 2 ); // Posts and Lists
+
+		// Check nav item content - should have Posts and Lists
+		const navTexts = navItems.map( ( item ) => item.textContent );
+		expect( navTexts ).toContain( 'Posts' );
+		expect( navTexts ).toContain( 'Lists' );
+	} );
+
+	/**
+	 * Test: Bio not rendered when not provided
+	 *
+	 * Verifies that:
+	 * 1. Bio section is not rendered when user has no bio
+	 */
+	test( 'should not render bio section when user has no bio', () => {
+		render( <UserProfileHeader user={ defaultUser } /> );
+
+		// Bio section should not be present
+		const bioSection = document.querySelector( '.user-profile-header__bio' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( bioSection ).not.toBeInTheDocument();
+	} );
+
+	/**
+	 * Test: Bio rendering
+	 *
+	 * Verifies that:
+	 * 1. Bio section is rendered when user has a bio
+	 * 2. The bio text is displayed correctly
+	 */
+	test( 'should render bio section when user has a bio', () => {
+		const userWithBio = {
+			...defaultUser,
+			bio: 'This is my test biography that describes me as a test user.',
+		};
+
+		render( <UserProfileHeader user={ userWithBio } /> );
+
+		// Bio section should be present
+		const bioText = screen.getByText( userWithBio.bio );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( bioText ).toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( bioText.closest( '[class*="user-profile-header__bio"]' ) ).toBeInTheDocument();
+	} );
+
+	/**
+	 * Test: Bio with profile URL
+	 *
+	 * Verifies that:
+	 * 1. Read More link is displayed when bio is long and profile URL exists
+	 */
+	test( 'should render Read More link for long bio with profile URL', () => {
+		// Create a long bio that will likely be clamped
+		const longBio =
+			'This is a very long biography that will definitely exceed the three lines limit and therefore should display the Read More link. '.repeat(
+				5
+			);
+		const userWithLongBio = {
+			...defaultUser,
+			bio: longBio,
+		};
+
+		// We need to mock Element.scrollHeight and Element.offsetHeight to simulate text being clamped
+		Object.defineProperty( HTMLElement.prototype, 'scrollHeight', {
+			configurable: true,
+			get: function () {
+				// Return a large value for bio text element to simulate clamping
+				if ( this.classList.contains( 'user-profile-header__bio-desc-text' ) ) {
+					return 200;
+				}
+				return 100;
+			},
+		} );
+
+		render( <UserProfileHeader user={ userWithLongBio } /> );
+
+		// "Read More" link should be present for long bio
+		const readMoreLink = screen.getByText( 'Read More' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( readMoreLink ).toBeInTheDocument();
+		expect( readMoreLink.getAttribute( 'href' ) ).toBe( userWithLongBio.profile_URL );
+
+		// External icon should be displayed
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'icon' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -103,38 +103,4 @@ describe( 'UserProfileHeader', () => {
 		const bioText = screen.getByText( userWithBio.bio );
 		expect( bioText ).toBeInTheDocument();
 	} );
-
-	test( 'should render Read More link for long bio with profile URL', () => {
-		// Create a long bio that will likely be clamped
-		const longBio =
-			'This is a very long biography that will definitely exceed the three lines limit and therefore should display the Read More link. '.repeat(
-				5
-			);
-		const userWithLongBio = {
-			...defaultUser,
-			bio: longBio,
-		};
-
-		// We need to mock Element.scrollHeight and Element.offsetHeight to simulate text being clamped
-		Object.defineProperty( HTMLElement.prototype, 'scrollHeight', {
-			configurable: true,
-			get: function () {
-				// Return a large value for bio text element to simulate clamping
-				if ( this.classList.contains( 'user-profile-header__bio-desc-text' ) ) {
-					return 200;
-				}
-				return 100;
-			},
-		} );
-
-		render( <UserProfileHeader user={ userWithLongBio } /> );
-
-		// "Read More" link should be present for long bio
-		const readMoreLink = screen.getByText( 'Read More' );
-		expect( readMoreLink ).toBeInTheDocument();
-		expect( readMoreLink.getAttribute( 'href' ) ).toBe( userWithLongBio.profile_URL ?? '' );
-
-		// External icon should be displayed
-		expect( screen.getByTestId( 'icon' ) ).toBeInTheDocument();
-	} );
 } );

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -57,13 +57,6 @@ describe( 'UserProfileHeader', () => {
 		bio: undefined,
 	};
 
-	/**
-	 * Test: Avatar rendering
-	 *
-	 * Verifies that:
-	 * 1. The avatar component is rendered with correct props
-	 * 2. The correct user data is passed to the avatar component
-	 */
 	test( 'should render the avatar with correct user information', () => {
 		render( <UserProfileHeader user={ defaultUser } /> );
 
@@ -87,12 +80,6 @@ describe( 'UserProfileHeader', () => {
 		expect( mobileAvatar ).toBeInTheDocument();
 	} );
 
-	/**
-	 * Test: Display name rendering
-	 *
-	 * Verifies that:
-	 * 1. The user's display name is shown in the header
-	 */
 	test( 'should render the user display name', () => {
 		render( <UserProfileHeader user={ defaultUser } /> );
 
@@ -102,12 +89,6 @@ describe( 'UserProfileHeader', () => {
 		expect( displayNameEl ).toBeInTheDocument();
 	} );
 
-	/**
-	 * Test: Navigation rendering
-	 *
-	 * Verifies that:
-	 * 1. The navigation tabs are rendered with Posts and Lists options
-	 */
 	test( 'should render navigation tabs with Posts and Lists options', () => {
 		render( <UserProfileHeader user={ defaultUser } /> );
 
@@ -127,12 +108,6 @@ describe( 'UserProfileHeader', () => {
 		expect( navTexts ).toContain( 'Lists' );
 	} );
 
-	/**
-	 * Test: Bio not rendered when not provided
-	 *
-	 * Verifies that:
-	 * 1. Bio section is not rendered when user has no bio
-	 */
 	test( 'should not render bio section when user has no bio', () => {
 		render( <UserProfileHeader user={ defaultUser } /> );
 
@@ -142,13 +117,6 @@ describe( 'UserProfileHeader', () => {
 		expect( bioSection ).not.toBeInTheDocument();
 	} );
 
-	/**
-	 * Test: Bio rendering
-	 *
-	 * Verifies that:
-	 * 1. Bio section is rendered when user has a bio
-	 * 2. The bio text is displayed correctly
-	 */
 	test( 'should render bio section when user has a bio', () => {
 		const userWithBio = {
 			...defaultUser,
@@ -163,12 +131,6 @@ describe( 'UserProfileHeader', () => {
 		expect( bioText ).toBeInTheDocument();
 	} );
 
-	/**
-	 * Test: Bio with profile URL
-	 *
-	 * Verifies that:
-	 * 1. Read More link is displayed when bio is long and profile URL exists
-	 */
 	test( 'should render Read More link for long bio with profile URL', () => {
 		// Create a long bio that will likely be clamped
 		const longBio =

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -4,6 +4,7 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { UserData } from 'calypso/lib/user/user';
 import UserProfileHeader from '../index';
 
 // Mock external icon
@@ -47,7 +48,7 @@ jest.mock( 'calypso/components/section-nav/item', () => ( {
 } ) );
 
 describe( 'UserProfileHeader', () => {
-	const defaultUser = {
+	const defaultUser: UserData = {
 		ID: 123,
 		user_login: 'testuser',
 		display_name: 'Test User',
@@ -96,7 +97,7 @@ describe( 'UserProfileHeader', () => {
 		render( <UserProfileHeader user={ defaultUser } /> );
 
 		// Check if display name is rendered
-		const displayNameEl = screen.getByText( defaultUser.display_name );
+		const displayNameEl = screen.getByText( defaultUser.display_name ?? '' );
 		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( displayNameEl ).toBeInTheDocument();
 
@@ -204,7 +205,7 @@ describe( 'UserProfileHeader', () => {
 		const readMoreLink = screen.getByText( 'Read More' );
 		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( readMoreLink ).toBeInTheDocument();
-		expect( readMoreLink.getAttribute( 'href' ) ).toBe( userWithLongBio.profile_URL );
+		expect( readMoreLink.getAttribute( 'href' ) ).toBe( userWithLongBio.profile_URL ?? '' );
 
 		// External icon should be displayed
 		// @ts-expect-error -- jest-dom matchers are available globally

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -7,45 +7,30 @@ import React from 'react';
 import { UserData } from 'calypso/lib/user/user';
 import UserProfileHeader from '../index';
 
-// Mock external icon
 jest.mock( '@wordpress/icons', () => ( {
 	external: 'mock-external-icon',
 	Icon: ( { icon } ) => <span data-testid="icon">{ icon }</span>,
 } ) );
 
-// Mock ReaderAvatar component
-jest.mock( 'calypso/blocks/reader-avatar', () => ( {
-	__esModule: true,
-	default: ( { author, iconSize } ) => (
-		<div data-testid="reader-avatar" data-author-id={ author.ID } data-icon-size={ iconSize }>
-			{ author.avatar_URL && (
-				<img src={ author.avatar_URL } alt="avatar" data-testid="avatar-img" />
-			) }
-		</div>
-	),
-} ) );
+jest.mock( 'calypso/blocks/reader-avatar', () => ( { author, iconSize } ) => (
+	<div data-testid="reader-avatar" data-author-id={ author.ID } data-icon-size={ iconSize }>
+		{ author.avatar_URL && <img src={ author.avatar_URL } alt="avatar" data-testid="avatar-img" /> }
+	</div>
+) );
 
-// Mock SectionNav components
-jest.mock( 'calypso/components/section-nav', () => ( {
-	__esModule: true,
-	default: ( { children } ) => <div data-testid="section-nav">{ children }</div>,
-} ) );
+jest.mock( 'calypso/components/section-nav', () => ( { children } ) => (
+	<div data-testid="section-nav">{ children }</div>
+) );
 
-// Mock SectionNav/Tabs component
-jest.mock( 'calypso/components/section-nav/tabs', () => ( {
-	__esModule: true,
-	default: ( { children } ) => <div data-testid="nav-tabs">{ children }</div>,
-} ) );
+jest.mock( 'calypso/components/section-nav/tabs', () => ( { children } ) => (
+	<div data-testid="nav-tabs">{ children }</div>
+) );
 
-// Mock SectionNav/Item component
-jest.mock( 'calypso/components/section-nav/item', () => ( {
-	__esModule: true,
-	default: ( { children, path, selected } ) => (
-		<a href={ path } data-testid="nav-item" data-selected={ selected ? 'true' : 'false' }>
-			{ children }
-		</a>
-	),
-} ) );
+jest.mock( 'calypso/components/section-nav/item', () => ( { children, path, selected } ) => (
+	<a href={ path } data-testid="nav-item" data-selected={ selected ? 'true' : 'false' }>
+		{ children }
+	</a>
+) );
 
 describe( 'UserProfileHeader', () => {
 	const defaultUser: UserData = {

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -46,22 +46,18 @@ describe( 'UserProfileHeader', () => {
 		render( <UserProfileHeader user={ defaultUser } /> );
 
 		const avatars = screen.getAllByTestId( 'reader-avatar' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( avatars[ 0 ] ).toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( avatars[ 0 ] ).toHaveAttribute( 'data-author-id', defaultUser.ID.toString() );
 
 		// Test that desktop and mobile versions are properly rendered
 		const desktopAvatar = document.querySelector(
 			'.user-profile-header__avatar-desktop [data-testid="reader-avatar"]'
 		);
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( desktopAvatar ).toBeInTheDocument();
 
 		const mobileAvatar = document.querySelector(
 			'.user-profile-header__avatar-mobile [data-testid="reader-avatar"]'
 		);
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( mobileAvatar ).toBeInTheDocument();
 	} );
 
@@ -78,9 +74,7 @@ describe( 'UserProfileHeader', () => {
 		render( <UserProfileHeader user={ defaultUser } /> );
 
 		// Check if navigation section is rendered
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'section-nav' ) ).toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'nav-tabs' ) ).toBeInTheDocument();
 
 		// Check for navigation items
@@ -98,7 +92,6 @@ describe( 'UserProfileHeader', () => {
 
 		// Bio section should not be present
 		const bioSection = document.querySelector( '.user-profile-header__bio' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( bioSection ).not.toBeInTheDocument();
 	} );
 
@@ -112,7 +105,6 @@ describe( 'UserProfileHeader', () => {
 
 		// Bio section should be present
 		const bioText = screen.getByText( userWithBio.bio );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( bioText ).toBeInTheDocument();
 	} );
 
@@ -143,12 +135,10 @@ describe( 'UserProfileHeader', () => {
 
 		// "Read More" link should be present for long bio
 		const readMoreLink = screen.getByText( 'Read More' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( readMoreLink ).toBeInTheDocument();
 		expect( readMoreLink.getAttribute( 'href' ) ).toBe( userWithLongBio.profile_URL ?? '' );
 
 		// External icon should be displayed
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'icon' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/reader/user-profile/components/user-profile-header/test/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.tsx
@@ -50,14 +50,10 @@ describe( 'UserProfileHeader', () => {
 		expect( avatars[ 0 ] ).toHaveAttribute( 'data-author-id', defaultUser.ID.toString() );
 
 		// Test that desktop and mobile versions are properly rendered
-		const desktopAvatar = document.querySelector(
-			'.user-profile-header__avatar-desktop [data-testid="reader-avatar"]'
-		);
+		const desktopAvatar = screen.getByTestId( 'desktop-avatar' );
 		expect( desktopAvatar ).toBeInTheDocument();
 
-		const mobileAvatar = document.querySelector(
-			'.user-profile-header__avatar-mobile [data-testid="reader-avatar"]'
-		);
+		const mobileAvatar = screen.getByTestId( 'mobile-avatar' );
 		expect( mobileAvatar ).toBeInTheDocument();
 	} );
 

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -13,7 +13,7 @@ import { requestUser } from 'calypso/state/reader/users/actions';
 import getReaderUser from 'calypso/state/selectors/get-reader-user';
 import './style.scss';
 
-interface UserProfileProps {
+export interface UserProfileProps {
 	userLogin: string;
 	userId: string;
 	user: UserData | undefined;

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -1,0 +1,230 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import page from '@automattic/calypso-router';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { UserProfile } from '../index';
+
+/**
+ * Mock the router to simulate navigation and current path
+ * This allows testing the component's behavior when paths change
+ */
+jest.mock( '@automattic/calypso-router', () => ( {
+	replace: jest.fn(),
+	current: '/reader/users/testuser',
+} ) );
+
+/**
+ * Mock the child components to isolate testing to just the UserProfile component
+ * Each mock returns a simple div with a data-testid to verify rendering
+ */
+jest.mock( 'calypso/reader/user-profile/components/user-profile-header', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="user-profile-header">User Profile Header</div>,
+} ) );
+
+jest.mock( 'calypso/reader/user-profile/views/posts', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="user-posts">User Posts</div>,
+} ) );
+
+jest.mock( 'calypso/reader/user-profile/views/lists', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="user-lists">User Lists</div>,
+} ) );
+
+/**
+ * Mock the back button to test click handling
+ * Includes onClick handler to test interaction
+ */
+jest.mock( 'calypso/components/back-button', () => ( {
+	__esModule: true,
+	default: ( { onClick } ) => (
+		<button data-testid="back-button" onClick={ onClick }>
+			Back
+		</button>
+	),
+} ) );
+
+/**
+ * Mock the empty content component to test error state
+ * Preserves props to verify correct error message display
+ */
+jest.mock( 'calypso/components/empty-content', () => ( {
+	__esModule: true,
+	default: ( { title, line, action } ) => (
+		<div data-testid="empty-content">
+			<h2>{ title }</h2>
+			<p>{ line }</p>
+			<button>{ action }</button>
+		</div>
+	),
+} ) );
+
+describe( 'UserProfile', () => {
+	/**
+	 * Set up mock functions and default props for all tests
+	 * - mockRequestUser: Simulates API call to fetch user data
+	 * - mockHandleBack: Simulates the back button click handler
+	 */
+	const mockRequestUser = jest.fn().mockResolvedValue( undefined );
+	const mockHandleBack = jest.fn();
+
+	const defaultProps = {
+		userLogin: 'testuser',
+		userId: '',
+		path: '/reader/users/testuser',
+		requestUser: mockRequestUser,
+		user: undefined,
+		isLoading: false,
+		showBack: false,
+		handleBack: mockHandleBack,
+	};
+
+	beforeEach( () => {
+		// Reset mock function calls between tests
+		jest.clearAllMocks();
+	} );
+
+	/**
+	 * Test: Empty state when user is not found
+	 *
+	 * Verifies that:
+	 * 1. The empty content component is displayed when no user data is available
+	 * 2. The requestUser function is called with the correct username
+	 */
+	test( 'should render empty content when user is not found', () => {
+		render( <UserProfile { ...defaultProps } /> );
+
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'empty-content' ) ).toBeInTheDocument();
+		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );
+	} );
+
+	/**
+	 * Test: User profile display
+	 *
+	 * Verifies that:
+	 * 1. The user profile header is rendered when user data is available
+	 * 2. The posts view is displayed (default view for the profile)
+	 */
+	test( 'should render user profile when user is available', () => {
+		const user = {
+			ID: 123,
+			user_login: 'testuser',
+			display_name: 'Test User',
+			avatar_URL: 'https://example.com/avatar.jpg',
+		};
+
+		render( <UserProfile { ...defaultProps } user={ user } /> );
+
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'user-posts' ) ).toBeInTheDocument();
+	} );
+
+	/**
+	 * Test: Lists view rendering
+	 *
+	 * Verifies that:
+	 * 1. The user profile header is rendered
+	 * 2. The lists view is displayed when the path includes "/lists"
+	 * This tests the component's routing logic
+	 */
+	test( 'should render lists view when path includes /lists', () => {
+		const user = {
+			ID: 123,
+			user_login: 'testuser',
+			display_name: 'Test User',
+			avatar_URL: 'https://example.com/avatar.jpg',
+		};
+
+		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/testuser/lists" /> );
+
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'user-lists' ) ).toBeInTheDocument();
+	} );
+
+	/**
+	 * Test: Back button functionality
+	 *
+	 * Verifies that:
+	 * 1. The back button is displayed when showBack prop is true
+	 * 2. The handleBack callback is triggered when the back button is clicked
+	 */
+	test( 'should show back button when showBack is true', () => {
+		const user = {
+			ID: 123,
+			user_login: 'testuser',
+			display_name: 'Test User',
+			avatar_URL: 'https://example.com/avatar.jpg',
+		};
+
+		render( <UserProfile { ...defaultProps } user={ user } showBack /> );
+
+		const backButton = screen.getByTestId( 'back-button' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( backButton ).toBeInTheDocument();
+
+		// Simulate clicking the back button
+		backButton.click();
+		expect( mockHandleBack ).toHaveBeenCalled();
+	} );
+
+	/**
+	 * Test: Loading state
+	 *
+	 * Verifies that:
+	 * 1. No content is displayed when the isLoading prop is true
+	 * 2. Neither empty content nor profile components are rendered during loading
+	 */
+	test( 'should not show content when isLoading is true', () => {
+		render( <UserProfile { ...defaultProps } isLoading /> );
+
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.queryByTestId( 'empty-content' ) ).not.toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.queryByTestId( 'user-profile-header' ) ).not.toBeInTheDocument();
+	} );
+
+	/**
+	 * Test: Page replacement for user ID paths
+	 *
+	 * Verifies that:
+	 * 1. When path starts with '/reader/users/id/' and user data is available
+	 * 2. The page is redirected to the username-based URL
+	 */
+	test( 'should redirect from user ID path to user login path when user is loaded', () => {
+		const user = {
+			ID: 123,
+			user_login: 'testuser',
+			display_name: 'Test User',
+			avatar_URL: 'https://example.com/avatar.jpg',
+		};
+
+		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/id/123" /> );
+
+		// Verify the redirect was called with the correct path
+		expect( page.replace ).toHaveBeenCalledWith( '/reader/users/testuser' );
+	} );
+
+	/**
+	 * Test: Multiple API calls
+	 *
+	 * Verifies that:
+	 * 1. When both userLogin and userId are provided
+	 * 2. The requestUser function is called for both
+	 */
+	test( 'should request user data with both login and ID when provided', () => {
+		render( <UserProfile { ...defaultProps } userLogin="testuser" userId="123" /> );
+
+		// Verify both API calls were made
+		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );
+		expect( mockRequestUser ).toHaveBeenCalledWith( '123', true );
+	} );
+} );

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -5,29 +5,11 @@
 import page from '@automattic/calypso-router';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { Provider } from 'react-redux';
-import { legacy_createStore as createStore } from 'redux';
 import { UserProfile, UserProfileProps } from '../index';
-
-// Create a Redux store with initial state where user is logged in
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const initialState: any = {
-	currentUser: { id: 123 }, // This makes isUserLoggedIn return true
-};
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const store = createStore( ( state: any = initialState ) => state );
 
 jest.mock( '@automattic/calypso-router', () => ( {
 	replace: jest.fn(),
 	current: '/reader/users/testuser',
-	lastRoute: '/reader', // This makes userHasHistory return true
-} ) );
-
-// Mock shouldShowBackButton to ensure it returns true for our test
-jest.mock( 'calypso/reader/controller-helper', () => ( {
-	...jest.requireActual( 'calypso/reader/controller-helper' ),
-	shouldShowBackButton: () => true,
-	userHasHistory: () => true,
 } ) );
 
 jest.mock( 'calypso/reader/user-profile/components/user-profile-header', () => () => (
@@ -42,10 +24,8 @@ jest.mock( 'calypso/reader/user-profile/views/lists', () => () => (
 	<div data-testid="user-lists">User Lists</div>
 ) );
 
-jest.mock( 'calypso/components/back-button', () => ( { onClick } ) => (
-	<button data-testid="back-button" onClick={ onClick }>
-		Back
-	</button>
+jest.mock( 'calypso/reader/components/back-button', () => () => (
+	<button data-testid="back-button">Back</button>
 ) );
 
 jest.mock( 'calypso/components/empty-content', () => ( { title, line, action } ) => (
@@ -58,7 +38,6 @@ jest.mock( 'calypso/components/empty-content', () => ( { title, line, action } )
 
 describe( 'UserProfile', () => {
 	const mockRequestUser = jest.fn().mockResolvedValue( undefined );
-	const mockHandleBack = jest.fn();
 
 	const defaultProps: UserProfileProps = {
 		userLogin: 'testuser',
@@ -67,8 +46,6 @@ describe( 'UserProfile', () => {
 		requestUser: mockRequestUser,
 		user: undefined,
 		isLoading: false,
-		showBack: false,
-		handleBack: mockHandleBack,
 	};
 
 	beforeEach( () => {
@@ -76,12 +53,8 @@ describe( 'UserProfile', () => {
 		jest.clearAllMocks();
 	} );
 
-	const renderWithProvider = ( ui ) => {
-		return render( <Provider store={ store }>{ ui }</Provider> );
-	};
-
 	test( 'should render empty content when user is not found', () => {
-		renderWithProvider( <UserProfile { ...defaultProps } /> );
+		render( <UserProfile { ...defaultProps } /> );
 
 		expect( screen.getByTestId( 'empty-content' ) ).toBeInTheDocument();
 		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );
@@ -95,7 +68,7 @@ describe( 'UserProfile', () => {
 			avatar_URL: 'https://example.com/avatar.jpg',
 		};
 
-		renderWithProvider( <UserProfile { ...defaultProps } user={ user } /> );
+		render( <UserProfile { ...defaultProps } user={ user } /> );
 
 		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'user-posts' ) ).toBeInTheDocument();
@@ -109,34 +82,14 @@ describe( 'UserProfile', () => {
 			avatar_URL: 'https://example.com/avatar.jpg',
 		};
 
-		renderWithProvider(
-			<UserProfile { ...defaultProps } user={ user } path="/reader/users/testuser/lists" />
-		);
+		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/testuser/lists" /> );
 
 		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'user-lists' ) ).toBeInTheDocument();
 	} );
 
-	test( 'should show back button when showBack is true', () => {
-		const user = {
-			ID: 123,
-			user_login: 'testuser',
-			display_name: 'Test User',
-			avatar_URL: 'https://example.com/avatar.jpg',
-		};
-
-		renderWithProvider( <UserProfile { ...defaultProps } user={ user } showBack /> );
-
-		const backButton = screen.getByTestId( 'back-button' );
-		expect( backButton ).toBeInTheDocument();
-
-		// Simulate clicking the back button
-		backButton.click();
-		expect( mockHandleBack ).toHaveBeenCalled();
-	} );
-
 	test( 'should not show content when isLoading is true', () => {
-		renderWithProvider( <UserProfile { ...defaultProps } isLoading /> );
+		render( <UserProfile { ...defaultProps } isLoading /> );
 
 		expect( screen.queryByTestId( 'empty-content' ) ).not.toBeInTheDocument();
 		expect( screen.queryByTestId( 'user-profile-header' ) ).not.toBeInTheDocument();
@@ -150,16 +103,14 @@ describe( 'UserProfile', () => {
 			avatar_URL: 'https://example.com/avatar.jpg',
 		};
 
-		renderWithProvider(
-			<UserProfile { ...defaultProps } user={ user } path="/reader/users/id/123" />
-		);
+		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/id/123" /> );
 
 		// Verify the redirect was called with the correct path
 		expect( page.replace ).toHaveBeenCalledWith( '/reader/users/testuser' );
 	} );
 
 	test( 'should request user data with both login and ID when provided', () => {
-		renderWithProvider( <UserProfile { ...defaultProps } userLogin="testuser" userId="123" /> );
+		render( <UserProfile { ...defaultProps } userLogin="testuser" userId="123" /> );
 
 		// Verify both API calls were made
 		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -5,7 +5,7 @@
 import page from '@automattic/calypso-router';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { UserProfile } from '../index';
+import { UserProfile, UserProfileProps } from '../index';
 
 /**
  * Mock the router to simulate navigation and current path
@@ -72,7 +72,7 @@ describe( 'UserProfile', () => {
 	const mockRequestUser = jest.fn().mockResolvedValue( undefined );
 	const mockHandleBack = jest.fn();
 
-	const defaultProps = {
+	const defaultProps: UserProfileProps = {
 		userLogin: 'testuser',
 		userId: '',
 		path: '/reader/users/testuser',

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -9,13 +9,25 @@ import { Provider } from 'react-redux';
 import { legacy_createStore as createStore } from 'redux';
 import { UserProfile, UserProfileProps } from '../index';
 
-// Create a simple Redux store mock to provide context for connected components
+// Create a Redux store with initial state where user is logged in
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const store = createStore( ( state: any = {} ) => state );
+const initialState: any = {
+	currentUser: { id: 123 }, // This makes isUserLoggedIn return true
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const store = createStore( ( state: any = initialState ) => state );
 
 jest.mock( '@automattic/calypso-router', () => ( {
 	replace: jest.fn(),
 	current: '/reader/users/testuser',
+	lastRoute: '/reader', // This makes userHasHistory return true
+} ) );
+
+// Mock shouldShowBackButton to ensure it returns true for our test
+jest.mock( 'calypso/reader/controller-helper', () => ( {
+	...jest.requireActual( 'calypso/reader/controller-helper' ),
+	shouldShowBackButton: () => true,
+	userHasHistory: () => true,
 } ) );
 
 jest.mock( 'calypso/reader/user-profile/components/user-profile-header', () => () => (

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -12,40 +12,31 @@ jest.mock( '@automattic/calypso-router', () => ( {
 	current: '/reader/users/testuser',
 } ) );
 
-jest.mock( 'calypso/reader/user-profile/components/user-profile-header', () => ( {
-	__esModule: true,
-	default: () => <div data-testid="user-profile-header">User Profile Header</div>,
-} ) );
+jest.mock( 'calypso/reader/user-profile/components/user-profile-header', () => () => (
+	<div data-testid="user-profile-header">User Profile Header</div>
+) );
 
-jest.mock( 'calypso/reader/user-profile/views/posts', () => ( {
-	__esModule: true,
-	default: () => <div data-testid="user-posts">User Posts</div>,
-} ) );
+jest.mock( 'calypso/reader/user-profile/views/posts', () => () => (
+	<div data-testid="user-posts">User Posts</div>
+) );
 
-jest.mock( 'calypso/reader/user-profile/views/lists', () => ( {
-	__esModule: true,
-	default: () => <div data-testid="user-lists">User Lists</div>,
-} ) );
+jest.mock( 'calypso/reader/user-profile/views/lists', () => () => (
+	<div data-testid="user-lists">User Lists</div>
+) );
 
-jest.mock( 'calypso/components/back-button', () => ( {
-	__esModule: true,
-	default: ( { onClick } ) => (
-		<button data-testid="back-button" onClick={ onClick }>
-			Back
-		</button>
-	),
-} ) );
+jest.mock( 'calypso/components/back-button', () => ( { onClick } ) => (
+	<button data-testid="back-button" onClick={ onClick }>
+		Back
+	</button>
+) );
 
-jest.mock( 'calypso/components/empty-content', () => ( {
-	__esModule: true,
-	default: ( { title, line, action } ) => (
-		<div data-testid="empty-content">
-			<h2>{ title }</h2>
-			<p>{ line }</p>
-			<button>{ action }</button>
-		</div>
-	),
-} ) );
+jest.mock( 'calypso/components/empty-content', () => ( { title, line, action } ) => (
+	<div data-testid="empty-content">
+		<h2>{ title }</h2>
+		<p>{ line }</p>
+		<button>{ action }</button>
+	</div>
+) );
 
 describe( 'UserProfile', () => {
 	const mockRequestUser = jest.fn().mockResolvedValue( undefined );

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -7,19 +7,11 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { UserProfile, UserProfileProps } from '../index';
 
-/**
- * Mock the router to simulate navigation and current path
- * This allows testing the component's behavior when paths change
- */
 jest.mock( '@automattic/calypso-router', () => ( {
 	replace: jest.fn(),
 	current: '/reader/users/testuser',
 } ) );
 
-/**
- * Mock the child components to isolate testing to just the UserProfile component
- * Each mock returns a simple div with a data-testid to verify rendering
- */
 jest.mock( 'calypso/reader/user-profile/components/user-profile-header', () => ( {
 	__esModule: true,
 	default: () => <div data-testid="user-profile-header">User Profile Header</div>,
@@ -35,10 +27,6 @@ jest.mock( 'calypso/reader/user-profile/views/lists', () => ( {
 	default: () => <div data-testid="user-lists">User Lists</div>,
 } ) );
 
-/**
- * Mock the back button to test click handling
- * Includes onClick handler to test interaction
- */
 jest.mock( 'calypso/components/back-button', () => ( {
 	__esModule: true,
 	default: ( { onClick } ) => (
@@ -48,10 +36,6 @@ jest.mock( 'calypso/components/back-button', () => ( {
 	),
 } ) );
 
-/**
- * Mock the empty content component to test error state
- * Preserves props to verify correct error message display
- */
 jest.mock( 'calypso/components/empty-content', () => ( {
 	__esModule: true,
 	default: ( { title, line, action } ) => (
@@ -64,11 +48,6 @@ jest.mock( 'calypso/components/empty-content', () => ( {
 } ) );
 
 describe( 'UserProfile', () => {
-	/**
-	 * Set up mock functions and default props for all tests
-	 * - mockRequestUser: Simulates API call to fetch user data
-	 * - mockHandleBack: Simulates the back button click handler
-	 */
 	const mockRequestUser = jest.fn().mockResolvedValue( undefined );
 	const mockHandleBack = jest.fn();
 
@@ -88,13 +67,6 @@ describe( 'UserProfile', () => {
 		jest.clearAllMocks();
 	} );
 
-	/**
-	 * Test: Empty state when user is not found
-	 *
-	 * Verifies that:
-	 * 1. The empty content component is displayed when no user data is available
-	 * 2. The requestUser function is called with the correct username
-	 */
 	test( 'should render empty content when user is not found', () => {
 		render( <UserProfile { ...defaultProps } /> );
 
@@ -103,13 +75,6 @@ describe( 'UserProfile', () => {
 		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );
 	} );
 
-	/**
-	 * Test: User profile display
-	 *
-	 * Verifies that:
-	 * 1. The user profile header is rendered when user data is available
-	 * 2. The posts view is displayed (default view for the profile)
-	 */
 	test( 'should render user profile when user is available', () => {
 		const user = {
 			ID: 123,
@@ -126,14 +91,6 @@ describe( 'UserProfile', () => {
 		expect( screen.getByTestId( 'user-posts' ) ).toBeInTheDocument();
 	} );
 
-	/**
-	 * Test: Lists view rendering
-	 *
-	 * Verifies that:
-	 * 1. The user profile header is rendered
-	 * 2. The lists view is displayed when the path includes "/lists"
-	 * This tests the component's routing logic
-	 */
 	test( 'should render lists view when path includes /lists', () => {
 		const user = {
 			ID: 123,
@@ -150,13 +107,6 @@ describe( 'UserProfile', () => {
 		expect( screen.getByTestId( 'user-lists' ) ).toBeInTheDocument();
 	} );
 
-	/**
-	 * Test: Back button functionality
-	 *
-	 * Verifies that:
-	 * 1. The back button is displayed when showBack prop is true
-	 * 2. The handleBack callback is triggered when the back button is clicked
-	 */
 	test( 'should show back button when showBack is true', () => {
 		const user = {
 			ID: 123,
@@ -176,13 +126,6 @@ describe( 'UserProfile', () => {
 		expect( mockHandleBack ).toHaveBeenCalled();
 	} );
 
-	/**
-	 * Test: Loading state
-	 *
-	 * Verifies that:
-	 * 1. No content is displayed when the isLoading prop is true
-	 * 2. Neither empty content nor profile components are rendered during loading
-	 */
 	test( 'should not show content when isLoading is true', () => {
 		render( <UserProfile { ...defaultProps } isLoading /> );
 
@@ -192,13 +135,6 @@ describe( 'UserProfile', () => {
 		expect( screen.queryByTestId( 'user-profile-header' ) ).not.toBeInTheDocument();
 	} );
 
-	/**
-	 * Test: Page replacement for user ID paths
-	 *
-	 * Verifies that:
-	 * 1. When path starts with '/reader/users/id/' and user data is available
-	 * 2. The page is redirected to the username-based URL
-	 */
 	test( 'should redirect from user ID path to user login path when user is loaded', () => {
 		const user = {
 			ID: 123,
@@ -213,13 +149,6 @@ describe( 'UserProfile', () => {
 		expect( page.replace ).toHaveBeenCalledWith( '/reader/users/testuser' );
 	} );
 
-	/**
-	 * Test: Multiple API calls
-	 *
-	 * Verifies that:
-	 * 1. When both userLogin and userId are provided
-	 * 2. The requestUser function is called for both
-	 */
 	test( 'should request user data with both login and ID when provided', () => {
 		render( <UserProfile { ...defaultProps } userLogin="testuser" userId="123" /> );
 

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -61,7 +61,6 @@ describe( 'UserProfile', () => {
 	test( 'should render empty content when user is not found', () => {
 		render( <UserProfile { ...defaultProps } /> );
 
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'empty-content' ) ).toBeInTheDocument();
 		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );
 	} );
@@ -76,9 +75,7 @@ describe( 'UserProfile', () => {
 
 		render( <UserProfile { ...defaultProps } user={ user } /> );
 
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'user-posts' ) ).toBeInTheDocument();
 	} );
 
@@ -92,9 +89,7 @@ describe( 'UserProfile', () => {
 
 		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/testuser/lists" /> );
 
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'user-lists' ) ).toBeInTheDocument();
 	} );
 
@@ -109,7 +104,6 @@ describe( 'UserProfile', () => {
 		render( <UserProfile { ...defaultProps } user={ user } showBack /> );
 
 		const backButton = screen.getByTestId( 'back-button' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( backButton ).toBeInTheDocument();
 
 		// Simulate clicking the back button
@@ -120,9 +114,7 @@ describe( 'UserProfile', () => {
 	test( 'should not show content when isLoading is true', () => {
 		render( <UserProfile { ...defaultProps } isLoading /> );
 
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.queryByTestId( 'empty-content' ) ).not.toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.queryByTestId( 'user-profile-header' ) ).not.toBeInTheDocument();
 	} );
 

--- a/client/reader/user-profile/test/index.tsx
+++ b/client/reader/user-profile/test/index.tsx
@@ -5,7 +5,13 @@
 import page from '@automattic/calypso-router';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { Provider } from 'react-redux';
+import { legacy_createStore as createStore } from 'redux';
 import { UserProfile, UserProfileProps } from '../index';
+
+// Create a simple Redux store mock to provide context for connected components
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const store = createStore( ( state: any = {} ) => state );
 
 jest.mock( '@automattic/calypso-router', () => ( {
 	replace: jest.fn(),
@@ -58,8 +64,12 @@ describe( 'UserProfile', () => {
 		jest.clearAllMocks();
 	} );
 
+	const renderWithProvider = ( ui ) => {
+		return render( <Provider store={ store }>{ ui }</Provider> );
+	};
+
 	test( 'should render empty content when user is not found', () => {
-		render( <UserProfile { ...defaultProps } /> );
+		renderWithProvider( <UserProfile { ...defaultProps } /> );
 
 		expect( screen.getByTestId( 'empty-content' ) ).toBeInTheDocument();
 		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );
@@ -73,7 +83,7 @@ describe( 'UserProfile', () => {
 			avatar_URL: 'https://example.com/avatar.jpg',
 		};
 
-		render( <UserProfile { ...defaultProps } user={ user } /> );
+		renderWithProvider( <UserProfile { ...defaultProps } user={ user } /> );
 
 		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'user-posts' ) ).toBeInTheDocument();
@@ -87,7 +97,9 @@ describe( 'UserProfile', () => {
 			avatar_URL: 'https://example.com/avatar.jpg',
 		};
 
-		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/testuser/lists" /> );
+		renderWithProvider(
+			<UserProfile { ...defaultProps } user={ user } path="/reader/users/testuser/lists" />
+		);
 
 		expect( screen.getByTestId( 'user-profile-header' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'user-lists' ) ).toBeInTheDocument();
@@ -101,7 +113,7 @@ describe( 'UserProfile', () => {
 			avatar_URL: 'https://example.com/avatar.jpg',
 		};
 
-		render( <UserProfile { ...defaultProps } user={ user } showBack /> );
+		renderWithProvider( <UserProfile { ...defaultProps } user={ user } showBack /> );
 
 		const backButton = screen.getByTestId( 'back-button' );
 		expect( backButton ).toBeInTheDocument();
@@ -112,7 +124,7 @@ describe( 'UserProfile', () => {
 	} );
 
 	test( 'should not show content when isLoading is true', () => {
-		render( <UserProfile { ...defaultProps } isLoading /> );
+		renderWithProvider( <UserProfile { ...defaultProps } isLoading /> );
 
 		expect( screen.queryByTestId( 'empty-content' ) ).not.toBeInTheDocument();
 		expect( screen.queryByTestId( 'user-profile-header' ) ).not.toBeInTheDocument();
@@ -126,14 +138,16 @@ describe( 'UserProfile', () => {
 			avatar_URL: 'https://example.com/avatar.jpg',
 		};
 
-		render( <UserProfile { ...defaultProps } user={ user } path="/reader/users/id/123" /> );
+		renderWithProvider(
+			<UserProfile { ...defaultProps } user={ user } path="/reader/users/id/123" />
+		);
 
 		// Verify the redirect was called with the correct path
 		expect( page.replace ).toHaveBeenCalledWith( '/reader/users/testuser' );
 	} );
 
 	test( 'should request user data with both login and ID when provided', () => {
-		render( <UserProfile { ...defaultProps } userLogin="testuser" userId="123" /> );
+		renderWithProvider( <UserProfile { ...defaultProps } userLogin="testuser" userId="123" /> );
 
 		// Verify both API calls were made
 		expect( mockRequestUser ).toHaveBeenCalledWith( 'testuser' );

--- a/client/reader/user-profile/views/lists.tsx
+++ b/client/reader/user-profile/views/lists.tsx
@@ -23,7 +23,13 @@ interface UserListsProps {
 	isLoading?: boolean;
 }
 
-const UserLists = ( { user, requestUserLists, lists, isLoading }: UserListsProps ): JSX.Element => {
+// Added export keyword to make the component available for testing
+export const UserLists = ( {
+	user,
+	requestUserLists,
+	lists,
+	isLoading,
+}: UserListsProps ): JSX.Element => {
 	const translate = useTranslate();
 	const [ hasRequested, setHasRequested ] = useState( false );
 	const userLogin = user.user_login;

--- a/client/reader/user-profile/views/lists.tsx
+++ b/client/reader/user-profile/views/lists.tsx
@@ -23,7 +23,6 @@ interface UserListsProps {
 	isLoading?: boolean;
 }
 
-// Added export keyword to make the component available for testing
 export const UserLists = ( {
 	user,
 	requestUserLists,

--- a/client/reader/user-profile/views/test/lists.tsx
+++ b/client/reader/user-profile/views/test/lists.tsx
@@ -29,13 +29,6 @@ describe( 'UserLists', () => {
 
 	const mockRequestUserLists = jest.fn();
 
-	/**
-	 * Test: Empty state when user has no lists
-	 *
-	 * Verifies that:
-	 * 1. Empty content component is displayed when no lists are available
-	 * 2. The requestUserLists function is called with the username
-	 */
 	test( 'should render empty content when user has no lists', () => {
 		render(
 			<UserLists
@@ -62,12 +55,6 @@ describe( 'UserLists', () => {
 		expect( mockRequestUserLists ).toHaveBeenCalledWith( defaultUser.user_login );
 	} );
 
-	/**
-	 * Test: Loading state
-	 *
-	 * Verifies that:
-	 * 1. The component renders nothing when in loading state
-	 */
 	test( 'should render nothing when in loading state', () => {
 		const { container } = render(
 			<UserLists user={ defaultUser } requestUserLists={ mockRequestUserLists } isLoading />
@@ -78,14 +65,6 @@ describe( 'UserLists', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	/**
-	 * Test: Lists rendering
-	 *
-	 * Verifies that:
-	 * 1. Lists are rendered when user has lists
-	 * 2. Each list shows proper title and description
-	 * 3. Each list links to the correct URL
-	 */
 	test( 'should render lists when user has lists', () => {
 		const mockLists: List[] = [
 			{

--- a/client/reader/user-profile/views/test/lists.tsx
+++ b/client/reader/user-profile/views/test/lists.tsx
@@ -4,6 +4,8 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { UserData } from 'calypso/lib/user/user';
+import { List } from 'calypso/reader/list-manage/types';
 import { UserLists } from '../lists';
 
 // Mock the EmptyContent component
@@ -18,7 +20,7 @@ jest.mock( 'calypso/components/empty-content', () => ( {
 } ) );
 
 describe( 'UserLists', () => {
-	const defaultUser = {
+	const defaultUser: UserData = {
 		ID: 123,
 		user_login: 'testuser',
 		display_name: 'Test User',
@@ -85,13 +87,13 @@ describe( 'UserLists', () => {
 	 * 3. Each list links to the correct URL
 	 */
 	test( 'should render lists when user has lists', () => {
-		const mockLists = [
+		const mockLists: List[] = [
 			{
 				ID: 1,
 				title: 'Test List 1',
 				description: 'This is test list 1',
 				slug: 'test-list-1',
-				owner: defaultUser.user_login,
+				owner: 'testuser',
 				is_public: true,
 				is_owner: true,
 			},
@@ -100,7 +102,7 @@ describe( 'UserLists', () => {
 				title: 'Test List 2',
 				description: 'This is test list 2',
 				slug: 'test-list-2',
-				owner: defaultUser.user_login,
+				owner: 'testuser',
 				is_public: true,
 				is_owner: true,
 			},

--- a/client/reader/user-profile/views/test/lists.tsx
+++ b/client/reader/user-profile/views/test/lists.tsx
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { UserLists } from '../lists';
+
+// Mock the EmptyContent component
+jest.mock( 'calypso/components/empty-content', () => ( {
+	__esModule: true,
+	default: ( { icon, line } ) => (
+		<div data-testid="empty-content">
+			{ icon && <div data-testid="empty-content-icon">{ icon }</div> }
+			{ line && <p data-testid="empty-content-line">{ line }</p> }
+		</div>
+	),
+} ) );
+
+describe( 'UserLists', () => {
+	const defaultUser = {
+		ID: 123,
+		user_login: 'testuser',
+		display_name: 'Test User',
+		avatar_URL: 'https://example.com/avatar.jpg',
+	};
+
+	const mockRequestUserLists = jest.fn();
+
+	/**
+	 * Test: Empty state when user has no lists
+	 *
+	 * Verifies that:
+	 * 1. Empty content component is displayed when no lists are available
+	 * 2. The requestUserLists function is called with the username
+	 */
+	test( 'should render empty content when user has no lists', () => {
+		render(
+			<UserLists
+				user={ defaultUser }
+				requestUserLists={ mockRequestUserLists }
+				lists={ [] }
+				isLoading={ false }
+			/>
+		);
+
+		// Empty content should be displayed
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'empty-content' ) ).toBeInTheDocument();
+
+		// Icon should be displayed
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'empty-content-icon' ) ).toBeInTheDocument();
+
+		// "No lists yet" message should be displayed
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByTestId( 'empty-content-line' ) ).toHaveTextContent( 'No lists yet.' );
+
+		// Request function should be called with the username
+		expect( mockRequestUserLists ).toHaveBeenCalledWith( defaultUser.user_login );
+	} );
+
+	/**
+	 * Test: Loading state
+	 *
+	 * Verifies that:
+	 * 1. The component renders nothing when in loading state
+	 */
+	test( 'should render nothing when in loading state', () => {
+		const { container } = render(
+			<UserLists user={ defaultUser } requestUserLists={ mockRequestUserLists } isLoading />
+		);
+
+		// Container should be empty
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	/**
+	 * Test: Lists rendering
+	 *
+	 * Verifies that:
+	 * 1. Lists are rendered when user has lists
+	 * 2. Each list shows proper title and description
+	 * 3. Each list links to the correct URL
+	 */
+	test( 'should render lists when user has lists', () => {
+		const mockLists = [
+			{
+				ID: 1,
+				title: 'Test List 1',
+				description: 'This is test list 1',
+				slug: 'test-list-1',
+				owner: defaultUser.user_login,
+				is_public: true,
+				is_owner: true,
+			},
+			{
+				ID: 2,
+				title: 'Test List 2',
+				description: 'This is test list 2',
+				slug: 'test-list-2',
+				owner: defaultUser.user_login,
+				is_public: true,
+				is_owner: true,
+			},
+		];
+
+		render(
+			<UserLists
+				user={ defaultUser }
+				requestUserLists={ mockRequestUserLists }
+				lists={ mockLists }
+				isLoading={ false }
+			/>
+		);
+
+		const listsContainer = document.querySelector( '.user-profile__lists-body' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( listsContainer ).toBeInTheDocument();
+
+		// List titles should be displayed
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByText( 'Test List 1' ) ).toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByText( 'Test List 2' ) ).toBeInTheDocument();
+
+		// List descriptions should be displayed
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByText( 'This is test list 1' ) ).toBeInTheDocument();
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( screen.getByText( 'This is test list 2' ) ).toBeInTheDocument();
+
+		// Links should be correct
+		const links = Array.from( document.querySelectorAll( 'a.user-profile__lists-body-link' ) );
+		// @ts-expect-error -- jest matchers are available globally
+		expect( links ).toHaveLength( 2 );
+		expect( links[ 0 ].getAttribute( 'href' ) ).toBe(
+			`/reader/list/${ defaultUser.user_login }/test-list-1`
+		);
+		expect( links[ 1 ].getAttribute( 'href' ) ).toBe(
+			`/reader/list/${ defaultUser.user_login }/test-list-2`
+		);
+	} );
+} );

--- a/client/reader/user-profile/views/test/lists.tsx
+++ b/client/reader/user-profile/views/test/lists.tsx
@@ -36,15 +36,12 @@ describe( 'UserLists', () => {
 		);
 
 		// Empty content should be displayed
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'empty-content' ) ).toBeInTheDocument();
 
 		// Icon should be displayed
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'empty-content-icon' ) ).toBeInTheDocument();
 
 		// "No lists yet" message should be displayed
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByTestId( 'empty-content-line' ) ).toHaveTextContent( 'No lists yet.' );
 
 		// Request function should be called with the username
@@ -57,7 +54,6 @@ describe( 'UserLists', () => {
 		);
 
 		// Container should be empty
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
@@ -93,24 +89,18 @@ describe( 'UserLists', () => {
 		);
 
 		const listsContainer = document.querySelector( '.user-profile__lists-body' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( listsContainer ).toBeInTheDocument();
 
 		// List titles should be displayed
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByText( 'Test List 1' ) ).toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByText( 'Test List 2' ) ).toBeInTheDocument();
 
 		// List descriptions should be displayed
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByText( 'This is test list 1' ) ).toBeInTheDocument();
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( screen.getByText( 'This is test list 2' ) ).toBeInTheDocument();
 
 		// Links should be correct
 		const links = Array.from( document.querySelectorAll( 'a.user-profile__lists-body-link' ) );
-		// @ts-expect-error -- jest matchers are available globally
 		expect( links ).toHaveLength( 2 );
 		expect( links[ 0 ].getAttribute( 'href' ) ).toBe(
 			`/reader/list/${ defaultUser.user_login }/test-list-1`

--- a/client/reader/user-profile/views/test/lists.tsx
+++ b/client/reader/user-profile/views/test/lists.tsx
@@ -8,16 +8,12 @@ import { UserData } from 'calypso/lib/user/user';
 import { List } from 'calypso/reader/list-manage/types';
 import { UserLists } from '../lists';
 
-// Mock the EmptyContent component
-jest.mock( 'calypso/components/empty-content', () => ( {
-	__esModule: true,
-	default: ( { icon, line } ) => (
-		<div data-testid="empty-content">
-			{ icon && <div data-testid="empty-content-icon">{ icon }</div> }
-			{ line && <p data-testid="empty-content-line">{ line }</p> }
-		</div>
-	),
-} ) );
+jest.mock( 'calypso/components/empty-content', () => ( { icon, line } ) => (
+	<div data-testid="empty-content">
+		{ icon && <div data-testid="empty-content-icon">{ icon }</div> }
+		{ line && <p data-testid="empty-content-line">{ line }</p> }
+	</div>
+) );
 
 describe( 'UserLists', () => {
 	const defaultUser: UserData = {

--- a/client/reader/user-profile/views/test/posts.tsx
+++ b/client/reader/user-profile/views/test/posts.tsx
@@ -52,13 +52,6 @@ describe( 'UserPosts', () => {
 		avatar_URL: 'https://example.com/avatar.jpg',
 	};
 
-	/**
-	 * Test: Stream component rendering
-	 *
-	 * Verifies that:
-	 * 1. The Stream component is rendered with the correct props
-	 * 2. The stream key is properly formatted with the user ID
-	 */
 	test( 'should render Stream component with correct props', () => {
 		render( <UserPosts user={ defaultUser } /> );
 
@@ -96,13 +89,6 @@ describe( 'UserPosts', () => {
 		expect( propsContainer.querySelector( '[data-prop="showBack"]' ) ).toHaveTextContent( 'false' );
 	} );
 
-	/**
-	 * Test: Empty content rendering
-	 *
-	 * Verifies that:
-	 * 1. The empty content function is provided to Stream
-	 * 2. When invoked, it renders the empty state correctly
-	 */
 	test( 'should provide empty content function that renders correctly', () => {
 		render( <UserPosts user={ defaultUser } /> );
 

--- a/client/reader/user-profile/views/test/posts.tsx
+++ b/client/reader/user-profile/views/test/posts.tsx
@@ -53,11 +53,9 @@ describe( 'UserPosts', () => {
 
 		// Stream component should be rendered
 		const streamComponent = screen.getByTestId( 'reader-stream' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( streamComponent ).toBeInTheDocument();
 
 		// Stream key should include user ID
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( streamComponent ).toHaveAttribute( 'data-stream-key', `user:${ defaultUser.ID }` );
 
 		// Class name should indicate user profile
@@ -65,15 +63,12 @@ describe( 'UserPosts', () => {
 
 		// Props should be correctly set
 		const propsContainer = screen.getByTestId( 'stream-props' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( propsContainer.querySelector( '[data-prop="showFollowButton"]' ) ).toHaveTextContent(
 			'false'
 		);
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( propsContainer.querySelector( '[data-prop="showSiteNameOnCards"]' ) ).toHaveTextContent(
 			'true'
 		);
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( propsContainer.querySelector( '[data-prop="sidebarTabTitle"]' ) ).toHaveTextContent(
 			'Related'
 		);
@@ -81,7 +76,6 @@ describe( 'UserPosts', () => {
 		expect( propsContainer.querySelector( '[data-prop="useCompactCards"]' ) ).toHaveTextContent(
 			'true'
 		);
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( propsContainer.querySelector( '[data-prop="showBack"]' ) ).toHaveTextContent( 'false' );
 	} );
 
@@ -90,25 +84,21 @@ describe( 'UserPosts', () => {
 
 		// Empty content should be present
 		const emptyContent = screen.getByTestId( 'empty-content' );
-		// @ts-expect-error -- jest-dom matchers are available globally
 		expect( emptyContent ).toBeInTheDocument();
 
 		// Empty content component should render inside
 		expect(
 			emptyContent.querySelector( '[data-testid="empty-content-component"]' )
-			// @ts-expect-error -- jest-dom matchers are available globally
 		).toBeInTheDocument();
 
 		// Icon should be present
 		expect(
 			emptyContent.querySelector( '[data-testid="empty-content-icon"]' )
-			// @ts-expect-error -- jest-dom matchers are available globally
 		).toBeInTheDocument();
 
 		// "No posts yet" message should be displayed
-		expect(
-			emptyContent.querySelector( '[data-testid="empty-content-line"]' )
-			// @ts-expect-error -- jest-dom matchers are available globally
-		).toHaveTextContent( 'No posts yet.' );
+		expect( emptyContent.querySelector( '[data-testid="empty-content-line"]' ) ).toHaveTextContent(
+			'No posts yet.'
+		);
 	} );
 } );

--- a/client/reader/user-profile/views/test/posts.tsx
+++ b/client/reader/user-profile/views/test/posts.tsx
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import UserPosts from '../posts';
+
+// Mock the Stream component
+jest.mock( 'calypso/reader/stream', () => ( {
+	__esModule: true,
+	default: ( {
+		streamKey,
+		className,
+		emptyContent,
+		showFollowButton,
+		showSiteNameOnCards,
+		sidebarTabTitle,
+		useCompactCards,
+		showBack,
+	} ) => (
+		<div data-testid="reader-stream" data-stream-key={ streamKey } className={ className }>
+			<div data-testid="stream-props">
+				<span data-prop="showFollowButton">{ String( showFollowButton ) }</span>
+				<span data-prop="showSiteNameOnCards">{ String( showSiteNameOnCards ) }</span>
+				<span data-prop="sidebarTabTitle">{ sidebarTabTitle }</span>
+				<span data-prop="useCompactCards">{ String( useCompactCards ) }</span>
+				<span data-prop="showBack">{ String( showBack ) }</span>
+			</div>
+			{ emptyContent && <div data-testid="empty-content">{ emptyContent() }</div> }
+		</div>
+	),
+} ) );
+
+// Mock the EmptyContent component that might be used in Stream
+jest.mock( 'calypso/components/empty-content', () => ( {
+	__esModule: true,
+	default: ( { icon, line } ) => (
+		<div data-testid="empty-content-component">
+			{ icon && <div data-testid="empty-content-icon">{ icon }</div> }
+			{ line && <p data-testid="empty-content-line">{ line }</p> }
+		</div>
+	),
+} ) );
+
+describe( 'UserPosts', () => {
+	const defaultUser = {
+		ID: 123,
+		user_login: 'testuser',
+		display_name: 'Test User',
+		avatar_URL: 'https://example.com/avatar.jpg',
+	};
+
+	/**
+	 * Test: Stream component rendering
+	 *
+	 * Verifies that:
+	 * 1. The Stream component is rendered with the correct props
+	 * 2. The stream key is properly formatted with the user ID
+	 */
+	test( 'should render Stream component with correct props', () => {
+		render( <UserPosts user={ defaultUser } /> );
+
+		// Stream component should be rendered
+		const streamComponent = screen.getByTestId( 'reader-stream' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( streamComponent ).toBeInTheDocument();
+
+		// Stream key should include user ID
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( streamComponent ).toHaveAttribute( 'data-stream-key', `user:${ defaultUser.ID }` );
+
+		// Class name should indicate user profile
+		expect( streamComponent ).toHaveClass( 'is-user-profile' );
+
+		// Props should be correctly set
+		const propsContainer = screen.getByTestId( 'stream-props' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( propsContainer.querySelector( '[data-prop="showFollowButton"]' ) ).toHaveTextContent(
+			'false'
+		);
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( propsContainer.querySelector( '[data-prop="showSiteNameOnCards"]' ) ).toHaveTextContent(
+			'true'
+		);
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( propsContainer.querySelector( '[data-prop="sidebarTabTitle"]' ) ).toHaveTextContent(
+			'Related'
+		);
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( propsContainer.querySelector( '[data-prop="useCompactCards"]' ) ).toHaveTextContent(
+			'true'
+		);
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( propsContainer.querySelector( '[data-prop="showBack"]' ) ).toHaveTextContent( 'false' );
+	} );
+
+	/**
+	 * Test: Empty content rendering
+	 *
+	 * Verifies that:
+	 * 1. The empty content function is provided to Stream
+	 * 2. When invoked, it renders the empty state correctly
+	 */
+	test( 'should provide empty content function that renders correctly', () => {
+		render( <UserPosts user={ defaultUser } /> );
+
+		// Empty content should be present
+		const emptyContent = screen.getByTestId( 'empty-content' );
+		// @ts-expect-error -- jest-dom matchers are available globally
+		expect( emptyContent ).toBeInTheDocument();
+
+		// Empty content component should render inside
+		expect(
+			emptyContent.querySelector( '[data-testid="empty-content-component"]' )
+			// @ts-expect-error -- jest-dom matchers are available globally
+		).toBeInTheDocument();
+
+		// Icon should be present
+		expect(
+			emptyContent.querySelector( '[data-testid="empty-content-icon"]' )
+			// @ts-expect-error -- jest-dom matchers are available globally
+		).toBeInTheDocument();
+
+		// "No posts yet" message should be displayed
+		expect(
+			emptyContent.querySelector( '[data-testid="empty-content-line"]' )
+			// @ts-expect-error -- jest-dom matchers are available globally
+		).toHaveTextContent( 'No posts yet.' );
+	} );
+} );

--- a/client/reader/user-profile/views/test/posts.tsx
+++ b/client/reader/user-profile/views/test/posts.tsx
@@ -7,42 +7,38 @@ import React from 'react';
 import { UserData } from 'calypso/lib/user/user';
 import UserPosts from '../posts';
 
-// Mock the Stream component
-jest.mock( 'calypso/reader/stream', () => ( {
-	__esModule: true,
-	default: ( {
-		streamKey,
-		className,
-		emptyContent,
-		showFollowButton,
-		showSiteNameOnCards,
-		sidebarTabTitle,
-		useCompactCards,
-		showBack,
-	} ) => (
-		<div data-testid="reader-stream" data-stream-key={ streamKey } className={ className }>
-			<div data-testid="stream-props">
-				<span data-prop="showFollowButton">{ String( showFollowButton ) }</span>
-				<span data-prop="showSiteNameOnCards">{ String( showSiteNameOnCards ) }</span>
-				<span data-prop="sidebarTabTitle">{ sidebarTabTitle }</span>
-				<span data-prop="useCompactCards">{ String( useCompactCards ) }</span>
-				<span data-prop="showBack">{ String( showBack ) }</span>
+jest.mock(
+	'calypso/reader/stream',
+	() =>
+		( {
+			streamKey,
+			className,
+			emptyContent,
+			showFollowButton,
+			showSiteNameOnCards,
+			sidebarTabTitle,
+			useCompactCards,
+			showBack,
+		} ) => (
+			<div data-testid="reader-stream" data-stream-key={ streamKey } className={ className }>
+				<div data-testid="stream-props">
+					<span data-prop="showFollowButton">{ String( showFollowButton ) }</span>
+					<span data-prop="showSiteNameOnCards">{ String( showSiteNameOnCards ) }</span>
+					<span data-prop="sidebarTabTitle">{ sidebarTabTitle }</span>
+					<span data-prop="useCompactCards">{ String( useCompactCards ) }</span>
+					<span data-prop="showBack">{ String( showBack ) }</span>
+				</div>
+				{ emptyContent && <div data-testid="empty-content">{ emptyContent() }</div> }
 			</div>
-			{ emptyContent && <div data-testid="empty-content">{ emptyContent() }</div> }
-		</div>
-	),
-} ) );
+		)
+);
 
-// Mock the EmptyContent component that might be used in Stream
-jest.mock( 'calypso/components/empty-content', () => ( {
-	__esModule: true,
-	default: ( { icon, line } ) => (
-		<div data-testid="empty-content-component">
-			{ icon && <div data-testid="empty-content-icon">{ icon }</div> }
-			{ line && <p data-testid="empty-content-line">{ line }</p> }
-		</div>
-	),
-} ) );
+jest.mock( 'calypso/components/empty-content', () => ( { icon, line } ) => (
+	<div data-testid="empty-content-component">
+		{ icon && <div data-testid="empty-content-icon">{ icon }</div> }
+		{ line && <p data-testid="empty-content-line">{ line }</p> }
+	</div>
+) );
 
 describe( 'UserPosts', () => {
 	const defaultUser: UserData = {

--- a/client/reader/user-profile/views/test/posts.tsx
+++ b/client/reader/user-profile/views/test/posts.tsx
@@ -4,6 +4,7 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { UserData } from 'calypso/lib/user/user';
 import UserPosts from '../posts';
 
 // Mock the Stream component
@@ -44,7 +45,7 @@ jest.mock( 'calypso/components/empty-content', () => ( {
 } ) );
 
 describe( 'UserPosts', () => {
-	const defaultUser = {
+	const defaultUser: UserData = {
 		ID: 123,
 		user_login: 'testuser',
 		display_name: 'Test User',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/98553

## Proposed Changes

* Add unit tests for the Reader User Profile components:
  - UserProfileHeader tests (verifying avatar, display name, bio clamping, and navigation tabs)
  - UserPosts tests (verifying Stream component rendering and empty state)
  - UserLists tests (verifying list rendering, empty state, and loading behavior)
  - UserProfile tests (verifying user profile loading, error states, and view switching)
* Fix a console warning on long user bios

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Giving the Reader User Profile some basic test coverage to make it more robust for future iterations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn test-client client/reader/user-profile` to verify all tests pass
* Try specific component tests with `yarn test-client client/reader/user-profile/components/user-profile-header/test/index.tsx`
* Use Calypso Live to Ensure there are no regressions on user profile pages with a long bio, such as /reader/users/robertbpugh

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
