### PR TITLE
Plans Features: Add locale support and suggested domain name

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-selected-feature.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-selected-feature.ts
@@ -8,7 +8,8 @@ import useSelectedFeature from '../use-selected-feature';
 const mockFeature = {
 	getSlug: () => 'feature-1',
 	getTitle: () => 'Feature 1',
-	getDescription: () => 'Description 1',
+	getDescription: ( { suggestedDomainName }: { suggestedDomainName?: string } ) =>
+		suggestedDomainName ? `Description for ${ suggestedDomainName }` : 'Description 1',
 	availableForCurrentPlan: true,
 	availableOnlyForAnnualPlans: false,
 };
@@ -108,5 +109,21 @@ describe( 'useSelectedFeature', () => {
 			} )
 		);
 		expect( result.current ).toBeNull();
+	} );
+
+	it( 'passes suggestedDomainName to getDescription', () => {
+		const { result } = renderHook( () =>
+			useSelectedFeature( {
+				gridPlans: mockGridPlans,
+				selectedFeature: 'feature-1',
+				selectedPlan: 'plan-1',
+				suggestedDomainName: 'example.com',
+			} )
+		);
+		expect( result.current ).toEqual( {
+			slug: 'feature-1',
+			title: 'Feature 1',
+			description: 'Description for example.com',
+		} );
 	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-selected-feature.ts
+++ b/client/my-sites/plans-features-main/hooks/use-selected-feature.ts
@@ -5,6 +5,7 @@ interface Params {
 	gridPlans: GridPlan[] | null;
 	selectedFeature?: string;
 	selectedPlan?: string;
+	suggestedDomainName?: string;
 }
 
 export type SelectedFeatureData = {
@@ -17,6 +18,7 @@ const useSelectedFeature = ( {
 	selectedFeature,
 	selectedPlan,
 	gridPlans,
+	suggestedDomainName,
 }: Params ): SelectedFeatureData | null => {
 	const selectedFeatureData = useMemo( () => {
 		if ( ! selectedPlan || ! selectedFeature ) {
@@ -52,7 +54,7 @@ const useSelectedFeature = ( {
 		return {
 			slug: selectedFeature as string,
 			title: selectedFeatureData.getTitle(),
-			description: selectedFeatureData.getDescription(),
+			description: selectedFeatureData.getDescription( { suggestedDomainName } ),
 		};
 	}
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -16,10 +16,17 @@ import {
 	getPlanFeaturesGroupedForComparisonGrid,
 	getWooExpressFeaturesGroupedForFeaturesGrid,
 	getSimplifiedPlanFeaturesGroupedForFeaturesGrid,
+	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
-import { WpcomPlansUI, AddOns, Plans, OnboardSelect } from '@automattic/data-stores';
+import {
+	WpcomPlansUI,
+	AddOns,
+	Plans,
+	OnboardSelect,
+	DomainSuggestions,
+} from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
@@ -131,7 +138,7 @@ export interface PlansFeaturesMainProps {
 	hideSpotlightPlan?: boolean;
 	hidePlansFeatureComparison?: boolean;
 	coupon?: string;
-
+	locale?: string;
 	/**
 	 * @deprecated use intent mechanism instead
 	 */
@@ -225,6 +232,7 @@ const PlansFeaturesMain = ( {
 	coupon,
 	onPlanIntervalUpdate,
 	selectedThemeType,
+	locale = 'en',
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	// TODO: Remove temporary eslint disable
@@ -247,6 +255,22 @@ const PlansFeaturesMain = ( {
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
+
+	// If the selected feature is the custom domain feature, fetch a domain suggestion.
+	const { data: wordPressSubdomainSuggestions } = DomainSuggestions.useGetDomainSuggestions(
+		/*
+		 * Only make the request if the selected feature is the custom domain feature.
+		 * See packages/data-stores/src/domain-suggestions/queries.ts.
+		 */
+		selectedFeature === FEATURE_CUSTOM_DOMAIN ? siteSlug : undefined,
+		{
+			quantity: 1,
+			include_wordpressdotcom: false,
+			include_dotblogsubdomain: false,
+			locale,
+			tlds: [ 'com' ],
+		}
+	);
 
 	const longerPlanTermDefaultExperiment = useLongerPlanTermDefaultExperiment( flowName );
 
@@ -760,6 +784,7 @@ const PlansFeaturesMain = ( {
 		gridPlans: gridPlansForFeaturesGrid,
 		selectedPlan,
 		selectedFeature,
+		suggestedDomainName: wordPressSubdomainSuggestions?.[ 0 ]?.domain_name,
 	} );
 
 	return (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -159,6 +159,7 @@ class PlansComponent extends Component {
 		domainAndPlanPackage: PropTypes.bool,
 		intervalType: PropTypes.string,
 		customerType: PropTypes.string,
+		locale: PropTypes.string,
 		selectedFeature: PropTypes.string,
 		redirectTo: PropTypes.string,
 		selectedSite: PropTypes.object,
@@ -244,7 +245,8 @@ class PlansComponent extends Component {
 	};
 
 	renderPlansMain() {
-		const { selectedSite, isUntangled, isWPForTeamsSite, currentPlanIntervalType } = this.props;
+		const { selectedSite, isUntangled, isWPForTeamsSite, currentPlanIntervalType, locale } =
+			this.props;
 
 		if ( isEnabled( 'p2/p2-plus' ) && isWPForTeamsSite ) {
 			return (
@@ -288,6 +290,7 @@ class PlansComponent extends Component {
 				intent={ plansIntent }
 				isSpotlightOnCurrentPlan={ ! this.props.isDomainAndPlanPackageFlow }
 				showPlanTypeSelectorDropdown={ isEnabled( 'onboarding/interval-dropdown' ) }
+				locale={ locale }
 			/>
 		);
 	}

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -658,11 +658,23 @@ const FEATURES_LIST: FeatureList = {
 			} );
 		},
 		getAlternativeTitle: () => i18n.translate( 'Free custom domain' ),
-		getDescription: ( { domainName = undefined } = {} ) => {
+		getDescription: ( { domainName = undefined, suggestedDomainName = undefined } = {} ) => {
 			if ( domainName ) {
 				return i18n.translate( 'Your domain (%s) is included with this plan.', {
 					args: domainName,
 				} );
+			}
+
+			if ( suggestedDomainName ) {
+				return i18n.translate(
+					'A custom domain like {{i}}%s{{/i}} is available and free for the first year.',
+					{
+						args: suggestedDomainName,
+						components: {
+							i: <i />,
+						},
+					}
+				);
 			}
 
 			return i18n.translate(

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -70,7 +70,10 @@ export type FeatureObject = {
 	getTitle: ( params?: { domainName?: string } ) => TranslateResult;
 	getAlternativeTitle?: () => TranslateResult;
 	getHeader?: () => TranslateResult;
-	getDescription?: ( params?: { domainName?: string } ) => TranslateResult;
+	getDescription?: ( params?: {
+		domainName?: string;
+		suggestedDomainName?: string;
+	} ) => TranslateResult;
 	getStoreSlug?: () => string;
 	getCompareTitle?: () => TranslateResult;
 	getCompareSubtitle?: () => TranslateResult;


### PR DESCRIPTION
Enhance Plans Features: Add locale support and suggested domain name handling

* Introduce locale prop in PlansComponent and PlansFeaturesMain for internationalization.
* Update useSelectedFeature hook to accept suggestedDomainName and pass it to getDescription.
* Modify feature description logic to include suggested domain name in the features list.
* Add unit tests to ensure correct behavior with suggested domain name in useSelectedFeature.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

Try it out on a free site or site with current plan at `/plans/[YOUR_SITE].wordpress.com?plan=value_bundle&feature=custom-domain`

Question: should we display something different if a site has already redeemed site credit (`currentPlan?.hasRedeemedDomainCredit === true`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
