### PR TITLE
Plugins: Update whitespace between nudge and browser list again

### DIFF
--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .plugins-browser-list {
-	padding-top: 16px;
+	padding-top: 40px;
 	padding-inline: 0;
 
 	.feature-example & {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -25,7 +25,8 @@
 	}
 
 	.upsell-nudge {
-		margin-top: 32px;
+		margin-top: 40px;
+		margin-bottom: 0;
 
 		@include breakpoint-deprecated( "<660px" ) {
 			margin: 16px;


### PR DESCRIPTION
Restores the 40px top space shown in Figma kyCC1EHKtv4qsElmlAzp5T-fi-537_125503

Follow-up to #101340

### After

![image](https://github.com/user-attachments/assets/966678f8-bc5a-47f7-a8c8-a6d9f40a6c69)

No upsell nudge
![image](https://github.com/user-attachments/assets/88dd7c83-6acf-4114-b13a-33b6e43d3c7a)

### Before

![image](https://github.com/user-attachments/assets/c8a94e28-c928-43ee-b58e-61e679ff45c3)

No upsell nudge

<img width="1733" alt="image" src="https://github.com/user-attachments/assets/0a992169-4ec7-420e-98df-d55c1552e273" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the plugin screen on a Free Plan, Simple site: [wordpress.com/plugins/:site](https://wordpress.com/plugins/:site)
* Confirm the changes look as in the screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?