### PR TITLE
Render copy about verifying your email in order to modify your username as a new user

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -34,6 +34,7 @@ import AccountEmailField from 'calypso/me/account/account-email-field';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
+	isCurrentUserEmailVerified,
 	getCurrentUserDate,
 	getCurrentUserDisplayName,
 	getCurrentUserName,
@@ -889,7 +890,17 @@ class Account extends Component {
 							{ renderUsernameForm ? (
 								this.renderUsernameValidation()
 							) : (
-								<FormSettingExplanation>{ this.renderJoinDate() }</FormSettingExplanation>
+								<FormSettingExplanation>
+									{ ! this.props.isEmailVerified ? (
+										<span>
+											{ translate(
+												'Username can be changed once your email address is verified.'
+											) }
+										</span>
+									) : (
+										this.renderJoinDate()
+									) }
+								</FormSettingExplanation>
 							) }
 						</FormFieldset>
 
@@ -992,6 +1003,7 @@ export default compose(
 			userSettings: getUserSettings( state ),
 			unsavedUserSettings: getUnsavedUserSettings( state ),
 			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),
+			isEmailVerified: isCurrentUserEmailVerified( state ),
 		} ),
 		{
 			clearUnsavedUserSettings,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100341

## Proposed Changes

Before
<img  src=https://github.com/user-attachments/assets/4dc503be-56ca-40ed-b9e4-f474fcba1a21/>

After
<img  src=https://github.com/user-attachments/assets/d6f57762-8547-4de1-be83-2d8a0806cf63/>

## Testing Instructions

- [ ] Visit /me/account with a new account and observe the new message while your email isn't verified. 
- [ ] Verify your email address, see the message return back to "Joined <date>".
- [ ] Change your email address, confirm the "Joined <date>" message is still present due to username being editable.