### PR TITLE
Odyssey Widget: Fix chart crash when hovering and import tooltip styles

### DIFF
--- a/apps/odyssey-stats/src/components/root-child.tsx
+++ b/apps/odyssey-stats/src/components/root-child.tsx
@@ -8,7 +8,6 @@ import { useLayoutEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { FunctionComponent, ReactNode } from 'react';
 
 // We cannot use any of the Calypso state selectors here, as the RootChild component doesn't have Redux context.
@@ -16,7 +15,7 @@ const RootChild: FunctionComponent< { children: ReactNode } > = ( { children } )
 	const [ containerEl, setContainerEl ] = useState< HTMLDivElement | null >( null );
 
 	const state = config( 'intial_state' );
-	const siteId = getSelectedSiteId( state );
+	const siteId = config( 'blog_id' ) as number;
 	const isSiteJetpack = isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } );
 	const customTheme = useWPAdminTheme( isSiteJetpack );
 

--- a/apps/odyssey-stats/src/components/root-child.tsx
+++ b/apps/odyssey-stats/src/components/root-child.tsx
@@ -3,18 +3,22 @@
  * The the new RootChild component supports setting the Calypso color scheme based on the selected site's admin color.
  * Location: https://github.com/Automattic/wp-calypso/blob/322700bb214dfcffa06cf33d88e333c576493965/packages/components/src/root-child/index.tsx
  */
+import config from '@automattic/calypso-config';
 import { useLayoutEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
-import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { FunctionComponent, ReactNode } from 'react';
 
+// We cannot use any of the Calypso state selectors here, as the RootChild component doesn't have Redux context.
 const RootChild: FunctionComponent< { children: ReactNode } > = ( { children } ) => {
 	const [ containerEl, setContainerEl ] = useState< HTMLDivElement | null >( null );
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const customTheme = useWPAdminTheme( siteId );
+	const state = config( 'intial_state' );
+	const siteId = getSelectedSiteId( state );
+	const isSiteJetpack = isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } );
+	const customTheme = useWPAdminTheme( isSiteJetpack );
 
 	useLayoutEffect( () => {
 		const element = document.createElement( 'div' );

--- a/apps/odyssey-stats/src/components/root-child.tsx
+++ b/apps/odyssey-stats/src/components/root-child.tsx
@@ -10,7 +10,7 @@ import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { FunctionComponent, ReactNode } from 'react';
 
-// We cannot use any of the Calypso state selectors here, as the RootChild component doesn't have Redux context.
+// We cannot use any of the Calypso state selectors here, as the RootChild component is used in Odyssey Widget, where there is no Redux context.
 const RootChild: FunctionComponent< { children: ReactNode } > = ( { children } ) => {
 	const [ containerEl, setContainerEl ] = useState< HTMLDivElement | null >( null );
 

--- a/apps/odyssey-stats/src/styles/widget-base.scss
+++ b/apps/odyssey-stats/src/styles/widget-base.scss
@@ -2,11 +2,10 @@
 
 // External Dependencies
 @import "calypso/assets/stylesheets/vendor";
-
 // Color Schemes
 @import "@automattic/calypso-color-schemes/src/calypso-color-schemes-root";
-
 @import "./variables";
+@import "calypso/my-sites/stats/modernized-tooltip-styles";
 
 @mixin stats-widget-single-column-view {
 

--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -2,11 +2,15 @@ import clsx from 'clsx';
 import Main, { MainProps } from 'calypso/components/main';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export default function StatsMain( { children, ...props }: MainProps ) {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const customTheme = useWPAdminTheme( siteId );
+	const isSiteJetpack = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } )
+	);
+	const customTheme = useWPAdminTheme( isSiteJetpack );
 
 	return (
 		<Main { ...props } className={ clsx( 'stats-main', 'color-scheme', customTheme ) }>

--- a/client/my-sites/stats/hooks/use-wp-admin-theme.tsx
+++ b/client/my-sites/stats/hooks/use-wp-admin-theme.tsx
@@ -1,12 +1,8 @@
 import config from '@automattic/calypso-config';
 import { useMemo } from 'react';
-import { useSelector } from 'calypso/state';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 
-export default function useWPAdminTheme( siteId: number | null ) {
-	const isSiteJetpack = useSelector( ( state ) =>
-		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } )
-	);
+// We cannot use any of the Calypso state selectors here, as this hook is used in the RootChild component, where there is no Redux context.
+export default function useWPAdminTheme( isSiteJetpack: boolean | null ) {
 	const isWPAdmin = config.isEnabled( 'is_odyssey' );
 
 	const customTheme = useMemo( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1741859527142119-slack-C82FZ5T4G

## Proposed Changes

* do not use Redux in RootChild as it doesn't have context
* import tooltip styling to match the dashboard

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow test instructions Option 1: PCYsg-Pp7-p2
* Open WP Admin dashboard
* Hover on the bar chart
* Ensure it doesn't crash
* Ensure the tooltip looks okay

<img width="574" alt="image" src="https://github.com/user-attachments/assets/2c75a1a5-0346-4506-8be2-7e13acdd2cba" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?