### PR TITLE
Subscribers: Add success notice for deleted subscriber

### DIFF
--- a/client/components/confirm-modal/index.tsx
+++ b/client/components/confirm-modal/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Modal } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import './styles.scss';
 
@@ -22,6 +23,36 @@ const ConfirmModal = ( {
 	onConfirm,
 }: ConfirmModalProps ) => {
 	const translate = useTranslate();
+	const modalRef = useRef< HTMLDivElement >( null );
+	const previousFocusRef = useRef< HTMLElement | null >( null );
+
+	// Handle focus management
+	useEffect( () => {
+		if ( isVisible ) {
+			const modal = modalRef.current;
+			// Store the previously focused element
+			previousFocusRef.current = document.activeElement as HTMLElement;
+
+			// Focus the primary button when modal opens
+			const primaryButton = modal?.querySelector(
+				'button[type="button"].is-primary'
+			) as HTMLElement;
+			primaryButton?.focus();
+
+			// Prevent focus from leaving the modal
+			const handleFocusOut = ( event: FocusEvent ) => {
+				if ( modal && ! modal.contains( event.relatedTarget as Node ) ) {
+					primaryButton?.focus();
+				}
+			};
+
+			modal?.addEventListener( 'focusout', handleFocusOut );
+			return () => modal?.removeEventListener( 'focusout', handleFocusOut );
+		} else if ( previousFocusRef.current ) {
+			// Restore focus when modal closes
+			requestAnimationFrame( () => previousFocusRef.current?.focus() );
+		}
+	}, [ isVisible ] );
 
 	if ( ! isVisible ) {
 		return null;
@@ -29,14 +60,16 @@ const ConfirmModal = ( {
 
 	return (
 		<Modal overlayClassName="confirm-modal" title={ title } onRequestClose={ onCancel }>
-			{ text && <p className="confirm-modal__text">{ text }</p> }
-			<div className="confirm-modal__buttons">
-				<Button variant="tertiary" onClick={ onCancel }>
-					{ cancelButtonLabel ?? translate( 'Cancel' ) }
-				</Button>
-				<Button onClick={ onConfirm } variant="primary">
-					{ confirmButtonLabel ?? translate( 'Confirm' ) }
-				</Button>
+			<div ref={ modalRef }>
+				{ text && <p className="confirm-modal__text">{ text }</p> }
+				<div className="confirm-modal__buttons">
+					<Button variant="tertiary" onClick={ onCancel }>
+						{ cancelButtonLabel ?? translate( 'Cancel' ) }
+					</Button>
+					<Button onClick={ onConfirm } variant="primary">
+						{ confirmButtonLabel ?? translate( 'Confirm' ) }
+					</Button>
+				</div>
 			</div>
 		</Modal>
 	);

--- a/client/components/confirm-modal/index.tsx
+++ b/client/components/confirm-modal/index.tsx
@@ -1,5 +1,4 @@
 import { Button, Modal } from '@wordpress/components';
-import { useEffect, useRef } from '@wordpress/element';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import './styles.scss';
 
@@ -23,36 +22,6 @@ const ConfirmModal = ( {
 	onConfirm,
 }: ConfirmModalProps ) => {
 	const translate = useTranslate();
-	const modalRef = useRef< HTMLDivElement >( null );
-	const previousFocusRef = useRef< HTMLElement | null >( null );
-
-	// Handle focus management
-	useEffect( () => {
-		if ( isVisible ) {
-			const modal = modalRef.current;
-			// Store the previously focused element
-			previousFocusRef.current = document.activeElement as HTMLElement;
-
-			// Focus the primary button when modal opens
-			const primaryButton = modal?.querySelector(
-				'button[type="button"].is-primary'
-			) as HTMLElement;
-			primaryButton?.focus();
-
-			// Prevent focus from leaving the modal
-			const handleFocusOut = ( event: FocusEvent ) => {
-				if ( modal && ! modal.contains( event.relatedTarget as Node ) ) {
-					primaryButton?.focus();
-				}
-			};
-
-			modal?.addEventListener( 'focusout', handleFocusOut );
-			return () => modal?.removeEventListener( 'focusout', handleFocusOut );
-		} else if ( previousFocusRef.current ) {
-			// Restore focus when modal closes
-			requestAnimationFrame( () => previousFocusRef.current?.focus() );
-		}
-	}, [ isVisible ] );
 
 	if ( ! isVisible ) {
 		return null;
@@ -60,16 +29,14 @@ const ConfirmModal = ( {
 
 	return (
 		<Modal overlayClassName="confirm-modal" title={ title } onRequestClose={ onCancel }>
-			<div ref={ modalRef }>
-				{ text && <p className="confirm-modal__text">{ text }</p> }
-				<div className="confirm-modal__buttons">
-					<Button variant="tertiary" onClick={ onCancel }>
-						{ cancelButtonLabel ?? translate( 'Cancel' ) }
-					</Button>
-					<Button onClick={ onConfirm } variant="primary">
-						{ confirmButtonLabel ?? translate( 'Confirm' ) }
-					</Button>
-				</div>
+			{ text && <p className="confirm-modal__text">{ text }</p> }
+			<div className="confirm-modal__buttons">
+				<Button variant="tertiary" onClick={ onCancel }>
+					{ cancelButtonLabel ?? translate( 'Cancel' ) }
+				</Button>
+				<Button onClick={ onConfirm } variant="primary">
+					{ confirmButtonLabel ?? translate( 'Confirm' ) }
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -1,8 +1,9 @@
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { UnsubscribeActionType } from '../components/unsubscribe-modal';
 import { useSubscriberRemoveMutation } from '../mutations';
@@ -20,6 +21,7 @@ const useUnsubscribeModal = (
 	const recordRemoveModal = useRecordRemoveModal();
 	const { mutate } = useSubscriberRemoveMutation( siteId, subscriberQueryParams, detailsView );
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const onSetUnsubscribers = ( subscribers: Subscriber[] ) => {
 		setCurrentSubscribers( subscribers );
@@ -43,6 +45,25 @@ const useUnsubscribeModal = (
 		) {
 			mutate( subscribers, {
 				onSuccess: () => {
+					// Show success notice.
+					dispatch(
+						successNotice(
+							translate(
+								'%s has been removed from your subscribers list.',
+								'%d subscribers have been removed from your list.',
+								{
+									count: subscribers.length,
+									args:
+										subscribers.length === 1
+											? [ subscribers[ 0 ].display_name ]
+											: [ numberFormat( subscribers.length ) ],
+									comment:
+										'First %s is subscriber name, second %d is the number of subscribers removed',
+								}
+							),
+							{ duration: 5000 }
+						)
+					);
 					resetSubscribers();
 					onSuccess?.();
 				},

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -1,3 +1,4 @@
+import { speak } from '@wordpress/a11y';
 import { useEffect, useState } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -48,19 +48,19 @@ const useUnsubscribeModal = (
 					// Show success notice.
 					dispatch(
 						successNotice(
-							translate(
-								'%s has been removed from your subscribers list.',
-								'%d subscribers have been removed from your list.',
-								{
-									count: subscribers.length,
-									args:
-										subscribers.length === 1
-											? [ subscribers[ 0 ].display_name ]
-											: [ numberFormat( subscribers.length ) ],
-									comment:
-										'First %s is subscriber name, second %d is the number of subscribers removed',
-								}
-							),
+							subscribers.length === 1
+								? translate( 'Subscriber %(name)s has been removed from your subscribers list.', {
+										args: {
+											name: subscribers[ 0 ].display_name,
+										},
+										comment: 'Shows when a single subscriber is removed, using their name',
+								  } )
+								: translate( '%(count)d subscribers have been removed from your list.', {
+										args: {
+											count: numberFormat( subscribers.length ),
+										},
+										comment: 'Shows when multiple subscribers are removed, using the count',
+								  } ),
 							{ duration: 5000 }
 						)
 					);

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -49,18 +49,23 @@ const useUnsubscribeModal = (
 					dispatch(
 						successNotice(
 							subscribers.length === 1
-								? translate( 'Subscriber %(name)s has been removed from your subscribers list.', {
+								? translate( '%(name)s has been removed from your subscribers list.', {
 										args: {
 											name: subscribers[ 0 ].display_name,
 										},
 										comment: 'Shows when a single subscriber is removed, using their name',
 								  } )
-								: translate( '%(count)d subscribers have been removed from your list.', {
-										args: {
-											count: numberFormat( subscribers.length ),
-										},
-										comment: 'Shows when multiple subscribers are removed, using the count',
-								  } ),
+								: translate(
+										'%(count)d subscriber has been removed from your list.',
+										'%(count)d subscribers have been removed from your list.',
+										{
+											count: subscribers.length,
+											args: {
+												count: numberFormat( subscribers.length ),
+											},
+											comment: 'Shows when multiple subscribers are removed, using the count',
+										}
+								  ),
 							{ duration: 5000 }
 						)
 					);

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -1,4 +1,4 @@
-import { speak } from '@wordpress/a11y';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
@@ -19,6 +19,7 @@ const useUnsubscribeModal = (
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const recordRemoveModal = useRecordRemoveModal();
 	const { mutate } = useSubscriberRemoveMutation( siteId, subscriberQueryParams, detailsView );
+	const translate = useTranslate();
 
 	const onSetUnsubscribers = ( subscribers: Subscriber[] ) => {
 		setCurrentSubscribers( subscribers );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/488

## Proposed Changes

* Add success notice when a subscriber is successfully deleted. 
<img width="634" alt="Screen Shot 2025-03-13 at 2 03 32 PM" src="https://github.com/user-attachments/assets/c937458d-b13d-485b-9d6f-8f71405a6e98" />

Multiple subscribers deleted:

<img width="477" alt="Screen Shot 2025-03-17 at 12 01 14 PM" src="https://github.com/user-attachments/assets/e73188d8-f621-4589-8c57-c38fb271e81a" />


Note we've decided not to fix the original aria-hidden console warning. Adding focus management made the experience worse. The issue will need to be fixed upstream in core.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Click on a subscriber to open the details panel, or click the Actions three dots and click Remove.
* Click to delete the subscriber.
* Check that you see a success notice for 5 seconds.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
