### PR TITLE
Reader: Like, reblog, comment tooltip consistency

### DIFF
--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -19,12 +20,15 @@ function CommentButton( {
 	const translate = useTranslate();
 	const showLabel = commentCount > 0 || defaultLabel;
 	const label = commentCount || defaultLabel;
+	// Show a tooltip only when we are showing the number of existing comments.
+	const showTooltip = commentCount > 0;
 
 	return (
 		<TagName
-			className="comment-button tooltip"
-			// Show a tooltip only when we are showing the number of existing comments.
-			data-tooltip={ commentCount > 0 ? translate( 'Comment' ) : undefined }
+			className={ clsx( 'comment-button', {
+				tooltip: showTooltip,
+			} ) }
+			data-tooltip={ showTooltip ? translate( 'Comment' ) : undefined }
 			onClick={ onClick }
 			href={ 'a' === TagName ? href : undefined }
 			target={ 'a' === TagName ? target : undefined }

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -23,7 +23,8 @@ function CommentButton( {
 	return (
 		<TagName
 			className="comment-button tooltip"
-			data-tooltip={ translate( 'Comment' ) }
+			// Show a tooltip only when we are showing the number of existing comments.
+			data-tooltip={ commentCount > 0 ? translate( 'Comment' ) : undefined }
 			onClick={ onClick }
 			href={ 'a' === TagName ? href : undefined }
 			target={ 'a' === TagName ? target : undefined }

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -97,7 +97,7 @@ class LikeButton extends PureComponent {
 					onClick: ! isLink ? this.toggleLiked : null,
 					onMouseEnter,
 					onMouseLeave,
-					title: this.props.liked ? translate( 'Liked' ) : translate( 'Like' ),
+					'aria-label': this.props.liked ? translate( 'Liked' ) : translate( 'Like' ),
 				},
 				( prop ) => prop === null
 			),

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -138,9 +138,7 @@ class ReaderShare extends Component {
 					onTouchStart={ preloadEditor }
 					ref={ this.shareButton }
 					data-tooltip={
-						this.props.isReblogSelection
-							? translate( 'Repost with your thoughts' )
-							: translate( 'Share' )
+						this.props.isReblogSelection ? translate( 'Repost with your thoughts' ) : undefined
 					}
 				>
 					{ ! this.props.isReblogSelection ? (

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -112,7 +112,7 @@ class ReaderShare extends Component {
 			'reader-share__button': true,
 			'ignore-click': true,
 			'is-active': this.state.showingMenu,
-			tooltip: true,
+			tooltip: this.props.isReblogSelection,
 		} );
 
 		const popoverProps = {


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/100350

>Comment, Repost, Share, have custom tooltips. In the case of share and comment, those are entirely redundant since when the title itself is visible in the button, the tooltip should not be present, otherwise it will be announced twice to screen readers. Repost has a tooltip of "Repost with your thoughts".


## Proposed Changes
1. Remove the tooltip from `share` button
2. Show the tooltip for `comment` button only if we show the number of existing comments and not the label.


## Notes
I haven't updated the `Like` tooltip yet, because I didn't find a good solution to suggest. The challenges are:
1. It also renders a second toolitp with the users that have liked the entity. Does this mean it could be removed altogether based on the context (and the second tooltip)? I'd expect probably not, but 🤷 
2. If we want a tooltip for `Like` button (for example when we're showing the number of likes), it probably gonna need some more changes due to the current implementation. The other buttons are using the `Button` component from `@automattic/components` but the `like` (LikeButton) component is kind of more 'open' by allowing to pass any `tag` and tries to make every use case work, by [providing more props to the consumers](https://github.com/Automattic/wp-calypso/blob/trunk/client/blocks/like-button/button.jsx#L10). This is quite convoluted already and I don't think there will be clean solution to achieve what we want.


## Testing Instructions
1. In the reader see the post actions with the `share, repost, comment, like` buttons
2. These buttons are reused for the comment actions too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
