### PR TITLE
A4A > WooPayments: CFT enhancements 2

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-assign-licenses-to-site.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-assign-licenses-to-site.ts
@@ -24,6 +24,7 @@ const useAssignLicensesToSite = (
 ): {
 	assignLicensesToSite: ( licenseKeys: string[] ) => Promise< PurchasedProductsInfo >;
 	isReady: boolean;
+	isPending: boolean;
 } => {
 	const products = useProductsQuery();
 	const assignLicense = useAssignLicenseMutation( {
@@ -31,6 +32,7 @@ const useAssignLicensesToSite = (
 	} );
 
 	const isReady = assignLicense.isIdle;
+	const isPending = assignLicense.isPending;
 	const assignLicensesToSite = useCallback(
 		async ( licenseKeys: string[] ): Promise< PurchasedProductsInfo > => {
 			// Only proceed if the mutation is in a fresh/ready state
@@ -90,7 +92,7 @@ const useAssignLicensesToSite = (
 					await assignLicense
 						.mutateAsync( { licenseKey: key, selectedSite: selectedSiteId } )
 						.then( () => ( { key, name, status: 'fulfilled' } ) as ProductInfo )
-						.catch( () => ( { key, name, status: 'rejected' } ) as ProductInfo )
+						.catch( ( error ) => ( { key, name, status: 'rejected', error } ) as ProductInfo )
 				);
 			}
 
@@ -102,7 +104,7 @@ const useAssignLicensesToSite = (
 		[ selectedSite, assignLicense, products ]
 	);
 
-	return { assignLicensesToSite, isReady };
+	return { assignLicensesToSite, isReady, isPending };
 };
 
 export default useAssignLicensesToSite;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-licenses.tsx
@@ -34,7 +34,7 @@ type UseIssueLicensesOptions = {
 const useIssueLicenses = ( options: UseIssueLicensesOptions = {} ) => {
 	const { paymentMethodRequired } = usePaymentMethod();
 
-	const { mutateAsync, isIdle } = useIssueLicenseMutation( {
+	const { mutateAsync, isIdle, isPending } = useIssueLicenseMutation( {
 		onError: options.onError ?? NO_OP,
 		retry: ( errorCount, error ) => {
 			// There's a slight delay before the license creation API is made
@@ -71,6 +71,7 @@ const useIssueLicenses = ( options: UseIssueLicensesOptions = {} ) => {
 	return {
 		isReady: isIdle,
 		issueLicenses,
+		isPending,
 	};
 };
 

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/modal.tsx
@@ -18,7 +18,7 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 
 	const [ selectedSite, setSelectedSite ] = useState< WooPaymentsSiteItem | null >( null );
 
-	const { issueAndAssignLicenses, isReady: isIssueAndAssignReady } = useIssueAndAssignLicenses(
+	const { issueAndAssignLicenses, isLoading } = useIssueAndAssignLicenses(
 		selectedSite ? { ID: selectedSite.rawSite.blog_id, domain: selectedSite.site } : null,
 		{
 			redirectTo: addQueryArgs( A4A_WOOPAYMENTS_SITE_SETUP_LINK, {
@@ -66,8 +66,8 @@ const AddWooPaymentsToSiteModal = ( { onClose }: { onClose: () => void } ) => {
 				<Button
 					variant="primary"
 					onClick={ handleAddSite }
-					disabled={ ! selectedSite || ! isIssueAndAssignReady }
-					isBusy={ ! isIssueAndAssignReady }
+					disabled={ ! selectedSite || isLoading }
+					isBusy={ isLoading }
 				>
 					{ translate( 'Add WooPayments to selected site' ) }
 				</Button>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -296,7 +296,12 @@ export type AgencyDashboardFilter = {
 	isNotMultisite?: boolean;
 };
 
-export type ProductInfo = { name: string; key: string; status: 'rejected' | 'fulfilled' };
+export type ProductInfo = {
+	name: string;
+	key: string;
+	status: 'rejected' | 'fulfilled';
+	error?: APIError;
+};
 
 export type PurchasedProductsInfo = {
 	selectedSite: string;


### PR DESCRIPTION
## Proposed Changes

This PR adds error handling when assigning a license to a site.

## Why are these changes being made?

* To handle error scenarios while assigning a license to a site.

## Testing Instructions

* Create a test WPCOM account > Use the A4A MC tool, and go to the Partner key page and ensure the billable type is set to "Stripe". Please change it to the previous type after testing.
* Switch to this branch locally and log-in using the new account.
* Make sure you don't add a payment method.
* Use JN to create a new site. Add this site to the test user you created using the A4A client plugin from the `Add sites` dropdown.
* Go to WooPayments > Open the network tab > Click the Add WooPayments to site > Select the site that was newly added and proceed > Verify that an error is displayed as shown below:

<img width="771" alt="Screenshot 2025-03-17 at 8 05 20 PM" src="https://github.com/user-attachments/assets/6a799f2c-6fe9-4820-97e5-1c8859cd5a3e" />

Default error message, no need to test this. This is for the translators:

<img width="771" alt="Screenshot 2025-03-17 at 8 07 14 PM" src="https://github.com/user-attachments/assets/44d543d5-98ae-45b6-a1a2-68cc61c2f9cd" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?