### PR TITLE
Update Add New Site Modal color to fix regression.

### DIFF
--- a/client/components/sites-add-new-site/style.scss
+++ b/client/components/sites-add-new-site/style.scss
@@ -120,6 +120,7 @@
 			width: 24px;
 			height: 24px;
 			max-width: fit-content;
+			color: var(--color-text-black);
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

A change in https://github.com/Automattic/wp-calypso/pull/101438, led to the greying out of the icons in the modal.

This PR explicitely sets the icon color to harden the styles.

## Screenshots

| Before | After |
|--------|--------|
| <img width="919" alt="Screenshot 2025-03-18 at 9 45 45 AM" src="https://github.com/user-attachments/assets/3c3cda41-2833-46c3-9a22-223a90d41083" /> | <img width="916" alt="Screenshot 2025-03-18 at 9 45 24 AM" src="https://github.com/user-attachments/assets/9b798e91-e942-49bf-ab31-221803fb8056" /> | 




## Testing Instructions
- Go to wp.com/sites
- Click "Add new site"
- Verify that the icons are dark colored.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
