### PR TITLE
Stats: use Calypso header for simple sites

### DIFF
--- a/apps/odyssey-stats/src/components/formatted-header.tsx
+++ b/apps/odyssey-stats/src/components/formatted-header.tsx
@@ -1,0 +1,19 @@
+import config from '@automattic/calypso-config';
+// `index` is a must have for the import path as we are replacing `calypso/components/formatted-header` in webpack config.
+import CalypsoFormattedHeader, {
+	Props as FormattedHeaderProps,
+} from 'calypso/components/formatted-header/index';
+import JetpackHeader from 'calypso/components/jetpack/jetpack-header';
+import { useSelector } from 'calypso/state';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
+
+export default function FormattedHeader( { ...props }: FormattedHeaderProps ) {
+	const isSiteSimple = useSelector( ( state ) => isSimpleSite( state ) );
+	const isWPAdmin = config.isEnabled( 'is_odyssey' );
+
+	// Calypso deals with admin colors already, so skip if not in WP Admin.
+	if ( ! isWPAdmin || isSiteSimple ) {
+		return <CalypsoFormattedHeader { ...props } />;
+	}
+	return <JetpackHeader { ...props } />;
+}

--- a/apps/odyssey-stats/src/components/odyssey-formatted-header.tsx
+++ b/apps/odyssey-stats/src/components/odyssey-formatted-header.tsx
@@ -1,8 +1,7 @@
 import config from '@automattic/calypso-config';
-// `index` is a must have for the import path as we are replacing `calypso/components/formatted-header` in webpack config.
 import CalypsoFormattedHeader, {
 	Props as FormattedHeaderProps,
-} from 'calypso/components/formatted-header/index';
+} from 'calypso/components/formatted-header';
 import JetpackHeader from 'calypso/components/jetpack/jetpack-header';
 import { useSelector } from 'calypso/state';
 import { isSimpleSite } from 'calypso/state/sites/selectors';

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -110,6 +110,7 @@ module.exports = {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
+		alias: {},
 	},
 	node: false,
 	plugins: [
@@ -187,7 +188,15 @@ module.exports = {
 		),
 		new webpack.NormalModuleReplacementPlugin(
 			/^calypso\/components\/formatted-header$/,
-			path.resolve( __dirname, 'src/components/formatted-header' )
+			( resource ) => {
+				// Only replace for the navigation-header context
+				if ( resource.context.includes( 'components/navigation-header' ) ) {
+					resource.request = resource.request.replace(
+						/^calypso\/components\/formatted-header$/,
+						path.resolve( __dirname, 'src/components/odyssey-formatted-header' )
+					);
+				}
+			}
 		),
 		new webpack.NormalModuleReplacementPlugin(
 			/^calypso\/components\/data\/query-site-purchases$/,

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -187,7 +187,7 @@ module.exports = {
 		),
 		new webpack.NormalModuleReplacementPlugin(
 			/^calypso\/components\/formatted-header$/,
-			'calypso/components/jetpack/jetpack-header'
+			path.resolve( __dirname, 'src/components/formatted-header' )
 		),
 		new webpack.NormalModuleReplacementPlugin(
 			/^calypso\/components\/data\/query-site-purchases$/,

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -110,7 +110,6 @@ module.exports = {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
-		alias: {},
 	},
 	node: false,
 	plugins: [

--- a/client/components/formatted-header/index.tsx
+++ b/client/components/formatted-header/index.tsx
@@ -4,7 +4,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import type { ElementType, FC, PropsWithChildren, ReactNode } from 'react';
 import './style.scss';
 
-interface Props extends PropsWithChildren {
+export interface Props extends PropsWithChildren {
 	align?: 'center' | 'left' | 'right';
 	brandFont?: boolean;
 	className?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes: https://github.com/Automattic/wp-calypso/issues/100501

## Proposed Changes

* Wrap and replace header in Odyssey Stats to only show the Calypso header just for Simple sites in Odyssey Stats

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Use Calypso Header for Simple sites; other site types are not affected

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow Option 3 `PCYsg-Pp7-p2`
* Set up a Simple site with WP Admin interface in General settings
* Ensure its header looks like the following

![image](https://github.com/user-attachments/assets/5a2ba086-0034-401c-a80d-8cb4c4cd5a24)

* Ensure Jetpack site are not affected in Odyssey
* Ensure the header still works the same in Calypso Stats


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
