### PR TITLE
Re-enable the newsletter launchpad tasks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -6,7 +6,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { type ReactNode, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { useGoalsFirstCumulativeExperience } from 'calypso/data/experiment/use-goals-first-cumulative-experience';
 import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -63,7 +62,6 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 	const refParameter = getQueryArgs()?.ref as string;
 
 	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-	const [ , isIntentNewsletterGoalEnabled ] = useGoalsFirstCumulativeExperience();
 	const isIntentCreateCourseGoalEnabled = useCreateCourseGoalFeature();
 
 	useEffect( () => {
@@ -118,7 +116,6 @@ const GoalsStep: StepType = ( { navigation, flow } ) => {
 		( action: string, eventProps: Record< string, unknown > = {} ) =>
 		() => {
 			const intent = goalsToIntent( goals, {
-				isIntentNewsletterGoalEnabled,
 				isIntentCreateCourseGoalEnabled,
 			} );
 			setIntent( intent );

--- a/packages/data-stores/src/onboard/test/utils.ts
+++ b/packages/data-stores/src/onboard/test/utils.ts
@@ -40,24 +40,7 @@ describe( 'Test onboard utils', () => {
 		},
 		{
 			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
-			expectedIntent: SiteIntent.Write,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: false,
-			},
-		},
-		{
-			goals: [ SiteGoal.Write, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: true,
-			},
-		},
-		{
-			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
-			expectedIntent: SiteIntent.Sell,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: false,
-			},
 		},
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Courses ],
@@ -69,9 +52,6 @@ describe( 'Test onboard utils', () => {
 		{
 			goals: [ SiteGoal.Sell, SiteGoal.Newsletter ],
 			expectedIntent: SiteIntent.NewsletterGoal,
-			featureFlags: {
-				isIntentNewsletterGoalEnabled: true,
-			},
 		},
 	] )(
 		'Should map the $goals to $expectedIntent intent ($featureFlags)',

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,12 +1,11 @@
 import { SiteGoal, SiteIntent } from './constants';
 
 interface Flags {
-	isIntentNewsletterGoalEnabled?: boolean;
 	isIntentCreateCourseGoalEnabled?: boolean;
 }
 
 export const goalsToIntent = ( goals: SiteGoal[], flags?: Flags ): SiteIntent => {
-	const { isIntentNewsletterGoalEnabled, isIntentCreateCourseGoalEnabled } = flags ?? {};
+	const { isIntentCreateCourseGoalEnabled } = flags ?? {};
 
 	// When DIFM and Import goals are selected together, DIFM Intent will have the priority and will be set.
 	if ( goals.includes( SiteGoal.DIFM ) ) {
@@ -22,7 +21,7 @@ export const goalsToIntent = ( goals: SiteGoal[], flags?: Flags ): SiteIntent =>
 	}
 
 	// Newsletter flow
-	if ( isIntentNewsletterGoalEnabled && goals.includes( SiteGoal.Newsletter ) ) {
+	if ( goals.includes( SiteGoal.Newsletter ) ) {
 		return SiteIntent.NewsletterGoal;
 	}
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101554

## Proposed Changes

* They were disabled as a side-effect of the goals-first experiment being stopped.

![CleanShot 2025-03-19 at 14 39 08@2x](https://github.com/user-attachments/assets/d8b110a8-20b4-45f2-8655-1ccf11c8047e)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Choosing both newsletter and blog tasks in the goal step should result in the newsletter launchpad tasks being shown (you can tell because it has the "Write a welcome message" task)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
