### PR TITLE
Update disabled credit card input styles.

### DIFF
--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -48,6 +48,8 @@
 		background:
 			url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1IDYuNzUwMDFMOSAxMi43NUwzIDYuNzUwMDFMNC4wNjA1IDUuNjg5NTFMOSAxMC42MjlMMTMuOTM5NSA1LjY4OTUxTDE1IDYuNzUwMDFaIiBmaWxsPSIjQzNDNEM3Ii8+Cjwvc3ZnPgo=)
 			no-repeat right 10px center;
+		background-color: var(--studio-gray-0);
+		border-color: var(--studio-gray-10);
 	}
 
 	// A smaller variant that works well when presented inline with text
@@ -97,7 +99,7 @@
 	}
 
 	&:disabled {
-		color: var(--color-neutral-10);
+		color: var(--studio-gray-20);
 	}
 }
 

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -49,7 +49,8 @@
 			url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1IDYuNzUwMDFMOSAxMi43NUwzIDYuNzUwMDFMNC4wNjA1IDUuNjg5NTFMOSAxMC42MjlMMTMuOTM5NSA1LjY4OTUxTDE1IDYuNzUwMDFaIiBmaWxsPSIjQzNDNEM3Ii8+Cjwvc3ZnPgo=)
 			no-repeat right 10px center;
 		background-color: var(--studio-gray-0);
-		border-color: var(--studio-gray-10);
+		border-color: var(--gray-gray-10, #c3c4c7);
+		opacity: 1;
 	}
 
 	// A smaller variant that works well when presented inline with text

