### PR TITLE
Security Keys: Fix invalid error message key.

### DIFF
--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -80,7 +80,7 @@ export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 			let error;
 			if ( httpError instanceof Error ) {
 				const errorKey = httpError.message.includes( 'document is not focused' )
-					? errorMessages.NotFocusedError
+					? 'NotFocusedError'
 					: httpError.name;
 				const message = errorMessages[ errorKey ] ?? errorMessages.default;
 				error = { code: httpError.name, message, field: 'global' };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use the appropriate error message key for Safari users.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a follow up for #101232. There was a small bug for Safari users where the "document not focused" error was mapped to a generic error message.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to a WP.com account with a security key as second factor on Safari.
* Just after entering the password and before the security key workflow starts, quickly switch to another window.
* You should see the following error: `It seems the page is not active for authentication. Please click anywhere on the page and try again while keeping the window open.`, instead of `Oops! Something went wrong. Please try again.`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
