### PR TITLE
Onboarding consistency: Use StepContainerV2 in the 'Create your account' screen

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -320,6 +320,7 @@ class PasswordlessSignupForm extends Component {
 				>
 					{ submitButtonText }
 				</Button>
+				{ this.props.secondaryFooterButton }
 			</LoggedOutFormFooter>
 		);
 	}
@@ -330,6 +331,12 @@ class PasswordlessSignupForm extends Component {
 
 	render() {
 		const { errorMessages, isSubmitting } = this.state;
+
+		const terms = ! this.props.disableTosText && this.props.renderTerms?.();
+
+		const elements = this.props.secondaryFooterButton
+			? [ this.formFooter(), terms ]
+			: [ terms, this.formFooter() ];
 
 		return (
 			<div className="signup-form__passwordless-form-wrapper">
@@ -353,8 +360,7 @@ class PasswordlessSignupForm extends Component {
 						/>
 						{ this.props.children }
 					</ValidationFieldset>
-					{ ! this.props.disableTosText && this.props.renderTerms?.() }
-					{ this.formFooter() }
+					{ elements }
 				</LoggedOutForm>
 			</div>
 		);

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
+import { chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
@@ -40,7 +41,9 @@ interface SignupFormSocialFirst {
 	userEmail: string;
 	notice: JSX.Element | false;
 	isSocialFirst: boolean;
+	backButtonInFooter?: boolean;
 	passDataToNextStep?: boolean;
+	emailLabelText?: string;
 }
 
 const options = {
@@ -76,6 +79,8 @@ const SignupFormSocialFirst = ( {
 	notice,
 	isSocialFirst,
 	passDataToNextStep,
+	backButtonInFooter = true,
+	emailLabelText,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState( 'initial' );
 	const { __ } = useI18n();
@@ -105,6 +110,10 @@ const SignupFormSocialFirst = ( {
 				),
 				options
 			);
+		}
+
+		if ( ! tosText ) {
+			return null;
 		}
 
 		return <p className="signup-form-social-first__tos-link">{ tosText }</p>;
@@ -157,10 +166,17 @@ const SignupFormSocialFirst = ( {
 						goToNextStep={ goToNextStep }
 						logInUrl={ logInUrl }
 						queryArgs={ queryArgs }
-						labelText={ __( 'Your email' ) }
+						labelText={ emailLabelText ?? __( 'Your email' ) }
 						submitButtonLabel={ __( 'Continue' ) }
 						userEmail={ userEmail }
 						renderTerms={ renderEmailStepTermsOfService }
+						secondaryFooterButton={
+							backButtonInFooter ? undefined : (
+								<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
+									{ __( 'See all options' ) }
+								</Button>
+							)
+						}
 						passDataToNextStep={ passDataToNextStep }
 						onCreateAccountError={ ( error: { error: string }, email: string ) => {
 							if ( isExistingAccountError( error.error ) ) {
@@ -179,13 +195,15 @@ const SignupFormSocialFirst = ( {
 						onCreateAccountSuccess={ onCreateAccountSuccess }
 						{ ...gravatarProps }
 					/>
-					<Button
-						onClick={ () => setCurrentStep( 'initial' ) }
-						className="back-button"
-						variant="link"
-					>
-						<span>{ __( 'Back' ) }</span>
-					</Button>
+					{ backButtonInFooter ? (
+						<Button
+							onClick={ () => setCurrentStep( 'initial' ) }
+							className="back-button"
+							variant="link"
+						>
+							<span>{ __( 'Back' ) }</span>
+						</Button>
+					) : null }
 				</div>
 			);
 		}

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -1,7 +1,7 @@
 import configApi from '@automattic/calypso-config';
-import { SITE_SETUP_FLOW } from '@automattic/onboarding';
+import { SITE_SETUP_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
 
-const FLOWS_USING_STEP_CONTAINER_V2 = [ SITE_SETUP_FLOW ];
+const FLOWS_USING_STEP_CONTAINER_V2 = [ SITE_SETUP_FLOW, ONBOARDING_FLOW ];
 
 export const shouldUseStepContainerV2 = ( flow: string ) => {
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -8,6 +8,42 @@ $gray-50: #646970;
 $breakpoint-mobile: 660px;
 
 .step-route.user {
+	.locale-suggestions {
+		margin: 0 auto;
+	}
+
+	.signup-form-social-first__tos-link,
+	.signup-form-social-first__email-tos-link {
+		color: var(--studio-gray-60, #646970);
+		font-family: "SF Pro Text", sans-serif;
+		font-size: 0.75rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px;
+		margin-bottom: 0;
+
+		a {
+			color: var(--studio-gray-60, #646970);
+			text-decoration-line: underline;
+		}
+	}
+
+	.signup-form-social-first__tos-link {
+		margin-top: 3rem;
+		text-align: center;
+	}
+
+	.signup-form-social-first-email {
+		.card {
+			background: transparent;
+			box-shadow: none;
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}
+
+.step-route.user:not(:has(.step-container-v2--user)) {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -16,8 +52,6 @@ $breakpoint-mobile: 660px;
 	margin: 20px 0;
 
 	.locale-suggestions {
-		margin: 0 auto;
-
 		@include break-medium {
 			width: 100%;
 		}
@@ -82,36 +116,10 @@ $breakpoint-mobile: 660px;
 		.auth-form__social {
 			padding: 0 !important;
 		}
-
-		.signup-form-social-first__tos-link,
-		.signup-form-social-first__email-tos-link {
-			color: var(--studio-gray-50, #646970);
-			font-family: "SF Pro Text", sans-serif;
-			font-size: 0.75rem;
-			font-style: normal;
-			font-weight: 400;
-			line-height: 18px;
-			margin-top: 3rem;
-			margin-bottom: 0;
-
-			a {
-				color: var(--studio-gray-50, #646970);
-				text-decoration-line: underline;
-			}
-		}
-
-		.signup-form-social-first__tos-link {
-			text-align: center;
-		}
 	}
 
 	.signup-form-social-first-email {
 		.card {
-			background: transparent;
-			box-shadow: none;
-			padding-left: 0;
-			padding-right: 0;
-
 			button:not(.is-borderless, .signup-form__domain-suggestion-confirmation) {
 				display: block;
 				max-width: 327px;
@@ -185,5 +193,59 @@ $breakpoint-mobile: 660px;
 				outline-offset: 1px;
 			}
 		}
+	}
+}
+
+.step-container-v2:has(.step-container-v2--user) {
+	.locale-suggestions {
+		margin: 0;
+		width: 100%;
+		max-width: 100%;
+
+		@include break-small {
+			margin: 0 auto;
+			max-width: 500px;
+		}
+
+		.notice {
+			margin-bottom: 0;
+		}
+	}
+
+	.signup-form-social-first {
+		&,
+		.card.auth-form__social,
+		.card.logged-out-form {
+			width: 100%;
+			max-width: 100%;
+			padding: 0;
+			margin: 0;
+		}
+
+		.card.logged-out-form__footer {
+			margin: 24px 0 0 0;
+			padding: 0;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 8px;
+
+			&::after {
+				display: none;
+			}
+		}
+	}
+
+	.signup-form-social-first__tos-link,
+	.signup-form-social-first__email-tos-link {
+		text-align: left;
+
+		@include break-small {
+			text-align: center;
+		}
+	}
+
+	.signup-form-social-first__email-tos-link {
+		margin-top: 3rem;
 	}
 }

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -1,6 +1,7 @@
 @import '../../../../styles/mixins';
 
 .step-container-v2 {
+	width: 100%;
 	min-height: 100vh;
 	margin: 0;
 	display: flex;
@@ -16,13 +17,13 @@
 		&.padding {
 			padding: 2rem 1rem;
 
-			@include step-large-viewport {
+			@include step-medium-viewport {
 				padding: 2rem 3rem;
 			}
 		}
 
 		&.vertical-align-center {
-			@include step-large-viewport {
+			@include step-medium-viewport {
 				position: absolute;
 				inset: 0;
 				width: 100%;

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -8,7 +8,7 @@
 	align-items: center;
 	padding: 1rem;
 
-	@include step-large-viewport {
+	@include step-medium-viewport {
 		padding-inline: 1.5rem;
 	}
 
@@ -25,10 +25,10 @@
 		height: 1rem;
 		background-color: var(--color-border-subtle);
 
-		margin-inline: 0.5rem;
+		margin-inline: 1rem 0.5rem;
 
-		@include step-large-viewport {
-			margin-left: 1rem;
+		@include step-medium-viewport {
+			margin-inline: 1.5rem 0.75rem;
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101190.

## Proposed Changes

I'm deliberately not including the "Create with email" heading customization for now. It's a bit complex, and I'm unsure of the benefits of adding it to the list of changes in this PR. I also have some questions about it: W9xI27S6Swvw5Ku21EbZvn-fi-10384_20729#1178856782

### Method chooser

| Before | After | Small screen |
| ------ | ------ | --------- |
| ![image](https://github.com/user-attachments/assets/097ccdb7-f4a4-402c-9b4b-84730b88ca0e) | ![image](https://github.com/user-attachments/assets/24444329-40cf-4283-8057-05d9db1a62c2) | ![image](https://github.com/user-attachments/assets/5ad21369-54e3-40b3-bb53-c3d3ce1ab6cd) |

### Email sign up

| Before | After | Small screen |
| ------ | ------ | --------- |
| ![image](https://github.com/user-attachments/assets/69796cd9-523b-4bc4-893e-effacbb0aaf1) | ![image](https://github.com/user-attachments/assets/7997b8a1-ae47-4b23-b091-6381628efcd7) | ![image](https://github.com/user-attachments/assets/6c03ec03-ac04-4705-9df1-f207334c90e3) |