### PR TITLE
Display something when is not possible to transfer the user to user support

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -7,6 +7,7 @@ import ChatWithSupportLabel from '../chat-with-support';
 import CustomALink from './custom-a-link';
 import DislikeFeedbackMessage from './dislike-feedback-message';
 import ErrorMessage from './error-message';
+import { NewThirdPartyCookiesNotice } from './get-support';
 import { uriTransformer } from './uri-transformer';
 import { UserMessage } from './user-message';
 import type { ZendeskMessage, Message } from '../../types';
@@ -70,6 +71,7 @@ export const MessageContent = ( {
 				<div className={ messageClasses }>
 					{ message?.context?.flags?.show_ai_avatar !== false && messageHeader }
 					{ message.type === 'error' && <ErrorMessage message={ message } /> }
+					{ message.type === 'cant_transfer' && <NewThirdPartyCookiesNotice /> }
 					{ ( [ 'message', 'image', 'image-placeholder', 'file', 'text' ].includes(
 						message.type
 					) ||

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -52,8 +52,14 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, botNameSlug, experimentVariationName, isChatLoaded, isUserEligibleForPaidSupport } =
-		useOdieAssistantContext();
+	const {
+		addMessage,
+		chat,
+		botNameSlug,
+		experimentVariationName,
+		isChatLoaded,
+		isUserEligibleForPaidSupport,
+	} = useOdieAssistantContext();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const resetSupportInteraction = useResetSupportInteraction();
 	const [ searchParams, setSearchParams ] = useSearchParams();
@@ -130,14 +136,22 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 
 			resetSupportInteraction().then( ( interaction ) => {
 				if ( isChatLoaded ) {
-					createZendeskConversation( {
-						avoidTransfer: true,
-						interactionId: interaction?.uuid,
-						section: searchParams.get( 'section' ),
-						createdFrom: 'direct_url',
-					} ).then( () => {
-						setChatMessagesLoaded( true );
-					} );
+					if ( createZendeskConversation ) {
+						createZendeskConversation( {
+							avoidTransfer: true,
+							interactionId: interaction?.uuid,
+							section: searchParams.get( 'section' ),
+							createdFrom: 'direct_url',
+						} ).then( () => {
+							setChatMessagesLoaded( true );
+						} );
+					} else {
+						addMessage( {
+							content: '',
+							role: 'bot',
+							type: 'cant_transfer',
+						} );
+					}
 				}
 			} );
 		}

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -51,8 +51,10 @@ export const useSendOdieMessage = () => {
 		if ( ! Array.isArray( message ) ) {
 			const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
 			if ( isRequestingHumanSupport && isUserEligibleForPaidSupport ) {
-				newConversation( { createdFrom: 'automatic_escalation' } );
-				return;
+				if ( newConversation ) {
+					newConversation( { createdFrom: 'automatic_escalation' } );
+					return;
+				}
 			}
 		}
 

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -8,17 +8,19 @@ import { useOdieAssistantContext } from '../context';
 import { useManageSupportInteraction } from '../data';
 import { setHelpCenterZendeskConversationStarted } from '../utils';
 
-export const useCreateZendeskConversation = (): ( ( {
-	avoidTransfer,
-	interactionId,
-	section,
-	createdFrom,
-}: {
-	avoidTransfer?: boolean;
-	interactionId?: string;
-	section?: string | null;
-	createdFrom?: string;
-} ) => Promise< void > ) => {
+export const useCreateZendeskConversation = ():
+	| ( ( {
+			avoidTransfer,
+			interactionId,
+			section,
+			createdFrom,
+	  }: {
+			avoidTransfer?: boolean;
+			interactionId?: string;
+			section?: string | null;
+			createdFrom?: string;
+	  } ) => Promise< void > )
+	| null => {
 	const {
 		selectedSiteId,
 		selectedSiteURL,
@@ -39,6 +41,10 @@ export const useCreateZendeskConversation = (): ( ( {
 		useUpdateZendeskUserFields();
 	const { addEventToInteraction } = useManageSupportInteraction();
 	const chatId = chat.odieId;
+
+	if ( typeof Smooch.createConversation !== 'function' ) {
+		return null;
+	}
 
 	const createConversation = async ( {
 		avoidTransfer = false,

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -144,7 +144,8 @@ export type MessageType =
 	| 'help-link'
 	| 'file'
 	| 'image'
-	| 'introduction';
+	| 'introduction'
+	| 'cant_transfer';
 
 export type Message = {
 	content: string;

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -37,7 +37,7 @@ export function useCanConnectToZendeskMessaging( enabled = true ) {
 	}, [ query.isSuccess, queryClient ] );
 
 	useEffect( () => {
-		if ( ! query.data && query.status !== 'pending' ) {
+		if ( query.status === 'error' ) {
 			recordTracksEvent( 'calypso_helpcenter_zendesk_config_error', {
 				status: query.status,
 				status_text: query.error?.message,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
