### PR TITLE
Sidebar: Update the style of the Coming Soon badge

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -217,6 +217,13 @@
 		background: var(--p2-color-link);
 		color: var(--p2-color-white);
 	}
+
+	&.site__badge-private,
+	&.site__badge-coming-soon {
+		background-color: transparent;
+		color: var(--color-neutral-60);
+		border: solid 1px color-mix( in srgb, currentColor 50%, transparent );
+	}
 }
 
 .current-site .site:hover .site__badge,
@@ -228,6 +235,13 @@
 	&.is-p2-workspace {
 		background: var(--p2-color-link-dark);
 		color: var(--p2-color-white);
+	}
+
+	&.site__badge-private,
+	&.site__badge-coming-soon {
+		background-color: transparent;
+		color: var(--color-sidebar-text);
+		border: solid 1px color-mix( in srgb, currentColor 50%, transparent );
 	}
 }
 
@@ -245,6 +259,13 @@
 		&.is-p2-workspace {
 			background: var(--p2-color-link);
 			color: var(--p2-color-white);
+		}
+
+		&.site__badge-private,
+		&.site__badge-coming-soon {
+			background-color: transparent;
+			color: var(--color-sidebar-text);
+			border: solid 1px color-mix( in srgb, currentColor 50%, transparent );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101285

## Proposed Changes

* Update the style of the Coming Soon badge below

| Color Scheme | Coming Soon |
| - | - |
| fresh (default) | <img width="269" alt="Image" src="https://github.com/user-attachments/assets/afc86610-9e81-4453-87b2-a6d2bf662946" /> |
| light | <img width="271" alt="Image" src="https://github.com/user-attachments/assets/446e69a3-c898-40da-af36-e57e8f602c6a" /> |
| modern | <img width="269" alt="Image" src="https://github.com/user-attachments/assets/de27694b-4efe-4b4f-ba8f-db63cb0e70eb" /> |
| blue | <img width="268" alt="Image" src="https://github.com/user-attachments/assets/26fbc9be-2bbf-4bf9-bbb0-28a22d3b609a" /> |
| midnight | <img width="267" alt="Image" src="https://github.com/user-attachments/assets/a6d28c84-87ea-43e2-a927-6958e3cdbbb1" /> |
| sunrise | <img width="267" alt="Image" src="https://github.com/user-attachments/assets/f925127a-5f7a-4aec-98af-02d58c497fb4" /> |
| ectoplasm | <img width="268" alt="Image" src="https://github.com/user-attachments/assets/1955ff65-59ec-49e2-92e4-3a340e08b17c" /> |
| ocean | <img width="267" alt="Image" src="https://github.com/user-attachments/assets/8b6b0b8e-c4b9-47e3-8efc-b7425ab28fd7" /> |
| coffee | <img width="265" alt="Image" src="https://github.com/user-attachments/assets/f91c687d-6e2f-4d2d-b2f4-a3afe22193f2" /> |

Only list Core's color schemes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* WP.com polish

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick any site that is either unlaunched site or a coming soon site
* Ensure the styles of the Coming Soon on the Sidebar look good
* Change to another color scheme
* Ensure it still looks good!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
