### PR TITLE
Add transferred license ownership purchases to `me/purchases` page.

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -83,7 +83,9 @@ const siteStatus: SiteStatus = {
 	hasExpired: 30,
 	hasExpiringSoon: 40,
 	hasPaymentMethodExpired: 50,
+	sitelessPlan: 55, // i.e. - Akismet plans
 	noPaymentActionNeeded: 60,
+	hasOwnershipTransferred: 80,
 	hasCannotManage: 100,
 };
 
@@ -93,18 +95,23 @@ const purchaseStatus: PurchaseStatus = {
 	paymentMethodExpired: 20,
 	expiringSoon: 30,
 	noPaymentActionNeeded: 40,
+	ownershipTransferred: 80,
 	cannotManage: 100,
 };
 
 function getSitePurchasesStatus( site: SiteWithPurchases ) {
-	if ( ! site.isConnected ) {
+	if ( ! site.isConnected && ! site.slug.startsWith( 'siteless.akismet.com' ) ) {
 		if ( site.slug === 'siteless.jetpack.com' ) {
 			return 'pendingActivation';
 		}
 		return 'disconnected';
 	}
 	const { purchases } = site;
-
+	if (
+		purchases.some( ( purchase ) => purchase.currentPurchaseStatus === 'ownershipTransferred' )
+	) {
+		return 'hasOwnershipTransferred';
+	}
 	if ( purchases.some( ( purchase ) => purchase.currentPurchaseStatus === 'cannotManage' ) ) {
 		return 'hasCannotManage';
 	}
@@ -119,12 +126,19 @@ function getSitePurchasesStatus( site: SiteWithPurchases ) {
 	if ( purchases.some( ( purchase ) => purchase.currentPurchaseStatus === 'expiringSoon' ) ) {
 		return 'hasExpiringSoon';
 	}
+	if ( ! site.isConnected && site.slug?.startsWith( 'siteless.akismet.com' ) ) {
+		return 'sitelessPlan'; // i.e. - Akismet plans
+	}
 
 	return 'noPaymentActionNeeded';
 }
 
-function getPurchaseStatus( purchase: PurchaseWithStatus ) {
+function getPurchaseStatus( purchase: PurchaseWithStatus, userId?: number ) {
 	const expiry = moment( purchase.expiryDate );
+
+	if ( userId && purchase.userId !== userId && purchase?.purchaserId === userId ) {
+		return 'ownershipTransferred';
+	}
 
 	if ( purchase.isInAppPurchase || isPartnerPurchase( purchase ) ) {
 		return 'cannotManage';
@@ -155,7 +169,8 @@ function getPurchaseStatus( purchase: PurchaseWithStatus ) {
  */
 export function getPurchasesBySite(
 	purchases: Purchase[],
-	sites: SiteDetails[]
+	sites: SiteDetails[],
+	userId?: number
 ): SiteWithPurchases[] {
 	const purchasesBySite = purchases.reduce( ( result: SiteWithPurchases[], currentValue ) => {
 		const site = result.find( ( site ) => site.id === currentValue.siteId );
@@ -163,7 +178,7 @@ export function getPurchasesBySite(
 		if ( site ) {
 			site.purchases = site.purchases.concat( {
 				...currentValue,
-				currentPurchaseStatus: getPurchaseStatus( currentValue as PurchaseWithStatus ),
+				currentPurchaseStatus: getPurchaseStatus( currentValue as PurchaseWithStatus, userId ),
 			} ) as PurchaseWithStatus[];
 			site.isConnected = true;
 			return result;
@@ -183,7 +198,7 @@ export function getPurchasesBySite(
 			purchases: [
 				{
 					...currentValue,
-					currentPurchaseStatus: getPurchaseStatus( currentValue as PurchaseWithStatus ),
+					currentPurchaseStatus: getPurchaseStatus( currentValue as PurchaseWithStatus, userId ),
 				},
 			],
 			isConnected: siteObject ? true : false,

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -21,7 +21,7 @@ import {
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
-import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
 import ManagePurchase from './manage-purchase';
@@ -117,10 +117,13 @@ export function confirmCancelDomain( context, next ) {
 }
 
 export function list( context, next ) {
+	const state = context.store.getState();
+	const currentUser = getCurrentUser( state );
+	const userId = currentUser?.ID;
 	const ListWrapper = localize( () => {
 		return (
 			<PurchasesWrapper>
-				<PurchasesList noticeType={ context.params.noticeType } />
+				<PurchasesList userId={ userId } noticeType={ context.params.noticeType } />
 			</PurchasesWrapper>
 		);
 	} );

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -1,9 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CompactCard } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
+import useGetJetpackTransferredLicensePurchases from '@automattic/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
-import { LocalizeProps, localize } from 'i18n-calypso';
-import { Component } from 'react';
+import { useTranslate, localize } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
@@ -25,6 +26,7 @@ import {
 	WithStoredPaymentMethodsProps,
 	withStoredPaymentMethods,
 } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
 import {
 	getUserPurchases,
@@ -50,28 +52,66 @@ export interface PurchasesListProps {
 export interface PurchasesListConnectedProps {
 	hasLoadedUserPurchasesFromServer: boolean;
 	isFetchingUserPurchases: boolean;
-	purchases: Purchase[] | null;
+	purchases: Purchase[];
 	subscriptions: MembershipSubscription[];
 	sites: SiteDetails[];
 	nextAppointment: NextAppointment | null;
 	isUserBlocked: boolean;
 	availableSessions: number[];
 	siteId: number | null;
+	userId: number | undefined;
 }
 
-class PurchasesList extends Component<
-	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps & LocalizeProps
-> {
-	isDataLoading() {
-		if ( this.props.isFetchingUserPurchases && ! this.props.hasLoadedUserPurchasesFromServer ) {
+const PurchasesList: React.FC<
+	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps
+> = ( {
+	hasLoadedUserPurchasesFromServer,
+	isFetchingUserPurchases,
+	purchases,
+	subscriptions,
+	sites,
+	nextAppointment,
+	isUserBlocked,
+	availableSessions,
+	userId,
+	paymentMethodsState,
+} ) => {
+	const translate = useTranslate();
+	const {
+		data: transferredOwnershipPurchases,
+		isLoading,
+		isSuccess: hasLoadedTransferredOwnershipPurchases,
+	} = useGetJetpackTransferredLicensePurchases( { userId } );
+
+	const isDataLoading = useCallback( () => {
+		if (
+			( isFetchingUserPurchases && ! hasLoadedUserPurchasesFromServer ) ||
+			( isLoading && ! hasLoadedTransferredOwnershipPurchases )
+		) {
 			return true;
 		}
 
-		return ! this.props.sites.length && ! this.props.subscriptions.length;
-	}
+		return ! sites.length && ! subscriptions.length;
+	}, [
+		hasLoadedUserPurchasesFromServer,
+		isFetchingUserPurchases,
+		isLoading,
+		hasLoadedTransferredOwnershipPurchases,
+		sites.length,
+		subscriptions.length,
+	] );
 
-	renderConciergeBanner() {
-		const { nextAppointment, availableSessions, isUserBlocked } = this.props;
+	const allPurchasesLoaded =
+		hasLoadedUserPurchasesFromServer && hasLoadedTransferredOwnershipPurchases;
+
+	const allPurchases = useMemo( () => {
+		if ( allPurchasesLoaded ) {
+			return [ ...purchases, ...transferredOwnershipPurchases ];
+		}
+		return [];
+	}, [ allPurchasesLoaded, purchases, transferredOwnershipPurchases ] );
+
+	const renderConciergeBanner = () => {
 		return (
 			<PurchaseListConciergeBanner
 				nextAppointment={ nextAppointment ?? undefined }
@@ -79,37 +119,34 @@ class PurchasesList extends Component<
 				isUserBlocked={ isUserBlocked }
 			/>
 		);
-	}
+	};
 
-	renderMembershipSubscriptions() {
-		const { subscriptions } = this.props;
-
-		if ( ! subscriptions.length || this.isDataLoading() ) {
+	const renderMembershipSubscriptions = () => {
+		if ( ! subscriptions.length || ! allPurchasesLoaded ) {
 			return null;
 		}
 
 		return getSubscriptionsBySite( subscriptions ).map( ( site ) => (
 			<MembershipSite site={ site } key={ site.id } />
 		) );
+	};
+
+	const commonEventProps = { context: 'me' };
+	let content;
+
+	if ( isDataLoading() ) {
+		content = <PurchasesSite isPlaceholder />;
 	}
 
-	render() {
-		const { purchases, sites, translate, subscriptions } = this.props;
-		const commonEventProps = { context: 'me' };
-		let content;
+	if ( allPurchases && allPurchasesLoaded && allPurchases.length ) {
+		content = (
+			<>
+				{ renderConciergeBanner() }
 
-		if ( this.isDataLoading() ) {
-			content = <PurchasesSite isPlaceholder />;
-		}
+				<PurchasesListHeader showSite />
 
-		if ( purchases && purchases.length ) {
-			content = (
-				<>
-					{ this.renderConciergeBanner() }
-
-					<PurchasesListHeader showSite />
-
-					{ getPurchasesBySite( purchases, sites ).map( ( site ) => (
+				{ getPurchasesBySite( allPurchases, sites, userId ).map( ( site ) => {
+					return (
 						<PurchasesSite
 							key={ site.id }
 							siteId={ site.id }
@@ -117,87 +154,94 @@ class PurchasesList extends Component<
 							slug={ site.slug }
 							purchases={ site.purchases }
 							showSite
-							cards={ this.props.paymentMethodsState.paymentMethods }
+							cards={ paymentMethodsState.paymentMethods }
 						/>
-					) ) }
-				</>
-			);
-		}
-
-		if ( purchases && ! purchases.length && ! subscriptions.length ) {
-			if ( ! sites.length ) {
-				return (
-					<Main wideLayout className="purchases-list">
-						<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
-						<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
-						<PurchasesNavigation section="activeUpgrades" />
-						<NoSitesMessage />
-					</Main>
-				);
-			}
-			content = (
-				<>
-					{ this.renderConciergeBanner() }
-					<CompactCard className="purchases-list__no-content">
-						<>
-							<TrackComponentView
-								eventName="calypso_no_purchases_upgrade_nudge_impression"
-								eventProperties={ commonEventProps }
-							/>
-							<EmptyContent
-								title={ translate( 'Looking to upgrade?' ) }
-								line={ translate(
-									'Our plans give your site the power to thrive. ' +
-										'Find the plan that works for you.'
-								) }
-								action={ translate( 'Upgrade now' ) }
-								actionURL="/plans"
-								illustration={ noSitesIllustration }
-								actionCallback={ () => {
-									recordTracksEvent( 'calypso_no_purchases_upgrade_nudge_click', commonEventProps );
-								} }
-							/>
-						</>
-					</CompactCard>
-				</>
-			);
-		}
-
-		return (
-			<Main wideLayout className="purchases-list">
-				<QueryUserPurchases />
-				<QueryMembershipsSubscriptions />
-				<PageViewTracker path="/me/purchases" title="Purchases" />
-
-				<NavigationHeader
-					navigationItems={ [] }
-					title={ titles.sectionTitle }
-					subtitle={ translate(
-						'View, manage, or cancel your plan and other purchases. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
-							},
-						}
-					) }
-				/>
-				<PurchasesNavigation section="activeUpgrades" />
-				{ content }
-				{ this.renderMembershipSubscriptions() }
-				<QueryConciergeInitial />
-			</Main>
+					);
+				} ) }
+			</>
 		);
 	}
-}
+
+	if (
+		purchases &&
+		! purchases.length &&
+		! subscriptions.length &&
+		transferredOwnershipPurchases &&
+		! transferredOwnershipPurchases.length
+	) {
+		if ( ! sites.length ) {
+			return (
+				<Main wideLayout className="purchases-list">
+					<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
+					<PurchasesNavigation section="activeUpgrades" />
+					<NoSitesMessage />
+				</Main>
+			);
+		}
+		content = (
+			<>
+				{ renderConciergeBanner() }
+				<CompactCard className="purchases-list__no-content">
+					<>
+						<TrackComponentView
+							eventName="calypso_no_purchases_upgrade_nudge_impression"
+							eventProperties={ commonEventProps }
+						/>
+						<EmptyContent
+							title={ translate( 'Looking to upgrade?' ) }
+							line={ translate(
+								'Our plans give your site the power to thrive. ' +
+									'Find the plan that works for you.'
+							) }
+							action={ translate( 'Upgrade now' ) }
+							actionURL="/plans"
+							illustration={ noSitesIllustration }
+							actionCallback={ () => {
+								recordTracksEvent( 'calypso_no_purchases_upgrade_nudge_click', commonEventProps );
+							} }
+						/>
+					</>
+				</CompactCard>
+			</>
+		);
+	}
+
+	return (
+		<Main wideLayout className="purchases-list">
+			<QueryUserPurchases />
+			<QueryMembershipsSubscriptions />
+			<PageViewTracker path="/me/purchases" title="Purchases" />
+
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ titles.sectionTitle }
+				subtitle={ translate(
+					'View, manage, or cancel your plan and other purchases. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,
+						},
+					}
+				) }
+			/>
+			<PurchasesNavigation section="activeUpgrades" />
+			{ content }
+			{ renderMembershipSubscriptions() }
+			<QueryConciergeInitial />
+		</Main>
+	);
+};
 
 export default connect( ( state: AppState ) => ( {
 	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 	isFetchingUserPurchases: isFetchingUserPurchases( state ),
-	purchases: getUserPurchases( state ),
+	purchases: getUserPurchases( state ) ?? [],
 	subscriptions: getAllSubscriptions( state ),
 	sites: getSites( state ).filter( isValueTruthy ),
 	nextAppointment: getConciergeNextAppointment( state ),
 	isUserBlocked: getConciergeUserBlocked( state ),
 	availableSessions: getAvailableConciergeSessions( state ),
 	siteId: getSiteId( state, null ),
+	userId: getCurrentUserId( state ),
 } ) )( withStoredPaymentMethods( localize( PurchasesList ), { type: 'card', expired: true } ) );

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -124,6 +124,10 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		isAutoRenewEnabled: parseInt( purchase.auto_renew ?? '' ) === 1,
 	};
 
+	if ( purchase.purchaser_id ) {
+		object.purchaserId = purchase.purchaser_id;
+	}
+
 	if ( isCreditCardPurchase( purchase ) ) {
 		object.payment.creditCard = {
 			id: Number( purchase.payment_card_id ),

--- a/packages/data-stores/src/purchases/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/purchases/queries/lib/use-query-keys-factory.ts
@@ -1,5 +1,6 @@
 const useQueryKeysFactory = () => ( {
 	sitePurchases: ( siteId?: string | number | null ) => [ 'site-purchases', siteId ],
+	transferredPurchases: ( userId?: string | number | null ) => [ 'transferred-purchases', userId ],
 } );
 
 export default useQueryKeysFactory;

--- a/packages/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases.tsx
+++ b/packages/data-stores/src/purchases/queries/use-get-jetpack-transferred-license-purchases.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import { createPurchaseObject } from '../lib/assembler';
+import useQueryKeysFactory from './lib/use-query-keys-factory';
+import type { RawPurchase, Purchase } from '../types';
+
+export interface PurchasesIndex {
+	[ purchaseId: number ]: Purchase;
+}
+
+interface Props {
+	userId?: string | number;
+}
+
+export function getUseTransferredPurchasesOptions(
+	{ userId }: Props,
+	queryKey: ( string | number | null | undefined )[]
+) {
+	return {
+		queryKey,
+		queryFn: async (): Promise< Purchase[] > => {
+			const purchases: RawPurchase[] = await wpcomRequest( {
+				path: '/me/purchases/transferred-owner',
+				apiVersion: '1.1',
+			} );
+
+			return purchases.map( ( rawPurchase ) => createPurchaseObject( rawPurchase ) );
+		},
+		enabled: !! userId,
+	};
+}
+
+/**
+ * Fetches all purchases for a given site, transformed into a map of purchaseId => Purchase
+ * @param {Object} props - The properties for the function
+ * @param props.userId Site ID
+ * @returns Query result
+ */
+function useGetJetpackTransferredLicensePurchases( { userId }: Props ) {
+	const queryKeys = useQueryKeysFactory();
+
+	return useQuery< Purchase[] >(
+		getUseTransferredPurchasesOptions( { userId }, queryKeys.transferredPurchases( userId ) )
+	);
+}
+
+export default useGetJetpackTransferredLicensePurchases;

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -60,6 +60,7 @@ export interface Purchase {
 	productSlug: string;
 	productType: string;
 	purchaseRenewalQuantity: number | null;
+	purchaserId?: number;
 
 	/**
 	 * The refund amount for the purchase, not including bundled domains, as a
@@ -239,6 +240,7 @@ export interface RawPurchase {
 	product_type: string;
 	product_display_price: string;
 	price_integer: number;
+	purchaser_id?: number;
 	total_refund_amount: number | undefined;
 	total_refund_currency: string;
 	total_refund_integer: number;


### PR DESCRIPTION
TBD ..
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD... Coming soon..

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
