### PR TITLE
PlansGridNext: Increase color contrast of green text

### DIFF
--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -30,7 +30,7 @@ $mobile-card-max-width: 440px;
 }
 
 .plans-grid-next-storage-feature-label__offset-price {
-	color: var(--studio-green-50);
+	color: var(--studio-green-60);
 	font-size: $font-body-extra-small;
 	font-weight: 500;
 }

--- a/packages/plans-grid-next/src/components/dropdown-option.tsx
+++ b/packages/plans-grid-next/src/components/dropdown-option.tsx
@@ -16,7 +16,7 @@ const Container = styled.div`
 	}
 
 	span {
-		color: var( --studio-green-50 );
+		color: var( --studio-green-60 );
 	}
 
 	.title {


### PR DESCRIPTION
Part of #101301 

## Proposed Changes

Darkens the green text in PlansGridNext from `green-50` to `green-60`.

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/cba7d8a0-6ffe-4f41-988c-08e72b31d199" alt="Green text in PlansGrid, before" width="604">|<img src="https://github.com/user-attachments/assets/0fe81e2d-93c1-4a7c-a766-ad520dc3bd6f" alt="Green text in PlansGrid, after" width="604">|


## Why are these changes being made?

To unify color usage so it's harder to create failing contrast scenarios. In this specific case, `green-50` is set on a `#ffffff` background so the contrast ratio was already passing. However, it would've failed on a `#fdfdfd` background, which happens often enough.

## Testing Instructions

Apply this diff to force the condition:

```diff
diff --git a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
index b141cdf5f1..f609aed659 100644
--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
@@ -51,7 +51,7 @@ const StorageFeatureLabel = ( { planSlug }: Props ) => {
 		</div>
 	);
 
-	return formattedMonthlyAddedCost ? (
+	return true ? (
 		<div className={ containerClasses }>
 			{ volumeJSX }
 			<div className="plans-grid-next-storage-feature-label__offset-price">
```

`yarn start` and go to the `/plans` page for one of your sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
