### PR TITLE
Domain-To-Plan Credit: Avoid widow in notice copy

### DIFF
--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -64,6 +64,7 @@ $plan-features-header-banner-height: 20px;
 .notice.plan-features-main__notice {
 	margin: 0 20px 24px;
 	width: unset;
+	text-wrap: pretty;
 
 	@include plans-section-custom-mobile-breakpoint {
 		margin: 0 0 24px;

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -133,6 +133,7 @@ $blueberry-color: #3858e9;
 
 .hosting-overview__domain-to-plan-credit-notice {
 	grid-column: 1 / -1;
+	text-wrap: pretty;
 }
 
 .hosting-overview__navigation-header {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/3643

## Proposed Changes

Updates styling of the below notices to avoid the term 'today!' breaking onto a new line by itself.

`/overview/:site`

| Before | After |
| -- | -- |
|![CleanShot 2025-03-18 at 11 19 03@2x](https://github.com/user-attachments/assets/417986fd-a264-439e-90e1-6ca0b9a762a8)|![CleanShot 2025-03-18 at 11 19 25@2x](https://github.com/user-attachments/assets/dacebd84-706f-4f40-8e22-4989d1f99cce)|

`/home/:site`

| Before | After |
| -- | -- |
|![CleanShot 2025-03-18 at 11 21 00@2x](https://github.com/user-attachments/assets/83b45878-361a-46a0-808e-3f231c50ec93)|![CleanShot 2025-03-18 at 11 22 19@2x](https://github.com/user-attachments/assets/dff59f6b-a0a9-4ef7-9613-c44ffb864e39)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improve readability and polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test using a free site with a custom [.com, .net, .org, .blog] domain
2. Add user to the treatment group for experiment: 22202-explat-experiment
3. Visit `/overview/:site` & `/home/:site`
4. For both pages, reduce the size of the viewport to force the notice copy to wrap
5. Verify that 'today!' does not wrap onto the next line by itself

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?