### PR TITLE
A4A: Update Sites pages to use Core's typography.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/dev-site-delete-confirmation-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/sites/dev-site-delete-confirmation-dialog/style.scss
@@ -1,10 +1,13 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .dev-site-delete-confirmation-dialog {
 	&.dialog.card {
 		max-width: 800px;
 	}
 
 	p {
-		font-size: 1rem;
+		@include body-large;
 		margin-bottom: 1rem;
 	}
 
@@ -13,8 +16,7 @@
 		margin-bottom: 0;
 
 		label {
-			font-size: 1rem;
-			font-weight: 500;
+			@include heading-large;
 
 			strong {
 				color: var(--color-scary-50);

--- a/client/a8c-for-agencies/sections/sites/features/hosting/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/hosting/style.scss
@@ -31,22 +31,18 @@
 
 	.hosting__content-label {
 		color: var(--color-accent-60, #50575e);
-		font-size: rem(13px);
-		font-weight: 500;
-		line-height: 20px;
+		@include heading-medium;
 	}
 
 	.hosting__content-value {
 		display: flex;
 		align-items: center;
-		font-size: rem(14px);
-		font-weight: 500;
+		@include heading-medium;
 		line-height: 20px;
 	}
 
 	.hosting__content-live-text {
-		font-size: rem(12px);
-		font-weight: 500;
+		@include heading-small;
 		line-height: 20px;
 		padding: 0 10px;
 		color: var(--Green-Green-80, #00450c);

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/stats/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/stats/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .upsell-stats-card__wrapper {
 	.upsell-stats-card__features {
 		list-style: none;
@@ -28,7 +31,7 @@
 	}
 
 	.jetpack-rna-action-card__action {
-		font-size: 0.875rem;
+		@include body-medium;
 		gap: 8px;
 
 		.jetpack-rna-action-card__button {
@@ -50,7 +53,7 @@
 				box-sizing: border-box;
 				border-radius: 4px;
 				border-color: var(--color-neutral-5);
-				font-size: 1rem;
+				@include body-large;
 				padding: 8px 32px;
 				border-style: solid;
 				border-width: 1px;

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .plan-field {
 	display: flex;
@@ -31,23 +32,18 @@
 }
 
 .plan-field__name {
-	font-size: 0.875rem;
-	line-height: 1.4;
-	font-weight: 500;
+	@include heading-medium;
 }
 
 .plan-field__sub {
-	font-size: 0.75rem;
-	line-height: 1.3;
-	font-weight: 400;
+	@include body-medium;
 	color: var(--color-neutral-50);
 }
 
 .plan-field__button {
 	padding: 1px;
 	text-decoration: underline;
-	font-size: rem(13px);
-	font-weight: 400;
+	@include body-medium;
 	cursor: pointer;
 
 	@include break-medium {
@@ -61,8 +57,7 @@
 	gap: 8px;
 	align-items: center;
 	padding: 8px 16px;
-	font-size: rem(13px);
-	font-weight: 400;
+	@include body-medium;
 
 	.components-spinner {
 		margin: 0;

--- a/client/a8c-for-agencies/sections/sites/site-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-actions/style.scss
@@ -1,6 +1,7 @@
 
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .site-actions__actions-large-screen {
 	cursor: pointer;
@@ -32,7 +33,7 @@
 	border-style: solid;
 	border-color: var(--studio-gray-5);
 	border-width: 0 0 1px;
-	font-size: 0.875rem;
+	@include body-medium;
 	height: 40px;
 	box-sizing: border-box;
 	color: var(--studio-black);

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .hosting-dashboard-item-view {
 
@@ -77,7 +78,7 @@
 
 	.site-preview-pane__plugins-caption {
 		padding-top: 16px;
-		font-size: small;
+		@include body-small;
 	}
 
 	.site-preview-pane__plugins-icon {
@@ -132,7 +133,7 @@
 .site-preview-pane__stats-content {
 
 	.shortened-number {
-		font-size: 2rem;
+		@include body-x-large;
 	}
 
 	.site-expanded-content__card-content-column {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -22,8 +22,7 @@
 	overflow: hidden;
 	white-space: nowrap;
 	width: 180px;
-	font-weight: 500;
-	font-size: rem(14px);
+	@include heading-medium;
 	margin-inline-end: 16px;
 
 	.status-badge {
@@ -36,9 +35,8 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	font-size: rem(12px);
+	@include body-small;
 	color: var(--color-neutral-60);
-	font-weight: 400;
 }
 
 .sites-dataviews__site-error-indicator {

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 
 .main.hosting-dashboard-layout.sites-dashboard {
 	.hosting-dashboard-layout-column {
@@ -66,8 +66,7 @@
 		}
 
 		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-title {
-			font-size: 1.25rem;
-			font-weight: 500;
+			@include heading-x-large;
 		}
 
 		&.sites-dashboard__layout:not(.preview-hidden) .sites-overview__page-subtitle {
@@ -92,7 +91,7 @@
 					a.button.split-button__main {
 						width: auto;
 						height: auto;
-						font-size: rem(12px);
+						@include body-small;
 						line-height: 24px;
 						padding: 0 12px;
 					}
@@ -104,7 +103,7 @@
 
 				a.sites-overview__issue-license-button {
 					display: flex;
-					font-size: rem(12px);
+					@include body-small;
 					justify-content: center;
 					align-items: center;
 					height: 28px;
@@ -187,8 +186,7 @@
 
 				// FIXME: Remove this style, as the list view will likely be removed in the future.
 				.hosting-dashboard-layout__header-title {
-					font-size: rem(20px);
-					font-weight: 500;
+					@include heading-x-large;
 				}
 			}
 
@@ -201,7 +199,7 @@
 				height: 28px;
 				width: auto;
 				line-height: 11px;
-				font-size: rem(12px);
+				@include body-small;
 			}
 
 			.sites-overview__page-subtitle {
@@ -214,13 +212,12 @@
 			}
 
 			.sites-overview__page-title {
-				font-size: rem(20px);
-				font-weight: 500;
+				@include heading-x-large;
 			}
 
 			.sites-overview__issue-license-button {
 				display: flex;
-				font-size: rem(12px);
+				@include body-small;
 				justify-content: center;
 				align-items: center;
 				height: 28px;
@@ -293,8 +290,7 @@
 	}
 
 	thead .dataviews-view-table__row th span {
-		font-size: rem(11px);
-		font-weight: 500;
+		@include heading-small;
 		line-height: 20px;
 		color: var(--color-accent-80);
 	}
@@ -408,7 +404,7 @@
 		}
 
 		.sites-overview__page-title {
-			font-size: rem(24px);
+			@include heading-x-large;
 		}
 
 		.hosting-dashboard-item-view {
@@ -458,7 +454,7 @@
 
 		> a,
 		> button {
-			font-size: 1rem;
+			@include body-large;
 			box-sizing: border-box;
 			max-height: 40px;
 		}
@@ -506,8 +502,7 @@
 		background: var(--color-light-backdrop);
 		box-sizing: border-box;
 		border-radius: 12px; /* stylelint-disable-line scales/radii */
-		font-weight: 500;
-		font-size: 0.75rem;
+		@include body-small;
 		vertical-align: middle;
 		color: var(--color-accent-80);
 		border: 1px solid var(--color-accent-5);
@@ -589,7 +584,7 @@
 	.sites-overview__stats-trend .shortened-number {
 		vertical-align: middle;
 		color: var(--color-accent-80);
-		font-size: 0.75rem;
+		@include body-medium;
 	}
 	.sites-overview__disabled {
 		color: var(--color-accent-5);
@@ -612,7 +607,7 @@
 			width: calc(100% - 120px);
 			margin-inline-start: 8px;
 			margin-inline-end: 5px;
-			font-size: 1rem !important;
+			@include body-large;
 		}
 	}
 
@@ -652,7 +647,7 @@
 		justify-content: center;
 	}
 	.sites-overview__error-message {
-		font-size: 0.75rem;
+		@include body-medium;
 		color: var(--color-light-backdrop);
 		padding: 0.5em;
 		margin: auto 0;
@@ -670,7 +665,7 @@
 		}
 	}
 	.sites-overview__error-message-link {
-		font-size: 0.75rem;
+		@include body-medium;
 		color: var(--color-text-white) !important;
 		padding: 6px;
 		position: absolute;
@@ -679,7 +674,7 @@
 		font-weight: 500;
 	}
 	.sites-overview__badge {
-		font-size: 0.75rem !important;
+		@include body-medium;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -732,7 +727,7 @@
 		width: 24px;
 		height: 24px;
 		text-align: center;
-		font-size: 0.75rem;
+		@include body-medium;
 		line-height: 20px;
 		box-sizing: border-box;
 	}
@@ -781,7 +776,7 @@
 	}
 	.sites-overview__no-sites {
 		text-align: center;
-		font-size: 1.5rem;
+		@include heading-x-large;
 		margin-top: 16px;
 	}
 
@@ -811,7 +806,7 @@
 	}
 
 	.sites-overview__column-content {
-		font-size: 0.75rem !important;
+		@include body-medium;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -943,8 +938,7 @@
 }
 
 .sites-dashboard-empty__heading {
-	font-size: rem(24px);
-	font-weight: 600;
+	@include heading-x-large;
 }
 
 .sites-dashboard-empty__subheading {
@@ -976,13 +970,12 @@
 	}
 
 	.sites-dashboard-empty__content-heading {
-		font-size: rem(16px);
-		font-weight: 500;
+		@include heading-large;
 	}
 
 	.sites-dashboard-empty__content-description {
 		margin-block-start: 4px;
-		font-size: rem(14px);
+		@include body-large;
 		line-height: 1.7;
 		color: var(--color-accent);
 	}

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+
 .sites-header__actions {
 	display: flex;
 	align-items: center;
@@ -6,8 +9,7 @@
 	.button {
 		border-radius: 4px;
 		border: 1px solid var(--color-neutral-10);
-		font-size: 0.875rem;
-		font-weight: inherit;
+		@include body-medium;
 	}
 
 	.button.split-button__main {


### PR DESCRIPTION
This PR updates the Sites page to now use the Core's typography.

<img width="1450" alt="Screenshot 2025-03-10 at 10 31 06 PM" src="https://github.com/user-attachments/assets/f83ddd7f-4287-41ab-9730-3adfc0d8dfb9" />
<img width="1462" alt="Screenshot 2025-03-10 at 10 32 33 PM" src="https://github.com/user-attachments/assets/7c2b177f-5275-417a-9d06-4758f11de9de" />


Follow up  https://github.com/Automattic/wp-calypso/pull/101085

## Proposed Changes

* Update the Sites page to use the Core's typography.

## Why are these changes being made?

* This initiative aims to align with the Core library.

## Testing Instructions

* Use the A4A live link and go to the `/sites` page.
* Verify that the font sizes are close to the design. Expect some slight changes on the size but should be close enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
