### PR TITLE
Tools import: Fix loading issue from Calypso importing screen

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -106,7 +106,11 @@ class FileImporter extends PureComponent {
 			cardProps.href = overrideDestination
 				.replace( '%SITE_SLUG%', site.slug )
 				.replace( '%SITE_ID%', site.ID );
-			cardProps.onClick = this.handleClick.bind( this, false );
+
+			cardProps.onClick = ( e ) => {
+				e.stopPropagation();
+				this.handleClick.apply( this, [ false ] );
+			};
 		}
 
 		return (


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/100897

## Proposed Changes

* Fixes loading issue from Calypso importing screen to Stepper framework.
* Stops click event propagation to avoid a state between hard redirects if `overrideDestination` is true.

## Testing Instructions

* Go to `Tools / Import`
* Click on `WordPress` importer
* Check if it redirects to the stepper framework with no extra state in between the Calypso and Stepper screens

| Screen 1 | Screen 2 |
|--------|--------|
| <img width="799" alt="Screenshot 2025-03-13 at 13 26 29" src="https://github.com/user-attachments/assets/dd58885e-4e71-4024-aa76-8b3925416259" /> | <img width="801" alt="Screenshot 2025-03-13 at 13 26 36" src="https://github.com/user-attachments/assets/2c912004-ba7e-4700-9f14-e297e5e9af9e" /> | 


For more info, see: https://github.com/Automattic/wp-calypso/issues/100897

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
