### PR TITLE
Update the Woo.com auth flow to use WooCommerce logo instead of WordPress logo for the loading state.

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -21,7 +21,7 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
-import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isGravPoweredOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
 import { initialClientsData, gravatarClientData } from 'calypso/state/oauth2-clients/reducer';
 import { isBilmurEnabled, getBilmurUrl } from './utils/bilmur';
@@ -102,31 +102,45 @@ class Document extends Component {
 
 		const theme = config( 'theme' );
 
-		const LoadingLogo = chooseLoadingLogo( this.props, app?.isWpMobileApp, app?.isWcMobileApp );
-
 		const isRTL = isLocaleRtl( lang );
 
 		let headTitle = head.title;
 		let headFaviconUrl;
+		let isWCCOM = false;
 
 		// To customize the page title and favicon for Gravatar-related login pages.
 		if ( sectionName === 'login' && typeof query?.redirect_to === 'string' ) {
 			const searchParams = new URLSearchParams( query.redirect_to.split( '?' )[ 1 ] );
+
 			// To cover the case where the `client_id` is not provided, e.g. /log-in/link/use
 			const oauth2Client = initialClientsData[ searchParams.get( 'client_id' ) ] || {};
 
-			if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
-				headTitle = oauth2Client.title;
-				headFaviconUrl = oauth2Client.favicon;
-			} else if ( query?.gravatar_flow ) {
-				// Use Gravatar's favicon + title for the Gravatar-related OAuth2 clients in SSR.
-				headTitle = gravatarClientData.title;
-				headFaviconUrl = gravatarClientData.favicon;
+			switch ( true ) {
+				case isGravPoweredOAuth2Client( oauth2Client ):
+					headTitle = oauth2Client.title;
+					headFaviconUrl = oauth2Client.favicon;
+					break;
+				case isWooOAuth2Client( oauth2Client ):
+					isWCCOM = true;
+					headTitle = oauth2Client.title;
+					headFaviconUrl = oauth2Client.favicon;
+					break;
+				case query?.gravatar_flow:
+					// Use Gravatar's favicon + title for the Gravatar-related OAuth2 clients in SSR.
+					headTitle = gravatarClientData.title;
+					headFaviconUrl = gravatarClientData.favicon;
+					break;
 			}
 		}
 
 		const shouldNotShowLoadingLogo =
 			sectionName === 'checkout' || sectionName === 'stepper' || sectionName === 'signup';
+
+		const LoadingLogo = chooseLoadingLogo( this.props, {
+			isWpMobileApp: app?.isWpMobileApp,
+			isWcMobileApp: app?.isWcMobileApp,
+			isWCCOM,
+		} );
 
 		return (
 			<html
@@ -292,12 +306,12 @@ class Document extends Component {
 	}
 }
 
-function chooseLoadingLogo( { useLoadingEllipsis }, isWpMobileApp, isWcMobileApp ) {
+function chooseLoadingLogo( { useLoadingEllipsis }, { isWpMobileApp, isWcMobileApp, isWCCOM } ) {
 	if ( useLoadingEllipsis ) {
 		return LoadingEllipsis;
 	}
 
-	if ( isWcMobileApp ) {
+	if ( isWcMobileApp || isWCCOM ) {
 		return WooCommerceLogo;
 	}
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -111,7 +111,6 @@ class Document extends Component {
 		// To customize the page title and favicon for Gravatar-related login pages.
 		if ( sectionName === 'login' && typeof query?.redirect_to === 'string' ) {
 			const searchParams = new URLSearchParams( query.redirect_to.split( '?' )[ 1 ] );
-
 			// To cover the case where the `client_id` is not provided, e.g. /log-in/link/use
 			const oauth2Client = initialClientsData[ searchParams.get( 'client_id' ) ] || {};
 
@@ -120,15 +119,15 @@ class Document extends Component {
 					headTitle = oauth2Client.title;
 					headFaviconUrl = oauth2Client.favicon;
 					break;
-				case isWooOAuth2Client( oauth2Client ):
-					isWCCOM = true;
-					headTitle = oauth2Client.title;
-					headFaviconUrl = oauth2Client.favicon;
-					break;
 				case query?.gravatar_flow:
 					// Use Gravatar's favicon + title for the Gravatar-related OAuth2 clients in SSR.
 					headTitle = gravatarClientData.title;
 					headFaviconUrl = gravatarClientData.favicon;
+					break;
+				case isWooOAuth2Client( oauth2Client ):
+					isWCCOM = true;
+					headTitle = oauth2Client.title;
+					headFaviconUrl = oauth2Client.favicon;
 					break;
 			}
 		}

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -8,6 +8,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import getGravatarOAuth2Flow from 'calypso/lib/get-gravatar-oauth2-flow';
@@ -283,8 +284,13 @@ class HandleEmailedLinkForm extends Component {
 			);
 		}
 
+		const showLoadingLogo = isFetching || transition || this.state.isRedirecting;
 		// transition is a GET parameter for when the user is transitioning from email user to WPCom user
-		if ( isFetching || transition || this.state.isRedirecting ) {
+		if ( showLoadingLogo ) {
+			if ( isWCCOM ) {
+				return <WooCommerceLogo size={ 72 } className="wpcom-site__logo" />;
+			}
+
 			return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/team-ghidorah/issues/290

## Proposed Changes

* Implement loading states with WooCommerce logos during transitions when user is coming from WooCommerce.com.

Before:

https://github.com/user-attachments/assets/206fbcf5-32fd-453f-b567-bb30de725f7a

After:

https://github.com/user-attachments/assets/3ff83a90-cc37-4327-9666-7a718030bc22




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Enhance the visual feedback during authentication transitions to make it more consistent with the branding of different services

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Use woo start env
* Go to WooCommerce.com
* Click on Login
* Verify loading states show Woo logo
* Log in using a passwordless account
* Click the magic link in the email
* Verify the loading page shows the WooCommerce logo


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
