### PR TITLE
Fix: Align 'Skip to dashboard' button with other links on mobile screens

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -47,7 +47,7 @@
 	.select-goals__alternative-flows-container {
 		display: grid;
 		width: 100%;
-		grid-template-columns: max-content;
+		grid-template-columns: 1fr;
 		gap: 20px 8px;
 		padding-bottom: 60px + 48px; // height of sticky footer
 
@@ -66,15 +66,20 @@
 	.components-button.select-goals__link.is-link { // extra specificity to override default link styles
 		color: var(--color-neutral-100);
 		font-size: $font-body-small;
+		justify-content: flex-start;
+		width: fit-content;
 	}
 
 	.select-goals__dashboard-button.select-goals__link { // extra specificity to override default link styles
-		margin-left: auto;
+		margin-left: 0;
 		margin-right: auto;
 		gap: 8px;
+		display: flex;
+		justify-content: flex-start;
 
 		@include break-small {
 			grid-column: span 3;
+			margin-left: auto;
 		}
 	}
 


### PR DESCRIPTION
# Fix 'Skip to dashboard' button alignment on mobile screens
Related to:
- https://github.com/Automattic/wp-calypso/issues/101112

## Proposed Changes

- Changed grid template for alternative flows container to use full width (1fr) on mobile
- Added left alignment to link buttons with `justify-content: flex-start`
- Set proper width constraints with `width: fit-content`
- Modified margin settings to ensure consistent alignment on mobile
- Maintained the original centered layout for desktop screens

## Why are these changes being made?
Currently, the "Skip to dashboard" button is inconsistently centered on mobile screens while other links in the Goals screen are left-aligned. This update provides a more consistent mobile experience.

Testing Instructions

1. Log into your WordPress.com account
2. Create a new site and navigate to the onboarding flow and reach the Goals selection screen
3. Test on mobile device or using browser dev tools in mobile viewport mode
      - Verify the "Skip to dashboard" button is properly left-aligned with other links
      - Expand viewport to desktop size and confirm the button is still centered on larger screens


| Before | After |
| ---- | ---- |
|![before](https://github.com/user-attachments/assets/2e2d1104-7396-4b5f-a6a0-2947916e84f8) | ![after](https://github.com/user-attachments/assets/78aeebd3-a8db-44d1-9bb6-1553643a45bf)

