### PR TITLE
Subscribers: Show error message when gifting to an email-only subscriber

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -6,8 +6,9 @@ import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { trash } from '@wordpress/icons';
 import { translate, fixMe } from 'i18n-calypso';
 import { useSubscribedNewsletterCategories } from 'calypso/data/newsletter-categories';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
 import { getCouponsAndGiftsEnabledForSiteId } from 'calypso/state/memberships/settings/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
@@ -79,6 +80,7 @@ const SubscriberDataViews = ( {
 	isUnverified,
 	subscriberId,
 }: SubscriberDataViewsProps ) => {
+	const dispatch = useDispatch();
 	const isMobile = useBreakpoint( '<660px' );
 	const recordSubscriberClicked = useRecordSubscriberClicked();
 	const recordSubscriberSearch = useRecordSubscriberSearch();
@@ -341,7 +343,18 @@ const SubscriberDataViews = ( {
 				id: 'gift',
 				label: translate( 'Gift a subscription' ),
 				callback: ( items: Subscriber[] ) => {
-					if ( items[ 0 ] && items[ 0 ].user_id ) {
+					if ( items[ 0 ] ) {
+						if ( ! items[ 0 ].user_id ) {
+							dispatch(
+								errorNotice(
+									translate(
+										'This subscriber needs to create a WordPress.com account before they can receive a gift subscription.'
+									),
+									{ duration: 10000 }
+								)
+							);
+							return;
+						}
 						onGiftSubscription( items[ 0 ] );
 					}
 				},
@@ -356,8 +369,7 @@ const SubscriberDataViews = ( {
 		handleUnsubscribe,
 		onGiftSubscription,
 		couponsAndGiftsEnabled,
-		recordSubscriberClicked,
-		siteId,
+		dispatch,
 	] );
 
 	const handleViewChange = useCallback(

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -343,20 +343,24 @@ const SubscriberDataViews = ( {
 				id: 'gift',
 				label: translate( 'Gift a subscription' ),
 				callback: ( items: Subscriber[] ) => {
-					if ( items[ 0 ] ) {
-						if ( ! items[ 0 ].user_id ) {
-							dispatch(
-								errorNotice(
-									translate(
-										'This subscriber needs to create a WordPress.com account before they can receive a gift subscription.'
-									),
-									{ duration: 10000 }
-								)
-							);
-							return;
-						}
-						onGiftSubscription( items[ 0 ] );
+					const subscriber = items[ 0 ];
+					if ( ! subscriber ) {
+						return;
 					}
+
+					if ( ! subscriber.user_id ) {
+						dispatch(
+							errorNotice(
+								translate(
+									'This subscriber needs to create a WordPress.com account before they can receive a gift subscription.'
+								),
+								{ duration: 10000 }
+							)
+						);
+						return;
+					}
+
+					onGiftSubscription( subscriber );
 				},
 				isPrimary: false,
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/593

## Proposed Changes

* Show an error notice when attempting to add a gift subscription to an email-only subscriber (no user id). Currently, nothing happens when you click.

<img width="203" alt="Screen Shot 2025-03-17 at 1 07 21 PM" src="https://github.com/user-attachments/assets/4bbe5e9d-b875-4423-a4f6-c23c8fc7465a" />

<img width="818" alt="Screen Shot 2025-03-18 at 2 24 53 PM" src="https://github.com/user-attachments/assets/f4d522c2-7a2a-41f5-8699-f95106afb98d" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It's not clear to the user why the gift subscription modal isn't opening.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a site with paid newsletter tiers and gifts enabled. See: PCYsg-qBq-p2 -- the gifts can be enabled via a blog sticker. Or, I can add you to my test site.
* Add both an email-only subscriber and an email associated with a Dotcom account.
* Click Actions > Gift a subscription next to the email-only subscriber. You should see the error.
* Click Actions > Gift a subscription next to the Dotcom subscriber. You should see a modal and be able to gift them a subscription.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?