### PR TITLE
Launch: Business Tax Project

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -336,6 +336,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/vat-gst-other-taxes/#other-tax-exempt-customers',
 		post_id: 234670,
 	},
+	'business-tax-rates-in-ohio-and-connecticut': {
+		link: 'https://wordpress.com/support/vat-gst-other-taxes/#business-tax-rates-in-ohio-and-connecticut',
+		post_id: 234670,
+	},
 	team: {
 		link: 'https://wordpress.com/support/user-roles/',
 		post_id: 1221,

--- a/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
@@ -73,8 +73,7 @@ export function IsForBusinessCheckbox( {
 						components: {
 							link: (
 								<InlineSupportLink
-									id="checkout-is-business-checkbox"
-									supportContext="tax-exempt-customers"
+									supportContext="business-tax-rates-in-ohio-and-connecticut"
 									showIcon={ false }
 								/>
 							),

--- a/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
@@ -1,5 +1,5 @@
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { hasCheckoutVersion, ManagedContactDetails, styled } from '@automattic/wpcom-checkout';
+import { ManagedContactDetails, styled } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -60,7 +60,7 @@ export function IsForBusinessCheckbox( {
 	const isDisabled = formStatus !== FormStatus.READY;
 
 	// Hide checkbox if not eligible
-	if ( ! isUnitedStateWithBusinessOption || ! hasCheckoutVersion( 'business-use-tax' ) ) {
+	if ( ! isUnitedStateWithBusinessOption ) {
 		return null;
 	}
 


### PR DESCRIPTION
This PR is the final step in the Business Tax Project 🥳 


Related to pfOicC-ch-p2#comment-471 

## Proposed Changes

* This PR will remove the `?checkoutVersion=business-use-tax` feature flag from the `isForBusinessCheckbox` component in production - thus launching the project and making it available to customers from Ohio and Connecticut.
* This PR also updates the 'Learn more' link that appears next to the new checkbox, it should now correctly open the [new section](https://wordpress.com/support/vat-gst-other-taxes/#business-tax-rates-in-ohio-and-connecticut) of the _Tax on WordPress.com_ support documentation

## Testing Instructions

* Load a Calypso.live link and go to Checkout
* Scroll down to Billing Information and enter your country as **United States** and enter a **postal code** from Ohio or Connecticut (Do both! Here are some examples - **Ohio**: 43010 - **Connecticut**: 06028)
* The checkbox should now appear below these fields, you can [follow these testing steps](https://github.com/Automattic/wp-calypso/pull/99833) to test the checkbox - just disregard the step about the `checkoutVersion=business-use-tax`, as this PR is meant to remove that
* Add a new card and complete a purchase
* Renew the purchase with the new card
* The purchase should be using the tax rate in the table here pbg9X-krs-p2

* Do the same for the Add Payment Method Page, the Change Payment Method Page (specifically the Add Credit Card portion of the form)

> [!NOTE] 
> Really, at this stage we are just testing to ensure the feature flag no longer hides the feature in production and that the Learn More support link properly opens the correct section in the Help Center
