### PR TITLE
A4A: remove referral commissions for 3rd party woo plugins

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/index.tsx
@@ -16,6 +16,11 @@ export default function CommissionsInfo( { items }: { items: ShoppingCartItem[] 
 		return acc + totalCommissions;
 	}, 0 );
 
+	// If the total commissions are 0, don't show the commissions info
+	if ( totalCommissions === 0 ) {
+		return null;
+	}
+
 	return (
 		<div className="commissions-info">
 			<span>{ translate( 'Your estimated commission:' ) }</span>

--- a/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/commissions.ts
@@ -1,8 +1,23 @@
 import type { Referral } from '../types';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
+export const isProductEligibleForCommission = ( slug: string ) => {
+	const thirdPartyProducts = [
+		'woocommerce-constellation',
+		'woocommerce-dynamic-pricing',
+		'woocommerce-rental-products',
+		'woocommerce-smart-coupons',
+		'woocommerce-variation-swatches-and-photos',
+	];
+
+	if ( thirdPartyProducts.includes( slug ) ) {
+		return false;
+	}
+	return true;
+};
+
 export const getProductCommissionPercentage = ( slug?: string ) => {
-	if ( ! slug ) {
+	if ( ! slug || ! isProductEligibleForCommission( slug ) ) {
 		return 0;
 	}
 	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( slug ) ) {

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -1,19 +1,7 @@
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { Referral } from '../types';
+import { getProductCommissionPercentage } from './commissions';
 import { getNextPayoutDateActivityWindow } from './get-next-payout-date';
-
-export const getProductCommissionPercentage = ( slug?: string ) => {
-	if ( ! slug ) {
-		return 0;
-	}
-	if ( [ 'wpcom-hosting', 'pressable-hosting' ].includes( slug ) ) {
-		return 0.2;
-	}
-	if ( slug.startsWith( 'jetpack-' ) || slug.startsWith( 'woocommerce-' ) ) {
-		return 0.5;
-	}
-	return 0;
-};
 
 export const getDailyPrice = ( product: APIProductFamilyProduct, quantity: number ) => {
 	// If quantity is not 1 than we search corresponding bundle

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
@@ -1,32 +1,8 @@
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import {
-	getEstimatedCommission,
-	getProductCommissionPercentage,
-	getDailyPrice,
-} from '../get-estimated-commission';
+import { getEstimatedCommission, getDailyPrice } from '../get-estimated-commission';
 import type { Referral } from '../../types';
 
 describe( 'get-estimated-commission', () => {
-	describe( 'getProductCommissionPercentage', () => {
-		it( 'returns 0 for undefined slug', () => {
-			expect( getProductCommissionPercentage( undefined ) ).toBe( 0 );
-		} );
-
-		it( 'returns 20% for hosting products', () => {
-			expect( getProductCommissionPercentage( 'wpcom-hosting' ) ).toBe( 0.2 );
-			expect( getProductCommissionPercentage( 'pressable-hosting' ) ).toBe( 0.2 );
-		} );
-
-		it( 'returns 50% for Jetpack and WooCommerce products', () => {
-			expect( getProductCommissionPercentage( 'jetpack-backup' ) ).toBe( 0.5 );
-			expect( getProductCommissionPercentage( 'woocommerce-payments' ) ).toBe( 0.5 );
-		} );
-
-		it( 'returns 0 for unknown products', () => {
-			expect( getProductCommissionPercentage( 'unknown-product' ) ).toBe( 0 );
-		} );
-	} );
-
 	describe( 'getDailyPrice', () => {
 		const mockProduct: APIProductFamilyProduct = {
 			product_id: 1,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1925

## Proposed Changes

- We don't calculate commissions for WooCommerce 3rd party extensions, that are referred through marketplace. This PR fixes behavior.
<img width="587" alt="Screenshot 2025-03-14 at 3 13 15 PM" src="https://github.com/user-attachments/assets/37c54a3b-395e-4324-8862-4f7f6e12a7a8" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using live link navigate to `/marketplace` and enable referral mode
- Make a referral for new email (or remember the amount of commission for previous referral email on `/referrals/dashboard`) on of 3rd party products:
```
'woocommerce-constellation',
'woocommerce-dynamic-pricing',
'woocommerce-rental-products',
'woocommerce-smart-coupons',
'woocommerce-variation-swatches-and-photos',
```
- Check `cart` and `checkout page` and verify there's no commission displayed
- Using link from email, complete purchase
- On agency referral dashboard `/referrals/dashboard` verify that commission didn't chaged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
