### PR TITLE
Subscribers: Fix incorrect padding when no sidebar

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -17,10 +17,19 @@ body.is-section-subscribers,
                  $padding-standard
                  calc(var(--sidebar-width-max) + #{$padding-standard});
 
-            // This is a Jetpack Cloud breakpoint.
-            @media( max-width: 660px ) {
-                padding-left: 0;
-                padding-right: 0;
+            // Full width rules when sidebar is collapsed
+            &:where(body.is-section-subscribers *) {
+                @media( max-width: $break-medium ) {
+                    padding-left: 0;
+                    padding-right: 0;
+                }
+            }
+
+            &:where(.theme-jetpack-cloud.is-group-jetpack-cloud.is-section-jetpack-subscribers *) {
+                @media( max-width: 660px ) {
+                    padding-left: 0;
+                    padding-right: 0;
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/594

## Proposed Changes

* Reduce padding at different widths for Calypso Blue vs. Jetpack Cloud.

Calypso Blue before | Calypso Blue After
---- | ----
<img width="659" alt="Screen Shot 2025-03-17 at 2 17 10 PM" src="https://github.com/user-attachments/assets/2fd9dcf1-bfcd-4c72-b538-0ee97b91e37f" /> | <img width="661" alt="Screen Shot 2025-03-17 at 2 17 18 PM" src="https://github.com/user-attachments/assets/6c2d9666-3f40-4050-8f02-9eb7af5f368e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Jetpack Cloud breakpoint doesn't look right on Calypso Blue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers
* Resize the window and check that when the sidebar collapses, Subscribers changes to full width.
* Test in Jetpack Cloud as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
