### PR TITLE
Reader Editor: Add simple content persistence

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/verbum-block-editor';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { stripHTML } from 'calypso/lib/formatting';
@@ -51,7 +51,11 @@ function QuickPost( {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
-	const [ postContent, setPostContent ] = useState( '' );
+	const STORAGE_KEY = 'reader_quick_post_content';
+	const [ postContent, setPostContent ] = useState( () => {
+		// Use localStorage to save content between sessions.
+		return localStorage.getItem( STORAGE_KEY ) || '';
+	} );
 	const [ editorKey, setEditorKey ] = useState( 0 );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const selectedSiteId = useSelector( getSelectedSiteId );
@@ -61,7 +65,15 @@ function QuickPost( {
 	const hasLoaded = useSelector( hasLoadedSites );
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
 
+	useEffect( () => {
+		if ( postContent ) {
+			localStorage.setItem( STORAGE_KEY, postContent );
+		}
+	}, [ postContent ] );
+
 	const clearEditor = () => {
+		localStorage.removeItem( STORAGE_KEY );
+		setPostContent( '' );
 		setEditorKey( ( key ) => key + 1 );
 	};
 
@@ -163,7 +175,7 @@ function QuickPost( {
 				<div className="verbum-editor-wrapper" ref={ editorRef }>
 					<Editor
 						key={ editorKey }
-						initialContent=""
+						initialContent={ postContent }
 						onChange={ setPostContent }
 						isRTL={ isLocaleRtl( locale ) ?? false }
 						isDarkMode={ false }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/565

## Proposed Changes

- Uses localStorage to save post content and retrieve it when the page loads

### Before

**![Image](https://github.com/user-attachments/assets/b9c63939-3844-4e49-a706-55132a031c77)**

### After

https://github.com/user-attachments/assets/1a75e53f-e9af-46e9-b956-ecfbcda6710d

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To improve the editor experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader`
- Open the quick editor and write some content but don't publish
- Navigate away from the page, then go back  to `/reader` and open the quick editor again
- Ensure your content is persisted
- Publish and ensure the editor is cleared upon success
- Ensure pressing 'Cancel' removes the content


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
