### PR TITLE
Check if zendeskKey exists before loading script

### DIFF
--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -32,8 +32,8 @@ function getConfigName( keyType: KeyType ): ZendeskConfigName {
 		case 'jpAgency':
 			return 'zendesk_presales_chat_key_jp_agency_dashboard';
 		case 'jpCheckout':
-		case 'jpGeneral':
 			return 'zendesk_presales_chat_key_jp_checkout';
+		case 'jpGeneral':
 		case 'wpcom':
 		default:
 			return 'zendesk_presales_chat_key';

--- a/packages/zendesk-client/src/use-load-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-load-zendesk-messaging.ts
@@ -51,13 +51,11 @@ export function useLoadZendeskMessaging(
 			setMessagingScriptLoaded( true );
 		}
 
-		if ( zendeskKey ) {
-			loadScript(
-				'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( zendeskKey ),
-				setUpMessagingEventHandlers,
-				{ id: ZENDESK_SCRIPT_ID }
-			);
-		}
+		loadScript(
+			'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( zendeskKey ),
+			setUpMessagingEventHandlers,
+			{ id: ZENDESK_SCRIPT_ID }
+		);
 	}, [ setMessagingScriptLoaded, enabled, zendeskKey, isMessagingScriptLoaded ] );
 
 	if (

--- a/packages/zendesk-client/src/use-load-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-load-zendesk-messaging.ts
@@ -51,11 +51,13 @@ export function useLoadZendeskMessaging(
 			setMessagingScriptLoaded( true );
 		}
 
-		loadScript(
-			'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( zendeskKey ),
-			setUpMessagingEventHandlers,
-			{ id: ZENDESK_SCRIPT_ID }
-		);
+		if ( zendeskKey ) {
+			loadScript(
+				'https://static.zdassets.com/ekr/snippet.js?key=' + encodeURIComponent( zendeskKey ),
+				setUpMessagingEventHandlers,
+				{ id: ZENDESK_SCRIPT_ID }
+			);
+		}
 	}, [ setMessagingScriptLoaded, enabled, zendeskKey, isMessagingScriptLoaded ] );
 
 	if (


### PR DESCRIPTION

## Proposed Changes

* Only load zendesk chat API script if the zendeskKey exists

## Why are these changes being made?

There is a current issue in Calypso on the Jetpack Pricing page in which the zendesk script is being loaded with a key of `false`. Even if this does not fix the issue and load the chat bubble, it is still a good check to be in place so we aren't loading invalid scripts

Slack: p1741973257298129/1741381212.626449-slack-CDLH4C1UZ

## Testing Instructions

1. Open the Calypso Green live link
2. Go to `/pricing` and ensure the chat bubble is loaded
![image](https://github.com/user-attachments/assets/871659e9-65c2-449e-920e-4ab346b32b01)
3. Go to `/features/comparison` and ensure that it is loaded there as well
![image](https://github.com/user-attachments/assets/d7f964d3-2aec-4c89-a656-20ff7e9bf0bf)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?