### PR TITLE
Add refresh URL argument to hosting overview

### DIFF
--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,9 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
+import { type FC, useEffect, useState } from 'react';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { isNotAtomicJetpack, isMigrationInProgress } from 'calypso/sites-dashboard/utils';
-import { useSelector } from 'calypso/state';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { useDispatch, useSelector } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
+import { isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ActiveDomainsCard from './active-domains-card';
 import MigrationOverview from './migration-overview';
 import PlanCard from './plan-card';
@@ -16,7 +19,51 @@ import './style.scss';
 
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const isRequestingSelectedSite = useSelector(
+		( state ) => !! selectedSiteId && isRequestingSite( state, selectedSiteId )
+	);
+	const isRequestingAllSites = useSelector( isRequestingSites );
+	const [ siteRequested, setSiteRequested ] = useState( false );
+	const [ wasAllSitesPending, setWasAllSitesPending ] = useState( false );
+
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( siteRequested || ! selectedSiteId ) {
+			return;
+		}
+
+		const urlParams = new URLSearchParams( globalThis.location?.search ?? '' );
+		if ( urlParams.get( 'refresh' ) !== 'true' ) {
+			return;
+		}
+
+		// If we're already fetching the site or all sites, no need to force a refresh.
+		if ( isRequestingSelectedSite || isRequestingAllSites ) {
+			setSiteRequested( true );
+			if ( isRequestingAllSites ) {
+				setWasAllSitesPending( true );
+			}
+			return;
+		}
+
+		dispatch( requestSite( selectedSiteId ) );
+		setSiteRequested( true );
+	}, [ dispatch, isRequestingSelectedSite, isRequestingAllSites, selectedSiteId, siteRequested ] );
+
+	if (
+		selectedSiteId &&
+		siteRequested &&
+		( isRequestingSelectedSite || ( wasAllSitesPending && isRequestingAllSites ) )
+	) {
+		return (
+			<div className="hosting-overview is-loading">
+				<LoadingEllipsis />
+			</div>
+		);
+	}
 
 	if ( site ) {
 		if ( isMigrationInProgress( site ) ) {

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -59,7 +59,7 @@ const HostingOverview: FC = () => {
 		( isRequestingSelectedSite || ( wasAllSitesPending && isRequestingAllSites ) )
 	) {
 		return (
-			<div className="hosting-overview is-loading">
+			<div className="hosting-overview is-loading" data-testid="hosting-overview-loading">
 				<ProgressBar className="hosting-overview__progress-bar" />
 			</div>
 		);

--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,6 +1,6 @@
+import { ProgressBar } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, useEffect, useState } from 'react';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { isNotAtomicJetpack, isMigrationInProgress } from 'calypso/sites-dashboard/utils';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -60,7 +60,7 @@ const HostingOverview: FC = () => {
 	) {
 		return (
 			<div className="hosting-overview is-loading">
-				<LoadingEllipsis />
+				<ProgressBar className="hosting-overview__progress-bar" />
 			</div>
 		);
 	}

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -133,8 +133,8 @@ $blueberry-color: #3858e9;
 		display: flex;
 		justify-content: center;
 
-		.wpcom__loading-ellipsis {
-			margin-top: 5vh;
+		.hosting-overview__progress-bar {
+			margin-top: 10vh;
 		}
 	}
 }

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -129,6 +129,14 @@ $blueberry-color: #3858e9;
 		}
 	}
 
