### PR TITLE
Plugins: Update sizing of list items to properly align to the container borders and update their border radius

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -133,11 +133,11 @@
 
 	&.extended {
 		@include break-large {
-			width: calc(50% - 9px); // 2 column grid with 18px gutter
+			width: calc((100% - 18px) / 2); // 2 column grid with 18px gutter
 		}
 
 		@include break-wide {
-			width: calc(33% - 10px); // 3 column grid with 20px gutter
+			width: calc((100% - 36px) / 3); // 3 column grid with 18px gutter
 		}
 	}
 

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -167,7 +167,7 @@
 	padding: 24px;
 	box-sizing: border-box;
 	border: 1px solid var(--studio-gray-5);
-	border-radius: 5px; /* stylelint-disable-line scales/radii */
+	border-radius: 4px;
 
 	&:focus,
 	&:hover {


### PR DESCRIPTION
Fixes alignment of items to the container and updates border radius on tiems to align to the 4px from the figma file kyCC1EHKtv4qsElmlAzp5T-fi-537_125503.

#92274 tackled an issue with `justify-content: space-between` when there were two just results in the list, but the items stopped being aligned with the container.


Related to #

## Proposed Changes

* Defines max-width instead of width for items in the plugins list. 
* Updates items border radius to 4px.

### After

![image](https://github.com/user-attachments/assets/6e5c1c48-19f4-49f5-a077-bd36b3eedfc5)

### Before

![image](https://github.com/user-attachments/assets/f4b37813-f714-4ced-98c4-7fb3dd803542)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at /plugins
* Confirm spacing is as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?