### PR TITLE
Stats: Updates to the UTM Builder UI

### DIFF
--- a/apps/odyssey-stats/src/styles/typography.scss
+++ b/apps/odyssey-stats/src/styles/typography.scss
@@ -9,6 +9,14 @@
 	@include stats-section-header-for-jetpack;
 }
 
+// Replace fonts in client/my-sites/stats/stats-module-utm-builder/style.scss.
+// Need to be pretty specific to take precedence over those rules.
+.is-odyssey-stats.stats-utm-builder__overlay
+	.components-modal__header
+	.components-modal__header-heading {
+	@include stats-section-header-for-jetpack;
+}
+
 // Replace fonts in packages/components/src/highlight-cards/style.scss.
 $highlight-card-count-font: $font-sf-pro-display;
 $highlight-card-heading-font: $display-type-font;

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -122,9 +122,9 @@ const UtmBuilder: React.FC< UtmBuilderProps > = ( { initialData } ) => {
 	const translate = useTranslate();
 	const [ url, setUrl ] = useState( initialData?.url || '' );
 	const [ inputValues, setInputValues ] = useState< inputValuesType >( {
+		utm_campaign: initialData?.utm_campaign || '',
 		utm_source: initialData?.utm_source || '',
 		utm_medium: initialData?.utm_medium || '',
-		utm_campaign: initialData?.utm_campaign || '',
 	} );
 	// Focus the initial input field when rendered.
 	const initialFieldReference = useRef< HTMLLabelElement >( null );
@@ -142,6 +142,11 @@ const UtmBuilder: React.FC< UtmBuilderProps > = ( { initialData } ) => {
 			placeholder: '',
 			describedBy: 'stats-utm-builder-help-section-url',
 		},
+		utm_campaign: {
+			label: translate( 'UTM Campaign' ),
+			placeholder: translate( 'e.g. promotion' ),
+			describedBy: 'stats-utm-builder-help-section-campaign-name',
+		},
 		utm_source: {
 			label: translate( 'UTM Source' ),
 			placeholder: translate( 'e.g. newsletter' ),
@@ -151,11 +156,6 @@ const UtmBuilder: React.FC< UtmBuilderProps > = ( { initialData } ) => {
 			label: translate( 'UTM Medium' ),
 			placeholder: translate( 'e.g. email, social' ),
 			describedBy: 'stats-utm-builder-help-section-campaign-medium',
-		},
-		utm_campaign: {
-			label: translate( 'UTM Campaign' ),
-			placeholder: translate( 'e.g. promotion' ),
-			describedBy: 'stats-utm-builder-help-section-campaign-name',
 		},
 	};
 

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -113,6 +113,7 @@ const InputField: React.FC< InputFieldProps > = ( {
 				placeholder={ placeholder }
 				aria-describedby={ ariaDescribedBy }
 				aria-labelledby={ `${ id }-label` }
+				autocomplete="off"
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -138,22 +138,22 @@ const UtmBuilder: React.FC< UtmBuilderProps > = ( { initialData } ) => {
 
 	const fromLabels: formLabelsType = {
 		url: {
-			label: translate( 'Site or post URL' ),
+			label: translate( 'Destination URL' ),
 			placeholder: '',
 			describedBy: 'stats-utm-builder-help-section-url',
 		},
 		utm_source: {
-			label: translate( 'UTM source' ),
+			label: translate( 'UTM Source' ),
 			placeholder: translate( 'e.g. newsletter' ),
 			describedBy: 'stats-utm-builder-help-section-campaign-source',
 		},
 		utm_medium: {
-			label: translate( 'UTM medium' ),
+			label: translate( 'UTM Medium' ),
 			placeholder: translate( 'e.g. email, social' ),
 			describedBy: 'stats-utm-builder-help-section-campaign-medium',
 		},
 		utm_campaign: {
-			label: translate( 'UTM campaign' ),
+			label: translate( 'UTM Campaign' ),
 			placeholder: translate( 'e.g. promotion' ),
 			describedBy: 'stats-utm-builder-help-section-campaign-name',
 		},

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -106,7 +106,6 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 							</VisuallyHidden>
 
 							<section id="stats-utm-builder-help-section-campaign-name">
-								<h3 className="stats-utm-builder__label">{ translate( 'Campaign Name' ) }</h3>
 								<pre className="stats-utm-builder__help-section-parameter">utm_campaign</pre>
 								<p>
 									{ translate(
@@ -119,7 +118,6 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 							</section>
 
 							<section id="stats-utm-builder-help-section-campaign-source">
-								<h3 className="stats-utm-builder__label">{ translate( 'Campaign Source' ) }</h3>
 								<pre className="stats-utm-builder__help-section-parameter">utm_source</pre>
 								<p>
 									{ translate(
@@ -132,7 +130,6 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 							</section>
 
 							<section id="stats-utm-builder-help-section-campaign-medium">
-								<h3 className="stats-utm-builder__label">{ translate( 'Campaign Medium' ) }</h3>
 								<pre className="stats-utm-builder__help-section-parameter">utm_medium</pre>
 								<p>
 									{ translate(

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -107,37 +107,25 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 
 							<section id="stats-utm-builder-help-section-campaign-name">
 								<pre className="stats-utm-builder__help-section-parameter">utm_campaign</pre>
-								<p>
-									{ translate(
-										'Use utm_campaign to identify a specific product promotion or strategic campaign.'
-									) }
-								</p>
+								<p>{ translate( 'Name your campaign' ) }</p>
 								<p className="stats-utm-builder__help-section-parameter-example">
-									{ translate( 'Example: promotion, sale' ) }
+									{ translate( 'Example: christmas, flash-sale' ) }
 								</p>
 							</section>
 
 							<section id="stats-utm-builder-help-section-campaign-source">
 								<pre className="stats-utm-builder__help-section-parameter">utm_source</pre>
-								<p>
-									{ translate(
-										'Use utm_source to identify a search engine, newsletter name or other source.'
-									) }
-								</p>
+								<p>{ translate( 'Define where traffic originates' ) }</p>
 								<p className="stats-utm-builder__help-section-parameter-example">
-									{ translate( 'Example: newsletter, X, Google' ) }
+									{ translate( 'Example: newsletter, facebook, google' ) }
 								</p>
 							</section>
 
 							<section id="stats-utm-builder-help-section-campaign-medium">
 								<pre className="stats-utm-builder__help-section-parameter">utm_medium</pre>
-								<p>
-									{ translate(
-										'Use utm_medium to identify a medium such as email or cost-per-click.'
-									) }
-								</p>
+								<p>{ translate( 'Define the channel type' ) }</p>
 								<p className="stats-utm-builder__help-section-parameter-example">
-									{ translate( 'Example: cpc, banner, email' ) }
+									{ translate( 'Example: email, social, cpc' ) }
 								</p>
 							</section>
 

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -86,14 +86,15 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 						</div>
 						<div className="stats-utm-builder__help">
 							<div className="stats-utm-builder__help-bg"></div>
-							<div className="stats-utm-builder__label">
+							<h2 className="stats-utm-builder__label">
 								{ translate( 'Why should I use this?' ) }
-							</div>
-							<div className="stats-utm-builder__description">
+							</h2>
+							<p className="stats-utm-builder__description">
 								{ translate(
 									'UTM codes help track where your traffic comes from. Adding them to your URLs gives you insights into what works and where to optimize.'
 								) }
-							</div>
+							</p>
+
 							<VisuallyHidden>
 								<section id="stats-utm-builder-help-section-url">
 									<div className="stats-utm-builder__label">{ translate( 'URL' ) }</div>
@@ -103,41 +104,44 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 									</div>
 								</section>
 							</VisuallyHidden>
+
 							<section id="stats-utm-builder-help-section-campaign-name">
-								<div className="stats-utm-builder__label">{ translate( 'Campaign Name' ) }</div>
-								<div className="stats-utm-builder__help-section-parameter">utm_campaign</div>
-								<div>
+								<h3 className="stats-utm-builder__label">{ translate( 'Campaign Name' ) }</h3>
+								<pre className="stats-utm-builder__help-section-parameter">utm_campaign</pre>
+								<p>
 									{ translate(
 										'Use utm_campaign to identify a specific product promotion or strategic campaign.'
 									) }
-								</div>
-								<div className="stats-utm-builder__help-section-parameter-example">
+								</p>
+								<p className="stats-utm-builder__help-section-parameter-example">
 									{ translate( 'Example: promotion, sale' ) }
-								</div>
+								</p>
 							</section>
+
 							<section id="stats-utm-builder-help-section-campaign-source">
-								<div className="stats-utm-builder__label">{ translate( 'Campaign Source' ) }</div>
-								<div className="stats-utm-builder__help-section-parameter">utm_source</div>
-								<div>
+								<h3 className="stats-utm-builder__label">{ translate( 'Campaign Source' ) }</h3>
+								<pre className="stats-utm-builder__help-section-parameter">utm_source</pre>
+								<p>
 									{ translate(
 										'Use utm_source to identify a search engine, newsletter name or other source.'
 									) }
-								</div>
-								<div className="stats-utm-builder__help-section-parameter-example">
+								</p>
+								<p className="stats-utm-builder__help-section-parameter-example">
 									{ translate( 'Example: newsletter, X, Google' ) }
-								</div>
+								</p>
 							</section>
+
 							<section id="stats-utm-builder-help-section-campaign-medium">
-								<div className="stats-utm-builder__label">{ translate( 'Campaign Medium' ) }</div>
-								<div className="stats-utm-builder__help-section-parameter">utm_medium</div>
-								<div>
+								<h3 className="stats-utm-builder__label">{ translate( 'Campaign Medium' ) }</h3>
+								<pre className="stats-utm-builder__help-section-parameter">utm_medium</pre>
+								<p>
 									{ translate(
 										'Use utm_medium to identify a medium such as email or cost-per-click.'
 									) }
-								</div>
-								<div className="stats-utm-builder__help-section-parameter-example">
+								</p>
+								<p className="stats-utm-builder__help-section-parameter-example">
 									{ translate( 'Example: cpc, banner, email' ) }
-								</div>
+								</p>
 							</section>
 						</div>
 					</div>

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -72,7 +72,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 			{ triggerNode }
 			{ isOpen && (
 				<Modal
-					title={ translate( 'URL Builder' ) }
+					title={ translate( 'Generate URL' ) }
 					onRequestClose={ closeModal }
 					overlayClassName={ utmBuilderClasses }
 					bodyOpenClassName="stats-utm-builder__body-modal-open"

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -98,6 +98,18 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 									</div>
 								</section>
 							</VisuallyHidden>
+							<section id="stats-utm-builder-help-section-campaign-name">
+								<div className="stats-utm-builder__label">{ translate( 'Campaign Name' ) }</div>
+								<div className="stats-utm-builder__help-section-parameter">utm_campaign</div>
+								<div>
+									{ translate(
+										'Use utm_campaign to identify a specific product promotion or strategic campaign.'
+									) }
+								</div>
+								<div className="stats-utm-builder__help-section-parameter-example">
+									{ translate( 'Example: promotion, sale' ) }
+								</div>
+							</section>
 							<section id="stats-utm-builder-help-section-campaign-source">
 								<div className="stats-utm-builder__label">{ translate( 'Campaign Source' ) }</div>
 								<div className="stats-utm-builder__help-section-parameter">utm_source</div>
@@ -120,18 +132,6 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 								</div>
 								<div className="stats-utm-builder__help-section-parameter-example">
 									{ translate( 'Example: cpc, banner, email' ) }
-								</div>
-							</section>
-							<section id="stats-utm-builder-help-section-campaign-name">
-								<div className="stats-utm-builder__label">{ translate( 'Campaign Name' ) }</div>
-								<div className="stats-utm-builder__help-section-parameter">utm_campaign</div>
-								<div>
-									{ translate(
-										'Use utm_campaign to identify a specific product promotion or strategic campaign.'
-									) }
-								</div>
-								<div className="stats-utm-builder__help-section-parameter-example">
-									{ translate( 'Example: promotion, sale' ) }
 								</div>
 							</section>
 						</div>

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -140,6 +140,12 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 									{ translate( 'Example: cpc, banner, email' ) }
 								</p>
 							</section>
+
+							<p>
+								{ translate(
+									'Use your generated URLs in social posts, emails, or ads. Jetpack Stats will track UTM codes, giving you accurate insights into your traffic.'
+								) }
+							</p>
 						</div>
 					</div>
 				</Modal>

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -86,8 +86,13 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 						</div>
 						<div className="stats-utm-builder__help">
 							<div className="stats-utm-builder__help-bg"></div>
+							<div className="stats-utm-builder__label">
+								{ translate( 'Why should I use this?' ) }
+							</div>
 							<div className="stats-utm-builder__description">
-								{ translate( 'Parameter descriptions and examples.' ) }
+								{ translate(
+									'UTM codes help track where your traffic comes from. Adding them to your URLs gives you insights into what works and where to optimize.'
+								) }
 							</div>
 							<VisuallyHidden>
 								<section id="stats-utm-builder-help-section-url">

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Modal, Button, VisuallyHidden } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { link } from '@wordpress/icons';
@@ -63,6 +64,9 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 		</Button>
 	);
 
+	const isWPAdmin = config.isEnabled( 'is_odyssey' );
+	const utmBuilderClasses = clsx( 'stats-utm-builder__overlay', { 'is-odyssey-stats': isWPAdmin } );
+
 	return (
 		<>
 			{ triggerNode }
@@ -70,7 +74,7 @@ const UTMBuilder: React.FC< Props > = ( { modalClassName, trigger, initialData }
 				<Modal
 					title={ translate( 'URL Builder' ) }
 					onRequestClose={ closeModal }
-					overlayClassName="stats-utm-builder__overlay"
+					overlayClassName={ utmBuilderClasses }
 					bodyOpenClassName="stats-utm-builder__body-modal-open"
 				>
 					<div className={ clsx( modalClassName, 'stats-utm-builder-modal' ) }>

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -101,8 +101,12 @@ $modal-content-padding: 32px;
 		position: relative;
 	}
 
-	section + section {
-		padding-top: 12px;
+	section {
+		margin-bottom: 24px;
+	}
+
+	section p {
+		margin-bottom: 0;
 	}
 }
 

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -27,6 +27,7 @@ $modal-content-padding: 32px;
 		h1.components-modal__header-heading {
 			font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
 			line-height: 39px;
+			font-weight: 400;
 		}
 	}
 }

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -151,6 +151,7 @@ $modal-content-padding: 32px;
 
 .stats-utm-builder__help-section-parameter-example {
 	font-style: italic;
+	color: $studio-gray-40;
 }
 
 .stats-utm-builder__trigger {

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -94,6 +94,7 @@ $modal-content-padding: 32px;
 .stats-utm-builder__help {
 	flex: 1 0 45%;
 	padding: 0 0 0 $stats-utm-builder-help-padding;
+	max-width: 35em;
 
 	@media (max-width: $break-small) {
 		padding: $stats-utm-builder-vertical-spacing 0 0 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/2339

## Proposed Changes

Implements changes to URL Builder per the linked Issue.

- Updates title
- Updates order of fields to emphasize campaign
- Updates help section
- Updates underlying HTML to use more semantic markup
- Updates styles for presentation & layout

### Screenshot with updated copy

<img width="997" alt="418183398-be612590-9ab5-496c-8db5-9f07882664e4" src="https://github.com/user-attachments/assets/cb1f7a29-d80b-41fc-9f46-6eec174924a7" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of Code Blue project and ongoing Stats maintenance work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Stats → Traffic page.
* Scroll down to the UTM module and open the UTM link builder.
* Confirm the UI matches the updated designs in [2339](https://github.com/Automattic/jetpack-roadmap/issues/2339).

### Note on fonts

To properly test the font changes, you'll need to test with a self-hosted setup as outlined here:

PCYsg-Pp7-p2

- Confirm the modal header is Recoleta in Calypso.
- Confirm the modal header is SF Pro Display in self-hosted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?