### PR TITLE
A4A: Replace Pressable offering badge with CoreBadge

### DIFF
--- a/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/index.tsx
@@ -9,7 +9,7 @@ import { A4A_MARKETPLACE_HOSTING_WPCOM_LINK } from 'calypso/a8c-for-agencies/com
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import './styles.scss';
-import PressableOffering from './pressable-oferring';
+import PressableOffering from './pressable-offering';
 
 const OverviewBodyHosting = () => {
 	const translate = useTranslate();

--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
@@ -1,10 +1,12 @@
 import page from '@automattic/calypso-router';
-import { Badge, Button, FoldableCard, Gridicon } from '@automattic/components';
+import { Button, FoldableCard, Gridicon } from '@automattic/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
+import CoreBadge from 'calypso/components/core/badge';
 import { getActiveAgency, isAgencyOwner } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 
@@ -39,14 +41,14 @@ const PressableOffering = () => {
 	const header = (
 		<div className="a4a-offering-item__title-container">
 			<img className="pressable-icon" src={ pressableIcon } alt="Pressable" />
-			<div className="a4a-overview-pressable-offering-header-title">
-				<h3 className="a4a-offering-item__title">
-					{ translate( 'Pressable' ) }
+			<h3 className="a4a-offering-item__title">
+				<HStack spacing={ 3 }>
+					<span>{ translate( 'Pressable' ) }</span>
 					{ isPressableRegular && (
-						<Badge type="success">{ translate( "You're signed up!" ) }</Badge>
+						<CoreBadge intent="success">{ translate( "You're signed up!" ) }</CoreBadge>
 					) }
-				</h3>
-			</div>
+				</HStack>
+			</h3>
 		</div>
 	);
 

--- a/client/a8c-for-agencies/sections/overview/body/hosting/styles.scss
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/styles.scss
@@ -3,25 +3,6 @@
 	margin: 0;
 }
 
-.a4a-overview-pressable-offering-header-title {
-	.badge {
-		margin-left: 12px;
-	}
-
-	.badge--success {
-		background: var(--studio-green-5);
-		color: var(--studio-green-50);
-	}
-	.badge--warning {
-		background: var(--studio-yellow-5);
-		color: var(--studio-yellow-70);
-	}
-	.badge--error {
-		background: var(--studio-red-5);
-		color: var(--studio-red-70);
-	}
-}
-
 .pressable-icon {
 	width: 24px;
 	height: 24px;

--- a/client/components/core/badge/README.md
+++ b/client/components/core/badge/README.md
@@ -1,6 +1,6 @@
 # CoreBadge Component
 
-A wrapper component around WordPress's private `Badge` component from `@wordpress/components`.
+A wrapper component around WordPress's private [`Badge` component](https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs) from `@wordpress/components`.
 
 ## Usage
 

--- a/client/components/core/badge/index.tsx
+++ b/client/components/core/badge/index.tsx
@@ -1,16 +1,30 @@
 import { privateApis } from '@wordpress/components';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import React from 'react';
+import type { BadgeProps } from '@wordpress/components/src/badge/types';
 
-const CoreBadge = ( { children }: { children: React.ReactNode } ) => {
-	// TODO: When the component is publicly available, we should remove the private API usage and
-	// import it directly from @wordpress/components as it will cause a build error.
-	const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-		'@wordpress/components'
-	);
-	const { Badge } = unlock( privateApis );
-	return <Badge>{ children }</Badge>;
+// TODO: When the component is publicly available, we should remove the private API usage and
+// import it directly from @wordpress/components as it will cause a build error.
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+const { Badge } = unlock( privateApis );
+
+/**
+ * A wrapper component around WordPress's private [`Badge` component](https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs)
+ * from `@wordpress/components`.
+ *
+ * ```jsx
+ * import CoreBadge from 'calypso/components/core/badge';
+ *
+ * function MyComponent() {
+ * 	return <CoreBadge>Badge Content</CoreBadge>;
+ * }
+ * ```
+ */
+const CoreBadge = ( props: BadgeProps & React.HTMLAttributes< HTMLSpanElement > ) => {
+	return <Badge { ...props } />;
 };
 
 export default CoreBadge;


### PR DESCRIPTION
Part of #101301
Stacked on #101377

## Proposed Changes

Replaces the Pressable offering badge in the A4A overview, from the `a8c-components` `Badge` with style overrides to the standard `CoreBadge`.

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/85689f56-f639-4bac-b085-0706b16ddf3a" alt="Offering badge, before" width="663">|<img src="https://github.com/user-attachments/assets/2aeb8558-c691-42d0-be62-3a9b97cfd14b" alt="Offering badge, after" width="663">|

## Why are these changes being made?

To fix color contrast issues and consistency.

## Testing Instructions

Force enable this condition to show the badge:

```diff
diff --git a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offerring.tsx b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offerring.tsx
index 9c363dd01b..73e462526b 100644
--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offerring.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offerring.tsx
@@ -44,9 +44,7 @@ const PressableOffering = () => {
 			<h3 className="a4a-offering-item__title">
 				<HStack spacing={ 3 }>
 					<span>{ translate( 'Pressable' ) }</span>
-					{ isPressableRegular && (
-						<CoreBadge intent="success">{ translate( "You're signed up!" ) }</CoreBadge>
-					) }
+					{ true && <CoreBadge intent="success">{ translate( "You're signed up!" ) }</CoreBadge> }
 				</HStack>
 			</h3>
 		</div>
```

Run `yarn start-a8c-for-agencies` and go to `http://agencies.localhost:3000/overview`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
