### PR TITLE
Self Service Downgrades: Calculate feature differences given two plans and feature bundle name

### DIFF
--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -948,3 +948,34 @@ export function isValidFeatureKey( feature: string ) {
 export function getFeatureByKey( feature: string ) {
 	return FEATURES_LIST[ feature ];
 }
+
+export function getFeatureDifference(
+	smallerPlan: string,
+	biggerPlan: string,
+	featureBundleSelector: keyof Plan
+) {
+	let biggerPlanObject = ( getPlan( biggerPlan ) as Plan )?.[ featureBundleSelector ] as
+		| Array< string >
+		| ( () => Array< string > );
+	let smallerPlanObject = ( getPlan( smallerPlan ) as Plan )?.[ featureBundleSelector ] as
+		| Array< string >
+		| ( () => Array< string > );
+
+	if ( typeof biggerPlanObject === 'function' ) {
+		biggerPlanObject = biggerPlanObject();
+	} else if ( ! Array.isArray( biggerPlanObject ) ) {
+		biggerPlanObject = [];
+	}
+
+	if ( typeof smallerPlanObject === 'function' ) {
+		smallerPlanObject = smallerPlanObject();
+	} else if ( ! Array.isArray( smallerPlanObject ) ) {
+		smallerPlanObject = [];
+	}
+
+	const difference = biggerPlanObject.filter(
+		( feature ) => ! smallerPlanObject.includes( feature )
+	);
+
+	return difference;
+}

--- a/packages/calypso-products/test/get-feature-difference.ts
+++ b/packages/calypso-products/test/get-feature-difference.ts
@@ -1,0 +1,78 @@
+import {
+	FEATURE_DEV_TOOLS,
+	FEATURE_PRIORITY_24_7_SUPPORT,
+	FEATURE_UPLOAD_PLUGINS,
+	getFeatureDifference,
+	PLAN_BUSINESS,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+	FEATURE_STYLE_CUSTOMIZATION,
+	FEATURE_CONNECT_ANALYTICS,
+	FEATURE_UPLOAD_VIDEO,
+	FEATURE_STATS_ADVANCED_20250206,
+	PLAN_ECOMMERCE,
+	FEATURE_THEMES_PREMIUM_AND_STORE,
+	FEATURE_WOOCOMMERCE_HOSTING,
+	PLAN_FREE,
+	FEATURE_AD_FREE_EXPERIENCE,
+	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
+	FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+	FEATURE_STATS_BASIC_20250206,
+	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_ACCEPT_PAYMENTS,
+	FEATURE_SHIPPING_CARRIERS,
+	FEATURE_UNLIMITED_PRODUCTS_SERVICES,
+	FEATURE_INVENTORY,
+	FEATURE_CUSTOM_MARKETING_AUTOMATION,
+} from '../src';
+
+describe( 'getFeatureDifference function related tests', () => {
+	it( 'get2023PricingGridSignupWpcomFeatures bundle selector extractor: Free --> Personal difference', () => {
+		expect(
+			getFeatureDifference( PLAN_FREE, PLAN_PERSONAL, 'get2023PricingGridSignupWpcomFeatures' )
+		).toEqual( [
+			FEATURE_CUSTOM_DOMAIN,
+			FEATURE_AD_FREE_EXPERIENCE,
+			WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
+			FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+			FEATURE_STATS_BASIC_20250206,
+		] );
+	} );
+
+	it( 'get2023PricingGridSignupWpcomFeatures bundle selector extractor: Personal --> Premium difference', () => {
+		expect(
+			getFeatureDifference( PLAN_PERSONAL, PLAN_PREMIUM, 'get2023PricingGridSignupWpcomFeatures' )
+		).toEqual( [
+			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+			FEATURE_STYLE_CUSTOMIZATION,
+			FEATURE_CONNECT_ANALYTICS,
+			FEATURE_UPLOAD_VIDEO,
+			FEATURE_STATS_ADVANCED_20250206,
+		] );
+	} );
+
+	it( 'get2023PricingGridSignupWpcomFeatures bundle selector: Premium --> Business difference', () => {
+		expect(
+			getFeatureDifference( PLAN_PREMIUM, PLAN_BUSINESS, 'get2023PricingGridSignupWpcomFeatures' )
+		).toEqual( [ FEATURE_PRIORITY_24_7_SUPPORT, FEATURE_UPLOAD_PLUGINS, FEATURE_DEV_TOOLS ] );
+	} );
+
+	it( 'get2023PricingGridSignupWpcomFeatures bundle selector extractor: Business --> Woo difference', () => {
+		expect(
+			getFeatureDifference( PLAN_BUSINESS, PLAN_ECOMMERCE, 'get2023PricingGridSignupWpcomFeatures' )
+		).toEqual( [ FEATURE_THEMES_PREMIUM_AND_STORE, FEATURE_WOOCOMMERCE_HOSTING ] );
+	} );
+
+	it( 'Other feature bundle selector, differentiates plan featurescorrectly, Business', () => {
+		expect( getFeatureDifference( PLAN_BUSINESS, PLAN_ECOMMERCE, 'getCheckoutFeatures' ) ).toEqual(
+			[
+				FEATURE_ACCEPT_PAYMENTS,
+				FEATURE_SHIPPING_CARRIERS,
+				FEATURE_UNLIMITED_PRODUCTS_SERVICES,
+				FEATURE_INVENTORY,
+				FEATURE_CUSTOM_MARKETING_AUTOMATION,
+			]
+		);
+	} );
+} );

--- a/packages/calypso-products/test/get-feature-difference.ts
+++ b/packages/calypso-products/test/get-feature-difference.ts
@@ -25,6 +25,7 @@ import {
 	FEATURE_UNLIMITED_PRODUCTS_SERVICES,
 	FEATURE_INVENTORY,
 	FEATURE_CUSTOM_MARKETING_AUTOMATION,
+	getPlan,
 } from '../src';
 
 describe( 'getFeatureDifference function related tests', () => {
@@ -74,5 +75,43 @@ describe( 'getFeatureDifference function related tests', () => {
 				FEATURE_CUSTOM_MARKETING_AUTOMATION,
 			]
 		);
+	} );
+
+	it( 'If no feature difference should return emtpty array', () => {
+		expect( getFeatureDifference( PLAN_BUSINESS, PLAN_BUSINESS, 'getCheckoutFeatures' ) ).toEqual(
+			[]
+		);
+	} );
+
+	it( 'Returns empty array when feature bundle selector does not exist', () => {
+		expect(
+			getFeatureDifference( PLAN_PREMIUM, PLAN_BUSINESS, 'nonExistentSelector' as any )
+		).toEqual( [] );
+	} );
+
+	it( 'Handles case when feature bundle selector returns a function instead of array', () => {
+		const mockPlan = getPlan( PLAN_BUSINESS );
+		jest
+			.spyOn( mockPlan as any, 'getCheckoutFeatures' )
+			.mockImplementation( () => [ FEATURE_PRIORITY_24_7_SUPPORT, FEATURE_UPLOAD_PLUGINS ] );
+
+		expect( getFeatureDifference( PLAN_PREMIUM, PLAN_BUSINESS, 'getCheckoutFeatures' ) ).toEqual( [
+			FEATURE_PRIORITY_24_7_SUPPORT,
+			FEATURE_UPLOAD_PLUGINS,
+		] );
+	} );
+
+	it( 'Difference should not contain features from smaller plan', () => {
+		const mockFeatureSelector = 'get2023PricingGridSignupWpcomFeatures';
+
+		const difference = getFeatureDifference( PLAN_PERSONAL, PLAN_PREMIUM, mockFeatureSelector );
+
+		const planPersonalFeatures = getPlan( PLAN_PERSONAL )?.[
+			mockFeatureSelector
+		]?.() as unknown as Array< string >;
+
+		planPersonalFeatures.forEach( ( f ) => {
+			expect( difference ).not.toContain( f );
+		} );
 	} );
 } );

