### PR TITLE
Reader: add check on immutablity

### DIFF
--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -170,7 +170,7 @@ function ReaderListEdit( props ) {
 								>
 									{ translate( 'Export' ) }
 								</NavItem>
-								{ list.is_public !== 2 && (
+								{ ! list?.is_immutable && (
 									<NavItem
 										selected={ selectedSection === 'delete' }
 										path={ `/reader/list/${ props.owner }/${ props.slug }/delete` }

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -13,6 +13,7 @@ import FormTextarea from 'calypso/components/forms/form-textarea';
 const INITIAL_UPDATE_FORM_STATE = {
 	description: '',
 	is_public: true,
+	is_immutable: false,
 	title: '',
 };
 const INITIAL_CREATE_FORM_STATE = {
@@ -26,8 +27,8 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list = {
 		isCreateForm ? INITIAL_CREATE_FORM_STATE : { ...INITIAL_UPDATE_FORM_STATE, ...list }
 	);
 
-	// If list.is_public is 2 this list is permanent - render minimal form with no edit options
-	if ( list.is_public === 2 ) {
+	// If list.is_immutable this list is permanent - render minimal form with no edit options
+	if ( list?.is_immutable ) {
 		return (
 			<Card>
 				<FormFieldset>

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -83,7 +83,7 @@ class ListStream extends Component {
 				/>
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader
-					isPublic={ list?.is_public === 1 }
+					isPublic={ list?.is_public }
 					icon={
 						<svg
 							className={ listStreamIconClasses }

--- a/client/state/reader/lists/schema.js
+++ b/client/state/reader/lists/schema.js
@@ -13,6 +13,7 @@ export const itemsSchema = {
 				owner: { type: 'string' },
 				is_owner: { type: 'boolean' },
 				is_public: { type: 'boolean' },
+				is_immutable: { type: 'boolean' },
 			},
 		},
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/101387

## Proposed Changes

* Adds check on new `is_immutable` list property to know when to hide delete and edit form fields. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the patch 177421-ghe-Automattic/wpcom
* Sandbox public-api.wordpress.com
* Create test list - set to private - confirm list is private (should see lock icon below)
* Set to public - confirm lock icon isn't visible

<img width="227" alt="Screenshot 2025-03-18 at 21 30 30" src="https://github.com/user-attachments/assets/3055472e-c636-4207-b4b3-c6477f40a3e7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?