### PR TITLE
Plugins Marketplace: Adjust header spacing

### DIFF
--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -7,6 +7,10 @@
 	column-gap: 12px;
 
 	.plugins-results-header__titles {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+
 		.plugins-results-header__title {
 			font-size: $font-body;
 			font-weight: 500;
@@ -14,7 +18,6 @@
 		}
 
 		.plugins-results-header__subtitle {
-			margin-top: 6.5px;
 			font-size: $font-body-small;
 			line-height: 20px;
 			color: var(--studio-gray-80);


### PR DESCRIPTION
## Proposed Changes

This PR updates the spacing between header title and subtitle from 6.5px to 4px to confirm to the design guidelines.

| Before | After |
| --- | --- | 
| ![Screenshot 2025-03-14 at 8 20 47 AM](https://github.com/user-attachments/assets/68918a97-6638-4359-a236-20146eecd476) |  ![Screenshot 2025-03-14 at 8 36 02 AM](https://github.com/user-attachments/assets/0e847747-f3d7-48d1-a87a-bfb09f9ca6fb) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /plugins
* Ensure that the spacing is updated as described above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