+	&.is-loading {
+		display: flex;
+		justify-content: center;
+
+		.wpcom__loading-ellipsis {
+			margin-top: 5vh;
+		}
+	}
 }
 
 .hosting-overview__domain-to-plan-credit-notice {

--- a/client/sites/overview/components/test/hosting-overview.tsx
+++ b/client/sites/overview/components/test/hosting-overview.tsx
@@ -6,20 +6,32 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
+import { createReduxStore } from 'calypso/state';
+import { SITE_REQUEST, SITES_REQUEST, SELECTED_SITE_SET } from 'calypso/state/action-types';
+import { setStore } from 'calypso/state/redux-store';
 import * as siteActions from 'calypso/state/sites/actions';
 import HostingOverview from '../hosting-overview';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { UnknownAction } from 'redux';
+
 // Store original location so we can restore it after all tests.
 const originalLocation = window.location;
 
-// Mock the QuerySitePlans component to return null as it dispatches
-// a non-object thunk action that isn't handled by the mocked Redux store.
-jest.mock( 'calypso/components/data/query-site-plans', () => jest.fn( () => null ) );
+type LocalRenderWithProviderOptions = {
+	initialState?: Record< string, unknown >;
+	additionalActions?: UnknownAction[];
+};
+const localRenderWithProvider = (
+	element,
+	{ initialState, additionalActions = [] }: LocalRenderWithProviderOptions
+) => {
+	const store = createReduxStore( initialState ?? {} );
 
-const localRenderWithProvider = ( element, { initialState } ) => {
-	const mockStore = configureStore();
-	const store = mockStore( initialState );
+	setStore( store );
+
+	additionalActions.forEach( ( action ) => {
+		store.dispatch( action );
+	} );
 
 	const queryClient = new QueryClient();
 	return render(
@@ -97,9 +109,6 @@ const mockCalypsoState = {
 		capabilities: {},
 		flags: [],
 	},
-	purchases: {
-		isFetchingSitePurchases: true,
-	},
 	sites: {
 		items: {
 			[ mockSiteId ]: buildMockSite( {} ),
@@ -115,13 +124,19 @@ const mockCalypsoState = {
 		requesting: {},
 		requestingAll: false,
 	},
-	ui: {
-		selectedSiteId: mockSiteId,
-	},
 };
 
-const mockRequestSiteAction = {
-	type: 'SITE_REQUEST',
+const mockRequestSiteAction: UnknownAction = {
+	type: SITE_REQUEST,
+	siteId: mockSiteId,
+};
+
+const mockRequestSitesAction: UnknownAction = {
+	type: SITES_REQUEST,
+};
+
+const mockSetSelectedSiteIdAction: UnknownAction = {
+	type: SELECTED_SITE_SET,
 	siteId: mockSiteId,
 };
 
@@ -145,55 +160,57 @@ describe( 'HostingOverview', () => {
 			window.location.search = '';
 		} );
 
-		it( 'should load the page and not request site details', () => {
-			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+		it( 'should load the page and not request site details', async () => {
+			const requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
 
-			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+			const { getByText, queryByTestId } = localRenderWithProvider( <HostingOverview />, {
 				initialState: mockCalypsoState,
+				additionalActions: [ mockSetSelectedSiteIdAction ],
 			} );
 
 			expect( requestSiteSpy ).not.toHaveBeenCalled();
 
-			waitFor( () => {
+			await waitFor( () => {
+				// NavigationHeader
+				expect( getByText( 'Overview' ) ).toBeVisible();
 				// SiteBackupCard
 				expect( getByText( 'Site backup' ) ).toBeVisible();
 				// QuickActionsCard
 				expect( getByText( 'Command Palette' ) ).toBeVisible();
-				// ActiveDomainsCard
-				expect( getByText( 'Active domains' ) ).toBeVisible();
 				// SupportCard
 				expect( getByText( 'Need some help?' ) ).toBeVisible();
 
-				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+				expect( queryByTestId( 'hosting-overview-loading' ) ).not.toBeInTheDocument();
 			} );
 		} );
 
-		it( 'should not request the site details when refresh is present', () => {
+		it( 'should not request the site details when refresh is present', async () => {
 			window.location.search = '?refresh';
 
-			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+			const requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
 
-			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+			const { getByText, queryByTestId } = localRenderWithProvider( <HostingOverview />, {
 				initialState: mockCalypsoState,
+				additionalActions: [ mockSetSelectedSiteIdAction ],
 			} );
 
 			expect( requestSiteSpy ).not.toHaveBeenCalled();
 
-			waitFor( () => {
+			await waitFor( () => {
+				// NavigationHeader
+				expect( getByText( 'Overview' ) ).toBeVisible();
 				// SiteBackupCard
 				expect( getByText( 'Site backup' ) ).toBeVisible();
 				// QuickActionsCard
 				expect( getByText( 'Command Palette' ) ).toBeVisible();
-				// ActiveDomainsCard
-				expect( getByText( 'Active domains' ) ).toBeVisible();
 				// SupportCard
 				expect( getByText( 'Need some help?' ) ).toBeVisible();
 
-				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+				expect( queryByTestId( 'hosting-overview-loading' ) ).not.toBeInTheDocument();
 			} );
 		} );
 
-		it( 'should load the page when the current site details are being requested', () => {
+		it( 'should load the page when the current site details are being requested', async () => {
 			const initialState = {
 				...mockCalypsoState,
 				sites: {
@@ -203,30 +220,32 @@ describe( 'HostingOverview', () => {
 					},
 				},
 			};
+			const additionalActions = [ mockSetSelectedSiteIdAction, mockRequestSiteAction ];
 
-			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+			const requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
 
-			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+			const { getByText, queryByTestId } = localRenderWithProvider( <HostingOverview />, {
 				initialState,
+				additionalActions,
 			} );
 
 			expect( requestSiteSpy ).not.toHaveBeenCalled();
 
-			waitFor( () => {
+			await waitFor( () => {
+				// NavigationHeader
+				expect( getByText( 'Overview' ) ).toBeVisible();
 				// SiteBackupCard
 				expect( getByText( 'Site backup' ) ).toBeVisible();
 				// QuickActionsCard
 				expect( getByText( 'Command Palette' ) ).toBeVisible();
-				// ActiveDomainsCard
-				expect( getByText( 'Active domains' ) ).toBeVisible();
 				// SupportCard
 				expect( getByText( 'Need some help?' ) ).toBeVisible();
 
-				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+				expect( queryByTestId( 'hosting-overview-loading' ) ).not.toBeInTheDocument();
 			} );
 		} );
 
-		it( 'should load the page when all site details are being requested', () => {
+		it( 'should load the page when all site details are being requested', async () => {
 			const initialState = {
 				...mockCalypsoState,
 				sites: {
@@ -234,26 +253,28 @@ describe( 'HostingOverview', () => {
 					requestingAll: true,
 				},
 			};
+			const additionalActions = [ mockRequestSitesAction ];
 
-			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+			const requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
 
-			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+			const { getByText, queryByTestId } = localRenderWithProvider( <HostingOverview />, {
 				initialState,
+				additionalActions,
 			} );
 
 			expect( requestSiteSpy ).not.toHaveBeenCalled();
 
-			waitFor( () => {
+			await waitFor( () => {
+				// NavigationHeader
+				expect( getByText( 'Overview' ) ).toBeVisible();
 				// SiteBackupCard
 				expect( getByText( 'Site backup' ) ).toBeVisible();
 				// QuickActionsCard
 				expect( getByText( 'Command Palette' ) ).toBeVisible();
-				// ActiveDomainsCard
-				expect( getByText( 'Active domains' ) ).toBeVisible();
 				// SupportCard
 				expect( getByText( 'Need some help?' ) ).toBeVisible();
 
-				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+				expect( queryByTestId( 'hosting-overview-loading' ) ).not.toBeInTheDocument();
 			} );
 		} );
 	} );
@@ -263,53 +284,44 @@ describe( 'HostingOverview', () => {
 			window.location.search = '?refresh=true';
 		} );
 
-		it( 'should request the site details when no site data is being requested', () => {
-			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+		it( 'should request the site details when no site data is being requested', async () => {
+			const requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
 			requestSiteSpy.mockImplementation( () => {
 				return mockRequestSiteAction;
 			} );
 
-			const { getByTestId } = localRenderWithProvider( <HostingOverview />, {
+			const { getByTestId } = localRenderWithProvider( <HostingOverview debug />, {
 				initialState: mockCalypsoState,
+				additionalActions: [ mockSetSelectedSiteIdAction ],
 			} );
 
-			expect( requestSiteSpy ).toHaveBeenCalled();
-			waitFor( () => {
+			await waitFor( () => {
+				expect( requestSiteSpy ).toHaveBeenCalled();
 				expect( getByTestId( 'hosting-overview-loading' ) ).toBeVisible();
 			} );
 		} );
 
 		it( 'should not request the site details when the current site is being requested', () => {
-			const initialState = {
-				...mockCalypsoState,
-				sites: {
-					...mockCalypsoState.sites,
-					requesting: {
-						[ mockSiteId ]: true,
-					},
-				},
-			};
+			const requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+			const additionalActions = [ mockSetSelectedSiteIdAction, mockRequestSiteAction ];
 
-			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
-
-			const { getByTestId } = localRenderWithProvider( <HostingOverview />, { initialState } );
+			const { getByTestId } = localRenderWithProvider( <HostingOverview />, {
+				initialState: mockCalypsoState,
+				additionalActions,
+			} );
 
 			expect( requestSiteSpy ).not.toHaveBeenCalled();
 			expect( getByTestId( 'hosting-overview-loading' ) ).toBeVisible();
 		} );
 
 		it( 'should not request the site details when all sites are being requested', () => {
-			const initialState = {
-				...mockCalypsoState,
-				sites: {
-					...mockCalypsoState.sites,
-					requestingAll: true,
-				},
-			};
+			const requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+			const additionalActions = [ mockSetSelectedSiteIdAction, mockRequestSitesAction ];
 
-			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
-
-			const { getByTestId } = localRenderWithProvider( <HostingOverview />, { initialState } );
+			const { getByTestId } = localRenderWithProvider( <HostingOverview />, {
+				initialState: mockCalypsoState,
+				additionalActions,
+			} );
 
 			expect( requestSiteSpy ).not.toHaveBeenCalled();
 			expect( getByTestId( 'hosting-overview-loading' ) ).toBeVisible();

--- a/client/sites/overview/components/test/hosting-overview.tsx
+++ b/client/sites/overview/components/test/hosting-overview.tsx
@@ -2,14 +2,13 @@
  * @jest-environment jsdom
  */
 import { MigrationStatus } from '@automattic/data-stores';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import React from 'react';
-import { Provider } from 'react-redux';
 import { createReduxStore } from 'calypso/state';
 import { SITE_REQUEST, SITES_REQUEST, SELECTED_SITE_SET } from 'calypso/state/action-types';
 import { setStore } from 'calypso/state/redux-store';
 import * as siteActions from 'calypso/state/sites/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import HostingOverview from '../hosting-overview';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { UnknownAction } from 'redux';
@@ -33,12 +32,7 @@ const localRenderWithProvider = (
 		store.dispatch( action );
 	} );
 
-	const queryClient = new QueryClient();
-	return render(
-		<QueryClientProvider client={ queryClient }>
-			<Provider store={ store }>{ element }</Provider>
-		</QueryClientProvider>
-	);
+	return renderWithProvider( element, { store } );
 };
 
 const mockSiteId = 123;

--- a/client/sites/overview/components/test/hosting-overview.tsx
+++ b/client/sites/overview/components/test/hosting-overview.tsx
@@ -1,0 +1,318 @@
+/**
+ * @jest-environment jsdom
+ */
+import { MigrationStatus } from '@automattic/data-stores';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import * as siteActions from 'calypso/state/sites/actions';
+import HostingOverview from '../hosting-overview';
+import type { SiteDetails } from '@automattic/data-stores';
+// Store original location so we can restore it after all tests.
+const originalLocation = window.location;
+
+// Mock the QuerySitePlans component to return null as it dispatches
+// a non-object thunk action that isn't handled by the mocked Redux store.
+jest.mock( 'calypso/components/data/query-site-plans', () => jest.fn( () => null ) );
+
+const localRenderWithProvider = ( element, { initialState } ) => {
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+
+	const queryClient = new QueryClient();
+	return render(
+		<QueryClientProvider client={ queryClient }>
+			<Provider store={ store }>{ element }</Provider>
+		</QueryClientProvider>
+	);
+};
+
+const mockSiteId = 123;
+
+type MockSiteOptions = {
+	is_wpcom_atomic?: boolean;
+	migrationStatus?: MigrationStatus;
+	migrationSticker?: string;
+};
+
+const buildMockSite = ( {
+	is_wpcom_atomic = false,
+	migrationStatus = MigrationStatus.UNKNOWN,
+	migrationSticker,
+}: MockSiteOptions ): SiteDetails => {
+	return {
+		ID: mockSiteId,
+		slug: 'test-site.wordpress.com',
+		URL: 'https://test-site.wordpress.com',
+		capabilities: {
+			activate_plugins: false,
+			activate_wordads: false,
+			delete_others_posts: true,
+			delete_posts: true,
+			delete_users: true,
+			edit_others_pages: true,
+			edit_others_posts: true,
+			edit_pages: true,
+			edit_posts: true,
+			edit_theme_options: true,
+			edit_users: true,
+			list_users: true,
+			manage_categories: true,
+			manage_options: true,
+			moderate_comments: true,
+			own_site: true,
+			promote_users: true,
+			publish_posts: true,
+			remove_users: true,
+			upload_files: true,
+			update_plugins: false,
+			view_hosting: true,
+			view_stats: true,
+		},
+		description: 'Test site description',
+		domain: 'test-site.wordpress.com',
+		jetpack: true,
+		launch_status: 'launched',
+		locale: 'en_US',
+		is_wpcom_atomic,
+		logo: {
+			id: '123',
+			sizes: [ 'thumbnail', 'medium', 'large' ],
+			url: 'https://test-site.wordpress.com/logo.png',
+		},
+		name: 'Test Site',
+		title: 'Test Site',
+		site_migration: {
+			status: migrationStatus,
+			last_modified: '2025-03-03',
+			migration_status: migrationSticker,
+		},
+	};
+};
+
+const mockCalypsoState = {
+	currentUser: {
+		capabilities: {},
+		flags: [],
+	},
+	purchases: {
+		isFetchingSitePurchases: true,
+	},
+	sites: {
+		items: {
+			[ mockSiteId ]: buildMockSite( {} ),
+		},
+		plans: {
+			[ mockSiteId ]: {
+				data: null,
+				error: null,
+				hasLoadedFromServer: false,
+				isRequesting: true,
+			},
+		},
+		requesting: {},
+		requestingAll: false,
+	},
+	ui: {
+		selectedSiteId: mockSiteId,
+	},
+};
+
+const mockRequestSiteAction = {
+	type: 'SITE_REQUEST',
+	siteId: mockSiteId,
+};
+
+describe( 'HostingOverview', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+		} );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', originalLocation );
+	} );
+
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	describe( 'when refresh parameter is not true', () => {
+		beforeEach( () => {
+			window.location.search = '';
+		} );
+
+		it( 'should load the page and not request site details', () => {
+			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+
+			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+				initialState: mockCalypsoState,
+			} );
+
+			expect( requestSiteSpy ).not.toHaveBeenCalled();
+
+			waitFor( () => {
+				// SiteBackupCard
+				expect( getByText( 'Site backup' ) ).toBeVisible();
+				// QuickActionsCard
+				expect( getByText( 'Command Palette' ) ).toBeVisible();
+				// ActiveDomainsCard
+				expect( getByText( 'Active domains' ) ).toBeVisible();
+				// SupportCard
+				expect( getByText( 'Need some help?' ) ).toBeVisible();
+
+				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+			} );
+		} );
+
+		it( 'should not request the site details when refresh is present', () => {
+			window.location.search = '?refresh';
+
+			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+
+			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+				initialState: mockCalypsoState,
+			} );
+
+			expect( requestSiteSpy ).not.toHaveBeenCalled();
+
+			waitFor( () => {
+				// SiteBackupCard
+				expect( getByText( 'Site backup' ) ).toBeVisible();
+				// QuickActionsCard
+				expect( getByText( 'Command Palette' ) ).toBeVisible();
+				// ActiveDomainsCard
+				expect( getByText( 'Active domains' ) ).toBeVisible();
+				// SupportCard
+				expect( getByText( 'Need some help?' ) ).toBeVisible();
+
+				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+			} );
+		} );
+
+		it( 'should load the page when the current site details are being requested', () => {
+			const initialState = {
+				...mockCalypsoState,
+				sites: {
+					...mockCalypsoState.sites,
+					requesting: {
+						[ mockSiteId ]: true,
+					},
+				},
+			};
+
+			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+
+			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+				initialState,
+			} );
+
+			expect( requestSiteSpy ).not.toHaveBeenCalled();
+
+			waitFor( () => {
+				// SiteBackupCard
+				expect( getByText( 'Site backup' ) ).toBeVisible();
+				// QuickActionsCard
+				expect( getByText( 'Command Palette' ) ).toBeVisible();
+				// ActiveDomainsCard
+				expect( getByText( 'Active domains' ) ).toBeVisible();
+				// SupportCard
+				expect( getByText( 'Need some help?' ) ).toBeVisible();
+
+				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+			} );
+		} );
+
+		it( 'should load the page when all site details are being requested', () => {
+			const initialState = {
+				...mockCalypsoState,
+				sites: {
+					...mockCalypsoState.sites,
+					requestingAll: true,
+				},
+			};
+
+			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+
+			const { getByTestId, getByText } = localRenderWithProvider( <HostingOverview />, {
+				initialState,
+			} );
+
+			expect( requestSiteSpy ).not.toHaveBeenCalled();
+
+			waitFor( () => {
+				// SiteBackupCard
+				expect( getByText( 'Site backup' ) ).toBeVisible();
+				// QuickActionsCard
+				expect( getByText( 'Command Palette' ) ).toBeVisible();
+				// ActiveDomainsCard
+				expect( getByText( 'Active domains' ) ).toBeVisible();
+				// SupportCard
+				expect( getByText( 'Need some help?' ) ).toBeVisible();
+
+				expect( getByTestId( 'hosting-overview-loading' ) ).not.toBeVisible();
+			} );
+		} );
+	} );
+
+	describe( 'when refresh parameter is true', () => {
+		beforeEach( () => {
+			window.location.search = '?refresh=true';
+		} );
+
+		it( 'should request the site details when no site data is being requested', () => {
+			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+			requestSiteSpy.mockImplementation( () => {
+				return mockRequestSiteAction;
+			} );
+
+			const { getByTestId } = localRenderWithProvider( <HostingOverview />, {
+				initialState: mockCalypsoState,
+			} );
+
+			expect( requestSiteSpy ).toHaveBeenCalled();
+			waitFor( () => {
+				expect( getByTestId( 'hosting-overview-loading' ) ).toBeVisible();
+			} );
+		} );
+
+		it( 'should not request the site details when the current site is being requested', () => {
+			const initialState = {
+				...mockCalypsoState,
+				sites: {
+					...mockCalypsoState.sites,
+					requesting: {
+						[ mockSiteId ]: true,
+					},
+				},
+			};
+
+			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+
+			const { getByTestId } = localRenderWithProvider( <HostingOverview />, { initialState } );
+
+			expect( requestSiteSpy ).not.toHaveBeenCalled();
+			expect( getByTestId( 'hosting-overview-loading' ) ).toBeVisible();
+		} );
+
+		it( 'should not request the site details when all sites are being requested', () => {
+			const initialState = {
+				...mockCalypsoState,
+				sites: {
+					...mockCalypsoState.sites,
+					requestingAll: true,
+				},
+			};
+
+			requestSiteSpy = jest.spyOn( siteActions, 'requestSite' );
+
+			const { getByTestId } = localRenderWithProvider( <HostingOverview />, { initialState } );
+
+			expect( requestSiteSpy ).not.toHaveBeenCalled();
+			expect( getByTestId( 'hosting-overview-loading' ) ).toBeVisible();
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
 * https://github.com/Automattic/wp-calypso/pull/101156
 * https://github.com/Automattic/wp-calypso/issues/100879
 * https://github.com/Automattic/wp-calypso/issues/101017

## Proposed Changes

* This PR adds support for a new `refresh` URL parameter in the Hosting Overview component that makes it possible to force a (re)fetch of the site details. The (re)fetch can be triggered by passing in `refresh=true` as a URL parameter to `/overview/:siteSlug`.
  - When the URL parameter is present, we'll trigger a single (re)fetch of the current site's data, provided we're not already fetching data for the current site or all sites.
    * The protections against double-fetching are not rock-solid, as there are other components that may trigger all sites being refetched, or the current site being refetched, and it 
  - While the data is being fetched as a result of the new logic, we'll show an ~ellipsis loader~ `ProgressBar` instead of the content -- see [this comment](https://github.com/Automattic/wp-calypso/pull/101371#issuecomment-2728848736) for direction

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In the related issues and PR, we are trying to redirect users to this overview screen directly from migration flows. However, we've often seen stale data displayed in this overview screen, which can lead to pretty jarring experiences for users, as the display changes drastically between the standard overview layout and any of the more specific migration layouts.
* This PR makes it generally possible to provide a clearer API for triggering a refetch of the site data when referring users to this page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Screen recordings

Both recordings were taken with Chrome emulating a slow connection so the loading state is extra-visible.

#### Desktop

https://github.com/user-attachments/assets/fa13a29a-a80d-41d4-80dd-0732814c24d1

#### Mobile

https://github.com/user-attachments/assets/e747ecdd-e463-4091-802a-d680f69745fa

### Testing instructions

* Run this branch locally or via calypso.live
* Navigate to `/overview/:siteSlug` for one of your sites
* Open your browser developer tools to keep an eye on the network traffic
* Add `?refresh=true` to the URL, and verify that the loading state is shown briefly before the content is rendered
  - The new code cannot guarantee that we won't trigger an API call to the site-specific API
* Clear out the IndexedDB data, and then reload the page
  - On Chrome, you can do so by going to the _Application_ tab in the developer tools and then finding the `calypso_store` under _Storage_ > _IndexedDB_ > _calypso_, right clicking on `calypso_store` and then clicking on "Clear".
* Verify that you see the loading state when first loading the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [N/A] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
