### PR TITLE
Reader: Remove extra border from feed stream

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -5,7 +5,6 @@ body.is-section-reader {
 	div.layout.is-global-sidebar-visible {
 		.main {
 			padding: 24px;
-			border-block-end: 1px solid var(--studio-gray-0);
 
 			@media (max-width: $break-small) {
 				padding: 24px 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Remove extra border that is present on bottom of the feed stream. Very prominent when you use some extension for Dark Mode.

Normal View:

![Screenshot 2025-03-18 at 2 37 42 AM](https://github.com/user-attachments/assets/c115df2d-0ad0-4b7c-89fd-9360f6111a25)

Dark Mode View (via extension):

![Screenshot 2025-03-18 at 2 36 21 AM](https://github.com/user-attachments/assets/43516fa4-3b80-4a59-9856-99debd679236)

![Screenshot 2025-03-18 at 2 37 16 AM](https://github.com/user-attachments/assets/22abe76f-4ac1-4194-acab-50fc13f9ff66)

2 borders will appear for upcoming change that introduces feed previews which looks more odd.

![image](https://github.com/user-attachments/assets/15e7f40e-46ab-42a7-af6e-965e35eabaf3)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to reader empty feeds or end of the feeds and verify that there is no border now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
