### PR TITLE
Reader: Add Recommended Blogs list

### DIFF
--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -170,12 +170,14 @@ function ReaderListEdit( props ) {
 								>
 									{ translate( 'Export' ) }
 								</NavItem>
-								<NavItem
-									selected={ selectedSection === 'delete' }
-									path={ `/reader/list/${ props.owner }/${ props.slug }/delete` }
-								>
-									{ translate( 'Delete' ) }
-								</NavItem>
+								{ list.is_public !== 2 && (
+									<NavItem
+										selected={ selectedSection === 'delete' }
+										path={ `/reader/list/${ props.owner }/${ props.slug }/delete` }
+									>
+										{ translate( 'Delete' ) }
+									</NavItem>
+								) }
 							</NavTabs>
 						</SectionNav>
 						{ selectedSection === 'details' && <Details { ...sectionProps } /> }

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -25,6 +25,36 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list = {
 	const [ formList, updateFormList ] = useState(
 		isCreateForm ? INITIAL_CREATE_FORM_STATE : { ...INITIAL_UPDATE_FORM_STATE, ...list }
 	);
+
+	// If list.is_public is 2 this list is permanent - render minimal form with no edit options
+	if ( list.is_public === 2 ) {
+		return (
+			<Card>
+				<FormFieldset>
+					<FormLabel htmlFor="list-name">{ translate( 'Name' ) }</FormLabel>
+					<FormTextInput
+						data-key="title"
+						id="list-name"
+						name="list-name"
+						disabled
+						value={ formList.title }
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="list-slug">{ translate( 'Slug' ) }</FormLabel>
+					<FormTextInput
+						data-key="slug"
+						id="list-slug"
+						name="list-slug"
+						disabled
+						value={ formList.slug }
+					/>
+				</FormFieldset>
+			</Card>
+		);
+	}
+
 	const onChange = ( event ) => {
 		const update = { [ event.target.dataset.key ]: event.target.value };
 		if ( 'is_public' in update ) {

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -83,7 +83,7 @@ class ListStream extends Component {
 				/>
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader
-					isPublic={ list?.is_public }
+					isPublic={ list?.is_public === 1 }
 					icon={
 						<svg
 							className={ listStreamIconClasses }

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { translate } from 'i18n-calypso';
+import { isEnabled } from 'calypso/server/config';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -149,6 +150,11 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 						method: 'GET',
 						path: '/read/lists',
 						apiVersion: '1.2',
+						query: {
+							create_recommended_blogs_list: isEnabled( 'reader/recommended-blogs-list' )
+								? 'true'
+								: undefined,
+						},
 					},
 					action
 				),

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -1,6 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { translate } from 'i18n-calypso';
-import { isEnabled } from 'calypso/server/config';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/528

Related to pe7F0s-2Ba-p2

If we pass the `create_recommended_blogs_list` param in the `/read/lists` API request, the endpoint will create the recommended blogs list for this user (if it doesn't already exists).

Using the feature flag `reader/recommended-blogs-list` allows us to merge this without affecting users.

Works with 177026-ghe-Automattic/wpcom

The Recommended Blogs list is meant to be permanent and not editable - we can know if a list is permanent if the `is_public` field is set to `2`.

This PR updates the manage list form to hide the edit options.

<img width="1066" alt="Screenshot 2025-03-16 at 20 41 37" src="https://github.com/user-attachments/assets/8cc000df-9057-432f-b7bb-97f70ee8856d" />

## Proposed Changes

* Checks if feature flag `reader/recommended-blogs-list` is set - if it is passes the `create_recommended_blogs_list` in the `/read/lists` API request.
* Removes the "Delete" option for this list
* Removes the visibility option. Visibility will always be set to "Everyone can view this list".
* Removes the "Description" field (that normally shows for a list)
* Prevents the list name from being edited
* Removes the save button


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the patch 177026-ghe-Automattic/wpcom to sandbox
* Sandbox the public-api.wordpress.com
* Go to calypso live `/reader`
* Confirm you see the `Recommended Blogs` list upon refresh
* Click on the  `Recommended Blogs` list and confirm you can't edit or delete the list
* Confirm you can create new list and edit it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?