### PR TITLE
Inform user whether security keys are configured on the security checkup

### DIFF
--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -65,7 +65,7 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 
 				description = hasTwoStepSecurityKeyEnabled
 					? translate(
-							'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}, and security keys have been configured.',
+							'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}, and security keys have been registered.',
 							options
 					  )
 					: translate(
@@ -81,7 +81,7 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 
 				description = hasTwoStepSecurityKeyEnabled
 					? translate(
-							'You have two-step authentication {{strong}}enabled{{/strong}} using an app, and security keys have been configured.',
+							'You have two-step authentication {{strong}}enabled{{/strong}} using an app, and security keys have been registered.',
 							options
 					  )
 					: translate(

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -14,6 +14,8 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		areUserSettingsLoaded: PropTypes.bool,
 		hasTwoStepEnabled: PropTypes.bool,
 		hasTwoStepSmsEnabled: PropTypes.bool,
+		hasTwoStepSecurityKeyEnabled: PropTypes.bool,
+		hasTwoStepEnhancedSecurity: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
 		twoStepSmsPhoneNumber: PropTypes.string,
 	};
@@ -25,6 +27,8 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 			hasTwoStepSmsEnabled,
 			translate,
 			twoStepSmsPhoneNumber,
+			hasTwoStepSecurityKeyEnabled,
+			hasTwoStepEnhancedSecurity,
 		} = this.props;
 
 		if ( ! areUserSettingsLoaded ) {
@@ -34,32 +38,62 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		let icon;
 		let description;
 
-		if ( hasTwoStepSmsEnabled ) {
+		if ( ! hasTwoStepSmsEnabled && ! hasTwoStepEnabled ) {
+			icon = getWarningIcon();
+			description = translate( 'You do not have two-step authentication enabled.' );
+		} else {
 			icon = getOKIcon();
-			description = translate(
-				'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}.',
-				{
+
+			if ( hasTwoStepSmsEnabled ) {
+				const options = {
 					args: {
 						phoneNumber: twoStepSmsPhoneNumber,
 					},
 					components: {
 						strong: <strong />,
 					},
+				};
+
+				if ( hasTwoStepSecurityKeyEnabled ) {
+					description = translate(
+						'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}, and security keys have been configured.',
+						options
+					);
+				} else if ( hasTwoStepEnhancedSecurity ) {
+					description = translate(
+						'You have two-step authentication {{strong}}enabled{{/strong}} using security keys.',
+						options
+					);
+				} else {
+					description = translate(
+						'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}.',
+						options
+					);
 				}
-			);
-		} else if ( hasTwoStepEnabled ) {
-			icon = getOKIcon();
-			description = translate(
-				'You have two-step authentication {{strong}}enabled{{/strong}} using an app.',
-				{
+			} else if ( hasTwoStepEnabled ) {
+				const options = {
 					components: {
 						strong: <strong />,
 					},
+				};
+
+				if ( hasTwoStepSecurityKeyEnabled ) {
+					description = translate(
+						'You have two-step authentication {{strong}}enabled{{/strong}} using an app, and security keys have been configured.',
+						options
+					);
+				} else if ( hasTwoStepEnhancedSecurity ) {
+					description = translate(
+						'You have two-step authentication {{strong}}enabled{{/strong}} using security keys.',
+						options
+					);
+				} else {
+					description = translate(
+						'You have two-step authentication {{strong}}enabled{{/strong}} using an app.',
+						options
+					);
 				}
-			);
-		} else {
-			icon = getWarningIcon();
-			description = translate( 'You do not have two-step authentication enabled.' );
+			}
 		}
 
 		return (
@@ -78,4 +112,6 @@ export default connect( ( state ) => ( {
 	hasTwoStepEnabled: isTwoStepEnabled( state ),
 	hasTwoStepSmsEnabled: isTwoStepSmsEnabled( state ),
 	twoStepSmsPhoneNumber: getUserSetting( state, 'two_step_sms_phone_number' ),
+	hasTwoStepSecurityKeyEnabled: getUserSetting( state, 'two_step_security_key_enabled' ),
+	hasTwoStepEnhancedSecurity: getUserSetting( state, 'two_step_enhanced_security' ),
 } ) )( localize( SecurityCheckupTwoFactorAuthentication ) );

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -44,7 +44,16 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		} else {
 			icon = getOKIcon();
 
-			if ( hasTwoStepSmsEnabled ) {
+			if ( hasTwoStepEnhancedSecurity ) {
+				description = translate(
+					'You have two-step authentication {{strong}}enabled{{/strong}} using security keys.',
+					{
+						components: {
+							strong: <strong />,
+						},
+					}
+				);
+			} else if ( hasTwoStepSmsEnabled ) {
 				const options = {
 					args: {
 						phoneNumber: twoStepSmsPhoneNumber,
@@ -54,22 +63,15 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 					},
 				};
 
-				if ( hasTwoStepSecurityKeyEnabled ) {
-					description = translate(
-						'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}, and security keys have been configured.',
-						options
-					);
-				} else if ( hasTwoStepEnhancedSecurity ) {
-					description = translate(
-						'You have two-step authentication {{strong}}enabled{{/strong}} using security keys.',
-						options
-					);
-				} else {
-					description = translate(
-						'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}.',
-						options
-					);
-				}
+				description = hasTwoStepSecurityKeyEnabled
+					? translate(
+							'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}, and security keys have been configured.',
+							options
+					  )
+					: translate(
+							'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}.',
+							options
+					  );
 			} else if ( hasTwoStepEnabled ) {
 				const options = {
 					components: {
@@ -77,22 +79,15 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 					},
 				};
 
-				if ( hasTwoStepSecurityKeyEnabled ) {
-					description = translate(
-						'You have two-step authentication {{strong}}enabled{{/strong}} using an app, and security keys have been configured.',
-						options
-					);
-				} else if ( hasTwoStepEnhancedSecurity ) {
-					description = translate(
-						'You have two-step authentication {{strong}}enabled{{/strong}} using security keys.',
-						options
-					);
-				} else {
-					description = translate(
-						'You have two-step authentication {{strong}}enabled{{/strong}} using an app.',
-						options
-					);
-				}
+				description = hasTwoStepSecurityKeyEnabled
+					? translate(
+							'You have two-step authentication {{strong}}enabled{{/strong}} using an app, and security keys have been configured.',
+							options
+					  )
+					: translate(
+							'You have two-step authentication {{strong}}enabled{{/strong}} using an app.',
+							options
+					  );
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/87021

## Proposed Changes

* Inform user whether security keys are configured or enabled on the security checkup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Create a new user and activate the account, otherwise you can't set 2FA
* Go to `/me/security`
* Check that under `Two-Step Authentication` you see `You do not have two-step authentication enabled`
![image](https://github.com/user-attachments/assets/b32a013b-2957-4e0e-9984-4729f78e8580)
* Click on `Two-Step Authentication`
* Set it up using an app and go back to `/me/security`
* Check that under `Two-Step Authentication` you see `You have two-step authentication enabled using an app`
![image](https://github.com/user-attachments/assets/02e1113b-bf0c-4510-8c97-121375867401)
* Click on `Two-Step Authentication`
* Click on `Register key`
* Register a key and go back to `/me/security`
* Check that under `Two-Step Authentication` you see `You have two-step authentication enabled using an app, and security keys have been registered.`
![image](https://github.com/user-attachments/assets/be00f323-743a-4114-8fc3-cf9775dd7a23)
* Click on `Two-Step Authentication`
* Enable `Enhanced account security` and go back to `/me/security`
* Check that under `Two-Step Authentication` you see `You have two-step authentication enabled using security keys.`
![image](https://github.com/user-attachments/assets/20a32030-9318-4bec-8257-bae1f5d01abe)

* Click on `Two-Step Authentication`
* Disable `Enhanced account security`, delete the security key, and Disable two-step authentication
* Now set it up using SMS and go back to `/me/security`
* Check that under `Two-Step Authentication` you see `You have two-step authentication enabled using SMS messages to {PHONE_NUMBER}.`
![image](https://github.com/user-attachments/assets/b4c5584b-d357-42d6-ad04-be275fd08b71)
* Click on `Two-Step Authentication`
* Click on `Register key`
* Register a key and go back to `/me/security`
* Check that under `Two-Step Authentication` you see `You have two-step authentication enabled using SMS messages to {PHONE_NUMBER}, and security keys have been registered.`
![image](https://github.com/user-attachments/assets/30530be8-6cb0-45f4-9179-7a08a6f456f2)
* Click on `Two-Step Authentication`
* Enable `Enhanced account security` and go back to `/me/security`
* Check that under `Two-Step Authentication` you see `You have two-step authentication enabled using security keys.`
![image](https://github.com/user-attachments/assets/20a32030-9318-4bec-8257-bae1f5d01abe)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
