### PR TITLE
Domains step uses TwoColumnLayout

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -337,13 +337,16 @@
 	max-width: 100%;
 }
 
-body.is-section-stepper,
-body.is-section-signup {
+body.is-section-stepper:not(:has(.step-container-v2)),
+body.is-section-signup:not(:has(.step-container-v2)) {
 	svg {
 		padding-top: 0;
 		margin-right: 0;
 	}
+}
 
+body.is-section-stepper,
+body.is-section-signup {
 	.domain-registration-suggestion__badges {
 		margin-left: 0;
 		margin-bottom: 4px;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -199,6 +199,7 @@
 }
 
 body.is-section-stepper .step-container .featured-domain-suggestion.card,
+body.is-section-stepper .step-container-v2 .featured-domain-suggestion.card,
 body.is-section-signup .step-wrapper .featured-domain-suggestion.card {
 	border: none;
 	border-radius: 0;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -79,7 +79,7 @@ button {
 .newsletter-setup,
 .newsletter-goals,
 .plans,
-.domains,
+.domains:not(:has(.step-container-v2)),
 .patterns,
 .anchor-fm,
 .subscribers,

--- a/client/signup/steps/domains/async-domain-step-wrapper.tsx
+++ b/client/signup/steps/domains/async-domain-step-wrapper.tsx
@@ -1,0 +1,48 @@
+import { Step } from '@automattic/onboarding';
+
+interface AsyncDomainStepWrapperProps {
+	hideBack: boolean;
+	backLabelText: string;
+	backUrl: string;
+	isExternalBackUrl: boolean;
+	headerText: string;
+	subHeaderText: string;
+	goBack: () => void;
+	mainContent: React.ReactNode;
+	rightContent: React.ReactNode;
+}
+
+export default function AsyncDomainStepWrapper( props: AsyncDomainStepWrapperProps ) {
+	const {
+		hideBack,
+		backLabelText,
+		backUrl,
+		isExternalBackUrl,
+		headerText,
+		subHeaderText,
+		goBack,
+		mainContent,
+		rightContent,
+	} = props;
+
+	const backButton = (
+		<Step.BackButton
+			href={ backUrl }
+			rel={ isExternalBackUrl ? 'external' : '' }
+			onClick={ goBack }
+			label={ backLabelText }
+		/>
+	);
+
+	return (
+		<Step.TwoColumnLayout
+			firstColumnWidth={ 7 }
+			secondColumnWidth={ 3 }
+			topBar={ <Step.TopBar backButton={ ! hideBack && backButton } /> }
+			heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+		>
+			{ mainContent }
+			{ rightContent }
+		</Step.TwoColumnLayout>
+	);
+}

--- a/client/signup/steps/domains/async-domain-step-wrapper.tsx
+++ b/client/signup/steps/domains/async-domain-step-wrapper.tsx
@@ -10,6 +10,7 @@ interface AsyncDomainStepWrapperProps {
 	goBack: () => void;
 	mainContent: React.ReactNode;
 	rightContent: React.ReactNode;
+	className: string;
 }
 
 export default function AsyncDomainStepWrapper( props: AsyncDomainStepWrapperProps ) {
@@ -23,6 +24,7 @@ export default function AsyncDomainStepWrapper( props: AsyncDomainStepWrapperPro
 		goBack,
 		mainContent,
 		rightContent,
+		className,
 	} = props;
 
 	const backButton = (
@@ -40,6 +42,7 @@ export default function AsyncDomainStepWrapper( props: AsyncDomainStepWrapperPro
 			secondColumnWidth={ 3 }
 			topBar={ <Step.TopBar backButton={ ! hideBack && backButton } /> }
 			heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+			className={ className }
 		>
 			{ mainContent }
 			{ rightContent }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1416,6 +1416,7 @@ export class RenderDomainsStep extends Component {
 				return (
 					<AsyncLoad
 						require="./async-domain-step-wrapper"
+						className="domains__step-content domains__step-content-domain-step"
 						hideBack={ hideBack }
 						backUrl={ backUrl }
 						isExternalBackUrl={ isExternalBackUrl }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,6 +20,7 @@ import SideExplainer from 'calypso/components/domains/side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Notice from 'calypso/components/notice';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import {
 	domainRegistration,
@@ -1230,7 +1231,7 @@ export class RenderDomainsStep extends Component {
 		return this.props.isDomainOnly ? 'domain-first' : 'signup';
 	}
 
-	renderContent() {
+	getContentColumns() {
 		let content;
 		let sideContent;
 
@@ -1256,6 +1257,12 @@ export class RenderDomainsStep extends Component {
 				</div>
 			);
 		}
+
+		return [ content, sideContent ];
+	}
+
+	renderContent() {
+		const [ content, sideContent ] = this.getContentColumns();
 
 		return (
 			<div className="domains__step-content domains__step-content-domain-step">
@@ -1403,6 +1410,30 @@ export class RenderDomainsStep extends Component {
 		const fallbackSubHeaderText = this.getSubHeaderText();
 
 		if ( useStepperWrapper ) {
+			if ( shouldUseStepContainerV2( flowName ) ) {
+				const [ content, sideContent ] = this.getContentColumns();
+
+				return (
+					<AsyncLoad
+						require="./async-domain-step-wrapper"
+						hideBack={ hideBack }
+						backUrl={ backUrl }
+						isExternalBackUrl={ isExternalBackUrl }
+						mainContent={
+							<>
+								<QueryProductsList type="domains" />
+								{ content }
+							</>
+						}
+						rightContent={ sideContent }
+						headerText={ headerText }
+						subHeaderText={ fallbackSubHeaderText }
+						backLabelText={ backLabelText }
+						goBack={ goBack }
+					/>
+				);
+			}
+
 			return (
 				<AsyncLoad
 					require="@automattic/onboarding/src/step-container"

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1090,7 +1090,7 @@ export class RenderDomainsStep extends Component {
 					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
 				}
 				isOnboarding
-				sideContent={ this.getSideContent() }
+				sideContent={ ! shouldUseStepContainerV2( this.props.flowName ) && this.getSideContent() }
 				isInLaunchFlow={ 'launch-site' === this.props.flowName }
 				promptText={
 					this.isHostingFlow()

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -522,4 +522,19 @@ body.is-section-signup {
 			}
 		}
 	}
+
+	&:has(.step-container-v2) {
+		.register-domain-step__search-card {
+			margin: 0;
+		}
+
+		.register-domain-step__domain-side-content-container-domain-explanation-image {
+			max-width: 100%;
+			margin-bottom: 0;
+		}
+
+		.register-domain-step__example-prompt {
+			margin: 0;
+		}
+	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -250,7 +250,7 @@ body.is-section-stepper .domains__step-content,
 }
 
 .onboarding {
-	&.domains {
+	&.domains:not(:has(.step-container-v2)) {
 		&.step-route {
 			padding: 60px 12px 0 12px;
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -84,7 +84,7 @@ body.is-section-stepper .domains__step-content,
 		bottom: 0;
 		left: 0;
 		z-index: 99;
-		padding-bottom: 6px !important;
+		padding-bottom: 0 !important;
 		box-shadow: 0 -3px 10px 0 rgba(0, 0, 0, 0.12);
 
 		.foldable-card__main {
@@ -341,14 +341,6 @@ body.is-section-signup {
 
 		.domains__domain-side-content-container {
 			flex-direction: column;
-			margin-top: 40px;
-			display: none;
-
-			@include break-large {
-				margin-top: 0;
-				flex-direction: column;
-				display: flex;
-			}
 
 			&.is-sticky {
 				position: sticky;
@@ -406,6 +398,10 @@ body.is-section-signup {
 
 		.domains__domain-side-content:last-of-type {
 			border-bottom: none;
+		}
+
+		.domains__domain-cart-foldable-card .domains__domain-side-content {
+			padding: 0;
 		}
 
 		.register-domain-step {
@@ -512,6 +508,16 @@ body.is-section-signup {
 
 				@include break-huge {
 					margin: 0 0 0 60px;
+				}
+			}
+
+			.domains__domain-side-content-container {
+				display: none;
+				margin-top: 40px;
+
+				@include break-large {
+					display: flex;
+					margin-top: 0;
 				}
 			}
 		}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -389,23 +389,8 @@ body.is-section-signup {
 			padding: 20px 0;
 			margin: 0;
 
-			@include break-small {
-				width: 80%;
-				margin: 0 auto;
-			}
-
-			@include break-medium {
-				width: 290px;
-				margin: 0 20px;
-			}
-
 			@include break-large {
-				margin: 0 0 0 40px;
 				padding: 40px 0;
-			}
-
-			@include break-huge {
-				margin: 0 0 0 60px;
 			}
 
 			&.fade-out {
@@ -504,5 +489,31 @@ body.is-section-signup {
 			padding: 0;
 		}
 
+	}
+
+	// In StepContainerV2 the wireframe is responsible for the column
+	// padding. If we're not using this then we need our own column spacing.
+	&:not(:has(.step-container-v2)) {
+		.domains__step-content {
+			.domains__domain-side-content {
+				@include break-small {
+					width: 80%;
+					margin: 0 auto;
+				}
+
+				@include break-medium {
+					width: 290px;
+					margin: 0 20px;
+				}
+
+				@include break-large {
+					margin: 0 0 0 40px;
+				}
+
+				@include break-huge {
+					margin: 0 0 0 60px;
+				}
+			}
+		}
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -363,7 +363,7 @@ body.is-section-signup {
 			}
 
 			@include break-large {
-				display: none;
+				display: none !important;
 			}
 		}
 

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -25,7 +25,7 @@
 		height: 1rem;
 		background-color: var(--color-border-subtle);
 
-		margin-inline: 1rem 0.5rem;
+		margin-inline: 1rem 0;
 
 		@include step-medium-viewport {
 			margin-inline: 1.5rem 0.75rem;
@@ -39,6 +39,9 @@
 	&-wordpress-logo {
 		color: var(--color-text);
 		margin: 0;
-		margin-right: 0.5rem;
+
+		@include step-medium-viewport {
+			margin-right: 0.5rem;
+		}
 	}
 }

--- a/packages/onboarding/src/step-container-v2/components/buttons/BackButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/BackButton/style.scss
@@ -1,5 +1,6 @@
 .step-container-v2__back-button {
 	--wp-components-color-accent: var(--color-neutral-100);
+	--color-link: var(--color-neutral-100);
 	font-size: 0.875rem;
 	line-height: 1;
 	text-decoration: none !important;

--- a/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
@@ -42,14 +42,7 @@ export const TwoColumnLayout = ( props: TwoColumnLayoutProps ) => {
 						return null;
 					}
 
-					return (
-						<div
-							className={ `two-column-layout__column--${ index }` }
-							style={ { flex: getChildFlexGrow( index ) } }
-						>
-							{ child }
-						</div>
-					);
+					return <div style={ { flex: getChildFlexGrow( index ) } }>{ child }</div>;
 				} );
 			} }
 		</StepContainerV2>

--- a/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/style.scss
@@ -4,18 +4,11 @@
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
-	gap: 4rem;
+	gap: 3rem;
 
 	@include step-large-viewport {
+		gap: 4rem;
 		flex-direction: row;
 		align-items: flex-start;
 	}
-}
-
-.two-column-layout__column--0 {
-	// flex:2
-}
-
-.two-column-layout__column--1 {
-	// flex: 1
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101199

## Proposed Changes

* Wraps the domain step in a `<Step.TwoColumnLayout>` wrapper when the `onboarding/step-container-v2` flag is present.
* Adds `AsyncDomainStepWrapper` to async load the components which will be used to present the step.
* Uses the `<Step.TwoColumnLayout>` to lay out the column elements on mobile
  * Previously the sidebar content was duplicated in the main content column, and media queries where used to show/hide the appropriate elements
  * Now there's only one copy of the sidebar content and the layout changes from a flex row to a flex column.

There are a number of custom additions to the floating toolbar. For that reason this step isn't yet using the `<Step.StickyBottomBar>` component.

The responsiveness of the component is a bit broken. There are some browser widths where it really does not look good. And it doesn't automatically switching to the mobile layout, it needs a page refresh. This PR doesn't address these issues, they're in the production version. Though I would consider fixing these as part of the consistency work.

## Testing Instructions


https://github.com/user-attachments/assets/e4d2fbd1-9c86-4325-a199-5970581cd4d0


https://github.com/user-attachments/assets/ef5dfebf-4fcd-4c87-9dc0-bf3bc2f03cf4

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the step at `/setup/onboarding`
* Double check tracks events
* Ensure you also test using `?flags=-onboarding/step-container-v2` too to confirm that when the flag isn't present, nothing has changed ([excluding the sticky footer padding changes](https://github.com/Automattic/wp-calypso/pull/101431#discussion_r2006853962))

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
