### PR TITLE
Extend width for WooCommerce auth 2FA copies

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1894,6 +1894,9 @@ $breakpoint-mobile: 660px;
 				.security-key-form__add-wait-for-key {
 					margin-bottom: 48px;
 
+					p {
+						max-width: 515px;
+					}
 					p:first-child {
 						margin-bottom: 12px;
 					}
@@ -1911,7 +1914,7 @@ $breakpoint-mobile: 660px;
 			}
 
 			.two-factor-authentication__small-print {
-				max-width: $max-width;
+				max-width: 350px;
 				color: $gray-50;
 				text-align: center;
 				font-style: normal;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1001,7 +1001,7 @@ $breakpoint-mobile: 660px;
 		&.feature-flag-woocommerce-core-profiler-passwordless-auth {
 			.login form,
 			.signup-form {
-				max-width: 327px;
+				max-width: 515px;
 				margin: 48px auto;
 			}
 		}
@@ -1090,15 +1090,6 @@ $breakpoint-mobile: 660px;
 				p strong {
 					color: $gray-700;
 					font-weight: 400;
-				}
-
-				p:nth-child(2) {
-					@media screen and (min-width: 660px) {
-						// css to allow for this element to exceed parent's width
-						width: 152%; // 152% * 405px gets us to 615px which is the design spec
-						position: relative;
-						left: -26%; // shift position back by half of that so that it remains centered
-					}
 				}
 			}
 


### PR DESCRIPTION
Related to #99184

## Proposed Changes

Fixes the following:

### WooCommerce.com auth screens
- Backup code screen: Reduce helper copy to three lines long
- Security key screen: Normalize the paragraph to avoid orphaned words since it's not possible to have them all on one line

### Core profiler jetpack connection screen
- Backup code screen: Reduce helper copy to three lines long

## Testing Instructions

### WooCommerce.com auth screens

#### Testing backup code screen

1. In incognito window, open up [this URL](http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D626d720d78a1050a43f24641c43481699b878ca8057293955f505ceff8e14269%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1)
3. Login using an account with 2FA enabled
1. Observe the description no longer has an orphaned line
1. Adjust screen sizes to ensure its responsive

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3b4e0758-b850-4c3d-a4fc-62ecea57f5ed" />

#### Testing security key screen

1. Continuing from above instructions, click on `Continue with a backup code`
1. Observe the helper copy reduced to three lines
1. Adjust screen sizes to ensure its responsive

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7b0d23b1-8957-4a8e-8a4a-999ec26066e2" />


### Core profiler jetpack connection screen

#### Testing backup code screen

1. In an incognito window, open up [this URL](http://calypso.localhost:3000/log-in/jetpack/backup?from=woocommerce-core-profiler)
3. Login using an account with 2FA enabled
4. Click on `Continue with a backup code`
1. Observe the helper copy reduced to three lines
1. Adjust screen sizes to ensure its responsive

<img width="500" alt="image" src="https://github.com/user-attachments/assets/217be043-e3ce-4997-b786-654c7a752682" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
