### PR TITLE
Update FormTextInputWithAction to use tertiary variant for the button

### DIFF
--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -95,7 +95,9 @@ function FormTextInputWithAction( {
 			<Button
 				size="compact"
 				className="form-text-input-with-action__button"
+				variant="tertiary"
 				disabled={ disabled || ! value }
+				accessibleWhenDisabled
 				onClick={ handleAction }
 			>
 				{ action }

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -46,14 +46,6 @@
 				opacity: 0.3; // Same as disabled button's opacity.
 			}
 		}
-
-		.form-text-input-with-action__button {
-			color: var(--color-sidebar-submenu-text);
-
-			&:disabled {
-				color: var(--color-sidebar-submenu-text);
-			}
-		}
 	}
 
 	.reader-sidebar-tags__all-tags-link {


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/100393

The linked issue suggests to use the `tertiary` variant for the button to add tags in the Reader. The component I needed to update though (`FormTextInputWithAction`) is reused in a couple of places. I think it makes sense to have the `tertiary` button there, but design feedback is welcome.

The visual changes seem to be mostly when we hover the button, while it's not disabled.

In general `FormTextInputWithAction` doesn't seem to be great and maybe we should consider updating it more (in a follow up) or don't use it at all, at least for the Reader.

## Testing Instructions
1. Go to `/reader` and observe the button to add tags
2. Go to `/import/newsletter/substack/{SITE}` where {SITE} is an Atomic site slug, and observe the continue button
3. Go to `/devdocs/design/form-fields` and scroll to `Form Text Input With Action` component

#### Tags Before
https://github.com/user-attachments/assets/02a6e89a-f198-415a-afe2-4602355f5708

#### Tags After
https://github.com/user-attachments/assets/b8d82905-b0ab-46e0-9b45-0ad42ba2a7e4







Import before     | Import after
:-------------------------:|:-------------------------:
<img width="666" alt="before import" src="https://github.com/user-attachments/assets/a9b071f4-3cdb-4105-95d3-60d2d5cbfdb1" /> | <img width="664" alt="import after" src="https://github.com/user-attachments/assets/387b0f16-3c79-4959-bb54-c2d8bf179728" />



Docs before     | Docs after
:-------------------------:|:-------------------------:
<img width="532" alt="docs before" src="https://github.com/user-attachments/assets/d68cbeda-338b-420a-97cd-2e1bea6f19a1" /> | <img width="532" alt="docs after" src="https://github.com/user-attachments/assets/245a91f8-d494-4b53-a61d-1e97eafdd05c" />

 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
