### PR TITLE
Domains: Change 'Cancel' tooltip to 'Clear selection' for bulk actions

### DIFF
--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -29,121 +29,123 @@ type Props = {
 	queryParams: QueryParams;
 };
 
-export const DomainsDataViews = ({
+export const DomainsDataViews = ( {
 	domains,
 	isLoading,
 	sidebarMode,
 	selectedDomainName,
 	queryParams,
-}: Props) => {
+}: Props ) => {
 	const translate = useTranslate();
 	const { isDesktop, getSiteSlug, selectedFeature } = useDomainsDataViewsContext();
 
 	useBulkActionNotice();
 
-	const [view, setView] = useState(() => initializeViewState(isDesktop, queryParams, sidebarMode));
+	const [ view, setView ] = useState( () =>
+		initializeViewState( isDesktop, queryParams, sidebarMode )
+	);
 	const fields = useFields();
-	const actions = useActions(view.type);
-	const { data: domainsToDisplay, paginationInfo } = useMemo(() => {
-		return filterSortAndPaginate(domains || [], view, fields);
-	}, [domains, view, fields]);
+	const actions = useActions( view.type );
+	const { data: domainsToDisplay, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( domains || [], view, fields );
+	}, [ domains, view, fields ] );
 
-	const [selectedIds, setSelectedIds] = useState<string[]>([]);
+	const [ selectedIds, setSelectedIds ] = useState< string[] >( [] );
 	const selectedDomain = domainsToDisplay
-		.filter((d: PartialDomainData) => d.domain === selectedDomainName)
+		.filter( ( d: PartialDomainData ) => d.domain === selectedDomainName )
 		.pop();
 
-	useEffect(() => {
-		const fieldsForBreakpoint = getFieldsByBreakpoint(isDesktop, sidebarMode);
-		const sortedFieldsForBreakpoint = [...fieldsForBreakpoint].sort().toString();
-		const sortedExistingFields = [...(view?.fields ?? [])].sort().toString();
+	useEffect( () => {
+		const fieldsForBreakpoint = getFieldsByBreakpoint( isDesktop, sidebarMode );
+		const sortedFieldsForBreakpoint = [ ...fieldsForBreakpoint ].sort().toString();
+		const sortedExistingFields = [ ...( view?.fields ?? [] ) ].sort().toString();
 		// Compare the content of the arrays, not its referrences that will always be different.
 		// sort() sorts the array in place, so we need to clone them first.
-		if (sortedExistingFields !== sortedFieldsForBreakpoint) {
-			setView((prevState) => ({ ...prevState, fields: fieldsForBreakpoint }));
+		if ( sortedExistingFields !== sortedFieldsForBreakpoint ) {
+			setView( ( prevState ) => ( { ...prevState, fields: fieldsForBreakpoint } ) );
 		}
-	}, [isDesktop, sidebarMode, view, setView]);
+	}, [ isDesktop, sidebarMode, view, setView ] );
 
-	useEffect(() => {
+	useEffect( () => {
 		// Replace the "Cancel" tooltip with "Clear selection"
 		const replaceTooltip = () => {
 			const cancelButton = document.querySelector(
 				'button[aria-label="Cancel"]'
 			) as HTMLButtonElement | null;
-			if (!cancelButton) {
+			if ( ! cancelButton ) {
 				return;
 			}
 
 			// Setup our custom tooltip
-			cancelButton.removeAttribute('aria-describedby');
-			cancelButton.setAttribute('data-custom-tooltip', 'Clear selection');
+			cancelButton.removeAttribute( 'aria-describedby' );
+			cancelButton.setAttribute( 'data-custom-tooltip', 'Clear selection' );
 
 			// Remove any @wordpress/dataviews tooltips containing "Cancel"
-			document.querySelectorAll('.components-tooltip').forEach((tooltip: Element) => {
-				if (tooltip.textContent?.includes('Cancel')) {
+			document.querySelectorAll( '.components-tooltip' ).forEach( ( tooltip: Element ) => {
+				if ( tooltip.textContent?.includes( 'Cancel' ) ) {
 					tooltip.remove();
 				}
-			});
+			} );
 
 			// Match @wordpress/dataviews behavior: skip delay when other tooltips are visible
-			const otherTooltipsVisible = document.querySelectorAll('.components-tooltip').length > 0;
-			cancelButton.toggleAttribute('data-tooltip-active', otherTooltipsVisible);
+			const otherTooltipsVisible = document.querySelectorAll( '.components-tooltip' ).length > 0;
+			cancelButton.toggleAttribute( 'data-tooltip-active', otherTooltipsVisible );
 		};
 
 		// Initial setup
 		replaceTooltip();
 
 		// Watch for DOM changes that might affect tooltips
-		const observer = new MutationObserver((mutations: MutationRecord[]) => {
+		const observer = new MutationObserver( ( mutations: MutationRecord[] ) => {
 			const hasRelevantChanges = mutations.some(
-				(mutation) =>
+				( mutation ) =>
 					mutation.addedNodes.length > 0 ||
-					(mutation.target instanceof Element &&
-						mutation.target.classList?.contains('components-tooltip'))
+					( mutation.target instanceof Element &&
+						mutation.target.classList?.contains( 'components-tooltip' ) )
 			);
 
-			if (hasRelevantChanges) {
+			if ( hasRelevantChanges ) {
 				replaceTooltip();
 			}
-		});
+		} );
 
-		observer.observe(document.body, { childList: true, subtree: true });
+		observer.observe( document.body, { childList: true, subtree: true } );
 
 		// Add direct event listeners to detect hovering between tooltips more quickly
-		const handleMouseOver = (event: MouseEvent) => {
-			if (event.target instanceof Element) {
+		const handleMouseOver = ( event: MouseEvent ) => {
+			if ( event.target instanceof Element ) {
 				// When hovering any button or tooltip, immediately mark our tooltip for instant display
 				const cancelButton = document.querySelector(
 					'button[data-custom-tooltip]'
 				) as HTMLButtonElement | null;
 				if (
 					cancelButton &&
-					(event.target.tagName === 'BUTTON' ||
-						event.target.closest('button') ||
-						event.target.classList.contains('components-tooltip'))
+					( event.target.tagName === 'BUTTON' ||
+						event.target.closest( 'button' ) ||
+						event.target.classList.contains( 'components-tooltip' ) )
 				) {
-					cancelButton.setAttribute('data-tooltip-active', 'true');
+					cancelButton.setAttribute( 'data-tooltip-active', 'true' );
 					// Reset after a delay to allow standard behavior to resume
-					setTimeout(() => {
-						const tooltipsVisible = document.querySelectorAll('.components-tooltip').length > 0;
-						if (!tooltipsVisible) {
-							cancelButton.removeAttribute('data-tooltip-active');
+					setTimeout( () => {
+						const tooltipsVisible = document.querySelectorAll( '.components-tooltip' ).length > 0;
+						if ( ! tooltipsVisible ) {
+							cancelButton.removeAttribute( 'data-tooltip-active' );
 						}
-					}, 1000);
+					}, 1000 );
 				}
 			}
 		};
 
-		document.addEventListener('mouseover', handleMouseOver);
+		document.addEventListener( 'mouseover', handleMouseOver );
 
 		return () => {
 			observer.disconnect();
-			document.removeEventListener('mouseover', handleMouseOver);
+			document.removeEventListener( 'mouseover', handleMouseOver );
 		};
-	}, [selectedIds]);
+	}, [ selectedIds ] );
 
 	// Update URL with view control params on change.
-	useEffect(() => {
+	useEffect( () => {
 		const queryParams = {
 			search: view.search?.trim(),
 			page: view.page && view.page > 1 ? view.page : undefined,
@@ -153,62 +155,65 @@ export const DomainsDataViews = ({
 				view.sort?.direction === DEFAULT_SORT_DIRECTION ? undefined : view.sort?.direction,
 		};
 
-		window.setTimeout(() => {
-			const url = buildPathWithQueryParams(queryParams);
-			navigate(url, false, false);
-		});
-	}, [view.search, view.page, view.perPage, view.sort?.field, view.sort?.direction]);
+		window.setTimeout( () => {
+			const url = buildPathWithQueryParams( queryParams );
+			navigate( url, false, false );
+		} );
+	}, [ view.search, view.page, view.perPage, view.sort?.field, view.sort?.direction ] );
 
-	useEffect(() => {
-		setView((previousView) => ({
+	useEffect( () => {
+		setView( ( previousView ) => ( {
 			...previousView,
 			page: queryParams.page,
-		}));
-	}, [queryParams.page]);
+		} ) );
+	}, [ queryParams.page ] );
 
 	const layout = sidebarMode ? { list: {} } : { table: {} };
 
-	const onClickDomain = (item: PartialDomainData) => {
-		const siteSlug = getSiteSlug(item);
-		const domainManagementLink = !item.wpcom_domain
-			? addQueryArgs(queryParams, getDomainManagementLink(item, siteSlug, true, selectedFeature))
+	const onClickDomain = ( item: PartialDomainData ) => {
+		const siteSlug = getSiteSlug( item );
+		const domainManagementLink = ! item.wpcom_domain
+			? addQueryArgs(
+					queryParams,
+					getDomainManagementLink( item, siteSlug, true, selectedFeature )
+			  )
 			: '';
 
-		if (!domainManagementLink) {
+		if ( ! domainManagementLink ) {
 			return;
 		}
 
-		navigate(domainManagementLink);
+		navigate( domainManagementLink );
 	};
 
-	const onChangeSelection = (items: string[]) => {
-		setSelectedIds(items);
-		if (view.type === 'list') {
-			const selectedItem = domains?.find((d) => getDomainId(d) === items[0]);
-			if (selectedItem) {
-				onClickDomain(selectedItem);
+	const onChangeSelection = ( items: string[] ) => {
+		setSelectedIds( items );
+		if ( view.type === 'list' ) {
+			const selectedItem = domains?.find( ( d ) => getDomainId( d ) === items[ 0 ] );
+			if ( selectedItem ) {
+				onClickDomain( selectedItem );
 			}
 		}
 	};
 
 	return (
 		<>
-			<div className={clsx('domains-dataviews', { 'domains-dataviews-list': sidebarMode })}>
+			<div className={ clsx( 'domains-dataviews', { 'domains-dataviews-list': sidebarMode } ) }>
 				<DataViews
-					data={domainsToDisplay}
-					fields={fields}
-					onChangeView={(newView) => setView(() => newView)}
-					onClickItem={onClickDomain}
-					view={view}
-					actions={actions}
+					data={ domainsToDisplay }
+					fields={ fields }
+					onChangeView={ ( newView ) => setView( () => newView ) }
+					onClickItem={ onClickDomain }
+					view={ view }
+					actions={ actions }
 					search
-					searchLabel={translate('Search by domain…')}
-					paginationInfo={paginationInfo}
-					getItemId={getDomainId}
-					selection={selectedDomain ? [getDomainId(selectedDomain)] : selectedIds}
-					onChangeSelection={onChangeSelection}
-					isLoading={isLoading}
-					defaultLayouts={layout}
+					searchLabel={ translate( 'Search by domain…' ) }
+					paginationInfo={ paginationInfo }
+					getItemId={ getDomainId }
+					selection={ selectedDomain ? [ getDomainId( selectedDomain ) ] : selectedIds }
+					onChangeSelection={ onChangeSelection }
+					isLoading={ isLoading }
+					defaultLayouts={ layout }
 				/>
 			</div>
 		</>

--- a/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
+++ b/client/my-sites/domains/domain-management/dataviews/domains-dataviews.tsx
@@ -29,45 +29,121 @@ type Props = {
 	queryParams: QueryParams;
 };
 
-export const DomainsDataViews = ( {
+export const DomainsDataViews = ({
 	domains,
 	isLoading,
 	sidebarMode,
 	selectedDomainName,
 	queryParams,
-}: Props ) => {
+}: Props) => {
 	const translate = useTranslate();
 	const { isDesktop, getSiteSlug, selectedFeature } = useDomainsDataViewsContext();
 
 	useBulkActionNotice();
 
-	const [ view, setView ] = useState( () =>
-		initializeViewState( isDesktop, queryParams, sidebarMode )
-	);
+	const [view, setView] = useState(() => initializeViewState(isDesktop, queryParams, sidebarMode));
 	const fields = useFields();
-	const actions = useActions( view.type );
-	const { data: domainsToDisplay, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( domains || [], view, fields );
-	}, [ domains, view, fields ] );
+	const actions = useActions(view.type);
+	const { data: domainsToDisplay, paginationInfo } = useMemo(() => {
+		return filterSortAndPaginate(domains || [], view, fields);
+	}, [domains, view, fields]);
 
-	const [ selectedIds, setSelectedIds ] = useState< string[] >( [] );
+	const [selectedIds, setSelectedIds] = useState<string[]>([]);
 	const selectedDomain = domainsToDisplay
-		.filter( ( d: PartialDomainData ) => d.domain === selectedDomainName )
+		.filter((d: PartialDomainData) => d.domain === selectedDomainName)
 		.pop();
 
-	useEffect( () => {
-		const fieldsForBreakpoint = getFieldsByBreakpoint( isDesktop, sidebarMode );
-		const sortedFieldsForBreakpoint = [ ...fieldsForBreakpoint ].sort().toString();
-		const sortedExistingFields = [ ...( view?.fields ?? [] ) ].sort().toString();
+	useEffect(() => {
+		const fieldsForBreakpoint = getFieldsByBreakpoint(isDesktop, sidebarMode);
+		const sortedFieldsForBreakpoint = [...fieldsForBreakpoint].sort().toString();
+		const sortedExistingFields = [...(view?.fields ?? [])].sort().toString();
 		// Compare the content of the arrays, not its referrences that will always be different.
 		// sort() sorts the array in place, so we need to clone them first.
-		if ( sortedExistingFields !== sortedFieldsForBreakpoint ) {
-			setView( ( prevState ) => ( { ...prevState, fields: fieldsForBreakpoint } ) );
+		if (sortedExistingFields !== sortedFieldsForBreakpoint) {
+			setView((prevState) => ({ ...prevState, fields: fieldsForBreakpoint }));
 		}
-	}, [ isDesktop, sidebarMode, view, setView ] );
+	}, [isDesktop, sidebarMode, view, setView]);
+
+	useEffect(() => {
+		// Replace the "Cancel" tooltip with "Clear selection"
+		const replaceTooltip = () => {
+			const cancelButton = document.querySelector(
+				'button[aria-label="Cancel"]'
+			) as HTMLButtonElement | null;
+			if (!cancelButton) {
+				return;
+			}
+
+			// Setup our custom tooltip
+			cancelButton.removeAttribute('aria-describedby');
+			cancelButton.setAttribute('data-custom-tooltip', 'Clear selection');
+
+			// Remove any @wordpress/dataviews tooltips containing "Cancel"
+			document.querySelectorAll('.components-tooltip').forEach((tooltip: Element) => {
+				if (tooltip.textContent?.includes('Cancel')) {
+					tooltip.remove();
+				}
+			});
+
+			// Match @wordpress/dataviews behavior: skip delay when other tooltips are visible
+			const otherTooltipsVisible = document.querySelectorAll('.components-tooltip').length > 0;
+			cancelButton.toggleAttribute('data-tooltip-active', otherTooltipsVisible);
+		};
+
+		// Initial setup
+		replaceTooltip();
+
+		// Watch for DOM changes that might affect tooltips
+		const observer = new MutationObserver((mutations: MutationRecord[]) => {
+			const hasRelevantChanges = mutations.some(
+				(mutation) =>
+					mutation.addedNodes.length > 0 ||
+					(mutation.target instanceof Element &&
+						mutation.target.classList?.contains('components-tooltip'))
+			);
+
+			if (hasRelevantChanges) {
+				replaceTooltip();
+			}
+		});
+
+		observer.observe(document.body, { childList: true, subtree: true });
+
+		// Add direct event listeners to detect hovering between tooltips more quickly
+		const handleMouseOver = (event: MouseEvent) => {
+			if (event.target instanceof Element) {
+				// When hovering any button or tooltip, immediately mark our tooltip for instant display
+				const cancelButton = document.querySelector(
+					'button[data-custom-tooltip]'
+				) as HTMLButtonElement | null;
+				if (
+					cancelButton &&
+					(event.target.tagName === 'BUTTON' ||
+						event.target.closest('button') ||
+						event.target.classList.contains('components-tooltip'))
+				) {
+					cancelButton.setAttribute('data-tooltip-active', 'true');
+					// Reset after a delay to allow standard behavior to resume
+					setTimeout(() => {
+						const tooltipsVisible = document.querySelectorAll('.components-tooltip').length > 0;
+						if (!tooltipsVisible) {
+							cancelButton.removeAttribute('data-tooltip-active');
+						}
+					}, 1000);
+				}
+			}
+		};
+
+		document.addEventListener('mouseover', handleMouseOver);
+
+		return () => {
+			observer.disconnect();
+			document.removeEventListener('mouseover', handleMouseOver);
+		};
+	}, [selectedIds]);
 
 	// Update URL with view control params on change.
-	useEffect( () => {
+	useEffect(() => {
 		const queryParams = {
 			search: view.search?.trim(),
 			page: view.page && view.page > 1 ? view.page : undefined,
@@ -77,65 +153,62 @@ export const DomainsDataViews = ( {
 				view.sort?.direction === DEFAULT_SORT_DIRECTION ? undefined : view.sort?.direction,
 		};
 
-		window.setTimeout( () => {
-			const url = buildPathWithQueryParams( queryParams );
-			navigate( url, false, false );
-		} );
-	}, [ view.search, view.page, view.perPage, view.sort?.field, view.sort?.direction ] );
+		window.setTimeout(() => {
+			const url = buildPathWithQueryParams(queryParams);
+			navigate(url, false, false);
+		});
+	}, [view.search, view.page, view.perPage, view.sort?.field, view.sort?.direction]);
 
-	useEffect( () => {
-		setView( ( previousView ) => ( {
+	useEffect(() => {
+		setView((previousView) => ({
 			...previousView,
 			page: queryParams.page,
-		} ) );
-	}, [ queryParams.page ] );
+		}));
+	}, [queryParams.page]);
 
 	const layout = sidebarMode ? { list: {} } : { table: {} };
 
-	const onClickDomain = ( item: PartialDomainData ) => {
-		const siteSlug = getSiteSlug( item );
-		const domainManagementLink = ! item.wpcom_domain
-			? addQueryArgs(
-					queryParams,
-					getDomainManagementLink( item, siteSlug, true, selectedFeature )
-			  )
+	const onClickDomain = (item: PartialDomainData) => {
+		const siteSlug = getSiteSlug(item);
+		const domainManagementLink = !item.wpcom_domain
+			? addQueryArgs(queryParams, getDomainManagementLink(item, siteSlug, true, selectedFeature))
 			: '';
 
-		if ( ! domainManagementLink ) {
+		if (!domainManagementLink) {
 			return;
 		}
 
-		navigate( domainManagementLink );
+		navigate(domainManagementLink);
 	};
 
-	const onChangeSelection = ( items: string[] ) => {
-		setSelectedIds( items );
-		if ( view.type === 'list' ) {
-			const selectedItem = domains?.find( ( d ) => getDomainId( d ) === items[ 0 ] );
-			if ( selectedItem ) {
-				onClickDomain( selectedItem );
+	const onChangeSelection = (items: string[]) => {
+		setSelectedIds(items);
+		if (view.type === 'list') {
+			const selectedItem = domains?.find((d) => getDomainId(d) === items[0]);
+			if (selectedItem) {
+				onClickDomain(selectedItem);
 			}
 		}
 	};
 
 	return (
 		<>
-			<div className={ clsx( 'domains-dataviews', { 'domains-dataviews-list': sidebarMode } ) }>
+			<div className={clsx('domains-dataviews', { 'domains-dataviews-list': sidebarMode })}>
 				<DataViews
-					data={ domainsToDisplay }
-					fields={ fields }
-					onChangeView={ ( newView ) => setView( () => newView ) }
-					onClickItem={ onClickDomain }
-					view={ view }
-					actions={ actions }
+					data={domainsToDisplay}
+					fields={fields}
+					onChangeView={(newView) => setView(() => newView)}
+					onClickItem={onClickDomain}
+					view={view}
+					actions={actions}
 					search
-					searchLabel={ translate( 'Search by domain…' ) }
-					paginationInfo={ paginationInfo }
-					getItemId={ getDomainId }
-					selection={ selectedDomain ? [ getDomainId( selectedDomain ) ] : selectedIds }
-					onChangeSelection={ onChangeSelection }
-					isLoading={ isLoading }
-					defaultLayouts={ layout }
+					searchLabel={translate('Search by domain…')}
+					paginationInfo={paginationInfo}
+					getItemId={getDomainId}
+					selection={selectedDomain ? [getDomainId(selectedDomain)] : selectedIds}
+					onChangeSelection={onChangeSelection}
+					isLoading={isLoading}
+					defaultLayouts={layout}
 				/>
 			</div>
 		</>

--- a/client/my-sites/domains/domain-management/dataviews/style.scss
+++ b/client/my-sites/domains/domain-management/dataviews/style.scss
@@ -47,6 +47,47 @@ body.is-section-domains.is-bulk-all-domains-page {
 			margin-top: 0;
 			overflow: hidden;
 			padding-bottom: 0;
+			
+			button[data-custom-tooltip] {
+				position: relative;
+				
+				&::after {
+				  content: attr(data-custom-tooltip);
+				  position: absolute;
+				  bottom: calc(100% + 4px);
+				  left: 50%;
+				  transform: translateX(-50%);
+				  background: #1e1e1e;
+				  color: #fff;
+				  font-family: $sans;
+				  font-size: 0.75rem;
+				  line-height: 1.4;
+				  padding: 4px 8px;
+				  border-radius: 2px;
+				  white-space: nowrap;
+				  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+				  pointer-events: none;
+				  opacity: 0;
+				  z-index: 1000;
+				  transition: opacity 0.1s;
+				  transition-delay: 0.6s;
+				}
+				
+				/* Skip delay when other tooltips are already visible (matching @wordpress/dataviews behavior) */
+				&[data-tooltip-active="true"]::after {
+				  transition-delay: 0s !important;
+				  transition-duration: 0.05s;
+				}
+				
+				&:hover::after {
+				  opacity: 1;
+				}
+				
+				&:not(:hover)::after {
+				  transition-delay: 0s;
+				  opacity: 0;
+				}
+			  }
 
 			.domains-dataviews__domain-name-button {
 				width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Domains: Change 'Cancel' tooltip to 'Clear selection' for bulk actions

Fixes:
 - https://github.com/Automattic/wp-calypso/issues/99893

## Proposed changes:
This PR changes the tooltip text on the "X" icon button in the Domains DataViews bulk selection footer from "Cancel" to "Clear selection" to avoid user confusion. Users were concerned that clicking "Cancel" might cancel their domains rather than just clear their selection.

Key features:
* Changes tooltip text from "Cancel" to "Clear selection"
* Maintains consistent styling with other tooltips
* Preserves the same delay behavior as other tooltips
* No changes to button functionality - only improves clarity

## Implementation details:
* Uses a combination of DOM manipulation and CSS to replace the tooltip
* Adds a custom tooltip that matches WordPress styling exactly
* Ensures tooltip behavior is consistent with other WordPress tooltips
* Detects when other tooltips are visible to synchronize delay behavior

### Why this approach?
The complexity in this implementation is necessary because:

1. The "Cancel" tooltip comes from the WordPress DataViews component, which doesn't provide configuration options to customize tooltip text.

2. I explored simpler approaches first:
   - The DataViews component doesn't expose props or options to change this specific tooltip
   - The actions API doesn't control the clear selection button tooltips
   - No way to intercept the tooltip's content through normal component props

The DOM-based approach ensures users get a consistent experience while solving the UX issue with minimal risk to functionality.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Go to the Domains page
2. Select multiple domains to trigger the bulk actions footer
3. Hover over the "X" button on the right side of the footer
4. Verify that the tooltip says "Clear selection" instead of "Cancel"
5. Verify that hovering between this and other tooltips behaves consistently
6. After clicking the button, verify it still clears the selection as expected

Before | After
-------|------
<img width="306" alt="tooltip_before" src="https://github.com/user-attachments/assets/f9c21815-e929-4aea-8596-4ad6be6336fa" />| <img width="499" alt="tooltip after" src="https://github.com/user-attachments/assets/6dca4b32-37ce-48f3-81e6-d1e379ef7126" />
