### PR TITLE
Onboarding Consistency: Use StepContainerV2 in the Goals step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -69,7 +69,7 @@ button {
  * Site Setup
  */
 .new-hosted-site,
-.site-setup,
+.site-setup:not(:has(.step-container-v2)),
 .onboarding.goals,
 .onboarding.design-setup,
 .onboarding.design-choices,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -4,7 +4,7 @@ import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -1,9 +1,10 @@
 import { Onboard } from '@automattic/data-stores';
+import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
@@ -11,11 +12,12 @@ import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { useCreateCourseGoalFeature } from '../../hooks/use-create-course-goal-feature';
 import DashboardIcon from './dashboard-icon';
 import { GoalsCaptureContainer } from './goals-capture-container';
 import SelectGoals from './select-goals';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './style.scss';
 
@@ -46,7 +48,7 @@ const refGoals: Record< string, Onboard.SiteGoal[] > = {
 /**
  * The goals capture step
  */
-const GoalsStep: Step = ( { navigation, flow } ) => {
+const GoalsStep: StepType = ( { navigation, flow } ) => {
 	const translate = useTranslate();
 	const whatAreYourGoalsText = translate( 'What would you like to do?' );
 	const subHeaderText = translate(
@@ -166,12 +168,49 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ refParameter, refGoals ] );
 
+	const getStepContent = ( nextButton?: ReactNode ) => (
+		<div className="select-goals">
+			<SelectGoals selectedGoals={ goals } onChange={ setGoals } />
+			{ nextButton }
+			<div className="select-goals__alternative-flows-container">
+				<Button variant="link" onClick={ handleImportClick } className="select-goals__link">
+					{ translate( 'Import or migrate an existing site' ) }
+				</Button>
+				<span className="select-goals__link-separator" />
+				<Button variant="link" onClick={ handleDIFMClick } className="select-goals__link">
+					{ translate( 'Let us build a custom site for you' ) }
+				</Button>
+				{ ! isGoalsAtFrontExperiment && (
+					<Button
+						variant="link"
+						onClick={ handleDashboardClick }
+						className="select-goals__link select-goals__dashboard-button"
+					>
+						<DashboardIcon />
+						{ translate( 'Skip to dashboard' ) }
+					</Button>
+				) }
+			</div>
+		</div>
+	);
+
 	const isMediumOrBiggerScreen = useViewportMatch( 'small', '>=' );
 
-	return (
-		<>
-			<DocumentHead title={ whatAreYourGoalsText } />
+	const getStep = () => {
+		if ( shouldUseStepContainerV2( flow ) ) {
+			const nextButton = <Step.NextButton label={ translate( 'Next' ) } onClick={ handleNext } />;
 
+			return (
+				<Step.SixColumnsCenteredLayout
+					topBar={ <Step.TopBar skipButton={ <Step.SkipButton onClick={ handleSkip } /> } /> }
+					heading={ <Step.Heading text={ whatAreYourGoalsText } subText={ subHeaderText } /> }
+					stickyBottomBar={ <Step.StickyBottomBar rightButton={ nextButton } /> }
+					render={ ( { isMediumViewport } ) => getStepContent( isMediumViewport && nextButton ) }
+				/>
+			);
+		}
+
+		return (
 			<GoalsCaptureContainer
 				whatAreYourGoalsText={ whatAreYourGoalsText }
 				subHeaderText={ subHeaderText }
@@ -181,41 +220,27 @@ const GoalsStep: Step = ( { navigation, flow } ) => {
 				nextLabelText={ translate( 'Next' ) }
 				skipLabelText={ translate( 'Skip' ) }
 				recordTracksEvent={ recordTracksEvent }
-				stepContent={
-					<div className="select-goals">
-						<SelectGoals selectedGoals={ goals } onChange={ setGoals } />
-						{ isMediumOrBiggerScreen && (
-							<Button
-								__next40pxDefaultSize
-								className="select-goals__next"
-								variant="primary"
-								onClick={ handleNext }
-							>
-								{ translate( 'Next' ) }
-							</Button>
-						) }
-						<div className="select-goals__alternative-flows-container">
-							<Button variant="link" onClick={ handleImportClick } className="select-goals__link">
-								{ translate( 'Import or migrate an existing site' ) }
-							</Button>
-							<span className="select-goals__link-separator" />
-							<Button variant="link" onClick={ handleDIFMClick } className="select-goals__link">
-								{ translate( 'Let us build a custom site for you' ) }
-							</Button>
-							{ ! isGoalsAtFrontExperiment && (
-								<Button
-									variant="link"
-									onClick={ handleDashboardClick }
-									className="select-goals__link select-goals__dashboard-button"
-								>
-									<DashboardIcon />
-									{ translate( 'Skip to dashboard' ) }
-								</Button>
-							) }
-						</div>
-					</div>
-				}
+				stepContent={ getStepContent(
+					isMediumOrBiggerScreen && (
+						<Button
+							__next40pxDefaultSize
+							className="select-goals__next"
+							variant="primary"
+							onClick={ handleNext }
+						>
+							{ translate( 'Next' ) }
+						</Button>
+					)
+				) }
 			/>
+		);
+	};
+
+	return (
+		<>
+			<DocumentHead title={ whatAreYourGoalsText } />
+
+			{ getStep() }
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -198,7 +198,7 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 
 	const getStep = () => {
 		if ( shouldUseStepContainerV2( flow ) ) {
-			const nextButton = <Step.NextButton label={ translate( 'Next' ) } onClick={ handleNext } />;
+			const nextButton = <Step.NextButton onClick={ handleNext } />;
 
 			return (
 				<Step.SixColumnsCenteredLayout

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -202,6 +202,7 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 
 			return (
 				<Step.SixColumnsCenteredLayout
+					className="step-container-v2--goals"
 					topBar={ <Step.TopBar skipButton={ <Step.SkipButton onClick={ handleSkip } /> } /> }
 					heading={ <Step.Heading text={ whatAreYourGoalsText } subText={ subHeaderText } /> }
 					stickyBottomBar={ <Step.StickyBottomBar rightButton={ nextButton } /> }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -71,14 +71,15 @@
 	}
 
 	.select-goals__dashboard-button.select-goals__link { // extra specificity to override default link styles
+		margin-left: 0;
+		margin-right: auto;
 		gap: 8px;
 		display: flex;
 		justify-content: flex-start;
 
 		@include break-small {
-			margin-left: 0;
-			margin-right: auto;
 			grid-column: span 3;
+			margin-left: auto;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -18,7 +18,6 @@
 }
 
 .select-goals {
-	width: 100%;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -72,13 +71,13 @@
 	}
 
 	.select-goals__dashboard-button.select-goals__link { // extra specificity to override default link styles
-		margin-left: 0;
-		margin-right: auto;
 		gap: 8px;
 		display: flex;
 		justify-content: flex-start;
 
 		@include break-small {
+			margin-left: 0;
+			margin-right: auto;
 			grid-column: span 3;
 			margin-left: auto;
 		}
@@ -94,5 +93,16 @@
 		@include break-small {
 			display: block;
 		}
+	}
+}
+
+.step-container-v2--goals {
+	.select-goals,
+	.select-goals__cards-container {
+		width: 100%;
+	}
+
+	.select-goals__alternative-flows-container {
+		padding-bottom: 0;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -18,6 +18,7 @@
 }
 
 .select-goals {
+	width: 100%;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -79,7 +79,6 @@
 			margin-left: 0;
 			margin-right: auto;
 			grid-column: span 3;
-			margin-left: auto;
 		}
 	}
 

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -17,7 +17,7 @@
 			padding: 2rem 1rem;
 
 			@include step-large-viewport {
-				padding: 3rem;
+				padding: 2rem 3rem;
 			}
 		}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101189. Closes https://github.com/automattic/wp-calypso/issues/101112.

## Proposed Changes

The goals step uses `SixColumnsCenteredLayout` wireframe when `onboarding/step-container-v2` flag is enabled (by default, this is only in dev)

Desktop won't change much (the goals screen already mostly matched the latest figma W9xI27S6Swvw5Ku21EbZvn-fi-9588_13026), except it has a different wordmark now in the top left.

The mobile layout has a floating footer

**Desktop**

| Before | After |
| --- | --- |
| ![beforedesktop](https://github.com/user-attachments/assets/e1e0f309-1754-42c4-b4a9-db76234f9870) | ![afterdesktop](https://github.com/user-attachments/assets/40dce561-12c2-413d-9fb1-24d2b4a6caad) |

**Mobile**

| Before | After |
|---|---|
| ![beforemobile](https://github.com/user-attachments/assets/8ea02a55-f5eb-4081-b44f-ed3f7c17639c) | ![aftermobile](https://github.com/user-attachments/assets/69b1379c-31a0-40b2-a9a5-bda75d7686ad) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test locally or with `?flags=onboarding/step-container-v2` on staging
* You can test with an existing site at `/setup/site-setup?siteSlug={{ site slug }}`