### PR TITLE
Reader - fix all tags page sidebar selected state.

### DIFF
--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarHelper from '../helper';
 import ReaderSidebarTagsListItem from './list-item';
 
 export class ReaderSidebarTagsList extends Component {
@@ -34,16 +35,24 @@ export class ReaderSidebarTagsList extends Component {
 	render() {
 		return (
 			<li className="reader-sidebar-tags__list">
-				<ul>{ this.renderItems() }</ul>
-				<a
-					className={ clsx( 'sidebar__menu-link', 'sidebar__menu-item--see-all-tags-link' ) }
-					href="/tags"
-					onClick={ this.trackTagsPageClick }
-				>
-					<span className="reader-sidebar-tags__all-tags-link">
-						{ this.props.translate( 'See all tags' ) }
-					</span>
-				</a>
+				<ul>
+					{ this.renderItems() }
+					<li
+						className={ ReaderSidebarHelper.itemLinkClass( '/tags', this.props.path, {
+							'sidebar-dynamic-menu__tag': true,
+						} ) }
+					>
+						<a
+							className={ clsx( 'sidebar__menu-link', 'sidebar__menu-item--see-all-tags-link' ) }
+							href="/tags"
+							onClick={ this.trackTagsPageClick }
+						>
+							<span className="reader-sidebar-tags__all-tags-link">
+								{ this.props.translate( 'See all tags' ) }
+							</span>
+						</a>
+					</li>
+				</ul>
 			</li>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Fix the sidebar item for the "see all tags" page to show the selected style when on the all tags page.
* Uses `ReaderSidebarHelper.itemLinkClass` on this item to gain the functionality of adding the 'selected' class when on the designated path.
* Wraps this in a `<li>` element and moves it into the same `<ul>` that the other tag items are under. This makes the item consistent with the other tags in the list for dom layout and styles.

BEFORE
![Screenshot 2025-03-13 at 10 37 51 AM](https://github.com/user-attachments/assets/36481d44-2378-4148-aae3-cc0b0853872d)

AFTER
![Screenshot 2025-03-13 at 10 37 30 AM](https://github.com/user-attachments/assets/e9e48203-170a-4e94-bf78-3e2139dafefc)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* consistency, ui feedback, fix the bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader.
* Navigate to the tags menu group.
* Select different tags, they should show selected styles in the sidebar the same as before.
* Select "see all tags", verify it also now has a selected style when on this page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
