### PR TITLE
A4A > WooPayments: Add links to benefits & fix copy to clipboard

### DIFF
--- a/client/a8c-for-agencies/components/page-section-columns/style.scss
+++ b/client/a8c-for-agencies/components/page-section-columns/style.scss
@@ -38,6 +38,10 @@
 		flex-direction: row;
 		align-items: center;
 	}
+
+	button.components-button.is-tertiary {
+		color: var(--color-text);
+	}
 }
 
 

--- a/client/a8c-for-agencies/lib/translation.ts
+++ b/client/a8c-for-agencies/lib/translation.ts
@@ -1,0 +1,29 @@
+type Item =
+	| string
+	| number
+	| {
+			props?: {
+				children?: Item | Item[];
+				href?: string;
+			};
+	  };
+
+// Extract nested strings from a translated string
+export function extractStrings( item: Item, result: string = '' ): string {
+	if ( typeof item === 'string' || typeof item === 'number' ) {
+		result += item;
+	} else if ( item?.props ) {
+		if ( Array.isArray( item.props.children ) ) {
+			for ( const child of item.props.children ) {
+				result = extractStrings( child, result );
+			}
+		} else if ( item.props.children ) {
+			result = extractStrings( item.props.children, result );
+		}
+
+		if ( item.props.href ) {
+			result += `: ${ item.props.href }`;
+		}
+	}
+	return result;
+}

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -13,16 +13,66 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 
+type Item =
+	| string
+	| number
+	| {
+			props?: {
+				children?: Item | Item[];
+				href?: string;
+			};
+	  };
+
+function extractStrings( item: Item, result: string = '' ): string {
+	if ( typeof item === 'string' || typeof item === 'number' ) {
+		result += item;
+	} else if ( item?.props ) {
+		if ( Array.isArray( item.props.children ) ) {
+			for ( const child of item.props.children ) {
+				result = extractStrings( child, result );
+			}
+		} else if ( item.props.children ) {
+			result = extractStrings( item.props.children, result );
+		}
+
+		if ( item.props.href ) {
+			result += `: ${ item.props.href }`;
+		}
+	}
+	return result;
+}
 const WooPaymentsDashboardEmptyState = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const listItems1 = [
 		translate(
-			'WooPayments is available in 38 countries and accepts payments in 135+ currencies, no other extensions needed.'
+			'WooPayments is available in {{a}}38 countries{{/a}} and accepts payments in 135+ currencies, no other extensions needed.',
+			{
+				components: {
+					a: (
+						<a
+							href="https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
 		),
 		translate(
-			'Get started for free. Pay-as-you-go fees per transaction. There are no monthly fees, either. Learn more about our fees.'
+			'Get started for free. Pay-as-you-go fees per transaction. There are no monthly fees, either. {{a}}Learn more about WooPayments fees{{/a}}.',
+			{
+				components: {
+					a: (
+						<a
+							href="https://woocommerce.com/document/woopayments/fees-and-debits/fees"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
 		),
 		translate(
 			'Multi-Currency support is built-in. Accept payments in 135+ currencies using WooPayments.'
@@ -162,7 +212,7 @@ const WooPaymentsDashboardEmptyState = () => {
 						<span>{ translate( 'Benefits to share with your client' ) }</span>
 						<CopyToClipboardButton
 							textToCopy={ [ ...listItems1, ...listItems2 ]
-								.map( ( item ) => `• ${ item }` )
+								.map( ( item ) => `• ${ extractStrings( item ) }` )
 								.join( '\n' ) }
 							onClick={ () => {
 								dispatch(

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -4,6 +4,7 @@ import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies
 import CopyToClipboardButton from 'calypso/a8c-for-agencies/components/copy-to-clipboard-button';
 import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import { extractStrings } from 'calypso/a8c-for-agencies/lib/translation';
 import backgroundImage1 from 'calypso/assets/images/a8c-for-agencies/woopayments/background-image-1.svg';
 import cartImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cart.png';
 import ccImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cc-image.png';
@@ -13,34 +14,6 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 
-type Item =
-	| string
-	| number
-	| {
-			props?: {
-				children?: Item | Item[];
-				href?: string;
-			};
-	  };
-
-function extractStrings( item: Item, result: string = '' ): string {
-	if ( typeof item === 'string' || typeof item === 'number' ) {
-		result += item;
-	} else if ( item?.props ) {
-		if ( Array.isArray( item.props.children ) ) {
-			for ( const child of item.props.children ) {
-				result = extractStrings( child, result );
-			}
-		} else if ( item.props.children ) {
-			result = extractStrings( item.props.children, result );
-		}
-
-		if ( item.props.href ) {
-			result += `: ${ item.props.href }`;
-		}
-	}
-	return result;
-}
 const WooPaymentsDashboardEmptyState = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -78,13 +51,91 @@ const WooPaymentsDashboardEmptyState = () => {
 			'Multi-Currency support is built-in. Accept payments in 135+ currencies using WooPayments.'
 		),
 		translate(
-			'Increase conversions by enabling payment methods including WooPay, Apple Pay®, Google Pay, iDeal, P24, EPS, and Bancontact.'
+			'Increase conversions by enabling payment methods including {{wooPay}}WooPay{{/wooPay}}, {{applePay}}Apple Pay®{{/applePay}}, {{googlePay}}Google Pay{{/googlePay}}, {{iDeal}}iDeal{{/iDeal}}, {{p24}}P24{{/p24}}, {{eps}}EPS{{/eps}}, and {{bancontact}}Bancontact{{/bancontact}}.',
+			{
+				components: {
+					wooPay: (
+						<a
+							href="https://woocommerce.com/woopay-businesses"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					applePay: (
+						<a
+							href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					googlePay: (
+						<a
+							href="https://woocommerce.com/document/woopayments/payment-methods/google-pay"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					iDeal: (
+						<a
+							href="https://woocommerce.com/woocommerce-payments-ideal"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					p24: (
+						<a
+							href="https://woocommerce.com/woopayments-p24"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					eps: (
+						<a
+							href="https://woocommerce.com/woocommerce-payments-eps"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					bancontact: (
+						<a
+							href="https://woocommerce.com/woocommerce-payments-bancontact"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
+		),
+		translate(
+			'You may be eligible to earn up to {{a}}20% discount on Payment Processing Fees{{/a}}.',
+			{
+				components: {
+					a: (
+						<a
+							href="https://woocommerce.com/terms-conditions/woopayments-promotion"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
 		),
 	];
 
 	const listItems2 = [
 		translate(
-			'Enable buy now, pay later (BNPL) in one click. Sell more and reach new customers with top BNPL options built into your dashboard (not available in all geographies).'
+			'Enable buy now, pay later (BNPL) in one click. Sell more and reach new customers with {{a}}top BNPL options{{/a}} built into your dashboard (not available in all geographies).',
+			{
+				components: {
+					a: (
+						<a
+							href="https://woocommerce.com/buy-now-pay-later"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+				},
+			}
 		),
 		translate(
 			"Simplify your workflow. No more logging into third-party payment processor sites - manage everything from the comfort of your store's dashboard."
@@ -227,10 +278,18 @@ const WooPaymentsDashboardEmptyState = () => {
 				} }
 			>
 				<PageSectionColumns.Column>
-					<SimpleList applyCoreStyles items={ listItems1 } />
+					<SimpleList
+						className="woopayments-dashboard-empty-state__list"
+						applyCoreStyles
+						items={ listItems1 }
+					/>
 				</PageSectionColumns.Column>
 				<PageSectionColumns.Column>
-					<SimpleList applyCoreStyles items={ listItems2 } />
+					<SimpleList
+						className="woopayments-dashboard-empty-state__list"
+						applyCoreStyles
+						items={ listItems2 }
+					/>
 				</PageSectionColumns.Column>
 			</PageSectionColumns>
 

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -28,6 +28,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_benefits_countries_link_click' )
+								);
+							} }
 						/>
 					),
 				},
@@ -42,6 +47,9 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/document/woopayments/fees-and-debits/fees"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_fees_link_click' ) );
+							} }
 						/>
 					),
 				},
@@ -59,6 +67,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/woopay-businesses"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_benefits_wooPay_link_click' )
+								);
+							} }
 						/>
 					),
 					applePay: (
@@ -66,6 +79,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_benefits_applePay_link_click' )
+								);
+							} }
 						/>
 					),
 					googlePay: (
@@ -73,6 +91,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/document/woopayments/payment-methods/google-pay"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_benefits_googlePay_link_click' )
+								);
+							} }
 						/>
 					),
 					iDeal: (
@@ -80,6 +103,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/woocommerce-payments-ideal"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_benefits_iDeal_link_click' )
+								);
+							} }
 						/>
 					),
 					p24: (
@@ -87,6 +115,9 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/woopayments-p24"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_p24_link_click' ) );
+							} }
 						/>
 					),
 					eps: (
@@ -94,6 +125,9 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/woocommerce-payments-eps"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_eps_link_click' ) );
+							} }
 						/>
 					),
 					bancontact: (
@@ -101,6 +135,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/woocommerce-payments-bancontact"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_benefits_bancontact_link_click' )
+								);
+							} }
 						/>
 					),
 				},
