### PR TITLE
Reader: Fix feeds not unsubscribing on re-subscribe

### DIFF
--- a/client/blocks/reader-feed-item/index.tsx
+++ b/client/blocks/reader-feed-item/index.tsx
@@ -103,7 +103,9 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 			onSuccess: () => {
 				dispatch(
 					successNotice(
-						translate( 'Success! You are now subscribed to %s.', { args: filteredDisplayUrl } ),
+						translate( 'Success! You are now subscribed to "%s".', {
+							args: title ?? filteredDisplayUrl,
+						} ),
 						{ duration: 5000 }
 					)
 				);
@@ -170,7 +172,7 @@ export default function ReaderFeedItem( props: ReaderFeedItemProps ): JSX.Elemen
 
 	const SubscribeButton = (): JSX.Element => (
 		<Button
-			variant="primary"
+			variant={ subscribeDisabled ? 'secondary' : 'primary' }
 			disabled={ subscribeDisabled }
 			isBusy={ isSubscribing }
 			onClick={ onSubscribeClick }

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -142,16 +142,12 @@ const SiteSubscriptionRow = ( {
 				{
 					id: siteUnsubscribedNoticeId,
 					button: translate( 'Resubscribe' ),
+					duration: 5000,
 					onClick: () => {
 						if ( unsubscribeInProgress.current ) {
 							resubscribePending.current = true;
 						} else {
-							resubscribe( {
-								blog_id,
-								url,
-								doNotInvalidateSiteSubscriptions: true,
-								resubscribed: true,
-							} );
+							resubscribe( { blog_id, url, resubscribed: true } );
 							dispatch( removeNotice( siteUnsubscribedNoticeId ) );
 							scrollToFirstRow();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Refresh subscriptions list while resubscribing.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

It is difficult to unsubscribe the feed if re-subscribe functionality is used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On production go to `/reader/subscriptions`.
- Search new feed.
- Subscribe to it and note the subscription ID
- Unsubscribe from it and make sure that the API is called with the same ID.
- Subscribe from the notification that appears on top right side and note the subs ID
- Unsubscribe and note that API request isn't succeeding and giving subscription error. The reason is we are calling DELETE with old subscription ID.
- Now test the same case in this branch and verify that the unsubcription is working as expected and there is no edge case now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?