### PR TITLE
BT project follow-up: Improve 'no stored business cards' state in checkout

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -90,6 +90,7 @@ import { GoogleDomainsCopy } from './google-transfers-copy';
 import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-sidebar-plan-upsell';
 import { LeaveCheckoutModal, useCheckoutLeaveModal } from './leave-checkout-modal';
 import BeforeSubmitCheckoutHeader from './payment-method-step';
+import { PaymentMethodFilter } from './payment-methods-filter';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview, { CouponFieldArea } from './wp-checkout-order-review';
 import {
@@ -338,6 +339,8 @@ export default function CheckoutMainContent( {
 	isLoggedOutCart,
 	onPageLoadError,
 	paymentMethods,
+	areStoredCardsFiltered,
+	isBusinessCardsFilterEmpty,
 	removeProductFromCart,
 	showErrorMessageBriefly,
 	siteId,
@@ -359,6 +362,8 @@ export default function CheckoutMainContent( {
 	isLoggedOutCart: boolean;
 	onPageLoadError: CheckoutPageErrorCallback;
 	paymentMethods: PaymentMethod[];
+	areStoredCardsFiltered?: boolean;
+	isBusinessCardsFilterEmpty?: boolean;
 	removeProductFromCart: RemoveProductFromCart;
 	showErrorMessageBriefly: ( error: string ) => void;
 	siteId: number | undefined;
@@ -779,7 +784,15 @@ export default function CheckoutMainContent( {
 					/>
 				) }
 				<PaymentMethodStep
-					activeStepHeader={ <GoogleDomainsCopy responseCart={ responseCart } /> }
+					activeStepHeader={
+						<>
+							<GoogleDomainsCopy responseCart={ responseCart } />
+							<PaymentMethodFilter
+								areStoredCardsFiltered={ areStoredCardsFiltered }
+								isBusinessCardsFilterEmpty={ isBusinessCardsFilterEmpty }
+							/>
+						</>
+					}
 					canEditStep={ canEditPaymentStep() }
 					editButtonText={ String( translate( 'Edit' ) ) }
 					editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -349,6 +349,8 @@ export default function CheckoutMain( {
 			customizedPreviousPath
 		);
 
+	const isForBusiness = responseCart?.tax?.location?.is_for_business ?? false;
+
 	const {
 		paymentMethods: storedCards,
 		isLoading: isLoadingStoredCards,
@@ -356,8 +358,14 @@ export default function CheckoutMain( {
 	} = useStoredPaymentMethods( {
 		isLoggedOut: isLoggedOutCart,
 		type: 'card',
-		isForBusiness: responseCart ? responseCart?.tax?.location?.is_for_business : null,
+		isForBusiness,
 	} );
+
+	// Stored cards are filtered by the shoppingCart's tax_location->is_for_business value
+	const areStoredCardsFiltered = isForBusiness;
+
+	// If tax_location->is_for_business is set to true, then only business cards will show in Checkout
+	const isBusinessCardsFilterEmpty = isForBusiness && storedCards.length ? true : false;
 
 	useActOnceOnStrings( [ storedCardsError ].filter( isValueTruthy ), ( messages ) => {
 		messages.forEach( ( message ) => {
@@ -813,6 +821,8 @@ export default function CheckoutMain( {
 					isLoggedOutCart={ !! isLoggedOutCart }
 					onPageLoadError={ onPageLoadError }
 					paymentMethods={ paymentMethods }
+					areStoredCardsFiltered={ areStoredCardsFiltered }
+					isBusinessCardsFilterEmpty={ isBusinessCardsFilterEmpty }
 					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					siteId={ updatedSiteId }

--- a/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/is-for-business-checkbox.tsx
@@ -83,6 +83,7 @@ export function IsForBusinessCheckbox( {
 				checked={ isChecked }
 				disabled={ isDisabled }
 				onChange={ ( newValue ) => ! isDisabled && handleOnChange( newValue ) }
+				help={ isChecked && translate( 'Deselect to remove payment method filtering' ) }
 			/>
 		</CheckboxWrapper>
 	);

--- a/client/my-sites/checkout/src/components/payment-methods-filter.tsx
+++ b/client/my-sites/checkout/src/components/payment-methods-filter.tsx
@@ -1,0 +1,63 @@
+import { useMakeStepActive } from '@automattic/composite-checkout';
+import {
+	Button,
+	__experimentalSpacer as Spacer,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export interface PaymentMethodFilterProps {
+	areStoredCardsFiltered: boolean | undefined;
+	isBusinessCardsFilterEmpty: boolean | undefined;
+}
+
+export const PaymentMethodFilterNotice = ( {
+	isBusinessCardsFilterEmpty,
+}: {
+	isBusinessCardsFilterEmpty?: boolean;
+} ) => {
+	let noticeText;
+
+	if ( isBusinessCardsFilterEmpty ) {
+		noticeText = __( 'There are no stored business cards on your account. Please add one below.' );
+	} else {
+		noticeText = __( 'Payment methods filtered by Business Cards' );
+	}
+
+	return (
+		<Text color="var(--studio-gray-60)" size="14px">
+			{ noticeText }
+		</Text>
+	);
+};
+
+export const PaymentMethodFilterButton = () => {
+	const makeStepActive = useMakeStepActive();
+
+	return (
+		<Button
+			className="checkout-step__edit-button"
+			variant="link"
+			onClick={ () => makeStepActive( 'contact-form' ) }
+			label={ __( 'Remove payment method filter' ) }
+		>
+			<Text color="var(--color-link)" size="14px">
+				{ __( 'Remove' ) }
+			</Text>
+		</Button>
+	);
+};
+
+export const PaymentMethodFilter = ( {
+	areStoredCardsFiltered,
+	isBusinessCardsFilterEmpty,
+}: PaymentMethodFilterProps ) =>
+	areStoredCardsFiltered ? (
+		<Spacer marginTop="16px" marginBottom="16px">
+			<HStack alignment="center" justify="space-between">
+				<PaymentMethodFilterNotice isBusinessCardsFilterEmpty={ isBusinessCardsFilterEmpty } />
+				{ ! isBusinessCardsFilterEmpty && <PaymentMethodFilterButton /> }
+			</HStack>
+		</Spacer>
+	) : null;


### PR DESCRIPTION
Largely pulling the following from the base [issue](https://github.com/Automattic/payments-shilling/issues/3634):

### Background
We recently added an 'is this purchase for business' checkbox to Checkout's Billing Information step. Customers from Ohio and Connecticut can select this checkbox to opt into creating a stored card that is marked as "for business use" (more details [here](https://github.com/Automattic/wp-calypso/pull/99833)). 

One of the trade offs of this new "type" of card is that, at this time, is that this "business" designation for existing stored cards is essentially immutable. In order to keep customers from overwriting this value on their existing stored cards, we decided to simply filter the provided cards in Checkout by their business designation based on whether the `isForBusinessUseCheckbox` is checked or not.

While the checkbox and filtering code is deployed and works as expected, there is a few user experience issues we still need to resolve...

### The issues

Currently, when a customer first interacts with the business tax checkbox in Checkout, they do so from the Billing Information step. When they click on **"Continue to Payment"** the button callback triggers two key actions:

- It updates the shopping cart’s `tax_location->is_for_business` value to request a new tax rate from Taxamo. The cart is effectively in "business use mode" at this point.
- It filters stored payment methods to show only business cards or non-business cards, depending on the selection.

This approach simplifies managing the business tax override throughout Checkout, but it introduces an unintended friction point:

If a customer has never saved a business card before, they will see only the **“Add New Credit or Debit Card”** form, with no clear indication of why their existing cards are missing. While this technically allows them to proceed, it lacks helpful context. 

Similarly, when filtering for business cards there are no indicators that the selection is being affected by a filter, nor any useful actions to remove the filter on the payment methods.

### Proposed Improvements
**Clarify the empty state:**
- Add instructional text when no stored business cards exist, such as:
- “There are no stored business cards on your account. Please add one below.”

**Explain the filtering behavior:**
- If the payment methods list is filtered, display a message like:
- “Payment methods filtered by Business Cards”
- Provide a button to **Remove filter**

These small changes should help prevent customer confusion and improve the overall clarity of the Checkout flow.

### Implementation details
#### No stored business cards state
Provide a line of text clarifying what is expected. Might want to consider the "Remove filter" button here too
<img src="https://github.com/user-attachments/assets/48ccfe4d-ec1a-4568-935f-24221b712ec6"  width="600px" />


#### Filtered by Business Cards state
Provide a line of text denoting the filter that is applied, also a "Remove filter" button. This button will open the Billing Information step where the customer _should_ see the "help" label under the Checkbox which reads _"Deselect to remove payment method filtering"_. 
<img src="https://github.com/user-attachments/assets/593b6bd0-ac2c-4f40-84e8-09785c39f064"  width="600px" />

> [!NOTE] 
> In order to gain access to the setActiveStepNumber I had to export `CheckoutStepGroupContext` from composite-checkout which felt wrong, maybe @sirbrillig you have some ideas how to go about this?

#### Checkbox "help" label
The help label allows us to add in a little context about what the checkbox is doing. Maybe when a customer clicks on "Remove filter" and lands on the Billing Information step we could add some sort of "warning" state that highlights the checkbox in light yellow to draw their eye to it?
<img src="https://github.com/user-attachments/assets/ec458365-c134-4d00-b3cd-a37e1574bb2c"  width="600px" />

Related to https://github.com/Automattic/payments-shilling/issues/3634

## Testing Instructions

**Prerequisite for all test scenarios**
It's helpful to have two accounts, or maybe a sandboxed vs unsandboxed account, where you have one account with no stored business cards and the other _with_ stored business cards

- Go to Checkout > Billing Information
- Enter Country > United States, Postal code > 43010 (Ohio)
- Observe the "is this purchase for business?" checkbox that appears under the country/postal fields and proceed to the next test steps
- 
**Scenario 1: Unchecked box - no stored business cards**
- Leave the checkbox **unchecked**
- Click "Continue to Payment"
- All of your stored cards should be shown alongside any other payment methods
- At this point you shouldn't have a business card saved to your account, but even if you did they should not be shown here
_Expectation: All stored payment methods are available._

**Scenario 2: Checked box - no stored business cards**
- Check the checkbox and proceed to the payment step
- No stored cards should be shown and only the add new credit card form should appear with details labeled above it
_Expectation: The "Add new credit card" form should be the only "card" option with a label above the form that says "There are no stored business cards on your account. Please add one below."_

**Scenario 3: Checked box - stored business cards**
- With the box checked, go to payments step
- Only stored business cards should be displayed
- A filter label should be shown with a "Remove" button next to it
- Clicking the Remove button should reopen the Billing Information so the checkbox can be deselected

In all scenarios, checking the checkbox will show a help label under the checkbox with the text "Deselect to remove payment method filtering"