### PR TITLE
Pass prompt parameter to big sky

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, FormEvent, useState } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useIsBigSkyEligible } from '../../../../hooks/use-is-site-big-sky-eligible';
@@ -26,6 +27,7 @@ const LaunchBigSky: Step = function ( props ) {
 	const [ progress, setProgress ] = useState( 0 );
 	const { siteSlug, siteId, site } = useSiteData();
 	const translate = useTranslate();
+	const urlQuery = useQuery();
 	const { isEligible, isLoading } = useIsBigSkyEligible( flow );
 	const { setDesignOnSite, setStaticHomepageOnSite, setGoalsOnSite, setIntentOnSite } =
 		useDispatch( SITE_STORE );
@@ -104,8 +106,15 @@ const LaunchBigSky: Step = function ( props ) {
 				}
 				setProgress( 75 );
 
+				const prompt = urlQuery.get( 'prompt' );
+				let promptParam = '';
+
+				if ( prompt ) {
+					promptParam = `&prompt=${ encodeURIComponent( prompt ) }`;
+				}
+
 				window.location.replace(
-					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }`
+					`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ flow }${ promptParam }`
 				);
 			} catch ( error ) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
This is a follow up on #100948 

This passes the prompt from query string all the way to Big sky

## Testing instructions

1. Go to http://calypso.localhost:3000/setup/ai-site-builder/?prompt=mariachi%20restaurant%20in%20mexico%20city%20called%20matias%20loves%20mariachi,%20confirm%20site%20spec
**2. Allow 3rd party cookies**
3. Continue with user creation
4. Observe site being created and being redirected to something like https://((EXAMPLE)).wordpress.com/wp-admin/site-editor.php?canvas=edit&referrer=ai-site-builder&prompt=mariachi+restaurant+in+mexico+city+called+matias+loves+mariachi%2C+confirm+site+spec&p=%2F&ai-step=onboarding
5. Notice the prompt still in the URL