### PR TITLE
Me: Add hover animation to cover upload button

### DIFF
--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -92,7 +92,6 @@
 	width: 100%;
 	height: 100%;
 
-	// transform: translate(180%, 180%);
 	text-align: center;
 	display: flex;
 	align-items: center;
@@ -112,14 +111,23 @@
 
 }
 
+.gravatar {
+	transition: filter 0.3s ease;
+}
+
 .edit-gravatar__image-container:hover, .is-uploading .edit-gravatar__image-container {
 	.gravatar{
 		filter: brightness(0.7);
 	}
+
+	.edit-gravatar__label-container-icon {
+		background-color: var(--color-accent-70);
+
+	}
 }
 
 .edit-gravatar__image-container .edit-gravatar__label-container-icon {
-	background-color: var(--color-accent-70);
+	background-color: var(--color-accent-60);
 	border-color: #fff;
 }
 


### PR DESCRIPTION

Related to [#](https://github.com/Automattic/wp-calypso/pull/101256)

## Proposed Changes


## Why are these changes being made?
* Fix missing hover animation
* Use the correct blue color

## Testing Instructions

* Go to `/me`
* Check the hover animation

![CleanShot 2025-03-18 at 14 03 17](https://github.com/user-attachments/assets/c1b9ee69-f950-4eab-85b3-7a6d38710377)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
