### PR TITLE
Improve UI consistency in the DIFM migration flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -122,7 +122,6 @@ const SiteMigrationApplicationPasswordsAuthorization: Step = function ( { naviga
 				goBack={ navigation?.goBack }
 				goNext={ navigation?.submit }
 				hideSkip
-				isFullLayout
 				notice={ notice }
 				formattedHeader={ formattedHeader }
 				stepContent={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -93,7 +93,7 @@ const SiteMigrationApplicationPasswordsAuthorization: Step = function ( { naviga
 
 	// translators: %(sourceDomain)s is the source domain that is being migrated.
 	const subHeaderText = translate(
-		"We're ready to migrate {{strong}}%(sourceDomain)s{{/strong}} to WordPress.com. To make sure everything goes smoothly, we need you to authorize us for access in your WordPress admin.",
+		"We're ready to migrate {{strong}}%(sourceDomain)s{{/strong}} to WordPress.com. To ensure a smooth process, we need you to authorize us in your WordPress.com admin.",
 		{
 			args: {
 				sourceDomain,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
@@ -2,6 +2,24 @@
 @import "@wordpress/base-styles/mixins";
 
 .site-migration-application-password-authorization {
+	.step-container__header {
+		margin-left: auto;
+		margin-right: auto;
+		margin-bottom: 1rem;
+		padding-left: 1rem;
+		padding-right: 1rem;
+
+		@media ( min-width: 720px ) {
+			.formatted-header__subtitle {
+				max-width: 616px;
+				padding-left: 0;
+				padding-right: 0;
+				margin-left: auto;
+				margin-right: auto;
+			}
+		}
+	}
+
 	.site-migration-application-password-authorization__authorization {
 		display: flex;
 		flex-direction: column;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -95,7 +95,7 @@ const SiteMigrationHowToMigrate: FC< Props > = ( props ) => {
 					}
 			  )
 			: translate(
-					'Save yourself the headache of migrating. Our expert team takes care of everything without interrupting your current site. Plus you get 50% off our annual %(planName)s plan.',
+					'Skip the migration hassle. Our team handles everything without disrupting your current site, plus you get 50% off our annual %(planName)s plan.',
 					{
 						args: {
 							planName,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/test/index.tsx
@@ -40,7 +40,9 @@ describe( 'SiteMigrationHowToMigrate', () => {
 
 		render( { navigation } );
 
-		expect( screen.queryByText( /Plus you get 50% off our annual/ ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /Skip the migration hassle.*plus you get 50% off our annual/i )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should render proper subheading for Business plan', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -99,7 +99,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 				<Title>{ translate( 'Let’s find your site' ) }</Title>
 				<SubTitle>
 					{ translate(
-						"Drop your current site address below to get started. In the next step, we'll measure your site's performance and confirm its eligibility for migration."
+						"Drop your current site address below to get started. In the next step, we'll confirm your site's eligibility for migration."
 					) }
 				</SubTitle>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -98,9 +98,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'Let’s find your site' ) }</Title>
 				<SubTitle>
-					{ translate(
-						"Drop your current site address below to get started. In the next step, we'll confirm your site's eligibility for migration."
-					) }
+					{ translate( 'Enter your current site address below to get started.' ) }
 				</SubTitle>
 			</div>
 			<div className="import__capture-container">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -124,7 +124,7 @@ const SiteMigrationUpgradePlan: FC< Props > = ( {
 		  );
 	showVariants &&
 		( subHeaderText = translate(
-			'A %(planName)s plan is needed for Migrations. Pick one of the following options to tap into our lightning-fast infrastructure. Your site will be faster, smoother, and ready for anything.',
+			'A %(planName)s plan is needed for Migrations. Choose an option below to access our lightning-fast infrastructure for a faster, more reliable site.',
 			{
 				args: {
 					planName,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
@@ -13,7 +13,7 @@
 		padding-left: 1rem;
 		padding-right: 1rem;
 		@media ( min-width: 720px ) {
-			max-width: 640px;
+			max-width: 616px;
 			padding-left: 0;
 			padding-right: 0;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
@@ -13,7 +13,7 @@
 		padding-left: 1rem;
 		padding-right: 1rem;
 		@media ( min-width: 720px ) {
-			max-width: 720px;
+			max-width: 640px;
 			padding-left: 0;
 			padding-right: 0;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #100866

## Proposed Changes

Various spacing and copy tweaks on the DIFM migration flow and cleans up copy as described [here](https://github.com/Automattic/wp-calypso/issues/100866#issuecomment-2725106748).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Provides UI consistency across screens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll need a non-WPCOM, non-JN site to test with. You can use fakeblog.biek.dev if that helps.

* Use the calypso.live url or run locally.
* Go to `/start` and pick "Import or migrate" on the goals page.
* Make sure to pick the "Migrate" option (not import).
* On the "Let's find your site" step, make sure the subheader no longer mentions testing source site performance.
![CleanShot 2025-03-13 at 14 47 42](https://github.com/user-attachments/assets/f8734670-615e-4a46-8b5b-e02241437e22)
* Continue with a DIFM migration.
* When you reach the upgrade plan, verify that the subheader isn't as wide

**Before:**
![image](https://github.com/user-attachments/assets/f0e9b28d-4799-422f-be3b-b672f5b311c0)

**After:**
![image](https://github.com/user-attachments/assets/1caf6e4b-6c05-4ad5-ac9c-3f5aa51c4fee)

* When you reach the application password step, verify the subheader isn't as wide

**Before:**
![image](https://github.com/user-attachments/assets/dc22404b-215f-45c1-9b73-f2b13e88dc05)

**After:**
![CleanShot 2025-03-14 at 13 40 14](https://github.com/user-attachments/assets/f31da2fc-037d-401b-8da8-740d398e6fae)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
