### PR TITLE
A4A: [WIP] An early POC for using wpcom billing for referral purchases

### DIFF
--- a/client/a8c-for-agencies/sections/client/checkout-v2-error/index.tsx
+++ b/client/a8c-for-agencies/sections/client/checkout-v2-error/index.tsx
@@ -1,0 +1,19 @@
+import { TranslateResult } from 'i18n-calypso';
+
+import './style.scss';
+
+type Props = {
+	title: TranslateResult;
+	message: TranslateResult;
+};
+
+export default function ClientCheckoutV2Error( { title, message }: Props ) {
+	return (
+		<div className="client-checkout-v2">
+			<div className="client-checkout-v2__error">
+				<h2>{ title }</h2>
+				<p>{ message }</p>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/client/checkout-v2-error/style.scss
+++ b/client/a8c-for-agencies/sections/client/checkout-v2-error/style.scss
@@ -1,0 +1,18 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.client-checkout-v2__error {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	padding: 24px 16px;
+	margin: 0 auto;
+
+	gap: 24px;
+
+	@include break-large {
+		padding: 144px;
+	}
+}

--- a/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/index.tsx
+++ b/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/index.tsx
@@ -2,15 +2,17 @@ import './style.scss';
 
 export default function ClientCheckoutV2Placeholder() {
 	return (
-		<div className="client-checkout-v2-placeholder">
-			<div className="client-checkout-v2-placeholder__main-content">
-				<div className="client-checkout-v2-placeholder__line" style={ { width: '50%' } }></div>
-				<div className="client-checkout-v2-placeholder__line" style={ { width: '70%' } }></div>
-				<div className="client-checkout-v2-placeholder__line" style={ { width: '50%' } }></div>
-			</div>
-			<div className="client-checkout-v2-placeholder__sidebar-content">
-				<div className="client-checkout-v2-placeholder__line" style={ { width: '20%' } }></div>
-				<div className="client-checkout-v2-placeholder__line" style={ { width: '30%' } }></div>
+		<div className="client-checkout-v2">
+			<div className="client-checkout-v2-placeholder">
+				<div className="client-checkout-v2-placeholder__main-content">
+					<div className="client-checkout-v2-placeholder__line" style={ { width: '50%' } }></div>
+					<div className="client-checkout-v2-placeholder__line" style={ { width: '70%' } }></div>
+					<div className="client-checkout-v2-placeholder__line" style={ { width: '50%' } }></div>
+				</div>
+				<div className="client-checkout-v2-placeholder__sidebar-content">
+					<div className="client-checkout-v2-placeholder__line" style={ { width: '20%' } }></div>
+					<div className="client-checkout-v2-placeholder__line" style={ { width: '30%' } }></div>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/index.tsx
+++ b/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/index.tsx
@@ -1,0 +1,17 @@
+import './style.scss';
+
+export default function ClientCheckoutV2Placeholder() {
+	return (
+		<div className="client-checkout-v2-placeholder">
+			<div className="client-checkout-v2-placeholder__main-content">
+				<div className="client-checkout-v2-placeholder__line" style={ { width: '50%' } }></div>
+				<div className="client-checkout-v2-placeholder__line" style={ { width: '70%' } }></div>
+				<div className="client-checkout-v2-placeholder__line" style={ { width: '50%' } }></div>
+			</div>
+			<div className="client-checkout-v2-placeholder__sidebar-content">
+				<div className="client-checkout-v2-placeholder__line" style={ { width: '20%' } }></div>
+				<div className="client-checkout-v2-placeholder__line" style={ { width: '30%' } }></div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/style.scss
+++ b/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/style.scss
@@ -1,0 +1,60 @@
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+
+@mixin loading-effect {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-neutral-10);
+}
+
+.client-checkout-v2-placeholder {
+	display: grid;
+    grid-template-rows: auto;
+
+	@include break-large {
+		grid-template-columns: 1fr minmax(500px, 688px) 376px 1fr;
+		grid-template-areas: 'main-content main-content sidebar-content sidebar-content';
+		justify-items: end;
+	}
+}
+
+.client-checkout-v2-placeholder__main-content {
+	grid-area: main-content;
+	max-width: 688px;
+	padding: 144px 64px 0 24px;
+	width: 100%;
+
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.client-checkout-v2-placeholder__sidebar-content {
+	grid-area: sidebar-content;
+	background: #F6F7F7;
+	min-height: 100vh;
+	width: 100%;
+
+	margin-top: 0;
+	padding: 144px 24px 144px 64px;
+
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+
+.client-checkout-v2-placeholder__line {
+	@include loading-effect;
+	border-radius: 4px;
+
+
+	height: 32px;
+
+	.w-100 {
+		max-width: 200px;
+	}
+
+	.w-50 {
+		max-width: 100px;
+	}
+}

--- a/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/style.scss
+++ b/client/a8c-for-agencies/sections/client/checkout-v2-placeholder/style.scss
@@ -46,15 +46,5 @@
 .client-checkout-v2-placeholder__line {
 	@include loading-effect;
 	border-radius: 4px;
-
-
 	height: 32px;
-
-	.w-100 {
-		max-width: 200px;
-	}
-
-	.w-50 {
-		max-width: 100px;
-	}
 }

--- a/client/a8c-for-agencies/sections/client/controller.tsx
+++ b/client/a8c-for-agencies/sections/client/controller.tsx
@@ -58,6 +58,7 @@ function ClientCheckoutContent() {
 			return createRequestCartProduct( {
 				product_id: product.product_id,
 				product_slug: product.slug,
+				extra: { isA4ASitelessCheckout: true },
 			} );
 		} );
 

--- a/client/a8c-for-agencies/sections/client/controller.tsx
+++ b/client/a8c-for-agencies/sections/client/controller.tsx
@@ -1,14 +1,161 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { type Callback } from '@automattic/calypso-router';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
 import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
 import SidebarPlaceholder from 'calypso/a8c-for-agencies/components/sidebar-placeholder';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import ClientSidebar from '../../components/sidebar-menu/client';
+import useFetchClientReferral from '../client/hooks/use-fetch-client-referral';
+import useProductsById from '../marketplace/hooks/use-products-by-id';
+import { getClientReferralQueryArgs } from '../marketplace/lib/get-client-referral-query-args';
 import InvoicesOverview from '../purchases/invoices/invoices-overview';
 import PaymentMethodAdd from '../purchases/payment-methods/payment-method-add';
 import PaymentMethodOverview from '../purchases/payment-methods/payment-method-overview';
 import ClientLanding from './client-landing';
 import ClientCheckout from './primary/checkout';
 import SubscriptionsList from './primary/subscriptions-list';
+
+/**
+ * Client Checkout Component using the WordPress.com checkout
+ */
+function ClientCheckoutContent() {
+	const translate = useTranslate();
+	const [ isReady, setIsReady ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const { data: referral } = useFetchClientReferral( getClientReferralQueryArgs() );
+	const { referredProducts } = useProductsById( referral?.products ?? [] );
+
+	// Access the shopping cart API
+	const { addProductsToCart, responseCart } = useShoppingCart( 'no-site' );
+
+	// Add products to cart when referral data is loaded
+	useEffect( () => {
+		// Skip if we're already ready or have an error
+		if ( isReady || error ) {
+			console.log( '[A4A Checkout] Already ready or has error' );
+			return;
+		}
+
+		if ( ! referredProducts || referredProducts.length === 0 ) {
+			console.log( '[A4A Checkout] No referred products' );
+			return;
+		}
+
+		console.log( '[A4A Checkout] Referral', referral );
+		console.log( '[A4A Checkout] Referred products', referredProducts );
+
+		const productsToAdd = referredProducts.map( ( product ) => {
+			return createRequestCartProduct( {
+				product_id: product.product_id,
+				product_slug: product.slug,
+			} );
+		} );
+
+		console.log( '[A4A Checkout] Products to add', productsToAdd );
+
+		// Add products to cart
+		if ( productsToAdd.length > 0 ) {
+			addProductsToCart( productsToAdd )
+				.then( () => {
+					console.log( '[A4A Checkout] Products added to cart successfully' );
+					console.log( '[A4A Checkout] Cart', responseCart );
+					setIsReady( true );
+				} )
+				.catch( ( err ) => {
+					console.error( '[A4A Checkout] Failed to add products to cart:', err );
+					setError( 'Failed to add products to cart' );
+				} );
+		} else {
+			console.log( '[A4A Checkout] No matching products found to add to cart' );
+			setError( 'Could not find the requested products' );
+		}
+	}, [ isReady, error, referredProducts ] );
+
+	// Debugging: Set a timeout to force showing the checkout after 10 seconds
+	useEffect( () => {
+		if ( isReady || error ) {
+			return;
+		}
+
+		const timeoutId = setTimeout( () => {
+			console.log( '[A4A Checkout] Timeout reached, showing checkout anyway' );
+			setIsReady( true );
+		}, 10000 );
+
+		return () => clearTimeout( timeoutId );
+	}, [ isReady, error ] );
+
+	// Debugging: Show loading state
+	if ( ! isReady && ! error ) {
+		return (
+			<div className="client-checkout-v2__loading">
+				<h2>{ translate( 'Loading checkout' ) }</h2>
+				<p>{ translate( 'Setting up your products for purchase' ) }</p>
+			</div>
+		);
+	}
+
+	// Debugging: Show error state
+	if ( error ) {
+		return (
+			<div className="client-checkout-v2__error">
+				<h2>{ translate( 'Error' ) }</h2>
+				<p>{ error }</p>
+			</div>
+		);
+	}
+
+	// Show checkout
+	return (
+		<div className="client-checkout-v2">
+			<CheckoutMain
+				sitelessCheckoutType="a4a"
+				redirectTo="/client/subscriptions"
+				isInModal={ false }
+				siteSlug=""
+				siteId={ 0 }
+			/>
+		</div>
+	);
+}
+
+/**
+ * Wrapper component that provides necessary context providers
+ */
+function ClientCheckoutV2() {
+	const translate = useTranslate();
+	const locale = useSelector( getCurrentUserLocale );
+
+	return (
+		<>
+			<PageViewTracker title="Client > Checkout V2" path="/client/checkout/v2" />
+			<CheckoutErrorBoundary
+				errorMessage={ translate( 'Sorry, there was an error loading the checkout page.' ) }
+				onError={ ( error ) => {
+					console.error( 'Checkout error', error );
+				} }
+			>
+				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
+					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
+						<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+							<ClientCheckoutContent />
+						</RazorpayHookProvider>
+					</StripeHookProvider>
+				</CalypsoShoppingCartProvider>
+			</CheckoutErrorBoundary>
+		</>
+	);
+}
 
 export const clientLandingContext: Callback = ( context, next ) => {
 	context.primary = <ClientLanding />;
@@ -72,5 +219,10 @@ export const clientCheckoutContext: Callback = ( context, next ) => {
 			<ClientCheckout />
 		</>
 	);
+	next();
+};
+
+export const clientCheckoutV2Context: Callback = ( context, next ) => {
+	context.primary = <ClientCheckoutV2 />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/client/controller.tsx
+++ b/client/a8c-for-agencies/sections/client/controller.tsx
@@ -1,162 +1,15 @@
-import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { type Callback } from '@automattic/calypso-router';
-import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
 import { getQueryArg } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
 import SidebarPlaceholder from 'calypso/a8c-for-agencies/components/sidebar-placeholder';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
-import { useSelector } from 'calypso/state';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import ClientSidebar from '../../components/sidebar-menu/client';
-import useFetchClientReferral from '../client/hooks/use-fetch-client-referral';
-import useProductsById from '../marketplace/hooks/use-products-by-id';
-import { getClientReferralQueryArgs } from '../marketplace/lib/get-client-referral-query-args';
 import InvoicesOverview from '../purchases/invoices/invoices-overview';
 import PaymentMethodAdd from '../purchases/payment-methods/payment-method-add';
 import PaymentMethodOverview from '../purchases/payment-methods/payment-method-overview';
 import ClientLanding from './client-landing';
 import ClientCheckout from './primary/checkout';
+import ClientCheckoutV2 from './primary/checkout-v2';
 import SubscriptionsList from './primary/subscriptions-list';
-
-/**
- * Client Checkout Component using the WordPress.com checkout
- */
-function ClientCheckoutContent() {
-	const translate = useTranslate();
-	const [ isReady, setIsReady ] = useState( false );
-	const [ error, setError ] = useState< string | null >( null );
-
-	const { data: referral } = useFetchClientReferral( getClientReferralQueryArgs() );
-	const { referredProducts } = useProductsById( referral?.products ?? [] );
-
-	// Access the shopping cart API
-	const { addProductsToCart, responseCart } = useShoppingCart( 'no-site' );
-
-	// Add products to cart when referral data is loaded
-	useEffect( () => {
-		// Skip if we're already ready or have an error
-		if ( isReady || error ) {
-			console.log( '[A4A Checkout] Already ready or has error' );
-			return;
-		}
-
-		if ( ! referredProducts || referredProducts.length === 0 ) {
-			console.log( '[A4A Checkout] No referred products' );
-			return;
-		}
-
-		console.log( '[A4A Checkout] Referral', referral );
-		console.log( '[A4A Checkout] Referred products', referredProducts );
-
-		const productsToAdd = referredProducts.map( ( product ) => {
-			return createRequestCartProduct( {
-				product_id: product.product_id,
-				product_slug: product.slug,
-				extra: { isA4ASitelessCheckout: true },
-			} );
-		} );
-
-		console.log( '[A4A Checkout] Products to add', productsToAdd );
-
-		// Add products to cart
-		if ( productsToAdd.length > 0 ) {
-			addProductsToCart( productsToAdd )
-				.then( () => {
-					console.log( '[A4A Checkout] Products added to cart successfully' );
-					console.log( '[A4A Checkout] Cart', responseCart );
-					setIsReady( true );
-				} )
-				.catch( ( err ) => {
-					console.error( '[A4A Checkout] Failed to add products to cart:', err );
-					setError( 'Failed to add products to cart' );
-				} );
-		} else {
-			console.log( '[A4A Checkout] No matching products found to add to cart' );
-			setError( 'Could not find the requested products' );
-		}
-	}, [ isReady, error, referredProducts ] );
-
-	// Debugging: Set a timeout to force showing the checkout after 10 seconds
-	useEffect( () => {
-		if ( isReady || error ) {
-			return;
-		}
-
-		const timeoutId = setTimeout( () => {
-			console.log( '[A4A Checkout] Timeout reached, showing checkout anyway' );
-			setIsReady( true );
-		}, 10000 );
-
-		return () => clearTimeout( timeoutId );
-	}, [ isReady, error ] );
-
-	// Debugging: Show loading state
-	if ( ! isReady && ! error ) {
-		return (
-			<div className="client-checkout-v2__loading">
-				<h2>{ translate( 'Loading checkout' ) }</h2>
-				<p>{ translate( 'Setting up your products for purchase' ) }</p>
-			</div>
-		);
-	}
-
-	// Debugging: Show error state
-	if ( error ) {
-		return (
-			<div className="client-checkout-v2__error">
-				<h2>{ translate( 'Error' ) }</h2>
-				<p>{ error }</p>
-			</div>
-		);
-	}
-
-	// Show checkout
-	return (
-		<div className="client-checkout-v2">
-			<CheckoutMain
-				sitelessCheckoutType="a4a"
-				redirectTo="/client/subscriptions"
-				isInModal={ false }
-				siteSlug=""
-				siteId={ 0 }
-			/>
-		</div>
-	);
-}
-
-/**
- * Wrapper component that provides necessary context providers
- */
-function ClientCheckoutV2() {
-	const translate = useTranslate();
-	const locale = useSelector( getCurrentUserLocale );
-
-	return (
-		<>
-			<PageViewTracker title="Client > Checkout V2" path="/client/checkout/v2" />
-			<CheckoutErrorBoundary
-				errorMessage={ translate( 'Sorry, there was an error loading the checkout page.' ) }
-				onError={ ( error ) => {
-					console.error( 'Checkout error', error );
-				} }
-			>
-				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
-					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
-						<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
-							<ClientCheckoutContent />
-						</RazorpayHookProvider>
-					</StripeHookProvider>
-				</CalypsoShoppingCartProvider>
-			</CheckoutErrorBoundary>
-		</>
-	);
-}
 
 export const clientLandingContext: Callback = ( context, next ) => {
 	context.primary = <ClientLanding />;
@@ -224,6 +77,11 @@ export const clientCheckoutContext: Callback = ( context, next ) => {
 };
 
 export const clientCheckoutV2Context: Callback = ( context, next ) => {
-	context.primary = <ClientCheckoutV2 />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Client > Checkout V2" path="/client/checkout/v2" />
+			<ClientCheckoutV2 />
+		</>
+	);
 	next();
 };

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireClientAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
+import { isEnabled } from 'calypso/server/config';
 import * as controller from './controller';
 
 export default function () {
@@ -50,11 +51,13 @@ export default function () {
 	);
 
 	// New v2 route for WP.com-based checkout implementation
-	page(
-		'/client/checkout/v2',
-		requireClientAccessContext,
-		controller.clientCheckoutV2Context,
-		makeLayout,
-		clientRender
-	);
+	if ( isEnabled( 'a4a-client-checkout-v2' ) ) {
+		page(
+			'/client/checkout/v2',
+			requireClientAccessContext,
+			controller.clientCheckoutV2Context,
+			makeLayout,
+			clientRender
+		);
+	}
 }

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import {
 	A4A_CLIENT_LANDING_LINK,
@@ -9,7 +10,6 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireClientAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { isEnabled } from 'calypso/server/config';
 import * as controller from './controller';
 
 export default function () {

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -48,4 +48,13 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	// New v2 route for WP.com-based checkout implementation
+	page(
+		'/client/checkout/v2',
+		requireClientAccessContext,
+		controller.clientCheckoutV2Context,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -11,7 +11,8 @@ import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/st
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import { useSelector } from 'calypso/state';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import ClientCheckoutV2Error from '../../checkout-v2-error';
 import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
 import useFetchClientReferral from '../../hooks/use-fetch-client-referral';
 
@@ -32,6 +33,10 @@ function ClientCheckoutContent() {
 
 	// Access the shopping cart API
 	const { addProductsToCart, responseCart } = useShoppingCart( 'no-site' );
+
+	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
+
+	const isDoNotMatchReferralClientEmail = referral?.client?.email !== userEmail;
 
 	// Add products to cart when referral data is loaded
 	useEffect( () => {
@@ -75,7 +80,7 @@ function ClientCheckoutContent() {
 			debug( '[A4A Checkout] No matching products found to add to cart' );
 			setError( 'Could not find the requested products' );
 		}
-	}, [ isReady, error, referredProducts ] );
+	}, [ isReady, error, referredProducts, referral, addProductsToCart, responseCart ] );
 
 	// Debugging: Set a timeout to force showing the checkout after 10 seconds
 	useEffect( () => {
@@ -91,26 +96,34 @@ function ClientCheckoutContent() {
 		return () => clearTimeout( timeoutId );
 	}, [ isReady, error ] );
 
-	// Debugging: Show loading state
-	if ( ! isReady && ! error ) {
+	if ( ! isReady ) {
+		return <ClientCheckoutV2Placeholder />;
+	}
+
+	if ( isDoNotMatchReferralClientEmail ) {
 		return (
-			<div className="client-checkout-v2">
-				<ClientCheckoutV2Placeholder />
-			</div>
+			<ClientCheckoutV2Error
+				title={ translate( 'Permission denied' ) }
+				message={ translate(
+					'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
+					{
+						args: {
+							referralEmail: referral?.client?.email,
+						},
+						components: {
+							b: <b />,
+						},
+						comment: '%(referralEmail)s is the email of the referral client.',
+					}
+				) }
+			/>
 		);
 	}
 
-	// Debugging: Show error state
 	if ( error ) {
-		return (
-			<div className="client-checkout-v2 is-error">
-				<h2>{ translate( 'Error' ) }</h2>
-				<p>{ error }</p>
-			</div>
-		);
+		return <ClientCheckoutV2Error title={ translate( 'Error' ) } message={ error } />;
 	}
 
-	// Show checkout
 	return (
 		<div className="client-checkout-v2">
 			<CheckoutMain

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -12,6 +12,7 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import ClientCheckoutV2Placeholder from '../../checkout-v2-placeholder';
 import useFetchClientReferral from '../../hooks/use-fetch-client-referral';
 
 import './style.scss';
@@ -93,9 +94,8 @@ function ClientCheckoutContent() {
 	// Debugging: Show loading state
 	if ( ! isReady && ! error ) {
 		return (
-			<div className="client-checkout-v2__loading">
-				<h2>{ translate( 'Loading checkout' ) }</h2>
-				<p>{ translate( 'Setting up your products for purchase' ) }</p>
+			<div className="client-checkout-v2">
+				<ClientCheckoutV2Placeholder />
 			</div>
 		);
 	}
@@ -103,7 +103,7 @@ function ClientCheckoutContent() {
 	// Debugging: Show error state
 	if ( error ) {
 		return (
-			<div className="client-checkout-v2__error">
+			<div className="client-checkout-v2 is-error">
 				<h2>{ translate( 'Error' ) }</h2>
 				<p>{ error }</p>
 			</div>

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -142,7 +142,7 @@ function ClientCheckoutContent() {
 		<div className="client-checkout-v2">
 			<CheckoutMain
 				sitelessCheckoutType="a4a"
-				redirectTo="/client/subscriptions"
+				redirectTo={ window.location.origin + '/client/subscriptions' }
 				isInModal={ false }
 				siteSlug=""
 				siteId={ 0 }

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -37,7 +37,7 @@ function ClientCheckoutContent() {
 
 	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
 
-	const isDoNotMatchReferralClientEmail = referral?.client?.email !== userEmail;
+	const emailMismatchWithReferralClient = referral?.client?.email !== userEmail;
 
 	// Add products to cart when referral data is loaded
 	useEffect( () => {
@@ -85,7 +85,16 @@ function ClientCheckoutContent() {
 			debug( '[A4A Checkout] No matching products found to add to cart' );
 			setError( 'Could not find the requested products' );
 		}
-	}, [ isReady, error, referredProducts, referral, addProductsToCart, responseCart ] );
+	}, [
+		isReady,
+		error,
+		referredProducts,
+		referral,
+		addProductsToCart,
+		responseCart,
+		queryArgs.referralId,
+		queryArgs.agencyId,
+	] );
 
 	// Debugging: Set a timeout to force showing the checkout after 10 seconds
 	useEffect( () => {
@@ -105,7 +114,7 @@ function ClientCheckoutContent() {
 		return <ClientCheckoutV2Placeholder />;
 	}
 
-	if ( isDoNotMatchReferralClientEmail ) {
+	if ( emailMismatchWithReferralClient ) {
 		return (
 			<ClientCheckoutV2Error
 				title={ translate( 'Permission denied' ) }

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -1,0 +1,144 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
+import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { createRequestCartProduct, useShoppingCart } from '@automattic/shopping-cart';
+import debugFactory from 'debug';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import useProductsById from 'calypso/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id';
+import { getClientReferralQueryArgs } from 'calypso/a8c-for-agencies/sections/marketplace/lib/get-client-referral-query-args';
+import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import useFetchClientReferral from '../../hooks/use-fetch-client-referral';
+
+import './style.scss';
+
+const debug = debugFactory( 'client:checkout-v2' );
+
+/**
+ * Client Checkout Component using the WordPress.com checkout
+ */
+function ClientCheckoutContent() {
+	const translate = useTranslate();
+	const [ isReady, setIsReady ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+
+	const { data: referral } = useFetchClientReferral( getClientReferralQueryArgs() );
+	const { referredProducts } = useProductsById( referral?.products ?? [] );
+
+	// Access the shopping cart API
+	const { addProductsToCart, responseCart } = useShoppingCart( 'no-site' );
+
+	// Add products to cart when referral data is loaded
+	useEffect( () => {
+		// Skip if we're already ready or have an error
+		if ( isReady || error ) {
+			debug( '[A4A Checkout] Already ready or has error' );
+			return;
+		}
+
+		if ( ! referredProducts || referredProducts.length === 0 ) {
+			debug( '[A4A Checkout] No referred products' );
+			return;
+		}
+
+		debug( '[A4A Checkout] Referral', referral );
+		debug( '[A4A Checkout] Referred products', referredProducts );
+
+		const productsToAdd = referredProducts.map( ( product ) => {
+			return createRequestCartProduct( {
+				product_id: product.product_id,
+				product_slug: product.slug,
+				extra: { isA4ASitelessCheckout: true },
+			} );
+		} );
+
+		debug( '[A4A Checkout] Products to add', productsToAdd );
+
+		// Add products to cart
+		if ( productsToAdd.length > 0 ) {
+			addProductsToCart( productsToAdd )
+				.then( () => {
+					debug( '[A4A Checkout] Products added to cart successfully' );
+					debug( '[A4A Checkout] Cart', responseCart );
+					setIsReady( true );
+				} )
+				.catch( ( err ) => {
+					debug( '[A4A Checkout] Failed to add products to cart:', err );
+					setError( 'Failed to add products to cart' );
+				} );
+		} else {
+			debug( '[A4A Checkout] No matching products found to add to cart' );
+			setError( 'Could not find the requested products' );
+		}
+	}, [ isReady, error, referredProducts ] );
+
+	// Debugging: Set a timeout to force showing the checkout after 10 seconds
+	useEffect( () => {
+		if ( isReady || error ) {
+			return;
+		}
+
+		const timeoutId = setTimeout( () => {
+			debug( '[A4A Checkout] Timeout reached, showing checkout anyway' );
+			setIsReady( true );
+		}, 10000 );
+
+		return () => clearTimeout( timeoutId );
+	}, [ isReady, error ] );
+
+	// Debugging: Show loading state
+	if ( ! isReady && ! error ) {
+		return (
+			<div className="client-checkout-v2__loading">
+				<h2>{ translate( 'Loading checkout' ) }</h2>
+				<p>{ translate( 'Setting up your products for purchase' ) }</p>
+			</div>
+		);
+	}
+
+	// Debugging: Show error state
+	if ( error ) {
+		return (
+			<div className="client-checkout-v2__error">
+				<h2>{ translate( 'Error' ) }</h2>
+				<p>{ error }</p>
+			</div>
+		);
+	}
+
+	// Show checkout
+	return (
+		<div className="client-checkout-v2">
+			<CheckoutMain
+				sitelessCheckoutType="a4a"
+				redirectTo="/client/subscriptions"
+				isInModal={ false }
+				siteSlug=""
+				siteId={ 0 }
+			/>
+		</div>
+	);
+}
+
+export default function ClientCheckoutV2() {
+	const translate = useTranslate();
+	const locale = useSelector( getCurrentUserLocale );
+
+	return (
+		<CheckoutErrorBoundary
+			errorMessage={ translate( 'Sorry, there was an error loading the checkout page.' ) }
+		>
+			<CalypsoShoppingCartProvider shouldShowPersistentErrors>
+				<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
+					<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+						<ClientCheckoutContent />
+					</RazorpayHookProvider>
+				</StripeHookProvider>
+			</CalypsoShoppingCartProvider>
+		</CheckoutErrorBoundary>
+	);
+}

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -28,7 +28,8 @@ function ClientCheckoutContent() {
 	const [ isReady, setIsReady ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 
-	const { data: referral } = useFetchClientReferral( getClientReferralQueryArgs() );
+	const queryArgs = getClientReferralQueryArgs();
+	const { data: referral } = useFetchClientReferral( queryArgs );
 	const { referredProducts } = useProductsById( referral?.products ?? [] );
 
 	// Access the shopping cart API
@@ -58,7 +59,11 @@ function ClientCheckoutContent() {
 			return createRequestCartProduct( {
 				product_id: product.product_id,
 				product_slug: product.slug,
-				extra: { isA4ASitelessCheckout: true },
+				extra: {
+					isA4ASitelessCheckout: true,
+					referral_id: queryArgs.referralId,
+					agency_id: queryArgs.agencyId,
+				},
 			} );
 		} );
 

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
@@ -4,3 +4,7 @@
 		background-color: var(--color-surface);
 	}
 }
+
+.client-checkout-v2 {
+	min-height: 100vh;
+}

--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/style.scss
@@ -1,0 +1,6 @@
+.theme-a8c-for-agencies:has(.client-checkout-v2) {
+	.layout.has-no-masterbar .layout__content {
+		padding: 0;
+		background-color: var(--color-surface);
+	}
+}

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -298,6 +298,13 @@ export default function getThankYouPageUrl( {
 		return `/checkout/akismet/thank-you/${ productSlug }`;
 	}
 
+	// A4A client checkout uses a custom thank you page
+	if ( sitelessCheckoutType === 'a4a' ) {
+		debug( 'redirecting to A4A client subscriptions page' );
+		// If redirectTo is specified, use it. Otherwise, redirect to the client subscriptions page
+		return redirectTo || '/client/subscriptions';
+	}
+
 	// If there is no purchase, then send the user to a generic page (not
 	// post-purchase related).
 	if ( noPurchaseMade ) {

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1864,4 +1864,21 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 	} );
+
+	describe( 'A4A client checkout', () => {
+		it( 'should return the redirectTo URL when provided for A4A client checkout', () => {
+			const result = getThankYouPageUrl( {
+				sitelessCheckoutType: 'a4a',
+				redirectTo: '/custom/redirect/path',
+			} );
+			expect( result ).toBe( '/custom/redirect/path' );
+		} );
+
+		it( 'should return the default client subscriptions page for A4A client checkout without redirectTo', () => {
+			const result = getThankYouPageUrl( {
+				sitelessCheckoutType: 'a4a',
+			} );
+			expect( result ).toBe( '/client/subscriptions' );
+		} );
+	} );
 } );

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -549,7 +549,21 @@ export default function CheckoutMain( {
 				highlightOver: colors[ 'WordPress Blue 60' ],
 		  }
 		: {};
-	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
+	const a4aColors =
+		sitelessCheckoutType === 'a4a'
+			? {
+					primary: colors[ 'Automattic Blue' ],
+					primaryBorder: colors[ 'Automattic Blue 80' ],
+					primaryOver: colors[ 'Automattic Blue 60' ],
+					highlight: colors[ 'Automattic Blue 50' ],
+					highlightBorder: colors[ 'Automattic Blue 80' ],
+					highlightOver: colors[ 'Automattic Blue 60' ],
+			  }
+			: {};
+	const theme = {
+		...checkoutTheme,
+		colors: { ...checkoutTheme.colors, ...jetpackColors, ...a4aColors },
+	};
 
 	const isCheckoutV2ExperimentLoading = false;
 

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -148,7 +148,8 @@ export default function CheckoutMain( {
 	const isSiteless =
 		sitelessCheckoutType === 'jetpack' ||
 		sitelessCheckoutType === 'akismet' ||
-		sitelessCheckoutType === 'marketplace';
+		sitelessCheckoutType === 'marketplace' ||
+		sitelessCheckoutType === 'a4a';
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const { razorpayConfiguration, isRazorpayLoading, razorpayLoadingError } = useRazorpay();
 	const createUserAndSiteBeforeTransaction =

--- a/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
@@ -38,6 +38,10 @@ export default function useCheckoutFlowTrackKey( {
 			return 'marketplace_siteless_checkout';
 		}
 
+		if ( sitelessCheckoutType === 'a4a' ) {
+			return 'a4a_siteless_checkout';
+		}
+
 		if ( isLoggedOutCart ) {
 			return 'wpcom_registrationless';
 		}

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -235,6 +235,7 @@ export default function useCreatePaymentCompleteCallback( {
 					siteSlug,
 					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
 					receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
+					fromExternalCheckout: sitelessCheckoutType === 'a4a',
 				} );
 				return;
 			}
@@ -252,6 +253,7 @@ export default function useCreatePaymentCompleteCallback( {
 					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
 					receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
 					fromSiteSlug,
+					fromExternalCheckout: sitelessCheckoutType === 'a4a',
 				} );
 				return;
 			}
@@ -263,6 +265,7 @@ export default function useCreatePaymentCompleteCallback( {
 				siteSlug,
 				orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
 				receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
+				fromExternalCheckout: sitelessCheckoutType === 'a4a',
 			} );
 		},
 		[

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -44,7 +44,8 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true
+		"a4a-wc-asia-signup-enabled": true,
+		"a4a-client-checkout-v2": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -37,7 +37,8 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true
+		"a4a-wc-asia-signup-enabled": true,
+		"a4a-client-checkout-v2": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -37,7 +37,8 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true
+		"a4a-wc-asia-signup-enabled": true,
+		"a4a-client-checkout-v2": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -39,7 +39,8 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true
+		"a4a-wc-asia-signup-enabled": true,
+		"a4a-client-checkout-v2": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -884,6 +884,7 @@ export interface ResponseCartProductExtra {
 	isJetpackCheckout?: boolean;
 	isAkismetSitelessCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;
+	isA4aSitelessCheckout?: boolean;
 
 	/**
 	 * Marketplace properties
@@ -931,6 +932,7 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	isAkismetSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;
+	isA4ASitelessCheckout?: boolean;
 	intentId?: number;
 
 	/**

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -885,6 +885,8 @@ export interface ResponseCartProductExtra {
 	isAkismetSitelessCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;
 	isA4aSitelessCheckout?: boolean;
+	referral_id?: number;
+	agency_id?: number;
 
 	/**
 	 * Marketplace properties
@@ -933,6 +935,8 @@ export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	isJetpackCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;
 	isA4ASitelessCheckout?: boolean;
+	referral_id?: number;
+	agency_id?: number;
 	intentId?: number;
 
 	/**

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -657,4 +657,4 @@ export interface CountryListItemWithVat extends CountryListItemBase {
 }
 export type CountryListItem = CountryListItemWithVat | CountryListItemWithoutVat;
 
-export type SitelessCheckoutType = 'jetpack' | 'akismet' | 'marketplace' | undefined;
+export type SitelessCheckoutType = 'jetpack' | 'akismet' | 'marketplace' | 'a4a' | undefined;


### PR DESCRIPTION
<img width="2556" alt="Screenshot 2025-04-04 at 6 20 08 PM" src="https://github.com/user-attachments/assets/01517b63-1214-457c-b2a4-cfd9aaf01c8c" />

**NOTE: This PR only focuses on building the Checkout page. The complete checkout process remains non-functional and will be tackled in separate tickets.**

## Proposed Changes

* An early and minimal POC for using wpcom billing for referral purchases

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Setup
* Apply the backend PR: 177521-ghe-Automattic/wpcom
* Follow the instructions in that PR

#### Testing
* Create a new A4A referral for a single product.
* Visit the link from the email sent to the client in a private browser window.
* Once you authenticate and land on the existing checkout page (DO NOT CHECKOUT)
* Change the domain and path to `http://agencies.localhost:3000/client/checkout/v2` (or using the live linnk URL if using it). Keep the same URL parameters.
  * Example: `http://agencies.localhost:3000/client/checkout/v2?agency_id=235881081&referral_id=133&secret=INSERT_SECRET_HERE&client_id=95932`
* After loading, you should see the new checkout page with the correct product in the cart. The page currently has some UI issues but should work.
* Add payment details id needed
  * When using store sandbox you can use test cards like `4242 4242 4242 4242` and any future expiry and any cvv
* Checkout...
* Note that the flow is still broken. This will be addressed on a separate ticket.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
