### PR TITLE
Update test to avoid being flaky

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
+++ b/test/e2e/specs/onboarding/onboarding__focused-launchpad.ts
@@ -120,7 +120,8 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 
 			// The first time we save, we need to wait for the page to reload because it redirects to Calypo's settings page
 			// before loading /wp-admin settings page again, so we'd lose the settings updated notice
-			await new Promise( ( r ) => setTimeout( r, 2000 ) );
+			// We can probably remove this after the ungangling is completed.
+			await new Promise( ( r ) => setTimeout( r, 5000 ) );
 			await saveChangesButton.click();
 			// Wait for the success notice that appears after saving
 			await page.waitForSelector( '#setting-error-settings_updated' );
@@ -131,7 +132,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 
 		it( "It will write the user's first post", async function () {
 			const writeFirstPostButton = await page.getByText( 'Write your first post' );
-			await writeFirstPostButton.waitFor();
+			await writeFirstPostButton.waitFor( { timeout: 30 * 1000 } );
 			await writeFirstPostButton.click();
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pet6gk-26G-p2

## Proposed Changes

* Improve the test to avoid being flaky

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In the past 24 hours, this test failed once. The goal is to not fail anymore, unless it detects an unintended code change, of course.