--- a/packages/calypso-products/test/get-feature-difference.ts
+++ b/packages/calypso-products/test/get-feature-difference.ts
@@ -26,6 +26,7 @@ import {
 	FEATURE_INVENTORY,
 	FEATURE_CUSTOM_MARKETING_AUTOMATION,
 	getPlan,
+	FEATURE_SUPPORT_FROM_EXPERTS,
 } from '../src';
 
 describe( 'getFeatureDifference function related tests', () => {
@@ -36,7 +37,7 @@ describe( 'getFeatureDifference function related tests', () => {
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_AD_FREE_EXPERIENCE,
 			WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
-			FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+			FEATURE_SUPPORT_FROM_EXPERTS,
 			FEATURE_STATS_BASIC_20250206,
 		] );
 	} );
@@ -46,6 +47,7 @@ describe( 'getFeatureDifference function related tests', () => {
 			getFeatureDifference( PLAN_PERSONAL, PLAN_PREMIUM, 'get2023PricingGridSignupWpcomFeatures' )
 		).toEqual( [
 			WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+			FEATURE_FAST_SUPPORT_FROM_EXPERTS,
 			FEATURE_STYLE_CUSTOMIZATION,
 			FEATURE_CONNECT_ANALYTICS,
 			FEATURE_UPLOAD_VIDEO,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to: https://github.com/Automattic/wp-calypso/issues/100441

## Proposed Changes

* This change calculate the features that users will miss out on when they downgrade from higher plan to lower plan. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We are working on introducing self service downgrades. This change will provide a simple function which can be used to get the features that will be missed out on based on the downgraded to plan and the higher level plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
