### PR TITLE
A4A: Hide the 'Upgrade' button for WPCOM dev licenses.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -35,6 +35,7 @@ interface Props {
 	hasDownloads: boolean;
 	isChildLicense?: boolean;
 	isClientLicense?: boolean;
+	isDevSite?: boolean;
 }
 
 export default function LicenseDetailsActions( {
@@ -46,6 +47,7 @@ export default function LicenseDetailsActions( {
 	hasDownloads,
 	isChildLicense,
 	isClientLicense,
+	isDevSite,
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -131,6 +133,7 @@ export default function LicenseDetailsActions( {
 
 			{ ( isPressableLicense || isWPCOMHostingLicense ) &&
 				licenseState !== LicenseState.Revoked &&
+				! isDevSite &&
 				! isClientLicense && (
 					<Button
 						compact

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -20,6 +20,7 @@ interface Props {
 	licenseType: LicenseType;
 	isChildLicense?: boolean;
 	referral?: ReferralAPIResponse | null;
+	isDevSite?: boolean;
 }
 
 const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
@@ -31,6 +32,7 @@ export default function LicenseDetails( {
 	licenseType,
 	isChildLicense,
 	referral,
+	isDevSite,
 }: Props ) {
 	const licenseKey = license.licenseKey;
 	const product = license.product;
@@ -128,6 +130,7 @@ export default function LicenseDetails( {
 				hasDownloads={ hasDownloads }
 				isChildLicense={ isChildLicense }
 				isClientLicense={ !! referral }
+				isDevSite={ isDevSite }
 			/>
 		</Card>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -399,6 +399,7 @@ export default function LicensePreview( {
 						licenseType={ licenseType }
 						isChildLicense={ isChildLicense }
 						referral={ referral }
+						isDevSite={ isDevelopmentSite }
 					/>
 				) ) }
 		</div>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -89,7 +89,7 @@ export default function useLicenseActions(
 				href: A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_upgrade_click' ),
 				isExternalLink: false,
-				isEnabled: ! isClientLicense,
+				isEnabled: ! isClientLicense && ! isDevSite,
 			},
 			{
 				name: translate( 'Revoke' ),


### PR DESCRIPTION
This pull request resolves the issue of the **'Upgrade'** button being displayed for WPCOM development licenses.

| Before | After |
|--------|--------|
| <img width="339" alt="Screenshot 2025-03-17 at 9 01 45 PM" src="https://github.com/user-attachments/assets/e441ab11-d225-4e3b-ab8b-c5a21d9cd074" /> | <img width="313" alt="Screenshot 2025-03-17 at 9 07 25 PM" src="https://github.com/user-attachments/assets/ad42c35a-6353-4e9c-a2af-4269f4868f3f" /> | 
| <img width="1522" alt="Screenshot 2025-03-17 at 9 24 42 PM" src="https://github.com/user-attachments/assets/fb91c172-0d21-4ff6-8d88-3456b975da6c" /> | <img width="1538" alt="Screenshot 2025-03-17 at 9 25 29 PM" src="https://github.com/user-attachments/assets/aec1bcaf-ecae-494b-bb00-4000afc15071" /> |

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1930

## Proposed Changes

* Hide the 'Upgrade' button by adding a condition to check for a non-dev license.

## Why are these changes being made?

* The 'Upgrade' button is not intended for WPCOM dev licenses and causes confusion.

## Testing Instructions

* Create a dev site.
* Use the A4A live link and go to the `/purchases/licenses` page.
* Check for the WPCOM dev license and expand the action menu.
* Verify that the Upgrade button do not show.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
