### PR TITLE
TypeScript 5.6 fixes

### DIFF
--- a/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
+++ b/client/components/jetpack/upsell-product-wpcom-plan-card/index.tsx
@@ -58,7 +58,7 @@ export const UpsellProductWpcomPlanCard: React.FC< UpsellProductWpcomPlanCardPro
 	const secondaryCtaURL: string = `https://wordpress.com/plans/${ selectedSiteSlug }`;
 	const isFetchingPrices: boolean = ! siteProduct;
 	const originalPrice: number = siteProduct?.cost_smallest_unit ?? 0;
-	const displayPrice: number = siteProduct?.cost / 12 ?? 0;
+	const displayPrice: number = ( siteProduct?.cost ?? 0 ) / 12;
 
 	const ctaButtonLabel = translate( 'Get %(productName)s plan', {
 		args: {

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -78,7 +78,7 @@ function getChargebackErrorMessage( {
 		{
 			components: {
 				strong: <strong />,
-				a: <a href={ '/checkout/' + selectedSiteSlug ?? '' } />,
+				a: <a href={ '/checkout/' + ( selectedSiteSlug ?? '' ) } />,
 			},
 		}
 	);

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -391,7 +391,7 @@ export class CheckoutThankYou extends Component<
 					'calypstore',
 					true
 				);
-				page.redirect( '/themes/' + this.props.selectedSite?.slug ?? '' );
+				page.redirect( '/themes/' + ( this.props.selectedSite?.slug ?? '' ) );
 			} );
 		}
 	};

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -141,9 +141,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		product?.subscribe_as_site_subscriber ?? isOnlyTier
 	);
 
-	const [ editedPostIsTier, setEditedPostIsTier ] = useState(
-		product?.type === TYPE_TIER ?? false
-	);
+	const [ editedPostIsTier, setEditedPostIsTier ] = useState( product?.type === TYPE_TIER );
 	const [ editedSchedule, setEditedSchedule ] = useState(
 		product?.renewal_schedule ?? PLAN_MONTHLY_FREQUENCY
 	);

--- a/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
+++ b/client/my-sites/plans/jetpack-plans/product-card/product-tooltip.ts
@@ -62,7 +62,7 @@ export default function productTooltip(
 			components: {
 				strong: createElement( 'strong' ),
 				p: createElement( 'p' ),
-				Info: createElement( ExternalLink, {
+				Info: createElement( ExternalLink as any, {
 					icon: true,
 					href: 'https://jetpack.com/upgrade/search/',
 				} ),

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -79,6 +79,7 @@
 		"@testing-library/react": "^16.2.0",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/canvas-confetti": "^1.6.0",
+		"@types/node": "^22.7.5",
 		"@types/react-slider": "^1.3.6",
 		"postcss": "^8.5.3",
 		"resize-observer-polyfill": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,6 +691,7 @@ __metadata:
     "@testing-library/react": "npm:^16.2.0"
     "@testing-library/user-event": "npm:^14.6.1"
     "@types/canvas-confetti": "npm:^1.6.0"
+    "@types/node": "npm:^22.7.5"
     "@types/react-slider": "npm:^1.3.6"
     "@wordpress/base-styles": "npm:^5.20.0"
     "@wordpress/components": "npm:^29.6.0"


### PR DESCRIPTION
## Proposed Changes

This PR fixes some TypeScript errors that occur when updating TypeScript to 5.6.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

TypeScript 5.6.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

All type check tests should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
