### PR TITLE
A4A: Update some Marketplace components to Core typography.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .assign-license .hosting-dashboard-layout__body {
 	padding-block-start: 16px;
@@ -37,6 +38,5 @@
 
 .assign-license__sites-no-results {
 	text-align: center;
-	font-size: 1.25rem;
-	line-height: 24px;
+	@include body-x-large;
 }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -34,8 +34,7 @@
 	margin-block-start: 0.25rem;
 	color: var(--color-scary-40);
 	font-style: italic;
-	font-size: 0.875rem;
-	line-height: 14px;
+	@include body-medium;
 
 	&.hidden {
 		display: none;
@@ -174,14 +173,13 @@
 
 	h3 {
 		margin-block: 24px;
-		font-weight: 500;
-		font-size: 1rem;
+		@include heading-large;
 		color: var(--color-neutral-70);
 	}
 }
 
 .checkout__summary-notice-item {
-	font-size: 0.75rem;
+	@include body-small;
 	color: var(--color-neutral-50);
 	margin-block-end: 0.5rem;
 }
@@ -303,8 +301,7 @@
 	.checkout__summary-client-payment-notice {
 		margin-block-start: 48px;
 		color: var(--color-neutral-70);
-		font-size: rem(16px);
-		font-weight: 600;
+		@include heading-large;
 	}
 
 	.checkout__summary-notice {
@@ -327,7 +324,7 @@
 		.checkout__aside-powered-by {
 			div {
 				color: var(--color-neutral-70);
-				font-size: rem(12px);
+				@include body-small;
 			}
 
 			img {

--- a/client/a8c-for-agencies/sections/marketplace/commissions-info/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/commissions-info/style.scss
@@ -1,9 +1,10 @@
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
 .commissions-info {
 	color: var(--color-success);
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	font-weight: 500;
-	font-size: 1rem;
-	line-height: 1.5;
+	@include heading-large;
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .hosting-overview-features {
 	display: grid;
@@ -31,14 +32,10 @@
 }
 
 .hosting-overview-features__item-title {
-	font-size: rem(18px);
-	line-height: 1.4;
-	font-weight: 500;
+	@include heading-large;
 	margin-block-end: 8px;
 }
 
 .hosting-overview-features__item-description {
-	font-size: 1rem;
-	line-height: 1.6;
-	font-weight: 400;
+	@include body-large;
 }

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .hosting-overview .hosting-dashboard-layout__body-wrapper {
 	display: flex;
@@ -23,16 +24,12 @@
 }
 
 .hosting-overview__banner-title {
-	font-size: 2.25rem;
-	font-weight: 600;
-	line-height: 1.1;
+	@include heading-2x-large;
 	margin-block-end: 8px;
 }
 
 .hosting-overview__banner-subtitle {
-	font-size: 1rem;
-	font-weight: 400;
-	line-height: 1.1;
+	@include body-large;
 }
 
 .hosting-overview__footer {
@@ -41,8 +38,7 @@
 
 .hosting-overview__learn-more-link {
 	border-radius: 4px;
-	font-weight: 600;
-	font-size: 0.875rem;
+	@include heading-medium;
 	min-height: 40px;
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/style.scss
@@ -1,10 +1,11 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 @import "../mixins";
 
 .download-products-form {
 	p {
-		font-size: 1rem;
+		@include body-large;
 	}
 
 	.select-dropdown__container {
@@ -34,15 +35,15 @@
 }
 
 .download-products-form__action-items h4 {
-	font-size: 1.25rem;
+	@include heading-x-large;
 }
 
 .download-products-form__action-items h5 {
-	font-size: 1rem;
+	@include heading-large;
 }
 
 .download-products-form__action-items pre {
-	font-size: 0.875rem;
+	@include body-medium;
 	padding: 0;
 	margin-block-end: 0.6rem;
 }
@@ -100,7 +101,7 @@ p.download-products-form__description {
 	flex: 1 0 100%;
 	align-self: flex-end;
 	margin: 0 0 1rem;
-	font-size: 0.875rem;
+	@include body-medium;
 	color: var(--color-text-gray);
 
 	@include break-medium {

--- a/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/listing-section/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .listing-section {
 	margin-block-end: 20px;
@@ -12,9 +13,7 @@ h2.listing-section-title {
 	align-items: center;
 	gap: 10px;
 	margin-block-end: 10px;
-	font-size: rem(20px);
-	font-weight: 600;
-	line-height: 1.2;
+	@include heading-x-large;
 
 	hr {
 		color: var(--color-gray-5);
@@ -25,9 +24,7 @@ h2.listing-section-title {
 }
 
 p.listing-section-description {
-	font-size: rem(14px);
-	font-weight: 400;
-	line-height: 1.2;
+	@include body-medium;
 	margin-block-end: 32px;
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/mixins.scss
+++ b/client/a8c-for-agencies/sections/marketplace/mixins.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 @mixin licensing-portal-bottom-action-bar() {
 	position: fixed;
@@ -13,7 +14,7 @@
 	.button {
 		width: 100%;
 		padding: 8px 24px;
-		font-size: 1rem;
+		@include body-large;
 		white-space: nowrap;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/pressable-overview/plan-selection/style.scss
@@ -58,9 +58,7 @@
 }
 
 .pressable-overview-plan-selection__details-card-header-title {
-	font-size: 1rem;
-	line-height: 1.4;
-	font-weight: 600;
+	@include heading-large;
 }
 
 .pressable-overview-plan-selection__details-card-header-coming-soon {
@@ -88,16 +86,12 @@
 }
 
 .pressable-overview-plan-selection__details-card-header-price-value {
-	font-size: 2rem;
-	line-height: 1;
-	font-weight: 600;
+	@include heading-x-large;
 	display: block;
 }
 
 .pressable-overview-plan-selection__details-card-header-price-interval {
-	font-size: 0.75rem;
-	line-height: 0.85;
-	font-weight: 400;
+	@include body-medium;
 	color: var(--color-neutral-60);
 }
 
@@ -105,8 +99,7 @@
 	display: flex;
 	justify-content: center;
 	border-radius: 4px;
-	font-weight: 600;
-	font-size: 0.875rem;
+	@include heading-medium;
 	min-height: 40px;
 }
 
@@ -196,9 +189,7 @@
 
 .theme-a8c-for-agencies .components-button.pressable-overview-plan-selection__filter-button {
 	border: 1.5px solid var(--color-surface-backdrop);
-	font-size: 0.875rem;
-	font-weight: 600;
-	line-height: 1.1;
+	@include heading-medium;
 
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 29px;
@@ -227,7 +218,7 @@
 .a4a-pressable-filter-wrapper-visits {
 	@include breakpoint-deprecated( "<660px" ) {
 		.a4a-slider__marker-label {
-			font-size: 0.75rem;
+			@include body-medium;
 		}
 	}
 }
@@ -277,8 +268,7 @@
 	}
 
 	.pressable-overview-plan-selection__upgrade-title {
-		font-size: 2rem;
-		font-weight: bold;
+		@include heading-2x-large;
 		text-align: center;
 		margin-block: 56px 32px;
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/product-price-with-discount-info/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/product-price-with-discount-info/style.scss
@@ -1,9 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .product-price-with-discount__price {
-	font-size: 1.25rem;
-	font-weight: 600;
+	@include heading-x-large;
 	color: var(--studio-gray-80);
 	line-height: 1;
 
@@ -13,36 +13,31 @@
 
 	.product-price-with-discount__price-old {
 		text-decoration: line-through;
-		font-weight: 400;
-		font-size: 1rem;
+		@include body-large;
 		text-wrap: nowrap;
 	}
 
 	.product-price-with-discount__free {
 		margin-block-end: 1.5rem;
-		font-size: 1.5rem;
-		font-weight: 700;
+		@include heading-x-large;
 		color: var(--studio-black);
 	}
 
 	.product-price-with-discount__price-discount {
 		margin-inline-start: 8px;
-		font-size: 1rem;
-		font-weight: 500;
+		@include heading-large;
 		color: var(--color-link);
 		text-wrap: nowrap;
 	}
 
 	@include break-xlarge {
-		font-size: 1.5rem;
-		font-weight: 700;
+		@include heading-x-large;
 		color: var(--studio-black);
 	}
 }
 
 .product-price-with-discount__price-interval {
-	font-size: 0.75rem;
-	font-weight: 400;
+	@include body-medium;
 	color: var(--studio-gray-60);
 	line-height: 2;
 }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
@@ -115,12 +115,11 @@ $woocommerce-purple-50: #720EEC;
 	display: block;
 	justify-content: center;
 	text-align: center;
-	font-size: 1rem;
+	@include body-large;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		padding: 7px 12px;
-		font-size: 0.75rem;
-		font-weight: 600;
+		@include heading-medium;
 		height: 2rem;
 	}
 }
@@ -224,8 +223,7 @@ $woocommerce-purple-50: #720EEC;
 	}
 
 	.form-label {
-		font-size: 1rem;
-		line-height: 1.2;
+		@include body-large;
 		margin: 0;
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-filter/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .product-filter {
 	max-height: 33px;
@@ -47,7 +48,7 @@
 .product-filter-button {
 	white-space: nowrap;
 	max-height: 36px;
-	font-size: rem(13px);
+	@include body-small;
 	cursor: pointer;
 	color: var(--color-primary-60);
 	fill: var(--color-primary-60);

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/shopping-cart-menu/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .shopping-cart__menu {
 	padding: 24px 16px 16px;
@@ -26,8 +27,7 @@
 }
 
 .shopping-cart__menu-header-title {
-	font-size: 1.5rem;
-	line-height: 1.2;
+	@include heading-x-large;
 }
 
 .shopping-cart__menu-header-close-button {
@@ -59,9 +59,7 @@
 	flex-direction: column;
 	justify-content: space-between;
 	flex-grow: 1;
-	font-size: 0.875rem;
-	line-height: 1.7;
-	font-weight: 400;
+	@include body-medium;
 }
 
 .shopping-cart__menu-list-item-price-actual {
@@ -88,9 +86,7 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	font-weight: 500;
-	font-size: 1rem;
-	line-height: 1.5;
+	@include heading-large;
 }
 
 .shopping-cart__menu-checkout-button {
@@ -98,8 +94,7 @@
 	align-items: center;
 	justify-content: center;
 	min-height: 40px;
-	font-size: rem(14px);
-	font-weight: 600;
+	@include heading-medium;
 	border-radius: 4px;
 	margin-block-start: 20px;
 }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .shopping-cart {
 	@include break-large {
@@ -9,9 +10,7 @@
 
 .badge.shopping-cart__button-badge {
 	display: flex;
-	font-size: 0.75rem;
-	font-weight: 500;
-	line-height: 1.3;
+	@include heading-small;
 	width: 18px;
 	height: 18px;
 	padding: 0;


### PR DESCRIPTION
This PR updates several Marketplace-related components to utilize the Core typography.

Follow up on https://github.com/Automattic/wp-calypso/pull/101089

## Proposed Changes

| Description | Screenshot |
|--------|--------|
| Checkout > Total summary | <img width="577" alt="Screenshot 2025-03-18 at 9 14 28 PM" src="https://github.com/user-attachments/assets/635923de-8453-4000-92e7-939d45865b98" /> |
| Shopping cart | <img width="593" alt="Screenshot 2025-03-18 at 9 16 43 PM" src="https://github.com/user-attachments/assets/174a7f47-76d0-405f-bb7f-e186d0d5099a" /> |
| Assign license and Download flow | <img width="1600" alt="Screenshot 2025-03-18 at 9 22 51 PM" src="https://github.com/user-attachments/assets/21305356-dbc4-42d6-b976-f3ba5938ec43" /> |

## Why are these changes being made?
* This initiative aims to align with the Core library.

## Testing Instructions
* Use the A4A live link to explore the pages.
* Refer to the list above for components that require testing.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
