### PR TITLE
Site Visibility: Show the public details only when the current visibility is configured to public

### DIFF
--- a/client/sites/settings/site/privacy/form.tsx
+++ b/client/sites/settings/site/privacy/form.tsx
@@ -2,7 +2,6 @@ import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products'
 import { FormLabel } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -50,7 +49,6 @@ const SiteSettingPrivacyForm = ( {
 }: SiteSettingPrivacyFormProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const defaultFields = useMemo( () => fields, [ isSavingSettings ] ); // Keep the default value of the fields.
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -76,16 +74,6 @@ const SiteSettingPrivacyForm = ( {
 
 	const showPreviewLink = isComingSoon && hasSitePreviewLink;
 	const shouldShowPremiumStylesNotice = globalStylesInUse && shouldLimitGlobalStyles;
-
-	const showPublicDetails =
-		( ( 1 === Number( defaultFields.wpcom_public_coming_soon ) &&
-			0 === Number( defaultFields.blog_public ) &&
-			isComingSoonDisabled ) ||
-			( 0 === Number( defaultFields.blog_public ) &&
-				0 === Number( defaultFields.wpcom_public_coming_soon ) ) ||
-			1 === Number( defaultFields.blog_public ) ) &&
-		isPublicChecked &&
-		! isSavingSettings;
 
 	const discourageSearchChecked =
 		( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
@@ -199,7 +187,7 @@ const SiteSettingPrivacyForm = ( {
 					</>
 				) }
 
-				{ showPublicDetails && ! isWpcomStagingSite && (
+				{ isPublicChecked && ! isWpcomStagingSite && (
 					<>
 						<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
 							<FormInputCheckbox

--- a/client/sites/settings/site/privacy/form.tsx
+++ b/client/sites/settings/site/privacy/form.tsx
@@ -196,8 +196,7 @@ const SiteSettingPrivacyForm = ( {
 								checked={ discourageSearchChecked }
 								onChange={ () =>
 									handleVisibilityOptionChange( {
-										blog_public:
-											wpcomPublicComingSoon || blogPublic === -1 || blogPublic === 1 ? 0 : 1,
+										blog_public: wpcomPublicComingSoon || blogPublic !== 0 ? 0 : 1,
 										wpcom_coming_soon: 0,
 										wpcom_public_coming_soon: 0,
 										wpcom_data_sharing_opt_out: true,
@@ -227,8 +226,7 @@ const SiteSettingPrivacyForm = ( {
 									}
 									onChange={ () =>
 										handleVisibilityOptionChange( {
-											blog_public:
-												blogPublic === 1 || wpcomPublicComingSoon || blogPublic === -1 ? 1 : 0,
+											blog_public: wpcomPublicComingSoon || blogPublic !== 0 ? 1 : 0,
 											wpcom_coming_soon: 0,
 											wpcom_public_coming_soon: 0,
 											wpcom_data_sharing_opt_out: ! wpcomDataSharingOptOut,

--- a/client/sites/settings/site/privacy/form.tsx
+++ b/client/sites/settings/site/privacy/form.tsx
@@ -40,7 +40,6 @@ const SiteSettingPrivacyForm = ( {
 	siteIsJetpack,
 	updateFields,
 	isAtomicAndEditingToolkitDeactivated,
-	isComingSoon,
 	isRequestingSettings,
 	isSavingSettings,
 	isUnlaunchedSite,
@@ -72,7 +71,7 @@ const SiteSettingPrivacyForm = ( {
 		( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
 		blogPublic === 1;
 
-	const showPreviewLink = isComingSoon && hasSitePreviewLink;
+	const showPreviewLink = isAnyComingSoonEnabled && hasSitePreviewLink;
 	const shouldShowPremiumStylesNotice = globalStylesInUse && shouldLimitGlobalStyles;
 
 	const discourageSearchChecked =

--- a/client/sites/settings/site/privacy/form.tsx
+++ b/client/sites/settings/site/privacy/form.tsx
@@ -2,6 +2,7 @@ import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products'
 import { FormLabel } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -49,6 +50,7 @@ const SiteSettingPrivacyForm = ( {
 }: SiteSettingPrivacyFormProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const defaultFields = useMemo( () => fields, [ isSavingSettings ] ); // Keep the default value of the fields.
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -74,6 +76,16 @@ const SiteSettingPrivacyForm = ( {
 
 	const showPreviewLink = isComingSoon && hasSitePreviewLink;
 	const shouldShowPremiumStylesNotice = globalStylesInUse && shouldLimitGlobalStyles;
+
+	const showPublicDetails =
+		( ( 1 === Number( defaultFields.wpcom_public_coming_soon ) &&
+			0 === Number( defaultFields.blog_public ) &&
+			isComingSoonDisabled ) ||
+			( 0 === Number( defaultFields.blog_public ) &&
+				0 === Number( defaultFields.wpcom_public_coming_soon ) ) ||
+			1 === Number( defaultFields.blog_public ) ) &&
+		isPublicChecked &&
+		! isSavingSettings;
 
 	const discourageSearchChecked =
 		( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
@@ -187,7 +199,7 @@ const SiteSettingPrivacyForm = ( {
 					</>
 				) }
 
-				{ ! isWpcomStagingSite && (
+				{ showPublicDetails && ! isWpcomStagingSite && (
 					<>
 						<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
 							<FormInputCheckbox

--- a/client/sites/settings/site/privacy/form.tsx
+++ b/client/sites/settings/site/privacy/form.tsx
@@ -40,6 +40,7 @@ const SiteSettingPrivacyForm = ( {
 	siteIsJetpack,
 	updateFields,
 	isAtomicAndEditingToolkitDeactivated,
+	isComingSoon,
 	isRequestingSettings,
 	isSavingSettings,
 	isUnlaunchedSite,
@@ -71,7 +72,7 @@ const SiteSettingPrivacyForm = ( {
 		( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
 		blogPublic === 1;
 
-	const showPreviewLink = isAnyComingSoonEnabled && hasSitePreviewLink;
+	const showPreviewLink = isComingSoon && hasSitePreviewLink;
 	const shouldShowPremiumStylesNotice = globalStylesInUse && shouldLimitGlobalStyles;
 
 	const discourageSearchChecked =

--- a/client/sites/settings/site/privacy/index.tsx
+++ b/client/sites/settings/site/privacy/index.tsx
@@ -7,6 +7,7 @@ import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/compo
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -44,6 +45,7 @@ const PrivacyForm = ( {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isComingSoon = useSelector( ( state: AppState ) => isSiteComingSoon( state, siteId ) );
 	const isP2HubSite = useSelector( ( state: AppState ) => isSiteP2Hub( state, siteId ) );
 	const isUnlaunched = useSelector( ( state: AppState ) => isUnlaunchedSite( state, siteId ) );
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
@@ -87,6 +89,7 @@ const PrivacyForm = ( {
 					fields={ fields }
 					updateFields={ updateFields }
 					isAtomicAndEditingToolkitDeactivated={ isAtomicAndEditingToolkitDeactivated }
+					isComingSoon={ isComingSoon }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
 					isUnlaunchedSite={ isUnlaunched }

--- a/client/sites/settings/site/privacy/index.tsx
+++ b/client/sites/settings/site/privacy/index.tsx
@@ -7,7 +7,6 @@ import { PanelCard, PanelCardDescription, PanelCardHeading } from 'calypso/compo
 import { useRemoveDuplicateViewsExperimentEnabled } from 'calypso/lib/remove-duplicate-views-experiment';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -45,7 +44,6 @@ const PrivacyForm = ( {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
 	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const isComingSoon = useSelector( ( state: AppState ) => isSiteComingSoon( state, siteId ) );
 	const isP2HubSite = useSelector( ( state: AppState ) => isSiteP2Hub( state, siteId ) );
 	const isUnlaunched = useSelector( ( state: AppState ) => isUnlaunchedSite( state, siteId ) );
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
@@ -89,7 +87,6 @@ const PrivacyForm = ( {
 					fields={ fields }
 					updateFields={ updateFields }
 					isAtomicAndEditingToolkitDeactivated={ isAtomicAndEditingToolkitDeactivated }
-					isComingSoon={ isComingSoon }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
 					isUnlaunchedSite={ isUnlaunched }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/42230#issuecomment-2732658808

## Proposed Changes

* Show the public details only when the current visibility is configured to public as suggested.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick any launched site
* Switch to Settings tab
* Ensure the public details are hidden if the current site visibility is not set to public. Conversely, display the public details if the current site visibility is set to public.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
