### PR TITLE
Reader Editor: Do not show Reader editor if user has no sites

### DIFF
--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -11,7 +11,8 @@ import QuickPost from 'calypso/reader/components/quick-post';
 import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import ReaderStream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { selectSidebarRecentSite } from 'calypso/state/reader-ui/sidebar/actions';
 import Recent from '../recent';
 import { useSiteSubscriptions } from './use-site-subscriptions';
@@ -23,6 +24,8 @@ function FollowingStream( { ...props } ) {
 	const { currentView } = useFollowingView();
 	const { isLoading, hasNonSelfSubscriptions } = useSiteSubscriptions();
 	const dispatch = useDispatch();
+	const currentUser = useSelector( getCurrentUser );
+	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
 
 	// Set the selected feed based on route param.
 	useEffect( () => {
@@ -65,7 +68,7 @@ function FollowingStream( { ...props } ) {
 					>
 						<ViewToggle />
 					</NavigationHeader>
-					{ config.isEnabled( 'reader/quick-post' ) && (
+					{ config.isEnabled( 'reader/quick-post' ) && hasSites && (
 						<FoldableCard
 							header={ translate( 'Write a quick post' ) }
 							clickableHeader


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Do not show Reader Editor FoldableCard if user has no sites.

Before | After
--|--
<img width="1122" alt="Screenshot 2025-03-18 at 7 08 22 PM" src="https://github.com/user-attachments/assets/e6eacb50-b8c5-489d-a0a4-9a4d0dac3983" />  | <img width="1123" alt="Screenshot 2025-03-18 at 7 08 46 PM" src="https://github.com/user-attachments/assets/f7bf37f5-0668-4960-8495-57680e52ee88" />





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `QuickPost` component has [a check](https://github.com/Automattic/wp-calypso/blob/trunk/client/reader/components/quick-post/index.tsx#L159-L161) so that it does not render if the user has no sites. However, the `FoldableCard` wrapping the `QuickPost` component does not. We've discussed the idea of putting the `QuickPost` in a modal in the future, so by keeping the `FoldableCard` outside of the `QuickPost` component and adding a `hasSites` check to it, we keep `QuickPost` modular and hide the `FoldableCard` when appropriate.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live go to /reader (with an account with 1 or more sites)
* You should see the Reader Editor, and there should be no changes from production.
* Now test an account with no sites.
* The fastest way to create an account with no sites is to log out or open a private browser window and using Calypso Live go to /discover and create a new account using the "Sign up" link in the upper right.
* Go to /reader
* You should not see the Reader Editor
* If you'd like, create a new site on your new siteless account. You should now see the Reader Editor on /reader.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
