### PR TITLE
help-center-wp-admin-disconnected: Remove react

### DIFF
--- a/apps/help-center/help-center-wp-admin-disconnected.js
+++ b/apps/help-center/help-center-wp-admin-disconnected.js
@@ -1,24 +1,27 @@
 import './config';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { createRoot } from 'react-dom/client';
 import './help-center.scss';
 
-function AdminHelpCenterContent() {
+function initHelpCenterTracking() {
 	const button = document.getElementById( 'wp-admin-bar-help-center' );
 
-	const handleOpenHelpCenter = () => {
-		recordTracksEvent( `calypso_inlinehelp_show`, {
-			force_site_id: true,
-			location: 'help-center',
-			section: 'wp-admin',
-			jetpack_disconnected_site: true,
+	if ( button && ! button.dataset.trackingInitialized ) {
+		button.addEventListener( 'click', () => {
+			recordTracksEvent( 'calypso_inlinehelp_show', {
+				force_site_id: true,
+				location: 'help-center',
+				section: 'wp-admin',
+				jetpack_disconnected_site: true,
+			} );
 		} );
-	};
 
-	button.onclick = handleOpenHelpCenter;
+		// Prevent multiple initializations
+		button.dataset.trackingInitialized = 'true';
+	}
 }
 
-const target = document.getElementById( 'help-center-masterbar' );
-if ( target ) {
-	createRoot( target ).render( <AdminHelpCenterContent /> );
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', initHelpCenterTracking );
+} else {
+	initHelpCenterTracking();
 }


### PR DESCRIPTION
## Proposed Changes / Why are these changes being made?

* This removes the usage of react in `help-center-wp-admin-disconnected`.

In some cases, this script looks to be the only usage of react on the front-end, and it appears that react isn't even needed. The script looks to only add an event-listener to an existing dom element. This should be possible without react.

The relevant JP file is here: https://github.com/Automattic/jetpack/blob/e7157103862f9c8a026f411b6f41475e74b54b76/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php#L424-L427

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `yarn dev --sync` in apps/help-center.
- Sandbox widgets.wp.com
- While logged in, visit the frontpage of a simple site you own.
- Click the Help Center.
- It should open a new tab.
- The current tab should emit a tracks event `calypso_inlinehelp_show`.
- The new tab should have the Help Center open.
 
(Note that for it to be loaded, you have to view the front-end of a site while being logged in and having edit capabilities. )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
