### PR TITLE
Security: Update terminology from 'time code' to 'setup code' in 2FA setup

### DIFF
--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -40,9 +40,9 @@ class Security2faEnable extends Component {
 		smsRequestsAllowed: true,
 		smsRequestPerformed: false,
 		submittingCode: false,
-		setupCode: false,
+		oneTimeCode: false,
 		verificationCode: '',
-		setupCopied: false,
+		oneTimeCopied: false,
 	};
 
 	codeRequestTimer = false;
@@ -63,7 +63,7 @@ class Security2faEnable extends Component {
 
 			this.setState( {
 				otpAuthUri: data.otpauth_uri,
-				setupCode: data.time_code,
+				oneTimeCode: data.time_code,
 			} );
 		} );
 
@@ -207,12 +207,12 @@ class Security2faEnable extends Component {
 		);
 	};
 
-	renderSetupCode = () => {
+	renderOneTimeCode = () => {
 		return (
-			<div className="security-2fa-enable__setup-code-block">
-				<p className="security-2fa-enable__setup-instruction">
+			<div className="security-2fa-enable__one-time-code-block">
+				<p className="security-2fa-enable__one-time-instruction">
 					{ this.props.translate(
-						'Enter this setup code into your mobile app. {{toggleMethodLink}}Prefer to scan the code?{{/toggleMethodLink}}',
+						'Enter this one-time code into your mobile app. {{toggleMethodLink}}Prefer to scan the code?{{/toggleMethodLink}}',
 						{
 							components: {
 								toggleMethodLink: this.getToggleLink(),
@@ -220,27 +220,27 @@ class Security2faEnable extends Component {
 						}
 					) }
 				</p>
-				<div className="security-2fa-enable__setup-code-container">
-					<code className="security-2fa-enable__setup-code">{ this.state.setupCode }</code>
+				<div className="security-2fa-enable__one-time-code-container">
+					<code className="security-2fa-enable__one-time-code">{ this.state.oneTimeCode }</code>
 
 					<ClipboardButton
-						text={ this.state.setupCode }
+						text={ this.state.oneTimeCode }
 						className="security-2fa-enable__clipboard-button"
 						borderless
 						compact
 						onCopy={ () => {
-							gaRecordEvent( 'Me', 'Copied 2FA Setup Code' );
+							gaRecordEvent( 'Me', 'Copied 2FA One-Time Code' );
 
-							this.setState( { setupCopied: true } );
+							this.setState( { oneTimeCopied: true } );
 							setTimeout( () => {
-								this.setState( { setupCopied: false } );
+								this.setState( { oneTimeCopied: false } );
 							}, 2000 );
 						} }
 					>
 						<Gridicon icon="clipboard" />
 					</ClipboardButton>
 
-					{ this.state.setupCopied && (
+					{ this.state.oneTimeCopied && (
 						<span className="security-2fa-enable__copied-text">
 							{ this.props.translate( 'Copied!' ) }
 						</span>
@@ -257,7 +257,7 @@ class Security2faEnable extends Component {
 
 		return (
 			<div className="security-2fa-enable__code-block">
-				{ 'scan' === this.state.method ? this.renderQRCode() : this.renderSetupCode() }
+				{ 'scan' === this.state.method ? this.renderQRCode() : this.renderOneTimeCode() }
 			</div>
 		);
 	};

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -40,8 +40,9 @@ class Security2faEnable extends Component {
 		smsRequestsAllowed: true,
 		smsRequestPerformed: false,
 		submittingCode: false,
-		timeCode: false,
+		setupCode: false,
 		verificationCode: '',
+		setupCopied: false,
 	};
 
 	codeRequestTimer = false;
@@ -62,7 +63,7 @@ class Security2faEnable extends Component {
 
 			this.setState( {
 				otpAuthUri: data.otpauth_uri,
-				timeCode: data.time_code,
+				setupCode: data.time_code,
 			} );
 		} );
 
@@ -206,12 +207,12 @@ class Security2faEnable extends Component {
 		);
 	};
 
-	renderTimeCode = () => {
+	renderSetupCode = () => {
 		return (
-			<div className="security-2fa-enable__time-code-block">
-				<p className="security-2fa-enable__time-instruction">
+			<div className="security-2fa-enable__setup-code-block">
+				<p className="security-2fa-enable__setup-instruction">
 					{ this.props.translate(
-						'Enter this time code into your mobile app. {{toggleMethodLink}}Prefer to scan the code?{{/toggleMethodLink}}',
+						'Enter this setup code into your mobile app. {{toggleMethodLink}}Prefer to scan the code?{{/toggleMethodLink}}',
 						{
 							components: {
 								toggleMethodLink: this.getToggleLink(),
@@ -219,27 +220,27 @@ class Security2faEnable extends Component {
 						}
 					) }
 				</p>
-				<div className="security-2fa-enable__time-code-container">
-					<code className="security-2fa-enable__time-code">{ this.state.timeCode }</code>
+				<div className="security-2fa-enable__setup-code-container">
+					<code className="security-2fa-enable__setup-code">{ this.state.setupCode }</code>
 
 					<ClipboardButton
-						text={ this.state.timeCode }
+						text={ this.state.setupCode }
 						className="security-2fa-enable__clipboard-button"
 						borderless
 						compact
 						onCopy={ () => {
-							gaRecordEvent( 'Me', 'Copied 2FA Time Code' );
+							gaRecordEvent( 'Me', 'Copied 2FA Setup Code' );
 
-							this.setState( { timeCopied: true } );
+							this.setState( { setupCopied: true } );
 							setTimeout( () => {
-								this.setState( { timeCopied: false } );
+								this.setState( { setupCopied: false } );
 							}, 2000 );
 						} }
 					>
 						<Gridicon icon="clipboard" />
 					</ClipboardButton>
 
-					{ this.state.timeCopied && (
+					{ this.state.setupCopied && (
 						<span className="security-2fa-enable__copied-text">
 							{ this.props.translate( 'Copied!' ) }
 						</span>
@@ -256,7 +257,7 @@ class Security2faEnable extends Component {
 
 		return (
 			<div className="security-2fa-enable__code-block">
-				{ 'scan' === this.state.method ? this.renderQRCode() : this.renderTimeCode() }
+				{ 'scan' === this.state.method ? this.renderQRCode() : this.renderSetupCode() }
 			</div>
 		);
 	};

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -18,13 +18,13 @@
 	margin-top: 10px;
 }
 
-.security-2fa-enable__time-code-container {
+.security-2fa-enable__setup-code-container {
 	display: flex;
 	align-items: center;
 	margin: 6px 0;
 }
 
-.security-2fa-enable__time-code {
+.security-2fa-enable__setup-code {
 	font-weight: 600;
 	font-size: $font-body;
 	margin-right: 8px;

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -18,13 +18,13 @@
 	margin-top: 10px;
 }
 
-.security-2fa-enable__setup-code-container {
+.security-2fa-enable__one-time-code-container {
 	display: flex;
 	align-items: center;
 	margin: 6px 0;
 }
 
-.security-2fa-enable__setup-code {
+.security-2fa-enable__one-time-code {
 	font-weight: 600;
 	font-size: $font-body;
 	margin-right: 8px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Fixes:
- https://github.com/Automattic/wp-calypso/issues/99826

## Prerequisites:
This PR depends on #101335 which adds the clipboard button functionality to the 2FA setup screen. That PR should be reviewed and merged first before this terminology update PR.

## Proposed changes:
This PR updates the terminology in the two-factor authentication setup screen, changing "time code" to "setup code" for clarity and consistency. This improves the user experience by using more accurate terminology that better describes the purpose of the code.

Key changes:
* Changes text from "Enter this time code into your mobile app" to "Enter this setup code into your mobile app"
* Updates component method names, state variables, and CSS classes for consistency
* Updates related analytics event tracking to match new terminology
* Maintains all existing functionality

## Does this pull request change what data or activity we track or use?
Updated the name of an existing analytics event from "Copied 2FA Time Code" to "Copied 2FA Setup Code" for consistency.

## Testing instructions:
1. Go to https://wordpress.com/me/security/two-step
2. Click on "Set up Two-Step Authentication"
3. On the setup screen, click on "Can't scan the code?"
4. Verify the text now reads "Enter this setup code into your mobile app"
5. Test that all functionality (copying the code, toggling between scan/setup code views) still works as expected

Before | After
--- | ---
<img width="1049" alt="before_2fa" src="https://github.com/user-attachments/assets/b3f468ee-a109-4e2f-9497-7ac0ff082f71" /> | <img width="1050" alt="after_2fa" src="https://github.com/user-attachments/assets/bd4c0422-1637-46a8-81e7-a2944188ae5e" />
