### PR TITLE
Stats: Make the upsell modal view available on all Stats pages

### DIFF
--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -1,20 +1,26 @@
 import clsx from 'clsx';
 import Main, { MainProps } from 'calypso/components/main';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
+import StatsUpsellModal from 'calypso/my-sites/stats/stats-upsell-modal';
 import { useSelector } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export default function StatsMain( { children, ...props }: MainProps ) {
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) as number;
 	const isSiteJetpack = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } )
 	);
 	const customTheme = useWPAdminTheme( isSiteJetpack );
 
+	// Make the upsell modal view available on all Stats pages.
+	const upsellModalView = useSelector( ( state ) => getUpsellModalView( state, siteId ) );
+
 	return (
 		<Main { ...props } className={ clsx( 'stats-main', 'color-scheme', customTheme ) }>
 			{ children }
+			{ upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
 		</Main>
 	);
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -52,7 +52,6 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
-import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import StatsModuleAuthors from './features/modules/stats-authors';
 import StatsModuleClicks from './features/modules/stats-clicks';
@@ -83,7 +82,6 @@ import StatsPeriodNavigation from './stats-period-navigation';
 import StatsPlanUsage from './stats-plan-usage';
 import statsStrings from './stats-strings';
 import StatsUpsell from './stats-upsell/traffic-upsell';
-import StatsUpsellModal from './stats-upsell-modal';
 import { appendQueryStringForRedirection, getPathWithUpdatedQueryString } from './utils';
 
 // Sync hidable modules with StatsNavigation.
@@ -194,10 +192,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const moduleVisibility = useMemo(
 		() => moduleVisibilityWithUserConfiguration( moduleToggles, hasVideoPress ),
 		[ hasVideoPress, moduleToggles ]
-	);
-
-	const upsellModalView = useSelector(
-		( state ) => config.isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId )
 	);
 
 	const {
@@ -763,7 +757,6 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 			{ supportUserFeedback && <StatsFeedbackPresentor siteId={ siteId } /> }
 			<JetpackColophon />
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />
-			{ upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
 		</div>
 	);
 }

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -18,7 +18,6 @@ import StatsModuleSearch from 'calypso/my-sites/stats/features/modules/stats-sea
 import StatsModuleTopPosts from 'calypso/my-sites/stats/features/modules/stats-top-posts';
 import getMediaItem from 'calypso/state/selectors/get-media-item';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
-import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import StatsModuleLocations from '../features/modules/stats-locations';
 import StatsModuleUTM from '../features/modules/stats-utm';
@@ -27,7 +26,6 @@ import DownloadCsv from '../stats-download-csv';
 import AllTimeNav from '../stats-module/all-time-nav';
 import PageViewTracker from '../stats-page-view-tracker';
 import statsStringsFactory from '../stats-strings';
-import StatsUpsellModal from '../stats-upsell-modal';
 import VideoPlayDetails from '../stats-video-details';
 import StatsVideoSummary from '../stats-video-summary';
 import VideoPressStatsModule from '../videopress-stats-module';
@@ -402,7 +400,6 @@ class StatsSummary extends Component {
 					) }
 					<JetpackColophon />
 				</div>
-				{ this.props.upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
 			</Main>
 		);
 	}
@@ -410,7 +407,6 @@ class StatsSummary extends Component {
 
 export default connect( ( state, { context, postId } ) => {
 	const siteId = getSelectedSiteId( state );
-	const upsellModalView = isEnabled( 'stats/paid-wpcom-v2' ) && getUpsellModalView( state, siteId );
 
 	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
 
@@ -418,7 +414,6 @@ export default connect( ( state, { context, postId } ) => {
 		siteId: getSelectedSiteId( state ),
 		siteSlug: getSelectedSiteSlug( state, siteId ),
 		media: context.params.module === 'videodetails' ? getMediaItem( state, siteId, postId ) : false,
-		upsellModalView,
 		supportsUTMStats,
 	};
 } )( localize( StatsSummary ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101514

## Proposed Changes

* Make the `StatsUpsellModal` available on all Stats pages for upsell button actions.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The upsell modal was not introduced broadly for all upsell nudge on Stats pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Calypso Stats
* Build this change locally.
* Prepare a Simple site with the free plan.
* Navigate to Stats > Post details page for a post with views data: `/stats/post/{post-id}/{site-slug}`.
* Ensure the `Upgrade to Premium` button on the locked UTM module launches the upsell modal.
* Ensure the upsell modal launch in the Traffic and module summary pages works as previously.

### Odyssey Stats
* Use `Option 2` to build Odyssey Stats to test in WP-Admin of the Simple site: PCYsg-Pp7-p2#option-2.
* Follow the steps above for testing.

#### Post details page
<img width="1405" alt="截圖 2025-03-19 中午12 35 47" src="https://github.com/user-attachments/assets/e30067ea-723c-4c29-9d66-0b3f53d343d4" />

#### Traffic page
<img width="1431" alt="截圖 2025-03-19 下午2 47 04" src="https://github.com/user-attachments/assets/6b718066-cf14-493f-b9c2-616cbf6261be" />

#### UTM module summary page
<img width="1108" alt="截圖 2025-03-19 下午2 46 56" src="https://github.com/user-attachments/assets/f4c2ff12-9346-4aab-a10b-81092a0fdd8c" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?