### PR TITLE
Plans: display selected plan description

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -142,4 +142,8 @@
 		cursor: pointer;
 		color: var(--studio-gray-80);
 	}
+
+	.button.is-link {
+		line-height: inherit;
+	}
 }

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -3,8 +3,10 @@ import { OnboardSelect } from '@automattic/data-stores';
 import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { SelectedFeatureData } from '../hooks/use-selected-feature';
 
 const Subheader = styled.p`
 	margin: -32px 0 40px 0;
@@ -23,14 +25,36 @@ const Subheader = styled.p`
 	}
 `;
 
-const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
+const SecondaryFormattedHeader = ( {
+	siteSlug,
+	selectedFeature,
+}: {
+	siteSlug?: string | null;
+	selectedFeature: SelectedFeatureData | null;
+} ) => {
 	const translate = useTranslate();
-	const headerText = translate( 'Upgrade your plan to access this feature and more' );
-	const subHeaderText = (
+	let headerText: ReactNode = translate( 'Upgrade your plan to access this feature and more' );
+	let subHeaderText: ReactNode = (
 		<Button className="plans-features-main__view-all-plans is-link" href={ `/plans/${ siteSlug }` }>
 			{ translate( 'View all plans' ) }
 		</Button>
 	);
+	if ( selectedFeature?.description ) {
+		headerText = selectedFeature.description;
+		subHeaderText = translate(
+			'Upgrade your plan to access this feature and more. Or {{button}}view all plans{{/button}}.',
+			{
+				components: {
+					button: (
+						<Button
+							className="plans-features-main__view-all-plans is-link"
+							href={ `/plans/${ siteSlug }` }
+						/>
+					),
+				},
+			}
+		);
+	}
 
 	return (
 		<FormattedHeader
@@ -106,6 +130,7 @@ const PlansPageSubheader = ( {
 	showPlanBenefits,
 	offeringFreePlan,
 	onFreePlanCTAClick,
+	selectedFeature,
 }: {
 	siteSlug?: string | null;
 	isDisplayingPlansNeededForFeature: boolean;
@@ -113,6 +138,7 @@ const PlansPageSubheader = ( {
 	offeringFreePlan?: boolean;
 	showPlanBenefits?: boolean;
 	onFreePlanCTAClick: () => void;
+	selectedFeature: SelectedFeatureData | null;
 } ) => {
 	const translate = useTranslate();
 
@@ -149,7 +175,9 @@ const PlansPageSubheader = ( {
 			) : (
 				showPlanBenefits && <PlanBenefitHeader />
 			) }
-			{ isDisplayingPlansNeededForFeature && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
+			{ isDisplayingPlansNeededForFeature && (
+				<SecondaryFormattedHeader siteSlug={ siteSlug } selectedFeature={ selectedFeature } />
+			) }
 		</>
 	);
 };

--- a/client/my-sites/plans-features-main/hooks/test/use-selected-feature.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-selected-feature.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+import { GridPlan } from '@automattic/plans-grid-next';
+import { renderHook } from '@testing-library/react';
+import useSelectedFeature from '../use-selected-feature';
+
+const mockFeature = {
+	getSlug: () => 'feature-1',
+	getTitle: () => 'Feature 1',
+	getDescription: () => 'Description 1',
+	availableForCurrentPlan: true,
+	availableOnlyForAnnualPlans: false,
+};
+
+const mockGridPlans = [
+	{
+		planSlug: 'plan-1' as string,
+		features: {
+			wpcomFeatures: [ mockFeature ],
+			storageFeature: {
+				getSlug: () => 'feature-2',
+				getTitle: () => 'Feature 2',
+				getDescription: () => 'Description 2',
+				availableForCurrentPlan: true,
+				availableOnlyForAnnualPlans: false,
+			},
+			jetpackFeatures: [],
+		},
+		isVisible: true,
+		tagline: 'Test Plan',
+		planTitle: 'Test Plan',
+		availableForPurchase: true,
+		pricing: { price: 0 },
+	},
+] as unknown as GridPlan[];
+
+describe( 'useSelectedFeature', () => {
+	it( 'returns null when no feature or plan is selected', () => {
+		const { result } = renderHook( () =>
+			useSelectedFeature( {
+				gridPlans: mockGridPlans,
+				selectedFeature: undefined,
+				selectedPlan: undefined,
+			} )
+		);
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns null when plan is not found', () => {
+		const { result } = renderHook( () =>
+			useSelectedFeature( {
+				gridPlans: mockGridPlans,
+				selectedFeature: 'feature-1',
+				selectedPlan: 'non-existent-plan',
+			} )
+		);
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'finds feature in array type features', () => {
+		const { result } = renderHook( () =>
+			useSelectedFeature( {
+				gridPlans: mockGridPlans,
+				selectedFeature: 'feature-1',
+				selectedPlan: 'plan-1',
+			} )
+		);
+		expect( result.current ).toEqual( {
+			slug: 'feature-1',
+			title: 'Feature 1',
+			description: 'Description 1',
+		} );
+	} );
+
+	it( 'finds feature in object type features', () => {
+		const { result } = renderHook( () =>
+			useSelectedFeature( {
+				gridPlans: mockGridPlans,
+				selectedFeature: 'feature-2',
+				selectedPlan: 'plan-1',
+			} )
+		);
+		expect( result.current ).toEqual( {
+			slug: 'feature-2',
+			title: 'Feature 2',
+			description: 'Description 2',
+		} );
+	} );
+
+	it( 'returns null when feature is not found in plan', () => {
+		const { result } = renderHook( () =>
+			useSelectedFeature( {
+				gridPlans: mockGridPlans,
+				selectedFeature: 'non-existent-feature',
+				selectedPlan: 'plan-1',
+			} )
+		);
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'handles null gridPlans', () => {
+		const { result } = renderHook( () =>
+			useSelectedFeature( {
+				gridPlans: null,
+				selectedFeature: 'feature-1',
+				selectedPlan: 'plan-1',
+			} )
+		);
+		expect( result.current ).toBeNull();
+	} );
+} );

--- a/client/my-sites/plans-features-main/hooks/use-selected-feature.ts
+++ b/client/my-sites/plans-features-main/hooks/use-selected-feature.ts
@@ -1,0 +1,62 @@
+import { GridPlan } from '@automattic/plans-grid-next';
+import { useMemo } from '@wordpress/element';
+
+interface Params {
+	gridPlans: GridPlan[] | null;
+	selectedFeature?: string;
+	selectedPlan?: string;
+}
+
+export type SelectedFeatureData = {
+	slug: string;
+	title: string;
+	description: string;
+};
+
+const useSelectedFeature = ( {
+	selectedFeature,
+	selectedPlan,
+	gridPlans,
+}: Params ): SelectedFeatureData | null => {
+	const selectedFeatureData = useMemo( () => {
+		if ( ! selectedPlan || ! selectedFeature ) {
+			return null;
+		}
+
+		const selectedPlanGroup = gridPlans?.find( ( { planSlug } ) => planSlug === selectedPlan );
+
+		if ( ! selectedPlanGroup?.features ) {
+			return null;
+		}
+
+		for ( const featureType of Object.values( selectedPlanGroup.features ) ) {
+			if ( Array.isArray( featureType ) ) {
+				const foundFeature = featureType?.find(
+					( feature ) => feature?.getSlug() === selectedFeature
+				);
+				if ( foundFeature ) {
+					return foundFeature;
+				}
+			} else if (
+				featureType &&
+				typeof featureType === 'object' &&
+				featureType?.getSlug() === selectedFeature
+			) {
+				return featureType;
+			}
+		}
+		return null;
+	}, [ gridPlans, selectedFeature, selectedPlan ] );
+
+	if ( selectedFeatureData ) {
+		return {
+			slug: selectedFeature as string,
+			title: selectedFeatureData.getTitle(),
+			description: selectedFeatureData.getDescription(),
+		};
+	}
+
+	return null;
+};
+
+export default useSelectedFeature;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -79,6 +79,7 @@ import useGenerateActionHook from './hooks/use-generate-action-hook';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
+import useSelectedFeature from './hooks/use-selected-feature';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
 import type {
 	PlansIntent,
@@ -753,6 +754,12 @@ const PlansFeaturesMain = ( {
 		</div>
 	);
 
+	const selectedFeatureData = useSelectedFeature( {
+		gridPlans: gridPlansForFeaturesGrid,
+		selectedPlan,
+		selectedFeature,
+	} );
+
 	return (
 		<>
 			<div className={ clsx( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }>
@@ -806,6 +813,7 @@ const PlansFeaturesMain = ( {
 				<PlansPageSubheader
 					siteSlug={ siteSlug }
 					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
+					selectedFeature={ selectedFeatureData }
 					offeringFreePlan={ offeringFreePlan }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
 					onFreePlanCTAClick={ onFreePlanCTAClick }


### PR DESCRIPTION

## Proposed Changes


The proposal is to introduce some form of continuity into the targeted upsell flow.

It introduced a `useSelectedFeature` hook to retrieve selected feature data, if available.


## Why are these changes being made?


When a user clicks on an upsell CTA for a specific feature, the default text is "Upgrade your plan to access this feature and more".

What does "this feature" refer to? What are we asking the user to think here?

Let's reinforce their interest in the new feature, and confirm that the plans do have it.
  
So instead of this for everything:

<img width="300" alt="Screenshot 2025-03-17 at 1 16 55 pm" src="https://github.com/user-attachments/assets/4eee5113-604c-4f53-8cd6-92a024637c4c" />

Show the selected feature description:


| | |
|--------|--------|
| <img width="300" alt="Screenshot 2025-03-17 at 1 16 45 pm" src="https://github.com/user-attachments/assets/0021dd15-d034-46fc-bae8-9c0c9178d589" /> | <img width="300" alt="Screenshot 2025-03-17 at 1 22 12 pm" src="https://github.com/user-attachments/assets/f9b1c8b4-97fb-4428-b62e-c659e749279f" /> |
| <img width="300" alt="Screenshot 2025-03-17 at 1 35 52 pm" src="https://github.com/user-attachments/assets/71f3e592-9274-4586-b81f-29c0c88b732b" /> | <img width="300" alt="Screenshot 2025-03-17 at 1 36 36 pm" src="https://github.com/user-attachments/assets/53d373cc-d887-43a6-b9c2-e87d576b38df" /> |
| <img width="300" alt="Screenshot 2025-03-17 at 1 37 26 pm" src="https://github.com/user-attachments/assets/46d9c850-8692-4fea-baa5-7e4dacad44f5" /> | - | 



A further enhancement could be to add more visuals, especially in the case of features like video uploads, global styles to emphasize the value.





## Testing Instructions

Visit the plans page with a selected plan and feature:

`/plans/[YOUR_SITE].wordpress.com?plan=value_bundle&feature=custom-domain`

`/plans/[YOUR_SITE].wordpress.com?plan=value_bundle&feature=ad-free-experience`

`/plans/[YOUR_SITE].wordpress.com?plan=value_bundle&feature=feature-connect-analytics`

`/plans/[YOUR_SITE].wordpress.com?plan=value_bundle&feature=upload-video`

`/plans/[YOUR_SITE].wordpress.com?plan=business-bundle&feature=feature-unlimited-entities`

Where a feature does not appear for a selected plan and there's no description it will fallback to default behaviour.


Combining these is hit and miss I found. I managed to build URLS using the following files.

Supporting plan slugs:

https://github.com/Automattic/wp-calypso/blob/46d631945ca7b2dc93b195063e41a52c07c11256/packages/components/src/product-icon/config.ts#L80-L81

Plan feature assignments:

https://github.com/Automattic/wp-calypso/blob/348ee00b4d44160ee4a1a91f86a2e27156a47303/packages/calypso-products/src/plans-list.tsx

Feature constants:

https://github.com/Automattic/wp-calypso/blob/348ee00b4d44160ee4a1a91f86a2e27156a47303/packages/calypso-products/src/features-list.tsx

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
