### PR TITLE
Add: Back button to the goals capture screen.

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -511,6 +511,8 @@ const siteSetupFlow: FlowV1 = {
 
 		const goBack = () => {
 			switch ( currentStep ) {
+				case 'goals':
+					return history.back();
 				case 'bloggerStartingPoint':
 					return navigate( 'options' );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -34,9 +34,9 @@ import {
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
+import { SITE_STORE } from '../../../../stores';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
-import { SITE_STORE } from '../../../../stores';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './styles.scss';
 
@@ -146,10 +146,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 
 	async function createSite() {
 		const slug = getSignupCompleteSlug();
-		if (
-			isManageSiteFlow ||
-			( slug && ( await resolveSelect( SITE_STORE ).getSite?.( slug )?.plan?.is_free ) )
-		) {
+		const siteObj = await resolveSelect( SITE_STORE ).getSite?.( slug );
+		if ( isManageSiteFlow || ( slug && siteObj?.plan?.is_free ) ) {
 			if ( planCartItem && slug ) {
 				await addPlanToCart( slug, flow, true, theme, planCartItem );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -16,7 +16,7 @@ import {
 	isHostedSiteMigrationFlow,
 	Step,
 } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, resolveSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -36,6 +36,7 @@ import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
+import { SITE_STORE } from '../../../../stores';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './styles.scss';
 
@@ -144,9 +145,11 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const shouldGoToCheckout = Boolean( planCartItem );
 
 	async function createSite() {
-		if ( isManageSiteFlow ) {
-			const slug = getSignupCompleteSlug();
-
+		const slug = getSignupCompleteSlug();
+		if (
+			isManageSiteFlow ||
+			( slug && ( await resolveSelect( SITE_STORE ).getSite?.( slug )?.plan?.is_free ) )
+		) {
 			if ( planCartItem && slug ) {
 				await addPlanToCart( slug, flow, true, theme, planCartItem );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
@@ -9,6 +9,8 @@ type GoalsCaptureContainerProps = {
 	stepName: string;
 	onSkip(): void;
 	goNext: NavigationControls[ 'goNext' ];
+	goBack: NavigationControls[ 'goBack' ];
+	hideBack?: boolean;
 	nextLabelText: string;
 	skipLabelText: string;
 	stepContent: React.ReactElement;
@@ -26,7 +28,6 @@ export const GoalsCaptureContainer: React.FC< GoalsCaptureContainerProps > = ( {
 		<StepContainer
 			{ ...otherProps }
 			isHorizontalLayout={ false }
-			hideBack
 			hideSkip={ false }
 			hideNext={ isMediumOrBiggerScreen }
 			formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -10,6 +10,7 @@ import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { useSiteData } from '../../../../hooks/use-site-data';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { useCreateCourseGoalFeature } from '../../hooks/use-create-course-goal-feature';
 import DashboardIcon from './dashboard-icon';
@@ -190,6 +191,7 @@ const GoalsStep: StepType< {
 	);
 
 	const isMediumOrBiggerScreen = useViewportMatch( 'small', '>=' );
+	const { site } = useSiteData();
 
 	const getStep = () => {
 		if ( shouldUseStepContainerV2( flow ) ) {
@@ -199,7 +201,14 @@ const GoalsStep: StepType< {
 				<Step.CenteredColumnLayout
 					columnWidth={ 6 }
 					className="step-container-v2--goals"
-					topBar={ <Step.TopBar rightElement={ <Step.SkipButton onClick={ handleSkip } /> } /> }
+					topBar={
+						<Step.TopBar
+							rightElement={ <Step.SkipButton onClick={ handleSkip } /> }
+							leftElement={
+								site?.plan?.is_free ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
+							}
+						/>
+					}
 					heading={ <Step.Heading text={ whatAreYourGoalsText } subText={ subHeaderText } /> }
 					stickyBottomBar={ <Step.StickyBottomBar rightElement={ nextButton } /> }
 				>
@@ -218,6 +227,8 @@ const GoalsStep: StepType< {
 				nextLabelText={ translate( 'Next' ) }
 				skipLabelText={ translate( 'Skip' ) }
 				recordTracksEvent={ recordTracksEvent }
+				goBack={ navigation.goBack }
+				hideBack={ ! site?.plan?.is_free }
 				stepContent={ getStepContent(
 					isMediumOrBiggerScreen && (
 						<Button


### PR DESCRIPTION
Fix: https://github.com/Automattic/wp-calypso/issues/100571
Adds a back button to the goals screen. The back button when clicked goes back to the plan selection screen allowing the user to change the selected plan.
The back button only appears on free plans, on non--free plans the previous screen would be the payment if the user goes to the goal selection it means the user already paid in that case it does not make sense to go back because the payment is already made anyway.


## Testing Instructions
Add a new site with a free plan.
Verify there is a back button on the goal screen that allows to go back to the plan choosing UI and selecting a paid plan.
Repeat the steps on a paid plan and verify there is no back button the previous step is the payment.

## Screenshots
<img width="1707" alt="Screenshot 2025-03-13 at 16 25 44" src="https://github.com/user-attachments/assets/bc83c3fc-a4ee-4ae2-b900-bed093e2e86e" />


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
