### PR TITLE
A4A: Update common components to use Core's typography.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/components/a4a-confirmation-dialog/style.scss
@@ -1,8 +1,10 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-confirmation-dialog {
 	&__heading {
 		padding-bottom: 16px;
-		@include a4a-font-heading-lg;
+		@include heading-large;
 	}
 
 	& .dialog__action-buttons {

--- a/client/a8c-for-agencies/components/a4a-feedback/style.scss
+++ b/client/a8c-for-agencies/components/a4a-feedback/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 $highlight-color: #3858E9;
 
@@ -23,11 +24,11 @@ $highlight-color: #3858E9;
 }
 
 .a4a-feedback__title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 }
 
 .a4a-feedback__description {
-	@include  a4a-font-body-lg;
+	@include body-large;
 	color: var(--color-neutral-60);
 	padding-block: 4px 32px;
 }
@@ -43,16 +44,16 @@ $highlight-color: #3858E9;
 }
 
 .a4a-feedback__question-details {
-	@include a4a-font-heading-lg($font-weight: 500);
+	@include heading-large;
 }
 
 .a4a-feedback__experience-selector-label {
-	@include a4a-font-label-button;
+	@include heading-medium;
 	padding-block-end: 8px;
 }
 
 .a4a-feedback__comments-label {
-	@include a4a-font-label-button;
+	@include heading-medium;
 	padding-block-end: 8px;
 
 	span {

--- a/client/a8c-for-agencies/components/a4a-image-picker/style.scss
+++ b/client/a8c-for-agencies/components/a4a-image-picker/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .a4a-image-picker__upload-instructions {
 	border: 1px dotted var(--color-neutral-100);
 	border-radius: 4px;
@@ -32,8 +35,7 @@
 
 	.button-plain {
 		color: var(--color-primary);
-		font-size: rem(14px);
-		font-weight: 400;
+		@include body-medium;
 		text-decoration: underline;
 	}
 }
@@ -47,6 +49,5 @@
 
 .a4a-image-picker__error {
 	color: var(--color-error);
-	font-size: rem(14px);
-	font-weight: 400;
+	@include body-medium;
 }

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/migration-contact-support-form/style.scss
@@ -1,11 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .migration-contact-support-form {
 	width: 827px;
 	max-height: 100%;
 	margin: 0;
-	@include a4a-font-body-lg;
+	@include body-large;
 	color: var(--color-neutral-100);
 
 	@include breakpoint-deprecated( "<660px" ) {
@@ -54,7 +55,7 @@
 }
 
 .migration-contact-support-form__title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	margin: 0;
 	padding: 0;
 }

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v2/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-migration-offer-v2 {
 	display: flex;
@@ -45,7 +46,7 @@
 }
 
 .a4a-migration-offer-v2__title {
-	@include a4a-font-heading-md;
+	@include heading-medium;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -54,7 +55,7 @@
 	margin-block-end: 0;
 
 	@include break-medium {
-		@include a4a-font-heading-lg;
+		@include heading-large;
 		margin-block-start: 10px;
 		margin-block-end: 8px;
 	}
@@ -73,7 +74,7 @@
 }
 
 .a4a-migration-offer-v2__description {
-	@include a4a-font-body-md;
+	@include body-medium;
 	margin: 0;
 	max-width: 800px;
 
@@ -83,14 +84,13 @@
 	}
 
 	@include break-medium {
-		@include a4a-font-body-lg;
+		@include body-large;
 	}
 }
 
 .a4a-migration-offer-v2__asterisk {
 	color: var(--studio-gray-80);
-	font-size: 0.75rem;
-	font-weight: 400;
+	@include body-medium;
 	margin-block-start: 12px;
 	margin-bottom: 0;
 }
@@ -103,7 +103,7 @@
 	align-items: center;
 	align-content: center;
 
-	@include a4a-font-body-md;
+	@include body-medium;
 }
 
 .theme-a8c-for-agencies .components-button.a4a-migration-offer-v2__view-toggle-mobile {

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/style.scss
@@ -74,7 +74,7 @@
 }
 
 .a4a-migration-offer-v3__body-actions-footnote {
-	@include a4a-font-body-sm;
+	@include body-small;
 }
 
 .theme-a8c-for-agencies .components-button.a4a-migration-offer-v3__view-toggle-mobile {

--- a/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-migration-offer/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .a4a-migration-offer__wrapper {
 	border-radius: 4px;
 	background-color: var(--studio-automattic-blue-0);
@@ -65,24 +68,20 @@
 
 		h3 {
 			color: var(--studio-gray-100);
-			font-weight: 600;
-			font-size: 1rem;
+			@include body-large;
 		}
 	}
 
 	.a4a-migration-offer__description {
 		color: var(--studio-gray-80);
-		@include a4a-font-body-lg;
+		@include body-medium;
 		max-width: 850px;
-		font-size: 0.875rem;
-		font-weight: 500;
 		margin-block-end: 12px;
 	}
 
 	.a4a-migration-offer__asterisk {
 		color: var(--studio-gray-80);
-		font-size: 0.75rem;
-		font-weight: 400;
+		@include body-medium;
 		margin-block-start: 12px;
 		margin-bottom: 0;
 	}

--- a/client/a8c-for-agencies/components/a4a-modal/style.scss
+++ b/client/a8c-for-agencies/components/a4a-modal/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-modal {
 	max-width: 827px;
@@ -36,13 +37,13 @@
 	}
 
 	.a4a-modal__title {
-		@include a4a-font-heading-lg;
+		@include heading-large;
 		margin: 0;
 		padding: 0;
 	}
 
 	.a4a-modal__subtitle {
-		@include a4a-font-body-sm;
+		@include body-small;
 		margin: 0;
 		color: var(--color-accent-60);
 	}

--- a/client/a8c-for-agencies/components/a4a-popover/style.scss
+++ b/client/a8c-for-agencies/components/a4a-popover/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-popover__content {
 	display: flex;
@@ -13,7 +14,7 @@
 	}
 
 	.a4a-popover__title {
-		@include a4a-font-body-md;
+		@include body-medium;
 		color: var(--color-accent-60);
 	}
 }
