### PR TITLE
Update site address icon in jetpack connect

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -138,7 +138,7 @@ class JetpackConnectSiteUrlInput extends Component {
 			<div>
 				<FormLabel htmlFor="siteUrl">{ translate( 'Site address' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
-					<Gridicon size={ 24 } icon="globe" />
+					<Gridicon className="jetpack-connect__site-address-icon" size={ 24 } icon="domains" />
 					{ ! isSearch && (
 						<FormTextInput
 							ref={ this.refInput }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -166,7 +166,7 @@ $colophon-height: 50px;
 		position: relative;
 
 		.gridicons-user,
-		.gridicons-globe {
+		.jetpack-connect__site-address-icon {
 			position: absolute;
 			top: 8px;
 			left: 8px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100301

## Proposed Changes

* Change the icon of the site address field to domains
* Add a class to  the icon component to allow swapping icon names without having to update css

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because we want the domains icon to be uniformly used

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/jetpack/connect
* Notice the beautiful new icon in the site address field

Before:

<img width="854" alt="Screenshot 2025-03-13 at 20 30 35" src="https://github.com/user-attachments/assets/8c04950b-97f9-43ed-81dc-47c4f08aa2a6" />


After:

<img width="1007" alt="Screenshot 2025-03-13 at 20 28 50" src="https://github.com/user-attachments/assets/5ebb4c21-ac0f-4c29-85ac-5319baf03e74" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
