### PR TITLE
CoreBadge: Improve docs, types, unlocking

### DIFF
--- a/client/components/core/badge/README.md
+++ b/client/components/core/badge/README.md
@@ -1,6 +1,6 @@
 # CoreBadge Component
 
-A wrapper component around WordPress's private `Badge` component from `@wordpress/components`.
+A wrapper component around WordPress's private [`Badge` component](https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs) from `@wordpress/components`.
 
 ## Usage
 

--- a/client/components/core/badge/index.tsx
+++ b/client/components/core/badge/index.tsx
@@ -1,16 +1,30 @@
 import { privateApis } from '@wordpress/components';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import React from 'react';
+import type { BadgeProps } from '@wordpress/components/src/badge/types';
 
-const CoreBadge = ( { children }: { children: React.ReactNode } ) => {
-	// TODO: When the component is publicly available, we should remove the private API usage and
-	// import it directly from @wordpress/components as it will cause a build error.
-	const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-		'@wordpress/components'
-	);
-	const { Badge } = unlock( privateApis );
-	return <Badge>{ children }</Badge>;
+// TODO: When the component is publicly available, we should remove the private API usage and
+// import it directly from @wordpress/components as it will cause a build error.
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+const { Badge } = unlock( privateApis );
+
+/**
+ * A wrapper component around WordPress's private [`Badge` component](https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs)
+ * from `@wordpress/components`.
+ *
+ * ```jsx
+ * import CoreBadge from 'calypso/components/core/badge';
+ *
+ * function MyComponent() {
+ * 	return <CoreBadge>Badge Content</CoreBadge>;
+ * }
+ * ```
+ */
+const CoreBadge = ( props: BadgeProps & React.HTMLAttributes< HTMLSpanElement > ) => {
+	return <Badge { ...props } />;
 };
 
 export default CoreBadge;


### PR DESCRIPTION
Prerequisite for #101376

## Proposed Changes

Adds the following minor improvements to the `CoreBadge` component:

- Improve docs so they link to the WP Storybook docs.
- Add TypeScript types (we need to do this manually because unfortunately `unlock`ed APIs [do not retain type data](https://github.com/WordPress/gutenberg/pull/46131#issuecomment-1415812737) at the moment). Without this, the `intent` prop on the component will trigger a type error.
- Move the `unlock()` call outside of the component function so it doesn't have to be called on every render.

## Why are these changes being made?

Better devex, code quality.

As a follow-up, I'll be looking into improving the docs and other developer touch points so we can nudge everyone to start using `CoreBadge` instead of `@automattic/components` `Badge`.

## Testing Instructions

- The component docs should show up nicely in the IDE's IntelliSense.
- The existing usage should continue to work without issue. Use the A4A live link and go to the `/marketplace/products` page.

<img width="1029" alt="A4A Marketplace badges" src="https://github.com/user-attachments/assets/db42411a-cbff-4521-a673-9e98e6fc3fa4" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