--- a/client/my-sites/checkout/src/components/tax-fields.tsx
+++ b/client/my-sites/checkout/src/components/tax-fields.tsx
@@ -187,6 +187,7 @@ export default function TaxFields( {
 				countryCode={ countryCode?.value }
 				selectText={ STATE_SELECT_TEXT[ countryCode?.value ?? '' ] }
 				value={ state?.value }
+				disabled={ isDisabled }
 				onChange={ ( event: ChangeEvent< HTMLSelectElement > ) => {
 					onChange(
 						updateOnChangePayload(

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-cvv-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-cvv-field.tsx
@@ -69,7 +69,11 @@ export default function CreditCardCvvField( {
 			<LabelText>{ translate( 'Security code' ) }</LabelText>
 			<GridRow gap="4%" columnWidths="67% 29%">
 				<LeftColumn>
-					<StripeFieldWrapper className="cvv" hasError={ !! cardCvcError }>
+					<StripeFieldWrapper
+						className="cvv"
+						hasError={ !! cardCvcError }
+						isDisabled={ isDisabled }
+					>
 						<CardCvcElement
 							options={ {
 								style: stripeElementStyle,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-expiry-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-expiry-field.tsx
@@ -61,7 +61,11 @@ export default function CreditCardExpiryField( {
 	return (
 		<Label>
 			<LabelText>{ translate( 'Expiry date' ) }</LabelText>
-			<StripeFieldWrapper className="expiration-date" hasError={ !! cardExpiryError }>
+			<StripeFieldWrapper
+				className="expiration-date"
+				hasError={ !! cardExpiryError }
+				isDisabled={ isDisabled }
+			>
 				<CardExpiryElement
 					options={ {
 						style: stripeElementStyle,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
@@ -120,6 +120,10 @@ export default function CreditCardFields( {
 			'::placeholder': {
 				color: theme.colors.placeHolderTextColor,
 			},
+			borderRadius: '2px',
+			':disabled': {
+				color: theme.colors.textColorDisabled,
+			},
 		},
 		invalid: {
 			color: theme.colors.textColor,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-fields.tsx
@@ -120,7 +120,6 @@ export default function CreditCardFields( {
 			'::placeholder': {
 				color: theme.colors.placeHolderTextColor,
 			},
-			borderRadius: '2px',
 			':disabled': {
 				color: theme.colors.textColorDisabled,
 			},

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-number-field.tsx
@@ -62,7 +62,11 @@ export default function CreditCardNumberField( {
 	return (
 		<Label>
 			<LabelText>{ __( 'Card number' ) }</LabelText>
-			<StripeFieldWrapper className="number" hasError={ !! cardNumberError }>
+			<StripeFieldWrapper
+				className="number"
+				hasError={ !! cardNumberError }
+				isDisabled={ isDisabled }
+			>
 				<CardNumberElement
 					options={ {
 						style: stripeElementStyle,

--- a/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
@@ -83,7 +83,7 @@ export const CreditCardFieldsWrapper = styled.div< { isLoaded?: boolean } >`
 	input[type='tel'],
 	input[type='number'],
 	input[type='search'] {
-		border-radius: 3px;
+		border-radius: 2px;
 	}
 `;
 

--- a/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
@@ -83,7 +83,7 @@ export const CreditCardFieldsWrapper = styled.div< { isLoaded?: boolean } >`
 	input[type='tel'],
 	input[type='number'],
 	input[type='search'] {
-		border-radius: 2px;
+		border-radius: ${ ( props ) => props.theme.borderRadius.small };
 	}
 `;
 

--- a/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
@@ -44,8 +44,8 @@ export const StripeFieldWrapper = styled.span< { hasError?: boolean; isDisabled?
 		border: 1px solid
 			${ ( props ) =>
 				props.hasError ? props.theme.colors.error : props.theme.colors.borderColor };
-		border-radius: 2px;
-		padding: 12px 10px;
+		border-radius: 3px;
+		padding: 12px 14px;
 		line-height: 1.2;
 	}
 

--- a/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
@@ -44,7 +44,7 @@ export const StripeFieldWrapper = styled.span< { hasError?: boolean; isDisabled?
 		border: 1px solid
 			${ ( props ) =>
 				props.hasError ? props.theme.colors.error : props.theme.colors.borderColor };
-		border-radius: 3px;
+		border-radius: 2px;
 		padding: 12px 10px;
 		line-height: 1.2;
 	}

--- a/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
@@ -44,7 +44,7 @@ export const StripeFieldWrapper = styled.span< { hasError?: boolean; isDisabled?
 		border: 1px solid
 			${ ( props ) =>
 				props.hasError ? props.theme.colors.error : props.theme.colors.borderColor };
-		border-radius: 3px;
+		border-radius: ${ ( props ) => props.theme.borderRadius.small };
 		padding: 12px 14px;
 		line-height: 1.2;
 	}

--- a/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/form-layout-components.tsx
@@ -32,7 +32,7 @@ export const LabelText = styled.span`
 	color: ${ ( props ) => props.theme.colors.textColor };
 `;
 
-export const StripeFieldWrapper = styled.span< { hasError?: boolean } >`
+export const StripeFieldWrapper = styled.span< { hasError?: boolean; isDisabled?: boolean } >`
 	position: relative;
 	display: block;
 
@@ -56,6 +56,9 @@ export const StripeFieldWrapper = styled.span< { hasError?: boolean } >`
 	.StripeElement--focus.StripeElement--invalid {
 		outline: ${ ( props ) => props.theme.colors.error } solid 2px;
 	}
+
+	background: ${ ( props ) => props.isDisabled && props.theme.colors.disabledField };
+	cursor: ${ ( props ) => props.isDisabled && 'default' };
 `;
 
 export const StripeErrorMessage = styled.span`

--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -54,6 +54,9 @@ export type Theme = {
 	fontSize: {
 		small: string;
 	};
+	borderRadius: {
+		small: string;
+	};
 };
 
 const theme: Theme = {
@@ -108,6 +111,9 @@ const theme: Theme = {
 	},
 	fontSize: {
 		small: '14px',
+	},
+	borderRadius: {
+		small: '2px',
 	},
 };
 

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -131,6 +131,7 @@ const Input = styled.input< {
 
 	:disabled {
 		background: ${ ( props ) => props.theme.colors.disabledField };
+		color: var( --studio-gray-20 );
 	}
 `;
 

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -112,7 +112,7 @@ const Input = styled.input< {
 		${ ( props ) => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor ) };
 	line-height: 1.5;
 	font-size: 14px;
-	padding: 7px;
+	padding: 7px 14px;
 
 	::-webkit-inner-spin-button,
 	::-webkit-outer-spin-button {


### PR DESCRIPTION
Fixes #100558

## Proposed Changes

This PR updates tries to make input styles for the credit card fields more consistent, especially for the loading/disabled states.

The `<select>` components pose a bit of a styling dilemma because these styles are applied all across the app and are styled differently from `payment-methods` inputs.

Their general styling approach is to reduce opacity to denote disabled or loading states. The `payment-methods` fields use darker backgrounds to do so.

If we look at the Dotcom style guide, we see that the `payment-methods` approach aligns more closely with the newest styles. So we should darken the control when disabled. 

In addition, there are still inconsistencies with padding and border. The more legacy fields use a border-radius of `2px` and a padding of `7px 14px`. 

I chose to align the credit card fields with those styles because this ticket isn't about aligning the styles across the app and changing the styles in the existing fields would create a bigger change surface.

I am a bit confused about what css variables should be present and what theme object represent the latest styles. For example, the fields use a `border-color` of `var(--gray-gray-10, #c3c4c7);` across the app, but locally `--gray-gray-10` is not defined. I don't see `#c3c4c7` in `packages/composite-checkout/src/lib/theme.ts` and wonder if using `var(--gray-gray-10, #c3c4c7);` is a step backwards.

There's also an issue where input labels are bolder (`600`) for legacy fields and the ones in `payment-methods` are `500` which follow newer styles. I've left that in. The newer designs have the font-weight at `500` and the _legacy_ fields should be updated. This is a conditional dropdown so it's visibility is on the low side.

## Screenshot

| Before | After |
|--------|--------|
| <img width="746" alt="Screenshot 2025-03-21 at 1 23 03 PM" src="https://github.com/user-attachments/assets/0767c42e-86bc-4a2b-b6f9-011b444c3571" /> | <img width="742" alt="Screenshot 2025-03-21 at 1 17 52 PM" src="https://github.com/user-attachments/assets/ae81c00e-86d6-4fd2-9879-e819c0e4a001" /> | 

## Why are these changes being made?
It isn't clear that all the forms are disabled.

## Testing Instructions

**Me: Adding payment**
Go to: `me/purchases/add-payment-method`
 
Using the store sandbox, add a credit card for many different countries: [Canada, Japan, US, etc..]

**Checkout: Adding payment**

Same as above but add the payment while checking out.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
