### PR TITLE
Payment Methods: query all of a user's purchases when rendering site-level payment method list

### DIFF
--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -6,7 +6,7 @@ import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Layout from 'calypso/components/layout';
@@ -30,7 +30,6 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getAddNewPaymentMethodUrlFor, getPaymentMethodsUrlFor } from '../paths';
 
 function useLogPaymentMethodsError( message: string ) {
@@ -48,14 +47,17 @@ export function PaymentMethods( { siteSlug }: { siteSlug: string } ) {
 	const logPaymentMethodsError = useLogPaymentMethodsError(
 		'site level payment methods load error'
 	);
-	const siteId = useSelector( getSelectedSiteId );
 
 	return (
 		<Main wideLayout className="purchases">
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/purchases/payment-methods" title="Payment Methods" />
-			<QuerySitePurchases siteId={ siteId } />
+			{ /* Purchases are used to render the affected subscriptions when
+				removing a payment method. As such, we need to query all of a
+				user's purchases, instead of just the site-level purchases,
+				since a payment method can be used across sites. */ }
+			<QueryUserPurchases />
 			{ ! isJetpackCloud() && (
 				<NavigationHeader
 					title={ titles.sectionTitle }


### PR DESCRIPTION
This makes both the site-level and user-level Payment Methods list use the user-level `QueryUserPurchases` query component.

The `PaymentMethodList` component uses a list of purchases from state to warn the user about other subscriptions that share the same payment method when that payment method is about to be deleted. Since payment methods are account-level and can be used for subscriptions on multiple sites, we need to query all of a user's purchases when rendering the payment method list, instead of just the purchases for that specific site.

Fixes: https://github.com/Automattic/wp-calypso/issues/101168

**To test:**
- Make purchases on multiple different sites using the same saved payment method
- Visit the site-level payment method list (Sidebar > Purchases > Payment Methods) and clear your `purchases` state
- Reload the page
- Click "Remove payment method" for the payment method that's shared across sites
- In the warning modal, verify that all of the purchases attached to that payment method are shown