### PR TITLE
Sites: Update the color of the W logo when loading

### DIFF
--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -43,6 +43,13 @@
 	}
 }
 
+.is-section-sites-dashboard,
+.is-section-overview {
+	.wpcom-loading__boot {
+		transform: translateX(calc(var(--sidebar-width-max) * -0.5));
+	}
+}
+
 .wpcom__loading-ellipsis {
 	display: inline-block;
 	position: relative;

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -1,18 +1,23 @@
 .wpcom-site__logo {
-	fill: var(--color-neutral-10);
 	color: var(--color-neutral-10);
+	fill: currentColor;
 	position: fixed;
 	top: 50%;
 	left: 50%;
 	transform: translate(-50%, -50%);
+	animation: wpcom__loading-pulse 1.6s ease-in-out infinite;
 
 	path {
-		fill: var(--color-neutral-10);
+		fill: currentColor;
 	}
 
 	@include breakpoint-deprecated( ">960px" ) {
 		width: 100px;
 		height: 100px;
+	}
+
+	&--blue {
+		color: var(--studio-blue-50);
 	}
 }
 
@@ -40,13 +45,6 @@
 .is-section-signup {
 	.wpcom-loading__boot {
 		margin: calc( 32vh + 12px ) auto 0;
-	}
-}
-
-.is-section-sites-dashboard,
-.is-section-overview {
-	.wpcom-loading__boot {
-		transform: translateX(calc(var(--sidebar-width-max) * -0.5));
 	}
 }
 
@@ -110,5 +108,17 @@
 	}
 	100% {
 		transform: scale(0);
+	}
+}
+
+@keyframes wpcom__loading-pulse {
+	0% {
+		opacity: 0.5;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.5;
 	}
 }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -133,7 +133,11 @@ class Document extends Component {
 		}
 
 		const shouldNotShowLoadingLogo =
-			sectionName === 'checkout' || sectionName === 'stepper' || sectionName === 'signup';
+			sectionName === 'checkout' ||
+			sectionName === 'stepper' ||
+			sectionName === 'signup' ||
+			sectionName === 'sites-dashboard' ||
+			sectionName === 'overview';
 
 		const LoadingLogo = chooseLoadingLogo( this.props, {
 			isWpMobileApp: app?.isWpMobileApp,

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -133,11 +133,7 @@ class Document extends Component {
 		}
 
 		const shouldNotShowLoadingLogo =
-			sectionName === 'checkout' ||
-			sectionName === 'stepper' ||
-			sectionName === 'signup' ||
-			sectionName === 'sites-dashboard' ||
-			sectionName === 'overview';
+			sectionName === 'checkout' || sectionName === 'stepper' || sectionName === 'signup';
 
 		const LoadingLogo = chooseLoadingLogo( this.props, {
 			isWpMobileApp: app?.isWpMobileApp,
@@ -202,7 +198,7 @@ class Document extends Component {
 									{ shouldNotShowLoadingLogo ? (
 										<Loading className="wpcom-loading__boot" />
 									) : (
-										<LoadingLogo size={ 72 } className="wpcom-site__logo" />
+										<LoadingLogo size={ 72 } className="wpcom-site__logo wpcom-site__logo--blue" />
 									) }
 								</div>
 							</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101437#issuecomment-2729726473

## Proposed Changes

* Use the loading progress bar instead of the logo on both `sites-dashboard` and `overview` sections

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/da76d2d1-49d3-4d12-8091-62b15fdd589e) | ![image](https://github.com/user-attachments/assets/9e8b4193-5509-4fd4-8acc-922780e2f796) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistent progress bar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Ensure you can see the loading progress bar instead of W Logo when loading
* Pick any site
* Refresh the page
* Ensure you can see the loading progress bar instead of W Logo when loading again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
