### PR TITLE
A4A: Update Purchases pages to use Core's typography.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/billing/billing-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-details/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .billing-details__row {
 	display: grid;
@@ -9,7 +10,7 @@
 		"subtotal unassigned";
 	align-items: center;
 	grid-gap: 24px;
-	font-size: 1.25rem;
+	@include body-x-large;
 
 	> :nth-child(even) {
 		text-align: right;
@@ -34,8 +35,7 @@
 	display: none;
 
 	* {
-		font-weight: 400;
-		font-size: 0.875rem;
+		@include body-medium;
 		color: var(--color-accent-70);
 	}
 
@@ -70,23 +70,23 @@
 
 .billing-details__cost-label {
 	margin-block-end: 8px;
-	font-size: 1rem;
+	@include body-large;
 }
 
 .billing-details__cost-amount {
 	margin-block-end: 8px;
-	font-size: 1.25rem;
+	@include body-x-large;
 
 	@media (min-width: 661px) and (max-width: 781px) {
 		// Accounts for unbreakable long cost numbers breaking the layout due to the sidebar taking up
 		// a lot of the available space.
-		font-size: 1rem;
+		@include body-large;
 	}
 }
 
 .billing-details__line-item-meta {
 	display: block;
-	font-size: 0.875rem;
+	@include body-medium;
 	color: var(--color-neutral-70);
 
 	&--is-mobile {

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-summary/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-summary/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .billing-summary {
 	display: flex;
@@ -62,8 +63,7 @@
 .billing-summary__label {
 	display: block;
 	margin-block-end: 8px;
-	font-size: 1.25rem;
-	line-height: 28px;
+	@include body-x-large;
 	color: var(--color-neutral-80);
 
 	@include break-wide() {
@@ -73,14 +73,12 @@
 
 .billing-summary__value {
 	display: block;
-	font-weight: 700;
-	font-size: 1.75rem;
-	line-height: 36px;
+	@include heading-2x-large;
 
 	@media (min-width: 661px) and (max-width: 781px) {
 		// Accounts for unbreakable long cost numbers breaking the layout due to the sidebar taking up
 		// a lot of the available space.
-		font-size: 1.25rem;
+		@include heading-x-large;
 	}
 }
 
@@ -97,7 +95,7 @@
 		box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 
 		p {
-			font-size: 1rem;
+			@include body-large;
 			margin: 0;
 		}
 	}

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
@@ -1,13 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 
 .invoices-list-row__header {
 	display: none;
 
 	* {
-		font-weight: 400;
-		font-size: 0.875rem;
+		@include body-medium;
 		color: var(--color-neutral-70);
 	}
 
@@ -21,7 +20,7 @@
 	grid-template-columns: calc(34% - 16px) calc(34% - 16px) calc(34% - 16px);
 	align-items: center;
 	grid-gap: 24px;
-	font-size: 1.25rem;
+	@include body-x-large;
 
 	@include break-xlarge() {
 		grid-template-columns: 160px 1fr 100px 100px 128px;

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 
 .license-details {
 	margin: 0;
@@ -23,7 +23,7 @@
 
 	.license-details__list-item,
 	.license-details__list-item-small {
-		font-size: 1rem;
+		@include body-large;
 
 		&--wide {
 			@include break-xlarge() {
@@ -45,7 +45,7 @@
 	.license-details__license-key {
 		flex: 0 1 auto;
 		padding: 6px;
-		font-size: 0.875rem;
+		@include body-medium;
 		background: var(--color-neutral-0);
 		color: var(--color-neutral-70);
 		overflow: hidden;
@@ -66,7 +66,7 @@
 
 	.license-details__label {
 		margin-block-end: 8px;
-		font-size: 1rem;
+		@include body-large;
 		font-weight: bold;
 	}
 
@@ -104,7 +104,7 @@
 			display: none;
 		}
 	}
-	
+
 	.pressable-usage-details__card {
 		margin: 24px 0 8px;
 	}
@@ -120,13 +120,11 @@
 
 .license-details__actions .button.is-compact {
 	padding: 8px 14px;
-	font-size: 1rem;
-	font-weight: 500;
-	line-height: 1.375;
+	@include heading-large;
 
 	@include break-large {
 		padding: 7px;
-		font-size: 0.75rem;
+		@include body-medium;
 		line-height: 1;
 	}
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .license-list__header.card.is-compact {
 	display: none;
@@ -16,12 +17,12 @@
 	h2 {
 		margin-block-start: 3rem;
 		margin-block-end: 1rem;
-		font-size: $font-title-medium;
+		@include heading-medium;
 	}
 
 	p {
 		margin-block-end: 1rem;
-		font-size: $font-body;
+		@include body-large;
 
 		a {
 			color: var(--color-neutral-80);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -1,11 +1,10 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .license-preview {
 	margin: 0;
-	font-size: 0.875rem;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.25rem;
+	@include body-medium;
 	color: var(--color-neutral-70);
 	transition: margin 0.2s ease;
 
@@ -59,10 +58,7 @@
 .license-preview__domain {
 	padding: 0;
 	margin: 0 0 4px;
-	font-size: 1.25rem;
-	font-weight: normal;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.75rem;
+	@include body-x-large;
 	color: var(--color-neutral-100);
 	overflow: hidden;
 	word-break: break-all;
@@ -84,9 +80,7 @@
 
 .license-preview__tag {
 	white-space: nowrap;
-	font-size: 0.875rem;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1rem;
+	@include body-medium;
 
 	&--is-just-issued,
 	&--is-assigned {
@@ -149,8 +143,7 @@
 }
 
 .license-preview__assign-button {
-	font-size: 0.75rem;
-	font-weight: 400;
+	@include body-medium;
 	text-decoration: underline;
 	margin-inline-start: 10px;
 }
@@ -202,9 +195,7 @@ button.button.is-borderless.license-bundle-dropdown__button {
 }
 
 .license-preview__client-email {
-	font-size: 0.75rem;
-	line-height: 1.3;
-	font-weight: 400;
+	@include body-medium;
 	color: var(--color-neutral-50);
 	margin-block-start: 4px;
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -40,7 +40,7 @@
 
 	&,
 	&:visited {
-		@include a4a-font-body-md($font-weight: 500);
+		@include heading-medium;
 		display: flex;
 		flex-direction: row;
 		gap: 4px;
@@ -221,7 +221,7 @@ button.button.is-borderless.license-bundle-dropdown__button {
 
 .license-preview__migration-content {
 	min-width: 200px;
-	@include a4a-font-body-md;
+	@include body-medium;
 
 	@include break-mobile {
 		min-width: 300px;

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .revoke-license-dialog {
 	&.dialog.card {
@@ -28,7 +29,7 @@
 
 		&,
 		& p {
-			font-size: 1rem;
+			@include body-large;
 		}
 	}
 
@@ -75,9 +76,8 @@
 	.revoke-license-dialog__heading {
 		margin: -16px -16px 16px;
 		padding: 24px;
-		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+		@include heading-large;
 		font-weight: 600;
-		line-height: 20px;
 		color: var(--color-neutral-60);
 		border-bottom: 1px solid var(--color-neutral-5);
 
@@ -107,7 +107,7 @@
 		line-height: 30px;
 
 		code {
-			font-size: 0.875rem;
+			@include body-medium;
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/credit-card-fields/style.scss
@@ -1,4 +1,5 @@
-@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .credit-card-fields {
 	display: none;
@@ -19,8 +20,7 @@
 
 	input {
 		padding: 11px 16px;
-		line-height: 0.7;
-		font-size: $font-body-small;
+		@include body-small;
 		color: var(--color-neutral-80);
 	}
 }
@@ -55,8 +55,7 @@
 .credit-card-fields__input-field label {
 	display: block;
 	margin-bottom: 0.5rem;
-	font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
-	font-weight: 400;
+	@include body-x-large;
 	color: var(--color-neutral-80);
 }
 
@@ -64,9 +63,8 @@
 	display: block;
 	margin-block-start: 0.5rem;
 	color: var(--color-scary-50);
-	font-size: $font-body-small;
+	@include body-small;
 	font-style: italic;
-	font-weight: 400;
 }
 
 .credit-card-fields__stripe-element {
@@ -77,12 +75,11 @@
 .credit-card-fields__stripe-element .StripeElement {
 	display: block;
 	width: 100%;
-	font-size: 0.875rem;
+	@include body-medium;
 	box-sizing: border-box;
 	border: 1px solid var(--color-accent-60);
 	color: var(--color-neutral-80);
 	padding: 11px 16px;
-	line-height: 0.7;
 }
 
 .credit-card-fields__stripe-element--has-error .StripeElement {

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .payment-method-form {
 	display: flex;
 	flex-direction: column;
@@ -5,9 +8,7 @@
 }
 
 .payment-method-form__title {
-	font-size: rem(20px);
-	line-height: 1.2;
-	font-weight: 500;
+	@include heading-x-large;
 }
 
 .payment-method-form__footer {
@@ -31,15 +32,13 @@
 
 .payment-method-form__notice,
 .payment-method-form .credit-card-fields__input-field :is(label, .credit-card-fields__label-text) {
-	font-size: rem(14px);
-	line-height: 1.4;
-	font-weight: 500;
+	@include heading-medium;
 }
 
 .payment-method-form__notice {
 	color: var(--color-neutral-50);
-	font-weight: 400;
 	margin-block-start: 24px;
+	@include body-medium;
 	display: flex;
 	gap: 8px;
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/delete-primary-confirmation/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/delete-primary-confirmation/style.scss
@@ -1,16 +1,17 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .delete-primary-card-confirmation__separator {
 	margin: 24px 0;
 }
 
 .delete-primary-card-confirmation__card {
-	font-size: 0.875rem;
+	@include body-medium;
 }
 
 .delete-primary-card-confirmation__card-title {
-	font-weight: bold;
+	@include heading-large;
 }
 
 .delete-primary-card-confirmation__card-details {
@@ -41,5 +42,5 @@
 
 .delete-primary-card-confirmation__notice {
 	margin: 1rem 0 0;
-	font-size: 1rem;
+	@include body-large;
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card-delete-dialog/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .stored-credit-card-delete-dialog {
 	.dialog__content {
@@ -7,7 +8,7 @@
 
 		&,
 		& p {
-			font-size: 1rem;
+			@include body-large;
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/stored-credit-card/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .stored-credit-card__card {
 	position: relative;
@@ -29,29 +30,25 @@
 
 .stored-credit-card__card-number {
 	padding-block-start: 90px;
-	font-size: rem(24px);
-	font-weight: 700;
-	line-height: 1.5;
+	@include heading-x-large;
 
 	@include break-mobile {
-		font-size: rem(28px);
+		@include heading-2x-large;
 		padding-block-start: 65px;
 		text-wrap: nowrap;
 	}
 }
 
 .stored-credit-card__card-info-heading {
-	font-size: rem(11px);
+	@include body-small;
 	text-wrap: nowrap;
 }
 
 .stored-credit-card__card-info-value {
-	font-size: rem(14px);
-	font-weight: 700;
-	line-height: 1;
+	@include heading-medium;
 
 	@include break-mobile {
-		font-size: rem(18px);
+		@include heading-large;
 	}
 }
 
@@ -105,13 +102,11 @@
 }
 
 .stored-credit-card__card-footer-title {
-	font-size: rem(16px);
-	font-weight: 500;
+	@include heading-large;
 }
 
 .stored-credit-card__card-footer-subtitle {
-	font-size: rem(12px);
-	font-weight: 400;
+	@include body-small;
 }
 
 button.button.stored-credit-card__card-footer-actions {

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .payment-method-overview-empty-state {
 	margin-block-start: 60px;
@@ -43,14 +44,13 @@
 		}
 
 		.payment-method-overview-empty-state__card-title {
-			font-size: rem(18px);
-			font-weight: 600;
+			@include heading-x-large;
 			margin-block-end: 8px;
 		}
 
 		.payment-method-overview-empty-state__card-description {
 			color: var(--color-neutral-60);
-			font-size: rem(14px);
+			@include body-medium;
 		}
 
 		@include break-medium {
@@ -109,10 +109,8 @@
 
 	@include breakpoint-deprecated( "<660px" ) {
 		display: block;
-		font-size: 1rem;
+		@include body-large;
 		color: var(--color-neutral-60);
-		font-weight: 400;
-		line-height: 1.2;
 	}
 }
 


### PR DESCRIPTION
This PR updates the Purchases pages to now use the Core's typography.

<img width="1599" alt="Screenshot 2025-03-17 at 8 07 41 PM" src="https://github.com/user-attachments/assets/1258b1d9-8297-4b46-a099-20932875a5dc" />
<img width="1554" alt="Screenshot 2025-03-17 at 8 07 47 PM" src="https://github.com/user-attachments/assets/366bead9-fc23-4747-9f2d-680517a43dc8" />
<img width="731" alt="Screenshot 2025-03-17 at 8 07 55 PM" src="https://github.com/user-attachments/assets/4ede11e5-d59e-4b2a-be79-5570b6d6594b" />
<img width="1560" alt="Screenshot 2025-03-17 at 8 08 00 PM" src="https://github.com/user-attachments/assets/e243484c-70ea-4aa5-bfa3-3f3f479f434f" />

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1919

## Proposed Changes

* Update all components in the Purchases page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/purchases` page.
   * Licenses page
   * Billing page
   * Invoices page
   * Payment Methods - Overview Page (Empty) 
   * Payment Methods - Overview Page (With cards)
   * Payment Methods - Overview Page (Delete card confirmation dialog)
   * Payment Methods - Add a new card Page
* Verify that the font sizes are close to the design. Expect some slight changes in the size, but it should be close enough.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
