### PR TITLE
Try tidying up text decoration across the codebase (I know.... :'))

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -256,10 +256,6 @@ th {
 }
 
 /* Links */
-// a {
-// 	text-decoration: none;
-// }
-
 a,
 a:visited {
 	color: var(--color-link);

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -256,9 +256,9 @@ th {
 }
 
 /* Links */
-a {
-	text-decoration: none;
-}
+// a {
+// 	text-decoration: none;
+// }
 
 a,
 a:visited {

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -59,6 +59,12 @@
 	}
 }
 
+.author-compact-profile__names {
+	a {
+		text-decoration: none;
+	}
+}
+
 .author-compact-profile .reader-author-link,
 .author-compact-profile__site-link,
 .author-compact-profile__follow {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -526,6 +526,10 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .reader-full-post__header {
 	margin-bottom: 23px;
+
+	a {
+		text-decoration: none;
+	}
 }
 
 .reader-full-post__featured-image {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -400,6 +400,10 @@
 	}
 }
 
+.reader-post-card__tag-link {
+	text-decoration: none;
+}
+
 .reader-feed-header__seen-button:focus {
 	outline: dotted 1px;
 }

--- a/client/components/link-card/style.scss
+++ b/client/components/link-card/style.scss
@@ -4,3 +4,7 @@
 	--scss-font-body-small: #{$font-body-small};
 	--scss-font-body-extra-small: #{$font-body-extra-small};
 }
+
+.card-block {
+	text-decoration: none;
+}

--- a/client/components/section-nav/tabs.scss
+++ b/client/components/section-nav/tabs.scss
@@ -34,6 +34,10 @@
 	margin: 0;
 	list-style: none;
 
+	a {
+		text-decoration: none;
+	}
+
 	@mixin tabs-view-styles {
 		display: flex;
 		width: 100%;

--- a/client/components/vertical-nav/style.scss
+++ b/client/components/vertical-nav/style.scss
@@ -1,3 +1,7 @@
 .vertical-nav {
 	margin-top: 15px;
+
+	a {
+		text-decoration: none;
+	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -795,6 +795,10 @@ body.is-mobile-app-view {
 		min-width: 264px !important;
 		padding-top: 12px;
 
+		a {
+			text-decoration: none;
+		}
+
 		@media only screen and (max-width: 781px) {
 			max-height: 100%;
 		}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -158,6 +158,10 @@ $font-size: rem(14px);
 		min-height: calc(100vh - var(--masterbar-height));
 		box-sizing: border-box;
 
+		a {
+			text-decoration: none;
+		}
+
 		.sidebar__separator {
 			margin: 0 0 11px;
 		}

--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -36,6 +36,7 @@
 
 	&.is-card-link {
 		padding-right: 48px;
+		text-decoration: none;
 		&:not(a) {
 			color: var(--color-primary);
 			font-size: 100%;

--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -13,6 +13,10 @@
 	// Card class name is too generic. Which results and this component randomly getting borders.
 	border: none;
 
+	a {
+		text-decoration: none;
+	}
+
 	@include a8c-clear-fix;
 
 	@include break-mobile {

--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -13,8 +13,11 @@
 	// Card class name is too generic. Which results and this component randomly getting borders.
 	border: none;
 
-	a {
+	 a {
 		text-decoration: none;
+	}
+	p a {
+		text-decoration: underline;
 	}
 
 	@include a8c-clear-fix;

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -124,6 +124,7 @@
 		margin: $padding-outside $padding-outside 0;
 		display: block;
 		color: var(--color-text);
+		text-decoration: none; // TODO: Should this be a tertiary button component instead?
 
 		&:visited {
 			color: $font-color;

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -81,6 +81,7 @@
 
 					a {
 						font-size: $font-body-small;
+						text-decoration: none;
 					}
 
 					ol {

--- a/packages/help-center/src/components/help-center-article.scss
+++ b/packages/help-center/src/components/help-center-article.scss
@@ -54,10 +54,6 @@
 				border-color: inherit;
 			}
 
-			a:not(.help-center-article-content__header-title-link) {
-				text-decoration: none;
-			}
-
 			a[name="toc"] span {
 				color: var(--color-neutral-80);
 				font-size: $font-body;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #99254

## Proposed Changes

This is a very naive first attempt at removing the global text-decoration rule that affects all anchor tags, and replacing it with scoped rules for areas where we're pretty sure we don't need underlines on links.

For now I just removed the base rule and re-added it inside the nav sidebar and the card component.

I've noticed right away that there are underlines missing in places where I think they should exist, such as the copy inside this modal:

<img width="706" alt="Screenshot 2025-03-14 at 4 47 07 pm" src="https://github.com/user-attachments/assets/8a312296-5f95-482e-8056-75e5cc5db19a" />

Looks like there are more targeted text-decoration rules that will also have to be removed 😬 

To be updated as more testing occurs!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Look through all the Calypso screens and check whether there are underlines where there shouldn't be (and vice-versa)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
