### PR TITLE
Upsell Nudge:  Update to account for loading state when checking for features

### DIFF
--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -22,6 +22,7 @@ import Banner from 'calypso/components/banner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { addQueryArgs } from 'calypso/lib/url';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
@@ -41,7 +42,7 @@ const debug = debugFactory( 'calypso:upsell-nudge' );
 
 type ConnectedProps = {
 	site: SiteDetails | null | undefined;
-	selectedSiteHasFeature: boolean;
+	selectedSiteHasFeature: boolean | null;
 	canManageSite: boolean;
 	isJetpack: boolean;
 	isAtomic: boolean;
@@ -156,6 +157,7 @@ export const UpsellNudge = ( {
 		! site ||
 		typeof site !== 'object' ||
 		typeof site.jetpack !== 'boolean' ||
+		( feature && selectedSiteHasFeature === null ) || // Site features haven't loaded yet
 		( feature && selectedSiteHasFeature ) ||
 		( ! feature && ! ( site.plan && isFreePlanProduct( site.plan ) ) ) ||
 		( feature === WPCOM_FEATURES_NO_ADVERTS && site?.options?.wordads ) ||
@@ -292,10 +294,13 @@ export const UpsellNudge = ( {
 
 const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: OwnProps ) => {
 	const siteId = getSelectedSiteId( state );
+	const siteFeatures = getFeaturesBySiteId( state, siteId || undefined );
+	const hasFeature =
+		siteFeatures === null ? null : siteHasFeature( state, siteId, ownProps.feature || '' );
 
 	return {
 		site: getSite( state, siteId || undefined ),
-		selectedSiteHasFeature: siteHasFeature( state, siteId, ownProps.feature || '' ) || false,
+		selectedSiteHasFeature: hasFeature,
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		isJetpack: isJetpackSite( state, siteId ) || false,
 		isAtomic: isSiteAutomatedTransfer( state, siteId ) || false,


### PR DESCRIPTION
Updates the Upsell nudge to check if site features have been loaded before checking if the site should show the banner when checking against an available feature

Fixes a flash of the UpsellNudge appearing when loading a screen. One of the conditions for making it visible depends on information that's loaded asnychronously, so there's a moment in which the nudge is shown even if it doesn't have to be shown

Related to #

## Proposed Changes

* Makes the component's `selectedSiteHasFeature` be able to have a `null` value if we detect that the features for a site haven't been loaded. It will use this `null` value to decide not to render the nudge if it's being asked to check for availability of a feature with the `feature` prop

> [!NOTE]
> We should probably update the `siteHasFeature()` selector to return null if no data is loaded, but it has many implications in tests and probably components


The bug:

https://github.com/user-attachments/assets/afd358b6-876b-4669-aade-b0b9e8d59bef

After this fix:

https://github.com/user-attachments/assets/a9f91c22-0dae-4b0e-8cc5-f1942ae5f0a9


Confirmation that it works (Free plan same marketing tools page)

https://github.com/user-attachments/assets/72caf71d-a58f-4d5a-a925-92fcb751d86c


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Start with a site with Personal or Premium plan
* Visit the marketing page
* Expect not to see a flashing upsell nudge for No ads

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
