### PR TITLE
Fix: Prevent loading site migration checklist

### DIFF
--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -11,11 +11,12 @@ const SiteIntent = Onboard.SiteIntent;
 export const shouldShowLaunchpadFirst = ( site: SiteExcerptData ): boolean => {
 	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
 	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
+	const isMigrationIntent = site?.options?.site_intent === SiteIntent.SiteMigration;
 	// If we don't have a site intent, fall through to the next option.
 	const siteHasNoIntent =
 		site && site.options && ( site.options.site_intent === '' || ! site.options.site_intent );
 
-	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || siteHasNoIntent ) {
+	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || siteHasNoIntent || isMigrationIntent ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

Prevent showing empty launchpad first on sites with `site-migration` intent.
<img width="971" alt="image" src="https://github.com/user-attachments/assets/5e79a9ea-a5da-4cb1-8f30-d8b8ac8253ce" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When creating a new site via the import onboarding flow an empty Launchpad first is shown. This PR attempts to fix that by excluding the sites with `site-migration` intent explicitly from using the Launchpad first component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Select a free plan
* Select `Import or migrate an existing site`
* Choose `pick your current platform from a list`
* Pick WordPress
* Pick `Import content only`
* Upload an import and import it
* Wait
* Click `Pick a design`
* Select a free theme
* Click `Continue`
* Verify you arrive to /home and the Launchpad first is not shown
<img width="957" alt="image" src="https://github.com/user-attachments/assets/0084e7a2-8d11-4980-9f85-b8f59b11fe82" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
