### PR TITLE
Replace yearly with annually on WP VIP

### DIFF
--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -82,7 +82,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 
 		return (
 			<div className="plans-grid-next__billing-timeframe-vip-price">
-				{ translate( 'Starts at {{b}}%(price)s{{/b}} yearly', {
+				{ translate( 'Starts at {{b}}%(price)s{{/b}} annually', {
 					args: { price },
 					components: { b: <b /> },
 					comment: 'Translators: the price is in US dollars for all users (US$25,000)',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/101541

### Proposed changes

**Before**
![image](https://github.com/user-attachments/assets/79cc6b95-1189-46f8-8a1e-94c30304c50b)


**After**
<img width="1458" alt="Screenshot 2025-03-19 at 08 55 17" src="https://github.com/user-attachments/assets/1c497d7f-a38d-4920-8547-f2fc5a7690ed" />

### Why are these changes being made?
Consistency.


### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