@@ -115,6 +154,11 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/terms-conditions/woopayments-promotion"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch(
+									recordTracksEvent( 'calypso_a4a_woopayments_benefits_discount_link_click' )
+								);
+							} }
 						/>
 					),
 				},
@@ -132,6 +176,9 @@ const WooPaymentsDashboardEmptyState = () => {
 							href="https://woocommerce.com/buy-now-pay-later"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ () => {
+								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_bnpl_link_click' ) );
+							} }
 						/>
 					),
 				},

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
@@ -49,6 +49,11 @@ $woocommerce-purple-50: #720EEC;
 	}
 }
 
+.woopayments-dashboard-empty-state__list a {
+	text-decoration: underline;
+	color: var(--color-text);
+}
+
 a.components-button.woopayments-dashboard-empty-state__button {
 	&,
 	&:hover,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1922

## Proposed Changes

- Add links to the benefit list
- Add a new list item: You may be eligible to earn up to 20% discount on Payment Processing Fees
- Fix the copy to the clipboard to work with links

## Why are these changes being made?

* To add links to benefits and allow sharing of the links

## Testing Instructions

* Open the A4A live link > Verify that the benefits section on the empty state is updated with links as displayed below. Also, verify copying the text works fine with links in multiple languages. Note: All the languages may not work, you can choose Greek(EL: Ελληνικά) to test it.

<img width="1626" alt="Screenshot 2025-03-19 at 8 01 36 AM" src="https://github.com/user-attachments/assets/5b859112-9b1e-44f9-885b-2495bf15738a" />


Copied texts:

English:

```
• WooPayments is available in 38 countries: https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries and accepts payments in 135+ currencies, no other extensions needed.
• Get started for free. Pay-as-you-go fees per transaction. There are no monthly fees, either. Learn more about WooPayments fees: https://woocommerce.com/document/woopayments/fees-and-debits/fees.
• Multi-Currency support is built-in. Accept payments in 135+ currencies using WooPayments.
• Increase conversions by enabling payment methods including WooPay: https://woocommerce.com/woopay-businesses, Apple Pay®: https://woocommerce.com/document/woopayments/payment-methods/apple-pay, Google Pay: https://woocommerce.com/document/woopayments/payment-methods/google-pay, iDeal: https://woocommerce.com/woocommerce-payments-ideal, P24: https://woocommerce.com/woopayments-p24, EPS: https://woocommerce.com/woocommerce-payments-eps, and Bancontact: https://woocommerce.com/woocommerce-payments-bancontact.
• You may be eligible to earn up to 20% discount on Payment Processing Fees: https://woocommerce.com/terms-conditions/woopayments-promotion.
• Enable buy now, pay later (BNPL) in one click. Sell more and reach new customers with top BNPL options: https://woocommerce.com/buy-now-pay-later built into your dashboard (not available in all geographies).
• Simplify your workflow. No more logging into third-party payment processor sites - manage everything from the comfort of your store's dashboard.
• Set a custom payout schedule to get your funds into your bank account as often as you need — daily, weekly, monthly, or even on-demand.
• Reduce cart abandonment with a streamlined checkout flow.
```

Greek: 

```
• WooPayments is available in 38 countries: • WooPayments is available in 38 countries: https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries and accepts payments in 135+ currencies, no other extensions needed.
• Get started for free. Pay-as-you-go fees per transaction. There are no monthly fees, either. Learn more about WooPayments fees: https://woocommerce.com/document/woopayments/fees-and-debits/fees.
• Η υποστήριξη πολλαπλών νομισμάτων είναι ενσωματωμένη. Αποδέξου πληρωμές σε πάνω από 135 νομίσματα χρησιμοποιώντας το WooPayments.
• Increase conversions by enabling payment methods including WooPay: https://woocommerce.com/woopay-businesses, Apple Pay®: https://woocommerce.com/document/woopayments/payment-methods/apple-pay, Google Pay: https://woocommerce.com/document/woopayments/payment-methods/google-pay, iDeal: https://woocommerce.com/woocommerce-payments-ideal, P24: https://woocommerce.com/woopayments-p24, EPS: https://woocommerce.com/woocommerce-payments-eps, and Bancontact: https://woocommerce.com/woocommerce-payments-bancontact.
• You may be eligible to earn up to 20% discount on Payment Processing Fees: https://woocommerce.com/terms-conditions/woopayments-promotion.
• Ενεργοποιήστε την αγορά τώρα, πληρώστε αργότερα (BNPL) με ένα κλικ. Πουλήστε περισσότερα και προσεγγίστε νέους πελάτες με τις κορυφαίες επιλογές BNPL: https://woocommerce.com/buy-now-pay-later ενσωματωμένες στον πίνακα ελέγχου σας (δεν είναι διαθέσιμες σε όλες τις γεωγραφικές περιοχές).
• Απλοποίησε τη ροή εργασίας σου. Κανένα άλλο logging σε ιστότοπους τρίτων επεξεργαστών πληρωμών - διαχειρίσου τα πάντα από την άνεση του πίνακα ελέγχου του καταστήματός σου.
• Ρύθμισε ένα προσαρμοσμένο πρόγραμμα πληρωμών για να πάρεις τα χρήματά σου στον τραπεζικό σου λογαριασμό όσο συχνά χρειάζεσαι — καθημερινά, εβδομαδιαία, μηνιαία ή ακόμα και κατόπιν αιτήματος.
• Μειώστε την εγκατάλειψη καλαθιού με μια απλοποιημένη διαδικασία ολοκλήρωσης αγοράς.
```
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
