### PR TITLE
A4A > WooPayments: CFT enhancements

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/get-default-product.ts
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/get-default-product.ts
@@ -2,6 +2,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MIGRATIONS_MIGRATE_TO_PRESSABLE_LINK,
 	A4A_MIGRATIONS_MIGRATE_TO_WPCOM_LINK,
+	A4A_WOOPAYMENTS_DASHBOARD_LINK,
 } from '../sidebar-menu/lib/constants';
 
 // This map is used to determine the product when the user is on a specific page to preselect the product in the form.
@@ -9,6 +10,7 @@ const pathToProductMap: Record< string, string > = {
 	[ A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK ]: 'pressable',
 	[ A4A_MIGRATIONS_MIGRATE_TO_PRESSABLE_LINK ]: 'pressable',
 	[ A4A_MIGRATIONS_MIGRATE_TO_WPCOM_LINK ]: 'wpcom',
+	[ A4A_WOOPAYMENTS_DASHBOARD_LINK ]: 'woo',
 };
 
 export default function getDefaultProduct(): string {

--- a/client/a8c-for-agencies/components/a4a-modal/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-modal/index.tsx
@@ -18,7 +18,7 @@ export default function A4AModal( {
 	children: React.ReactNode;
 	extraActions?: React.ReactNode;
 	title: string;
-	subtile: string;
+	subtile: React.ReactNode;
 	className?: string;
 	showCloseButton?: boolean;
 } ) {

--- a/client/a8c-for-agencies/components/copy-to-clipboard-button/index.tsx
+++ b/client/a8c-for-agencies/components/copy-to-clipboard-button/index.tsx
@@ -1,4 +1,3 @@
-import { useBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { copy, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -12,7 +11,6 @@ const CopyToClipboardButton = ( {
 	onClick?: () => void;
 } ) => {
 	const translate = useTranslate();
-	const isNarrowView = useBreakpoint( '<960px' );
 
 	const [ copyStatus, setCopyStatus ] = useState( '' );
 
@@ -41,8 +39,7 @@ const CopyToClipboardButton = ( {
 				variant="tertiary"
 				onClick={ copyToClipboard }
 			>
-				{ ! isNarrowView &&
-					( copyStatus === 'success' ? translate( 'Copied' ) : translate( 'Copy to clipboard' ) ) }
+				{ copyStatus === 'success' ? translate( 'Copied' ) : translate( 'Copy to clipboard' ) }
 			</Button>
 		</>
 	);

--- a/client/a8c-for-agencies/components/page-section-columns/index.tsx
+++ b/client/a8c-for-agencies/components/page-section-columns/index.tsx
@@ -39,7 +39,6 @@ const PageSectionColumns = ( { heading, children, background }: PageSectionColum
 		<div
 			className={ clsx( 'page-section-columns', {
 				'is-dark-background': background?.isDarkBackground,
-				'is-narrow-view': isNarrowView,
 			} ) }
 			style={ {
 				backgroundColor: background?.color,

--- a/client/a8c-for-agencies/components/page-section-columns/style.scss
+++ b/client/a8c-for-agencies/components/page-section-columns/style.scss
@@ -11,13 +11,6 @@
 		color: var(--color-text-inverted);
 	}
 
-	&.is-narrow-view {
-		.page-section-columns__content {
-			grid-template-columns: 1fr;
-			gap: 4px;
-		}
-	}
-
 	@include breakpoint-deprecated( ">660px" ) {
 		padding-inline: 64px;
 	}
@@ -38,8 +31,13 @@
 	@include heading-x-large;
 	margin-block-end: 32px;
 	display: flex;
-	align-items: center;
 	gap: 8px;
+	flex-direction: column;
+
+	@include break-large {
+		flex-direction: row;
+		align-items: center;
+	}
 }
 
 
@@ -47,8 +45,12 @@
 	background-repeat: no-repeat;
 	background-position: top right;
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: 1fr;
 	gap: 32px;
+
+	@include break-large {
+		grid-template-columns: 1fr 1fr;
+	}
 }
 
 .page-section-column {
@@ -71,11 +73,15 @@
 
 	button, a {
 		&.components-button {
-			width: fit-content;
 			white-space: normal;
 			min-height: 40px;
 			height: auto;
 			text-align: center;
+			width: 100%;
+
+			@include break-large {
+				width: fit-content;
+			}
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -3,7 +3,10 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
-import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_WOOPAYMENTS_SITE_SETUP_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useIssueAndAssignLicenses from 'calypso/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -40,7 +43,23 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 		<A4AModal
 			title={ translate( 'Which site would you like to add WooPayments to?' ) }
 			subtile={ translate(
-				"If you don't see the site in the list, connect it first via the Sites Dashboard."
+				"If you don't see the site in the list, connect it first via the {{a}}Sites Dashboard{{/a}}.",
+				{
+					components: {
+						a: (
+							<a
+								href={ A4A_SITES_LINK }
+								onClick={ () =>
+									dispatch(
+										recordTracksEvent(
+											'calypso_a4a_woopayments_add_site_modal_sites_dashboard_click'
+										)
+									)
+								}
+							/>
+						),
+					},
+				}
 			) }
 			onClose={ onClose }
 			extraActions={

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -17,6 +17,12 @@
 		}
 	}
 
+	&.full-width-layout-with-table {
+		.consolidated-view {
+			padding: 16px 64px 48px;
+		}
+	}
+
 	.a4a-text-placeholder {
 		min-width: 70px;
 		height: 20px;

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -1,6 +1,6 @@
-import { useBreakpoint } from '@automattic/viewport-react';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import CopyToClipboardButton from 'calypso/a8c-for-agencies/components/copy-to-clipboard-button';
 import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
@@ -16,8 +16,6 @@ import AddWooPaymentsToSite from '../../add-woopayments-to-site';
 const WooPaymentsDashboardEmptyState = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-
-	const isNarrowView = useBreakpoint( '<960px' );
 
 	const listItems1 = [
 		translate(
@@ -59,18 +57,16 @@ const WooPaymentsDashboardEmptyState = () => {
 							</div>
 							<div className="woopayments-dashboard-empty-state__description">
 								{ translate(
-									"Accept credit/debit cards and local payment options with no setup or monthly fees. Earn revenue share on transactions from your clients' sites within Automattic for Agencies."
+									"Accept credit/debit cards and local payment options with no setup or monthly fees. Earn revenue share of 5 basis points on transactions from your clients' sites within Automattic for Agencies."
 								) }
 							</div>
 						</div>
 						<AddWooPaymentsToSite />
 					</div>
 				</PageSectionColumns.Column>
-				{ ! isNarrowView && (
-					<PageSectionColumns.Column alignCenter>
-						<img src={ ccImage } alt="WooPayments" />
-					</PageSectionColumns.Column>
-				) }
+				<PageSectionColumns.Column alignCenter>
+					<img src={ ccImage } alt="WooPayments" />
+				</PageSectionColumns.Column>
 			</PageSectionColumns>
 
 			<PageSectionColumns
@@ -128,15 +124,13 @@ const WooPaymentsDashboardEmptyState = () => {
 						</div>
 						<Button
 							__next40pxDefaultSize
-							href="/marketplace/products?show_license_modal=woocommerce-woopayments"
+							href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
 							className="woopayments-dashboard-empty-state__button"
 							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_view_details_button_click' )
-								);
+								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_contact_us_button_click' ) );
 							} }
 						>
-							{ translate( 'View details and start earning ↗' ) }
+							{ translate( 'Have questions? Contact us' ) }
 						</Button>
 					</>
 				</PageSectionColumns.Column>
@@ -157,11 +151,9 @@ const WooPaymentsDashboardEmptyState = () => {
 						</div>
 					</div>
 				</PageSectionColumns.Column>
-				{ ! isNarrowView && (
-					<PageSectionColumns.Column alignCenter>
-						<img src={ cartImage } alt="WooPayments" />
-					</PageSectionColumns.Column>
-				) }
+				<PageSectionColumns.Column alignCenter>
+					<img src={ cartImage } alt="WooPayments" />
+				</PageSectionColumns.Column>
 			</PageSectionColumns>
 
 			<PageSectionColumns
@@ -218,11 +210,9 @@ const WooPaymentsDashboardEmptyState = () => {
 						</Button>
 					</>
 				</PageSectionColumns.Column>
-				{ ! isNarrowView && (
-					<PageSectionColumns.Column alignCenter>
-						<img src={ demoImage } alt="WooPayments" />
-					</PageSectionColumns.Column>
-				) }
+				<PageSectionColumns.Column alignCenter>
+					<img src={ demoImage } alt="WooPayments" />
+				</PageSectionColumns.Column>
 			</PageSectionColumns>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -1,3 +1,4 @@
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Spinner } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -44,6 +45,8 @@ const sortByState = ( a: SitesWithWooPaymentsState, b: SitesWithWooPaymentsState
 
 const WooPaymentsDashboard = () => {
 	const translate = useTranslate();
+
+	const isDesktop = useDesktopBreakpoint();
 
 	const title = translate( 'WooPayments Commissions' );
 
@@ -96,7 +99,7 @@ const WooPaymentsDashboard = () => {
 
 	const createInitialSiteState = useCallback(
 		( license: License ) => {
-			const sitePlugin = sitesWithPlugins.find(
+			const sitePlugin = sitesWithPlugins?.find(
 				( site: SitesWithWooPaymentsPlugins ) => site.blog_id === license.blogId
 			);
 
@@ -110,7 +113,7 @@ const WooPaymentsDashboard = () => {
 	);
 
 	useEffect( () => {
-		if ( ! sitesWithPlugins?.length || ! licensesWithWooPayments?.items ) {
+		if ( ! licensesWithWooPayments?.items ) {
 			return;
 		}
 
@@ -122,7 +125,7 @@ const WooPaymentsDashboard = () => {
 	const sitesWithPluginsStatesSorted = useMemo( () => {
 		return sitesWithPluginsStates
 			.map( ( site ) => {
-				const connection = testConnections.find( ( connection ) => connection.ID === site.blogId );
+				const connection = testConnections?.find( ( connection ) => connection.ID === site.blogId );
 				return {
 					...site,
 					state: connection?.connected === false ? 'disconnected' : site.state,
@@ -145,7 +148,10 @@ const WooPaymentsDashboard = () => {
 
 	return (
 		<Layout
-			className={ clsx( 'woopayments-dashboard', { 'is-empty': showEmptyState } ) }
+			className={ clsx( 'woopayments-dashboard', {
+				'is-empty': showEmptyState,
+				'full-width-layout-with-table': ! showEmptyState && isDesktop && ! isLoading,
+			} ) }
 			title={ title }
 			wide
 		>


### PR DESCRIPTION
## Proposed Changes

This PR addresses some comments based on the CFT.

## Testing Instructions

* Open the A4A live link > 
* Go to WooPayments: Dashboard > Verify the changes on the empty state:

1) Verify that the button text is changed to “Have questions? Contact us” and opens the support modal with Woo preloaded when clicked.

<img width="804" alt="Screenshot 2025-03-17 at 3 27 34 PM" src="https://github.com/user-attachments/assets/8773a3fb-13f6-49af-8aea-8a2c751e987f" />


2) Verify the Copy to Clipboard text on the button is also shown on the mobile view.

<img width="375" alt="Screenshot 2025-03-17 at 3 28 23 PM" src="https://github.com/user-attachments/assets/9e63205e-4271-479c-896d-e0848f52a66f" />

3) Verify the images are displayed on the mobile view.

<img width="375" alt="Screenshot 2025-03-17 at 3 28 09 PM" src="https://github.com/user-attachments/assets/fbf6a0f9-4e5a-4ba8-bcb6-57cee69b70a6" />

4) Verify the text in this section is added to show 5 basis points

<img width="804" alt="Screenshot 2025-03-17 at 3 27 28 PM" src="https://github.com/user-attachments/assets/0081244d-94d2-4ed2-9d89-60dd0a040a33" />

* Click the `Add WooPayments to site` button > Verify the text Sites Dashboard is a link now and redirects to the Sites dashboard

<img width="804" alt="Screenshot 2025-03-17 at 3 26 26 PM" src="https://github.com/user-attachments/assets/2b4d47c6-65e5-463a-9120-0b6df6f84e05" />

* Also, on the sites with WooPayments view, Verify that the table runs to the edges of the page and does not have a margin
## Pre-merge Checklist

| Before | After |
|--------|--------|
| <img width="1633" alt="Screenshot 2025-03-17 at 3 25 12 PM" src="https://github.com/user-attachments/assets/e5a14475-31e0-49a8-8a18-9d3ab0eae898" /> | <img width="1633" alt="Screenshot 2025-03-17 at 3 25 38 PM" src="https://github.com/user-attachments/assets/33e154fd-e1ea-4d33-94ba-103835578066" />


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
