### PR TITLE
Update Notifications Email Settings Copy

### DIFF
--- a/client/me/notification-settings/navigation.jsx
+++ b/client/me/notification-settings/navigation.jsx
@@ -30,7 +30,7 @@ class NotificationSettingsNavigation extends Component {
 			'/me/notifications': this.props.translate( 'Notifications' ),
 			'/me/notifications/comments': this.props.translate( 'Comments' ),
 			'/me/notifications/updates': this.props.translate( 'Updates' ),
-			'/me/notifications/subscriptions': this.props.translate( 'Reader Subscriptions' ),
+			'/me/notifications/subscriptions': this.props.translate( 'Email Subscriptions' ),
 		};
 	};
 

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -85,11 +85,11 @@ class NotificationSubscriptions extends Component {
 						onSubmit={ this.props.submitForm }
 					>
 						<FormSectionHeading>
-							{ this.props.translate( 'Subscriptions delivery' ) }
+							{ this.props.translate( 'Email subscriptions' ) }
 						</FormSectionHeading>
 						<p>
 							{ this.props.translate(
-								'{{readerLink}}Use the Reader{{/readerLink}} to adjust delivery settings for your existing subscriptions.',
+								'{{readerLink}}Visit the Reader{{/readerLink}} to adjust individual site subscriptions.',
 								{
 									components: {
 										readerLink: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/595

## Proposed Changes

* Copy changes for clarity.

Before | After
--|--
<img width="1193" alt="Screenshot 2025-03-18 at 4 50 14 PM" src="https://github.com/user-attachments/assets/87e6a44e-ffbb-46ea-bed2-a91f324e8ec5" />  | <img width="1194" alt="Screenshot 2025-03-18 at 4 50 06 PM" src="https://github.com/user-attachments/assets/842dbbaf-318d-41ca-bf6e-75de77fc0a67" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve clarity around what this section of the Notifications does.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live and go to /me/notifications/subscriptions
* Does the updated copy look right and make sense?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
