### PR TITLE
A4A: Update some Referrals page to Core typography.

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/style.scss
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/style.scss
@@ -67,7 +67,6 @@
 
 .migrations-overview-v2__popover-column-heading {
 	color: var(--color-accent-40);
-	font-size: rem(12px);
-	font-weight: 500;
+	@include heading-small;
 	margin-block-end: 8px;
 }

--- a/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/style.scss
+++ b/client/a8c-for-agencies/sections/overview/partner-directory-onboarding-card/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .partner-directory-onboarding-card {
 	.sticky-card__body {
@@ -37,8 +38,7 @@
 
 .partner-directory-onboarding-card__content-title,
 .partner-directory-onboarding-card__content-description {
-	font-size: rem(14px);
-	line-height: 1.4;
+	@include body-medium;
 }
 
 .partner-directory-onboarding-card__content-title {

--- a/client/a8c-for-agencies/sections/referrals/common/referral-details-table/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/common/referral-details-table/style.scss
@@ -1,10 +1,10 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
 
 .referrals-details-table__container {
-
 	.referrals-details-table__heading {
 		padding-block-end: 16px;
-		font-size: rem(20px);
-		font-weight: 500;
+		@include heading-x-large;
 	}
 
 	.dataviews-view-table {

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/style.scss
@@ -30,14 +30,11 @@ $iframe-background-color: #f7f7f7;
 
 .bank-details__heading {
 	padding-block: 8px;
-	font-size: rem(24px);
-	font-weight: 600;
-	line-height: 1.3;
+	@include heading-x-large;
 }
 
 .bank-details__subheading {
-	font-size: rem(16px);
-	line-height: 1.5;
+	@include body-large;
 	color: var(--color-neutral-60);
 }
 

--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
 
 .commission-overview {
 	.commission-overview__section-container {
@@ -35,16 +37,14 @@
 
 	.foldable-card__header {
 		padding: 24px 24px 16px;
-		font-size: rem(16px);
-		font-weight: 600;
+		@include heading-large;
 	}
 
 
 	.foldable-card.foldable-card__content,
 	.foldable-card.is-expanded .foldable-card__content {
-		font-size: rem(14px);
+		@include body-medium;
 		color: var(--color-neutral-50);
-		font-weight: 400;
 		padding: 0 24px 24px;
 	}
 
@@ -75,13 +75,11 @@
 }
 
 .commission-overview__section-heading {
-	font-size: rem(24px);
+	@include heading-x-large;
 	margin-block-end: 8px;
-	font-weight: 600;
 }
 .commission-overview__section-subtitle {
-	font-size: rem(14px);
-	font-weight: 400;
+	@include body-medium;
 	color: var(--color-neutral-50);
 }
 

--- a/client/a8c-for-agencies/sections/referrals/primary/footer/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/footer/style.scss
@@ -1,6 +1,8 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .referrals-footer {
-	font-size: rem(14px);
-	font-weight: 400;
+	@include body-medium;
 	margin-block-end: 48px;
 	color: var(--color-neutral-50);
 

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -24,16 +24,15 @@ $data-view-border-color: #f1f1f1;
 
 .referrals-overview__section-heading {
 	margin-block-start: 24px;
-	font-size: rem(24px);
+	@include heading-x-large;
 	margin-block-end: 8px;
-	font-weight: 600;
 }
+
 .referrals-overview__section-subtitle {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
-	font-size: rem(14px);
-	font-weight: 400;
+	@include body-medium;
 	margin-block-end: 48px;
 	color: var(--color-neutral-50);
 }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/mobile/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .referral-purchases-mobile {
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 4px;
@@ -13,20 +16,17 @@
 	}
 
 	.referral-purchases-mobile__product-name {
-		font-weight: 500;
-		font-size: 0.875rem;
+		@include heading-medium;
 		color: var(--color-gray-80);
 	}
 
 	h3 {
-		font-weight: 500;
-		font-size: rem(11px);
+		@include heading-small;
 		color: var(--color-gray-80);
 	}
 
 	p {
-		font-weight: 400;
-		font-size: rem(13px);
+		@include body-medium;
 		color: var(--color-gray-70);
 		margin: 0;
 	}

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/style.scss
@@ -1,7 +1,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .a4a-referrals-client {
-	font-size: 0.875rem;
+	@include body-medium;
 	color: var(--color-accent-80);
 }


### PR DESCRIPTION
Follow up on https://github.com/Automattic/wp-calypso/pull/101238
<img width="2492" alt="Screenshot 2025-03-18 at 10 59 54 PM" src="https://github.com/user-attachments/assets/c468e16d-5bf6-42b1-be99-3f0a039b9b3b" />
<img width="1638" alt="Screenshot 2025-03-18 at 10 59 59 PM" src="https://github.com/user-attachments/assets/1c297886-abab-4e21-af61-072785bdba99" />
<img width="816" alt="Screenshot 2025-03-18 at 11 00 11 PM" src="https://github.com/user-attachments/assets/30ec0ad4-fd3d-4694-b8c6-7b195d2776ea" />

## Proposed Changes
* Update all components in the Referrals page to use the Core's typography.


## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions
* Use the A4A live link and go to the /referrals page.
* Verify that the font sizes are close to the design. Expect some slight changes in the size, but it should be close enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
