### PR TITLE
Purchases: remove the me/vat-details feature flag

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { CompactCard, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -72,10 +71,7 @@ function BillingHistory() {
 			<QueryBillingTransactions transactionType="past" />
 			<PurchasesNavigation section="billingHistory" />
 			<BillingHistoryContent siteId={ null } getReceiptUrlFor={ billingHistoryReceipt } />
-
-			{ config.isEnabled( 'me/vat-details' ) && (
-				<CompactCard href={ vatDetailsPath }>{ vatText }</CompactCard>
-			) }
+			<CompactCard href={ vatDetailsPath }>{ vatText }</CompactCard>
 		</Main>
 	);
 }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, Card, FormLabel } from '@automattic/components';
 import { IntroductoryOfferTerms } from '@automattic/shopping-cart';
@@ -201,7 +200,7 @@ export function ReceiptBody( {
 					) : (
 						<EmptyReceiptDetails />
 					) }
-					{ config.isEnabled( 'me/vat-details' ) && <VatDetails transaction={ transaction } /> }
+					<VatDetails transaction={ transaction } />
 				</ul>
 				<ReceiptLineItems transaction={ transaction } />
 
@@ -709,14 +708,6 @@ export function ReceiptPlaceholder() {
 function ReceiptLabels( { hideDetailsLabelOnPrint }: { hideDetailsLabelOnPrint?: boolean } ) {
 	const translate = useTranslate();
 
-	let labelContent = translate(
-		'Use this field to add your billing information (eg. VAT number, business address) before printing.'
-	);
-	if ( config.isEnabled( 'me/vat-details' ) ) {
-		labelContent = translate(
-			'Use this field to add your billing information (eg. business address) before printing.'
-		);
-	}
 	return (
 		<div>
 			<FormLabel
@@ -729,7 +720,9 @@ function ReceiptLabels( { hideDetailsLabelOnPrint }: { hideDetailsLabelOnPrint?:
 				className="billing-history__billing-details-description"
 				id="billing-history__billing-details-description"
 			>
-				{ labelContent }
+				{ translate(
+					'Use this field to add your billing information (eg. business address) before printing.'
+				) }
 			</div>
 		</div>
 	);

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { sidebar } from 'calypso/me/controller';
@@ -33,9 +32,7 @@ export default ( router ) => {
 		page.redirect( paths.addCreditCard );
 	} );
 
-	if ( config.isEnabled( 'me/vat-details' ) ) {
-		router( paths.vatDetails, sidebar, controller.vatDetails, makeLayout, clientRender );
-	}
+	router( paths.vatDetails, sidebar, controller.vatDetails, makeLayout, clientRender );
 
 	router(
 		paths.billingHistory,

--- a/config/development.json
+++ b/config/development.json
@@ -125,7 +125,6 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,7 +81,6 @@
 		"marketplace-reviews-notification": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
-		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,

--- a/config/production.json
+++ b/config/production.json
@@ -98,7 +98,6 @@
 		"marketplace-test": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"onboarding/create-course": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,7 +96,6 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"onboarding/create-course": false,

--- a/config/test.json
+++ b/config/test.json
@@ -78,7 +78,6 @@
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
 		"me/account-close": true,
-		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"onboarding/create-course": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -100,7 +100,6 @@
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
-		"me/vat-details": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
 		"network-connection": true,


### PR DESCRIPTION
Removes a feature flag that's been enabled in all environments for 4 years.

**How to test:**
Verify that the VAT details feature works, and that it's not accidentally enabled in Jetpack Cloud or similar.