### PR TITLE
Launch the "Publish a blog" goal project

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -1,4 +1,3 @@
-import configApi from '@automattic/calypso-config';
 import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from 'react';
@@ -171,9 +170,7 @@ const siteSetupFlow: FlowV1 = {
 		const getEnableFeaturesForGoals = () => {
 			const featuresForGoals: Onboard.SiteGoal[] = [];
 
-			if ( configApi.isEnabled( 'onboarding/enable-write-goal-features' ) ) {
-				featuresForGoals.push( Onboard.SiteGoal.Write );
-			}
+			featuresForGoals.push( Onboard.SiteGoal.Write );
 
 			return featuresForGoals.length > 0 ? featuresForGoals : undefined;
 		};

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -104,7 +104,6 @@
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,
-		"onboarding/enable-write-goal-features": true,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
 import * as oauthToken from '@automattic/oauth-token';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
@@ -73,11 +72,9 @@ export const fetchLaunchpad = (
 	const launchpadContextEncoded = launchpadContext ? encodeURIComponent( launchpadContext ) : null;
 	const queryArgs = {
 		_locale: 'user',
+		updated_write_tasklist: 'true',
 		...( checklistSlug && { checklist_slug: checklistSlugEncoded } ),
 		...( launchpadContext && { launchpad_context: launchpadContextEncoded } ),
-		...( isEnabled( 'onboarding/enable-write-goal-features' ) && {
-			updated_write_tasklist: 'true',
-		} ),
 	};
 	const token = oauthToken.getToken();
 	return canAccessWpcomApis()


### PR DESCRIPTION
This launches the features related to the "Publish a blog goal" project

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/98253

## Proposed Changes

* Removes the `onboarding/enable-write-blog` feature flag
* Rewrite code to assume it's enabled everywhere

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is the final step which launches the project pet6gk-24g-p2


E.g. new blog-related launchpad tasks
![image](https://github.com/user-attachments/assets/67db0157-5a2b-4bf9-bd5b-3c1e94c87fe7)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow testing instructions from CfT pdtkmj-3rd-p2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?