### PR TITLE
Plugins: Update whitespace space around upsell nudge and browser list

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .plugins-browser-list {
-	padding-top: 40px;
+	padding-top: 16px;
 	padding-inline: 0;
 
 	.feature-example & {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -25,7 +25,7 @@
 	}
 
 	.upsell-nudge {
-		margin-top: 16px;
+		margin-top: 32px;
 
 		@include breakpoint-deprecated( "<660px" ) {
 			margin: 16px;


### PR DESCRIPTION
Follow-up to #101049

Related to #

## Proposed Changes

* Updates top padding for plugin list form 40px to 16px
* Updates bottom top margin for upsell nudge from 16px to 32px

## Why are these changes being made?

Follow-up to #101049


### After

![image](https://github.com/user-attachments/assets/c8a94e28-c928-43ee-b58e-61e679ff45c3)

No upsell nudge

<img width="1733" alt="image" src="https://github.com/user-attachments/assets/0a992169-4ec7-420e-98df-d55c1552e273" />


### Before

<img src="https://private-user-images.githubusercontent.com/746152/421444971-61b35047-40f7-45d9-a61c-b388df8ff766.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDE5MDU1MTYsIm5iZiI6MTc0MTkwNTIxNiwicGF0aCI6Ii83NDYxNTIvNDIxNDQ0OTcxLTYxYjM1MDQ3LTQwZjctNDVkOS1hNjFjLWIzODhkZjhmZjc2Ni5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwMzEzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDMxM1QyMjMzMzZaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02MzVmOWI3Yjk3NzU0ZDdjNWVjZjlkMmNlMDdjNTZmYmQ0ZDZkN2FkZTljM2FmOWZmNTIzOWJlYTdmZDM5NGY1JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.NXjcvV4p94OWs21KT05Ri045FzFb634EnNXlbbLIauA" />

No upsell nudge

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/ad611aff-873b-4e62-a207-b4c8812fe33c" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the plugin screen on a Free Plan, Simple site: [wordpress.com/plugins/:site](https://wordpress.com/plugins/:site)
* Confirm the changes look as in the screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
