### PR TITLE
Reader: Check that comment author's URL is valid before use

### DIFF
--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Gridicon, TimeSince } from '@automattic/components';
-import { isURL, getProtocol } from '@wordpress/url';
+import { isURL, getProtocol, getAuthority } from '@wordpress/url';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { get, some, flatMap } from 'lodash';
@@ -322,7 +322,9 @@ class PostComment extends PureComponent {
 			const urlToCheck = commentAuthor?.URL;
 			if ( urlToCheck && isURL( urlToCheck ) ) {
 				const protocol = getProtocol( urlToCheck );
-				if ( protocol === 'http:' || protocol === 'https:' ) {
+				const domain = getAuthority( urlToCheck );
+				// isURL uses URL() which allows '%20' in Chromium but not Firefox, so we check ourselves.
+				if ( protocol === 'https:' && ! domain.includes( '%' ) ) {
 					commentAuthorUrl = urlToCheck;
 				}
 			}

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -318,10 +318,24 @@ class PostComment extends PureComponent {
 		} else if ( commentAuthor.site_ID ) {
 			commentAuthorUrl = getStreamUrl( null, commentAuthor.site_ID );
 		} else {
-			commentAuthorUrl = commentAuthor?.URL;
+			const urlToCheck = commentAuthor?.URL;
+			if ( urlToCheck && this.isValidUrl( urlToCheck ) ) {
+				commentAuthorUrl = urlToCheck;
+			}
 		}
 
 		return { comment, commentAuthor, commentAuthorUrl, commentAuthorName };
+	};
+
+	isValidUrl = ( url ) => {
+		try {
+			// URL constructor throws an error if the URL is invalid.
+			const urlObject = new URL( url );
+			// Only allow http or https URLs.
+			return urlObject.protocol === 'http:' || urlObject.protocol === 'https:';
+		} catch ( e ) {
+			return false;
+		}
 	};
 
 	renderAuthorTag = ( { authorName, authorUrl, commentId, className } ) => {

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Gridicon, TimeSince } from '@automattic/components';
+import { isURL, getProtocol } from '@wordpress/url';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { get, some, flatMap } from 'lodash';
@@ -319,23 +320,15 @@ class PostComment extends PureComponent {
 			commentAuthorUrl = getStreamUrl( null, commentAuthor.site_ID );
 		} else {
 			const urlToCheck = commentAuthor?.URL;
-			if ( urlToCheck && this.isValidUrl( urlToCheck ) ) {
-				commentAuthorUrl = urlToCheck;
+			if ( urlToCheck && isURL( urlToCheck ) ) {
+				const protocol = getProtocol( urlToCheck );
+				if ( protocol === 'http:' || protocol === 'https:' ) {
+					commentAuthorUrl = urlToCheck;
+				}
 			}
 		}
 
 		return { comment, commentAuthor, commentAuthorUrl, commentAuthorName };
-	};
-
-	isValidUrl = ( url ) => {
-		try {
-			// URL constructor throws an error if the URL is invalid.
-			const urlObject = new URL( url );
-			// Only allow http or https URLs.
-			return urlObject.protocol === 'http:' || urlObject.protocol === 'https:';
-		} catch ( e ) {
-			return false;
-		}
 	};
 
 	renderAuthorTag = ( { authorName, authorUrl, commentId, className } ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99012

## Proposed Changes

* Check that the comment author URL is valid before using it as a link.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* WordPress Core does not validate comment author URLs, so we need to check that these URLs are valid before using them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In production, go to http://wordpress.com/reader/feeds/151205063/posts/5582644405
* You should see several demo comments. The comment "Dusty Invalid URL" has a space in the author URL, and "Dusty FTP" is a link using the FTP protocol. In production, both of these links will be clickable.
* Use Calypso Live and go to /reader/feeds/151205063/posts/5582644405
* You'll see the same demo comments, but the one with an invalid author URL and the one using the FTP protocol will not be clickable. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
