### PR TITLE
PTO Square: Navigate to wc-admin when partnerBundle exists

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -11,6 +11,7 @@ import {
 	setSignupCompleteFlowName,
 	getSignupCompleteSiteID,
 	setSignupCompleteSiteID,
+	getSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { useDispatch as reduxUseDispatch, useSelector } from 'calypso/state';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
@@ -120,6 +121,7 @@ const hosting: Flow = {
 					const hasStudioSyncSiteId = queryParams.studioSiteId;
 					const hasPartnerBundle = queryParams.partnerBundle;
 					const siteId = providedDependencies.siteId || getSignupCompleteSiteID();
+					const siteSlug = providedDependencies.siteSlug || getSignupCompleteSlug();
 					const destinationParams: Record< string, string > = {
 						siteId,
 					};
@@ -128,8 +130,9 @@ const hosting: Flow = {
 							studioSiteId: queryParams.studioSiteId,
 						} );
 					} else if ( hasPartnerBundle ) {
+						// For partners, we'll redirect to the WooCommerce admin page
 						destinationParams[ 'redirect_to' ] = addQueryArgs(
-							`https://${ siteId }/wp-admin/admin.php?page=wc-admin`
+							`https://${ siteSlug }/wp-admin/admin.php?page=wc-admin`
 						);
 					}
 					// Purchasing Business or Commerce plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -118,6 +118,7 @@ const hosting: Flow = {
 
 				case 'processing': {
 					const hasStudioSyncSiteId = queryParams.studioSiteId;
+					const hasPartnerBundle = queryParams.partnerBundle;
 					const siteId = providedDependencies.siteId || getSignupCompleteSiteID();
 					const destinationParams: Record< string, string > = {
 						siteId,
@@ -126,6 +127,10 @@ const hosting: Flow = {
 						destinationParams[ 'redirect_to' ] = addQueryArgs( `/home/${ siteId }`, {
 							studioSiteId: queryParams.studioSiteId,
 						} );
+					} else if ( hasPartnerBundle ) {
+						destinationParams[ 'redirect_to' ] = addQueryArgs(
+							`https://${ siteId }/wp-admin/admin.php?page=wc-admin`
+						);
 					}
 					// Purchasing Business or Commerce plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.
 					const destination = addQueryArgs( '/setup/transferring-hosted-site', destinationParams );

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -3,6 +3,7 @@ import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
+import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
 import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/ad-track-trial-start';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -60,6 +61,7 @@ const hosting: Flow = {
 		const plan = queryParams.plan;
 		const flowName = this.name;
 		const showDomainStep = useShowDomainStep();
+		const isWooPartner = useIsValidWooPartner();
 
 		const goBack = () => {
 			if ( _currentStepSlug === 'plans' ) {
@@ -119,7 +121,6 @@ const hosting: Flow = {
 
 				case 'processing': {
 					const hasStudioSyncSiteId = queryParams.studioSiteId;
-					const hasPartnerBundle = queryParams.partnerBundle;
 					const siteId = providedDependencies.siteId || getSignupCompleteSiteID();
 					const siteSlug = providedDependencies.siteSlug || getSignupCompleteSlug();
 					const destinationParams: Record< string, string > = {
@@ -129,11 +130,11 @@ const hosting: Flow = {
 						destinationParams[ 'redirect_to' ] = addQueryArgs( `/home/${ siteId }`, {
 							studioSiteId: queryParams.studioSiteId,
 						} );
-					} else if ( hasPartnerBundle ) {
+					} else if ( isWooPartner ) {
 						// For partners, we'll redirect to the WooCommerce admin page
-						destinationParams[ 'redirect_to' ] = addQueryArgs(
-							`https://${ siteSlug }/wp-admin/admin.php?page=wc-admin`
-						);
+						destinationParams[
+							'redirect_to'
+						] = `https://${ siteSlug }/wp-admin/admin.php?page=wc-admin`;
 					}
 					// Purchasing Business or Commerce plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.
 					const destination = addQueryArgs( '/setup/transferring-hosted-site', destinationParams );

--- a/client/landing/stepper/hooks/use-is-valid-woo-partner.ts
+++ b/client/landing/stepper/hooks/use-is-valid-woo-partner.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useQuery } from './use-query';
+
+const VALID_WOO_PARTNERS = [ 'square', 'paypal', 'stripe' ];
+
+export const useIsValidWooPartner = () => {
+	const query = useQuery();
+	const queryParams = Object.fromEntries( query );
+	const partnerBundle = queryParams.partnerBundle;
+	return useMemo( () => {
+		if ( partnerBundle && VALID_WOO_PARTNERS.includes( partnerBundle ) ) {
+			return true;
+		}
+		return false;
+	}, [ partnerBundle ] );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10538
Resolves https://linear.app/a8c/issue/DOTOBRD-4/pto-square-land-into-wc-admin-page-when-coming-from-the-pto-flow

## Proposed Changes

* Add logic to redirect the user to `wc-admin` page when the `partnerBundle` query param exists

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This adapts a bit the current flow for partners, so the user lands into the WooCommerce admin page with the Launchpad tasks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes
* Navigate to the following URL to start the flow: http://calypso.localhost:3000/setup/new-hosted-site/plans?partnerBundle=square
* Complete the process of creating the site, either `Commerce` or `Business`
* Make sure the flow ends in the `wc-admin` page with the Launchapd tasks listed, i.e. 
![CleanShot 2025-03-14 at 19 12 58](https://github.com/user-attachments/assets/a22a6d2a-0fd9-4b04-9765-be5f79729586)

> [!WARNING]
> The WooCommerce Home page cannot be ready in the first redirection, but it should be available after some seconds. That is being tracked as part of https://github.com/Automattic/dotcom-forge/issues/10628 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
