### PR TITLE
Reader: Remove suggested follows modal when subscribing in `search` site list item

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -2,12 +2,10 @@ import { ExternalLink } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose, isEmpty, get } from 'lodash';
-import { useState } from 'react';
 import { connect } from 'react-redux';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import ReaderSubscriptionListItemPlaceholder from 'calypso/blocks/reader-subscription-list-item/placeholder';
-import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import FollowButton from 'calypso/reader/follow-button';
 import {
@@ -44,7 +42,6 @@ function ReaderSubscriptionListItem( {
 	railcar,
 	isLoggedIn,
 	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
-	disableSuggestedFollows,
 	onItemClick,
 	isSelected,
 	onFollowToggle,
@@ -61,19 +58,10 @@ function ReaderSubscriptionListItem( {
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isMultiAuthor = get( site, 'is_multi_author', false );
 	const preferGravatar = ! isMultiAuthor;
-	const [ isSuggestedFollowsModalOpen, setIsSuggestedFollowsModalOpen ] = useState( false );
 
 	if ( ! site && ! feed ) {
 		return <ReaderSubscriptionListItemPlaceholder />;
 	}
-
-	const openSuggestedFollowsModal = ( followClicked ) => {
-		setIsSuggestedFollowsModalOpen( followClicked );
-	};
-
-	const onCloseSuggestedFollowModal = () => {
-		setIsSuggestedFollowsModalOpen( false );
-	};
 
 	function recordEvent( name ) {
 		const props = {
@@ -232,19 +220,12 @@ function ReaderSubscriptionListItem( {
 					feedId={ feedId }
 					siteId={ siteId }
 					railcar={ railcar }
-					onFollowToggle={ disableSuggestedFollows ? onFollowToggle : openSuggestedFollowsModal }
+					onFollowToggle={ onFollowToggle }
 				/>
 				{ isFollowing && showNotificationSettings && (
 					<ReaderSiteNotificationSettings siteId={ siteId } />
 				) }
 			</div>
-			{ siteId && ! disableSuggestedFollows && (
-				<ReaderSuggestedFollowsDialog
-					onClose={ onCloseSuggestedFollowModal }
-					siteId={ +siteId }
-					isVisible={ isSuggestedFollowsModalOpen }
-				/>
-			) }
 		</div>
 	);
 }


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/100367

When we are in the `search` in Reader, each site item has a `subscribe` button. In trunk, if clicked it opens a dialog with more suggested sites to follow which is disruptive.

This PR removes that dialog in these two screens.

## Testing Instructions
1. go to `/reader/search`
2. subscribe to a site
3. observe that no dialog is rendered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
