### PR TITLE
Remove Global Button Overrides and Align Styling with Core

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -7,62 +7,20 @@
 
 /* @wordpress/components Button overrides */
 .components-button.is-primary {
-	background-color: var(--color-accent);
-	border-color: var(--color-accent);
-	color: var(--color-text-inverted);
-
-	&:is(:active, :hover, :focus):not(:disabled, [aria-disabled="true"]) {
-		background-color: var(--color-accent-60);
-		border-color: var(--color-accent-60);
-		color: var(--color-text-inverted);
-	}
-
-	&[disabled],
-	&:disabled,
-	&.disabled {
-		color: var(--color-neutral-20);
-		background-color: var(--color-neutral-5);
-		border-color: var(--color-neutral-5);
-	}
+	--wp-components-color-accent: var(--color-accent);
+	--wp-components-color-accent-inverted: var(--color-text-inverted);
+	--wp-components-color-accent-darker-10: var(--color-accent-60);
+	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }
 
 .components-button.is-secondary {
-	background-color: var(--color-surface);
-	color: var(--color-neutral-70);
-	box-shadow: inset 0 0 0 1px var(--color-neutral-10);
-
-	&:is(:active, :hover):not(:disabled, [aria-disabled="true"]) {
-		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
-		color: var(--color-neutral-70);
-	}
-
-	&:visited {
-		color: var(--color-neutral-70);
-	}
-
-	&[disabled],
-	&:disabled,
-	&.disabled {
-		color: var(--color-neutral-20);
-		background-color: var(--color-surface);
-		box-shadow: inset 0 0 0 1px var(--color-neutral-5);
-	}
+	--wp-components-color-accent: var(--color-accent);
+	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }
 
 .components-button.is-tertiary {
-	color: var(--color-accent);
-
-	&:is(:active, :hover):not(:disabled, [aria-disabled="true"]) {
-		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
-		color: var(--color-accent-60);
-	}
-
-	&:visited,
-	&[disabled],
-	&:disabled,
-	&.disabled {
-		color: var(--color-accent-60);
-	}
+	--wp-components-color-accent: var(--color-accent);
+	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }
 
 /* @wordpress/components ButtonGroup overrides */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix https://github.com/Automattic/dotcom-forge/issues/10600
Related https://github.com/Automattic/wp-calypso/pull/101053

## Proposed Changes

- Remove global button style overrides that were enforcing a custom color scheme across all instances of @wordpress/components's Button component.
- Update button styling to use variables like --wp-components-color-accent for better alignment with Core.

| before | after |
|--------|--------|
| <img width="957" alt="Screenshot 2025-03-13 at 13 24 45" src="https://github.com/user-attachments/assets/973e8598-8dc6-44b2-a4a9-e5dc5a16eb4d" /> | <img width="971" alt="Screenshot 2025-03-13 at 13 24 36" src="https://github.com/user-attachments/assets/2dc97a2f-8cf1-4d77-81e4-29130401aebe" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Currently, global overrides in Calypso enforce a custom button color scheme, which interferes with the default behavior of @wordpress/components's Button. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live: https://github.com/Automattic/wp-calypso/pull/101279#issuecomment-2719746171
* Go to /devdocs/wordpress-components-gallery
* Compare the Button section with https://wpcalypso.wordpress.com/devdocs/wordpress-components-gallery, including each state like `hover`, `active`, `focused`, `disabled`, etc.

Regression testing:

- Validate that as much as possible, no unexpected regressions occur in other areas of Calypso where the Button component is used. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
