### PR TITLE
Keep checklist indicator visible until complete or dismissed

### DIFF
--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -92,7 +92,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	} );
 
 	const {
-		data: { checklist, is_dismissed },
+		data: { checklist, is_dismissed, launchpad_screen },
 		isLoading,
 	} = useLaunchpad( site.slug, getChecklistSlug( site ), undefined, 'sites-dashboard' );
 
@@ -103,7 +103,7 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	let numberOfSteps = checklist.length || 0;
 	let completedSteps = ( checklist.filter( ( task ) => task.completed ) || [] ).length;
 
-	if ( shouldShowLaunchpadFirst( site ) ) {
+	if ( shouldShowLaunchpadFirst( site ) && launchpad_screen !== 'skipped' ) {
 		// The focused launchpad on My Home doesn't include the launch site task in the count.
 		// In which case, we want this donut to match the one on the focused launchpad.
 		const launchSiteTask = checklist?.find( ( task ) => task.isLaunchTask );

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -82,6 +82,16 @@ const getChecklistSlug = ( site: SiteExcerptData ) => {
 		return 'legacy-site-setup';
 	}
 
+	if ( site.launch_status === 'launched' ) {
+		if ( intent === 'build' ) {
+			return 'intent-build';
+		}
+
+		if ( intent === 'write' ) {
+			return 'intent-write';
+		}
+	}
+
 	return intent;
 };
 

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -71,6 +71,10 @@ const getChecklistSlug = ( site: SiteExcerptData ) => {
 		return 'legacy-site-setup';
 	}
 
+	if ( intent === 'assembler-first' ) {
+		return 'legacy-site-setup';
+	}
+
 	const isHostedSite =
 		'host-site' === intent || 'new-hosted-site' === flow || 'import-hosted-site' === flow;
 
@@ -88,11 +92,11 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	} );
 
 	const {
-		data: { checklist },
+		data: { checklist, is_dismissed },
 		isLoading,
 	} = useLaunchpad( site.slug, getChecklistSlug( site ), undefined, 'sites-dashboard' );
 
-	if ( 'unlaunched' !== site.launch_status || ! checklist || isLoading ) {
+	if ( ! checklist || isLoading || is_dismissed ) {
 		return null;
 	}
 
@@ -107,6 +111,10 @@ export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 
 		numberOfSteps = numberOfSteps - ( launchSiteTask ? 1 : 0 );
 		completedSteps = completedSteps - ( isLaunchSiteTaskComplete ? 1 : 0 );
+	}
+
+	if ( completedSteps === numberOfSteps ) {
+		return null;
 	}
 
 	const link = getDashboardUrl( site.slug );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100258

## Proposed Changes

We no longer care about launch status when deciding if we should show the checklist progress indicator on the /sites dashboard.

Now, we always show the indicator unless one of the following is true:

- The checklist has been dismissed
- The checklist has been completed

## Testing

- [ ] Complete all launchpad checklist tasks, if you now have new tasks, observe the checklist progress changing in /sites
- [ ] Now complete the new task list, observe the checklist being hidden once tasks are completed
- [ ] Dismiss a dismissable launchpad checklist, observe the checklist being hidden early (I think only the second round of tasks can be dismissed early)

Before
<img width=400 src=https://github.com/user-attachments/assets/0b3b7e1b-fd9b-433c-ace4-06ed6b285de9/>

After

<img width=400 src=https://github.com/user-attachments/assets/8c11a772-ebfb-43c4-a3ca-1128d1db2719/>
