### PR TITLE
fix header aligment and subtitle display on the affiliate start page

### DIFF
--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -16,6 +16,15 @@
 	padding: 36px 24px;
 	box-shadow: none;
 
+	& &__page-heading {
+		.formatted-header__title {
+			font-size: 2.25rem;
+			@include break-xlarge {
+				font-size: 2.75rem;
+			}
+		}
+	}
+
 	& &__domain-illustration {
 		margin-bottom: 36px;
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1182,6 +1182,10 @@ export class RenderDomainsStep extends Component {
 			return translate( 'Enter some descriptive keywords to get started' );
 		}
 
+		if ( stepSectionName === 'use-your-domain' ) {
+			return '';
+		}
+
 		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
 			? translate( 'Use a domain you already own with your new WordPress.com site.' )
 			: translate( "Enter your site's name or some keywords that describe it to get started." );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1182,11 +1182,11 @@ export class RenderDomainsStep extends Component {
 			return translate( 'Enter some descriptive keywords to get started' );
 		}
 
-		if ( stepSectionName === 'use-your-domain' ) {
+		if ( 'use-your-domain' === stepSectionName ) {
 			return '';
 		}
 
-		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
+		return 'transfer' === stepSectionName || 'mapping' === stepSectionName
 			? translate( 'Use a domain you already own with your new WordPress.com site.' )
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -460,7 +460,7 @@ body.is-section-signup {
 		}
 
 		.use-my-domain__page-heading {
-			text-align: left;
+			text-align: center;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #99928 

## Proposed Changes

* Fix the alignment for the header
* Removes the subtitle "Enter your site's name or some keywords that describe it to get started." from the "Use a domain I own" page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* On the use a domain I own page the domain step's sub-header is still visible here and it looks out of place to show a sub-header above the actual header for that page with a text that doesn't make much sense in that context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/start/onboarding-affiliate`
* Choose "use a domain I own"
* Check if the layout is good during this process and the domains sub-header doesn't show on top of the header "Use a domain I own"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
