### PR TITLE
Importer: Use a core component and proper blue color for the upload progress bar

### DIFF
--- a/client/blocks/importer/components/uploading-pane/uploading-pane.scss
+++ b/client/blocks/importer/components/uploading-pane/uploading-pane.scss
@@ -53,7 +53,18 @@
 	}
 
 	.progress-bar {
+		text-align: left;
 		width: 80%;
+
+		& > div {
+			background-color: var(--color-accent-50);
+		}
+
+		&.is-complete {
+			& > div {
+				background-color: var(--color-success);
+			}
+		}
 	}
 }
 

--- a/client/blocks/importer/components/uploading-pane/uploading-pane.tsx
+++ b/client/blocks/importer/components/uploading-pane/uploading-pane.tsx
@@ -1,4 +1,4 @@
-import { ProgressBar } from '@automattic/components';
+import { ProgressBar } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { truncate } from 'lodash';
@@ -27,7 +27,7 @@ export class UploadingPane extends UploadingPaneBase {
 		// Override base component only where we are uploading something
 		if ( importerState === appStates.UPLOAD_PROCESSING || importerState === appStates.UPLOADING ) {
 			const uploadPercent = percentComplete;
-			const progressClasses = clsx( {
+			const progressClasses = clsx( 'progress-bar', {
 				'is-complete': uploadPercent > 95,
 			} );
 			const uploaderPrompt =
@@ -41,13 +41,7 @@ export class UploadingPane extends UploadingPaneBase {
 			return (
 				<div>
 					<p>{ uploaderPrompt }</p>
-					<ProgressBar
-						compact
-						className={ progressClasses }
-						value={ uploadPercent }
-						total={ 100 }
-						isPulsing={ false }
-					/>
+					<ProgressBar className={ progressClasses } value={ uploadPercent } />
 				</div>
 			);
 		}


### PR DESCRIPTION
Related to #100884 

As it was suggested in the issue, the component was replaced with the one from WordPress.
(`@automattic/components` -> `@wordpress/components`).

I wasn't 100% sure about the proper blue color, here was a brief discussion: p1741896148432979-slack-C02NWDZBL0H

Also, I kept `is-complete` class and added styles for it similar to what I found in other parts of Calypso.

## Proposed Changes

* Replace the ProgressBar component with the one from `@wordpress/components`.
* Use the proper color for the progress bar.

## Why are these changes being made?

* Part of the project.

## Testing Instructions

- Visit `/sites`
- Press Add new site
- Pick Import
- Pick WordPress from the platform list
- Pick Import content only
- Upload a WordPress export file

## Video

https://github.com/user-attachments/assets/a5a86baf-fa04-4c3a-b002-89e3d5117e0a

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?