### PR TITLE
QueryBillingTransactions: rewrite to use Redux hooks

### DIFF
--- a/client/components/data/query-billing-transactions/index.tsx
+++ b/client/components/data/query-billing-transactions/index.tsx
@@ -1,35 +1,25 @@
-import React, { useEffect } from 'react';
-import { connect, ConnectedProps } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
 import { requestBillingTransactions } from 'calypso/state/billing-transactions/actions';
-import { BillingTransactionsType } from 'calypso/state/billing-transactions/types';
 import isRequestingBillingTransactions from 'calypso/state/selectors/is-requesting-billing-transactions';
-import { IAppState } from 'calypso/state/types';
+import type { BillingTransactionsType } from 'calypso/state/billing-transactions/types';
 
-export type QueryBillingTransactionsProps = ConnectedProps< typeof connector > & {
+type QueryBillingTransactionsProps = {
 	transactionType?: BillingTransactionsType;
 };
 
-const QueryBillingTransactions: React.FunctionComponent< QueryBillingTransactionsProps > = ( {
-	requestingBillingTransactions,
-	requestBillingTransactions,
+export default function QueryBillingTransactions( {
 	transactionType,
-} ) => {
+}: QueryBillingTransactionsProps ) {
+	const dispatch = useDispatch();
 	useEffect( () => {
-		if ( requestingBillingTransactions ) {
-			return;
-		}
-
-		requestBillingTransactions( transactionType );
-	}, [] );
+		dispatch( ( d, getState ) => {
+			if ( isRequestingBillingTransactions( getState() ) ) {
+				return;
+			}
+			d( requestBillingTransactions( transactionType ) );
+		} );
+	}, [ dispatch, transactionType ] );
 
 	return null;
-};
-
-const connector = connect(
-	( state: IAppState ) => ( {
-		requestingBillingTransactions: isRequestingBillingTransactions( state ),
-	} ),
-	{ requestBillingTransactions }
-);
-
-export default connector( QueryBillingTransactions );
+}

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -55,7 +55,7 @@ export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
 			{ isJetpackCloud() && <SidebarNavigation /> }
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker path="/purchases/billing-history" title="Billing History" />
-			<QueryBillingTransactions />
+			<QueryBillingTransactions transactionType="past" />
 			{ ! isJetpackCloud() && (
 				<NavigationHeader
 					title={ titles.sectionTitle }


### PR DESCRIPTION
This PR modernizes the `QueryBillingTransactions` component to use Redux hooks (`useDispatch`) instead of a `connect` HoC. Makes the component smaller and easier to read.

The second commit fixes a little glitch that was noticed by @sirbrillig in https://github.com/Automattic/payments-shilling/issues/2060#issuecomment-1746051981: when fetching transactions for a specific site on the `/purchases/billing-history/:site` page, the REST request doesn't have the `/past` suffix and loads also upcoming transactions. Here I fix that by adding a `transactionType="past"` prop. The site-specific view also uses just the past transactions: the `getPastBillingTransactions` selector in the `BillingHistoryListDataView` component.

This PR is a companion to @tyxla's #101459 but shouldn't conflict with it.

**How to test:**
Test both variants of billing history:
- `/me/purchases/billing`
- `/purchases/billing-history/:site`

Both use the same data view and the same REST query, the only difference is that in the site-specific view the data view does in-memory filtering by `siteId`.