### PR TITLE
A4A: update featured products in Marketplace

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -82,8 +82,11 @@ const getDisplayableFeaturedProducts = (
 ) => {
 	const featuredProductSlugs = [
 		'woocommerce-woopayments',
-		'jetpack-security-t1',
-		'woocommerce-subscriptions',
+		'woocommerce-constellation',
+		'woocommerce-dynamic-pricing',
+		'woocommerce-rental-products',
+		'woocommerce-smart-coupons',
+		'woocommerce-variation-swatches-and-photos',
 	]; // For now, we hardcode this until we understand how we want pick featured products.
 
 	// We do it this way to ensure we follow the same order as the featuredProductSlugs.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1903

## Proposed Changes

- Change featured marketplace items per request

<img width="1361" alt="Screenshot 2025-03-12 at 3 37 30 PM" src="https://github.com/user-attachments/assets/515679f1-d94e-4a81-845f-58a6eb9d38f4" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link below navigate to `/marketplace/products` and verify changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
