### PR TITLE
Reader Editor: Add link to open full editor

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -6,7 +6,8 @@ import {
 	loadBlocksWithCustomizations,
 	loadTextFormatting,
 } from '@automattic/verbum-block-editor';
-import { Button } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
+import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -148,6 +149,10 @@ function QuickPost( {
 		return translate( 'Post' );
 	};
 
+	const handleFullEditorClick = () => {
+		recordReaderTracksEvent( 'calypso_reader_quick_post_full_editor_opened' );
+	};
+
 	if ( ! hasLoaded ) {
 		return (
 			<div className="quick-post-input quick-post-input--loading">
@@ -171,6 +176,18 @@ function QuickPost( {
 						onSiteSelect={ handleSiteSelect }
 						isPlaceholder={ ! hasLoaded }
 					/>
+					<div>
+						<a
+							href={ selectedSiteId ? `/post/${ selectedSiteId }?type=post` : '/post' }
+							className="quick-post-input__open-full-editor-link"
+							target="_blank"
+							rel="noreferrer"
+							onClick={ handleFullEditorClick }
+						>
+							{ translate( 'Open Full Editor' ) }
+							<Icon icon={ external } />
+						</a>
+					</div>
 				</div>
 				<div className="verbum-editor-wrapper" ref={ editorRef }>
 					<Editor

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -6,11 +6,13 @@ import {
 	loadBlocksWithCustomizations,
 	loadTextFormatting,
 } from '@automattic/verbum-block-editor';
-import { Button, Icon } from '@wordpress/components';
-import { external } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { stripHTML } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
@@ -65,6 +67,8 @@ function QuickPost( {
 	const currentUser = useSelector( getCurrentUser );
 	const hasLoaded = useSelector( hasLoadedSites );
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
+	const [ isMenuVisible, setIsMenuVisible ] = useState( false );
+	const popoverButtonRef = useRef< HTMLButtonElement >( null );
 
 	useEffect( () => {
 		if ( postContent ) {
@@ -153,6 +157,9 @@ function QuickPost( {
 		recordReaderTracksEvent( 'calypso_reader_quick_post_full_editor_opened' );
 	};
 
+	const toggleMenu = () => setIsMenuVisible( ! isMenuVisible );
+	const closeMenu = () => setIsMenuVisible( false );
+
 	if ( ! hasLoaded ) {
 		return (
 			<div className="quick-post-input quick-post-input--loading">
@@ -176,17 +183,30 @@ function QuickPost( {
 						onSiteSelect={ handleSiteSelect }
 						isPlaceholder={ ! hasLoaded }
 					/>
-					<div>
-						<a
-							href={ selectedSiteId ? `/post/${ selectedSiteId }?type=post` : '/post' }
-							className="quick-post-input__open-full-editor-link"
-							target="_blank"
-							rel="noreferrer"
-							onClick={ handleFullEditorClick }
+					<div className="quick-post-input__actions-menu">
+						<Button
+							ref={ popoverButtonRef }
+							icon={ moreVertical }
+							onClick={ toggleMenu }
+							aria-expanded={ isMenuVisible }
+							className="quick-post-input__actions-toggle"
+						/>
+						<PopoverMenu
+							context={ popoverButtonRef.current }
+							isVisible={ isMenuVisible }
+							onClose={ closeMenu }
+							position="bottom"
+							className="quick-post-input__popover"
 						>
-							{ translate( 'Open Full Editor' ) }
-							<Icon icon={ external } />
-						</a>
+							<PopoverMenuItem
+								href={ selectedSiteId ? `/post/${ selectedSiteId }?type=post` : '/post' }
+								target="_blank"
+								rel="noreferrer"
+								onClick={ handleFullEditorClick }
+							>
+								{ translate( 'Open Full Editor' ) }
+							</PopoverMenuItem>
+						</PopoverMenu>
 					</div>
 				</div>
 				<div className="verbum-editor-wrapper" ref={ editorRef }>

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -13,6 +13,9 @@
 
 	&__site-select-wrapper {
 		margin-bottom: 16px;
+		display: flex;
+		justify-content: space-between;
+		align-items: end;
 
 		.sites-dropdown__wrapper {
 			border-color: var( --color-border-subtle );
@@ -27,6 +30,12 @@
 		.sites-dropdown.is-open .sites-dropdown__wrapper {
 			border-radius: 6px 6px 0 0;
 		}
+	}
+
+	&__open-full-editor-link {
+		display: flex;
+		align-items: center;
+		gap: 4px;
 	}
 
 	&__actions {

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -32,12 +32,6 @@
 		}
 	}
 
-	&__open-full-editor-link {
-		display: flex;
-		align-items: center;
-		gap: 4px;
-	}
-
 	&__actions {
 		display: flex;
 		justify-content: flex-end;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100867

## Proposed Changes

- Adds a link to open the full Gutenberg editor in a popover:

<img width="810" alt="Screenshot 2025-03-18 at 15 06 19" src="https://github.com/user-attachments/assets/7f3dd25c-811b-499a-95a2-497a199bffb4" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Part of ongoing updates to the quick edit

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader`
- Open the Quick Edit
- Click on the vertical menu and "Open Full Editor"
- Ensure you navigate to the Gutenberg editor for your currently selected site
- For this v1, the editor should just be blank

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
