### PR TITLE
Stats: DRY refactoring in UTM module

### DIFF
--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -152,7 +152,8 @@ const StatsModuleUTM = ( {
 		</StatsInfoArea>
 	);
 
-	// DRY: Same code is used twice below.
+	// DRY: Some inline functions to reduce duplication.
+	// Could be inlined if/when the render logic is simplified.
 	const renderExportButton = () => {
 		if ( ! showFooterWithDownloads ) {
 			return null;
@@ -163,6 +164,18 @@ const StatsModuleUTM = ( {
 			</div>
 		);
 	};
+
+	const utmControls = (
+		<div className="stats-module__extended-toggle">
+			<UTMBuilder />
+			<UTMDropdown
+				buttonLabel={ optionLabels[ selectedOption ].selectLabel }
+				onSelect={ setSelectedOption }
+				selectOptions={ optionLabels }
+				selected={ selectedOption }
+			/>
+		</div>
+	);
 
 	return (
 		<>
@@ -241,17 +254,7 @@ const StatsModuleUTM = ( {
 									error={ hasError && <ErrorPanel /> }
 									splitHeader
 									mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
-									toggleControl={
-										<div className="stats-module__extended-toggle">
-											<UTMBuilder />
-											<UTMDropdown
-												buttonLabel={ optionLabels[ selectedOption ].selectLabel }
-												onSelect={ setSelectedOption }
-												selectOptions={ optionLabels }
-												selected={ selectedOption }
-											/>
-										</div>
-									}
+									toggleControl={ utmControls }
 								/>
 								{ renderExportButton() }
 							</>
@@ -287,17 +290,7 @@ const StatsModuleUTM = ( {
 						loader={ showLoader && <StatsModulePlaceholder isLoading={ showLoader } /> }
 						splitHeader
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
-						toggleControl={
-							<div className="stats-module__extended-toggle">
-								<UTMBuilder />
-								<UTMDropdown
-									buttonLabel={ optionLabels[ selectedOption ].selectLabel }
-									onSelect={ setSelectedOption }
-									selectOptions={ optionLabels }
-									selected={ selectedOption }
-								/>
-							</div>
-						}
+						toggleControl={ utmControls }
 					/>
 					{ renderExportButton() }
 				</>

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -152,6 +152,18 @@ const StatsModuleUTM = ( {
 		</StatsInfoArea>
 	);
 
+	// DRY: Same code is used twice below.
+	const renderExportButton = () => {
+		if ( ! showFooterWithDownloads ) {
+			return null;
+		}
+		return (
+			<div className="stats-module__footer-actions stats-module__footer-actions--summary">
+				<UTMExportButton data={ data } fileName={ fileNameForExport } />
+			</div>
+		);
+	};
+
 	return (
 		<>
 			{ isNewEmptyStateEnabled && (
@@ -241,11 +253,7 @@ const StatsModuleUTM = ( {
 										</div>
 									}
 								/>
-								{ showFooterWithDownloads && (
-									<div className="stats-module__footer-actions stats-module__footer-actions--summary">
-										<UTMExportButton data={ data } fileName={ fileNameForExport } />
-									</div>
-								) }
+								{ renderExportButton() }
 							</>
 						) }
 				</>
@@ -291,11 +299,7 @@ const StatsModuleUTM = ( {
 							</div>
 						}
 					/>
-					{ showFooterWithDownloads && (
-						<div className="stats-module__footer-actions stats-module__footer-actions--summary">
-							<UTMExportButton data={ data } fileName={ fileNameForExport } />
-						</div>
-					) }
+					{ renderExportButton() }
 				</>
 			) }
 		</>

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -177,6 +177,21 @@ const StatsModuleUTM = ( {
 		</div>
 	);
 
+	const showMoreConfig =
+		displaySummaryLink && ! summary
+			? {
+					url: getHref(),
+					label:
+						data.length >= 10
+							? translate( 'View all', {
+									context: 'Stats: Button link to show more detailed stats information',
+							  } )
+							: translate( 'View details', {
+									context: 'Stats: Button label to see the detailed content of a panel',
+							  } ),
+			  }
+			: undefined;
+
 	return (
 		<>
 			{ isNewEmptyStateEnabled && (
@@ -234,23 +249,7 @@ const StatsModuleUTM = ( {
 									titleNodes={ titleNodes }
 									emptyMessage={ <div>{ moduleStrings.empty }</div> }
 									metricLabel={ metricLabel }
-									showMore={
-										displaySummaryLink && ! summary
-											? {
-													url: getHref(),
-													label:
-														data.length >= 10
-															? translate( 'View all', {
-																	context:
-																		'Stats: Button link to show more detailed stats information',
-															  } )
-															: translate( 'View details', {
-																	context:
-																		'Stats: Button label to see the detailed content of a panel',
-															  } ),
-											  }
-											: undefined
-									}
+									showMore={ showMoreConfig }
 									error={ hasError && <ErrorPanel /> }
 									splitHeader
 									mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
@@ -271,21 +270,7 @@ const StatsModuleUTM = ( {
 						title={ moduleStrings?.title }
 						emptyMessage={ <div>{ moduleStrings.empty }</div> }
 						metricLabel={ metricLabel }
-						showMore={
-							displaySummaryLink && ! summary
-								? {
-										url: getHref(),
-										label:
-											data.length >= 10
-												? translate( 'View all', {
-														context: 'Stats: Button link to show more detailed stats information',
-												  } )
-												: translate( 'View details', {
-														context: 'Stats: Button label to see the detailed content of a panel',
-												  } ),
-								  }
-								: undefined
-						}
+						showMore={ showMoreConfig }
 						error={ hasError && <ErrorPanel /> }
 						loader={ showLoader && <StatsModulePlaceholder isLoading={ showLoader } /> }
 						splitHeader

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -192,6 +192,21 @@ const StatsModuleUTM = ( {
 			  }
 			: undefined;
 
+	const commonStatsListCardProps = {
+		className: clsx( className, 'stats-module__card', path ),
+		moduleType: path,
+		data,
+		useShortLabel,
+		title: moduleStrings?.title,
+		emptyMessage: <div>{ moduleStrings.empty }</div>,
+		metricLabel,
+		showMore: showMoreConfig,
+		error: hasError && <ErrorPanel />,
+		splitHeader: true,
+		mainItemLabel: optionLabels[ selectedOption ]?.headerLabel,
+		toggleControl: utmControls,
+	};
+
 	return (
 		<>
 			{ isNewEmptyStateEnabled && (
@@ -240,21 +255,7 @@ const StatsModuleUTM = ( {
 					{ ! showLoader &&
 						!! data?.length && ( // show when new empty state is disabled or data is available
 							<>
-								<StatsListCard
-									className={ clsx( className, 'stats-module__card', path ) }
-									moduleType={ path }
-									data={ data }
-									useShortLabel={ useShortLabel }
-									title={ moduleStrings?.title }
-									titleNodes={ titleNodes }
-									emptyMessage={ <div>{ moduleStrings.empty }</div> }
-									metricLabel={ metricLabel }
-									showMore={ showMoreConfig }
-									error={ hasError && <ErrorPanel /> }
-									splitHeader
-									mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
-									toggleControl={ utmControls }
-								/>
+								<StatsListCard { ...commonStatsListCardProps } titleNodes={ titleNodes } />
 								{ renderExportButton() }
 							</>
 						) }
@@ -263,19 +264,8 @@ const StatsModuleUTM = ( {
 			{ ! isNewEmptyStateEnabled && (
 				<>
 					<StatsListCard
-						className={ clsx( className, 'stats-module__card', path ) }
-						moduleType={ path }
-						data={ data }
-						useShortLabel={ useShortLabel }
-						title={ moduleStrings?.title }
-						emptyMessage={ <div>{ moduleStrings.empty }</div> }
-						metricLabel={ metricLabel }
-						showMore={ showMoreConfig }
-						error={ hasError && <ErrorPanel /> }
+						{ ...commonStatsListCardProps }
 						loader={ showLoader && <StatsModulePlaceholder isLoading={ showLoader } /> }
-						splitHeader
-						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
-						toggleControl={ utmControls }
 					/>
 					{ renderExportButton() }
 				</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Refactors duplicate JSX code into const vars (and one render function) to reduce code duplication. Readability is only slightly improved but it should be easier to update if changes are only required in one place. Additionally, it clearly separates branch-specific differences (like usage of `titleNodes` and `loader` when all other props are the same).

The next step is probably to remove the "stats/empty-module-traffic" feature flag but that needs a bit more testing.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
