### PR TITLE
Fix/transfer domain modal copy

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/paid-domain-suggested-plan-section.tsx
@@ -26,9 +26,9 @@ export default function PaidDomainSuggestedPlanSection( props: {
 	const { paidDomainName, onPlanSelected, isBusy } = props;
 
 	const previousCopy = translate( 'Free for one year. Includes Premium themes.' );
-	const updatedCopy = translate( 'Free for one year, includes Premium themes' );
+	const updatedCopy = translate( 'Free for one year, plus premium features' );
 	const hasTranslationForUpdatedCopy = hasEnTranslation(
-		'Free for one year, includes Premium themes'
+		'Free for one year, plus premium features'
 	);
 
 	return (
@@ -36,7 +36,7 @@ export default function PaidDomainSuggestedPlanSection( props: {
 			{ paidDomainName && (
 				<DomainName>
 					<div>{ paidDomainName }</div>
-					<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
+					<FreeDomainText>{ translate( 'Free domain for one year' ) }</FreeDomainText>
 				</DomainName>
 			) }
 			<PlanUpsellButton

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
@@ -29,15 +29,15 @@ function PlanUpsellButton( {
 			} }
 		>
 			{ ! hidePrice
-				? translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-						comment: 'Eg: Get Personal $4/month',
+				? translate( 'Upgrade to %(planTitle)s–%(planPrice)s/month', {
+						comment: 'Eg: Upgrade to Personal–$4/month',
 						args: {
 							planTitle: planUpsellInfo.title,
 							planPrice: planUpsellInfo.formattedPriceMonthly,
 						},
 				  } )
-				: translate( 'Get %(planTitle)s', {
-						comment: 'Eg: Get Personal',
+				: translate( 'Upgrade to %(planTitle)s', {
+						comment: 'Eg: Upgrade to Personal',
 						args: {
 							planTitle: planUpsellInfo.title,
 						},

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -39,7 +39,7 @@ export function FreePlanPaidDomainDialog( {
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
-				{ translate( 'A paid plan is required for a custom primary domain.' ) }
+				{ translate( 'Paid plan required' ) }
 			</Heading>
 			<SubHeading id="plan-upsell-modal-description">
 				{ translate(

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -32,19 +32,20 @@ export function PaidPlanPaidDomainDialog( {
 
 	function handleFreeDomainClick() {
 		setIsBusy( true );
+		// should this be `onFreePlanSelected(true)` ?
 		onFreePlanSelected();
 	}
-
-	const upsellDescription = translate(
-		"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-	);
 
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
-				{ translate( 'A paid plan is required for your domain.' ) }
+				{ translate( 'Paid plan required' ) }
 			</Heading>
-			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
+			<SubHeading id="plan-upsell-modal-description">
+				{ translate(
+					'To use a personalized domain for your site, you’ll need a paid plan. Choose annual billing and get the domain free for a year.'
+				) }
+			</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
 					<PaidDomainSuggestedPlanSection


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100248

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
