### PR TITLE
Untangled Plans: implement the sticky plan comparison header logic

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -102,6 +102,7 @@ const PlanComparisonHeader = styled.h1`
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;
 	intent?: PlansIntent | null;
+	isInSiteDashboard?: boolean;
 	isInSignup?: boolean;
 	isCustomDomainAllowedOnFreePlan?: boolean;
 	plansWithScroll?: boolean;
@@ -128,7 +129,6 @@ export interface PlansFeaturesMainProps {
 	>;
 	planTypeSelector?: 'interval';
 	discountEndDate?: Date;
-	hideSpotlightPlan?: boolean;
 	hidePlansFeatureComparison?: boolean;
 	coupon?: string;
 
@@ -210,9 +210,9 @@ const PlansFeaturesMain = ( {
 	customerType = 'personal',
 	planTypeSelector = 'interval',
 	intervalType = 'yearly',
-	hideSpotlightPlan = false,
 	hidePlansFeatureComparison = false,
 	hideUnavailableFeatures = false,
+	isInSiteDashboard = false,
 	isInSignup = false,
 	isCustomDomainAllowedOnFreePlan = false,
 	isStepperUpgradeFlow = false,
@@ -594,10 +594,15 @@ const PlansFeaturesMain = ( {
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 
 	/**
-	 * Calculates the height of the masterbar if it exists, and passes it to the component as an offset
+	 * Calculates the height of the masterbar if it overlaps, and passes it to the component as an offset
 	 * for the sticky CTA bar.
 	 */
 	useLayoutEffect( () => {
+		if ( isInSiteDashboard ) {
+			// The masterbar does not overlap with the site dashboard's scrollable content.
+			return;
+		}
+
 		const masterbarElement = document.querySelector< HTMLDivElement >( 'header.masterbar' );
 
 		if ( ! masterbarElement ) {
@@ -848,7 +853,7 @@ const PlansFeaturesMain = ( {
 										coupon={ coupon }
 										currentSitePlanSlug={ sitePlanSlug }
 										generatedWPComSubdomain={ resolvedSubdomainName }
-										hideSpotlightPlan={ hideSpotlightPlan }
+										hideSpotlightPlan={ isInSiteDashboard }
 										gridPlanForSpotlight={ gridPlanForSpotlight }
 										gridPlans={ gridPlansForFeaturesGrid }
 										hideUnavailableFeatures={ hideUnavailableFeatures }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -166,7 +166,7 @@ body.is-section-signup {
 		.is-section-plans #plans & {
 			margin-left: -15px;
 		}
-		.is-section-plans #plan & {
+		.is-section-plans #site-plans & {
 			margin-left: -24px;
 		}
 	}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -161,8 +161,13 @@ body.is-section-signup {
 	 */
 	.is-sticky-plan-type-selector & {
 		.is-section-plans & {
-			margin-left: -15px;
 			width: 100vw;
+		}
+		.is-section-plans #plans & {
+			margin-left: -15px;
+		}
+		.is-section-plans #plan & {
+			margin-left: -24px;
 		}
 	}
 }
@@ -175,6 +180,12 @@ body.is-section-plans .layout__content .main {
 		padding: 0;
 		.is-2023-pricing-grid .plans-wrapper {
 			margin: 0;
+		}
+	}
+}
+body.is-section-plans .layout__content #plans .main {
+	@include plan-type-selector-custom-mobile-breakpoint {
+		.is-2023-pricing-grid .plans-wrapper {
 			padding: 17px;
 		}
 	}

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -494,7 +494,7 @@ class PlansComponent extends Component {
 								</div>
 							</>
 						) }
-						<div id={ isUntangled ? 'plan' : 'plans' } className="plans plans__has-sidebar">
+						<div id={ isUntangled ? 'site-plans' : 'plans' } className="plans plans__has-sidebar">
 							{ showPlansNavigation && <PlansNavigation path={ this.props.context.path } /> }
 							<Main fullWidthLayout={ ! isWooExpressTrial } wideLayout={ isWooExpressTrial }>
 								{ ! isDomainAndPlanPackageFlow && domainAndPlanPackage && (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -270,6 +270,7 @@ class PlansComponent extends Component {
 
 		return (
 			<PlansFeaturesMain
+				isInSiteDashboard={ isUntangled }
 				redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
 				hidePlanTypeSelector={ hidePlanTypeSelector }
 				hideFreePlan={ hideFreePlan }
@@ -282,7 +283,6 @@ class PlansComponent extends Component {
 				discountEndDate={ this.props.discountEndDate }
 				siteId={ selectedSite?.ID }
 				plansWithScroll={ false }
-				hideSpotlightPlan={ isUntangled }
 				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
 				showLegacyStorageFeature={ this.props.siteHasLegacyStorage }
 				intent={ plansIntent }
@@ -494,7 +494,7 @@ class PlansComponent extends Component {
 								</div>
 							</>
 						) }
-						<div id="plans" className="plans plans__has-sidebar">
+						<div id={ isUntangled ? 'plan' : 'plans' } className="plans plans__has-sidebar">
 							{ showPlansNavigation && <PlansNavigation path={ this.props.context.path } /> }
 							<Main fullWidthLayout={ ! isWooExpressTrial } wideLayout={ isWooExpressTrial }>
 								{ ! isDomainAndPlanPackageFlow && domainAndPlanPackage && (


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/10607

## Proposed Changes

This PR fixes the sticky plan comparison header so that it works in the new untangled Plans page.

I need to rework the stickiness calculation logic because in the sites dashboard, the masterbar does not actually block the sticky container, and the preview pane area has some top padding in it.

### Desktop

|<img width="1246" alt="image" src="https://github.com/user-attachments/assets/b1a0166a-b0c2-40bb-ae44-10bd59886ad3" />|<img width="1255" alt="image" src="https://github.com/user-attachments/assets/7cf1c94a-bf72-4af5-932b-152289e80e5a" />|
|-|-|

### Mobile

(notice the sticky "Pay yearly" term selector)

|<img width="245" alt="image" src="https://github.com/user-attachments/assets/bdd5255c-e1fd-4bdc-943c-cf111d2ac6d5" />|<img width="245" alt="image" src="https://github.com/user-attachments/assets/a896466c-f36d-4680-80a9-9531cc528acb" />|
|-|-|


## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

1. Go to `/plans/:site?flags=untangling/plans`
    - Verify the sticky behavior as seen in screenshot above, both desktop and mobile
    - (You might need to click the "Compare plans" button so that the content scrolls)
1. Go to `/plans/:site`
    - Verify the sticky behavior is still correct in existing Plans page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?