### PR TITLE
Convert `MarketplaceProgressBar` to use core `ProgressBar` component.

### DIFF
--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -1,7 +1,7 @@
 import { TranslateResult } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import './style.scss';
 import Loading from 'calypso/components/loading';
+import './style.scss';
 
 const ACCELERATED_REFRESH_INTERVAL = 750;
 const ACCELERATED_INCREMENT = 5;

--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -1,19 +1,7 @@
-import styled from '@emotion/styled';
-import { ProgressBar } from '@wordpress/components';
-import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { TranslateResult } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import './style.scss';
-
-const Container = styled.div`
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 20px;
-`;
-
-const Title = styled.h1`
-	font-size: 2rem;
-`;
+import Loading from 'calypso/components/loading';
 
 const ACCELERATED_REFRESH_INTERVAL = 750;
 const ACCELERATED_INCREMENT = 5;
@@ -29,7 +17,6 @@ export default function MarketplaceProgressBar( {
 	additionalSteps?: TranslateResult[];
 	additionalStepsTimeout?: number;
 } ) {
-	const translate = useTranslate();
 	const [ stepValue, setStepValue ] = useState( steps[ currentStep ] );
 	const [ additionalStepsTimeoutId, setAdditionalStepsTimeoutId ] = useState< NodeJS.Timeout >();
 	const [ currentAdditionalSteps, setCurrentAdditionalSteps ] = useState< TranslateResult[] >( [] );
@@ -95,16 +82,11 @@ export default function MarketplaceProgressBar( {
 		};
 	}, [ additionalSteps, currentStep ] );
 
-	/* translators: %(currentStep)s  Is the current step number, given that steps are set of counting numbers representing each step starting from 1, %(stepCount)s  Is the total number of steps, Eg: Step 1 of 3  */
-	const stepIndication = translate( 'Step %(currentStep)s of %(stepCount)s', {
-		args: { currentStep: currentStep + 1, stepCount: steps.length },
-	} );
-
 	return (
-		<Container>
-			<Title className="progressbar__title wp-brand-font">{ stepValue }</Title>
-			<ProgressBar value={ simulatedProgressPercentage } className="progressbar__bar" />
-			{ steps.length > 1 && <div>{ stepIndication }</div> }
-		</Container>
+		<Loading
+			title={ stepValue }
+			progress={ simulatedProgressPercentage }
+			className="marketplace__loading"
+		/>
 	);
 }

--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -1,13 +1,14 @@
-import { ProgressBar } from '@automattic/components';
 import styled from '@emotion/styled';
+import { ProgressBar } from '@wordpress/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import './style.scss';
 
 const Container = styled.div`
-	text-align: center;
-`;
-const StyledProgressBar = styled( ProgressBar )`
-	margin: 20px 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 20px;
 `;
 
 const Title = styled.h1`
@@ -102,11 +103,7 @@ export default function MarketplaceProgressBar( {
 	return (
 		<Container>
 			<Title className="progressbar__title wp-brand-font">{ stepValue }</Title>
-			<StyledProgressBar
-				value={ simulatedProgressPercentage }
-				color="var( --studio-wordpress-blue )"
-				compact
-			/>
+			<ProgressBar value={ simulatedProgressPercentage } className="progressbar__bar" />
 			{ steps.length > 1 && <div>{ stepIndication }</div> }
 		</Container>
 	);

--- a/client/my-sites/marketplace/components/progressbar/style.scss
+++ b/client/my-sites/marketplace/components/progressbar/style.scss
@@ -1,4 +1,4 @@
 
-.marketplace__loading {
-    margin-top: 0 !important;
+.marketplace__loading.marketplace__loading {
+    margin-top: 0;
 }

--- a/client/my-sites/marketplace/components/progressbar/style.scss
+++ b/client/my-sites/marketplace/components/progressbar/style.scss
@@ -1,5 +1,4 @@
-.progressbar__bar {
-    & > :first-child {
-        background-color: var( --studio-wordpress-blue );
-    }
+
+.marketplace__loading {
+    margin-top: 0 !important;
 }

--- a/client/my-sites/marketplace/components/progressbar/style.scss
+++ b/client/my-sites/marketplace/components/progressbar/style.scss
@@ -1,0 +1,5 @@
+.progressbar__bar {
+    & > :first-child {
+        background-color: var( --studio-wordpress-blue );
+    }
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100459

## Proposed Changes

`MarketplaceProgressBar` was using the `@automattic/components` ProgressBar. This PR switches it to use the `@wordpress/components` one. 
Styling has to be done via classname for the core component so I added a stylesheet to address that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Upgrade and install a plugin on a Free Simple site
* After clicking through the checkout, watch the new progress bar appear on the next screen.

Previously:

 
<img width="494" alt="Screenshot 2025-03-14 at 1 44 50 pm" src="https://github.com/user-attachments/assets/406a7545-5ed1-47f0-b0ed-1367967eac09" />

This PR:

<img width="439" alt="Screenshot 2025-03-14 at 1 36 30 pm" src="https://github.com/user-attachments/assets/0d02d91f-b37e-456e-9006-cbff959d4391" />


One thing I'm not 100% sure about is how to make the `'/marketplace/thank-you/:site?'` screen render a progress bar. That's relevant to this change because it's the other place where `MarketplaceProgressBar` is used aside from `/marketplace/plugin/:productSlug?/install/:site?`, so we can expect that progress bar to have also been changed.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
