### PR TITLE
Calypso checkout close button: Add more useful Tracks events

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -7,6 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import AkismetLogo from 'calypso/components/akismet-logo';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { DefaultMasterbarContact } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-valid-checkout-back-url';
@@ -54,17 +55,23 @@ const CheckoutMasterbar = ( {
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
-	const closeAndLeave = ( options?: { userHasClearedCart?: boolean } ) =>
+	const closeAndLeave = ( options?: { userHasClearedCart?: boolean } ) => {
+		const userHasClearedCart = options?.userHasClearedCart ?? false;
+		recordTracksEvent( 'calypso_masterbar_checkout_close_modal_submitted', {
+			user_has_cleared_cart: userHasClearedCart,
+		} );
 		leaveCheckout( {
 			siteSlug,
 			forceCheckoutBackUrl,
 			previousPath,
 			tracksEvent: 'calypso_masterbar_close_clicked',
-			userHasClearedCart: options?.userHasClearedCart ?? false,
+			userHasClearedCart: userHasClearedCart,
 		} );
+	};
 
 	const clickClose = () => {
 		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
 			setIsModalVisible( true );
 			return;
 		}

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -55,11 +55,16 @@ const CheckoutMasterbar = ( {
 	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
-	const closeAndLeave = ( options?: { userHasClearedCart?: boolean } ) => {
+	const closeAndLeave = ( options?: {
+		userHasClearedCart?: boolean;
+		closedWithoutConfirmation?: boolean;
+	} ) => {
 		const userHasClearedCart = options?.userHasClearedCart ?? false;
-		recordTracksEvent( 'calypso_masterbar_checkout_close_modal_submitted', {
-			user_has_cleared_cart: userHasClearedCart,
-		} );
+		if ( ! options?.closedWithoutConfirmation ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_submitted', {
+				user_has_cleared_cart: userHasClearedCart,
+			} );
+		}
 		leaveCheckout( {
 			siteSlug,
 			forceCheckoutBackUrl,
@@ -75,7 +80,9 @@ const CheckoutMasterbar = ( {
 			setIsModalVisible( true );
 			return;
 		}
-		closeAndLeave();
+		closeAndLeave( {
+			closedWithoutConfirmation: true,
+		} );
 	};
 
 	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );


### PR DESCRIPTION
## Proposed Changes

When a user clicks the close button in the top corner of checkout (thereby opening up a modal dialog), we should record a Tracks event for that, as well as record which option they wound up choosing in the modal dialog, if any.

## Why are these changes being made?

We would like to get some useful data for https://github.com/Automattic/wp-calypso/issues/100226, but currently we can't because the existing Tracks event (which this pull request does not touch) only records that checkout was closed, not which option they chose within it.

## Testing Instructions

In your browser console, run this code:

```
localStorage.setItem( 'debug', 'calypso:analytics' );
```

Then put something in your cart and monitor the console messages as you click the close button and then choose either the "Empty cart" or "Leave items" options.  Look for the new Tracks events to appear there as appropriate.

Note that if you click the close button in checkout very fast (as checkout is still loading) and don't see a modal at all, you shouldn't see any of the new Tracks events get recorded either.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
