### PR TITLE
Stats: make sure queryParams is not null before accessing navigation prop

### DIFF
--- a/client/my-sites/stats/stats-date-picker/with-is-drilling-down-hook.tsx
+++ b/client/my-sites/stats/stats-date-picker/with-is-drilling-down-hook.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 interface WithIsDrillingDownHookProps {
 	period: string;
-	queryParams: {
+	queryParams?: {
 		// Used to refresh isDrillingDown when navigating by clicking arrows.
 		navigation?: string;
 	};
@@ -20,7 +20,7 @@ function withIsDrillingDownHook( Component: React.ComponentType< WithIsDrillingD
 	return function WrappedComponent( props: WithIsDrillingDownHookProps ) {
 		const isDrillingDown = useMemo( () => {
 			return sessionStorage.getItem( 'jetpack_stats_date_range_is_drilling_down' );
-		}, [ props.period, props.queryParams.navigation ] ); // eslint-disable-line react-hooks/exhaustive-deps
+		}, [ props.period, props.queryParams?.navigation ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 		return <Component { ...props } isDrillingDown={ isDrillingDown } />;
 	};


### PR DESCRIPTION
Context: p1742293717052829-slack-C02FMH4G8

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

- Go to /stats
- It should work.