@@ -60,13 +61,11 @@
 	}
 
 	.a4a-popover__popover-button-heading {
-		font-size: rem(14px);
-		font-weight: 600;
+		@include heading-medium;
 	}
 
 	.a4a-popover__popover-button-description {
-		font-size: rem(12px);
-		line-height: 1.33;
+		@include body-small;
 		color: var(--color-accent);
 		padding-top: 4px;
 	}

--- a/client/a8c-for-agencies/components/a4a-request-wp-admin-access/style.scss
+++ b/client/a8c-for-agencies/components/a4a-request-wp-admin-access/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-request-wp-admin-access {
 	display: flex;
@@ -23,12 +24,12 @@
 	}
 
 	.a4a-request-wp-admin-access__heading {
-		@include a4a-font-heading-lg;
+		@include heading-x-large;
 		padding-block-end: 16px;
 	}
 
 	.a4a-request-wp-admin-access__description {
-		@include a4a-font-body-lg;
+		@include body-large;
 		padding-block-end: 24px;
 	}
 }
@@ -43,7 +44,7 @@
 }
 
 a.components-button.a4a-request-wp-admin-access__learn-more-button {
-	@include a4a-font-body-md;
+	@include body-medium;
 	color: var(--color-primary);
 	justify-content: flex-start;
 	background: none;

--- a/client/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/a4a-connection-modal/style.scss
@@ -1,17 +1,14 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-connection-modal__title {
-	font-size: rem(24px);
-	font-weight: 600;
-	line-height: 1.3;
+	@include heading-x-large;
 	margin-block-end: 16px;
 }
 
 .a4a-connection-modal__instruction {
-	font-size: rem(14px);
-	font-weight: 400;
-	line-height: 1.4;
+	@include body-medium;
 	margin-block-end: 24px;
 }
 

--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .import-from-wpcom-modal {
 	max-width: 827px;
@@ -37,13 +38,13 @@
 }
 
 .import-from-wpcom-modal__title {
-	@include a4a-font-heading-lg;
+	@include heading-x-large;
 	margin: 0;
 	padding: 0;
 }
 
 p.import-from-wpcom-modal__instruction {
-	@include a4a-font-body-sm;
+	@include body-small;
 	margin: 0;
 	color: var(--color-accent-60);
 }
@@ -154,7 +155,7 @@ p.import-from-wpcom-modal__instruction {
 	}
 
 	span {
-		@include a4a-font-body-sm;
+		@include body-small;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/jetpack-connection-modal/style.scss
@@ -1,17 +1,14 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .jetpack-connection-modal__title {
-	font-size: rem(24px);
-	font-weight: 600;
-	line-height: 1.3;
+	@include heading-x-large;
 	margin-block-end: 16px;
 }
 
 .jetpack-connection-modal__instruction {
-	font-size: rem(14px);
-	font-weight: 400;
-	line-height: 1.4;
+	@include body-medium;
 	margin-block-end: 24px;
 }
 

--- a/client/a8c-for-agencies/components/add-new-site-button/style.scss
+++ b/client/a8c-for-agencies/components/add-new-site-button/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .site-selector-and-importer__button {
 	.gridicon {
@@ -69,8 +70,7 @@
 
 .site-selector-and-importer__popover-column-heading {
 	color: var(--color-accent-40);
-	font-size: rem(12px);
-	font-weight: 500;
+	@include heading-small;
 	margin-block-end: 8px;
 }
 
@@ -151,20 +151,18 @@
 	}
 
 	.site-selector-and-importer__popover-button-heading {
-		font-size: rem(14px);
-		font-weight: 600;
+		@include heading-medium;
 	}
 
 	.site-selector-and-importer__popover-button-description {
-		font-size: rem(12px);
-		line-height: 1.33;
+		@include body-small;
 		color: var(--color-accent);
 		padding-top: 4px;
 	}
 }
 
 .site-selector-and-importer__popover-site-count {
-	font-size: rem(12px);
+	@include body-small;
 	font-style: italic;
 	color: var(--color-accent-100);
 	padding-top: 4px;
@@ -172,8 +170,7 @@
 
 .site-selector-and-importer__popover-development-site-cta {
 	padding-top: 12px;
-	font-size: rem(12px);
-	font-weight: 600;
+	@include heading-small;
 
 	&.disabled {
 		color: var(--color-accent-20);

--- a/client/a8c-for-agencies/components/agency-site-tag/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tag/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .agency-site-tag.badge {
 	background: var(--studio-gray-5);
 	border-radius: 4px;
@@ -11,7 +14,7 @@
 }
 
 .agency-site-tag__text {
-	font-size: 0.875rem;
+	@include body-small;
 }
 
 .agency-site-tag__close {

--- a/client/a8c-for-agencies/components/filter-search/style.scss
+++ b/client/a8c-for-agencies/components/filter-search/style.scss
@@ -21,7 +21,7 @@
 	}
 
 	.search__input.form-text-input[type="search"] {
-		@include a4a-font-body-md;
+		@include body-medium;
 		color: var(--color-text);
 	}
 }

--- a/client/a8c-for-agencies/components/foldable-nav/style.scss
+++ b/client/a8c-for-agencies/components/foldable-nav/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .foldable-nav.foldable-card.card {
 	margin: 0;
 	background-color: transparent;
@@ -17,7 +20,7 @@
 
 		.foldable-card__main {
 			color: var(--color-accent-100);
-			@include a4a-font-heading-md;
+			@include heading-large;
 		}
 	}
 
@@ -28,7 +31,7 @@
 		p.no-content,
 		.components-flex-item {
 			color: var(--color-accent-80);
-			@include a4a-font-body-md;
+			@include body-medium;
 			margin-bottom: 0;
 		}
 

--- a/client/a8c-for-agencies/components/form/field/style.scss
+++ b/client/a8c-for-agencies/components/form/field/style.scss
@@ -36,8 +36,7 @@
 	margin-block-start: 0.25rem;
 	color: var(--color-scary-40);
 	font-style: italic;
-	font-size: 0.875rem;
-	line-height: 14px;
+	@include body-small;
 
 	&.hidden {
 		display: none;

--- a/client/a8c-for-agencies/components/form/fieldset/style.scss
+++ b/client/a8c-for-agencies/components/form/fieldset/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .a4a-form-fieldset__header {
 	display: flex;
 
@@ -11,8 +14,7 @@
 	margin-block-start: 0.25rem;
 	color: var(--color-scary-40);
 	font-style: italic;
-	font-size: 0.875rem;
-	line-height: 14px;
+	@include body-small;
 
 	&.hidden {
 		display: none;
@@ -21,8 +23,6 @@
 
 .a4a-form-fieldset__description {
 	margin-block-start: 4px;
-	font-size: rem(14px);
-	line-height: 1.5;
-	font-weight: 400;
+	@include body-small;
 	color: var(--color-neutral-50);
 }

--- a/client/a8c-for-agencies/components/guide-modal/style.scss
+++ b/client/a8c-for-agencies/components/guide-modal/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .guide-modal__wrapper {
 	width: 400px;
 	align-self: start;
@@ -101,14 +104,12 @@
 	}
 
 	h3 {
-		font-size: 1rem;
-		font-weight: 600;
+		@include heading-large;
 		color: var(--color-neutral-100);
 	}
 
 	p {
-		font-size: 0.875rem;
-		font-weight: 400;
+		@include body-medium;
 		color: var(--color-neutral-80);
 	}
 }

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .dataviews-pagination {
 	flex-shrink: 0;
@@ -9,7 +10,7 @@
 	border-bottom-right-radius: 4px;
 	bottom: 0;
 	color: var(--Gray-Gray-40, #787c82);
-	@include a4a-font-body-sm;
+	@include body-small;
 	justify-content: space-between !important;
 	padding: 12px 16px 12px 16px;
 	margin-top: auto;

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 @media (max-width: 660px) {
 	.hosting-dashboard-layout__header-title {
@@ -44,7 +45,7 @@
 		justify-content: center;
 		align-content: center;
 		align-items: center;
-		font-size: 0.75rem;
+		@include body-small;
 	}
 
 	.a4a-layout__stepper-step-name {

--- a/client/a8c-for-agencies/components/list-item-cards/style.scss
+++ b/client/a8c-for-agencies/components/list-item-cards/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .list-item-cards {
 	overflow-y: auto;
 
@@ -20,7 +23,7 @@
 				justify-content: space-between;
 
 				.list-item-card-content__header-title {
-					@include a4a-font-body-sm($font-weight: 500);
+					@include heading-small;
 					color: var(--color-gray-80);
 				}
 			}

--- a/client/a8c-for-agencies/components/offering/style.scss
+++ b/client/a8c-for-agencies/components/offering/style.scss
@@ -1,17 +1,17 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 
 .a4a-offering-card__wrapper {
 	padding-block-start: 16px;
 
 	.a4a-offering-card__title {
-		@include a4a-font-heading-md;
+		@include heading-medium;
 		color: var(--color-neutral-100);
 	}
 
 	.a4a-offering-card__description {
-		@include a4a-font-body-md;
+		@include body-medium;
 		color: var(--color-neutral-60);
 		margin-block-end: 16px;
 	}
@@ -25,14 +25,14 @@
 
 			.a4a-offering-item__title {
 				color: var(--color-neutral-100);
-				@include a4a-font-heading-md;
+				@include heading-medium;
 				margin-inline-start: 10px;
 			}
 		}
 
 		.a4a-offering-item__description {
 			color: var(--color-neutral-60);
-			@include a4a-font-body-md;
+			@include body-medium;
 		}
 
 		.foldable-card__header {
@@ -80,7 +80,7 @@
 		color: var(--color-neutral-80);
 		display: flex;
 		align-items: flex-start;
-		@include a4a-font-body-md;
+		@include body-medium;
 	}
 
 	.a4a-offering-item__icon-container {

--- a/client/a8c-for-agencies/components/pressable-usage-details/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-details/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .pressable-usage-details__card {
 	display: flex;
@@ -9,12 +10,12 @@
 	margin: 0 auto;
 
 	.pressable-usage-details__empty-message {
-		font-size: 0.875rem;
+		@include body-medium;
 		margin-bottom: 16px;
 	}
 
 	.pressable-usage-details__title {
-		font-size: 1.5rem;
+		@include body-x-large;
 		margin-bottom: 10px;
 	}
 
@@ -61,7 +62,7 @@
 	}
 
 	.pressable-usage-details__info-label {
-		font-size: 0.875rem;
+		@include body-small;
 		text-transform: uppercase;
 	}
 
@@ -73,18 +74,16 @@
 	}
 
 	.pressable-usage-details__info-top-right {
-		font-size: 0.875rem;
+		@include body-medium;
 		color: var(--color-neutral-60);
 
 		&.storage {
-			font-weight: bold;
-			font-size: 1rem;
+			@include heading-large;
 		}
 	}
 
 	.pressable-usage-details__info-value {
-		font-size: 1rem;
-		font-weight: bold;
+		@include heading-large;
 		margin-top: 5px;
 	}
 }

--- a/client/a8c-for-agencies/components/pressable-usage-limit-notice/style.scss
+++ b/client/a8c-for-agencies/components/pressable-usage-limit-notice/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .pressable-usage-limit-notice {
 	.components-button {
 		margin-block-start: 1rem;
@@ -13,6 +16,6 @@
 }
 
 p.pressable-usage-limit-notice__message {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin: 0;
 }

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 // Rules in this file inspired by:
 // client/components/jetpack/profile-dropdown/style.scss
 
@@ -77,7 +80,7 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 		0 1px 2px rgba(var(--color-accent-100-rgb), 0.1);
 	list-style-type: none;
 
-	@include a4a-font-body-md;
+	@include body-medium;
 }
 
 .a4a-sidebar__profile-dropdown.is-align-menu-up .a4a-sidebar__profile-dropdown-menu {

--- a/client/a8c-for-agencies/components/site-configurations-modal/style.scss
+++ b/client/a8c-for-agencies/components/site-configurations-modal/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .configure-your-site-modal-form {
 	max-width: 650px;
@@ -15,8 +16,7 @@
 		display: flex;
 		font-weight: 400;
 		color: var(--color-neutral-50);
-		font-size: rem(14px);
-		line-height: 1.5;
+		@include body-small;
 		align-items: center;
 
 
@@ -80,14 +80,13 @@
 	.configure-your-site-modal-form__site-name-validation-message {
 		display: flex;
 		align-items: center;
-		font-size: rem(14px);
-		line-height: 1.5;
+		@include body-small;
 		color: var(--color-error);
 		margin-top: 4px;
 
 		.configure-your-site-modal-form__site-name-suggestion {
 			text-decoration: underline;
-			font-weight: bold;
+			@include heading-small;
 			color: var(--color-error);
 			cursor: pointer;
 		}

--- a/client/a8c-for-agencies/components/slider/style.scss
+++ b/client/a8c-for-agencies/components/slider/style.scss
@@ -1,6 +1,7 @@
 
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-slider {
 	display: flex;
@@ -125,9 +126,7 @@
 .a4a-slider__label,
 .a4a-slider__sub,
 .a4a-slider__marker {
-	font-size: 0.875rem;
-	font-weight: 500;
-	line-height: 1.1;
+	@include heading-medium;
 }
 
 

--- a/client/a8c-for-agencies/components/step-section-item/style.scss
+++ b/client/a8c-for-agencies/components/step-section-item/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+
 .step-section-item {
 	margin-block-end: 16px;
 	border-radius: 4px;
@@ -22,7 +23,7 @@
 	}
 
 	.step-section-item__heading {
-		@include heading-medium;
+		@include heading-large;
 	}
 
 	.step-section-item__description {
@@ -134,8 +135,7 @@
 .step-section-item__step-number {
 	display: none;
 	color: var(--color-accent);
-	font-size: rem(12px);
-	font-weight: 600;
+	@include heading-small;
 	text-align: center;
 	min-width: 20px;
 	height: 20px;

--- a/client/a8c-for-agencies/components/step-section/style.scss
+++ b/client/a8c-for-agencies/components/step-section/style.scss
@@ -35,7 +35,6 @@
 .referrals-layout--automated,
 .commission-overview__layout-automated {
 	.step-section .step-section__header .step-section__step-heading {
-		font-size: rem(16px);
+		@include heading-large;
 	}
 }
-

--- a/client/a8c-for-agencies/components/sticky-card/style.scss
+++ b/client/a8c-for-agencies/components/sticky-card/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .sticky-card {
 	--margin-spacing: 40px;
@@ -87,8 +88,7 @@
 }
 
 .sticky-card__heading-title {
-	font-size: rem(14px);
-	font-weight: 500;
+	@include heading-medium;
 }
 
 .sticky-card__dismiss-button {

--- a/client/a8c-for-agencies/components/task-steps/style.scss
+++ b/client/a8c-for-agencies/components/task-steps/style.scss
@@ -95,7 +95,7 @@
 	@include heading-medium;
 
 	@include break-large {
-		font-size: rem(20px)
+		@include heading-x-large;
 	}
 }
 
@@ -112,8 +112,7 @@
 	border-radius: 50%;
 	min-width: 30px;
 	max-width: 30px;
-	font-size: rem(16px);
-	font-weight: 600;
+	@include heading-large;
 	text-align: center;
 }
 

--- a/client/a8c-for-agencies/components/user-contact-support-modal-form/style.scss
+++ b/client/a8c-for-agencies/components/user-contact-support-modal-form/style.scss
@@ -1,11 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-contact-support-modal-form {
 	width: 827px;
 	max-height: 100%;
 	margin: 0;
-	@include a4a-font-body-lg;
+	@include body-large;
 	color: var(--color-neutral-100);
 
 	@include breakpoint-deprecated( "<660px" ) {
@@ -35,8 +36,7 @@
 
 	.form-field-description {
 		margin-top: -20px;
-		font-size: rem(14px);
-		font-weight: 400;
+		@include body-small;
 		color: var(--color-neutral-50);
 	}
 
@@ -57,7 +57,7 @@
 }
 
 .a4a-contact-support-modal-form__title {
-	@include a4a-font-heading-xl;
+	@include heading-x-large;
 	margin: 0;
 	padding: 0;
 }

--- a/client/a8c-for-agencies/components/user-feedback-modal-form/style.scss
+++ b/client/a8c-for-agencies/components/user-feedback-modal-form/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .user-feedback-modal-form {
 	max-width: 827px;
@@ -44,13 +45,13 @@
 }
 
 .user-feedback-modal-form__title {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin: 0;
 	padding: 0;
 }
 
 p.user-feedback-modal-form__instruction {
-	@include a4a-font-body-lg;
+	@include body-large;
 	margin: 0;
 }
 


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1908

## Proposed Changes

| Description | Screenshot | Test instruction |
|--------|--------|--------|
| Confirmation Dialog | <img width="734" alt="Screenshot 2025-03-17 at 8 42 46 PM" src="https://github.com/user-attachments/assets/2259cf4f-914d-46b9-bf36-20d4b1f7c592" /> | Payment Methods > Delete Card |
| Feedback form | <img width="767" alt="Screenshot 2025-03-17 at 8 52 38 PM" src="https://github.com/user-attachments/assets/116be4c6-eff3-457a-aa1d-5d42f65e6eab" /> | Marketplace > Create Referral order > Feedback form |
| Overview Offering cards | <img width="1054" alt="Screenshot 2025-03-17 at 10 31 59 PM" src="https://github.com/user-attachments/assets/592e9d48-8a67-4dbb-8fde-81b9782138d2" /> | Overview > Offering cards | 
| Foldable cards | <img width="508" alt="Screenshot 2025-03-17 at 10 38 18 PM" src="https://github.com/user-attachments/assets/461c39c1-76f0-498a-9c2d-e05abb91996d" /> | Overview > Quick nav |
| WP Admin access required | <img width="1462" alt="Screenshot 2025-03-17 at 10 43 56 PM" src="https://github.com/user-attachments/assets/f76d23ca-4a97-4074-9039-e2a36133b397" /> | Sites > Expand restricted site |
| Contact Support Modal | <img width="866" alt="Screenshot 2025-03-17 at 10 47 56 PM" src="https://github.com/user-attachments/assets/293048e1-3ac5-402f-a17f-46ee68fe7bce" /> | Sidebar > Contact Support button |
| Import WPCOM site modal | <img width="896" alt="Screenshot 2025-03-17 at 10 52 54 PM" src="https://github.com/user-attachments/assets/e4520d54-16a7-425c-8f5f-5698a22d631c" /> | Add site > Import Existing Site via WPCOM connection | 
| Pressable Storage usage | <img width="1091" alt="Screenshot 2025-03-17 at 11 25 08 PM" src="https://github.com/user-attachments/assets/fb2692f3-29ff-449f-a899-2313daf0ab35" /> | Marketplace > Pressable |

## Why are these changes being made?
* This initiative aims to align with the Core library.

## Testing Instructions

* Utilize the A4A live link to explore the pages.
* Refer to the list above for components that require testing.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
