### PR TITLE
Lint: disable rule for next line because component is not exported

### DIFF
--- a/packages/components/src/calendar/README.md
+++ b/packages/components/src/calendar/README.md
@@ -5,6 +5,7 @@ The Calendar component provides a date picker interface that allows users to sel
 ## Usage
 
 ```jsx
+// eslint-disable-next-line import/named
 import { Calendar } from '@automattic/components';
 import { useState } from '@wordpress/element';
 


### PR DESCRIPTION
## What

Disables a lint rule that signals the component is not exported.

## Why

https://github.com/Automattic/wp-calypso/pull/101300 removed the component from the exports, triggering this error.

## How 

Disable the rule.

