### PR TITLE
A4A: Update Signup pages to use Core's typography.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/agency-details-form/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .agency-details-form {
 
@@ -15,9 +16,7 @@
 
 	.agency-details-form__tos p {
 		margin: 45px 0 24px;
-		font-weight: 400;
-		font-size: 1rem;
-		line-height: 24px;
+		@include body-large;
 		color: var(--color-neutral-100);
 	}
 
@@ -41,8 +40,7 @@
 		margin-block-start: 0.25rem;
 		color: var(--color-scary-40);
 		font-style: italic;
-		font-size: 0.875rem;
-		line-height: 14px;
+		@include body-medium;
 
 		&.hidden {
 			display: none;
@@ -56,7 +54,7 @@
 	}
 
 	.company-details-form__tos p {
-		font-size: 1rem;
+		@include body-large;
 	}
 
 	.company-details-form__phone-input {
@@ -78,8 +76,7 @@
 	}
 
 	.components-base-control__label {
-		font-size: 0.875rem;
-		font-weight: 600;
+		@include heading-medium;
 		margin-bottom: 5px;
 		text-transform: none;
 	}

--- a/client/a8c-for-agencies/sections/signup/intro/style.scss
+++ b/client/a8c-for-agencies/sections/signup/intro/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .a4a-signup-intro {
 	text-align: center;
 	color: var(--color-text-white);
@@ -9,17 +12,14 @@
 	padding-bottom: 48px;
 
 	h1 {
-		font-size: 2.75rem;
+		@include heading-2x-large;
 		line-height: 1;
 		letter-spacing: -3%;
-		font-weight: 600;
 	}
 
 	p {
 		color: var(--color-neutral-10);
-		font-size: 1.25rem;
-		line-height: 1.4;
-		font-weight: 500;
+		@include heading-x-large;
 		max-width: 700px;
 		margin: 0;
 	}
@@ -56,9 +56,8 @@
 		border: 2px solid var(--color-primary-70);
 		border-radius: 24px; /* stylelint-disable-line scales/radii */
 		padding: 8px 16px;
-		font-size: 0.75rem;
+		@include heading-medium;
 		text-transform: uppercase;
-		font-weight: 700;
 		background-color: var(--color-surface-backdrop);
 
 		&::after {
@@ -77,8 +76,7 @@
 
 	&__wp-admin-link {
 		color: var(--color-neutral-10);
-		font-size: 0.875rem;
-		font-weight: 500;
+		@include heading-medium;
 		text-decoration: underline;
 		cursor: pointer;
 

--- a/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/style.scss
+++ b/client/a8c-for-agencies/sections/signup/primary/agency-signup-finish/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .agency-signup-finish__wrapper {
 	display: flex;
 	flex-direction: column;
@@ -7,7 +10,7 @@
 }
 
 .agency-signup-finish__text {
-	font-size: 2rem;
+	@include heading-2x-large;
 	text-align: center;
 	color: var(--color-neutral-10);
 }

--- a/client/a8c-for-agencies/sections/signup/signup-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-form/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .agency-signup-form {
 	max-width: 720px;
@@ -16,17 +17,13 @@
 
 	.agency-signup-form__heading {
 		margin: 0 0 24px;
-		font-weight: 700;
-		font-size: 2rem;
-		line-height: 40px;
+		@include heading-2x-large;
 		color: var(--color-neutral-100);
 	}
 
 	.agency-signup-form__subheading {
 		margin: 0 0 38px;
-		font-weight: 400;
-		font-size: 1rem;
-		line-height: 24px;
+		@include body-large;
 		color: var(--color-neutral-100);
 	}
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .contact-form__phone-input {
     display: flex;
@@ -19,7 +20,7 @@
 }
 
 .signup-contact-form__tos  p {
-	@include a4a-font-body-sm;
+	@include body-small;
 
 	.signup-contact-form__tos-link {
 		cursor: pointer;
@@ -50,7 +51,7 @@
 
 .signup-multi-step-form__terms {
 	text-align: center;
-	font-size: 0.875rem;
+	@include body-medium;
 	color: var(--color-neutral-40);
 	margin-top: 16px;
 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/tos-modal/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/tos-modal/style.scss
@@ -1,10 +1,13 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .a4a-tos-modal {
 	width: 80%;
 	max-width: 800px;
 }
 
 .a4a-tos-modal-list {
-    @include a4a-font-body-md;
+    @include body-medium;
     color: var(--color-neutral-50);
     margin-block: 16px;
     line-height: 1.6;

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .signup-personalization-form {
     .multi-checkbox {
@@ -25,7 +26,7 @@
         align-items: center;
         margin: 0;
         cursor: pointer;
-        font-size: rem(14px);
+        @include body-medium;
         color: var(--color-neutral-80);
         flex: 0 1 100%; // Full width on mobile
 

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .signup-multi-step-form {
 	.a4a-form {
@@ -25,15 +26,13 @@
 
 	.a4a-form__heading {
 		.a4a-form__heading-title {
-			font-size: 2rem;
-			font-weight: 600;
+			@include heading-2x-large;
 			margin-bottom: 16px;
 			color: var(--color-neutral-100);
 		}
 
 		.a4a-form__heading-description {
-			font-size: 1rem;
-			font-weight: 400;
+			@include body-large;
 			color: var(--color-neutral-60);
 			max-width: 460px;
 		}
@@ -95,7 +94,7 @@
 
 	.a4a-form__section-field-label,
 	.a4a-form__section-field-required {
-		@include a4a-font-heading-sm($font-size: rem(14px));
+		@include heading-medium;
 	}
 
 	@media (prefers-color-scheme: dark) {

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/signup-wrapper/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .signup-wrapper {
     display: flex;
@@ -57,8 +58,7 @@
     top: -1rem;
 
     .signup-wrapper__testimonial-text {
-      font-size: 1rem;
-      line-height: 1.5;
+      @include body-large;
       margin-bottom: 24px;
       color: var(--color-text);
     }
@@ -82,14 +82,12 @@
     }
 
     .signup-wrapper__testimonial-name {
-      font-weight: 600;
-      font-size: 1rem;
+      @include heading-large;
       color: var(--color-text);
     }
 
     .signup-wrapper__testimonial-title {
-      font-weight: 600;
-      font-size: 1rem;
+      @include heading-large;
       color: var(--color-text);
     }
   }
@@ -199,6 +197,6 @@
 	padding-block: 4px;
 
 	.form-radio__label {
-		@include a4a-font-body-md;
+		@include body-medium;
 	}
 }

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/step-progress/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .step-progress {
 	width: 100%;
 
@@ -47,8 +50,7 @@
 	}
 
 	.step-progress__step-label {
-		font-size: 0.875rem;
-		font-weight: 500;
+		@include body-medium;
 		transition: color 0.2s ease;
 		order: -1;
 		margin-bottom: 4px;
@@ -56,7 +58,7 @@
 }
 
 .field-mandatory-message {
-	@include a4a-font-body-sm;
+	@include body-small;
 	padding-block-end: 8px;
 
 	@media (prefers-color-scheme: dark) {


### PR DESCRIPTION
This PR updates the Signup pages to now use the Core's typography.
<img width="726" alt="Screenshot 2025-03-17 at 8 22 04 PM" src="https://github.com/user-attachments/assets/92c7704a-9156-48d9-a414-16fd285f57c5" />
<img width="1515" alt="Screenshot 2025-03-17 at 8 28 49 PM" src="https://github.com/user-attachments/assets/9cc02914-bd5a-4b9d-8138-e48a14b306b8" />
<img width="794" alt="Screenshot 2025-03-17 at 8 30 17 PM" src="https://github.com/user-attachments/assets/eb1a103f-fb54-413a-ab57-27988376cc86" />

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1929
## Proposed Changes

* Update all components in the Signup pages to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/signup` page.
* Use the A4A live link and go to the `/signup/wc-asia` page.
* Verify that the font sizes are close to the design. Expect some slight changes in the size, but it should be close enough.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
