### PR TITLE
Domain-To-Plan Credit: Remove the feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_100_YEARS, domainProductSlugs, isFreePlan } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import clsx from 'clsx';
@@ -46,11 +45,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 		return null;
 	}
 
-	if (
-		isEnabled( 'domain-to-plan-credit' ) &&
-		domainToPlanCreditsApplicable !== null &&
-		domainToPlanCreditsApplicable > 0
-	) {
+	if ( domainToPlanCreditsApplicable !== null && domainToPlanCreditsApplicable > 0 ) {
 		return null;
 	}
 

--- a/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
+++ b/client/my-sites/domains/domain-management/list/test/empty-domains-list-card.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import config from '@automattic/calypso-config';
 import { PLAN_100_YEARS } from '@automattic/calypso-products';
 import { screen } from '@testing-library/react';
 import React from 'react';
@@ -37,12 +36,6 @@ jest.mock( 'calypso/components/data/query-products-list', () => {
 	};
 } );
 
-jest.mock( '@automattic/calypso-config', () => {
-	const config = () => {};
-	config.isEnabled = jest.fn().mockReturnValue( false );
-	return config;
-} );
-
 jest.mock(
 	'calypso/my-sites/plans-features-main/hooks/use-domain-to-plan-credits-applicable',
 	() => ( {
@@ -65,11 +58,7 @@ describe( 'EmptyDomainsListCard', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'displays empty if feature flag is enabled and site has domain-to-plan credit', () => {
-			config.isEnabled.mockImplementation( ( flag: unknown ): boolean => {
-				return flag === 'domain-to-plan-credit';
-			} );
-
+		it( 'displays empty if site has domain-to-plan credit', () => {
 			useDomainToPlanCreditsApplicable.mockImplementationOnce( () => 1 );
 
 			const { container } = renderWithProvider(

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { PlanSlug, isProPlan, isStarterPlan } from '@automattic/calypso-products';
 import { Site, SiteMediaStorage } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
@@ -212,14 +211,12 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 			);
 		case DOMAIN_TO_PLAN_CREDIT_NOTICE:
 			return (
-				isEnabled( 'domain-to-plan-credit' ) && (
-					<PlanNoticeDomainToPlanCredit
-						className="plan-features-main__notice"
-						onDismissClick={ handleDismissNotice }
-						siteId={ siteId }
-						visiblePlans={ visiblePlans }
-					/>
-				)
+				<PlanNoticeDomainToPlanCredit
+					className="plan-features-main__notice"
+					onDismissClick={ handleDismissNotice }
+					siteId={ siteId }
+					visiblePlans={ visiblePlans }
+				/>
 			);
 		case MARKETING_NOTICE:
 		default:

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -1,6 +1,5 @@
 /** @jest-environment jsdom */
 
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_BUSINESS,
 	PLAN_PREMIUM,
@@ -92,7 +91,6 @@ const mGetCurrentUserCurrencyCode = getCurrentUserCurrencyCode as jest.MockedFun
 >;
 const mGetByPurchaseId = getByPurchaseId as jest.MockedFunction< typeof getByPurchaseId >;
 const mIsProPlan = isProPlan as jest.MockedFunction< typeof isProPlan >;
-const mIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 
 const plansList: PlanSlug[] = [
 	PLAN_FREE,
@@ -122,7 +120,6 @@ describe( '<PlanNotice /> Tests', () => {
 		mUseDomainToPlanCreditsApplicable.mockImplementation( () => 100 );
 		mGetByPurchaseId.mockImplementation( () => ( { isInAppPurchase: false } ) as Purchase );
 		mIsProPlan.mockImplementation( () => false );
-		mIsEnabled.mockImplementation( ( key ) => key !== 'domain-to-plan-credit' );
 	} );
 
 	test( 'A contact site owner <PlanNotice /> should be shown no matter what other conditions are met, when the current site owner is not logged in, and the site plan is paid', () => {
@@ -183,7 +180,6 @@ describe( '<PlanNotice /> Tests', () => {
 	test( 'A domain-to-plan credit <PlanNotice /> should be shown in a site where a domain has been purchased without a paid plan', () => {
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => null );
 		mUseDomainToPlanCreditsApplicable.mockImplementation( () => 1000 );
-		mIsEnabled.mockImplementation( ( key ) => key === 'domain-to-plan-credit' );
 
 		renderWithProvider(
 			<PlanNotice

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -37,7 +36,7 @@ const HostingOverview: FC = () => {
 				title={ translate( 'Overview' ) }
 				subtitle={ subtitle }
 			/>
-			{ isEnabled( 'domain-to-plan-credit' ) && <PlanCreditNotice /> }
+			<PlanCreditNotice />
 			<PlanCard />
 			<QuickActionsCard />
 			<SiteBackupCard />

--- a/config/development.json
+++ b/config/development.json
@@ -60,7 +60,6 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domain-to-plan-credit": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": false,
 		"google-drive": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,7 +31,6 @@
 		"current-site/stale-cart-notice": false,
 		"design-picker/use-assembler-styles": true,
 		"devdocs": false,
-		"domain-to-plan-credit": false,
 		"cookie-banner": true,
 		"google-my-business": false,
 		"global-styles/on-personal-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -42,7 +42,6 @@
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": false,
 		"cookie-banner": true,
-		"domain-to-plan-credit": false,
 		"google-my-business": true,
 		"global-styles/on-personal-plan": false,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,6 @@
 		"current-site/stale-cart-notice": false,
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
-		"domain-to-plan-credit": false,
 		"cookie-banner": false,
 		"google-my-business": true,
 		"global-styles/on-personal-plan": false,

--- a/config/test.json
+++ b/config/test.json
@@ -43,7 +43,6 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
-		"domain-to-plan-credit": false,
 		"cookie-banner": false,
 		"google-my-business": false,
 		"global-styles/on-personal-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -45,7 +45,6 @@
 		"dev/store-sandbox-helper": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"domain-to-plan-credit": false,
 		"email-accounts/enabled": true,
 		"cookie-banner": true,
 		"google-my-business": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3643

## Proposed Changes

Removes the feature flag that we were using to control visibility of the domain-to-plan credit notices. The visibility of these elements is now controlled by the backend alone, which takes into account the user's explat assignment.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The feature flag check in Calypso is redundant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test with a user that has a custom domain on a free plan.

Treatment

1. Assign your user to the treatment group for 22202-explat-experiment
2. Verify that the below UI notices are visible

Control

1. Assign your user to the control group for 22202-explat-experiment
2. Verify that the below UI notices are not visible

`/plans/:site`

![CleanShot 2025-03-13 at 16 41 52@2x](https://github.com/user-attachments/assets/8833da9f-e0c6-411a-8b86-fbdb75db076f)

`/overview/:site`

![CleanShot 2025-03-13 at 16 43 09@2x](https://github.com/user-attachments/assets/2d5c68fd-df38-4ba4-b068-40d24521987f)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?