### PR TITLE
Help Center: Minor refactor to remove extra state

### DIFF
--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -202,13 +202,17 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 							);
 						} ) }
 						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.provider === 'odie' && <ViewMostRecentOpenConversationNotice /> }
-						{ chat.status === 'dislike' && ! removeDislikeStatus && <DislikeThumb /> }
-						{ availableStatusWithFeedback.includes( chat.status ) && (
-							<div className="odie-chatbox__action-message">
-								{ chat.status === 'sending' && <ThinkingPlaceholder /> }
-								{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }
-							</div>
+						{ chat.provider === 'odie' && (
+							<>
+								<ViewMostRecentOpenConversationNotice />
+								{ chat.status === 'dislike' && ! removeDislikeStatus && <DislikeThumb /> }
+								{ availableStatusWithFeedback.includes( chat.status ) && (
+									<div className="odie-chatbox__action-message">
+										{ chat.status === 'sending' && <ThinkingPlaceholder /> }
+										{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }
+									</div>
+								) }
+							</>
 						) }
 					</>
 				) }

--- a/packages/odie-client/src/hooks/use-auto-scroll.ts
+++ b/packages/odie-client/src/hooks/use-auto-scroll.ts
@@ -16,7 +16,7 @@ export const useAutoScroll = (
 		}
 
 		const messageCount = chat.messages.length;
-		if ( messageCount < 1 || chat.status === 'loading' ) {
+		if ( messageCount < 1 || [ 'loading', 'sending' ].includes( chat.status ) ) {
 			return;
 		}
 

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -39,7 +39,6 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 	);
 
 	const [ mainChatState, setMainChatState ] = useState< Chat >( emptyChat );
-	const [ isEnabled, setIsEnabled ] = useState( true );
 	const chatStatus = mainChatState?.status;
 	const getZendeskConversation = useGetZendeskConversation();
 	const { data: odieChat, isFetching: isOdieChatLoading } = useOdieChat( Number( odieId ) );
@@ -48,11 +47,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 	const canFetchConversation = conversationId && canConnectToZendesk;
 
 	useEffect( () => {
-		if ( isOdieChatLoading || ! isEnabled ) {
-			return;
-		}
-		if ( chatStatus === 'loaded' ) {
-			setIsEnabled( false );
+		if ( isOdieChatLoading || chatStatus !== 'loading' ) {
 			return;
 		}
 
@@ -103,8 +98,6 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 			}
 		}
 	}, [
-		isEnabled,
-		setIsEnabled,
 		isOdieChatLoading,
 		chatStatus,
 		isChatLoaded,
@@ -118,37 +111,27 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 		trackEvent,
 	] );
 
+	// This effect sets the initial loading state when interaction is set, so that the chat is loaded
 	useEffect( () => {
 		if ( ! currentSupportInteraction?.uuid ) {
 			return;
 		}
 
 		setMainChatState( ( prevChat ) => {
-			if ( ! prevChat.supportInteractionId ) {
-				if ( ! odieId && ! conversationId ) {
-					return {
-						...emptyChat,
-						supportInteractionId: currentSupportInteraction!.uuid,
-						status: 'loaded',
-					};
-				}
-
+			if ( odieId || conversationId ) {
 				return {
 					...prevChat,
 					supportInteractionId: currentSupportInteraction!.uuid,
 					status: 'loading',
 				};
 			}
-			const isSameInteraction = prevChat.supportInteractionId === currentSupportInteraction!.uuid;
-			if ( ! isSameInteraction ) {
-				return {
-					...emptyChat,
-					supportInteractionId: currentSupportInteraction!.uuid,
-					status: 'loaded',
-				};
-			}
 
-			return { ...prevChat };
+			// empty chat nothing to load
+			return {
+				...emptyChat,
+				supportInteractionId: currentSupportInteraction!.uuid,
+				status: 'loaded',
+			};
 		} );
 	}, [ currentSupportInteraction?.uuid, odieId, conversationId ] );
 

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -119,6 +119,14 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 
 		setMainChatState( ( prevChat ) => {
 			if ( odieId || conversationId ) {
+				// when we have the same support interaction we don't need to load the messages
+				if ( prevChat?.supportInteractionId === currentSupportInteraction!.uuid ) {
+					return {
+						...prevChat,
+						status: 'loaded',
+					};
+				}
+
 				return {
 					...prevChat,
 					supportInteractionId: currentSupportInteraction!.uuid,

--- a/packages/odie-client/src/hooks/use-send-zendesk-message.ts
+++ b/packages/odie-client/src/hooks/use-send-zendesk-message.ts
@@ -23,7 +23,7 @@ export const useSendZendeskMessage = () => {
 
 	const conversationId = currentConversationId || chat.conversationId;
 	return async ( message: Message ) => {
-		setChatStatus( 'loading' );
+		setChatStatus( 'sending' );
 
 		if ( ! conversationId ) {
 			// Start a new conversation if it doesn't exist


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1742264733581789-slack-C02T4NVL4JJ

## Proposed Changes

The logic to assemble the chat messages is quite complex, and really prone to errors. This PR simplifies things and fixes a bug that happened when clicking on "View conversation" 

<img width="449" alt="image" src="https://github.com/user-attachments/assets/10d87c81-1b1b-4e6f-b638-035b7087adf2" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new paid user
* Open the Help Center and chat with Odie.
* Ask to talk with a human.
* Click the ellipsis menu icon in the header and start a new chat with Odie (AI)
* You should see the notice
* Clicking on that you should be brought to your old, open, chat
