### PR TITLE
Sites: Convert `getSite()` to TypeScript

### DIFF
--- a/client/my-sites/plugins/hooks/types.ts
+++ b/client/my-sites/plugins/hooks/types.ts
@@ -15,7 +15,7 @@ export type PluginActionName = ( typeof PluginActions )[ keyof typeof PluginActi
 export type Site = {
 	ID: number;
 	title: string;
-	canUpdateFiles?: boolean;
+	canUpdateFiles?: boolean | null;
 };
 
 export type Plugin = {

--- a/client/state/selectors/get-raw-site.ts
+++ b/client/state/selectors/get-raw-site.ts
@@ -5,7 +5,10 @@ import type { AppState } from 'calypso/types';
 /**
  * Returns a raw site object by its ID.
  */
-export default function getRawSite( state: AppState, siteId: number | null ): SiteDetails | null {
+export default function getRawSite(
+	state: AppState,
+	siteId: string | number | null | undefined
+): SiteDetails | null {
 	if ( ! siteId ) {
 		return null;
 	}

--- a/client/state/selectors/get-sites-items.ts
+++ b/client/state/selectors/get-sites-items.ts
@@ -6,6 +6,6 @@ const EMPTY_SITES = Object.freeze( {} );
 /**
  * Returns site items object or empty object.
  */
-export default function getSitesItems( state: AppState ): Record< number, SiteDetails > {
+export default function getSitesItems( state: AppState ): Record< number | string, SiteDetails > {
 	return state.sites.items || EMPTY_SITES;
 }

--- a/client/state/sites/selectors/get-site.ts
+++ b/client/state/sites/selectors/get-site.ts
@@ -1,4 +1,6 @@
+import { SiteDetails } from '@automattic/data-stores';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
+import { AppState } from 'calypso/types';
 import getJetpackComputedAttributes from './get-jetpack-computed-attributes';
 import getSiteBySlug from './get-site-by-slug';
 import getSiteComputedAttributes from './get-site-computed-attributes';
@@ -10,15 +12,22 @@ let getSiteCache = new WeakMap();
 
 /**
  * Returns a normalized site object by its ID or site slug.
- * @param  {Object}  state  Global state tree
- * @param  {number|string|null|undefined}  siteIdOrSlug Site ID or site slug
- * @returns {import('@automattic/data-stores').SiteDetails|null|undefined}        Site object
  */
-export default function getSite( state, siteIdOrSlug ) {
+export default function getSite(
+	state: AppState,
+	siteIdOrSlug: number | string | null | undefined
+): SiteDetails | null | undefined {
 	if ( ! siteIdOrSlug ) {
 		return null;
 	}
-	const rawSite = getRawSite( state, siteIdOrSlug ) || getSiteBySlug( state, siteIdOrSlug );
+
+	let rawSite;
+
+	if ( 'number' === typeof siteIdOrSlug ) {
+		rawSite = getRawSite( state, siteIdOrSlug );
+	} else {
+		rawSite = getSiteBySlug( state, siteIdOrSlug );
+	}
 	if ( ! rawSite ) {
 		return null;
 	}

--- a/client/state/sites/selectors/get-site.ts
+++ b/client/state/sites/selectors/get-site.ts
@@ -21,13 +21,8 @@ export default function getSite(
 		return null;
 	}
 
-	let rawSite;
+	const rawSite = getRawSite( state, siteIdOrSlug ) || getSiteBySlug( state, siteIdOrSlug );
 
-	if ( 'number' === typeof siteIdOrSlug ) {
-		rawSite = getRawSite( state, siteIdOrSlug );
-	} else {
-		rawSite = getSiteBySlug( state, siteIdOrSlug );
-	}
 	if ( ! rawSite ) {
 		return null;
 	}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -158,10 +158,10 @@ export interface SiteDetails {
 	user_interactions?: string[];
 
 	// Jetpack computed properties
-	canAutoupdateFiles?: boolean;
-	canUpdateFiles?: boolean;
-	isMainNetworkSite?: boolean;
-	isSecondaryNetworkSite?: boolean;
+	canAutoupdateFiles?: boolean | null;
+	canUpdateFiles?: boolean | null;
+	isMainNetworkSite?: boolean | null;
+	isSecondaryNetworkSite?: boolean | null;
 
 	// Migration
 	site_migration?: SourceSiteMigrationBase;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/86616

## Proposed Changes

* Make the `getSite` function more precise by converting it to TypeScript

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the work to implement DataViews in the `Active upgrades` screen, @sirbrillig  and I ran across this function which would benefit from using TypeScript rather than JSDocs. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection and automated tests should be sufficient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
