### PR TITLE
Reader: Update interests Modal

### DIFF
--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -1,4 +1,4 @@
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, fixMe } from 'i18n-calypso';
 import { get } from 'lodash';
 import ConversationsEmptyContent from 'calypso/blocks/conversations/empty';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -41,7 +41,11 @@ export default function ( props ) {
 				<ConversationTitle title={ props.title } />
 				<NavigationHeader
 					title={ translate( 'Conversations' ) }
-					subtitle={ translate( 'Check in on your comments.' ) }
+					subtitle={ fixMe( {
+						text: 'Check in on your open discussions.',
+						newCopy: translate( 'Check in on your open discussions.' ),
+						oldCopy: translate( 'Monitor all of your ongoing discussions.' ),
+					} ) }
 					className="conversations__header"
 				/>
 			</Stream>

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -41,7 +41,7 @@ export default function ( props ) {
 				<ConversationTitle title={ props.title } />
 				<NavigationHeader
 					title={ translate( 'Conversations' ) }
-					subtitle={ translate( 'Monitor all of your ongoing discussions.' ) }
+					subtitle={ translate( 'Check in on your comments.' ) }
 					className="conversations__header"
 				/>
 			</Stream>

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -58,7 +58,7 @@ function FollowingStream( { ...props } ) {
 					<BloganuaryHeader />
 					<NavigationHeader
 						title={ translate( 'Recent' ) }
-						subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }
+						subtitle={ translate( 'Fresh content from blogs you follow.' ) }
 						className={ clsx( 'following-stream-header', {
 							'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
 						} ) }

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { FoldableCard } from '@automattic/components';
 import clsx from 'clsx';
-import { translate } from 'i18n-calypso';
+import { translate, fixMe } from 'i18n-calypso';
 import { useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
@@ -58,7 +58,11 @@ function FollowingStream( { ...props } ) {
 					<BloganuaryHeader />
 					<NavigationHeader
 						title={ translate( 'Recent' ) }
-						subtitle={ translate( 'Fresh content from blogs you follow.' ) }
+						subtitle={ fixMe( {
+							text: 'Fresh content from blogs you follow.',
+							newCopy: translate( 'Fresh content from blogs you follow.' ),
+							oldCopy: translate( "Stay current with the blogs you've subscribed to." ),
+						} ) }
 						className={ clsx( 'following-stream-header', {
 							'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
 						} ) }

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { translate, fixMe } from 'i18n-calypso';
 import { Component } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -26,7 +26,11 @@ class LikedStream extends Component {
 					<DocumentHead title={ documentTitle } />
 					<NavigationHeader
 						title={ translate( 'Likes' ) }
-						subtitle={ translate( 'Revisit the posts and comments you liked.' ) }
+						subtitle={ fixMe( {
+							text: 'Revisit the posts and comments you liked.',
+							newCopy: translate( 'Revisit the posts and comments you liked.' ),
+							oldCopy: translate( 'Rediscover content that you liked.' ),
+						} ) }
 						className="liked-stream-header"
 					/>
 				</Stream>

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -26,7 +26,7 @@ class LikedStream extends Component {
 					<DocumentHead title={ documentTitle } />
 					<NavigationHeader
 						title={ translate( 'Likes' ) }
-						subtitle={ translate( 'Rediscover content that you liked.' ) }
+						subtitle={ translate( 'Revisit the posts and comments you liked.' ) }
 						className="liked-stream-header"
 					/>
 				</Stream>

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -1,6 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { SelectCardCheckbox } from '@automattic/onboarding';
-import { Modal, Button } from '@wordpress/components';
+import {
+	Modal,
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch, useStore } from 'react-redux';
@@ -185,33 +190,28 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 		},
 	];
 
-	const headerActions = (
-		<>
-			<Button onClick={ onClose } variant="link">
-				{ __( 'Cancel' ) }
-			</Button>
-			<Button onClick={ handleContinue } variant="primary" disabled={ isContinueDisabled }>
-				{ __( 'Continue' ) }
-			</Button>
-		</>
-	);
-
 	return (
 		isOpen && (
 			<Modal
 				onRequestClose={ onClose }
-				isFullScreen
-				headerActions={ headerActions }
-				isDismissible={ false }
+				size="large"
 				className="interests-modal"
+				overlayClassName="interests-modal__overlay"
 			>
-				<div className="interests-modal__content">
-					<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
-					<p className="interests-modal__subtitle">
-						{ __( 'Follow at least 3 topics to personalize your Reader feed.' ) }
-					</p>
+				<VStack spacing={ 8 } className="interests-modal__content">
+					<VStack spacing={ 0 }>
+						<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
+						<p className="interests-modal__subtitle">
+							{ __(
+								'​​Stay up-to-date with your favorite blogs and discover new voices—all from one place.'
+							) }
+						</p>
+						<p className="interests-modal__subtitle">
+							{ __( 'Follow at least 3 topics to personalize your feed.' ) }
+						</p>
+					</VStack>
 					{ categories.map( ( category ) => (
-						<div key={ category.name } className="interests-modal__category">
+						<div key={ category.name }>
 							<h3 className="interests-modal__section-header">{ category.name }</h3>
 							<div className="interests-modal__topics-list">
 								{ category.topics.map( ( topic ) => (
@@ -230,7 +230,23 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 							</div>
 						</div>
 					) ) }
-				</div>
+					<div className="interests-modal__footer">
+						<HStack justify="right" className="interests-modal__footer-actions">
+							<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								__next40pxDefaultSize
+								onClick={ handleContinue }
+								variant="primary"
+								disabled={ isContinueDisabled }
+								accessibleWhenDisabled
+							>
+								{ __( 'Continue' ) }
+							</Button>
+						</HStack>
+					</div>
+				</VStack>
 			</Modal>
 		)
 	);

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -192,12 +192,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 
 	return (
 		isOpen && (
-			<Modal
-				onRequestClose={ onClose }
-				size="large"
-				className="interests-modal"
-				overlayClassName="interests-modal__overlay"
-			>
+			<Modal onRequestClose={ onClose } size="large" className="interests-modal">
 				<VStack spacing={ 8 } className="interests-modal__content">
 					<VStack spacing={ 0 }>
 						<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -7,6 +7,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { fixMe } from 'i18n-calypso';
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch, useStore } from 'react-redux';
 import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding/constants';
@@ -202,7 +203,11 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 							) }
 						</p>
 						<p className="interests-modal__subtitle">
-							{ __( 'Follow at least 3 topics to personalize your feed.' ) }
+							{ fixMe( {
+								text: 'Follow at least 3 topics to personalize your feed.',
+								newCopy: __( 'Follow at least 3 topics to personalize your feed.' ),
+								oldCopy: __( 'Follow at least 3 topics to personalize your Reader feed.' ),
+							} ) }
 						</p>
 					</VStack>
 					{ categories.map( ( category ) => (

--- a/client/reader/onboarding/interests-modal/index.tsx
+++ b/client/reader/onboarding/interests-modal/index.tsx
@@ -50,7 +50,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 		}
 	}, [ followedTagsFromState, processingTags ] );
 
-	const isContinueDisabled = followedTags.length < 3;
+	const isContinueDisabled = followedTags.length < 4;
 
 	const handleTopicChange = ( checked: boolean, tag: string ) => {
 		// If the tag is already being processed, do nothing.
@@ -192,7 +192,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 
 	return (
 		isOpen && (
-			<Modal onRequestClose={ onClose } size="large" className="interests-modal">
+			<Modal onRequestClose={ onClose } size="fill" className="interests-modal">
 				<VStack spacing={ 8 } className="interests-modal__content">
 					<VStack spacing={ 0 }>
 						<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
@@ -225,8 +225,8 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 							</div>
 						</div>
 					) ) }
-					<div className="interests-modal__footer">
-						<HStack justify="right" className="interests-modal__footer-actions">
+					<div className="reader-onboarding-modal__footer">
+						<HStack justify="right" className="reader-onboarding-modal__footer-actions">
 							<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 								{ __( 'Cancel' ) }
 							</Button>

--- a/client/reader/onboarding/interests-modal/style.scss
+++ b/client/reader/onboarding/interests-modal/style.scss
@@ -4,8 +4,6 @@
 $actions-height: 64px;
 
 .interests-modal {
-	max-height: 90%;
-
 	&__content {
 		// Since the actions container is positioned absolutely,
 		// this padding bottom ensures that the content wrapper will properly
@@ -46,23 +44,6 @@ $actions-height: 64px;
 
 		@include break-large {
 			grid-template-columns: repeat( 3, 1fr );
-		}
-	}
-
-	&__footer {
-		height: $actions-height;
-		position: absolute;
-		bottom: 0;
-		width: 100%;
-		background-color: #fff;
-		margin-left: -32px; // $grid-unit-40
-		margin-right: -32px;
-		padding-left: 32px;
-		padding-right: 32px;
-		border-top: 1px solid #ddd; //$gray-300;
-
-		.interests-modal__footer-actions {
-			height: 100%;
 		}
 	}
 }

--- a/client/reader/onboarding/interests-modal/style.scss
+++ b/client/reader/onboarding/interests-modal/style.scss
@@ -1,13 +1,18 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 
-.interests-modal {
-	&__content {
-		padding: 24px;
+$actions-height: 64px;
 
-		@media ( max-width: $break-medium ) {
-			padding: 0;
-		}
+.interests-modal {
+	max-height: 90%;
+
+	&__content {
+		// Since the actions container is positioned absolutely,
+		// this padding bottom ensures that the content wrapper will properly
+		// detect overflowing content and start showing scrollbars at the right
+		// moment. Without this padding, the content would render under the actions
+		// bar without causing the wrapper to show a scrollbar.
+		padding-bottom: $actions-height;
 	}
 
 	&__title {
@@ -23,11 +28,7 @@
 
 	&__subtitle {
 		text-align: center;
-	}
-
-	&__category {
-		max-width: 1200px;
-		margin: 0 auto 32px auto;
+		margin: 0;
 	}
 
 	&__section-header {
@@ -48,15 +49,20 @@
 		}
 	}
 
-	.components-modal__header {
-		.components-button {
-			&.is-link {
-				margin-right: auto;
-			}
+	&__footer {
+		height: $actions-height;
+		position: absolute;
+		bottom: 0;
+		width: 100%;
+		background-color: #fff;
+		margin-left: -32px; // $grid-unit-40
+		margin-right: -32px;
+		padding-left: 32px;
+		padding-right: 32px;
+		border-top: 1px solid #ddd; //$gray-300;
 
-			&.is-primary {
-				margin-left: 16px;
-			}
+		.interests-modal__footer-actions {
+			height: 100%;
 		}
 	}
 }

--- a/client/reader/onboarding/style.scss
+++ b/client/reader/onboarding/style.scss
@@ -15,3 +15,22 @@
 		margin: 5px 5px 5px 10px;
 	}
 }
+
+$actions-height: 64px;
+
+.reader-onboarding-modal__footer {
+	height: $actions-height;
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	background-color: #fff;
+	margin-left: -32px; // $grid-unit-40
+	margin-right: -32px;
+	padding-left: 32px;
+	padding-right: 32px;
+	border-top: 1px solid #ddd; //$gray-300;
+
+	.reader-onboarding-modal__footer-actions {
+		height: 100%;
+	}
+}

--- a/client/reader/onboarding/subscribe-modal/index.tsx
+++ b/client/reader/onboarding/subscribe-modal/index.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Modal, Button } from '@wordpress/components';
+import { Modal, Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { getLocaleSlug } from 'i18n-calypso';
@@ -290,27 +290,14 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		handleClose();
 	}, [ dispatch, handleClose, queryClient ] );
 
-	const headerActions = (
-		<>
-			<Button onClick={ handleClose } variant="link">
-				{ __( 'Cancel' ) }
-			</Button>
-			<Button onClick={ handleContinue } variant="primary" disabled={ promptVerification }>
-				{ __( 'Continue' ) }
-			</Button>
-		</>
-	);
-
 	return (
 		isOpen && (
 			<Modal
 				onRequestClose={ handleClose }
-				isFullScreen
+				size="fill"
 				className={ clsx( 'subscribe-modal', {
 					'is-disabled': promptVerification,
 				} ) }
-				headerActions={ headerActions }
-				isDismissible={ false }
 			>
 				<div className="subscribe-modal__container">
 					{ promptVerification && <SubscribeVerificationNudge /> }
@@ -381,6 +368,22 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 									</>
 								) }
 							</div>
+						</div>
+						<div className="reader-onboarding-modal__footer">
+							<HStack justify="right" className="reader-onboarding-modal__footer-actions">
+								<Button __next40pxDefaultSize variant="tertiary" onClick={ handleClose }>
+									{ __( 'Cancel' ) }
+								</Button>
+								<Button
+									__next40pxDefaultSize
+									onClick={ handleContinue }
+									variant="primary"
+									disabled={ promptVerification }
+									accessibleWhenDisabled
+								>
+									{ __( 'Continue' ) }
+								</Button>
+							</HStack>
 						</div>
 					</div>
 				</div>

--- a/client/reader/onboarding/subscribe-modal/style.scss
+++ b/client/reader/onboarding/subscribe-modal/style.scss
@@ -14,6 +14,8 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 	}
 }
 
+$actions-height: 64px;
+
 .subscribe-modal {
 	&__title {
 		font-family: Recoleta, sans-serif;
@@ -29,6 +31,13 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 	}
 
 	&__content {
+		// Since the actions container is positioned absolutely,
+		// this padding bottom ensures that the content wrapper will properly
+		// detect overflowing content and start showing scrollbars at the right
+		// moment. Without this padding, the content would render under the actions
+		// bar without causing the wrapper to show a scrollbar.
+		padding-bottom: $actions-height;
+
 		display: flex;
 		flex-direction: column;
 		height: calc( 100vh - 200px );


### PR DESCRIPTION
Part of: https://github.com/Automattic/wp-calypso/issues/100211

This PR updates the interests Modal shown to users that visit the Reader for the first time.

The linked issue also suggests making some copy changes to some [subtitles](https://github.com/Automattic/wp-calypso/issues/100211#issuecomment-2681677257) and introduce a new header at the sidebar. 

We can explore this here or in a follow up to land this one faster.



## Testing Instructions
1. Visit the Reader (`/reader`) as if it was for the first time. I'm not sure if there is an easier way to do this, but I changed [this condition](https://github.com/Automattic/wp-calypso/blob/trunk/client/reader/following/main.tsx#L33) to `if ( true )`.
2. Observe the updated Modal
3. To see the new subtitles navigate to `Likes, Conversations and Discover` respectively. Noting that for `Discover` there are way more subtitles based on the tab selection below

Before     | After
:-------------------------:|:-------------------------:
<img width="1221" alt="before" src="https://github.com/user-attachments/assets/21201bdd-4ccb-4a78-a6f5-54635e745c97" /> | <img width="1221" alt="after" src="https://github.com/user-attachments/assets/f2241984-f77c-4ffc-97de-d6544f4f7e53" />


Before     | After
:-------------------------:|:-------------------------:
<img width="931" alt="disc before" src="https://github.com/user-attachments/assets/cc2fec02-bb15-4cf9-aca4-84bd5128068e" /> | <img width="931" alt="disc after" src="https://github.com/user-attachments/assets/68a402e7-63ed-4c22-b977-77a8b2b0185f" />


Before     | After
:-------------------------:|:-------------------------:
<img width="1221" alt="disc spli bef" src="https://github.com/user-attachments/assets/291ada20-5fb6-40bd-a50e-2d8654af77fc" /> | <img width="1221" alt="disc spli after" src="https://github.com/user-attachments/assets/1b36a2aa-50dd-405f-8874-452a4784d220" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
