### PR TITLE
Onboarding consistency: Use StepContainerV2 in DIFM starting point

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer, DIFM_FLOW } from '@automattic/onboarding';
+import { StepContainer, DIFM_FLOW, Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -8,11 +8,14 @@ import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
 import HelpCenterStepButton from 'calypso/signup/help-center-step-button';
 import useShouldRenderHelpCenterButton from 'calypso/signup/help-center-step-button/use-should-render-help-center-button';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
-import type { Step } from '../../types';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { StepContainerV2DIFMStartingPoint } from './step-container-v2-difm-starting-point';
+import type { Step as StepType } from '../../types';
 import type { AppState } from 'calypso/types';
 
 const STEP_NAME = 'difmStartingPoint';
-const DIFMStartingPoint: Step< {
+
+const DIFMStartingPoint: StepType< {
 	submits: { newOrExistingSiteChoice: 'existing-site' | 'new-site' };
 } > = function ( { flow, navigation } ) {
 	const { goNext, goBack, submit } = navigation;
@@ -30,11 +33,69 @@ const DIFMStartingPoint: Step< {
 		enabledGeos: [ 'US' ],
 	} );
 
+	const shouldRenderHelpCenter = isHelpCenterLinkEnabled && shouldRenderHelpCenterLink;
+
 	const onSubmit = ( value: 'existing-site' | 'new-site' ) => {
 		submit?.( {
 			newOrExistingSiteChoice: value,
 		} );
 	};
+
+	if ( shouldUseStepContainerV2( flow ) ) {
+		const primaryButton = showNewOrExistingSiteChoice ? (
+			<Step.NextButton
+				onClick={ () => onSubmit( 'existing-site' ) }
+				label={ translate( 'Use an existing site' ) }
+			/>
+		) : (
+			<Step.NextButton
+				onClick={ () => onSubmit( 'new-site' ) }
+				label={ translate( 'Get started' ) }
+			/>
+		);
+
+		const secondaryButton = showNewOrExistingSiteChoice ? (
+			<Step.NextButton
+				variant="secondary"
+				onClick={ () => onSubmit( 'new-site' ) }
+				label={ translate( 'Start a new site' ) }
+			/>
+		) : undefined;
+
+		return (
+			<>
+				<DocumentHead title={ translate( 'Let us build your site' ) } />
+				<StepContainerV2DIFMStartingPoint
+					topBar={
+						<Step.TopBar
+							backButton={ <Step.BackButton onClick={ goBack } /> }
+							skipButton={
+								shouldRenderHelpCenter ? (
+									<HelpCenterStepButton
+										flowName={ flow }
+										enabledGeos={ [ 'US' ] }
+										helpCenterButtonCopy={ translate( 'Questions?' ) }
+										helpCenterButtonLink={ translate( 'Contact our site building team' ) }
+									/>
+								) : (
+									<Step.SkipButton
+										onClick={ goNext }
+										label={ translate( 'No Thanks, I’ll Build It' ) }
+									/>
+								)
+							}
+						/>
+					}
+					stickyBottomBar={
+						<Step.StickyBottomBar leftButton={ secondaryButton } rightButton={ primaryButton } />
+					}
+					primaryButton={ primaryButton }
+					secondaryButton={ secondaryButton }
+					siteId={ siteId }
+				/>
+			</>
+		);
+	}
 
 	return (
 		<>
@@ -47,11 +108,11 @@ const DIFMStartingPoint: Step< {
 				isWideLayout
 				isLargeSkipLayout={ false }
 				skipLabelText={
-					shouldRenderHelpCenterLink ? undefined : translate( 'No Thanks, I’ll Build It' )
+					shouldRenderHelpCenter ? undefined : translate( 'No Thanks, I’ll Build It' )
 				}
-				hideSkip={ shouldRenderHelpCenterLink }
+				hideSkip={ shouldRenderHelpCenter }
 				customizedActionButtons={
-					isHelpCenterLinkEnabled ? (
+					shouldRenderHelpCenter ? (
 						<HelpCenterStepButton
 							flowName={ flow }
 							enabledGeos={ [ 'US' ] }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -68,7 +68,7 @@ const DIFMStartingPoint: StepType< {
 				<StepContainerV2DIFMStartingPoint
 					topBar={
 						<Step.TopBar
-							backButton={ <Step.BackButton onClick={ goBack } /> }
+							backButton={ goBack ? <Step.BackButton onClick={ goBack } /> : undefined }
 							skipButton={
 								shouldRenderHelpCenter ? (
 									<HelpCenterStepButton

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
@@ -1,0 +1,74 @@
+import { Step } from '@automattic/onboarding';
+import { useViewportMatch } from '@wordpress/compose';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
+import AsyncLoad from 'calypso/components/async-load';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { DIFMFAQ } from 'calypso/my-sites/marketing/do-it-for-me/faq';
+import { DIFMServiceDescription } from 'calypso/my-sites/marketing/do-it-for-me/service-description';
+import { useDIFMHeading } from 'calypso/my-sites/marketing/do-it-for-me/use-difm-heading';
+
+import './style.scss';
+
+export const StepContainerV2DIFMStartingPoint = ( {
+	topBar,
+	siteId,
+	stickyBottomBar,
+	primaryButton,
+	secondaryButton,
+}: {
+	topBar: ReactNode;
+	stickyBottomBar: ReactNode;
+	primaryButton: ReactNode;
+	siteId?: number;
+	secondaryButton?: ReactNode;
+} ) => {
+	const translate = useTranslate();
+
+	const { headerText, subHeaderText } = useDIFMHeading( {
+		isStoreFlow: false,
+		siteId,
+	} );
+
+	const isMediumViewport = useViewportMatch( 'small', '>=' );
+	const isExtraLargeViewport = useViewportMatch( 'large', '>=' );
+
+	const ctas = isMediumViewport && (
+		<>
+			{ primaryButton }
+			{ secondaryButton && <span>{ translate( 'or' ) }</span> }
+			{ secondaryButton }
+		</>
+	);
+
+	return (
+		<Step.TwoColumnLayout
+			className="step-container-v2--difm-starting-point"
+			firstColumnWidth={ 1 }
+			secondColumnWidth={ 1 }
+			topBar={ topBar }
+			stickyBottomBar={ stickyBottomBar }
+			isMediumViewport={ isMediumViewport }
+			footer={ <DIFMFAQ isStoreFlow={ false } siteId={ siteId } ctaSection={ ctas } /> }
+		>
+			{ () => (
+				<>
+					<div className="step-container-v2--difm-starting-point__left-column">
+						<Step.Heading text={ headerText } subText={ subHeaderText } align="left" />
+						<DIFMServiceDescription isStoreFlow={ false } />
+						{ ctas && <div className="step-container-v2--difm-starting-point__ctas">{ ctas }</div> }
+					</div>
+					{ isExtraLargeViewport && (
+						<div style={ { height: '562px' } }>
+							<AsyncLoad
+								require="calypso/my-sites/marketing/do-it-for-me/site-build-showcase"
+								placeholder={ <LoadingEllipsis /> }
+								isStoreFlow={ false }
+							/>
+						</div>
+					) }
+				</>
+			) }
+		</Step.TwoColumnLayout>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
@@ -1,5 +1,7 @@
 import { Step } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
@@ -49,7 +51,28 @@ export const StepContainerV2DIFMStartingPoint = ( {
 			topBar={ topBar }
 			stickyBottomBar={ stickyBottomBar }
 			isMediumViewport={ isMediumViewport }
-			footer={ <DIFMFAQ isStoreFlow={ false } siteId={ siteId } ctaSection={ ctas } /> }
+			footer={
+				<DIFMFAQ
+					isStoreFlow={ false }
+					siteId={ siteId }
+					ctaSection={ ctas }
+					renderExpanderButton={ ( { ref, onClick, isFAQSectionOpen, children } ) => {
+						return (
+							<Button
+								className="step-container-v2--difm-starting-point__faq-expander"
+								variant="secondary"
+								ref={ ref }
+								onClick={ onClick }
+								icon={ isFAQSectionOpen ? chevronUp : chevronDown }
+								iconPosition="right"
+								iconSize={ 18 }
+							>
+								{ children }
+							</Button>
+						);
+					} }
+				/>
+			}
 		>
 			<div className="step-container-v2--difm-starting-point__left-column">
 				<Step.Heading text={ headerText } subText={ subHeaderText } align="left" />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/step-container-v2-difm-starting-point.tsx
@@ -51,23 +51,19 @@ export const StepContainerV2DIFMStartingPoint = ( {
 			isMediumViewport={ isMediumViewport }
 			footer={ <DIFMFAQ isStoreFlow={ false } siteId={ siteId } ctaSection={ ctas } /> }
 		>
-			{ () => (
-				<>
-					<div className="step-container-v2--difm-starting-point__left-column">
-						<Step.Heading text={ headerText } subText={ subHeaderText } align="left" />
-						<DIFMServiceDescription isStoreFlow={ false } />
-						{ ctas && <div className="step-container-v2--difm-starting-point__ctas">{ ctas }</div> }
-					</div>
-					{ isExtraLargeViewport && (
-						<div style={ { height: '562px' } }>
-							<AsyncLoad
-								require="calypso/my-sites/marketing/do-it-for-me/site-build-showcase"
-								placeholder={ <LoadingEllipsis /> }
-								isStoreFlow={ false }
-							/>
-						</div>
-					) }
-				</>
+			<div className="step-container-v2--difm-starting-point__left-column">
+				<Step.Heading text={ headerText } subText={ subHeaderText } align="left" />
+				<DIFMServiceDescription isStoreFlow={ false } />
+				{ ctas && <div className="step-container-v2--difm-starting-point__ctas">{ ctas }</div> }
+			</div>
+			{ isExtraLargeViewport && (
+				<div className="step-container-v2--difm-starting-point__right-column">
+					<AsyncLoad
+						require="calypso/my-sites/marketing/do-it-for-me/site-build-showcase"
+						placeholder={ <LoadingEllipsis /> }
+						isStoreFlow={ false }
+					/>
+				</div>
 			) }
 		</Step.TwoColumnLayout>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
@@ -41,4 +41,16 @@
 	&__right-column {
 		height: 562px;
 	}
+
+	&__faq-expander {
+		--wp-components-color-accent: var(--color-neutral-60);
+		--wp-components-color-accent-darker-20: var(--color-neutral-80);
+
+		width: 100%;
+		justify-content: center !important;
+
+		@include break-small {
+			max-width: 404px;
+		}
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.step-container-v2 .step-container-v2--difm-starting-point {
+.step-container-v2:has(.step-container-v2--difm-starting-point) {
 	.help-center-step-button {
 		font-size: 0.875rem;
 		line-height: 1;
@@ -26,31 +26,33 @@
 		}
 	}
 
-	&__ctas {
-		display: flex;
-		gap: 16px;
-		align-items: center;
-	}
+	.step-container-v2--difm-starting-point {
+		&__ctas {
+			display: flex;
+			gap: 16px;
+			align-items: center;
+		}
 
-	&__left-column {
-		display: flex;
-		flex-direction: column;
-		gap: 32px;
-	}
+		&__left-column {
+			display: flex;
+			flex-direction: column;
+			gap: 32px;
+		}
 
-	&__right-column {
-		height: 562px;
-	}
+		&__right-column {
+			height: 562px;
+		}
 
-	&__faq-expander {
-		--wp-components-color-accent: var(--color-neutral-60);
-		--wp-components-color-accent-darker-20: var(--color-neutral-80);
+		&__faq-expander {
+			--wp-components-color-accent: var(--color-neutral-60);
+			--wp-components-color-accent-darker-20: var(--color-neutral-80);
 
-		width: 100%;
-		justify-content: center !important;
+			width: 100%;
+			justify-content: center !important;
 
-		@include break-small {
-			max-width: 404px;
+			@include break-small {
+				max-width: 404px;
+			}
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
@@ -37,4 +37,8 @@
 		flex-direction: column;
 		gap: 32px;
 	}
+
+	&__right-column {
+		height: 562px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
@@ -1,0 +1,40 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.step-container-v2 .step-container-v2--difm-starting-point {
+	.help-center-step-button {
+		font-size: 0.875rem;
+		line-height: 1;
+		height: 24px;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+
+		label {
+			display: none;
+
+			@include break-small {
+				display: inline;
+			}
+		}
+
+		&__button {
+			--wp-components-color-accent: var(--color-neutral-100);
+			font-size: inherit;
+			line-height: inherit;
+			font-weight: 500;
+		}
+	}
+
+	&__ctas {
+		display: flex;
+		gap: 16px;
+		align-items: center;
+	}
+
+	&__left-column {
+		display: flex;
+		flex-direction: column;
+		gap: 32px;
+	}
+}

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -141,7 +141,11 @@ export default function DIFMLanding( {
 					/>
 				</ImageSection>
 			</Wrapper>
-			<DIFMFAQ isStoreFlow={ isStoreFlow } siteId={ siteId ?? undefined } ctaSection={ ctas } />
+			<DIFMFAQ
+				isStoreFlow={ isStoreFlow }
+				siteId={ siteId ?? undefined }
+				ctaSection={ <CTASectionWrapper>{ ctas }</CTASectionWrapper> }
+			/>
 		</>
 	);
 }

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -1,58 +1,14 @@
-import {
-	WPCOM_DIFM_LITE,
-	getPlan,
-	isBusiness,
-	isPremium,
-	isEcommerce,
-	isPro,
-	getDIFMTieredPriceDetails,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	getFeatureByKey,
-} from '@automattic/calypso-products';
-import { Gridicon } from '@automattic/components';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import styled from '@emotion/styled';
-import { Button } from '@wordpress/components';
-import { formatCurrency, numberFormat, useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useTranslate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
-import QueryProductsList from 'calypso/components/data/query-products-list';
-import FoldableFAQComponent from 'calypso/components/foldable-faq';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
-import { CHARACTER_LIMIT } from 'calypso/signup/steps/website-content/section-types/constants';
-import { useSelector } from 'calypso/state';
-import {
-	getProductBySlug,
-	getProductCost,
-	getProductCurrencyCode,
-} from 'calypso/state/products-list/selectors';
-import { getSitePlan } from 'calypso/state/sites/selectors';
-import type { TranslateResult } from 'i18n-calypso';
+import { DIFMFAQ } from './faq';
+import { DIFMServiceDescription } from './service-description';
+import { useDIFMHeading } from './use-difm-heading';
 
 import './difm-landing.scss';
-
-const Placeholder = styled.span`
-	padding: 0 60px;
-	animation: loading-fade 800ms ease-in-out infinite;
-	background-color: var( --color-neutral-10 );
-	color: transparent;
-	min-height: 20px;
-	@keyframes loading-fade {
-		0% {
-			opacity: 0.5;
-		}
-		50% {
-			opacity: 1;
-		}
-		100% {
-			opacity: 0.5;
-		}
-	}
-`;
 
 const Wrapper = styled.div`
 	display: flex;
@@ -96,71 +52,6 @@ const Header = styled( FormattedHeader )`
 	}
 `;
 
-const FAQExpander = styled( Button )`
-	align-self: center;
-	background: var( --studio-gray-0 );
-	font-size: 0.875rem;
-	padding: 12px 0;
-	width: 500px;
-	height: 48px;
-	text-align: center;
-	&&& {
-		justify-content: center;
-	}
-	@media ( max-width: 660px ) {
-		width: 90vw;
-	}
-`;
-
-const FAQHeader = styled.h1`
-	font-size: 2rem;
-	text-align: center;
-	margin: 48px 0;
-`;
-
-const FAQSection = styled.div`
-	display: flex;
-	flex-direction: column;
-`;
-
-const FoldableFAQ = styled( FoldableFAQComponent )`
-	border: 1px solid #e9e9ea;
-	padding: 0;
-	border-radius: 4px;
-	margin-bottom: 24px;
-	.foldable-faq__question {
-		padding: 24px 16px 24px 24px;
-		flex-direction: row-reverse;
-		width: 100%;
-		svg {
-			margin-inline-end: 0;
-			margin-inline-start: auto;
-			flex-shrink: 0;
-		}
-		.foldable-faq__question-text {
-			padding-inline-start: 0;
-			font-size: 1.125rem;
-		}
-	}
-	&.is-expanded {
-		border: 2px solid var( --studio-wordpress-blue-50 );
-		.foldable-faq__answer {
-			margin: 0 16px 24px 0;
-			ul {
-				margin: 0 0 0 16px;
-			}
-		}
-	}
-	&:not( .is-expanded ) .foldable-faq__question:focus {
-		box-shadow: 0 0 0 var( --studio-wordpress-blue-50, var( --wp-admin-theme-color, #3858e9 ) );
-		outline: 3px solid transparent;
-	}
-	.foldable-faq__answer {
-		padding: 0 16px 0 24px;
-		border: 0;
-	}
-`;
-
 const CTASectionWrapper = styled.div`
 	display: flex;
 	align-items: center;
@@ -197,93 +88,6 @@ const CTASectionWrapper = styled.div`
 	}
 `;
 
-const StepContainer = styled.div`
-	display: flex;
-	gap: 20px;
-	margin-top: 0;
-`;
-
-const ProgressLine = styled.div`
-	width: 1px;
-	background: var( --studio-gray-5 );
-	height: 100%;
-`;
-
-const VerticalStepProgress = styled.div`
-	display: flex;
-	flex-direction: column;
-	margin: 36px 0 12px 0;
-	${ StepContainer }:last-child {
-		${ ProgressLine } {
-			display: none;
-		}
-	}
-`;
-
-const IndexContainer = styled.div`
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-`;
-
-const Index = styled.div`
-	border-radius: 50%;
-	border: 1px solid var( --studio-gray-5 );
-	color: var( --studio-gray-30 );
-	font-size: 1.125rem;
-	height: 20px;
-	line-height: 20px;
-	padding: 10px;
-	text-align: center;
-	width: 20px;
-`;
-const Title = styled.div`
-	margin-bottom: 6px;
-	color: var( --studio-gray-100 );
-	font-weight: 500;
-`;
-const Description = styled.div`
-	color: var( --studio-gray-60 );
-	padding-bottom: 18px;
-	font-size: 0.875rem;
-`;
-
-const hasHigherPlan = ( currentPlan: string, plan: typeof PLAN_PREMIUM | typeof PLAN_BUSINESS ) => {
-	const planMatchers =
-		plan === PLAN_PREMIUM
-			? [ isPremium, isBusiness, isEcommerce, isPro ]
-			: [ isBusiness, isEcommerce, isPro ];
-
-	return planMatchers.some( ( planMatcher ) =>
-		planMatcher( {
-			productSlug: currentPlan,
-		} )
-	);
-};
-
-const Step = ( {
-	index,
-	title,
-	description,
-}: {
-	index: TranslateResult;
-	title: TranslateResult;
-	description: TranslateResult;
-} ) => {
-	return (
-		<StepContainer>
-			<IndexContainer>
-				<Index>{ index }</Index>
-				<ProgressLine />
-			</IndexContainer>
-			<div>
-				<Title>{ title }</Title>
-				<Description>{ description }</Description>
-			</div>
-		</StepContainer>
-	);
-};
-
 export default function DIFMLanding( {
 	showNewOrExistingSiteChoice,
 	onPrimarySubmit,
@@ -297,182 +101,27 @@ export default function DIFMLanding( {
 	siteId?: number | null;
 	isStoreFlow: boolean;
 } ) {
-	const requiredProductSlugs = [ PLAN_PREMIUM, WPCOM_DIFM_LITE, PLAN_BUSINESS ];
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 
-	const product = useSelector( ( state ) => getProductBySlug( state, WPCOM_DIFM_LITE ) );
-	const productCost = product?.cost;
+	const { headerText, subHeaderText } = useDIFMHeading( {
+		isStoreFlow,
+		siteId: siteId ?? undefined,
+	} );
 
-	const planSlug = isStoreFlow ? PLAN_BUSINESS : PLAN_PREMIUM;
-	const planObject = getPlan( planSlug );
-	const planTitle = planObject?.getTitle();
-	const planCostInteger = useSelector( ( state ) => getProductCost( state, planSlug ) );
-	const planStorageSlug = planObject?.getStorageFeature?.();
-	const planStorageString = planStorageSlug ? getFeatureByKey( planStorageSlug )?.getTitle() : '';
-
-	const difmTieredPriceDetails = getDIFMTieredPriceDetails( product );
-	const extraPageCost = difmTieredPriceDetails?.perExtraPagePrice;
-
-	// This is used in a FAQ item.
-	const businessPlanCostInteger = useSelector( ( state ) =>
-		getProductCost( state, PLAN_BUSINESS )
+	const ctas = showNewOrExistingSiteChoice ? (
+		<>
+			<NextButton onClick={ onPrimarySubmit }>{ translate( 'Use an existing site' ) }</NextButton>
+			<span>{ translate( 'or' ) }</span>
+			<NextButton onClick={ onSecondarySubmit } variant="secondary">
+				{ translate( 'Start a new site' ) }
+			</NextButton>
+		</>
+	) : (
+		<NextButton onClick={ onPrimarySubmit }>{ translate( 'Get started' ) }</NextButton>
 	);
-
-	const currencyCode = useSelector( ( state ) => getProductCurrencyCode( state, WPCOM_DIFM_LITE ) );
-	const hasPriceDataLoaded =
-		productCost && extraPageCost && planCostInteger && businessPlanCostInteger && currencyCode;
-
-	const displayCost = hasPriceDataLoaded
-		? formatCurrency( productCost, currencyCode, { stripZeros: true } )
-		: '';
-
-	const planCost = hasPriceDataLoaded
-		? formatCurrency( planCostInteger, currencyCode, { stripZeros: true } )
-		: '';
-
-	const extraPageDisplayCost = hasPriceDataLoaded
-		? formatCurrency( extraPageCost, currencyCode, {
-				stripZeros: true,
-				isSmallestUnit: true,
-		  } )
-		: '';
-
-	const businessPlanCost = hasPriceDataLoaded
-		? formatCurrency( businessPlanCostInteger, currencyCode, { stripZeros: true } )
-		: '';
-
-	const faqHeader = useRef( null );
-	const [ isFAQSectionOpen, setIsFAQSectionOpen ] = useState( false );
-	const onFAQButtonClick = useCallback( () => {
-		setIsFAQSectionOpen( ( isFAQSectionOpen ) => ! isFAQSectionOpen );
-	}, [ setIsFAQSectionOpen ] );
-
-	useEffect( () => {
-		if ( isFAQSectionOpen && faqHeader.current ) {
-			scrollIntoViewport( faqHeader.current, {
-				behavior: 'smooth',
-				scrollMode: 'if-needed',
-			} );
-		}
-	}, [ isFAQSectionOpen ] );
-
-	const headerTextTranslateArgs = {
-		components: {
-			PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
-			sup: <sup />,
-		},
-		args: {
-			displayCost,
-			days: 4,
-		},
-	};
-	const headerText = isStoreFlow
-		? translate(
-				'Let us build your store in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
-				headerTextTranslateArgs
-		  )
-		: translate(
-				'Let us build your site in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
-				headerTextTranslateArgs
-		  );
-
-	const currentPlan = useSelector( ( state ) => ( siteId ? getSitePlan( state, siteId ) : null ) );
-	const hasCurrentPlanOrHigherPlan = currentPlan?.product_slug
-		? hasHigherPlan( currentPlan.product_slug, planSlug )
-		: false;
-
-	const subHeaderText = hasCurrentPlanOrHigherPlan
-		? translate(
-				'{{sup}}*{{/sup}}One time fee. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
-				{
-					args: {
-						freePages: 5,
-					},
-					components: {
-						sup: <sup />,
-					},
-				}
-		  )
-		: translate(
-				'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
-				{
-					args: {
-						plan: planTitle ?? '',
-						freePages: 5,
-					},
-					components: {
-						sup: <sup />,
-					},
-				}
-		  );
-
-	const faqPlanCostOldCopy = translate(
-		'The service costs %(displayCost)s, plus an additional %(planCost)s for the %(planTitle)s plan, which offers fast, secure hosting, video embedding, %(storage)s of storage, a free domain for one year, and live chat support.',
-		{
-			args: {
-				displayCost,
-				planTitle: planTitle ?? '',
-				planCost,
-				storage: planStorageString,
-			},
-		}
-	);
-	const faqPlanCostNewCopy = translate(
-		'The service costs %(displayCost)s, plus an additional %(planCost)s for the %(planTitle)s plan, which offers fast, secure hosting, video embedding, %(storage)s of storage, a free domain for one year, and expert support from our team.',
-		{
-			args: {
-				displayCost,
-				planTitle: planTitle ?? '',
-				planCost,
-				storage: planStorageString,
-			},
-		}
-	);
-
-	let faqRevisionsAnswer = translate(
-		'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
-			'Furthermore, our %s plan offers live chat and priority email support if you need assistance.',
-		{
-			args: [ planTitle || '' ],
-		}
-	);
-	if ( planSlug === PLAN_BUSINESS ) {
-		const isCopyTranslated = hasEnTranslation(
-			'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
-				'Furthermore, our %s plan offers 24X7 priority support from our experts if you need assistance.'
-		);
-		if ( isCopyTranslated ) {
-			faqRevisionsAnswer = translate(
-				'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
-					'Furthermore, our %s plan offers 24X7 priority support from our experts if you need assistance.',
-				{
-					args: [ planTitle || '' ],
-				}
-			);
-		}
-	}
-	if ( planSlug === PLAN_PREMIUM ) {
-		const isCopyTranslated = hasEnTranslation(
-			'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
-				'Furthermore, our %s plan offers fast support from our experts if you need assistance.'
-		);
-		if ( isCopyTranslated ) {
-			faqRevisionsAnswer = translate(
-				'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
-					'Furthermore, our %s plan offers fast support from our experts if you need assistance.',
-				{
-					args: [ planTitle || '' ],
-				}
-			);
-		}
-	}
 
 	return (
 		<>
-			{ ! hasPriceDataLoaded && (
-				<QueryProductsList productSlugList={ requiredProductSlugs } type="partial" />
-			) }
 			<Wrapper>
 				<ContentSection>
 					<Header
@@ -481,65 +130,8 @@ export default function DIFMLanding( {
 						headerText={ headerText }
 						subHeaderText={ subHeaderText }
 					/>
-					<VerticalStepProgress>
-						<Step
-							index={ translate( '1' ) }
-							title={ translate( 'Submit your business information' ) }
-							description={ translate( 'Optionally provide your profiles to be found on social.' ) }
-						/>
-
-						<Step
-							index={ translate( '2' ) }
-							title={ translate( 'Select your design and pages' ) }
-							description={ translate( 'Can’t decide? Let our experts choose the best design!' ) }
-						/>
-
-						<Step
-							index={ translate( '3' ) }
-							title={ translate( 'Complete the purchase' ) }
-							description={ translate( 'Try risk free with a %(days)d-day money back guarantee.', {
-								args: {
-									days: 14,
-								},
-								comment: 'the arg is the refund period in days',
-							} ) }
-						/>
-
-						<Step
-							index={ translate( '4' ) }
-							title={ translate( 'Submit content for your new website' ) }
-							description={
-								isStoreFlow
-									? translate( 'Products can be added later with the WordPress editor.' )
-									: translate( 'Content can be edited later with the WordPress editor.' )
-							}
-						/>
-					</VerticalStepProgress>
-					<p>
-						{ translate(
-							'Share your finished site with the world in %(days)d business days or less!',
-							{
-								args: {
-									days: 4,
-								},
-							}
-						) }
-					</p>
-					{ showNewOrExistingSiteChoice ? (
-						<CTASectionWrapper>
-							<NextButton onClick={ onPrimarySubmit }>
-								{ translate( 'Use an existing site' ) }
-							</NextButton>
-							<span>{ translate( 'or' ) }</span>
-							<NextButton onClick={ onSecondarySubmit } variant="secondary">
-								{ translate( 'Start a new site' ) }
-							</NextButton>
-						</CTASectionWrapper>
-					) : (
-						<CTASectionWrapper>
-							<NextButton onClick={ onPrimarySubmit }>{ translate( 'Get started' ) }</NextButton>
-						</CTASectionWrapper>
-					) }
+					<DIFMServiceDescription isStoreFlow={ isStoreFlow } />
+					<CTASectionWrapper>{ ctas }</CTASectionWrapper>
 				</ContentSection>
 				<ImageSection>
 					<AsyncLoad
@@ -549,244 +141,7 @@ export default function DIFMLanding( {
 					/>
 				</ImageSection>
 			</Wrapper>
-
-			<FAQSection>
-				<FAQExpander
-					ref={ faqHeader }
-					onClick={ onFAQButtonClick }
-					icon={ <Gridicon icon={ isFAQSectionOpen ? 'chevron-up' : 'chevron-down' } /> }
-				>
-					{ isFAQSectionOpen
-						? translate( 'Hide Frequently Asked Questions' )
-						: translate( 'Show Frequently Asked Questions' ) }
-				</FAQExpander>
-				{ isFAQSectionOpen && (
-					<>
-						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-						<FAQHeader className="wp-brand-font">
-							{ translate( 'Frequently Asked Questions' ) }{ ' ' }
-						</FAQHeader>
-						<FoldableFAQ
-							id="faq-1"
-							expanded
-							question={ translate(
-								'What is the Express Website Design Service, and who is it for?'
-							) }
-						>
-							<p>
-								{ translate(
-									'Our website-building service is for anyone who wants a polished website fast: small businesses, personal websites, bloggers, clubs or organizations, and more. ' +
-										"Just answer a few questions, submit your content, and we'll handle the rest. " +
-										"Click the button above to start, and you'll receive your customized 5-page site within 4 business days!"
-								) }
-							</p>
-						</FoldableFAQ>
-						<FoldableFAQ id="faq-2" question={ translate( 'How much does it cost?' ) }>
-							<p>
-								{ hasEnTranslation(
-									'The service costs %(displayCost)s, plus an additional %(planCost)s for the %(planTitle)s plan, which offers fast, secure hosting, video embedding, %(storage)s of storage, a free domain for one year, and fast support from our expert team.'
-								)
-									? faqPlanCostNewCopy
-									: faqPlanCostOldCopy }
-							</p>
-						</FoldableFAQ>
-						{ isStoreFlow && (
-							<FoldableFAQ
-								id="faq-2-1"
-								question={ translate( 'What does my store setup include?' ) }
-							>
-								<p>
-									{ translate(
-										'Your purchase includes the setup of the WooCommerce shop landing page, cart, checkout, and my account pages, along with additional pages you choose while signing up. ' +
-											'Please note, individual product setup, payments, taxes, shipping, and other WooCommerce extensions or settings are not included. ' +
-											'You can set these up later, support is happy to help if you have questions.'
-									) }
-								</p>
-							</FoldableFAQ>
-						) }
-						<FoldableFAQ
-							id="faq-3"
-							question={ translate( 'Can I purchase additional pages if I need more than five?' ) }
-						>
-							<p>
-								{ translate(
-									'Yes, extra pages can be purchased for %(extraPageDisplayCost)s each.',
-									{
-										args: {
-											extraPageDisplayCost,
-										},
-									}
-								) }
-							</p>
-						</FoldableFAQ>
-						<FoldableFAQ
-							id="faq-4"
-							question={ translate( "What if I don't have enough images or content?" ) }
-						>
-							<p>
-								{ translate(
-									"Don't worry if you don't have images or content for every page. " +
-										"After checkout, you'll have an option to opt into AI text creation. " +
-										'Our design team can select images and use AI to create your site content, all of which you can edit later using the editor. ' +
-										"If you select the blog page during sign up, we'll even create three blog posts for you to get you started!"
-								) }
-							</p>
-						</FoldableFAQ>
-						<FoldableFAQ id="faq-5" question={ translate( 'When will you contact me?' ) }>
-							<p>
-								{ translate(
-									'After you check out, you’ll fill out a content upload form that includes any design preferences and reference sites. ' +
-										"While we can't guarantee an exact match, we'll consider all your feedback during site construction, and you'll receive an email when your new site is ready — always within four business days."
-								) }
-							</p>
-						</FoldableFAQ>
-						<FoldableFAQ
-							id="faq-6"
-							question={ translate( 'What will my completed website look like?' ) }
-						>
-							<p>
-								{ translate(
-									'Each website is unique, mobile-friendly, and customized to your brand and content. ' +
-										'With a 97% satisfaction rate, we are confident that you will love your new site, just like hundreds of customers before you. ' +
-										'Additionally, we offer a 14-day refund window, giving you peace of mind.'
-								) }
-							</p>
-						</FoldableFAQ>
-						<FoldableFAQ id="faq-7" question={ translate( 'How many revisions are included?' ) }>
-							<p>{ faqRevisionsAnswer }</p>
-						</FoldableFAQ>
-						<FoldableFAQ
-							id="faq-8"
-							question={ translate( 'What happens to my existing content?' ) }
-						>
-							<p>
-								{ translate(
-									'If you choose to use your current WordPress.com site, your existing content will remain untouched. ' +
-										"We'll create new pages with your provided content while applying a new, customized theme. However, we won't edit any existing content on your site's pages."
-								) }
-							</p>
-						</FoldableFAQ>
-						<FoldableFAQ id="faq-9" question={ translate( 'What are the content guidelines?' ) }>
-							<p>
-								{ translate(
-									'{{strong}}Fresh Content Only:{{/strong}} Please provide original content rather than requesting migrations or content from existing pages, external websites, or files.',
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									"{{strong}}Timely Submission:{{/strong}} Submit your content {{strong}}within %(refundPeriodDays)d days{{/strong}} of purchase to keep things on track. If we don't receive it in time, we'll use AI-generated text and stock images based on your search terms to bring your site to life.",
-									{
-										components: {
-											strong: <strong />,
-										},
-										args: {
-											refundPeriodDays: 14,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									'{{strong}}Bite-sized Content:{{/strong}} Keep each page under %s characters. Longer content will be trimmed using AI to ensure everything looks great.',
-									{
-										components: {
-											strong: <strong />,
-										},
-										args: [ numberFormat( CHARACTER_LIMIT ) ],
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									"{{strong}}Design Approach:{{/strong}} We follow established design guidelines while customizing your site to reflect your brand. With your logo, colors, and style preferences, we'll create a professional site that captures your essence using our curated design elements.",
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									"{{strong}}Stay Connected:{{/strong}} After you submit your content, we'll review it. If everything meets our guidelines, we'll notify you when your site is ready for launch. If adjustments are needed, we'll reach out.",
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									"{{strong}}Perfect As-Is:{{/strong}} We aim to get it right the first time! While revisions aren't included, you can always make updates later using the WordPress editor.",
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									"{{strong}}Plugin Potential:{{/strong}} The initial setup doesn't include every feature, but it's a great starting point. Add options like appointments, courses, property listings, memberships, payments, animations, and more after we finish your site. Our Happiness Engineers can make recommendations based on your plan.",
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ translate(
-									"{{strong}}Custom Requests:{{/strong}} We focus on attractive and functional designs, but we can't accommodate very specific layout requests or exact matches to designs. For fully custom solutions or pixel-perfect recreations, we can connect you with an expert WordPress agency partner, with projects starting at $5,000.",
-									{
-										components: {
-											strong: <strong />,
-										},
-									}
-								) }
-							</p>
-						</FoldableFAQ>
-						<FoldableFAQ id="faq-10" question={ translate( 'Can I use my existing domain name?' ) }>
-							<p>
-								{ translate(
-									'Yes, our support team will help you connect your existing domain name to your site after the build is complete.'
-								) }
-							</p>
-						</FoldableFAQ>
-						{ ! isStoreFlow && (
-							<FoldableFAQ id="faq-11" question={ translate( 'Can I have a store set up?' ) }>
-								<>
-									<p>
-										{ translate(
-											'We offer an ecommerce store setup option which includes setup of the WooCommerce shop landing page, cart, checkout, and my account pages, along with additional pages you choose while signing up. ' +
-												'Please note, individual product setup, payments, taxes, shipping, and other WooCommerce extensions or settings are not included. You can set these up later, support is happy to help if you have questions. ' +
-												'An additional purchase of the %(businessPlanName)s plan, costing %(businessPlanCost)s, is required for a store site.',
-											{
-												args: {
-													businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
-													businessPlanCost,
-												},
-											}
-										) }
-									</p>
-									<Button
-										variant="primary"
-										onClick={ () => ( window.location.href = '/start/do-it-for-me-store' ) }
-									>
-										{ translate( 'Get started' ) }
-									</Button>
-								</>
-							</FoldableFAQ>
-						) }
-					</>
-				) }
-			</FAQSection>
+			<DIFMFAQ isStoreFlow={ isStoreFlow } siteId={ siteId ?? undefined } ctaSection={ ctas } />
 		</>
 	);
 }

--- a/client/my-sites/marketing/do-it-for-me/faq.tsx
+++ b/client/my-sites/marketing/do-it-for-me/faq.tsx
@@ -1,0 +1,414 @@
+import { getPlan, PLAN_BUSINESS, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { Gridicon } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
+import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
+import { numberFormat, useTranslate } from 'i18n-calypso';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
+import { CHARACTER_LIMIT } from 'calypso/signup/steps/website-content/section-types/constants';
+import FoldableFAQComponent from '../../../components/foldable-faq';
+import { useDIFMPlanInfo } from './use-difm-plan-info';
+
+const FAQHeader = styled.h1`
+	font-size: 2rem;
+	text-align: center;
+	margin: 48px 0;
+`;
+
+const FAQSection = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
+const FAQExpander = styled( Button )`
+	align-self: center;
+	background: var( --studio-gray-0 );
+	font-size: 0.875rem;
+	padding: 12px 0;
+	width: 500px;
+	height: 48px;
+	text-align: center;
+	&&& {
+		justify-content: center;
+	}
+	@media ( max-width: 660px ) {
+		width: 90vw;
+	}
+`;
+
+const FoldableFAQ = styled( FoldableFAQComponent )`
+	border: 1px solid #e9e9ea;
+	padding: 0;
+	border-radius: 4px;
+	margin-bottom: 24px;
+	.foldable-faq__question {
+		padding: 24px 16px 24px 24px;
+		flex-direction: row-reverse;
+		width: 100%;
+		svg {
+			margin-inline-end: 0;
+			margin-inline-start: auto;
+			flex-shrink: 0;
+		}
+		.foldable-faq__question-text {
+			padding-inline-start: 0;
+			font-size: 1.125rem;
+		}
+	}
+	&.is-expanded {
+		border: 2px solid var( --studio-wordpress-blue-50 );
+		.foldable-faq__answer {
+			margin: 0 16px 24px 0;
+			ul {
+				margin: 0 0 0 16px;
+			}
+		}
+	}
+	&:not( .is-expanded ) .foldable-faq__question:focus {
+		box-shadow: 0 0 0 var( --studio-wordpress-blue-50, var( --wp-admin-theme-color, #3858e9 ) );
+		outline: 3px solid transparent;
+	}
+	.foldable-faq__answer {
+		padding: 0 16px 0 24px;
+		border: 0;
+	}
+`;
+
+const CTASection = styled.div`
+	display: flex;
+	gap: 16px;
+	align-items: center;
+	justify-content: center;
+`;
+
+export const DIFMFAQ = ( {
+	isStoreFlow,
+	siteId,
+	ctaSection,
+}: {
+	isStoreFlow: boolean;
+	siteId?: number;
+	ctaSection?: ReactNode;
+} ) => {
+	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
+
+	const {
+		planTitle,
+		planSlug,
+		planCost,
+		extraPageDisplayCost,
+		businessPlanCost,
+		displayCost,
+		planStorageString,
+	} = useDIFMPlanInfo( {
+		isStoreFlow,
+		siteId,
+	} );
+
+	const faqHeader = useRef( null );
+	const [ isFAQSectionOpen, setIsFAQSectionOpen ] = useState( false );
+	const onFAQButtonClick = useCallback( () => {
+		setIsFAQSectionOpen( ( isFAQSectionOpen ) => ! isFAQSectionOpen );
+	}, [ setIsFAQSectionOpen ] );
+
+	useEffect( () => {
+		if ( isFAQSectionOpen && faqHeader.current ) {
+			scrollIntoViewport( faqHeader.current, {
+				behavior: 'smooth',
+				scrollMode: 'if-needed',
+			} );
+		}
+	}, [ isFAQSectionOpen ] );
+
+	const faqPlanCostOldCopy = translate(
+		'The service costs %(displayCost)s, plus an additional %(planCost)s for the %(planTitle)s plan, which offers fast, secure hosting, video embedding, %(storage)s of storage, a free domain for one year, and live chat support.',
+		{
+			args: {
+				displayCost,
+				planTitle: planTitle ?? '',
+				planCost,
+				storage: planStorageString,
+			},
+		}
+	);
+	const faqPlanCostNewCopy = translate(
+		'The service costs %(displayCost)s, plus an additional %(planCost)s for the %(planTitle)s plan, which offers fast, secure hosting, video embedding, %(storage)s of storage, a free domain for one year, and expert support from our team.',
+		{
+			args: {
+				displayCost,
+				planTitle: planTitle ?? '',
+				planCost,
+				storage: planStorageString,
+			},
+		}
+	);
+
+	let faqRevisionsAnswer = translate(
+		'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
+			'Furthermore, our %s plan offers live chat and priority email support if you need assistance.',
+		{
+			args: [ planTitle || '' ],
+		}
+	);
+	if ( planSlug === PLAN_BUSINESS ) {
+		const isCopyTranslated = hasEnTranslation(
+			'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
+				'Furthermore, our %s plan offers 24X7 priority support from our experts if you need assistance.'
+		);
+		if ( isCopyTranslated ) {
+			faqRevisionsAnswer = translate(
+				'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
+					'Furthermore, our %s plan offers 24X7 priority support from our experts if you need assistance.',
+				{
+					args: [ planTitle || '' ],
+				}
+			);
+		}
+	}
+	if ( planSlug === PLAN_PREMIUM ) {
+		const isCopyTranslated = hasEnTranslation(
+			'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
+				'Furthermore, our %s plan offers fast support from our experts if you need assistance.'
+		);
+		if ( isCopyTranslated ) {
+			faqRevisionsAnswer = translate(
+				'While this service does not include revisions, once you’ve received your completed site, you can modify everything using the WordPress editor – colors, text, images, adding new pages, and anything else you’d like to tweak. ' +
+					'Furthermore, our %s plan offers fast support from our experts if you need assistance.',
+				{
+					args: [ planTitle || '' ],
+				}
+			);
+		}
+	}
+
+	return (
+		<FAQSection>
+			<FAQExpander
+				ref={ faqHeader }
+				onClick={ onFAQButtonClick }
+				icon={ <Gridicon icon={ isFAQSectionOpen ? 'chevron-up' : 'chevron-down' } /> }
+			>
+				{ isFAQSectionOpen
+					? translate( 'Hide Frequently Asked Questions' )
+					: translate( 'Show Frequently Asked Questions' ) }
+			</FAQExpander>
+			{ isFAQSectionOpen && (
+				<>
+					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+					<FAQHeader className="wp-brand-font">
+						{ translate( 'Frequently Asked Questions' ) }{ ' ' }
+					</FAQHeader>
+					<FoldableFAQ
+						id="faq-1"
+						expanded
+						question={ translate(
+							'What is the Express Website Design Service, and who is it for?'
+						) }
+					>
+						<p>
+							{ translate(
+								'Our website-building service is for anyone who wants a polished website fast: small businesses, personal websites, bloggers, clubs or organizations, and more. ' +
+									"Just answer a few questions, submit your content, and we'll handle the rest. " +
+									"Click the button above to start, and you'll receive your customized 5-page site within 4 business days!"
+							) }
+						</p>
+					</FoldableFAQ>
+					<FoldableFAQ id="faq-2" question={ translate( 'How much does it cost?' ) }>
+						<p>
+							{ hasEnTranslation(
+								'The service costs %(displayCost)s, plus an additional %(planCost)s for the %(planTitle)s plan, which offers fast, secure hosting, video embedding, %(storage)s of storage, a free domain for one year, and fast support from our expert team.'
+							)
+								? faqPlanCostNewCopy
+								: faqPlanCostOldCopy }
+						</p>
+					</FoldableFAQ>
+					{ isStoreFlow && (
+						<FoldableFAQ id="faq-2-1" question={ translate( 'What does my store setup include?' ) }>
+							<p>
+								{ translate(
+									'Your purchase includes the setup of the WooCommerce shop landing page, cart, checkout, and my account pages, along with additional pages you choose while signing up. ' +
+										'Please note, individual product setup, payments, taxes, shipping, and other WooCommerce extensions or settings are not included. ' +
+										'You can set these up later, support is happy to help if you have questions.'
+								) }
+							</p>
+						</FoldableFAQ>
+					) }
+					<FoldableFAQ
+						id="faq-3"
+						question={ translate( 'Can I purchase additional pages if I need more than five?' ) }
+					>
+						<p>
+							{ translate( 'Yes, extra pages can be purchased for %(extraPageDisplayCost)s each.', {
+								args: {
+									extraPageDisplayCost,
+								},
+							} ) }
+						</p>
+					</FoldableFAQ>
+					<FoldableFAQ
+						id="faq-4"
+						question={ translate( "What if I don't have enough images or content?" ) }
+					>
+						<p>
+							{ translate(
+								"Don't worry if you don't have images or content for every page. " +
+									"After checkout, you'll have an option to opt into AI text creation. " +
+									'Our design team can select images and use AI to create your site content, all of which you can edit later using the editor. ' +
+									"If you select the blog page during sign up, we'll even create three blog posts for you to get you started!"
+							) }
+						</p>
+					</FoldableFAQ>
+					<FoldableFAQ id="faq-5" question={ translate( 'When will you contact me?' ) }>
+						<p>
+							{ translate(
+								'After you check out, you’ll fill out a content upload form that includes any design preferences and reference sites. ' +
+									"While we can't guarantee an exact match, we'll consider all your feedback during site construction, and you'll receive an email when your new site is ready — always within four business days."
+							) }
+						</p>
+					</FoldableFAQ>
+					<FoldableFAQ
+						id="faq-6"
+						question={ translate( 'What will my completed website look like?' ) }
+					>
+						<p>
+							{ translate(
+								'Each website is unique, mobile-friendly, and customized to your brand and content. ' +
+									'With a 97% satisfaction rate, we are confident that you will love your new site, just like hundreds of customers before you. ' +
+									'Additionally, we offer a 14-day refund window, giving you peace of mind.'
+							) }
+						</p>
+					</FoldableFAQ>
+					<FoldableFAQ id="faq-7" question={ translate( 'How many revisions are included?' ) }>
+						<p>{ faqRevisionsAnswer }</p>
+					</FoldableFAQ>
+					<FoldableFAQ id="faq-8" question={ translate( 'What happens to my existing content?' ) }>
+						<p>
+							{ translate(
+								'If you choose to use your current WordPress.com site, your existing content will remain untouched. ' +
+									"We'll create new pages with your provided content while applying a new, customized theme. However, we won't edit any existing content on your site's pages."
+							) }
+						</p>
+					</FoldableFAQ>
+					<FoldableFAQ id="faq-9" question={ translate( 'What are the content guidelines?' ) }>
+						<p>
+							{ translate(
+								'{{strong}}Fresh Content Only:{{/strong}} Please provide original content rather than requesting migrations or content from existing pages, external websites, or files.',
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								"{{strong}}Timely Submission:{{/strong}} Submit your content {{strong}}within %(refundPeriodDays)d days{{/strong}} of purchase to keep things on track. If we don't receive it in time, we'll use AI-generated text and stock images based on your search terms to bring your site to life.",
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: {
+										refundPeriodDays: 14,
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								'{{strong}}Bite-sized Content:{{/strong}} Keep each page under %s characters. Longer content will be trimmed using AI to ensure everything looks great.',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: [ numberFormat( CHARACTER_LIMIT ) ],
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								"{{strong}}Design Approach:{{/strong}} We follow established design guidelines while customizing your site to reflect your brand. With your logo, colors, and style preferences, we'll create a professional site that captures your essence using our curated design elements.",
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								"{{strong}}Stay Connected:{{/strong}} After you submit your content, we'll review it. If everything meets our guidelines, we'll notify you when your site is ready for launch. If adjustments are needed, we'll reach out.",
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								"{{strong}}Perfect As-Is:{{/strong}} We aim to get it right the first time! While revisions aren't included, you can always make updates later using the WordPress editor.",
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								"{{strong}}Plugin Potential:{{/strong}} The initial setup doesn't include every feature, but it's a great starting point. Add options like appointments, courses, property listings, memberships, payments, animations, and more after we finish your site. Our Happiness Engineers can make recommendations based on your plan.",
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								"{{strong}}Custom Requests:{{/strong}} We focus on attractive and functional designs, but we can't accommodate very specific layout requests or exact matches to designs. For fully custom solutions or pixel-perfect recreations, we can connect you with an expert WordPress agency partner, with projects starting at $5,000.",
+								{
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+					</FoldableFAQ>
+					<FoldableFAQ id="faq-10" question={ translate( 'Can I use my existing domain name?' ) }>
+						<p>
+							{ translate(
+								'Yes, our support team will help you connect your existing domain name to your site after the build is complete.'
+							) }
+						</p>
+					</FoldableFAQ>
+					{ ! isStoreFlow && (
+						<FoldableFAQ id="faq-11" question={ translate( 'Can I have a store set up?' ) }>
+							<>
+								<p>
+									{ translate(
+										'We offer an ecommerce store setup option which includes setup of the WooCommerce shop landing page, cart, checkout, and my account pages, along with additional pages you choose while signing up. ' +
+											'Please note, individual product setup, payments, taxes, shipping, and other WooCommerce extensions or settings are not included. You can set these up later, support is happy to help if you have questions. ' +
+											'An additional purchase of the %(businessPlanName)s plan, costing %(businessPlanCost)s, is required for a store site.',
+										{
+											args: {
+												businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
+												businessPlanCost,
+											},
+										}
+									) }
+								</p>
+								<Button variant="primary" href="/start/do-it-for-me-store">
+									{ translate( 'Get started' ) }
+								</Button>
+							</>
+						</FoldableFAQ>
+					) }
+					{ ctaSection && <CTASection>{ ctaSection }</CTASection> }
+				</>
+			) }
+		</FAQSection>
+	);
+};

--- a/client/my-sites/marketing/do-it-for-me/faq.tsx
+++ b/client/my-sites/marketing/do-it-for-me/faq.tsx
@@ -3,6 +3,7 @@ import { Gridicon } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
+import { RefObject } from '@wordpress/element';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
@@ -17,8 +18,8 @@ const FAQHeader = styled.h1`
 `;
 
 const FAQSection = styled.div`
-	display: flex;
-	flex-direction: column;
+	max-width: 615px;
+	margin: 0 auto;
 `;
 
 const FAQExpander = styled( Button )`
@@ -38,12 +39,13 @@ const FAQExpander = styled( Button )`
 `;
 
 const FoldableFAQ = styled( FoldableFAQComponent )`
-	border: 1px solid #e9e9ea;
-	padding: 0;
-	border-radius: 4px;
-	margin-bottom: 24px;
+	border: 1px solid var( --color-border-subtle );
+	padding: 0 !important;
+	width: 100%;
+	border-radius: 2px;
+	margin-bottom: 16px;
 	.foldable-faq__question {
-		padding: 24px 16px 24px 24px;
+		padding: 24px;
 		flex-direction: row-reverse;
 		width: 100%;
 		svg {
@@ -53,15 +55,26 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 		}
 		.foldable-faq__question-text {
 			padding-inline-start: 0;
-			font-size: 1.125rem;
+			font-size: 1rem;
+			line-height: 1.5;
 		}
 	}
 	&.is-expanded {
 		border: 2px solid var( --studio-wordpress-blue-50 );
+
+		.foldable-faq__question {
+			padding-bottom: 16px;
+		}
+
 		.foldable-faq__answer {
-			margin: 0 16px 24px 0;
-			ul {
-				margin: 0 0 0 16px;
+			margin: 0 24px;
+			padding: 0;
+			font-size: 0.875rem;
+			line-height: 1.5;
+			color: var( --studio-gray-60 );
+
+			p {
+				margin-bottom: 1.5em;
 			}
 		}
 	}
@@ -70,7 +83,6 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 		outline: 3px solid transparent;
 	}
 	.foldable-faq__answer {
-		padding: 0 16px 0 24px;
 		border: 0;
 	}
 `;
@@ -80,16 +92,44 @@ const CTASection = styled.div`
 	gap: 16px;
 	align-items: center;
 	justify-content: center;
+	margin-top: 48px;
+	margin-bottom: 32px;
 `;
+
+interface FAQExpanderProps {
+	ref: RefObject< HTMLButtonElement >;
+	onClick: () => void;
+	isFAQSectionOpen: boolean;
+	children: ReactNode;
+}
+
+const defaultRenderFAQExpander = ( {
+	ref,
+	onClick,
+	isFAQSectionOpen,
+	children,
+}: FAQExpanderProps ) => {
+	return (
+		<FAQExpander
+			ref={ ref }
+			onClick={ onClick }
+			icon={ <Gridicon icon={ isFAQSectionOpen ? 'chevron-up' : 'chevron-down' } /> }
+		>
+			{ children }
+		</FAQExpander>
+	);
+};
 
 export const DIFMFAQ = ( {
 	isStoreFlow,
 	siteId,
 	ctaSection,
+	renderExpanderButton = defaultRenderFAQExpander,
 }: {
 	isStoreFlow: boolean;
 	siteId?: number;
 	ctaSection?: ReactNode;
+	renderExpanderButton?: typeof defaultRenderFAQExpander;
 } ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
@@ -185,15 +225,17 @@ export const DIFMFAQ = ( {
 
 	return (
 		<FAQSection>
-			<FAQExpander
-				ref={ faqHeader }
-				onClick={ onFAQButtonClick }
-				icon={ <Gridicon icon={ isFAQSectionOpen ? 'chevron-up' : 'chevron-down' } /> }
-			>
-				{ isFAQSectionOpen
-					? translate( 'Hide Frequently Asked Questions' )
-					: translate( 'Show Frequently Asked Questions' ) }
-			</FAQExpander>
+			<div css={ { textAlign: 'center' } }>
+				{ renderExpanderButton( {
+					ref: faqHeader,
+					onClick: onFAQButtonClick,
+					isFAQSectionOpen,
+					children: isFAQSectionOpen
+						? translate( 'Hide Frequently Asked Questions' )
+						: translate( 'Show Frequently Asked Questions' ),
+				} ) }
+			</div>
+
 			{ isFAQSectionOpen && (
 				<>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
@@ -400,9 +442,11 @@ export const DIFMFAQ = ( {
 										}
 									) }
 								</p>
-								<Button variant="primary" href="/start/do-it-for-me-store">
-									{ translate( 'Get started' ) }
-								</Button>
+								<p>
+									<Button variant="primary" href="/start/do-it-for-me-store">
+										{ translate( 'Get started' ) }
+									</Button>
+								</p>
 							</>
 						</FoldableFAQ>
 					) }

--- a/client/my-sites/marketing/do-it-for-me/service-description.tsx
+++ b/client/my-sites/marketing/do-it-for-me/service-description.tsx
@@ -8,20 +8,18 @@ const ServiceDescription = styled.div`
 `;
 
 const Title = styled.div`
-	margin-bottom: 6px;
 	color: var( --studio-gray-100 );
 	font-weight: 500;
 `;
 const Description = styled.div`
 	color: var( --studio-gray-60 );
-	padding-bottom: 18px;
+	padding-bottom: 32px;
 	font-size: 0.875rem;
 `;
 
 const StepContainer = styled.div`
 	display: flex;
-	gap: 20px;
-	margin-top: 0;
+	gap: 16px;
 `;
 
 const ProgressLine = styled.div`
@@ -52,13 +50,22 @@ const IndexContainer = styled.div`
 const Index = styled.div`
 	border-radius: 50%;
 	border: 1px solid var( --studio-gray-5 );
-	color: var( --studio-gray-30 );
-	font-size: 1.125rem;
-	height: 20px;
-	line-height: 20px;
-	padding: 10px;
-	text-align: center;
-	width: 20px;
+	color: var( --studio-gray-100 );
+	font-size: 1rem;
+	font-weight: 500;
+	height: 40px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	flex-shrink: 0;
+`;
+
+const ContentWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	transform: translateY( -4px );
 `;
 
 const Step = ( {
@@ -76,10 +83,10 @@ const Step = ( {
 				<Index>{ index }</Index>
 				<ProgressLine />
 			</IndexContainer>
-			<div>
+			<ContentWrapper>
 				<Title>{ title }</Title>
 				<Description>{ description }</Description>
-			</div>
+			</ContentWrapper>
 		</StepContainer>
 	);
 };
@@ -123,7 +130,7 @@ export const DIFMServiceDescription = ( { isStoreFlow }: { isStoreFlow: boolean 
 					}
 				/>
 			</VerticalStepProgress>
-			<p>
+			<p css={ { fontSize: '0.875rem', lineHeight: 1.5, color: 'var( --color-text )' } }>
 				{ translate( 'Share your finished site with the world in %(days)d business days or less!', {
 					args: {
 						days: 4,

--- a/client/my-sites/marketing/do-it-for-me/service-description.tsx
+++ b/client/my-sites/marketing/do-it-for-me/service-description.tsx
@@ -1,0 +1,135 @@
+import styled from '@emotion/styled';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+
+const ServiceDescription = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+`;
+
+const Title = styled.div`
+	margin-bottom: 6px;
+	color: var( --studio-gray-100 );
+	font-weight: 500;
+`;
+const Description = styled.div`
+	color: var( --studio-gray-60 );
+	padding-bottom: 18px;
+	font-size: 0.875rem;
+`;
+
+const StepContainer = styled.div`
+	display: flex;
+	gap: 20px;
+	margin-top: 0;
+`;
+
+const ProgressLine = styled.div`
+	width: 1px;
+	background: var( --studio-gray-5 );
+	height: 100%;
+`;
+
+const VerticalStepProgress = styled.div`
+	display: flex;
+	flex-direction: column;
+	${ StepContainer }:last-child {
+		${ ProgressLine } {
+			display: none;
+		}
+		${ Description } {
+			padding-bottom: 0;
+		}
+	}
+`;
+
+const IndexContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+`;
+
+const Index = styled.div`
+	border-radius: 50%;
+	border: 1px solid var( --studio-gray-5 );
+	color: var( --studio-gray-30 );
+	font-size: 1.125rem;
+	height: 20px;
+	line-height: 20px;
+	padding: 10px;
+	text-align: center;
+	width: 20px;
+`;
+
+const Step = ( {
+	index,
+	title,
+	description,
+}: {
+	index: TranslateResult;
+	title: TranslateResult;
+	description: TranslateResult;
+} ) => {
+	return (
+		<StepContainer>
+			<IndexContainer>
+				<Index>{ index }</Index>
+				<ProgressLine />
+			</IndexContainer>
+			<div>
+				<Title>{ title }</Title>
+				<Description>{ description }</Description>
+			</div>
+		</StepContainer>
+	);
+};
+
+export const DIFMServiceDescription = ( { isStoreFlow }: { isStoreFlow: boolean } ) => {
+	const translate = useTranslate();
+
+	return (
+		<ServiceDescription>
+			<VerticalStepProgress>
+				<Step
+					index={ translate( '1' ) }
+					title={ translate( 'Submit your business information' ) }
+					description={ translate( 'Optionally provide your profiles to be found on social.' ) }
+				/>
+
+				<Step
+					index={ translate( '2' ) }
+					title={ translate( 'Select your design and pages' ) }
+					description={ translate( 'Can’t decide? Let our experts choose the best design!' ) }
+				/>
+
+				<Step
+					index={ translate( '3' ) }
+					title={ translate( 'Complete the purchase' ) }
+					description={ translate( 'Try risk free with a %(days)d-day money back guarantee.', {
+						args: {
+							days: 14,
+						},
+						comment: 'the arg is the refund period in days',
+					} ) }
+				/>
+
+				<Step
+					index={ translate( '4' ) }
+					title={ translate( 'Submit content for your new website' ) }
+					description={
+						isStoreFlow
+							? translate( 'Products can be added later with the WordPress editor.' )
+							: translate( 'Content can be edited later with the WordPress editor.' )
+					}
+				/>
+			</VerticalStepProgress>
+			<p>
+				{ translate( 'Share your finished site with the world in %(days)d business days or less!', {
+					args: {
+						days: 4,
+					},
+				} ) }
+			</p>
+		</ServiceDescription>
+	);
+};

--- a/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
+++ b/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
@@ -1,0 +1,89 @@
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { useDIFMPlanInfo } from './use-difm-plan-info';
+
+const Placeholder = styled.span`
+	padding: 0 60px;
+	animation: loading-fade 800ms ease-in-out infinite;
+	background-color: var( --color-neutral-10 );
+	color: transparent;
+	min-height: 20px;
+	@keyframes loading-fade {
+		0% {
+			opacity: 0.5;
+		}
+		50% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0.5;
+		}
+	}
+`;
+
+export const useDIFMHeading = ( {
+	isStoreFlow,
+	siteId,
+}: {
+	isStoreFlow: boolean;
+	siteId?: number;
+} ) => {
+	const translate = useTranslate();
+
+	const { planTitle, hasPriceDataLoaded, hasCurrentPlanOrHigherPlan, displayCost } =
+		useDIFMPlanInfo( {
+			isStoreFlow,
+			siteId,
+		} );
+
+	const headerTextTranslateArgs = {
+		components: {
+			PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
+			sup: <sup />,
+		},
+		args: {
+			displayCost,
+			days: 4,
+		},
+	};
+
+	const headerText = isStoreFlow
+		? translate(
+				'Let us build your store in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+				headerTextTranslateArgs
+		  )
+		: translate(
+				'Let us build your site in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+				headerTextTranslateArgs
+		  );
+
+	const subHeaderText = hasCurrentPlanOrHigherPlan
+		? translate(
+				'{{sup}}*{{/sup}}One time fee. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				{
+					args: {
+						freePages: 5,
+					},
+					components: {
+						sup: <sup />,
+					},
+				}
+		  )
+		: translate(
+				'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				{
+					args: {
+						plan: planTitle ?? '',
+						freePages: 5,
+					},
+					components: {
+						sup: <sup />,
+					},
+				}
+		  );
+
+	return {
+		headerText,
+		subHeaderText,
+	};
+};

--- a/client/my-sites/marketing/do-it-for-me/use-difm-plan-info.ts
+++ b/client/my-sites/marketing/do-it-for-me/use-difm-plan-info.ts
@@ -1,0 +1,114 @@
+import {
+	PLAN_PREMIUM,
+	WPCOM_DIFM_LITE,
+	PLAN_BUSINESS,
+	getPlan,
+	getDIFMTieredPriceDetails,
+	isPremium,
+	isBusiness,
+	isEcommerce,
+	isPro,
+	getFeatureByKey,
+} from '@automattic/calypso-products';
+import { formatCurrency } from 'i18n-calypso';
+import { useQueryProductsList } from 'calypso/components/data/query-products-list';
+import { useSelector } from 'calypso/state';
+import {
+	getProductBySlug,
+	getProductCost,
+	getProductCurrencyCode,
+} from 'calypso/state/products-list/selectors';
+import { getSitePlan } from 'calypso/state/sites/selectors';
+
+const hasHigherPlan = ( currentPlan: string, plan: typeof PLAN_PREMIUM | typeof PLAN_BUSINESS ) => {
+	const planMatchers =
+		plan === PLAN_PREMIUM
+			? [ isPremium, isBusiness, isEcommerce, isPro ]
+			: [ isBusiness, isEcommerce, isPro ];
+
+	return planMatchers.some( ( planMatcher ) =>
+		planMatcher( {
+			productSlug: currentPlan,
+		} )
+	);
+};
+
+export const useDIFMPlanInfo = ( {
+	isStoreFlow,
+	siteId,
+}: {
+	isStoreFlow: boolean;
+	siteId?: number;
+} ) => {
+	const currencyCode = useSelector( ( state ) => getProductCurrencyCode( state, WPCOM_DIFM_LITE ) );
+
+	useQueryProductsList( {
+		type: 'partial',
+		productSlugList: [ PLAN_PREMIUM, WPCOM_DIFM_LITE, PLAN_BUSINESS ],
+		currency: currencyCode,
+		persist: true,
+	} );
+
+	const product = useSelector( ( state ) => getProductBySlug( state, WPCOM_DIFM_LITE ) );
+	const productCost = product?.cost;
+
+	const planSlug = isStoreFlow ? PLAN_BUSINESS : PLAN_PREMIUM;
+	const planObject = getPlan( planSlug );
+	const planTitle = planObject?.getTitle();
+	const planCostInteger = useSelector( ( state ) => getProductCost( state, planSlug ) );
+
+	const difmTieredPriceDetails = getDIFMTieredPriceDetails( product );
+	const extraPageCost = difmTieredPriceDetails?.perExtraPagePrice;
+
+	// This is used in a FAQ item.
+	const businessPlanCostInteger = useSelector( ( state ) =>
+		getProductCost( state, PLAN_BUSINESS )
+	);
+
+	const hasPriceDataLoaded =
+		productCost && extraPageCost && planCostInteger && businessPlanCostInteger && currencyCode;
+
+	const displayCost = hasPriceDataLoaded
+		? formatCurrency( productCost, currencyCode, { stripZeros: true } )
+		: '';
+
+	const planCost = hasPriceDataLoaded
+		? formatCurrency( planCostInteger, currencyCode, { stripZeros: true } )
+		: '';
+
+	const currentPlan = useSelector( ( state ) => ( siteId ? getSitePlan( state, siteId ) : null ) );
+	const hasCurrentPlanOrHigherPlan = currentPlan?.product_slug
+		? hasHigherPlan( currentPlan.product_slug, planSlug )
+		: false;
+
+	const planStorageString = planObject?.getStorageFeature?.()
+		? getFeatureByKey( planObject.getStorageFeature() )?.getTitle()
+		: '';
+
+	const extraPageDisplayCost = hasPriceDataLoaded
+		? formatCurrency( extraPageCost, currencyCode, {
+				stripZeros: true,
+				isSmallestUnit: true,
+		  } )
+		: '';
+
+	const businessPlanCost = hasPriceDataLoaded
+		? formatCurrency( businessPlanCostInteger, currencyCode, { stripZeros: true } )
+		: '';
+
+	return {
+		planTitle,
+		planCostInteger,
+		extraPageCost,
+		businessPlanCostInteger,
+		currencyCode,
+		displayCost,
+		hasPriceDataLoaded,
+		hasCurrentPlanOrHigherPlan,
+		planSlug,
+		planStorageString,
+		planCost,
+		extraPageDisplayCost,
+		businessPlanCost,
+	};
+};

--- a/client/signup/help-center-step-button/index.tsx
+++ b/client/signup/help-center-step-button/index.tsx
@@ -25,9 +25,9 @@ const HelpCenterStepButton: FC< HelpCenterStepButtonProps > = ( {
 	}
 
 	return (
-		<div className="step-wrapper__help-center-button-container">
+		<div className="help-center-step-button">
 			<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) }</label>{ ' ' }
-			<HelpCenterInlineButton flowName={ flowName } className="step-wrapper__help-center-button">
+			<HelpCenterInlineButton flowName={ flowName } className="help-center-step-button__button">
 				{ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }
 			</HelpCenterInlineButton>
 		</div>

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -189,17 +189,19 @@
 	}
 }
 
-.step-wrapper__help-center-button-container {
-	font-weight: 500;
-	margin-left: auto;
-	
-	.components-button.step-wrapper__help-center-button {
-		font-size: rem(14px);
-		color: var( --studio-wordpress-blue );
-		text-decoration: underline;
+.step-wrapper {
+	.help-center-step-button {
+		font-weight: 500;
+		margin-left: auto;
 
-		&:hover {
-			text-decoration: none;
+		&__button {
+			font-size: rem(14px);
+			color: var( --studio-wordpress-blue );
+			text-decoration: underline;
+
+			&:hover {
+				text-decoration: none;
+			}
 		}
 	}
 }

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
@@ -16,6 +16,7 @@ export interface StepContainerV2Props {
 	className?: string;
 	topBar?: ReactNode;
 	heading?: ReactNode;
+	footer?: ReactNode;
 	stickyBottomBar?: ReactNode;
 	width?: 'standard' | 'wide' | 'full';
 	verticalAlign?: 'top' | 'center';
@@ -29,6 +30,7 @@ export const StepContainerV2 = ( {
 	className,
 	topBar,
 	heading,
+	footer,
 	stickyBottomBar,
 	width = 'standard',
 	verticalAlign = 'top',
@@ -72,6 +74,16 @@ export const StepContainerV2 = ( {
 					>
 						{ typeof children === 'function' ? children( stepContainerContextValue ) : children }
 					</div>
+					{ footer && (
+						<div
+							className={ clsx( 'step-container-v2__footer', {
+								wide: width === 'wide',
+								full: width === 'full',
+							} ) }
+						>
+							{ footer }
+						</div>
+					) }
 				</div>
 				{ ! isMediumViewport && stickyBottomBar }
 			</div>

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -35,7 +35,7 @@
 		}
 	}
 
-	&__content {
+	&__content, &__footer {
 		width: 100%;
 		box-sizing: border-box;
 

--- a/packages/onboarding/src/step-container-v2/components/buttons/NextButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/NextButton/style.scss
@@ -1,5 +1,6 @@
 .step-container-v2__content-wrapper .step-container-v2__next-button {
 	padding: 0.5rem 3rem;
 	font-size: 0.875rem;
+	line-height: 1;
 	justify-content: center;
 }

--- a/packages/onboarding/src/step-container-v2/components/buttons/NextButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/NextButton/style.scss
@@ -1,4 +1,4 @@
-.step-container-v2__content .step-container-v2__next-button {
+.step-container-v2__content-wrapper .step-container-v2__next-button {
 	padding: 0.5rem 3rem;
 	font-size: 0.875rem;
 	justify-content: center;

--- a/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
@@ -38,6 +38,10 @@ export const TwoColumnLayout = ( props: TwoColumnLayoutProps ) => {
 				}
 
 				return Children.map( childElements, ( child, index ) => {
+					if ( ! isValidElement( child ) ) {
+						return null;
+					}
+
 					return (
 						<div
 							className={ `two-column-layout__column--${ index }` }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101195.

## Proposed Changes

This PR introduces the new step container in the DIFM starting point onboarding/site-setup flows. It does so by making all elements in the existing DIFM screen reusable and instantiating the `TwoColumnLayout` wireframe.


https://github.com/user-attachments/assets/272d13da-99dd-4c75-ace2-a495307653e5


