### PR TITLE
Untangled Plans: update current plan info design

### DIFF
--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -25,7 +25,7 @@
 }
 
 body.is-section-plans {
-	.layout:not(.has-no-sidebar) .layout__content {
+	.layout:not(.has-no-sidebar):not(.is-global-sidebar-visible) .layout__content {
 		@media (min-width: $break-small) {
 			padding-left: 0 !important;
 			padding-right: 0 !important;

--- a/client/sites/components/dotcom-style.scss
+++ b/client/sites/components/dotcom-style.scss
@@ -283,6 +283,12 @@
 		}
 	}
 
+	&:has(.hosting-dashboard-item-view__navigation.is-hidden) {
+		.hosting-dashboard-item-view__content {
+			padding-top: 15px;
+		}
+	}
+
 	.is-staging-site {
 		position: relative;
 

--- a/client/sites/components/plan-pricing/index.tsx
+++ b/client/sites/components/plan-pricing/index.tsx
@@ -12,7 +12,11 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 
-export default function PlanPricing() {
+type PlanPricingProps = {
+	inline?: boolean;
+};
+
+export default function PlanPricing( { inline }: PlanPricingProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
@@ -58,37 +62,51 @@ export default function PlanPricing() {
 			  } );
 	};
 
-	return (
-		<>
-			{ isLoading ? (
-				<LoadingPlaceholder
-					className="plan-price-loading-placeholder"
-					width="100px"
-					height="32px"
-				/>
-			) : (
-				<div className="plan-price-wrapper">
-					<PlanPrice
-						currencyCode={ pricing?.currencyCode }
-						isSmallestUnit
-						rawPrice={ pricing?.originalPrice.monthly }
-					/>
-					<span className="plan-price-term">
-						{ translate( '/mo', {
-							comment: '/mo is short for per month, referring to the monthly price of a site plan',
-						} ) }
-					</span>
-				</div>
-			) }
-			{ isLoading ? (
+	const renderPrice = () => {
+		const price = (
+			<PlanPrice
+				currencyCode={ pricing?.currencyCode }
+				isSmallestUnit
+				rawPrice={ pricing?.originalPrice.monthly }
+				omitHeading={ inline }
+				className={ clsx( { 'plan-price--inline': inline } ) }
+			/>
+		);
+
+		if ( inline ) {
+			return isLoading ? (
 				<LoadingPlaceholder
 					className="plan-price-info-loading-placeholder"
 					width="200px"
 					height="16px"
 				/>
 			) : (
+				<div className="plan-price-info">
+					{ price } { getBillingDetails() }
+				</div>
+			);
+		}
+
+		return isLoading ? (
+			<LoadingPlaceholder className="plan-price-loading-placeholder" width="100px" height="48px" />
+		) : (
+			<>
+				<div className="plan-price-wrapper">
+					{ price }
+					<span className="plan-price-term">
+						{ translate( '/mo', {
+							comment: '/mo is short for per month, referring to the monthly price of a site plan',
+						} ) }
+					</span>
+				</div>
 				<div className="plan-price-info">{ getBillingDetails() }</div>
-			) }
+			</>
+		);
+	};
+
+	return (
+		<>
+			{ renderPrice() }
 			{ isLoading ? (
 				<LoadingPlaceholder
 					className="plan-price-info-loading-placeholder"

--- a/client/sites/components/plan-pricing/style.scss
+++ b/client/sites/components/plan-pricing/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/variables";
+
 .plan-price-wrapper {
 	display: flex;
 	align-items: center;
@@ -5,6 +7,15 @@
 
 .plan-price-loading-placeholder {
 	display: flex;
+}
+
+.plan-price--inline {
+	font-size: inherit;
+
+	.plan-price__currency-symbol {
+		font-size: inherit;
+		vertical-align: initial;
+	}
 }
 
 .plan-price-info {

--- a/client/sites/components/plan-stats/index.tsx
+++ b/client/sites/components/plan-stats/index.tsx
@@ -54,32 +54,33 @@ export default function PlanStats() {
 	const footerWrapperIsLink = useDisplayUpgradeLink( site?.ID ?? null );
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId: site?.ID } );
 
-	if ( isLoading ) {
-		return <LoadingPlaceholder width="100px" height="16px" />;
-	}
 	return (
-		<>
-			<div className="plan-stats">
-				<PlanStorage
-					className="plan-storage"
-					hideWhenNoStorage
-					siteId={ site?.ID }
-					storageBarComponent={ PlanStorageBar }
-				>
-					{ availableStorageAddOns.length && ! isAgencyPurchase ? (
-						<div className="plan-storage-footer">
-							<NeedMoreStorage noLink={ footerWrapperIsLink } />
-						</div>
-					) : null }
-				</PlanStorage>
+		<div className="plan-stats">
+			{ isLoading ? (
+				<LoadingPlaceholder width="400px" height="100px" />
+			) : (
+				<>
+					<PlanStorage
+						className="plan-storage"
+						hideWhenNoStorage
+						siteId={ site?.ID }
+						storageBarComponent={ PlanStorageBar }
+					>
+						{ availableStorageAddOns.length && ! isAgencyPurchase ? (
+							<div className="plan-storage-footer">
+								<NeedMoreStorage noLink={ footerWrapperIsLink } />
+							</div>
+						) : null }
+					</PlanStorage>
 
-				{ site && (
-					<div className="plan-stats__footer">
-						<PlanBandwidth siteId={ site.ID } />
-						<PlanSiteVisits siteId={ site.ID } />
-					</div>
-				) }
-			</div>
-		</>
+					{ site && (
+						<div className="plan-stats__footer">
+							<PlanBandwidth siteId={ site.ID } />
+							<PlanSiteVisits siteId={ site.ID } />
+						</div>
+					) }
+				</>
+			) }
+		</div>
 	);
 }

--- a/client/sites/components/plan-stats/plan-storage-bar.tsx
+++ b/client/sites/components/plan-stats/plan-storage-bar.tsx
@@ -1,5 +1,5 @@
-import { ProgressBar } from '@automattic/components';
 import { SiteMediaStorage } from '@automattic/data-stores';
+import { ProgressBar } from '@wordpress/components';
 import clsx from 'clsx';
 import filesize from 'filesize';
 import { useTranslate } from 'i18n-calypso';
@@ -44,10 +44,7 @@ const PlanStorageBar: FC< PropsWithChildren< Props > > = ( { children, mediaStor
 				</span>
 			</div>
 
-			<div className={ classes }>
-				<div className="plan-storage__bar-used" style={ { width: `${ usagePercent }%` } } />
-				<ProgressBar value={ usagePercent } total={ 100 } compact={ false } />
-			</div>
+			<ProgressBar className={ classes } value={ usagePercent } />
 
 			{ children }
 		</>

--- a/client/sites/components/plan-stats/style.scss
+++ b/client/sites/components/plan-stats/style.scss
@@ -5,6 +5,9 @@
 $blueberry-color: #3858e9;
 
 .plan-stats {
+	display: flex;
+	flex-direction: column;
+	flex-wrap: wrap;
 	color: var(--studio-gray-80, #2c3338);
 	font-family: "SF Pro Text", $sans;
 	font-size: $font-body-extra-small;
@@ -31,12 +34,14 @@ $blueberry-color: #3858e9;
 	}
 
 	.plan-storage {
+		flex: 3 1 auto;
 		gap: $grid-unit-15;
 	}
 
 	.plan-bandwidth,
 	.plan-site-visits {
 		flex: 1;
+		min-width: 150px;
 		gap: $grid-unit-10;
 	}
 
@@ -55,6 +60,8 @@ $blueberry-color: #3858e9;
 	}
 
 	.plan-storage-footer {
+		display: flex;
+		flex-wrap: wrap;
 		color: var(--color-link);
 
 		a:hover {
@@ -76,15 +83,11 @@ $blueberry-color: #3858e9;
 
 	.plan-stats__footer {
 		display: flex;
+		flex: 1 1 auto;
+		flex-wrap: wrap;
 		justify-content: space-between;
 		gap: $grid-unit-10;
 		margin-top: 8px;
-	}
-
-	@media (max-width: $break-mobile) {
-		.plan-stats__footer {
-			flex-direction: column;
-		}
 	}
 
 	@media (max-width: $break-xlarge) {

--- a/client/sites/components/plan-stats/style.scss
+++ b/client/sites/components/plan-stats/style.scss
@@ -14,12 +14,19 @@ $blueberry-color: #3858e9;
 	line-height: 16px;
 	margin-top: 30px;
 
-	.plan-storage__bar .progress-bar__progress {
-		background-color: $blueberry-color;
-	}
+	.plan-storage__bar {
+		width: 100%;
+		background: color-mix(in srgb, $blueberry-color 8%, transparent);
 
-	.plan-storage__bar.is-alert .progress-bar__progress {
-		background-color: var(--studio-red-30);
+		> div[class*="-Indicator"] {
+			background: $blueberry-color;
+		}
+
+		&.is-alert {
+			> div[class*="-Indicator"] {
+				background-color: var(--studio-red-30);
+			}
+		}
 	}
 
 	.plan-storage,
@@ -29,7 +36,7 @@ $blueberry-color: #3858e9;
 		flex-direction: column;
 		border-radius: 4px;
 		border: 1px solid var(--studio-gray-0);
-		background: var(--studio-gray-0);
+		background: color-mix(in srgb, $blueberry-color 4%, transparent);
 		padding: $grid-unit-20;
 	}
 
@@ -56,6 +63,8 @@ $blueberry-color: #3858e9;
 	.plan-storage-title,
 	.plan-bandwidth-title,
 	.plan-site-visits-title {
+		font-size: rem(11px);
+		font-weight: 500;
 		text-transform: uppercase;
 	}
 
@@ -67,12 +76,6 @@ $blueberry-color: #3858e9;
 		a:hover {
 			color: var(--color-link-dark);
 		}
-	}
-
-	.plan-storage-value,
-	.plan-bandwidth-content,
-	.plan-site-visits-content {
-		font-weight: 700;
 	}
 
 	.plan-bandwidth-placeholder,

--- a/client/sites/components/plan-stats/style.scss
+++ b/client/sites/components/plan-stats/style.scss
@@ -18,12 +18,12 @@ $blueberry-color: #3858e9;
 		width: 100%;
 		background: color-mix(in srgb, $blueberry-color 8%, transparent);
 
-		> div[class*="-Indicator"] {
+		> div {
 			background: $blueberry-color;
 		}
 
 		&.is-alert {
-			> div[class*="-Indicator"] {
+			> div {
 				background-color: var(--studio-red-30);
 			}
 		}

--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -1,5 +1,7 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import CoreBadge from 'calypso/components/core/badge';
 import PlanPricing from 'calypso/sites/components/plan-pricing';
 import PlanStats from 'calypso/sites/components/plan-stats';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
@@ -7,6 +9,7 @@ import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors
 import './style.scss';
 
 export default function CurrentPlanPanel() {
+	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
 	const isFreePlan = planDetails?.is_free;
@@ -16,14 +19,20 @@ export default function CurrentPlanPanel() {
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 	const isLoading = ! planDetails || planPurchaseLoading;
 
-	if ( isLoading ) {
-		return <LoadingPlaceholder width="100px" height="16px" />;
-	}
-
 	return (
 		<div className="current-plan-panel">
-			<h3>{ planName }</h3>
-			{ ! isFreePlan && <PlanPricing /> }
+			<div className="current-plan-name">
+				{ isLoading ? (
+					<LoadingPlaceholder width="200px" height="24px" />
+				) : (
+					<>
+						<h3>{ planName }</h3>
+						<CoreBadge>{ translate( 'Current plan' ) }</CoreBadge>
+					</>
+				) }
+			</div>
+
+			{ ! isFreePlan && <PlanPricing inline /> }
 			<PlanStats />
 			<hr />
 		</div>

--- a/client/sites/plan/components/current-plan-panel/style.scss
+++ b/client/sites/plan/components/current-plan-panel/style.scss
@@ -46,13 +46,7 @@
 			min-width: 300px;
 		}
 
-		.plan-storage-value,
-		.plan-bandwidth-content,
-		.plan-site-visits-content {
-			font-weight: inherit;
-		}
-
-		&__footer {
+		.plan-stats__footer {
 			gap: 16px;
 			margin-top: 0;
 

--- a/client/sites/plan/components/current-plan-panel/style.scss
+++ b/client/sites/plan/components/current-plan-panel/style.scss
@@ -21,6 +21,7 @@
 	hr {
 		margin-top: 32px;
 		margin-bottom: 8px;
+		background-color: $gray-100;
 	}
 
 	.plan-price-info {

--- a/client/sites/plan/components/current-plan-panel/style.scss
+++ b/client/sites/plan/components/current-plan-panel/style.scss
@@ -54,5 +54,12 @@
 				min-width: 200px;
 			}
 		}
+
+		@media (max-width: 400px) {
+			.plan-storage,
+			.plan-stats__footer > div {
+				min-width: unset;
+			}
+		}
 	}
 }

--- a/client/sites/plan/components/current-plan-panel/style.scss
+++ b/client/sites/plan/components/current-plan-panel/style.scss
@@ -1,16 +1,63 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
 .current-plan-panel {
+	.current-plan-name {
+		display: flex;
+		gap: 8px;
+		margin-bottom: 8px;
+	}
+
 	h3 {
-		color: #1e1e1e;
+		color: $gray-900;
 		font-family: "SF Pro", $sans;
 		font-size: rem(20px); //typography-exception
+		font-weight: 500;
 		line-height: 24px;
 	}
 
 	hr {
 		margin-top: 32px;
+		margin-bottom: 8px;
+	}
+
+	.plan-price-info {
+		font-size: rem(13px);  //typography-exception
+		color: $gray-700;
+	}
+
+	.plan-price--inline {
+		font-size: rem(13px);  //typography-exception
+
+		&, .plan-price__currency-symbol {
+			color: $gray-900;
+		}
+	}
+
+	.plan-stats {
+		gap: 16px;
+		flex-direction: row;
+
+		.plan-storage {
+			margin-top: 0;
+			min-width: 300px;
+		}
+
+		.plan-storage-value,
+		.plan-bandwidth-content,
+		.plan-site-visits-content {
+			font-weight: inherit;
+		}
+
+		&__footer {
+			gap: 16px;
+			margin-top: 0;
+
+			> div {
+				min-width: 200px;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/10607

## Proposed Changes

This PR adapts the current plan info design as per Figma (kyrhgvUpBQak3Qww1560PK-fi-349_16090)

### NOTE

This PR strictly only cares about the current plan info (above the separator). Please do not review anything else! Also, this PR excludes the buttons (e.g. Manage billing); they will be handled in separate PR.

### Desktop

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/0b55fa38-86be-40ba-841d-ebafc2024fbc" />


### Mobile

<img width="530" alt="image" src="https://github.com/user-attachments/assets/89c6405b-baff-4118-b5a2-a207779d34fe" />

### CAVEATS (cc: @matt-west) 

- I could not get the whole "US$ xx, per month" to be bold; only the "US$ x" part, because the "per month ..." text is based on backend response. It is impossible to only fetch the "per month..." phrase (because of translation). I hope this is OK! 
- Is it OK to have slightly larger gap between the breadcrumb and the page heading (plan name), than the Figma design? It's to align with how other pages e.g. "Reset site" have:

<img width="725" alt="image" src="https://github.com/user-attachments/assets/8c9f9cbf-b941-4013-9883-df380a02ce90" />


## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

Go to `/plans/:siteSlug?flags=untangling/plans` and verify the design as above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?