### PR TITLE
Account and Profile Settings: Reposition email verification banner

### DIFF
--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -3,7 +3,6 @@ import i18n, { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import AccountComponent, { noticeId as meSettingsNoticeId } from 'calypso/me/account/main';
 import { successNotice } from 'calypso/state/notices/actions';
-import EmailVerificationBanner from '../email-verification-banner';
 
 export function account( context, next ) {
 	// Update the url and show the notice after a redirect
@@ -25,7 +24,6 @@ export function account( context, next ) {
 
 	context.primary = (
 		<>
-			<EmailVerificationBanner />
 			<AccountTitle />
 			<AccountComponent path={ context.path } />
 		</>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -31,6 +31,7 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { clearStore } from 'calypso/lib/user/store';
 import wpcom from 'calypso/lib/wp';
 import AccountEmailField from 'calypso/me/account/account-email-field';
+import EmailVerificationBanner from 'calypso/me/email-verification-banner';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -861,7 +862,7 @@ class Account extends Component {
 						}
 					) }
 				/>
-
+				<EmailVerificationBanner />
 				<SectionHeader label={ translate( 'Account Information' ) } />
 				<Card className="account__settings">
 					<form onChange={ markChanged } onSubmit={ this.saveAccountSettings }>

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -80,8 +80,20 @@ fieldset.account__settings-admin-home {
 	}
 }
 
-main.account .navigation-header {
-	@media (min-width:  $break-small ) {
-		padding-bottom: 0;
+main.account {
+	.email-verification-banner {
+		margin-bottom: 16px;
+		margin-top: 0;
+
+		@media (min-width: $break-small) {
+			margin-top: 24px;
+			margin-bottom: 24px;
+		}
+	}
+
+	&:has(.email-verification-banner) .navigation-header {
+		@media (min-width: $break-small) {
+			padding-bottom: 0;
+		}
 	}
 }

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .account__username-form-toggle-enter {
 	opacity: 0.01;
@@ -76,5 +77,11 @@ fieldset.account__settings-admin-home {
 	a {
 		color: inherit;
 		text-decoration: underline;
+	}
+}
+
+main.account .navigation-header {
+	@media (min-width:  $break-small ) {
+		padding-bottom: 0;
 	}
 }

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -4,7 +4,6 @@ import { createElement } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import AppsComponent from 'calypso/me/get-apps';
 import SidebarComponent from 'calypso/me/sidebar';
-import EmailVerificationBanner from './email-verification-banner';
 
 export function sidebar( context, next ) {
 	context.secondary = createElement( SidebarComponent, {
@@ -24,7 +23,6 @@ export function profile( context, next ) {
 
 	context.primary = (
 		<>
-			<EmailVerificationBanner />
 			<ProfileTitle />
 			<ProfileComponent path={ context.path } />
 		</>

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -19,6 +19,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { protectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import DomainUpsell from 'calypso/me/domain-upsell';
+import EmailVerificationBanner from 'calypso/me/email-verification-banner';
 import withFormBase from 'calypso/me/form-base/with-form-base';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
@@ -73,7 +74,7 @@ class Profile extends Component {
 						}
 					) }
 				/>
-
+				<EmailVerificationBanner />
 				<SectionHeader label={ this.props.translate( 'Profile' ) } />
 				<Card className="profile__settings">
 					<EditGravatar />

--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -66,8 +66,20 @@
 	}
 }
 
-main.profile .navigation-header {
-	@media (min-width:  $break-small ) {
-		padding-bottom: 0;
+main.profile {
+	.email-verification-banner {
+		margin-bottom: 16px;
+		margin-top: 0;
+
+		@media (min-width: $break-small) {
+			margin-top: 24px;
+			margin-bottom: 24px;
+		}
+	}
+
+	&:has(.email-verification-banner) .navigation-header {
+		@media (min-width: $break-small) {
+			padding-bottom: 0;
+		}
 	}
 }

--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .profile__settings .edit-gravatar {
 	text-align: center;
@@ -62,5 +63,11 @@
 .profile-links__list {
 	.profile-link:last-of-type {
 		margin-bottom: 0;
+	}
+}
+
+main.profile .navigation-header {
+	@media (min-width:  $break-small ) {
+		padding-bottom: 0;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100164

## Proposed Changes

* Proposal for moving the email verification banner to a position where the Calypso global notice does not overlap.

￼
![CleanShot 2025-03-17 at 12 31 01@2x](https://github.com/user-attachments/assets/27946596-3444-4c46-af11-7806c01fa1d2)

￼
![CleanShot 2025-03-17 at 12 31 19@2x](https://github.com/user-attachments/assets/dc75b7aa-6b65-4bb9-b491-4b0a17990b2a)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ensure users can see both the banner and notification without any overlap. This will help ensure the banner's important message is always visible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Create a new email-based user
* Navigate to `/me/account`, change your email ( or trigger the Calypso notice in another way), and verify the notice is not overlapping the email verification banner.
* Navigate to `/me/` (My profile), change your email ( or trigger the Calypso notice in another way), and verify the notice is not overlapping the email verification banner.
