### PR TITLE
Fix button color

### DIFF
--- a/client/components/domains/side-explainer/style.scss
+++ b/client/components/domains/side-explainer/style.scss
@@ -36,6 +36,7 @@
 			text-decoration: underline;
 			cursor: pointer;
 			font-weight: 500;
+			color: var(--studio-black);
 
 			&:focus {
 				border-color: var(--color-primary);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101107

![image](https://github.com/user-attachments/assets/799aed35-3228-4d49-8a06-a1c3b1e430f1)

## Proposed Changes

* Fix domain explainer button color on safari

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix button color inconsistencies

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On mobile safari visit /start
* The domain explainer button colors should match the ones on desktop


