### PR TITLE
Design Picker: Try to avoid theme_not_found error when activating thew newly installed theme

### DIFF
--- a/client/landing/stepper/hooks/use-activate-design.ts
+++ b/client/landing/stepper/hooks/use-activate-design.ts
@@ -56,10 +56,15 @@ export const useActivateDesign = () => {
 				}
 			}
 
-			const activeTheme = await setDesignOnSite( site?.ID, design, {
-				enableThemeSetup: ! isJetpackOrAtomic,
-				...designOptions,
-			} );
+			const activeTheme = await setDesignOnSite(
+				site?.ID,
+				design,
+				{
+					enableThemeSetup: ! isJetpackOrAtomic,
+					...designOptions,
+				},
+				isJetpackOrAtomic === false
+			);
 
 			await reduxDispatch( setActiveTheme( site?.ID || -1, activeTheme ) );
 		},

--- a/client/landing/stepper/hooks/use-activate-design.ts
+++ b/client/landing/stepper/hooks/use-activate-design.ts
@@ -1,4 +1,5 @@
 import { getThemeIdFromStylesheet } from '@automattic/data-stores';
+import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '@automattic/global-styles';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -46,9 +47,11 @@ export const useActivateDesign = () => {
 			}
 
 			// Try to install the theme on Jetpack sites.
+			let isNewlyInstalledTheme = false;
 			if ( isJetpackOrAtomic ) {
 				try {
 					await installTheme( site?.ID, themeId );
+					isNewlyInstalledTheme = true;
 				} catch ( error: any ) {
 					if ( error.error !== 'theme_already_installed' ) {
 						throw error;
@@ -56,15 +59,16 @@ export const useActivateDesign = () => {
 				}
 			}
 
-			const activeTheme = await setDesignOnSite(
-				site?.ID,
-				design,
-				{
-					enableThemeSetup: ! isJetpackOrAtomic,
-					...designOptions,
-				},
-				isJetpackOrAtomic === false
-			);
+			const activeTheme = await setDesignOnSite( site?.ID, design, {
+				enableThemeSetup: ! isJetpackOrAtomic,
+				...designOptions,
+				// Prevent resetting global styles when a theme was recently installed generating an fatal error.
+				styleVariation:
+					isNewlyInstalledTheme &&
+					designOptions.styleVariation?.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG
+						? undefined
+						: designOptions.styleVariation,
+			} );
 
 			await reduxDispatch( setActiveTheme( site?.ID || -1, activeTheme ) );
 		},

--- a/client/landing/stepper/hooks/use-activate-design.ts
+++ b/client/landing/stepper/hooks/use-activate-design.ts
@@ -63,6 +63,7 @@ export const useActivateDesign = () => {
 				enableThemeSetup: ! isJetpackOrAtomic,
 				...designOptions,
 				// Prevent resetting global styles when a theme was recently installed generating an fatal error.
+				// See https://github.com/Automattic/wp-calypso/issues/101342.
 				styleVariation:
 					isNewlyInstalledTheme &&
 					designOptions.styleVariation?.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -400,16 +400,13 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	 * @param siteSlug The site slug.
 	 * @param selectedDesign The selected design.
 	 * @param options The options.
-	 * @param shouldResetGlobalStyles Whether to prevent resetting global styles.
-	 * This is needed to prevent resetting global styles when a theme was recently installed generating an fatal error.
 	 * @returns The activated theme.
 	 * @yields Yields effects for theme activation and global styles reset, including API calls and Redux actions.
 	 */
 	function* setDesignOnSite(
 		siteSlug: string,
 		selectedDesign: Design,
-		options: DesignOptions = {},
-		shouldResetGlobalStyles = true
+		options: DesignOptions = {}
 	) {
 		const themeSlug =
 			selectedDesign.slug ||
@@ -426,10 +423,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 		const activatedThemeId = activatedTheme.stylesheet ?? activatedTheme.id;
 
-		if (
-			shouldResetGlobalStyles &&
-			styleVariation?.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG
-		) {
+		if ( styleVariation?.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG ) {
 			yield* resetGlobalStyles( siteSlug, activatedThemeId, activatedTheme );
 		}
 		// @todo Always use the global styles for consistency

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -395,10 +395,21 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 	}
 
+	/**
+	 * Set the design on the site.
+	 * @param siteSlug The site slug.
+	 * @param selectedDesign The selected design.
+	 * @param options The options.
+	 * @param shouldResetGlobalStyles Whether to prevent resetting global styles.
+	 * This is needed to prevent resetting global styles when a theme was recently installed generating an fatal error.
+	 * @returns The activated theme.
+	 * @yields Yields effects for theme activation and global styles reset, including API calls and Redux actions.
+	 */
 	function* setDesignOnSite(
 		siteSlug: string,
 		selectedDesign: Design,
-		options: DesignOptions = {}
+		options: DesignOptions = {},
+		shouldResetGlobalStyles = true
 	) {
 		const themeSlug =
 			selectedDesign.slug ||
@@ -415,7 +426,10 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 		const activatedThemeId = activatedTheme.stylesheet ?? activatedTheme.id;
 
-		if ( styleVariation?.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG ) {
+		if (
+			shouldResetGlobalStyles &&
+			styleVariation?.slug === DEFAULT_GLOBAL_STYLES_VARIATION_SLUG
+		) {
 			yield* resetGlobalStyles( siteSlug, activatedThemeId, activatedTheme );
 		}
 		// @todo Always use the global styles for consistency


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101342

## Proposed Changes

- Proposed a hotfix by preventing the [resetGlobalStyles call](https://github.com/Automattic/wp-calypso/blob/trunk/packages/data-stores/src/site/actions.ts#L418-L420) on a newly installed theme as the theme might not be available immediately.
- Another way is to add `retry` mechanism as we cannot ensure whether the theme is available after the installation...

NOTE: It's weird that the `/themes/mine` didn't report the theme didn't exist...

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fix the `theme_not_found` error during the onboarding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with eCommerce plan
* Pick any goals on the Goals screen
* Pick TT5 on the Design Picker screen
* Continue to activate the TT5
* Ensure you won't see the `theme_not_found` error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
