### PR TITLE
Staging Sites: Remove smoothing from staging / production site sync

### DIFF
--- a/client/state/sync/constants.ts
+++ b/client/state/sync/constants.ts
@@ -14,5 +14,4 @@ export enum SiteSyncStatusProgress {
 	COMPLETED = 1,
 	FAILED = 0,
 	ALLOW_RETRY = 0.1,
-	DELTA = 0.004,
 }

--- a/client/state/sync/constants.ts
+++ b/client/state/sync/constants.ts
@@ -13,5 +13,4 @@ export enum SiteSyncStatusProgress {
 	RESTORE = 0.6,
 	COMPLETED = 1,
 	FAILED = 0,
-	ALLOW_RETRY = 0.1,
 }

--- a/client/state/sync/constants.ts
+++ b/client/state/sync/constants.ts
@@ -13,4 +13,5 @@ export enum SiteSyncStatusProgress {
 	RESTORE = 0.6,
 	COMPLETED = 1,
 	FAILED = 0,
+	ALLOW_RETRY = 0.1,
 }

--- a/client/state/sync/reducer.js
+++ b/client/state/sync/reducer.js
@@ -134,32 +134,22 @@ export const progress = withPersistence( ( state = 0, action ) => {
 		case REQUEST_STATUS:
 			return state;
 		case SET_STATUS: {
-			let newStatus = state + SiteSyncStatusProgress.DELTA;
-			newStatus = Math.min( newStatus, 1 );
-
 			switch ( action.status ) {
 				case SiteSyncStatus.PENDING:
-					newStatus = Math.max( newStatus, SiteSyncStatusProgress.PENDING );
-					break;
+					return SiteSyncStatusProgress.PENDING;
 				case SiteSyncStatus.BACKUP:
-					newStatus = Math.max( newStatus, SiteSyncStatusProgress.BACKUP );
-					break;
+					return SiteSyncStatusProgress.BACKUP;
 				case SiteSyncStatus.RESTORE:
-					newStatus = Math.max( newStatus, SiteSyncStatusProgress.RESTORE );
-					break;
+					return SiteSyncStatusProgress.RESTORE;
 				case SiteSyncStatus.COMPLETED:
-					newStatus = Math.max( newStatus, SiteSyncStatusProgress.COMPLETED );
-					break;
+					return SiteSyncStatusProgress.COMPLETED;
 				case SiteSyncStatus.ALLOW_RETRY:
-					newStatus = Math.max( newStatus, SiteSyncStatusProgress.ALLOW_RETRY );
-					break;
+					return SiteSyncStatusProgress.ALLOW_RETRY;
 				case SiteSyncStatus.FAILED:
-					newStatus = SiteSyncStatusProgress.FAILED;
-					break;
+					return SiteSyncStatusProgress.FAILED;
 				default:
-					return newStatus;
+					return state;
 			}
-			return newStatus;
 		}
 		case REQUEST_STATUS_FAILURE:
 			return 0;

--- a/client/state/sync/reducer.js
+++ b/client/state/sync/reducer.js
@@ -142,8 +142,9 @@ export const progress = withPersistence( ( state = 0, action ) => {
 				case SiteSyncStatus.RESTORE:
 					return SiteSyncStatusProgress.RESTORE;
 				case SiteSyncStatus.COMPLETED:
-				case SiteSyncStatus.ALLOW_RETRY:
 					return SiteSyncStatusProgress.COMPLETED;
+				case SiteSyncStatus.ALLOW_RETRY:
+					return SiteSyncStatusProgress.ALLOW_RETRY;
 				case SiteSyncStatus.FAILED:
 					return SiteSyncStatusProgress.FAILED;
 				default:

--- a/client/state/sync/reducer.js
+++ b/client/state/sync/reducer.js
@@ -142,9 +142,8 @@ export const progress = withPersistence( ( state = 0, action ) => {
 				case SiteSyncStatus.RESTORE:
 					return SiteSyncStatusProgress.RESTORE;
 				case SiteSyncStatus.COMPLETED:
-					return SiteSyncStatusProgress.COMPLETED;
 				case SiteSyncStatus.ALLOW_RETRY:
-					return SiteSyncStatusProgress.ALLOW_RETRY;
+					return SiteSyncStatusProgress.COMPLETED;
 				case SiteSyncStatus.FAILED:
 					return SiteSyncStatusProgress.FAILED;
 				default:

--- a/client/state/sync/test/reducer.js
+++ b/client/state/sync/test/reducer.js
@@ -117,7 +117,7 @@ describe( 'state', () => {
 				);
 				expect( newState ).toHaveProperty( 'isSyncingInProgress', false );
 				expect( newState ).toHaveProperty( 'status', SiteSyncStatus.ALLOW_RETRY );
-				expect( newState ).toHaveProperty( 'progress', 1 );
+				expect( newState ).toHaveProperty( 'progress', 0.1 );
 				expect( newState ).toHaveProperty( 'fetchingStatus', false );
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/10615.
Resolves DOTHF-6-linear-issue

## Proposed Changes

* remove smoothing from staging / production site sync

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/dotcom-forge/issues/10615

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build it with `yarn start` (or use Calypso Live). 
2. Head over to `http://calypso.localhost:3000/staging-site/{atomic-site-slug}` of your test site and create a staging site if it does not exist yet.
3. Initiate a site sync.
4. Observe the progress bar. it should progress only based on specific sync stages and should not progress in-between with increments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?