### PR TITLE
Improve success message after import

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -10,6 +10,7 @@ import { appStates } from 'calypso/state/imports/constants';
 import ErrorPane from './error-pane';
 import ImporterHeader from './importer-header';
 import ImportingPane from './importing-pane';
+import SuccessPanel from './success-panel';
 import UploadingPane from './uploading-pane';
 
 import './file-importer.scss';
@@ -18,12 +19,7 @@ import './file-importer.scss';
  * Module variables
  */
 const compactStates = [ appStates.DISABLED, appStates.INACTIVE ];
-const importingStates = [
-	appStates.IMPORT_FAILURE,
-	appStates.IMPORT_SUCCESS,
-	appStates.IMPORTING,
-	appStates.MAP_AUTHORS,
-];
+const importingStates = [ appStates.IMPORT_FAILURE, appStates.IMPORTING, appStates.MAP_AUTHORS ];
 const uploadingStates = [
 	appStates.UPLOAD_PROCESSING,
 	appStates.READY_FOR_UPLOAD,
@@ -109,14 +105,19 @@ class FileImporter extends PureComponent {
 			cardProps.onClick = this.handleClick.bind( this, false );
 		}
 
+		const isImportSuccess = importerStatus.importerState === appStates.IMPORT_SUCCESS;
+		const showheader = ! isImportSuccess;
+
 		return (
 			<Card className={ cardClasses } { ...( showStart ? cardProps : undefined ) }>
-				<ImporterHeader
-					importerStatus={ importerStatus }
-					icon={ icon }
-					title={ title }
-					description={ description }
-				/>
+				{ showheader && (
+					<ImporterHeader
+						importerStatus={ importerStatus }
+						icon={ icon }
+						title={ title }
+						description={ description }
+					/>
+				) }
 				{ errorData && (
 					<ErrorPane
 						type={ errorData.type }
@@ -143,6 +144,7 @@ class FileImporter extends PureComponent {
 						hideActionButtons={ hideActionButtons }
 					/>
 				) }
+				{ isImportSuccess && <SuccessPanel site={ site } importerStatus={ importerStatus } /> }
 			</Card>
 		);
 	}

--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -19,6 +19,7 @@ export class DoneButton extends PureComponent {
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
 		} ),
+		customizeSiteVariant: PropTypes.bool,
 	};
 
 	handleClick = () => {
@@ -26,15 +27,18 @@ export class DoneButton extends PureComponent {
 			importerStatus: { type },
 			site: { ID: siteId },
 			siteSlug,
+			customizeSiteVariant,
 		} = this.props;
 
 		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
 			blog_id: siteId,
 			importer_id: type,
-			action: 'view-site',
+			action: customizeSiteVariant ? 'customize-site' : 'view-site',
 		} );
 
-		const destination = '/view/' + ( siteSlug || '' );
+		const destination = customizeSiteVariant
+			? '/customize/' + ( siteSlug || '' )
+			: '/view/' + ( siteSlug || '' );
 		page( destination );
 	};
 
@@ -52,11 +56,14 @@ export class DoneButton extends PureComponent {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, customizeSiteVariant } = this.props;
+
+		const viewSiteText = translate( 'View site' );
+		const customizeSiteText = translate( 'Customize site' );
 
 		return (
-			<ImporterActionButton primary onClick={ this.handleClick }>
-				{ translate( 'View site' ) }
+			<ImporterActionButton primary={ !! customizeSiteVariant } onClick={ this.handleClick }>
+				{ customizeSiteVariant ? customizeSiteText : viewSiteText }
 			</ImporterActionButton>
 		);
 	}

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -298,10 +298,16 @@ class SectionImport extends Component {
 					comment:
 						'This text appears above a list of service icons (e.g. Wix, Squarespace) asking the user to choose one.',
 			  } );
+		const isImportSuccess = this.props.siteImports.some(
+			( importItem ) => importItem.importerState === appStates.IMPORT_SUCCESS
+		);
+		const skipHeader = isSpecificImporter && isImportSuccess;
 		return (
 			<>
 				<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
-				<SectionHeader label={ sectionHeaderLabel } className="importer__section-header" />
+				{ ! skipHeader && (
+					<SectionHeader label={ sectionHeaderLabel } className="importer__section-header" />
+				) }
 				{ this.renderImporters() }
 			</>
 		);

--- a/client/my-sites/importer/success-panel.scss
+++ b/client/my-sites/importer/success-panel.scss
@@ -1,0 +1,7 @@
+.importer__success-panel {
+	.importer__success-panel-message {
+		margin: 24px 0 32px 0 ;
+		font-size: $font-body-small;
+		color: var(--color-text-subtle);
+	}
+}

--- a/client/my-sites/importer/success-panel.tsx
+++ b/client/my-sites/importer/success-panel.tsx
@@ -1,0 +1,36 @@
+import { useTranslate } from 'i18n-calypso';
+import ImporterActionButtonContainer from './importer-action-buttons/container';
+import DoneButton from './importer-action-buttons/done-button';
+
+import './success-panel.scss';
+
+interface SuccessPanelProps {
+	site: {
+		title: string;
+	};
+	importerStatus: {
+		importerId: string;
+		type: string;
+	};
+}
+
+const SuccessPanel = ( { site, importerStatus }: SuccessPanelProps ) => {
+	const translate = useTranslate();
+	return (
+		<div className="importer__success-panel">
+			<h2>{ translate( 'Success!' ) } 🎉</h2>
+			<p className="importer__success-panel-message">
+				{ translate( 'Your content has been imported successfully to %(title)s.', {
+					args: { title: site.title },
+					comment: '%(title)s is the title of the site which user is importing content to.',
+				} ) }
+			</p>
+			<ImporterActionButtonContainer>
+				<DoneButton customizeSiteVariant importerStatus={ importerStatus } site={ site } />
+				<DoneButton importerStatus={ importerStatus } site={ site } />
+			</ImporterActionButtonContainer>
+		</div>
+	);
+};
+
+export default SuccessPanel;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/100893
## Proposed Changes

![image](https://github.com/user-attachments/assets/277097a4-0b58-4b07-be4d-5817524d73ac)

When successfully importing a site, the current message seems disabled and out of place.
We are updating it to the new design proposed here: mi5D8kRQkiiNKT0QhEkf6M-fi-882_8043

This also includes a new `Customize site` button that redirects the user to the /customize page.

## Testing Instructions

- Export one of your sites to the XML format. Free sites from wordpress.com should work. I can do that through Tools > Export.
- Visit Tools > Import
- Chose Wordpress.
- On `What do you want to do?` step, choose `Import content only`.
- Complete the import steps.
- You should be presented with the new design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?