### PR TITLE
A4A > WooPayments: Fix WooPayment data polling

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -89,6 +89,8 @@ const WooPaymentsDashboard = () => {
 	useEffect( () => {
 		if ( isInProgress ) {
 			setIsWooPaymentsDataLoading( true );
+		} else {
+			setIsWooPaymentsDataLoading( false );
 		}
 	}, [ isInProgress, sitesWithPluginsStates ] );
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1921

## Proposed Changes

This PR fixes an issue with WooPayment data polling, where it is polling after the latest data is fetched.

## Why are these changes being made?

* To stop polling after the latest data is fetched.

## Testing Instructions

* Open the A4A live link
* Open the network tab
* Go to WooPayments: Dashboard > Verify that the API call to fetch the WooPayments data stops when the status becomes "success". Please note you need to be on the same tab for around 1 minute to verify. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
