### PR TITLE
Stats: Update Stats widget bar link with date range parameters

### DIFF
--- a/apps/odyssey-stats/src/widget/mini-chart.tsx
+++ b/apps/odyssey-stats/src/widget/mini-chart.tsx
@@ -5,10 +5,10 @@ import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import Chart from 'calypso/components/chart';
 import Legend from 'calypso/components/chart/legend';
 import { rectIsEqual, rectIsZero, NullableDOMRect } from 'calypso/lib/track-element-size';
-import { DATE_FORMAT } from 'calypso/my-sites/stats/constants';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import StatsEmptyState from 'calypso/my-sites/stats/stats-empty-state';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
+import { getChartRangeParams } from 'calypso/my-sites/stats/utils';
 import nothing from '../components/nothing';
 import useVisitsQuery from '../hooks/use-visits-query';
 import { Unit } from '../typings';
@@ -54,19 +54,9 @@ const MiniChart: FunctionComponent< MiniChartProps > = ( {
 	const { isLoading, data } = useVisitsQuery( siteId, period, quantity, queryDate );
 
 	const barClick = ( bar: { data: BarData } ) => {
-		const chartStart = bar.data.period;
-		const chartEnd = moment( chartStart )
-			.endOf( period === 'week' ? 'isoWeek' : period )
-			.format( DATE_FORMAT );
+		const { chartStart, chartEnd, chartPeriod } = getChartRangeParams( bar.data.period, period );
 
-		let targetPeriod = 'day';
-		if ( period === 'day' ) {
-			targetPeriod = 'hour';
-		} else if ( period === 'year' ) {
-			targetPeriod = 'month';
-		}
-
-		window.location.href = `${ statsBaseUrl }/stats/${ targetPeriod }/${ siteId }?chartStart=${ chartStart }&chartEnd=${ chartEnd }`;
+		window.location.href = `${ statsBaseUrl }/stats/${ chartPeriod }/${ siteId }?chartStart=${ chartStart }&chartEnd=${ chartEnd }`;
 	};
 
 	const chartData = buildChartData(

--- a/apps/odyssey-stats/src/widget/mini-chart.tsx
+++ b/apps/odyssey-stats/src/widget/mini-chart.tsx
@@ -5,6 +5,7 @@ import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import Chart from 'calypso/components/chart';
 import Legend from 'calypso/components/chart/legend';
 import { rectIsEqual, rectIsZero, NullableDOMRect } from 'calypso/lib/track-element-size';
+import { DATE_FORMAT } from 'calypso/my-sites/stats/constants';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import StatsEmptyState from 'calypso/my-sites/stats/stats-empty-state';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
@@ -53,7 +54,19 @@ const MiniChart: FunctionComponent< MiniChartProps > = ( {
 	const { isLoading, data } = useVisitsQuery( siteId, period, quantity, queryDate );
 
 	const barClick = ( bar: { data: BarData } ) => {
-		window.location.href = `${ statsBaseUrl }/stats/${ period }/${ siteId }?startDate=${ bar.data.period }`;
+		const chartStart = bar.data.period;
+		const chartEnd = moment( chartStart )
+			.endOf( period === 'week' ? 'isoWeek' : period )
+			.format( DATE_FORMAT );
+
+		let targetPeriod = 'day';
+		if ( period === 'day' ) {
+			targetPeriod = 'hour';
+		} else if ( period === 'year' ) {
+			targetPeriod = 'month';
+		}
+
+		window.location.href = `${ statsBaseUrl }/stats/${ targetPeriod }/${ siteId }?chartStart=${ chartStart }&chartEnd=${ chartEnd }`;
 	};
 
 	const chartData = buildChartData(

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -35,6 +35,7 @@ import {
 	STATS_PRODUCT_NAME,
 } from 'calypso/my-sites/stats/constants';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
+import { getChartRangeParams } from 'calypso/my-sites/stats/utils';
 import {
 	recordGoogleEvent,
 	recordTracksEvent,
@@ -263,11 +264,9 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		// Mark the drilled-down period page should use the go-back action.
 		sessionStorage.setItem( 'jetpack_stats_date_range_is_drilling_down', 1 );
 
-		let chartStart = periodStartDate;
-		let chartEnd = moment( chartStart )
-			.endOf( currentPeriod === 'week' ? 'isoWeek' : currentPeriod )
-			.format( DATE_FORMAT );
+		const chartRangeParams = getChartRangeParams( periodStartDate, currentPeriod );
 
+		let { chartStart, chartEnd } = chartRangeParams;
 		// Limit navigation within the currently selected range.
 		const currentChartStart = context.query?.chartStart;
 		const currentChartEnd = context.query?.chartEnd;
@@ -278,15 +277,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 			chartEnd = currentChartEnd;
 		}
 
-		// Determine the target period for the navigation.
-		let targetPeriod = 'day';
-		if ( currentPeriod === 'day' ) {
-			targetPeriod = 'hour';
-		} else if ( currentPeriod === 'year' ) {
-			targetPeriod = 'month';
-		}
-
-		const path = `/stats/${ targetPeriod }/${ slug }`;
+		const path = `/stats/${ chartRangeParams.chartPeriod }/${ slug }`;
 		const url = getPathWithUpdatedQueryString( { chartStart, chartEnd }, path );
 
 		return url;

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -92,10 +92,18 @@ export const parseLocalDate = ( dateString ) => {
 };
 
 /**
- * Process the start date and original period to determine the chart range parameters.
+ * The chart range parameters include the chart start date, chart end date, and chart period.
+ * @typedef {Object} ChartRangeParams
+ * @property {string} chartStart The start date of the chart range.
+ * @property {string} chartEnd The end date of the chart range.
+ * @property {string} chartPeriod The period of the chart range.
+ */
+
+/**
+ * Process the start date and from period to determine the target chart range parameters.
  * @param {string} startDate The start date of the chart range.
- * @param {string} fromPeriod The original period of the chart.
- * @returns {Object} The chart range parameters including the start date, end date, and period.
+ * @param {string} fromPeriod The period of the chart where the action comes from.
+ * @returns {ChartRangeParams} The chart range parameters for navigating the chart.
  */
 export const getChartRangeParams = ( startDate, fromPeriod ) => {
 	const chartStart = startDate;
@@ -103,6 +111,7 @@ export const getChartRangeParams = ( startDate, fromPeriod ) => {
 		.endOf( fromPeriod === 'week' ? 'isoWeek' : fromPeriod )
 		.format( DATE_FORMAT );
 
+	// Do not go beyond the current date.
 	if ( moment().isBefore( chartEnd ) ) {
 		chartEnd = moment().format( DATE_FORMAT );
 	}

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -2,7 +2,9 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
+import moment from 'moment';
 import { parse as parseQs, stringify as stringifyQs } from 'qs';
+import { DATE_FORMAT } from 'calypso/my-sites/stats/constants';
 
 /**
  * Update query for current page or passed in URL
@@ -87,4 +89,34 @@ export const parseLocalDate = ( dateString ) => {
 	date.setMinutes( date.getMinutes() + date.getTimezoneOffset() );
 
 	return date;
+};
+
+/**
+ * Process the start date and original period to determine the chart range parameters.
+ * @param {string} startDate The start date of the chart range.
+ * @param {string} fromPeriod The original period of the chart.
+ * @returns {Object} The chart range parameters including the start date, end date, and period.
+ */
+export const getChartRangeParams = ( startDate, fromPeriod ) => {
+	const chartStart = startDate;
+	let chartEnd = moment( chartStart )
+		.endOf( fromPeriod === 'week' ? 'isoWeek' : fromPeriod )
+		.format( DATE_FORMAT );
+
+	if ( moment().isBefore( chartEnd ) ) {
+		chartEnd = moment().format( DATE_FORMAT );
+	}
+
+	let chartPeriod = 'day';
+	if ( fromPeriod === 'day' ) {
+		chartPeriod = 'hour';
+	} else if ( fromPeriod === 'year' ) {
+		chartPeriod = 'month';
+	}
+
+	return {
+		chartStart,
+		chartEnd,
+		chartPeriod,
+	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/328

## Proposed Changes

* Fix the Jetpack Stats widget bar link to navigate to the correct corresponding chart range.
* Refactor shared function `getChartRangeParams` to determine date range parameters `chartStart`, `chartEnd`, and `chartPeriod`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Jetpack Stats widget does not apply new date range query parameters when clicking the chart bars.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the local Jetpack site: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/some-path-to/jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to the `/wp-admin` of the Jetpack site.
* Click on the chart bars of the Jetpack Stats widget.
* Ensure the page is directed to the Stats Traffic page with the correct data range.

https://github.com/user-attachments/assets/d9971ec1-8172-4045-b5ad-55b3054821bc

* Ensure the target date range does not go after the current date, especially when navigating from the monthly or yearly chart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
