### PR TITLE
Enable skipping after a successful import

### DIFF
--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useCallback } from 'react';
@@ -23,7 +24,6 @@ import type {
 	ImportJobParams,
 	StepNavigator,
 } from 'calypso/blocks/importer/types';
-
 import './style.scss';
 
 type RenderState = 'idle' | 'progress' | 'upgrade-plan' | 'error' | 'success';
@@ -113,7 +113,9 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 			job?.importerFileType !== 'playground' &&
 			isEnabled( 'onboarding/import-redirect-to-themes' )
 		) {
-			stepNavigator?.navigate?.( 'design-setup' );
+			stepNavigator?.navigate?.(
+				addQueryArgs( 'design-setup', { comingFromSuccessfulImport: '1' } )
+			);
 		} else {
 			stepNavigator?.goToSiteViewPage?.();
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -146,6 +146,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	);
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const isComingFromTheUpgradeScreen = queryParams.get( 'continue' ) === '1';
+	const isComingFromSuccessfulImport = queryParams.get( 'comingFromSuccessfulImport' ) === '1';
 
 	const isPremiumThemeAvailable = Boolean(
 		useSelect(
@@ -907,19 +908,28 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		</>
 	);
 
+	const getGoBackHandler = () => {
+		if ( isComingFromSuccessfulImport ) {
+			return undefined;
+		}
+		return intent === 'update-design' ? submit : handleBackClick;
+	};
+
 	return (
 		<StepContainer
 			stepName={ STEP_NAME }
 			className="unified-design-picker__has-categories"
 			skipButtonAlign="top"
 			hideFormattedHeader
-			hideSkip={ ! isGoalsAtFrontExperiment }
-			skipLabelText={ translate( 'Skip setup' ) }
+			hideSkip={ ! isGoalsAtFrontExperiment && ! isComingFromSuccessfulImport }
+			skipLabelText={
+				isComingFromSuccessfulImport ? translate( 'Skip to dashboard' ) : translate( 'Skip setup' )
+			}
 			backLabelText={ translate( 'Back' ) }
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }
 			goNext={ handleSubmit }
-			goBack={ intent === 'update-design' ? submit : handleBackClick }
+			goBack={ getGoBackHandler() }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100888

## Proposed Changes

This PR
* removes the `< Back` button from the import success step and adds a `Skip to dashboard` link
* removes the `< Back` button from the design selection step and adds a `Skip to dashboard` link

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The PR in itself it's hacky. I am adding a query param to signal we are coming from a successful import state in the unified design picker. I went down this route because both the importer flow and the unified design picker needs refactoring. I added this code in the spirit of fixing the v0 bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /sites
* Press Add new site
* Pick import
* Click on the pick a platform from the list
* Pick WordPress
* Pick import
* Upload a WordPress export file
* Wait until you see the following screen and verify 
   * you see the skip to dashboard button on the top right
   * you don't see a back button
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/710f6a71-805e-4019-849b-50809eae9980" />
* Click on `Pick a design`
* Verify you don't see the `< Back` button and there's a `Skip to dashboard` link on the top right of the screen
<img width="1538" alt="image" src="https://github.com/user-attachments/assets/beb1d7ab-ed37-4f79-8254-6b60b6b4d43c" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
