### PR TITLE
A4A: Remove Temporary Core style props on Simple list, Consolidated card and Step section components.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
@@ -69,7 +69,6 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 				{ isExpanded && (
 					<div className="a4a-migration-offer-v3__body">
 						<SimpleList
-							applyCoreStyles
 							items={ [
 								translate(
 									'{{b}}All migrations:{{/b}} Your first month of hosting will be free when you migrate twenty or more sites to us from any host.',

--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -82,7 +82,6 @@ interface ConsolidatedStatsCardProps {
 	popoverTitle?: string;
 	popoverContent: React.ReactNode;
 	isLoading?: boolean;
-	applyCoreStyles?: boolean;
 }
 
 export function ConsolidatedStatsCard( {
@@ -91,27 +90,16 @@ export function ConsolidatedStatsCard( {
 	popoverTitle,
 	popoverContent,
 	isLoading = false,
-	applyCoreStyles = false,
 }: ConsolidatedStatsCardProps ) {
 	const cardRef = useRef< HTMLDivElement | null >( null );
 
 	return (
-		<Card
-			compact
-			ref={ cardRef }
-			className={ clsx( 'consolidated-stats-card', { 'is-core-styles': applyCoreStyles } ) }
-		>
+		<Card compact ref={ cardRef } className="consolidated-stats-card">
 			<div className="consolidated-stats-card__value">
 				{ isLoading ? <TextPlaceholder /> : value }
 			</div>
 			<CardInfo title={ popoverTitle } wrapperRef={ cardRef } footerText={ footerText }>
-				<div
-					className={ clsx( 'consolidated-stats-card__popover-content', {
-						'is-core-styles': applyCoreStyles,
-					} ) }
-				>
-					{ popoverContent }
-				</div>
+				<div className="consolidated-stats-card__popover-content">{ popoverContent }</div>
 			</CardInfo>
 		</Card>
 	);

--- a/client/a8c-for-agencies/components/consolidated-stats-card/style.scss
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/style.scss
@@ -36,8 +36,7 @@
 
 .consolidated-stats-card__value {
 	color: var(--color-accent-100);
-	font-size: rem(24px);
-	font-weight: 700;
+	@include heading-x-large;
 	margin-block-end: 8px;
 }
 
@@ -81,7 +80,7 @@
 
 .consolidated-stats-card__label {
 	color: var(--color-accent);
-	font-size: rem(12px);
+	@include body-medium;
 	text-wrap: balance;
 }
 
@@ -94,7 +93,7 @@
 
 .consolidated-stats-card__popover-content {
 	min-width: 200px;
-	@include a4a-font-body-md;
+	@include body-medium;
 
 	@include break-mobile {
 		min-width: 300px;
@@ -109,21 +108,3 @@
 		outline: none;
 	}
 }
-
-// Core styles
-
-.consolidated-stats-card.is-core-styles {
-	.consolidated-stats-card__value {
-		@include heading-x-large;
-	}
-
-	.consolidated-stats-card__label {
-		@include body-medium;
-	}
-}
-
-.consolidated-stats-card__popover-content.is-core-styles {
-	@include body-medium;
-}
-
-// End of core styles

--- a/client/a8c-for-agencies/components/simple-list/index.tsx
+++ b/client/a8c-for-agencies/components/simple-list/index.tsx
@@ -6,18 +6,12 @@ import './style.scss';
 export default function SimpleList( {
 	items,
 	className,
-	applyCoreStyles = false,
 }: {
 	items: ReactNode[];
 	className?: string;
-	applyCoreStyles?: boolean;
 } ) {
 	return (
-		<ul
-			className={ clsx( 'simple-list', className, {
-				'is-core-styles': applyCoreStyles,
-			} ) }
-		>
+		<ul className={ clsx( 'simple-list', className ) }>
 			{ items.map( ( item, index ) => (
 				<li key={ `item-${ index }` }>
 					<Icon className="simple-list-icon" icon={ check } size={ 24 } />

--- a/client/a8c-for-agencies/components/simple-list/style.scss
+++ b/client/a8c-for-agencies/components/simple-list/style.scss
@@ -13,13 +13,7 @@
 	li {
 		display: flex;
 		flex-direction: row;
-		@include a4a-font-body-lg($line-height: 1.625);
-	}
-
-	&.is-core-styles {
-		li {
-			@include body-large;
-		}
+		@include body-large;
 	}
 }
 

--- a/client/a8c-for-agencies/components/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/index.tsx
@@ -20,7 +20,6 @@ interface StepSectionItemProps {
 	iconClassName?: string;
 	isNewLayout?: boolean;
 	stepNumber?: number;
-	applyCoreStyles?: boolean;
 }
 
 export default function StepSectionItem( {
@@ -33,7 +32,6 @@ export default function StepSectionItem( {
 	iconClassName,
 	isNewLayout = false,
 	stepNumber,
-	applyCoreStyles = false,
 }: StepSectionItemProps ) {
 	const status = <StatusBadge statusProps={ statusProps } />;
 
@@ -48,9 +46,7 @@ export default function StepSectionItem( {
 	);
 
 	return (
-		<div
-			className={ clsx( 'step-section-item', className, { 'is-core-styles': applyCoreStyles } ) }
-		>
+		<div className={ clsx( 'step-section-item', className ) }>
 			{ icon && (
 				<div className={ clsx( 'step-section-item__icon', iconClassName ) }>
 					<Icon className="sidebar__menu-icon" icon={ icon } size={ ICON_SIZE } />

--- a/client/a8c-for-agencies/components/step-section-item/style.scss
+++ b/client/a8c-for-agencies/components/step-section-item/style.scss
@@ -22,14 +22,12 @@
 	}
 
 	.step-section-item__heading {
-		font-size: rem(16px);
-		font-weight: 500;
+		@include heading-medium;
 	}
 
 	.step-section-item__description {
 		margin-block-start: 4px;
-		font-size: rem(14px);
-		line-height: 1.7;
+		@include body-medium;
 		color: var(--color-accent);
 	}
 
@@ -46,16 +44,6 @@
 				width: auto;
 				height: inherit;
 			}
-		}
-	}
-
-	&.is-core-styles {
-		.step-section-item__heading {
-			@include heading-medium;
-		}
-
-		.step-section-item__description {
-			@include body-medium;
 		}
 	}
 }

--- a/client/a8c-for-agencies/components/step-section/index.tsx
+++ b/client/a8c-for-agencies/components/step-section/index.tsx
@@ -8,7 +8,6 @@ interface StepSectionProps {
 	stepCount?: number;
 	children: React.ReactNode;
 	className?: string;
-	applyCoreStyles?: boolean;
 }
 
 export default function StepSection( {
@@ -16,10 +15,9 @@ export default function StepSection( {
 	heading,
 	children,
 	className,
-	applyCoreStyles = false,
 }: StepSectionProps ) {
 	return (
-		<div className={ clsx( 'step-section', className, { 'is-core-styles': applyCoreStyles } ) }>
+		<div className={ clsx( 'step-section', className ) }>
 			<div className="step-section__header">
 				{ !! stepCount && <div className="step-section__step-count">{ stepCount }</div> }
 				<div className="step-section__step-heading">{ heading }</div>

--- a/client/a8c-for-agencies/components/step-section/style.scss
+++ b/client/a8c-for-agencies/components/step-section/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+
 .step-section {
 	.step-section__header {
 		display: flex;
@@ -16,8 +17,7 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			font-size: rem(12px);
-			font-weight: 600;
+			@include heading-small;
 			background: var(--color-primary-50);
 			width: 24px;
 			border-radius: 50%;
@@ -26,15 +26,8 @@
 		}
 
 		.step-section__step-heading {
-			font-size: rem(20px);
-			font-weight: 600;
-			text-wrap: pretty;
-		}
-	}
-
-	&.is-core-styles {
-		.step-section__step-heading {
 			@include heading-large;
+			text-wrap: pretty;
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
@@ -30,11 +30,7 @@ function FeatureCard( {
 				<h2 className="hosting-features-section-v2__card-title">{ title }</h2>
 			</div>
 
-			<SimpleList
-				applyCoreStyles
-				className="hosting-features-section-v2__card-list"
-				items={ items }
-			/>
+			<SimpleList className="hosting-features-section-v2__card-list" items={ items } />
 		</Card>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/enterprise-agency-hosting/index.tsx
@@ -93,7 +93,6 @@ export default function EnterpriseAgencyHosting( { isReferMode }: { isReferMode:
 					) }
 
 					<SimpleList
-						applyCoreStyles
 						items={ [
 							translate( 'Unmatched flexibility to build a customized web experience' ),
 							translate( 'Tools to increase customer engagement' ),

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/pressable-plan-section/index.tsx
@@ -164,7 +164,6 @@ export default function PressablePlanSection( {
 
 				{ isCustomPlan ? (
 					<SimpleList
-						applyCoreStyles
 						items={ [
 							translate( 'Custom WordPress installs' ),
 							translate( '{{b}}%(count)s{{/b}} visits per month*', {

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/standard-agency-hosting/wpcom-plan-section/index.tsx
@@ -132,7 +132,6 @@ export default function WPCOMPlanSection( { onSelect }: Props ) {
 					</p>
 
 					<SimpleList
-						applyCoreStyles
 						items={ [
 							translate( '{{b}}50GB{{/b}} of storage', { components: { b: <b /> } } ),
 							translate( '{{b}}Free{{/b}} staging site', { components: { b: <b /> } } ),

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/details.tsx
@@ -111,7 +111,6 @@ export default function PlanSelectionDetails( {
 
 				{ ! isRegularOwnership && ! isReferMode && (
 					<SimpleList
-						applyCoreStyles
 						items={ [
 							info?.install
 								? translate(

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/empty-state.tsx
@@ -25,12 +25,8 @@ export default function MigrationsCommissionsEmptyState( {
 	const a4aPluginUrl = 'https://wordpress.org/plugins/automattic-for-agencies-client';
 
 	return (
-		<StepSection
-			applyCoreStyles
-			heading={ translate( 'View your migrated websites and commisions right here.' ) }
-		>
+		<StepSection heading={ translate( 'View your migrated websites and commisions right here.' ) }>
 			<StepSectionItem
-				applyCoreStyles
 				isNewLayout
 				heading={ translate( "We'll tag the sites we moved for you once they're transferred." ) }
 				description={ preventWidows(
@@ -41,7 +37,6 @@ export default function MigrationsCommissionsEmptyState( {
 			/>
 			<StepSectionItem
 				isNewLayout
-				applyCoreStyles
 				heading={ translate( 'Tag your transferred sites so we can pay you for them.' ) }
 				description={
 					<>

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -24,11 +24,7 @@ function FeatureCard( {
 				<h2 className="migrations-hosting-features__card-title">{ title }</h2>
 			</div>
 
-			<SimpleList
-				applyCoreStyles
-				className="migrations-hosting-features__card-list"
-				items={ items }
-			/>
+			<SimpleList className="migrations-hosting-features__card-list" items={ items } />
 		</Card>
 	);
 }

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -212,7 +212,6 @@ const PartnerDirectoryDashboard = () => {
 
 	const programLinks = (
 		<StepSection
-			applyCoreStyles
 			className="partner-directory-dashboard__learn-more-section"
 			heading={ translate( 'Learn more about the program' ) }
 		>
@@ -291,7 +290,6 @@ const PartnerDirectoryDashboard = () => {
 
 						return (
 							<StepSectionItem
-								applyCoreStyles
 								key={ application.brand }
 								isNewLayout
 								iconClassName={ clsx( brandMeta.className ) }
@@ -302,7 +300,6 @@ const PartnerDirectoryDashboard = () => {
 						);
 					} ) }
 				<StepSection
-					applyCoreStyles
 					className="partner-directory-dashboard__edit-section"
 					heading={ translate( "Edit your agency's information" ) }
 				>
@@ -344,9 +341,8 @@ const PartnerDirectoryDashboard = () => {
 					'List your agency in our partner directories. Showcase your skills, attract clients, and grow your business.'
 				) }
 			</div>
-			<StepSection applyCoreStyles heading={ translate( 'How do I start?' ) }>
+			<StepSection heading={ translate( 'How do I start?' ) }>
 				<StepSectionItem
-					applyCoreStyles
 					isNewLayout
 					className={
 						currentApplicationStep > 0 ? 'partner-directory-dashboard__checked-step' : ''
@@ -392,7 +388,6 @@ const PartnerDirectoryDashboard = () => {
 					} }
 				/>
 				<StepSectionItem
-					applyCoreStyles
 					isNewLayout
 					className={
 						currentApplicationStep > 1 ? 'partner-directory-dashboard__checked-step' : ''
@@ -413,7 +408,6 @@ const PartnerDirectoryDashboard = () => {
 					} }
 				/>
 				<StepSectionItem
-					applyCoreStyles
 					isNewLayout
 					stepNumber={ currentApplicationStep > 2 ? undefined : 3 }
 					icon={ currentApplicationStep > 2 ? check : undefined }

--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -29,7 +29,6 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 		<ConsolidatedStatsGroup className="consolidated-view">
 			{ totalPayouts !== undefined && (
 				<ConsolidatedStatsCard
-					applyCoreStyles
 					value={ formatCurrency( totalPayouts, 'USD' ) }
 					footerText={ translate( 'All time referral payouts' ) }
 					popoverTitle={ translate( 'Total payouts' ) }
@@ -46,7 +45,6 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				/>
 			) }
 			<ConsolidatedStatsCard
-				applyCoreStyles
 				value={ formatCurrency( expectedCommission, 'USD' ) }
 				footerText={ translate( 'Next estimated payout amount' ) }
 				popoverTitle={ translate( 'Estimated amount' ) }
@@ -70,7 +68,6 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				isLoading={ isFetching }
 			/>
 			<ConsolidatedStatsCard
-				applyCoreStyles
 				value={ nextPayoutDate + '*' }
 				footerText={ translate( 'Next estimated payout date' ) }
 				popoverTitle={ translate( 'Estimated date' ) }
@@ -87,7 +84,6 @@ export default function ConsolidatedViews( { referrals, totalPayouts }: Consolid
 				) }
 			/>
 			<ConsolidatedStatsCard
-				applyCoreStyles
 				value={ pendingOrders }
 				footerText={ translate( 'Pending referral orders' ) }
 				popoverTitle={ translate( 'Pending orders' ) }

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -99,7 +99,7 @@ export default function CommissionOverview( {
 					</>
 				) }
 				<div className="commission-overview__section-container">
-					<StepSection applyCoreStyles heading={ translate( 'How much can I earn?' ) }>
+					<StepSection heading={ translate( 'How much can I earn?' ) }>
 						<FoldableCard
 							header={
 								<>
@@ -181,10 +181,7 @@ export default function CommissionOverview( {
 						</FoldableCard>
 					</StepSection>
 
-					<StepSection
-						applyCoreStyles
-						heading={ translate( 'Eligibility requirements and terms of use?' ) }
-					>
+					<StepSection heading={ translate( 'Eligibility requirements and terms of use?' ) }>
 						<FoldableCard
 							header={ translate( 'Active referrals' ) }
 							expanded

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -213,7 +213,6 @@ export default function LayoutBodyContent( {
 					<>
 						{ ! isAutomatedReferral && <MigrationOffer /> }
 						<StepSection
-							applyCoreStyles
 							heading={
 								isAutomatedReferral
 									? translate( 'How do I start?' )
@@ -221,7 +220,6 @@ export default function LayoutBodyContent( {
 							}
 						>
 							<StepSectionItem
-								applyCoreStyles
 								isNewLayout={ isAutomatedReferral }
 								icon={ tipaltiLogo }
 								heading={
@@ -268,7 +266,6 @@ export default function LayoutBodyContent( {
 							/>
 							{ isAutomatedReferral ? (
 								<StepSectionItem
-									applyCoreStyles
 									iconClassName="referrals-overview__opacity-70-percent"
 									isNewLayout
 									icon={ reusableBlock }
@@ -285,7 +282,6 @@ export default function LayoutBodyContent( {
 								/>
 							) : (
 								<StepSectionItem
-									applyCoreStyles
 									iconClassName="referrals-overview__opacity-70-percent"
 									icon={ plugins }
 									heading={ translate( 'Verify your relationship with your clients' ) }
@@ -301,7 +297,6 @@ export default function LayoutBodyContent( {
 								/>
 							) }
 							<StepSectionItem
-								applyCoreStyles
 								isNewLayout={ isAutomatedReferral }
 								className="referrals-overview__step-section-woo-payments"
 								icon={ <WooLogo /> }
@@ -343,7 +338,6 @@ export default function LayoutBodyContent( {
 						</StepSection>
 						{ isAutomatedReferral && (
 							<StepSection
-								applyCoreStyles
 								className="referrals-overview__step-section-learn-more"
 								heading={ translate( 'Find out more' ) }
 							>

--- a/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/get-started/index.tsx
@@ -58,9 +58,8 @@ export default function GetStarted() {
 					) }
 				</div>
 
-				<StepSection applyCoreStyles heading={ translate( 'How do I start?' ) }>
+				<StepSection heading={ translate( 'How do I start?' ) }>
 					<StepSectionItem
-						applyCoreStyles
 						isNewLayout
 						stepNumber={ 1 }
 						heading={ translate( 'Invite a team member' ) }
@@ -88,7 +87,7 @@ export default function GetStarted() {
 					/>
 				</StepSection>
 
-				<StepSection applyCoreStyles heading={ translate( 'Learn more about team members' ) }>
+				<StepSection heading={ translate( 'Learn more about team members' ) }>
 					<Button
 						className="team-list-get-started__learn-more-button"
 						variant="link"

--- a/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-accept-invite/no-multi-agency-message.tsx
@@ -51,7 +51,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 				) }
 			</div>
 
-			<StepSection applyCoreStyles heading={ translate( 'How to fix this:' ) }>
+			<StepSection heading={ translate( 'How to fix this:' ) }>
 				<StepSectionItem
 					isNewLayout
 					stepNumber={ 1 }
@@ -100,7 +100,7 @@ export default function NoMultiAgencyMessage( { currentAgency, targetAgency }: P
 				/>
 			</StepSection>
 
-			<StepSection applyCoreStyles heading={ translate( 'Learn more about Agency membership' ) }>
+			<StepSection heading={ translate( 'Learn more about Agency membership' ) }>
 				<Button
 					className="team-accept-invite__learn-more-button"
 					variant="link"

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/consolidated-views.tsx
@@ -21,7 +21,6 @@ const WooPaymentsConsolidatedViews = () => {
 	return (
 		<ConsolidatedStatsGroup className="consolidated-view">
 			<ConsolidatedStatsCard
-				applyCoreStyles
 				value={ formatCurrency( totalCommission, 'USD' ) }
 				footerText={ translate( 'Total WooPayments commissions paid' ) }
 				popoverTitle={ translate( 'Total WooPayments commissions paid' ) }
@@ -38,7 +37,6 @@ const WooPaymentsConsolidatedViews = () => {
 				isLoading={ isLoadingWooPaymentsData }
 			/>
 			<ConsolidatedStatsCard
-				applyCoreStyles
 				value={ formatCurrency( expectedCommission, 'USD' ) }
 				footerText={ translate( 'Next estimated payout amount' ) }
 				popoverTitle={ translate( 'Estimated amount' ) }
@@ -62,7 +60,6 @@ const WooPaymentsConsolidatedViews = () => {
 				isLoading={ isLoadingWooPaymentsData }
 			/>
 			<ConsolidatedStatsCard
-				applyCoreStyles
 				value={ nextPayoutDate + '*' }
 				footerText={ translate( 'Next estimated payout date' ) }
 				popoverTitle={ translate( 'Estimated date' ) }

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -325,18 +325,10 @@ const WooPaymentsDashboardEmptyState = () => {
 				} }
 			>
 				<PageSectionColumns.Column>
-					<SimpleList
-						className="woopayments-dashboard-empty-state__list"
-						applyCoreStyles
-						items={ listItems1 }
-					/>
+					<SimpleList className="woopayments-dashboard-empty-state__list" items={ listItems1 } />
 				</PageSectionColumns.Column>
 				<PageSectionColumns.Column>
-					<SimpleList
-						className="woopayments-dashboard-empty-state__list"
-						applyCoreStyles
-						items={ listItems2 }
-					/>
+					<SimpleList className="woopayments-dashboard-empty-state__list" items={ listItems2 } />
 				</PageSectionColumns.Column>
 			</PageSectionColumns>
 

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -176,9 +176,8 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 								'Follow the steps below to complete the process so you can earn commissions.'
 							) }
 						</div>
-						<StepSection applyCoreStyles heading={ translate( 'Next steps' ) }>
+						<StepSection heading={ translate( 'Next steps' ) }>
 							<StepSectionItem
-								applyCoreStyles
 								isNewLayout
 								heading={ translate( 'Install and activate the plugin on WP-Admin' ) }
 								description={
@@ -227,7 +226,6 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 								}
 							/>
 							<StepSectionItem
-								applyCoreStyles
 								isNewLayout
 								heading={ translate( 'Earn commissions' ) }
 								description={


### PR DESCRIPTION
Previously, we introduced a temporary `applyCoreStyle` prop to certain comments for selective updates on specific pages. Since all pages are now utilizing the core style, this prop is no longer necessary.
<img width="2159" alt="Screenshot 2025-03-18 at 6 42 40 PM" src="https://github.com/user-attachments/assets/c033cffd-0ee6-4927-b46b-26b413e5d3be" />
<img width="577" alt="Screenshot 2025-03-18 at 6 42 48 PM" src="https://github.com/user-attachments/assets/ae96c47a-b1de-4e88-a0c0-3c755fa14ed0" />
<img width="780" alt="Screenshot 2025-03-18 at 6 45 40 PM" src="https://github.com/user-attachments/assets/4e9022e1-c3ca-4828-a3d4-59fa43d48c06" />

## Proposed Changes

* Remove the `applyCoreStyle` prop and make the core style non-optional.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Utilize the live link to investigate the impacted components.
* Confirm that the three components remain unchanged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
