### PR TITLE
[Odie] Disable message input field

### DIFF
--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -3,6 +3,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import {
 	useAttachFileToConversation,
 	useAuthenticateZendeskMessaging,
+	useCanConnectToZendeskMessaging,
 } from '@automattic/zendesk-client';
 import { DropZone, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -46,6 +47,11 @@ export const OdieSendMessageButton = () => {
 	const inputRef = useRef< HTMLTextAreaElement >( null );
 	const attachmentButtonRef = useRef< HTMLElement >( null );
 	const { trackEvent, chat, addMessage, isUserEligibleForPaidSupport } = useOdieAssistantContext();
+	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
+	const cantTransferToZendesk =
+		( chat.messages?.[ chat.messages.length - 1 ]?.context?.flags?.forward_to_human_support &&
+			! canConnectToZendeskMessaging ) ??
+		false;
 	const sendMessage = useSendChatMessage();
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
 	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
@@ -190,6 +196,7 @@ export const OdieSendMessageButton = () => {
 				>
 					<ResizableTextarea
 						shouldDisableInputField={ isChatBusy || isAttachingFile }
+						cantTransferToZendesk={ cantTransferToZendesk }
 						sendMessageHandler={ sendMessageHandler }
 						className="odie-send-message-input"
 						inputRef={ inputRef }

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -41,6 +41,18 @@ const getPlaceholderAttachmentMessage = ( file: File ) => {
 	} );
 };
 
+const getTextAreaPlaceholder = (
+	shouldDisableInputField: boolean,
+	cantTransferToZendesk: boolean
+) => {
+	if ( cantTransferToZendesk ) {
+		return __( 'Oops, something went wrong', __i18n_text_domain__ );
+	}
+	return shouldDisableInputField
+		? __( 'Just a moment…', __i18n_text_domain__ )
+		: __( 'Type a message…', __i18n_text_domain__ );
+};
+
 export const OdieSendMessageButton = () => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
 	const inputRef = useRef< HTMLTextAreaElement >( null );
@@ -70,6 +82,8 @@ export const OdieSendMessageButton = () => {
 
 	const { isPending: isAttachingFile, mutateAsync: attachFileToConversation } =
 		useAttachFileToConversation();
+
+	const textAreaPlaceholder = getTextAreaPlaceholder( isChatBusy, cantTransferToZendesk );
 
 	const handleFileUpload = useCallback(
 		async ( file: File ) => {
@@ -194,14 +208,14 @@ export const OdieSendMessageButton = () => {
 					className="odie-send-message-input-container"
 				>
 					<ResizableTextarea
-						shouldDisableInputField={ isChatBusy || isAttachingFile }
-						cantTransferToZendesk={ cantTransferToZendesk }
+						shouldDisableInputField={ isChatBusy || isAttachingFile || cantTransferToZendesk }
 						sendMessageHandler={ sendMessageHandler }
 						className="odie-send-message-input"
 						inputRef={ inputRef }
 						setSubmitDisabled={ setSubmitDisabled }
 						keyUpHandle={ onKeyUp }
 						onPasteHandle={ onPaste }
+						placeholder={ textAreaPlaceholder }
 					/>
 					{ isChatBusy && <Spinner className="odie-send-message-input-spinner" /> }
 					{ showAttachmentButton && (

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -3,7 +3,6 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import {
 	useAttachFileToConversation,
 	useAuthenticateZendeskMessaging,
-	useCanConnectToZendeskMessaging,
 } from '@automattic/zendesk-client';
 import { DropZone, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -46,11 +45,11 @@ export const OdieSendMessageButton = () => {
 	const divContainerRef = useRef< HTMLDivElement >( null );
 	const inputRef = useRef< HTMLTextAreaElement >( null );
 	const attachmentButtonRef = useRef< HTMLElement >( null );
-	const { trackEvent, chat, addMessage, isUserEligibleForPaidSupport } = useOdieAssistantContext();
-	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
+	const { trackEvent, chat, addMessage, isUserEligibleForPaidSupport, canConnectToZendesk } =
+		useOdieAssistantContext();
 	const cantTransferToZendesk =
 		( chat.messages?.[ chat.messages.length - 1 ]?.context?.flags?.forward_to_human_support &&
-			! canConnectToZendeskMessaging ) ??
+			! canConnectToZendesk ) ??
 		false;
 	const sendMessage = useSendChatMessage();
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';

--- a/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
+++ b/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
@@ -4,6 +4,7 @@ import autosize from 'autosize';
 import React, { KeyboardEvent } from 'react';
 
 export const ResizableTextarea: React.FC< {
+	cantTransferToZendesk?: boolean;
 	className: string;
 	inputRef: React.RefObject< HTMLTextAreaElement >;
 	keyUpHandle: () => void;
@@ -12,6 +13,7 @@ export const ResizableTextarea: React.FC< {
 	setSubmitDisabled: ( shouldBeDisabled: boolean ) => void;
 	shouldDisableInputField: boolean;
 } > = ( {
+	cantTransferToZendesk = true,
 	className,
 	sendMessageHandler,
 	inputRef,
@@ -84,10 +86,14 @@ export const ResizableTextarea: React.FC< {
 			className={ className }
 			onKeyUp={ onKeyUp }
 			onPaste={ onPasteHandle }
-			placeholder={ textAreaPlaceholder }
+			placeholder={
+				cantTransferToZendesk
+					? __( 'Oops, something went wrong', __i18n_text_domain__ )
+					: textAreaPlaceholder
+			}
 			onKeyDown={ onKeyDown }
 			style={ { transition: 'none' } }
-			disabled={ shouldDisableInputField }
+			disabled={ shouldDisableInputField || cantTransferToZendesk }
 		/>
 	);
 };

--- a/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
+++ b/packages/odie-client/src/components/send-message-input/resizable-textarea.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import autosize from 'autosize';
 import React, { KeyboardEvent } from 'react';
 
 export const ResizableTextarea: React.FC< {
-	cantTransferToZendesk?: boolean;
 	className: string;
 	inputRef: React.RefObject< HTMLTextAreaElement >;
 	keyUpHandle: () => void;
@@ -12,8 +10,8 @@ export const ResizableTextarea: React.FC< {
 	onPasteHandle: ( event: React.ClipboardEvent ) => void;
 	setSubmitDisabled: ( shouldBeDisabled: boolean ) => void;
 	shouldDisableInputField: boolean;
+	placeholder?: string;
 } > = ( {
-	cantTransferToZendesk = true,
 	className,
 	sendMessageHandler,
 	inputRef,
@@ -21,11 +19,8 @@ export const ResizableTextarea: React.FC< {
 	setSubmitDisabled,
 	shouldDisableInputField = false,
 	onPasteHandle,
+	placeholder,
 } ) => {
-	const textAreaPlaceholder = shouldDisableInputField
-		? __( 'Just a moment…', __i18n_text_domain__ )
-		: __( 'Type a message…', __i18n_text_domain__ );
-
 	const onKeyUp = useCallback(
 		async ( event: KeyboardEvent< HTMLTextAreaElement > ) => {
 			if ( inputRef.current?.value.trim() === '' ) {
@@ -86,14 +81,10 @@ export const ResizableTextarea: React.FC< {
 			className={ className }
 			onKeyUp={ onKeyUp }
 			onPaste={ onPasteHandle }
-			placeholder={
-				cantTransferToZendesk
-					? __( 'Oops, something went wrong', __i18n_text_domain__ )
-					: textAreaPlaceholder
-			}
+			placeholder={ placeholder }
 			onKeyDown={ onKeyDown }
 			style={ { transition: 'none' } }
-			disabled={ shouldDisableInputField || cantTransferToZendesk }
+			disabled={ shouldDisableInputField }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Disable the input field when the user has asked for user support and ZD is not available.

## Why are these changes being made?
When ZD is not available the user experience is poor, due to the user not knowing has not been transferred.

## Testing Instructions

Block the ZD embed config widget URL using a tool like ModResponse
Try to escalate in a new conversation
Check that a Third Party Cookies notice banner is present, and you can't type anymore
Unblock the URL and open a new conversation, try to escalate and assert that it's possible

![image](https://github.com/user-attachments/assets/4aa1df3d-ac54-4659-b5e9-d544df88832f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
