### PR TITLE
Revert/cleanup create course project

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -172,7 +172,7 @@ const onboarding: Flow = {
 		 */
 		const getPostCheckoutDestination = (
 			providedDependencies: ProvidedDependencies
-		): [ string, string | null ] => {
+		): [ string, string ] => {
 			if ( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment ) {
 				const destination = addQueryArgs(
 					withLocale( '/setup/site-setup/launch-big-sky', locale ),
@@ -189,10 +189,6 @@ const onboarding: Flow = {
 						isBigSkyBeforePlansFlow: true,
 					} ),
 				];
-			}
-
-			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
-				return [ `/home/${ providedDependencies.siteSlug }`, null ];
 			}
 
 			const destination = addQueryArgs( withLocale( '/setup/site-setup', locale ), {
@@ -384,7 +380,7 @@ const onboarding: Flow = {
 									}
 								),
 								signup: 1,
-								checkoutBackUrl: pathToUrl( backDestination ?? '' ),
+								checkoutBackUrl: pathToUrl( backDestination ),
 								coupon,
 								...( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment
 									? { [ 'big-sky-checkout' ]: 1 }

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -694,9 +694,7 @@ const siteSetupFlow: FlowV1 = {
 		const dispatch = reduxDispatch();
 
 		const skippedCheckout = useQuery().get( 'skippedCheckout' );
-
 		const activateDesign = useActivateDesign();
-
 		const isPendingActionSet = useRef( false );
 
 		useEffect( () => {
@@ -714,7 +712,6 @@ const siteSetupFlow: FlowV1 = {
 				if ( ! selectedDesign ) {
 					return;
 				}
-
 				try {
 					await activateDesign( selectedDesign, {
 						styleVariation: selectedStyleVariation,

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -694,7 +694,9 @@ const siteSetupFlow: FlowV1 = {
 		const dispatch = reduxDispatch();
 
 		const skippedCheckout = useQuery().get( 'skippedCheckout' );
+
 		const activateDesign = useActivateDesign();
+
 		const isPendingActionSet = useRef( false );
 
 		useEffect( () => {
@@ -712,6 +714,7 @@ const siteSetupFlow: FlowV1 = {
 				if ( ! selectedDesign ) {
 					return;
 				}
+
 				try {
 					await activateDesign( selectedDesign, {
 						styleVariation: selectedStyleVariation,

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-create-course-goal-feature/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-create-course-goal-feature/index.tsx
@@ -1,6 +1,0 @@
-import config from '@automattic/calypso-config';
-
-export function useCreateCourseGoalFeature() {
-	// Feature flag approach can be replaced with experiment later
-	return config.isEnabled( 'onboarding/create-course' );
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
@@ -64,8 +63,6 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
-	// Use the experiment flag instead of the feature flag to ensure the experiment is running
-	const isIntentCreateCourseGoalEnabled = config.isEnabled( 'onboarding/create-course' );
 
 	useEffect( () => {
 		resetIntent();
@@ -118,10 +115,7 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 	const getStepSubmissionHandler =
 		( action: string, eventProps: Record< string, unknown > = {} ) =>
 		() => {
-			const intent = goalsToIntent( goals, {
-				isIntentNewsletterGoalEnabled,
-				isIntentCreateCourseGoalEnabled,
-			} );
+			const intent = goalsToIntent( goals, isIntentNewsletterGoalEnabled );
 			setIntent( intent );
 
 			recordGoalsSelectTracksEvent( goals, intent );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
@@ -12,6 +13,7 @@ import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import DashboardIcon from './dashboard-icon';
 import { GoalsCaptureContainer } from './goals-capture-container';
 import SelectGoals from './select-goals';
@@ -62,6 +64,8 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
+	// Use the experiment flag instead of the feature flag to ensure the experiment is running
+	const isIntentCreateCourseGoalEnabled = config.isEnabled( 'onboarding/create-course' );
 
 	useEffect( () => {
 		resetIntent();
@@ -114,7 +118,10 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 	const getStepSubmissionHandler =
 		( action: string, eventProps: Record< string, unknown > = {} ) =>
 		() => {
-			const intent = goalsToIntent( goals, isIntentNewsletterGoalEnabled );
+			const intent = goalsToIntent( goals, {
+				isIntentNewsletterGoalEnabled,
+				isIntentCreateCourseGoalEnabled,
+			} );
 			setIntent( intent );
 
 			recordGoalsSelectTracksEvent( goals, intent );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
@@ -63,8 +62,6 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
-	// Use the experiment flag instead of the feature flag to ensure the experiment is running
-	const isIntentCreateCourseGoalEnabled = config.isEnabled( 'onboarding/create-course' );
 
 	useEffect( () => {
 		resetIntent();
@@ -117,10 +114,7 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 	const getStepSubmissionHandler =
 		( action: string, eventProps: Record< string, unknown > = {} ) =>
 		() => {
-			const intent = goalsToIntent( goals, {
-				isIntentNewsletterGoalEnabled,
-				isIntentCreateCourseGoalEnabled,
-			} );
+			const intent = goalsToIntent( goals, isIntentNewsletterGoalEnabled );
 			setIntent( intent );
 
 			recordGoalsSelectTracksEvent( goals, intent );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
@@ -12,8 +13,6 @@ import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
-import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
-import { useCreateCourseGoalFeature } from '../../hooks/use-create-course-goal-feature';
 import DashboardIcon from './dashboard-icon';
 import { GoalsCaptureContainer } from './goals-capture-container';
 import SelectGoals from './select-goals';
@@ -64,7 +63,8 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
-	const isIntentCreateCourseGoalEnabled = useCreateCourseGoalFeature();
+	// Use the experiment flag instead of the feature flag to ensure the experiment is running
+	const isIntentCreateCourseGoalEnabled = config.isEnabled( 'onboarding/create-course' );
 
 	useEffect( () => {
 		resetIntent();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,4 +1,3 @@
-import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import Loading from 'calypso/components/loading';
@@ -10,33 +9,10 @@ import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import type { Step } from '../../types';
 import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 
-const usePluginByGoal = () => {
-	const intent = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
-		[]
-	);
-
-	if ( intent === SiteIntent.CreateCourseGoal ) {
-		return 'sensei-lms';
-	}
-
-	return null;
-};
-
 const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 	const { submit } = navigation;
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { site, siteSlug } = useSiteData();
-
-	const intent = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
-		[]
-	);
-
-	const goals = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
-		[]
-	);
 
 	const selectedDesign = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
@@ -67,35 +43,11 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 	const { waitForInitiateTransfer, waitForTransfer, waitForFeature, waitForLatestSiteData } =
 		useWaitForAtomic( {} );
 
-	const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
-
 	const waitForAtomic = async () => {
 		await waitForTransfer();
-		await setIntentOnSite( siteSlug, intent );
-		await setGoalsOnSite( siteSlug, goals );
 		await waitForFeature();
 		await waitForLatestSiteData();
 	};
-
-	const pluginByGoal = usePluginByGoal();
-	const hasPluginByGoal = !! pluginByGoal;
-
-	/**
-	 * If an externally managed theme is selected, we need to check the following:
-	 * - Ensure the theme is available. If it's not, we do nothing, as the user may remove the theme product during checkout.
-	 * - Verify that the site is atomic, as the theme should be installed on the user's site.
-	 *
-	 * The atomic transfer will be initiated immediately after the user purchases an externally managed theme.
-	 * If it’s not initiated, we need to trigger the atomic transfer manually.
-	 *
-	 * Note that an externally managed theme is only available when both of the following conditions are met:
-	 * - The site must be subscribed to the theme.
-	 * - The site must be eligible for managed external themes.
-	 */
-	const hasExternalTheme =
-		selectedDesign?.is_externally_managed &&
-		isMarketplaceThemeSubscribed &&
-		isExternallyManagedThemeAvailable;
 
 	useEffect( () => {
 		if (
@@ -108,20 +60,31 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 		}
 
 		setPendingAction( async () => {
-			const providedDependencies = {
-				siteSlug,
-				hasExternalTheme,
-				hasPluginByGoal,
-			};
-
+			const providedDependencies = { siteSlug };
 			if ( isJetpackOrAtomic ) {
 				return providedDependencies;
 			}
 
+			/**
+			 * If an externally managed theme is selected, we need to check the following:
+			 * - Ensure the theme is available. If it's not, we do nothing, as the user may remove the theme product during checkout.
+			 * - Verify that the site is atomic, as the theme should be installed on the user's site.
+			 *
+			 * The atomic transfer will be initiated immediately after the user purchases an externally managed theme.
+			 * If it’s not initiated, we need to trigger the atomic transfer manually.
+			 *
+			 * Note that an externally managed theme is only available when both of the following conditions are met:
+			 * - The site must be subscribed to the theme.
+			 * - The site must be eligible for managed external themes.
+			 */
 			if ( siteTransferStatusData?.isTransferring ) {
 				await waitForAtomic();
-			} else if ( hasExternalTheme || hasPluginByGoal ) {
-				await waitForInitiateTransfer( pluginByGoal );
+			} else if (
+				selectedDesign?.is_externally_managed &&
+				isMarketplaceThemeSubscribed &&
+				isExternallyManagedThemeAvailable
+			) {
+				await waitForInitiateTransfer();
 				await waitForAtomic();
 			}
 
@@ -139,7 +102,6 @@ const PostCheckoutOnboarding: Step = ( { navigation } ) => {
 		selectedDesign,
 		isMarketplaceThemeSubscribed,
 		isExternallyManagedThemeAvailable,
-		hasPluginByGoal,
 	] );
 
 	return <Loading className="wpcom-loading__boot" />;

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -92,39 +92,4 @@ describe( 'Onboarding Flow', () => {
 			expect( getFlowLocation().path ).toBe( '/design-setup' );
 		} );
 	} );
-
-	describe( 'Processing step navigation', () => {
-		it( 'should redirect to home when hasPluginByGoal true and hasExternalTheme false', async () => {
-			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.PROCESSING.slug,
-				dependencies: {
-					hasExternalTheme: false,
-					hasPluginByGoal: true,
-					siteSlug: 'test-site.wordpress.com',
-				},
-			} );
-
-			expect( window.location.replace ).toHaveBeenCalledWith( '/home/test-site.wordpress.com' );
-		} );
-
-		it( 'should redirect to home when hasExternalTheme true', async () => {
-			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.PROCESSING.slug,
-				dependencies: {
-					hasExternalTheme: true,
-					siteSlug: 'test-site.wordpress.com',
-				},
-			} );
-
-			expect( window.location.replace ).toHaveBeenCalledWith(
-				addQueryArgs( '/setup/site-setup', {
-					siteSlug: 'test-site.wordpress.com',
-				} )
-			);
-		} );
-	} );
 } );

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -3,7 +3,6 @@
  */
 import { SiteIntent } from '@automattic/data-stores/src/onboard/constants';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
-import { addQueryArgs } from '@wordpress/url';
 import onboarding from '../flows/onboarding/onboarding';
 import { STEPS } from '../internals/steps';
 import { getFlowLocation, renderFlow } from './helpers';

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -54,9 +54,9 @@ export const useWaitForAtomic = ( {
 		[]
 	);
 
-	const waitForInitiateTransfer = async ( plugin?: string | null ) => {
+	const waitForInitiateTransfer = async () => {
 		const initiateTransferContext = searchParams.get( 'initiate_transfer_context' );
-		if ( ! initiateTransferContext && ! plugin ) {
+		if ( ! initiateTransferContext ) {
 			return;
 		}
 
@@ -64,9 +64,9 @@ export const useWaitForAtomic = ( {
 			initiateThemeTransfer(
 				siteId,
 				null,
-				plugin || '',
+				'',
 				searchParams.get( 'initiate_transfer_geo_affinity' ) || '',
-				initiateTransferContext || 'onboarding'
+				initiateTransferContext
 			)
 		);
 	};

--- a/config/development.json
+++ b/config/development.json
@@ -130,7 +130,7 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"oauth": false,
-		"onboarding/create-course": false,
+		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/development.json
+++ b/config/development.json
@@ -69,7 +69,6 @@
 		"help": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
-
 		"hosting-server-settings-enhancements": true,
 		"hosting/datacenter-picker": true,
 		"i18n/community-translator": false,
@@ -130,7 +129,6 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"oauth": false,
-		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -85,7 +85,7 @@
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
-		"onboarding/create-course": false,
+		"onboarding/create-course": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"plans/hosting-trial": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -85,7 +85,6 @@
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
-		"onboarding/create-course": true,
 		"p2/p2-plus": true,
 		"p2-enabled": false,
 		"plans/hosting-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -101,7 +101,6 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
-		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,6 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
-		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -81,7 +81,7 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
-		"onboarding/create-course": false,
+		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/test.json
+++ b/config/test.json
@@ -81,7 +81,6 @@
 		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
-		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,7 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"onboarding/enable-write-goal-features": true,
-		"onboarding/create-course": false,
+		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,7 +105,6 @@
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
 		"onboarding/enable-write-goal-features": true,
-		"onboarding/create-course": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
 		"onboarding/import-from-medium": true,

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -37,7 +37,6 @@ export enum SiteIntent {
 	AIAssembler = 'ai-assembler',
 	Newsletter = 'newsletter',
 	NewsletterGoal = 'intent-newsletter-goal',
-	CreateCourseGoal = 'create-course-goal',
 	FreePostSetup = 'free-post-setup', // non-signup flow
 	SiteMigration = 'site-migration',
 	UpdateDesign = 'update-design', // non-signup flow

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -41,42 +41,30 @@ describe( 'Test onboard utils', () => {
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.Write,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: false,
-			},
+			isIntentNewsletterGoalsEnabled: false,
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: true,
-			},
+			isIntentNewsletterGoalsEnabled: true,
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.Sell,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: false,
-			},
-		},
-		{
-			goals: [ SiteGoal.Sell, SiteGoal.Courses ],
-			expectedIntent: SiteIntent.CreateCourseGoal,
-			featureFlags: {
-				isIntentCreateCourseGoalEnabled: true,
-			},
+			isIntentNewsletterGoalsEnabled: false,
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: true,
-			},
+			isIntentNewsletterGoalsEnabled: true,
 		},
 	] )(
 		'Should map the $goals to $expectedIntent intent ($featureFlags)',
-		( { goals, expectedIntent, featureFlags } ) => {
-			expect( goalsToIntent( goals, featureFlags ) ).toBe( expectedIntent );
+		( { goals, expectedIntent, featureFlags = {}, isIntentNewsletterGoalsEnabled = false } ) => {
+			( config.isEnabled as jest.Mock ).mockImplementation( ( flag ) =>
+				Boolean( featureFlags[ flag ] )
+			);
+			expect( goalsToIntent( goals, isIntentNewsletterGoalsEnabled ) ).toBe( expectedIntent );
 		}
 	);
 } );

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,13 +1,9 @@
 import { SiteGoal, SiteIntent } from './constants';
 
-interface Flags {
-	isIntentNewsletterGoalEnabled?: boolean;
-	isIntentCreateCourseGoalEnabled?: boolean;
-}
-
-export const goalsToIntent = ( goals: SiteGoal[], flags?: Flags ): SiteIntent => {
-	const { isIntentNewsletterGoalEnabled, isIntentCreateCourseGoalEnabled } = flags ?? {};
-
+export const goalsToIntent = (
+	goals: SiteGoal[],
+	isIntentNewsletterGoalEnabled: boolean
+): SiteIntent => {
 	// When DIFM and Import goals are selected together, DIFM Intent will have the priority and will be set.
 	if ( goals.includes( SiteGoal.DIFM ) ) {
 		return SiteIntent.DIFM;
@@ -15,10 +11,6 @@ export const goalsToIntent = ( goals: SiteGoal[], flags?: Flags ): SiteIntent =>
 
 	if ( goals.includes( SiteGoal.Import ) ) {
 		return SiteIntent.Import;
-	}
-
-	if ( goals.includes( SiteGoal.Courses ) && isIntentCreateCourseGoalEnabled ) {
-		return SiteIntent.CreateCourseGoal;
 	}
 
 	// Newsletter flow


### PR DESCRIPTION
## Proposed Changes

After Create course goal project was put on hold, we were suggested to cleanup the code.
This reverts the following PRS:
https://github.com/Automattic/wp-calypso/pull/101149
https://github.com/Automattic/wp-calypso/pull/100490
https://github.com/Automattic/wp-calypso/pull/100408
https://github.com/Automattic/wp-calypso/pull/100001

## Testing Instructions
A good code review is welcome.

Create a new Wordpress site, choosing the "create course" as a goal. Use a business plan. Do not chose "Course" theme.
You should experience all steps without anything breaking.

#### Sensei should not be installed
- Open the new created site dashboard.
- Check for plugins. Sensei should not be installed.

#### Course intent should not be set for this site.
- Go to https://developer.wordpress.com/docs/api/console/.
- Request GET /sites/{site-id}
![image](https://github.com/user-attachments/assets/ef60e77d-7ffa-472d-bc77-244e2367a599)
- On the response, inside options object, you should be able to read site-intent. Check that it is **not** `create-course-goal` but `build`.
![image](https://github.com/user-attachments/assets/4a4afa20-5e17-4d2b-9979-6e6e70388ea9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
