### PR TITLE
Stats: Fix "Stats: Resolve unexpected back actions after chart arrow navigation"

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -123,6 +123,7 @@ const StatsDateControl = ( {
 		const queryParamsObject = qs.parse( queryParams );
 		removeOutOfRangeStartDate( queryParamsObject, startDate, endDate );
 		delete queryParamsObject.shortcut;
+		delete queryParamsObject.navigation;
 
 		const dateRangeParams = Object.assign( {}, queryParamsObject, {
 			chartStart: startDate,

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -577,6 +577,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 							period={ period }
 							date={ date }
 							query={ query }
+							queryParams={ context.query }
 							statsType="statsTopPosts"
 							showQueryDate
 							isShort

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -24,6 +24,7 @@ class StatsDatePicker extends Component {
 		period: PropTypes.string.isRequired,
 		summary: PropTypes.bool,
 		query: PropTypes.object,
+		queryParams: PropTypes.object,
 		statType: PropTypes.string,
 		isActivity: PropTypes.bool,
 		showQueryDate: PropTypes.bool,

--- a/client/my-sites/stats/stats-date-picker/with-is-drilling-down-hook.tsx
+++ b/client/my-sites/stats/stats-date-picker/with-is-drilling-down-hook.tsx
@@ -2,6 +2,10 @@ import { useMemo } from 'react';
 
 interface WithIsDrillingDownHookProps {
 	period: string;
+	queryParams: {
+		// Used to refresh isDrillingDown when navigating by clicking arrows.
+		navigation?: string;
+	};
 	isDrillingDown: string | null;
 }
 
@@ -16,7 +20,7 @@ function withIsDrillingDownHook( Component: React.ComponentType< WithIsDrillingD
 	return function WrappedComponent( props: WithIsDrillingDownHookProps ) {
 		const isDrillingDown = useMemo( () => {
 			return sessionStorage.getItem( 'jetpack_stats_date_range_is_drilling_down' );
-		}, [ props.period ] ); // eslint-disable-line react-hooks/exhaustive-deps
+		}, [ props.period, props.queryParams.navigation ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 		return <Component { ...props } isDrillingDown={ isDrillingDown } />;
 	};

--- a/client/my-sites/stats/stats-date-picker/with-is-drilling-down-hook.tsx
+++ b/client/my-sites/stats/stats-date-picker/with-is-drilling-down-hook.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 interface WithIsDrillingDownHookProps {
 	period: string;
-	queryParams: {
+	queryParams?: {
 		// Used to refresh isDrillingDown when navigating by clicking arrows.
 		navigation?: string;
 	};
@@ -20,7 +20,7 @@ function withIsDrillingDownHook( Component: React.ComponentType< WithIsDrillingD
 	return function WrappedComponent( props: WithIsDrillingDownHookProps ) {
 		const isDrillingDown = useMemo( () => {
 			return sessionStorage.getItem( 'jetpack_stats_date_range_is_drilling_down' );
-		}, [ props.period, props.queryParams.navigation ] ); // eslint-disable-line react-hooks/exhaustive-deps
+		}, [ props.period, props.queryParams?.navigation ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 		return <Component { ...props } isDrillingDown={ isDrillingDown } />;
 	};

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -241,7 +241,10 @@ class StatsPeriodNavigation extends PureComponent {
 		const chartEnd = navigationEnd.format( 'YYYY-MM-DD' );
 
 		const path = `/stats/${ period }/${ slug }`;
-		const url = getPathWithUpdatedQueryString( { chartStart, chartEnd }, path );
+		const url = getPathWithUpdatedQueryString(
+			{ chartStart, chartEnd, navigation: 'arrow' },
+			path
+		);
 
 		page( url );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101503, https://github.com/Automattic/wp-calypso/pull/101504

## Proposed Changes

* Cherry-pick the original PR commit along with the fix.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Restore the reverted changes with the fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the testing instructions of https://github.com/Automattic/wp-calypso/pull/101239 and make sure the error `TypeError: Cannot read properties of undefined (reading 'navigation')` does not occur.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
