### PR TITLE
FeaturesGrid: Fix color contrast on discount badge

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/style.scss
+++ b/packages/plans-grid-next/src/components/shared/header-price/style.scss
@@ -76,9 +76,9 @@
 }
 
 .plans-grid-next-header-price__badge {
-	background-color: var(--studio-green-0);
+	background-color: var(--studio-green-5);
 	border-radius: 4px;
-	color: var(--studio-green-40);
+	color: var(--studio-green-80);
 	display: inline-block;
 	font-size: 0.75rem;
 	font-weight: 500;


### PR DESCRIPTION
Part of #101301

## Proposed Changes

Fixes the color contrast of the green discount badge in the FeaturesGrid.

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/8b2cfdcc-9d5c-47ef-b01c-435326f09bed" alt="Discount badge, before" width="1048">|<img src="https://github.com/user-attachments/assets/16850d6b-36c1-4833-93da-e59223072087" alt="Discount badge, after" width="1048">|

Also fixed on the "Special Offer" badge:

<img src="https://github.com/user-attachments/assets/18bf2eee-e326-411b-8b1a-0436054dc56a" alt="Special offer badge" width="500">

## Why are these changes being made?

Color contrast does not pass WCAG AA.

Note that doing ad hoc color combinations like this is not sustainable — the original issue (#101301) mentions that there will be a separate project to unify the badges.

## Testing Instructions

Apply this patch to modify the mock data in Storybook:

```diff
diff --git a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
index e2aa419b06..016d8a7dd2 100644
--- a/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.stories.tsx
@@ -43,6 +43,21 @@ const ComponentWrapper = ( props: Omit< FeaturesGridExternalProps, 'gridPlans' >
 
 	const featureGroupMap = getPlanFeaturesGroupedForFeaturesGrid();
 
+	gridPlans?.forEach( ( plan ) => ( plan.pricing.discountedPrice.monthly = 30 ) );
+
+	/* Uncomment the follwing to see the "Special offer" badge */
+
+	// gridPlans?.forEach(
+	// 	( plan ) =>
+	// 		( plan.pricing.introOffer = {
+	// 			formattedPrice: '30',
+	// 			rawPrice: { monthly: 30, full: 30 },
+	// 			intervalUnit: 'month',
+	// 			intervalCount: 1,
+	// 			isOfferComplete: false,
+	// 		} )
+	// );
+
 	return (
 		gridPlans && (
 			<FeaturesGrid
```

Run `yarn workspace @automattic/plans-grid-next run storybook` and see the FeaturesGrid stories.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
