### PR TITLE
Fix calypso_domain_management_point_to_wpcom Tracks event

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -92,7 +92,15 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 		useState< ResponseDomain | null >( null );
 
 	const onPointToWpcom = async ( domain: string ) => {
+		if ( ! domain ) {
+			return;
+		}
 		setIsPointingToWpcom( true );
+		dispatch(
+			recordTracksEvent( 'calypso_domain_management_point_to_wpcom', {
+				domain,
+			} )
+		);
 		try {
 			await wpcomRequest( {
 				path: '/domains/point-to-wpcom',
@@ -189,11 +197,6 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					visible={ showPointToWpcomModal }
 					onClose={ ( accepted: boolean ) => {
 						setShowPointToWpcomModal( false );
-						dispatch(
-							recordTracksEvent( 'calypso_domain_management_point_to_wpcom', {
-								accepted,
-							} )
-						);
 						if ( accepted ) {
 							onPointToWpcom( domainToPointToWpcom ?? '' );
 						}


### PR DESCRIPTION
## Proposed Changes

Quick fix for calypso_domain_management_point_to_wpcom. 

## Why are these changes being made?
We need to send the domain name in the event props. I also updated the code to trigger the event inside `onPointToWpcom` callback

## Testing Instructions
Code inspection is enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
