### PR TITLE
Stepper: Remove excess CSS from the user step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -1,6 +1,11 @@
-@import "calypso/signup/style";
+@import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+
+$gray-100: #101517;
+$gray-60: #50575e;
+$gray-50: #646970;
+$breakpoint-mobile: 660px;
 
 .step-route.user {
 	display: flex;
@@ -12,9 +17,27 @@
 
 	.locale-suggestions {
 		margin: 0 auto;
+
 		@include break-medium {
 			width: 100%;
 		}
+	}
+
+	.formatted-header__title {
+		@include onboarding-font-recoleta;
+		color: $gray-100;
+		margin-top: 0;
+		font-size: 2.25rem;
+
+		@include break-xlarge {
+			font-size: 2.75rem;
+		}
+	}
+
+	.formatted-header__subtitle {
+		color: $gray-60;
+		font-size: 1rem;
+		margin-bottom: 0;
 	}
 
 	a.step-wrapper__navigation-link {


### PR DESCRIPTION
Probably fixes: https://github.com/Automattic/wp-calypso/issues/101252#issuecomment-2718659374

## Proposed Changes

This removes the client/signup CSS loaded in the Stepper's user step. Most of it was not needed and it collided with a few things (newsletter setup and site migration flows). 

## Why are these changes being made?
Smaller bundle and fewer CSS collisions.

## Testing Instructions

1. Go to /setup/onboarding of this branch and of wordpress.com
2. Compare them side to side in all screens resolutions. They should be identical. Although, there is a slight difference on mobile, which I deemed an improvement.
