### PR TITLE
Site Migration flow: Update copy for DIY pending migrations in the hosting overview

### DIFF
--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -32,12 +32,21 @@ const getContinueMigrationUrl = ( site: SiteDetails ): string | null => {
 
 export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	const translate = useTranslate();
+	const migrationType = getMigrationType( site );
 	const continueMigrationUrl = getContinueMigrationUrl( site );
 
 	const title = translate( 'Your WordPress site is ready to be migrated' );
-	const subTitle = translate(
-		'Start your migration today and get ready for unmatched WordPress hosting.'
-	);
+	const subTitle =
+		'diy' === migrationType
+			? translate(
+					'Complete your migration in the {{strong}}Migrate to WordPress.com{{/strong}} plugin and get ready for unmatched WordPress hosting.',
+					{
+						components: {
+							strong: <strong />,
+						},
+					}
+			  )
+			: translate( 'Start your migration today and get ready for unmatched WordPress hosting.' );
 
 	const {
 		isModalVisible: isCancellationModalVisible,
@@ -85,7 +94,9 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 				{ continueMigrationUrl && (
 					<div className="migration-pending__buttons">
 						<HostingHeroButton href={ continueMigrationUrl }>
-							{ translate( 'Start your migration' ) }
+							{ 'diy' === migrationType
+								? translate( 'Complete your migration' )
+								: translate( 'Start your migration' ) }
 						</HostingHeroButton>
 						<Button
 							variant="link"

--- a/client/sites/overview/components/migration-overview/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/test/index.tsx
@@ -37,19 +37,21 @@ jest.mock( 'calypso/state/ui/selectors', () => ( {
 const render = ( ui: React.ReactElement ) => renderWithProvider( ui );
 
 describe( 'MigrationOverview', () => {
-	const getStartMigrationLink = () => {
+	const getStartDIYMigrationLink = () => {
+		return screen.queryByRole( 'link', { name: 'Complete your migration' } );
+	};
+
+	const getStartDIFMMigrationLink = () => {
 		return screen.queryByRole( 'link', { name: 'Start your migration' } );
 	};
 
 	describe( 'DIY pending migration', () => {
-		it( 'shows the migrating pending instructions', () => {
+		it( 'shows the migration pending instructions', () => {
 			const site = buildMigrationSite( { status: 'pending', how: 'diy' } );
 
 			const { getByText } = render( <MigrationOverview site={ site } /> );
 
-			expect(
-				getByText( /Start your migration today and get ready for unmatched WordPress hosting./ )
-			).toBeVisible();
+			expect( getByText( /Complete your migration in the/ ) ).toBeVisible();
 		} );
 
 		it( 'shows a link to the instructions page', () => {
@@ -61,7 +63,7 @@ describe( 'MigrationOverview', () => {
 
 			render( <MigrationOverview site={ site } /> );
 
-			const link = getStartMigrationLink();
+			const link = getStartDIYMigrationLink();
 
 			expect( link ).toHaveAttribute(
 				'href',
@@ -90,7 +92,7 @@ describe( 'MigrationOverview', () => {
 
 			render( <MigrationOverview site={ site } /> );
 
-			const link = getStartMigrationLink();
+			const link = getStartDIFMMigrationLink();
 
 			expect( link ).toHaveAttribute(
 				'href',
@@ -113,7 +115,7 @@ describe( 'MigrationOverview', () => {
 
 			render( <MigrationOverview site={ site } /> );
 
-			expect( getStartMigrationLink() ).not.toBeInTheDocument();
+			expect( getStartDIYMigrationLink() ).not.toBeInTheDocument();
 		} );
 	} );
 
@@ -136,7 +138,7 @@ describe( 'MigrationOverview', () => {
 
 			render( <MigrationOverview site={ site } /> );
 
-			expect( getStartMigrationLink() ).not.toBeInTheDocument();
+			expect( getStartDIFMMigrationLink() ).not.toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100879

## Proposed Changes

* Updates copy for pending DIY migrations for clarity.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/100879

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/start`
* Select import/migrate at the goals step
* Input your WordPress-based test site, choose Migrate, and choose "I'll do it myself"
* Checkout and wait for the key to be retrieved on the instructions screen
* Go to `/sites` and click on your new target site to open the hosting overview
* You should see the new copy:

<img width="858" alt="Screenshot 2025-03-18 at 12 14 24 PM" src="https://github.com/user-attachments/assets/9d051d0a-e2f6-4a19-a726-5259a74070e8" />

* The copy for DIFM migrations should still look like this:

<img width="852" alt="Screenshot 2025-03-18 at 11 40 03 AM" src="https://github.com/user-attachments/assets/9b038590-dd51-4e04-b90d-ae4b1de06d48" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
