### PR TITLE
Auto select the plataform on the Import step

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon, FormLabel, SelectDropdown } from '@automattic/compone
 import { Title, SubTitle } from '@automattic/onboarding';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
 	getImportersAsImporterOption,
@@ -38,6 +39,7 @@ export default function ListStep( props: Props ) {
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 	const fromSite = urlQueryParams.get( 'from' );
+	const platform = urlQueryParams.get( 'platform' );
 	const title = props.title || __( 'Import content from another platform or file' );
 	const subTitle = props.subTitle || __( "Select the platform you're coming from" );
 
@@ -59,6 +61,17 @@ export default function ListStep( props: Props ) {
 		);
 		submit?.( { platform, url: importerUrl } );
 	};
+
+	useEffect( () => {
+		if ( platform ) {
+			const foundPlatform = [ ...primaryListOptions, ...secondaryListOptions ].find(
+				( x ) => x.value === platform
+			);
+			if ( foundPlatform ) {
+				onImporterSelect( foundPlatform.value );
+			}
+		}
+	}, [ platform, submit, onImporterSelect, primaryListOptions, secondaryListOptions ] );
 
 	return (
 		<>

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -2,7 +2,6 @@ import { Button, Gridicon, FormLabel, SelectDropdown } from '@automattic/compone
 import { Title, SubTitle } from '@automattic/onboarding';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
 	getImportersAsImporterOption,
@@ -39,7 +38,6 @@ export default function ListStep( props: Props ) {
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 	const fromSite = urlQueryParams.get( 'from' );
-	const platform = urlQueryParams.get( 'platform' );
 	const title = props.title || __( 'Import content from another platform or file' );
 	const subTitle = props.subTitle || __( "Select the platform you're coming from" );
 
@@ -61,17 +59,6 @@ export default function ListStep( props: Props ) {
 		);
 		submit?.( { platform, url: importerUrl } );
 	};
-
-	useEffect( () => {
-		if ( platform ) {
-			const foundPlatform = [ ...primaryListOptions, ...secondaryListOptions ].find(
-				( x ) => x.value === platform
-			);
-			if ( foundPlatform ) {
-				onImporterSelect( foundPlatform.value );
-			}
-		}
-	}, [ platform, submit, onImporterSelect, primaryListOptions, secondaryListOptions ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -27,11 +27,30 @@ import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
+<<<<<<< HEAD
 import type {
 	AssertConditionResult,
 	FlowV2,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
+=======
+import { HOW_TO_MIGRATE_OPTIONS } from '../../../constants';
+import { useIsSiteAdmin } from '../../../hooks/use-is-site-admin';
+import { useSiteData } from '../../../hooks/use-site-data';
+import { useSiteSlugParam } from '../../../hooks/use-site-slug-param';
+import { USER_STORE, SITE_STORE, ONBOARD_STORE } from '../../../stores';
+import { goToCheckout } from '../../../utils/checkout';
+import { STEPS } from '../../internals/steps';
+import {
+	getFullImporterUrl,
+	isPlatformImportable,
+} from '../../internals/steps-repository/import/helper';
+import { getSiteIdParam } from '../../internals/steps-repository/import/util';
+import { type SiteMigrationIdentifyAction } from '../../internals/steps-repository/site-migration-identify';
+import { AssertConditionState } from '../../internals/types';
+import { goToImporter } from '../../migration/helpers';
+import type { AssertConditionResult, Flow, ProvidedDependencies } from '../../internals/types';
+>>>>>>> 3a2970d75f1 (Add a new function to handle the full path of the redirects)
 
 const BASE_STEPS = [
 	STEPS.SITE_MIGRATION_IDENTIFY,
@@ -250,14 +269,17 @@ const siteMigration: FlowV2 = {
 
 				case STEPS.PROCESSING.slug: {
 					if ( providedDependencies?.siteCreated ) {
-						if ( platformQueryParam && fromQueryParam ) {
+						if (
+							platformQueryParam &&
+							isPlatformImportable( platformQueryParam as ImporterPlatform ) &&
+							fromQueryParam
+						) {
 							return exitFlow(
-								'/setup/site-setup/' +
-									getFinalImporterUrl(
-										siteSlug,
-										fromQueryParam,
-										platformQueryParam as ImporterPlatform
-									)
+								getFullImporterUrl(
+									platformQueryParam as ImporterPlatform,
+									siteSlug,
+									fromQueryParam
+								)
 							);
 						}
 						if ( ! fromQueryParam || providedDependencies?.skipMigration ) {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -9,7 +9,10 @@ import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 //TODO: Move to a shared place
-import { getFinalImporterUrl } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
+import {
+	isPlatformImportable,
+	getFullImporterUrl,
+} from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
 import { getSiteIdParam } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -27,30 +30,11 @@ import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
-<<<<<<< HEAD
 import type {
 	AssertConditionResult,
 	FlowV2,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
-=======
-import { HOW_TO_MIGRATE_OPTIONS } from '../../../constants';
-import { useIsSiteAdmin } from '../../../hooks/use-is-site-admin';
-import { useSiteData } from '../../../hooks/use-site-data';
-import { useSiteSlugParam } from '../../../hooks/use-site-slug-param';
-import { USER_STORE, SITE_STORE, ONBOARD_STORE } from '../../../stores';
-import { goToCheckout } from '../../../utils/checkout';
-import { STEPS } from '../../internals/steps';
-import {
-	getFullImporterUrl,
-	isPlatformImportable,
-} from '../../internals/steps-repository/import/helper';
-import { getSiteIdParam } from '../../internals/steps-repository/import/util';
-import { type SiteMigrationIdentifyAction } from '../../internals/steps-repository/site-migration-identify';
-import { AssertConditionState } from '../../internals/types';
-import { goToImporter } from '../../migration/helpers';
-import type { AssertConditionResult, Flow, ProvidedDependencies } from '../../internals/types';
->>>>>>> 3a2970d75f1 (Add a new function to handle the full path of the redirects)
 
 const BASE_STEPS = [
 	STEPS.SITE_MIGRATION_IDENTIFY,

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -9,6 +9,7 @@ import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
 //TODO: Move to a shared place
+import { getFinalImporterUrl } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
 import { getSiteIdParam } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -249,6 +250,16 @@ const siteMigration: FlowV2 = {
 
 				case STEPS.PROCESSING.slug: {
 					if ( providedDependencies?.siteCreated ) {
+						if ( platformQueryParam && fromQueryParam ) {
+							return exitFlow(
+								'/setup/site-setup/' +
+									getFinalImporterUrl(
+										siteSlug,
+										fromQueryParam,
+										platformQueryParam as ImporterPlatform
+									)
+							);
+						}
 						if ( ! fromQueryParam || providedDependencies?.skipMigration ) {
 							// If we get to this point without a fromQueryParam then we are coming from a direct
 							// pick your current platform link. That's why we navigate to the importList step.

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -121,6 +121,7 @@ const siteMigration: FlowV2 = {
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
 		const actionQueryParam = urlQueryParams.get( 'action' );
+		const platformQueryParam = urlQueryParams.get( 'platform' );
 		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
 
 		const { get, sessionId } = useFlowState();
@@ -259,6 +260,7 @@ const siteMigration: FlowV2 = {
 										origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
 										backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
 										...( fromQueryParam && { from: fromQueryParam } ),
+										...( platformQueryParam && { platform: platformQueryParam } ),
 									},
 									'/setup/site-setup/importList'
 								)

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -271,7 +271,6 @@ const siteMigration: FlowV2 = {
 										origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
 										backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
 										...( fromQueryParam && { from: fromQueryParam } ),
-										...( platformQueryParam && { platform: platformQueryParam } ),
 									},
 									'/setup/site-setup/importList'
 								)

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -255,6 +255,7 @@ const siteMigration: FlowV2 = {
 					if ( providedDependencies?.siteCreated ) {
 						if (
 							platformQueryParam &&
+							platformQueryParam !== 'wordpress' &&
 							isPlatformImportable( platformQueryParam as ImporterPlatform ) &&
 							fromQueryParam
 						) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -141,7 +141,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const urlQueryParams = useQuery();
 	const skipMigration = urlQueryParams.get( 'skipMigration' ) || '';
 	const platform = urlQueryParams.get( 'platform' ) || '';
-	const { data: sourceMigrationStatus } = useSourceMigrationStatusQuery( sourceSiteSlug );
 	const useThemeHeadstart = ! isStartWritingFlow( flow ) && ! isNewHostedSiteCreationFlow( flow );
 	const shouldGoToCheckout = Boolean( planCartItem );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -140,6 +140,8 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	);
 	const urlQueryParams = useQuery();
 	const skipMigration = urlQueryParams.get( 'skipMigration' ) || '';
+	const platform = urlQueryParams.get( 'platform' ) || '';
+	const { data: sourceMigrationStatus } = useSourceMigrationStatusQuery( sourceSiteSlug );
 	const useThemeHeadstart = ! isStartWritingFlow( flow ) && ! isNewHostedSiteCreationFlow( flow );
 	const shouldGoToCheckout = Boolean( planCartItem );
 
@@ -215,6 +217,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			goToCheckout: shouldGoToCheckout,
 			siteCreated: true,
 			skipMigration,
+			platform,
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -75,3 +75,46 @@ export function generateStepPath( stepName: string, stepSectionName?: string ) {
 		}
 	}
 }
+
+/**
+ * Returns true if the platform is importable
+ *
+ * @param platform - The platform to check
+ * @returns True if the platform is importable, false otherwise
+ */
+export function isPlatformImportable( platform: ImporterPlatform ) {
+	const productImporters = getImporterEngines();
+	return productImporters.includes( platform );
+}
+
+/**
+ * Returns the full importer URL for the given platform
+ *
+ * @param platform - The platform to get the importer URL for
+ * @param targetSlug - The target slug for the importer URL
+ * @param fromSite - The from site for the importer URL
+ */
+export function getFullImporterUrl(
+	platform: ImporterPlatform,
+	targetSlug: string,
+	fromSite: string
+) {
+	if ( ! isPlatformImportable( platform ) ) {
+		return getWpOrgImporterUrl( targetSlug, platform );
+	}
+
+	const hasSiteSetupImporter = [ 'blogger', 'medium', 'squarespace', 'wix', 'wordpress' ];
+	if ( hasSiteSetupImporter.includes( platform ) ) {
+		let url = '/setup/site-setup/' + getWpComOnboardingUrl( targetSlug, platform, fromSite );
+
+		if ( platform === 'wix' ) {
+			url = addQueryArgs( url, {
+				run: true,
+			} );
+		}
+
+		return url;
+	}
+
+	return getImporterUrl( targetSlug, platform, fromSite );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100859
Depends on 177025-ghe-Automattic/wpcom

## Proposed Changes

* Added the handle for the `platform` argument that we will use to redirect the user to the appropriate import tool when they analyze the site on the `/move` page.
* Automatically selects the platform to import to.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The UX for the `/move` page when we detected that a site could not be migrated but imported was not great. We decided that we should take the user to the Import tool in that case. 
* Instead of simply showing the message to the users, we decided to redirect the users to the appropriate import tool.

## TODO

- [ ] We should come up with a strategy to not make the Import Step flicker when the user reaches it with the `platform` argument. This happens because we are performing the submit in the Import Step component. We have a few options here:
  - We could add a loading state to the Import Step component when we have the `platform` argument available.
  - We could handle the redirect to the Import Tool directly on the `hosted-site-migration` flow processing step. But this would demand a duplication of the logic already existing in the site setup.
  - Instead of redirecting the user to the `/site-setup/importList` step from the `hosted-site-migration` flow, we could redirect the user to the processing step with the platform provided and handle it in the `site-setup` flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below
* Now, we should simulate the arguments that we will get once 177025-ghe-Automattic/wpcom is merged. Navigate to:
```
/setup/hosted-site-migration/create-site?from=https%3A%2F%2Fwww.yarzatwins.com%2F&sessionId=hY&skipMigration=true&platform=squarespace
```
* This should create the site and then redirect you to the Squarespace import page.
* You can use another site in the `from` argument and change `platform` to test other flows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?