### PR TITLE
Fix Reader related posts cropped off descenders

### DIFF
--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -8,12 +8,10 @@
 	-webkit-line-clamp: 2;
 	font-size: $font-body;
 	line-height: 1.618;
-	max-height: 45px;
 
 	@include breakpoint-deprecated( "<480px" ) {
 		font-size: $font-body;
 		line-height: 22px;
-		max-height: 22px * 3;
 	}
 
 	p {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/100263

>Go to the reader, view related posts, and note that the descenders on the letters of the 2nd line of related posts descriptions is cropped off:

I removed the hard coded `max-height` as it doesn't seem to be needed since we have the `line-clamp` rule. I tested in Chrome and Safari and didn't notice any regression.

## Testing Instructions
1. Subscribe to a blog that has related posts enabled, such as https://filipponow.wordpress.com/
2. Open this blog in the reader, i.e. Reader > Sidebar > NOW
3. Click an individual post so you see the full post
4. Scroll down to the "More in NOW" section.
5. Observe that the descenders are not cropped off

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
