### PR TITLE
Updating gap between goal checkboxes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -26,7 +26,7 @@
 	&__cards-container {
 		font-family: Inter, $sans;
 		display: grid;
-		gap: 16px;
+		gap: 12px;
 		width: 100%;
 		grid-template-columns: repeat(1, 1fr);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101189

## Proposed Changes

* Slightly narrower gap between onboarding goal checkboxes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Note the updated gap in Figma W9xI27S6Swvw5Ku21EbZvn-fi-9588_13026

Part of the onboarding consistency pass work p9Jlb4-fMP-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/setup/site-setup?siteSlug={{ some existing site }}`
* Check various browser sizes
* The gap between goal checkboxes should be 12px

![CleanShot 2025-03-14 at 20 13 55@2x](https://github.com/user-attachments/assets/11940f22-e734-402a-acd5-b16c99be942b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?