### PR TITLE
Business Tax: Add business card badge component

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -340,6 +340,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/vat-gst-other-taxes/#business-tax-rates-in-ohio-and-connecticut',
 		post_id: 234670,
 	},
+	'setting-up-a-business-card': {
+		link: 'https://wordpress.com/support/vat-gst-other-taxes/#setting-up-a-business-card',
+		post_id: 234670,
+	},
 	team: {
 		link: 'https://wordpress.com/support/user-roles/',
 		post_id: 1221,

--- a/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
+++ b/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
@@ -78,7 +78,7 @@ export default function PaymentMethodBackupToggle( { card }: { card: StoredPayme
 				checked={ isBackup }
 				onChange={ toggleIsBackup }
 				label={
-					translate( 'Use as backup.{{supportLink /}}', {
+					translate( 'Use as backup{{supportLink /}}', {
 						components: {
 							supportLink: (
 								<InlineSupportLink

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -53,6 +53,8 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 				alt=""
 			/>
 			<div className="payment-method-details__details">
+				{ razorpayVpa && <span className="payment-method-details__vpa">{ razorpayVpa }</span> }
+				<span className="payment-method-details__name">{ name }</span>
 				<span className="payment-method-details__number">
 					<PaymentMethodSummary type={ type } digits={ lastDigits } email={ email } />
 				</span>
@@ -76,10 +78,6 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 						{ translate( 'Credit card expired' ) }
 					</span>
 				) }
-
-				{ razorpayVpa && <span className="payment-method-details__vpa">{ razorpayVpa }</span> }
-
-				<span className="payment-method-details__name">{ name }</span>
 			</div>
 		</div>
 	);

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -3,11 +3,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import {
-	getPaymentMethodImageURL,
-	PaymentMethodSummary,
-} from 'calypso/lib/checkout/payment-methods';
-import BusinessCardBadge from 'calypso/my-sites/checkout/src/components/business-card-badge';
+import { PaymentMethodSummary } from 'calypso/lib/checkout/payment-methods';
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
@@ -33,7 +29,6 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 	email,
 	paymentPartner,
 	isExpired,
-	isForBusiness,
 	razorpayVpa,
 } ) => {
 	const translate = useTranslate();
@@ -47,18 +42,12 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 
 	return (
 		<div className="payment-method-details">
-			<img
-				src={ getPaymentMethodImageURL( type ) }
-				className="payment-method-details__image"
-				alt=""
-			/>
 			<div className="payment-method-details__details">
 				{ razorpayVpa && <span className="payment-method-details__vpa">{ razorpayVpa }</span> }
 				<span className="payment-method-details__name">{ name }</span>
 				<span className="payment-method-details__number">
 					<PaymentMethodSummary type={ type } digits={ lastDigits } email={ email } />
 				</span>
-
 				{ displayExpirationDate && (
 					<span className="payment-method-details__expiration-date">
 						{ translate( 'Expires %(date)s', {
@@ -67,7 +56,6 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 						} ) }
 					</span>
 				) }
-				{ isForBusiness && <BusinessCardBadge /> }
 				{ isExpired && (
 					<span
 						className={ clsx( 'payment-method-details__expiration-notice', {

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -20,6 +20,7 @@ interface Props {
 	paymentPartner?: string;
 	selected?: boolean;
 	isExpired?: boolean;
+	isForBusiness?: boolean;
 	razorpayVpa?: string;
 }
 
@@ -32,6 +33,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 	email,
 	paymentPartner,
 	isExpired,
+	isForBusiness,
 	razorpayVpa,
 } ) => {
 	const translate = useTranslate();
@@ -63,7 +65,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 						} ) }
 					</span>
 				) }
-				<BusinessCardBadge />
+				{ isForBusiness && <BusinessCardBadge /> }
 				{ isExpired && (
 					<span
 						className={ clsx( 'payment-method-details__expiration-notice', {

--- a/client/me/purchases/payment-methods/payment-method-details.tsx
+++ b/client/me/purchases/payment-methods/payment-method-details.tsx
@@ -7,7 +7,7 @@ import {
 	getPaymentMethodImageURL,
 	PaymentMethodSummary,
 } from 'calypso/lib/checkout/payment-methods';
-
+import BusinessCardBadge from 'calypso/my-sites/checkout/src/components/business-card-badge';
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface Props {
@@ -63,7 +63,7 @@ const PaymentMethodDetails: FunctionComponent< Props > = ( {
 						} ) }
 					</span>
 				) }
-
+				<BusinessCardBadge />
 				{ isExpired && (
 					<span
 						className={ clsx( 'payment-method-details__expiration-notice', {

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -29,6 +29,7 @@ export default function PaymentMethod( { paymentMethod }: { paymentMethod: Store
 					name={ paymentMethod.name }
 					expiry={ paymentMethod.expiry }
 					isExpired={ paymentMethod.is_expired }
+					isForBusiness={ paymentMethod.tax_location?.is_for_business }
 					razorpayVpa={ 'razorpay_vpa' in paymentMethod ? paymentMethod.razorpay_vpa : undefined }
 				/>
 				{ isCreditCard( paymentMethod ) && <PaymentMethodBackupToggle card={ paymentMethod } /> }

--- a/client/me/purchases/payment-methods/payment-method.tsx
+++ b/client/me/purchases/payment-methods/payment-method.tsx
@@ -1,16 +1,21 @@
 import { CompactCard } from '@automattic/components';
 import clsx from 'clsx';
-import { isCreditCard } from 'calypso/lib/checkout/payment-methods';
+import { isCreditCard, getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethodBackupToggle from 'calypso/me/purchases/payment-methods/payment-method-backup-toggle';
 import PaymentMethodDelete from 'calypso/me/purchases/payment-methods/payment-method-delete';
+import BusinessCardBadge from 'calypso/my-sites/checkout/src/components/business-card-badge';
 import { TaxInfoArea } from 'calypso/my-sites/checkout/src/components/payment-method-tax-info';
 import PaymentMethodDetails from './payment-method-details';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
-
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 export default function PaymentMethod( { paymentMethod }: { paymentMethod: StoredPaymentMethod } ) {
+	const cardType = 'card_type' in paymentMethod ? paymentMethod.card_type : undefined;
+	const displayBrand = 'display_brand' in paymentMethod ? paymentMethod.display_brand : undefined;
+	const paymentPartner = paymentMethod.payment_partner;
+	const type = displayBrand ?? ( cardType?.toLocaleLowerCase() || paymentPartner || '' );
+	const isForBusiness = paymentMethod.tax_location?.is_for_business;
 	return (
 		<CompactCard
 			className={ clsx( 'payment-method__wrapper', {
@@ -18,6 +23,14 @@ export default function PaymentMethod( { paymentMethod }: { paymentMethod: Store
 			} ) }
 		>
 			<div className="payment-method">
+				<div className="payment-method-card">
+					<img
+						src={ getPaymentMethodImageURL( type ) }
+						className="payment-method-details__image"
+						alt=""
+					/>
+					{ isForBusiness && <BusinessCardBadge /> }
+				</div>
 				<PaymentMethodDetails
 					lastDigits={ 'card_last_4' in paymentMethod ? paymentMethod.card_last_4 : undefined }
 					email={ paymentMethod.email }

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -1,9 +1,19 @@
-.payment-method-list__payment-methods {
-	margin-top: 12px;
+$card_width: $font-body * 3.75; // roughly 60px wide
+@mixin payment-details-col-start( $reset: false ) {
+	// Handles the logo column spacing
+	@if $reset == false {
+		margin-inline-start: calc( #{$card-width} + #{$font-body} );
+	} @else {
+		margin-inline-start: 0;
+	}
 }
 
-.payment-method-list__payment-methods > div {
-	width: 100%;
+.payment-method-list__payment-methods {
+	margin-top: 12px;
+
+	> div {
+		width: 100%;
+	}
 }
 
 .payment-method-list__loader {
@@ -20,113 +30,135 @@
 }
 
 .payment-method {
-	margin-bottom: 0;
 	display: grid;
 	grid-template-areas:
-		"payment-method-details"
-		"payment-method-billing-information"
-		"payment-method-backup"
-		"payment-method-delete";
+		'payment-method-details'
+		'payment-method-billing-information'
+		'payment-method-backup'
+		'payment-method-delete';
 	grid-template-columns: 1fr;
 	align-items: center;
-	justify-content: space-between;
-	flex-wrap: wrap;
 	width: 100%;
+	gap: 0.75rem 1rem;
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		grid-template-areas:
-			"payment-method-details payment-method-backup"
-			"payment-method-billing-information payment-method-delete";
+			'payment-method-details payment-method-backup'
+			'payment-method-billing-information payment-method-delete';
 		grid-template-columns: 2fr 1fr;
 	}
-}
 
-.payment-method-details {
-	display: flex;
-	align-items: center;
-	grid-area: payment-method-details;
-}
+	// Payment Method Details (Row 1)
+	&-details {
+		display: flex;
+		align-items: center;
+		grid-area: payment-method-details;
+		gap: $font-body;
+		width: 100%;
 
-.payment-method-details__image {
-	width: 60px;
-	height: 38px;
-	margin-right: 16px;
-}
+		&__image {
+			width: 60px;
+			height: 38px;
+			flex-shrink: 0;
+		}
 
-.payment-method-details__details {
-	flex-grow: 1;
-	margin-right: 16px;
-}
+		&__details {
+			display: flex;
+			flex-wrap: wrap;
+			flex-grow: 1;
+			gap: 0.25rem 0.5rem;
+			align-items: baseline;
+			min-width: 0; // Prevents overflow issues
+		}
 
-.payment-method-details__number {
-	color: var(--color-neutral-80);
-	display: block;
-	margin-right: 12px;
+		&__name,
+		&__vpa {
+			color: var( --color-neutral-50 );
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+			flex-basis: 100%; // Ensures full-width name/VPA line
+			font-size: $font-body;
+			gap: 0.5rem;
 
-	@include breakpoint-deprecated( ">960px" ) {
-		display: inline;
-	}
-}
+			.components-badge {
+				flex-shrink: 0;
+			}
+		}
 
-.payment-method-details__expiration-date {
-	margin-right: 12px;
-	display: block;
-
-	@include breakpoint-deprecated( ">960px" ) {
-		display: inline;
-	}
-}
-
-.payment-method-details__expiration-notice {
-	font-size: 0.875rem;
-	display: block;
-
-	@include breakpoint-deprecated( ">960px" ) {
-		display: inline-block;
-	}
-
-	.gridicon {
-		vertical-align: text-bottom;
-		margin-right: 4px;
+		&__number,
+		&__expiration-date {
+			color: var( --color-neutral-80 );
+			white-space: nowrap;
+			font-size: $font-body-small;
+			display: inline-flex;
+			min-width: 0;
+		}
 	}
 
-	&.is-expired {
-		color: var(--color-error);
+	// Billing Info (Row 2)
+	&-tax-info {
+		@include payment-details-col-start;
+		font-size: $font-body-small;
+		grid-area: payment-method-billing-information;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			width: auto;
+		}
 	}
-}
 
-.payment-method-details__name,
-.payment-method-details__vpa {
-	color: var(--color-neutral-50);
-	display: block;
-	font-size: 0.875rem;
-}
+	// Backup Toggle & Delete Button (Share common styles)
+	&-backup-toggle,
+	&-delete {
+		@include payment-details-col-start;
 
-.payment-method .payment-method-tax-info {
-	font-size: 0.875rem;
-	grid-area: payment-method-billing-information;
-	margin-left: 76px;
+		@include breakpoint-deprecated( '>480px' ) {
+			@include payment-details-col-start( true );
+			justify-self: flex-end;
 
-	@include breakpoint-deprecated( ">480px" ) {
-		width: auto;
+			&__button {
+				text-align: end;
+			}
+		}
 	}
-}
 
-.payment-method-delete {
-	grid-area: payment-method-delete;
-	margin-top: 12px;
-	text-align: right;
+	&-backup-toggle {
+		grid-area: payment-method-backup;
 
-	@include breakpoint-deprecated( ">480px" ) {
-		margin-top: 0;
-		justify-self: flex-end;
+		// Ensure checkbox, label, and icon align properly
+		.components-flex {
+			display: flex;
+			align-items: center;
+			column-gap: 0.5rem;
+			min-width: 0; // Ensures text wraps naturally if needed
+		}
+
+		// Ensure the text takes up available space
+		.components-checkbox-control__label {
+			display: flex;
+			align-items: center;
+			flex-grow: 1;
+			white-space: normal;
+			column-gap: 0.25rem;
+		}
+
+		// Prevent checkbox and icon from shrinking
+		.components-base-control__field,
+		.components-checkbox-control__input-container,
+		.inline-support-link {
+			margin: 0;
+			flex-shrink: 0;
+		}
 	}
-}
 
-.payment-method-delete__button {
-	text-decoration: underline;
-	padding: 0;
-	text-align: right;
+	&-delete {
+		grid-area: payment-method-delete;
+
+		&__button {
+			text-decoration: underline;
+			padding: 0;
+		}
+	}
 }
 
 .payment-method-delete-dialog {
@@ -138,12 +170,12 @@
 			font-size: $font-body-small;
 
 			&.payment-method-delete-dialog__affected-subscription-domain {
-				color: var(--color-text-subtle);
+				color: var( --color-text-subtle );
 				font-size: $font-body-extra-small;
 			}
 
 			&.payment-method-delete-dialog__affected-subscription-date span {
-				color: var(--color-error);
+				color: var( --color-error );
 				font-size: $font-body-extra-small;
 				text-align: center;
 			}
@@ -151,30 +183,8 @@
 	}
 
 	.payment-method-delete-dialog__affected-subscriptions-wrapper {
-		border-top: 1px solid var(--color-border-subtle);
+		border-top: 1px solid var( --color-border-subtle );
 		padding-top: 12px;
-	}
-
-	.payment-method-delete-dialog__affected-subscriptions-title-wrapper {
-		display: flex;
-		gap: 12px;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		margin-bottom: 8px;
-
-		.card-heading {
-			margin: 0;
-		}
-	}
-
-	.payment-method-delete-dialog__affected-subscription {
-		background: var(--color-neutral-0);
-		border-radius: 4px;
-		display: flex;
-		gap: 12px;
-		justify-content: space-between;
-		padding: 12px;
-		margin-top: 14px;
 	}
 
 	.payment-method-delete-dialog__warning {
@@ -183,42 +193,22 @@
 		gap: 12px;
 
 		.gridicon {
-			fill: var(--color-warning);
+			fill: var( --color-warning );
 		}
 
 		p {
-			color: var(--color-warning);
+			color: var( --color-warning );
 			font-size: $font-body-small;
 		}
-	}
-
-	.card-heading {
-		margin-top: 0;
-	}
-}
-
-.payment-method-backup-toggle {
-	grid-area: payment-method-backup;
-	margin-inline-start: 76px;
-	margin-top: 16px;
-	width: 100%;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		margin-left: 0;
-		margin-top: 0;
-		width: auto;
-		justify-self: flex-end;
 	}
 }
 
 .payment-method__wrapper {
 	margin-bottom: 0;
-}
 
-/* Jetpack cloud overwrites */
-
-.payment-method__wrapper--jetpack-cloud {
-	.components-checkbox-control__input[type="checkbox"]:checked {
-		background-color: var(--studio-jetpack-green-50);
+	&--jetpack-cloud {
+		.components-checkbox-control__input[type='checkbox']:checked {
+			background-color: var( --studio-jetpack-green-50 );
+		}
 	}
 }

--- a/client/me/purchases/payment-methods/style.scss
+++ b/client/me/purchases/payment-methods/style.scss
@@ -1,13 +1,3 @@
-$card_width: $font-body * 3.75; // roughly 60px wide
-@mixin payment-details-col-start( $reset: false ) {
-	// Handles the logo column spacing
-	@if $reset == false {
-		margin-inline-start: calc( #{$card-width} + #{$font-body} );
-	} @else {
-		margin-inline-start: 0;
-	}
-}
-
 .payment-method-list__payment-methods {
 	margin-top: 12px;
 
@@ -32,20 +22,33 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 .payment-method {
 	display: grid;
 	grid-template-areas:
-		'payment-method-details'
-		'payment-method-billing-information'
-		'payment-method-backup'
-		'payment-method-delete';
-	grid-template-columns: 1fr;
+	'payment-method-card payment-method-details'
+	'. payment-method-billing-information'
+	'. payment-method-backup'
+	'. payment-method-delete';
+	grid-template-columns: auto 1fr;
 	align-items: center;
 	width: 100%;
 	gap: 0.75rem 1rem;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		grid-template-areas:
-			'payment-method-details payment-method-backup'
-			'payment-method-billing-information payment-method-delete';
-		grid-template-columns: 2fr 1fr;
+			'payment-method-card payment-method-details payment-method-backup'
+			'payment-method-card payment-method-billing-information payment-method-delete';
+		grid-template-columns: auto 1fr auto;
+	}
+
+	&-card {
+		grid-area: payment-method-card;
+		grid-row: 1 / -1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		row-gap: .25rem;
+
+		@include breakpoint-deprecated( '>480px' ) {
+			grid-row: span 2;
+		}
 	}
 
 	// Payment Method Details (Row 1)
@@ -98,7 +101,6 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 
 	// Billing Info (Row 2)
 	&-tax-info {
-		@include payment-details-col-start;
 		font-size: $font-body-small;
 		grid-area: payment-method-billing-information;
 
@@ -110,10 +112,7 @@ $card_width: $font-body * 3.75; // roughly 60px wide
 	// Backup Toggle & Delete Button (Share common styles)
 	&-backup-toggle,
 	&-delete {
-		@include payment-details-col-start;
-
 		@include breakpoint-deprecated( '>480px' ) {
-			@include payment-details-col-start( true );
 			justify-self: flex-end;
 
 			&__button {

--- a/client/my-sites/checkout/src/components/business-card-badge.tsx
+++ b/client/my-sites/checkout/src/components/business-card-badge.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+
+const StyledBadge = styled.span`
+	background-color: var( --studio-blue-10 );
+	margin-bottom: 0.1em;
+	padding: 0.1em 0.8em;
+	border-radius: 5px;
+	display: inline-block;
+	font-size: small;
+
+	a,
+	a:visited {
+		color: var( --studio-blue-60 );
+		font-weight: 500;
+	}
+`;
+
+const BusinessCardBadge = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<StyledBadge>
+				{
+					translate( '{{link}}Business{{/link}}', {
+						components: {
+							link: (
+								<InlineSupportLink
+									id="setting-up-a-business-card"
+									supportContext="tax-exempt-customers"
+									showIcon={ false }
+								/>
+							),
+						},
+					} ) as string
+				}
+			</StyledBadge>
+		</>
+	);
+};
+
+export default BusinessCardBadge;

--- a/client/my-sites/checkout/src/components/business-card-badge.tsx
+++ b/client/my-sites/checkout/src/components/business-card-badge.tsx
@@ -1,42 +1,30 @@
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import CoreBadge from 'calypso/components/core/badge';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
-const StyledBadge = styled.span`
+const StyledBadge = styled( CoreBadge )`
 	background-color: var( --studio-blue-10 );
-	margin-bottom: 0.1em;
-	padding: 0.1em 0.8em;
-	border-radius: 5px;
-	display: inline-block;
-	font-size: small;
-
 	a,
 	a:visited {
 		color: var( --studio-blue-60 );
-		font-weight: 500;
 	}
 `;
 
 const BusinessCardBadge = () => {
 	const translate = useTranslate();
 	return (
-		<>
-			<StyledBadge>
-				{
-					translate( '{{link}}Business{{/link}}', {
-						components: {
-							link: (
-								<InlineSupportLink
-									id="setting-up-a-business-card"
-									supportContext="tax-exempt-customers"
-									showIcon={ false }
-								/>
-							),
-						},
-					} ) as string
-				}
-			</StyledBadge>
-		</>
+		<StyledBadge>
+			{
+				translate( '{{link}}Business{{/link}}', {
+					components: {
+						link: (
+							<InlineSupportLink supportContext="setting-up-a-business-card" showIcon={ false } />
+						),
+					},
+				} ) as string
+			}
+		</StyledBadge>
 	);
 };
 


### PR DESCRIPTION
WIP

This PR adds a BusinessCardBadge component to `my-sites > checkout > components`. This component can be used to label and identify business cards throughout Calypso.

This badge also serves as a clickable link that will open the Help Center and provide more information about what a business card is and how to use it.

Related to #

## Testing Instructions

*
