### PR TITLE
Add https to the sitemap urls

### DIFF
--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -45,7 +45,13 @@ class Sitemaps extends Component {
 	}
 
 	renderSitemapLink( sitemapUrl ) {
-		const url = new URL( sitemapUrl );
+		let url;
+		try {
+			url = new URL( sitemapUrl );
+		} catch ( error ) {
+			return null;
+		}
+
 		url.protocol = 'https:';
 		const secureSitemap = url.toString();
 

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -45,15 +45,19 @@ class Sitemaps extends Component {
 	}
 
 	renderSitemapLink( sitemapUrl ) {
+		const url = new URL( sitemapUrl );
+		url.protocol = 'https:';
+		const secureSitemap = url.toString();
+
 		return (
-			<div key={ sitemapUrl }>
+			<div key={ secureSitemap }>
 				<ExternalLink
-					href={ sitemapUrl }
+					href={ secureSitemap }
 					icon
 					target="_blank"
 					style={ { overflowWrap: 'anywhere' } }
 				>
-					{ sitemapUrl }
+					{ secureSitemap }
 				</ExternalLink>
 			</div>
 		);


### PR DESCRIPTION
We redirect to https anyway

I considered using the setUrlScheme function but it looks buggy and not widely adopted

Related to #50051

## Proposed Changes

*

## Why are these changes being made?
* We shouldn't display the incorrect http:// addresses given that we'll serve the sitemaps using https and redirect to the https url

## Testing Instructions

Before / After
<img width="90%" alt="Screenshot 2025-03-13 at 15 14 38" src="https://github.com/user-attachments/assets/50aa0735-1d60-45e9-ad02-c0b072814154" />
<img width="90%" alt="Screenshot 2025-03-13 at 15 15 05" src="https://github.com/user-attachments/assets/babc1bc6-ca5b-4eb4-a094-7e8098404143" />

* On a site with a custom domain
* Go to http://calypso.localhost:3000/marketing/traffic/[SITE]
* Click the sitemaps - they should look like https:// links and should work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
