### PR TITLE
Purchases: Convert PurchaseItem to TypeScript

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -877,7 +877,7 @@ export function isAgencyPartnerType( partnerType: string ) {
 	return [ 'agency', 'a4a_agency' ].includes( partnerType );
 }
 
-export function purchaseType( purchase: Purchase ) {
+export function purchaseType( purchase: Purchase ): string | null {
 	if ( isThemePurchase( purchase ) ) {
 		return i18n.translate( 'Premium Theme' );
 	}
@@ -916,6 +916,7 @@ export function purchaseType( purchase: Purchase ) {
 
 	if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
 		return i18n.translate( 'Mailboxes and Productivity Tools at %(domain)s', {
+			textOnly: true,
 			args: {
 				domain: purchase.meta as string,
 			},
@@ -924,6 +925,7 @@ export function purchaseType( purchase: Purchase ) {
 
 	if ( isTitanMail( purchase ) ) {
 		return i18n.translate( 'Mailboxes at %(domain)s', {
+			textOnly: true,
 			args: {
 				domain: purchase.meta as string,
 			},

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -16,7 +16,6 @@ import { ExternalLink } from '@wordpress/components';
 import { Icon, warning as warningIcon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { formatCurrency, localize, useTranslate } from 'i18n-calypso';
-import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -63,23 +62,31 @@ import type { LocalizeProps } from 'i18n-calypso';
 
 const eventProperties = ( warning: string ) => ( { warning, position: 'purchase-list' } );
 
+interface PurchaseItemPropsPlaceholder {
+	isPlaceholder: true;
+}
+
 interface PurchaseItemProps {
 	getManagePurchaseUrlFor: ( targetSiteSlug: string, targetPurchaseId: string | number ) => string;
 	purchase: Purchases.Purchase;
 	site?: SiteDetails | null | undefined;
-	name: string;
 	slug?: string;
 	showSite?: boolean;
 	isPlaceholder?: boolean;
 	isJetpack?: boolean;
 	isDisconnectedSite?: boolean;
 	isBackupMethodAvailable?: boolean;
+}
+
+interface PurchaseItemPropsConnected {
 	translate: LocalizeProps[ 'translate' ];
 	moment: ReturnType< typeof useLocalizedMoment >;
 	iconUrl: string | undefined;
 }
 
-class PurchaseItem extends Component< PurchaseItemProps > {
+class PurchaseItem extends Component<
+	PurchaseItemPropsPlaceholder | ( PurchaseItemProps & PurchaseItemPropsConnected )
+> {
 	trackImpression( warning: string ) {
 		return (
 			<TrackComponentView
@@ -90,7 +97,10 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 	}
 
 	getStatus() {
-		const { purchase, translate, moment, name, isJetpack, isDisconnectedSite } = this.props;
+		if ( this.props.isPlaceholder ) {
+			return null;
+		}
+		const { purchase, translate, moment, isJetpack, isDisconnectedSite } = this.props;
 		const expiry = moment( purchase.expiryDate );
 		// @todo: There isn't currently a way to get the taxName based on the
 		// country. The country is not included in the purchase information
@@ -164,9 +174,6 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 					{ translate(
 						'You no longer have access to this site and its purchases. {{button}}Contact support{{/button}}',
 						{
-							args: {
-								site: name,
-							},
 							components: {
 								button: (
 									<button
@@ -397,6 +404,9 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 	}
 
 	getPurchaseType() {
+		if ( this.props.isPlaceholder ) {
+			return null;
+		}
 		const { purchase, site, translate, slug, showSite, isDisconnectedSite } = this.props;
 		if ( isTemporarySitePurchase( purchase ) ) {
 			return null;
@@ -538,6 +548,9 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 	}
 
 	getPaymentMethod() {
+		if ( this.props.isPlaceholder ) {
+			return null;
+		}
 		const { purchase, translate } = this.props;
 
 		if ( isIncludedWithPlan( purchase ) ) {
@@ -617,6 +630,9 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 	}
 
 	getSiteIcon = () => {
+		if ( this.props.isPlaceholder ) {
+			return null;
+		}
 		const { site, isDisconnectedSite, purchase, iconUrl } = this.props;
 
 		if ( isAkismetTemporarySitePurchase( purchase ) ) {
@@ -653,6 +669,9 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 	};
 
 	renderPurchaseItemContent = () => {
+		if ( this.props.isPlaceholder ) {
+			return null;
+		}
 		const { purchase, showSite, isBackupMethodAvailable } = this.props;
 
 		return (
@@ -682,20 +701,7 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 	};
 
 	render() {
-		const {
-			isPlaceholder,
-			isDisconnectedSite,
-			getManagePurchaseUrlFor,
-			purchase,
-			slug,
-			isJetpack,
-		} = this.props;
-
-		const classes = clsx( 'purchase-item', {
-			'purchase-item--disconnected': isDisconnectedSite,
-		} );
-
-		if ( isPlaceholder ) {
+		if ( this.props.isPlaceholder ) {
 			return (
 				<>
 					<CompactCard className="purchase-item__placeholder-wrapper purchases-list-header" />
@@ -706,10 +712,16 @@ class PurchaseItem extends Component< PurchaseItemProps > {
 			);
 		}
 
+		const { isDisconnectedSite, getManagePurchaseUrlFor, purchase, slug, isJetpack } = this.props;
+
+		const classes = clsx( 'purchase-item', {
+			'purchase-item--disconnected': isDisconnectedSite,
+		} );
+
 		let onClick;
 		let href;
 
-		if ( ! isPlaceholder && getManagePurchaseUrlFor && slug ) {
+		if ( getManagePurchaseUrlFor && slug ) {
 			// A "disconnected" Jetpack site's purchases may be managed.
 			// A "disconnected" WordPress.com site may *NOT* be managed (the user has been removed), unless it is a
 			// WPCOM generated temporary site, which is created during the siteless checkout flow. (currently Jetpack & Akismet can have siteless purchases).
@@ -751,17 +763,22 @@ function BackupPaymentMethodNotice() {
 	);
 }
 
-export default connect( ( state: AppState, ownProps: PurchaseItemProps ) => {
-	const { site } = ownProps;
-	const stateSite = getSite( state, get( site, 'ID' ) );
+export default connect(
+	( state: AppState, ownProps: PurchaseItemPropsPlaceholder | PurchaseItemProps ) => {
+		if ( ownProps.isPlaceholder ) {
+			return {};
+		}
 
-	if ( ! stateSite ) {
+		const stateSite = getSite( state, ownProps.site?.ID );
+
+		if ( ! stateSite ) {
+			return {
+				iconUrl: ownProps.site?.icon?.img,
+			};
+		}
+
 		return {
-			iconUrl: site?.icon?.img,
+			iconUrl: getSiteIconUrl( state, stateSite.ID ),
 		};
 	}
-
-	return {
-		iconUrl: getSiteIconUrl( state, stateSite.ID ),
-	};
-} )( localize( withLocalizedMoment( PurchaseItem ) ) );
+)( localize( withLocalizedMoment( PurchaseItem ) ) );

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -17,7 +17,6 @@ import { Icon, warning as warningIcon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { formatCurrency, localize, useTranslate } from 'i18n-calypso';
 import { get } from 'lodash';
-import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -26,7 +25,7 @@ import payPalImage from 'calypso/assets/images/upgrades/paypal-full.svg';
 import upiImage from 'calypso/assets/images/upgrades/upi.svg';
 import SiteIcon from 'calypso/blocks/site-icon';
 import InfoPopover from 'calypso/components/info-popover';
-import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { getPaymentMethodImageURL } from 'calypso/lib/checkout/payment-methods';
 import {
@@ -57,12 +56,31 @@ import {
 	isMarketplaceTemporarySitePurchase,
 } from '../utils';
 import OwnerInfo from './owner-info';
+import type { Purchases, SiteDetails } from '@automattic/data-stores';
 import 'calypso/me/purchases/style.scss';
+import type { AppState } from 'calypso/types';
+import type { LocalizeProps } from 'i18n-calypso';
 
-const eventProperties = ( warning ) => ( { warning, position: 'purchase-list' } );
+const eventProperties = ( warning: string ) => ( { warning, position: 'purchase-list' } );
 
-class PurchaseItem extends Component {
-	trackImpression( warning ) {
+interface PurchaseItemProps {
+	getManagePurchaseUrlFor: ( targetSiteSlug: string, targetPurchaseId: string | number ) => string;
+	purchase: Purchases.Purchase;
+	site?: SiteDetails | null | undefined;
+	name: string;
+	slug?: string;
+	showSite?: boolean;
+	isPlaceholder?: boolean;
+	isJetpack?: boolean;
+	isDisconnectedSite?: boolean;
+	isBackupMethodAvailable?: boolean;
+	translate: LocalizeProps[ 'translate' ];
+	moment: ReturnType< typeof useLocalizedMoment >;
+	iconUrl: string | undefined;
+}
+
+class PurchaseItem extends Component< PurchaseItemProps > {
+	trackImpression( warning: string ) {
 		return (
 			<TrackComponentView
 				eventName="calypso_subscription_warning_impression"
@@ -96,11 +114,14 @@ class PurchaseItem extends Component {
 		} );
 
 		if ( purchase && isPartnerPurchase( purchase ) ) {
-			return translate( 'Managed by %(partnerName)s', {
-				args: {
-					partnerName: getPartnerName( purchase ),
-				},
-			} );
+			const partnerName = getPartnerName( purchase );
+			if ( partnerName ) {
+				return translate( 'Managed by %(partnerName)s', {
+					args: {
+						partnerName,
+					},
+				} );
+			}
 		}
 
 		if (
@@ -165,7 +186,7 @@ class PurchaseItem extends Component {
 			);
 		}
 
-		if ( purchase.isInAppPurchase ) {
+		if ( purchase.isInAppPurchase && purchase.iapPurchaseManagementLink ) {
 			return translate(
 				'This product is an in-app purchase. You can manage it from within {{managePurchase}}the app store{{/managePurchase}}.',
 				{
@@ -383,7 +404,7 @@ class PurchaseItem extends Component {
 
 		const productType = purchaseType( purchase );
 		if ( showSite && site ) {
-			if ( productType && site.name ) {
+			if ( productType && site.name && slug ) {
 				// translators: The string contains the product name, the name of the site, and the URL for the site e.g. Premium plan for Block Store (blockstore.com)
 				return translate(
 					'%(purchaseType)s for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})',
@@ -403,6 +424,7 @@ class PurchaseItem extends Component {
 										page( getPurchaseListUrlFor( slug ) );
 									} }
 									title={ translate( 'View subscriptions for %(siteName)s', {
+										textOnly: true,
 										args: {
 											siteName: site.name,
 										},
@@ -416,6 +438,7 @@ class PurchaseItem extends Component {
 									target="_blank"
 									rel="noreferrer"
 									title={ translate( 'View %(siteName)s', {
+										textOnly: true,
 										args: {
 											siteName: site.name,
 										},
@@ -427,7 +450,7 @@ class PurchaseItem extends Component {
 				);
 			}
 
-			if ( productType ) {
+			if ( productType && slug ) {
 				// translators: The string contains the product name, and the URL of the site e.g. Premium plan for blockstore.com
 				return translate( '%(purchaseType)s for {{button}}%(siteDomain)s{{/button}}', {
 					args: {
@@ -444,6 +467,7 @@ class PurchaseItem extends Component {
 									page( getPurchaseListUrlFor( slug ) );
 								} }
 								title={ translate( 'View subscriptions for %(siteDomain)s', {
+									textOnly: true,
 									args: {
 										siteDomain: site.domain,
 									},
@@ -454,47 +478,55 @@ class PurchaseItem extends Component {
 				} );
 			}
 
-			// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
-			return translate( 'for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})', {
-				args: {
-					siteName: site.name,
-					siteDomain: site.domain,
-				},
-				components: {
-					button: (
-						<button
-							className="purchase-item__link"
-							onClick={ ( event ) => {
-								event.stopPropagation();
-								event.preventDefault();
-								page( getPurchaseListUrlFor( slug ) );
-							} }
-							title={ translate( 'View subscriptions for %(siteName)s', {
-								args: {
-									siteName: site.name,
-								},
-							} ) }
-						/>
-					),
-					link: (
-						<a
-							className="purchase-item__link"
-							href={ 'https://' + site.domain }
-							target="_blank"
-							rel="noreferrer"
-							title={ translate( 'View %(siteName)s', {
-								args: {
-									siteName: site.name,
-								},
-							} ) }
-						/>
-					),
-				},
-			} );
+			if ( site.name && slug ) {
+				// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
+				return translate(
+					'for {{button}}%(siteName)s{{/button}} ({{link}}%(siteDomain)s{{/link}})',
+					{
+						args: {
+							siteName: site.name,
+							siteDomain: site.domain,
+						},
+						components: {
+							button: (
+								<button
+									className="purchase-item__link"
+									onClick={ ( event ) => {
+										event.stopPropagation();
+										event.preventDefault();
+										page( getPurchaseListUrlFor( slug ) );
+									} }
+									title={ translate( 'View subscriptions for %(siteName)s', {
+										textOnly: true,
+										args: {
+											siteName: site.name,
+										},
+									} ) }
+								/>
+							),
+							link: (
+								<a
+									className="purchase-item__link"
+									href={ 'https://' + site.domain }
+									target="_blank"
+									rel="noreferrer"
+									title={ translate( 'View %(siteName)s', {
+										textOnly: true,
+										args: {
+											siteName: site.name,
+										},
+									} ) }
+								/>
+							),
+						},
+					}
+				);
+			}
 		}
 
-		if ( isDisconnectedSite ) {
+		if ( isDisconnectedSite && productType ) {
 			return translate( '%(purchaseType)s for %(site)s', {
+				textOnly: true,
 				args: {
 					purchaseType: productType,
 					site: purchase.domain,
@@ -549,7 +581,7 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isRenewing( purchase ) ) {
-			if ( purchase.payment.type === 'credit_card' ) {
+			if ( purchase.payment.type === 'credit_card' && purchase.payment.creditCard ) {
 				const paymentMethodType = purchase.payment.creditCard.displayBrand
 					? purchase.payment.creditCard.displayBrand
 					: purchase.payment.creditCard.type || purchase.payment.paymentPartner || '';
@@ -617,7 +649,7 @@ class PurchaseItem extends Component {
 			);
 		}
 
-		return <SiteIcon site={ site } size={ 36 } />;
+		return <SiteIcon site={ site ?? undefined } size={ 36 } />;
 	};
 
 	renderPurchaseItemContent = () => {
@@ -677,7 +709,7 @@ class PurchaseItem extends Component {
 		let onClick;
 		let href;
 
-		if ( ! isPlaceholder && getManagePurchaseUrlFor ) {
+		if ( ! isPlaceholder && getManagePurchaseUrlFor && slug ) {
 			// A "disconnected" Jetpack site's purchases may be managed.
 			// A "disconnected" WordPress.com site may *NOT* be managed (the user has been removed), unless it is a
 			// WPCOM generated temporary site, which is created during the siteless checkout flow. (currently Jetpack & Akismet can have siteless purchases).
@@ -719,18 +751,8 @@ function BackupPaymentMethodNotice() {
 	);
 }
 
-PurchaseItem.propTypes = {
-	getManagePurchaseUrlFor: PropTypes.func,
-	isDisconnectedSite: PropTypes.bool,
-	isJetpack: PropTypes.bool,
-	isPlaceholder: PropTypes.bool,
-	purchase: PropTypes.object,
-	showSite: PropTypes.bool,
-	slug: PropTypes.string,
-	isBackupMethodAvailable: PropTypes.bool,
-};
-
-export default connect( ( state, { site } ) => {
+export default connect( ( state: AppState, ownProps: PurchaseItemProps ) => {
+	const { site } = ownProps;
 	const stateSite = getSite( state, get( site, 'ID' ) );
 
 	if ( ! stateSite ) {

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -57,6 +57,7 @@ import {
 import OwnerInfo from './owner-info';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
 import 'calypso/me/purchases/style.scss';
+import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 import type { AppState } from 'calypso/types';
 import type { LocalizeProps } from 'i18n-calypso';
 
@@ -67,7 +68,7 @@ interface PurchaseItemPropsPlaceholder {
 }
 
 interface PurchaseItemProps {
-	getManagePurchaseUrlFor: ( targetSiteSlug: string, targetPurchaseId: string | number ) => string;
+	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
 	purchase: Purchases.Purchase;
 	site?: SiteDetails | null | undefined;
 	slug?: string;

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -113,7 +113,6 @@ class PurchasesList extends Component<
 						<PurchasesSite
 							key={ site.id }
 							siteId={ site.id }
-							name={ site.name }
 							slug={ site.slug }
 							purchases={ site.purchases }
 							showSite

--- a/client/me/purchases/purchases-site/index.tsx
+++ b/client/me/purchases/purchases-site/index.tsx
@@ -11,7 +11,7 @@ import { getSite } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import PurchaseItem from '../purchase-item';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase, GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 
 import './style.scss';
 
@@ -22,7 +22,7 @@ export default function PurchasesSite(
 				siteId?: number;
 		  }
 		| {
-				getManagePurchaseUrlFor?: ( slug: string, purchaseId: string | number ) => string;
+				getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
 				isPlaceholder?: false;
 				siteId: number;
 				purchases: Purchase[];

--- a/client/me/purchases/purchases-site/index.tsx
+++ b/client/me/purchases/purchases-site/index.tsx
@@ -22,11 +22,10 @@ export default function PurchasesSite(
 				siteId?: number;
 		  }
 		| {
-				getManagePurchaseUrlFor?: ( slug: string, purchaseId: number ) => string;
+				getManagePurchaseUrlFor?: ( slug: string, purchaseId: string | number ) => string;
 				isPlaceholder?: false;
 				siteId: number;
 				purchases: Purchase[];
-				name: string | undefined;
 				slug: string;
 				cards: StoredPaymentMethod[];
 				showSite?: boolean;
@@ -41,7 +40,6 @@ export default function PurchasesSite(
 		getManagePurchaseUrlFor = managePurchase,
 		siteId,
 		purchases,
-		name,
 		slug,
 		cards,
 		showSite = false,
@@ -74,7 +72,6 @@ export default function PurchasesSite(
 						isJetpack={ isJetpackPlan( purchase ) || isJetpackProduct( purchase ) }
 						site={ site }
 						showSite={ showSite }
-						name={ name }
 						isBackupMethodAvailable={ isBackupMethodAvailable }
 					/>
 				);

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -64,7 +64,6 @@ function SubscriptionsContent( {
 					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
 					key={ selectedSite.ID }
 					siteId={ selectedSite.ID }
-					name={ selectedSite.name }
 					slug={ selectedSite.slug }
 					purchases={ purchases }
 					cards={ cards }

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -20,6 +20,7 @@ import {
 } from 'calypso/state/purchases/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
 
 import './style.scss';
 
@@ -36,7 +37,7 @@ function SubscriptionsContent( {
 	selectedSite: undefined | null | SiteDetails;
 	purchases: Purchase[];
 } ) {
-	const getManagePurchaseUrlFor = ( siteSlug: string, purchaseId: string | number ) =>
+	const getManagePurchaseUrlFor: GetManagePurchaseUrlFor = ( siteSlug, purchaseId ) =>
 		`/purchases/subscriptions/${ siteSlug }/${ purchaseId }`;
 	const { paymentMethods: cards } = useStoredPaymentMethods( { type: 'card' } );
 

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -36,7 +36,7 @@ function SubscriptionsContent( {
 	selectedSite: undefined | null | SiteDetails;
 	purchases: Purchase[];
 } ) {
-	const getManagePurchaseUrlFor = ( siteSlug: string, purchaseId: number ) =>
+	const getManagePurchaseUrlFor = ( siteSlug: string, purchaseId: string | number ) =>
 		`/purchases/subscriptions/${ siteSlug }/${ purchaseId }`;
 	const { paymentMethods: cards } = useStoredPaymentMethods( { type: 'card' } );
 

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -320,6 +320,7 @@ export interface PurchasePayment {
 	storedDetailsId: string | number | undefined | null;
 	expiryDate?: string;
 	creditCard?: PurchasePaymentCreditCard;
+	paymentPartner?: string;
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

This PR converts the `PurchaseItem` component to TypeScript with as few functional changes as possible. This is the component used for each purchase row when viewing a list of purchases.

## Testing Instructions

Automated tests should cover type errors. As for the functional changes, we should view the `/me/purchases` page to make sure that each line item looks correct.