### PR TITLE
Reader Editor: Set `selectedSiteId` if not present

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -24,7 +24,7 @@ import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receiveNewPost } from 'calypso/state/reader/streams/actions';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getMostRecentlySelectedSiteId, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -51,6 +51,7 @@ function QuickPost( {
 	receivePosts: ( posts: PostItem[] ) => Promise< void >;
 	successNotice: ( message: string, options: object ) => void;
 } ) {
+	const state = useSelector( ( state ) => state );
 	const translate = useTranslate();
 	const locale = useLocale();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
@@ -78,10 +79,13 @@ function QuickPost( {
 
 	// Set initial selected site if none is selected
 	useEffect( () => {
-		if ( ! selectedSiteId && currentUser?.primary_blog ) {
-			dispatch( setSelectedSiteId( currentUser.primary_blog ) );
+		if ( ! selectedSiteId ) {
+			const siteId = getMostRecentlySelectedSiteId( state ) || currentUser?.primary_blog;
+			if ( siteId ) {
+				dispatch( setSelectedSiteId( siteId ) );
+			}
 		}
-	} );
+	}, [ selectedSiteId, dispatch, state, currentUser ] );
 
 	const clearEditor = () => {
 		localStorage.removeItem( STORAGE_KEY );

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -85,7 +85,7 @@ function QuickPost( {
 		setEditorKey( ( key ) => key + 1 );
 	};
 
-	const siteId = selectedSiteId || mostRecentlySelectedSiteId || primarySiteId;
+	const siteId = selectedSiteId || mostRecentlySelectedSiteId || primarySiteId || undefined;
 
 	const handleSubmit = () => {
 		if ( ! postContent.trim() || ! siteId || isSubmitting ) {
@@ -184,7 +184,7 @@ function QuickPost( {
 			<div className="quick-post-input__fields">
 				<div className="quick-post-input__site-select-wrapper">
 					<SitesDropdown
-						selectedSiteId={ siteId || undefined }
+						selectedSiteId={ siteId }
 						onSiteSelect={ handleSiteSelect }
 						isPlaceholder={ ! hasLoaded }
 					/>

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -76,6 +76,13 @@ function QuickPost( {
 		}
 	}, [ postContent ] );
 
+	// Set initial selected site if none is selected
+	useEffect( () => {
+		if ( ! selectedSiteId && currentUser?.primary_blog ) {
+			dispatch( setSelectedSiteId( currentUser.primary_blog ) );
+		}
+	} );
+
 	const clearEditor = () => {
 		localStorage.removeItem( STORAGE_KEY );
 		setPostContent( '' );

--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -22,6 +22,7 @@ import { successNotice } from 'calypso/state/notices/actions';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receiveNewPost } from 'calypso/state/reader/streams/actions';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getMostRecentlySelectedSiteId, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -51,7 +52,6 @@ function QuickPost( {
 	receivePosts: ( posts: PostItem[] ) => Promise< void >;
 	successNotice: ( message: string, options: object ) => void;
 } ) {
-	const state = useSelector( ( state ) => state );
 	const translate = useTranslate();
 	const locale = useLocale();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
@@ -62,10 +62,12 @@ function QuickPost( {
 	} );
 	const [ editorKey, setEditorKey ] = useState( 0 );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
-	const selectedSiteId = useSelector( getSelectedSiteId );
 	const editorRef = useRef< HTMLDivElement >( null );
 	const dispatch = useDispatch();
 	const currentUser = useSelector( getCurrentUser );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const mostRecentlySelectedSiteId = useSelector( getMostRecentlySelectedSiteId );
+	const primarySiteId = useSelector( getPrimarySiteId );
 	const hasLoaded = useSelector( hasLoadedSites );
 	const hasSites = ( currentUser?.site_count ?? 0 ) > 0;
 	const [ isMenuVisible, setIsMenuVisible ] = useState( false );
@@ -77,31 +79,23 @@ function QuickPost( {
 		}
 	}, [ postContent ] );
 
-	// Set initial selected site if none is selected
-	useEffect( () => {
-		if ( ! selectedSiteId ) {
-			const siteId = getMostRecentlySelectedSiteId( state ) || currentUser?.primary_blog;
-			if ( siteId ) {
-				dispatch( setSelectedSiteId( siteId ) );
-			}
-		}
-	}, [ selectedSiteId, dispatch, state, currentUser ] );
-
 	const clearEditor = () => {
 		localStorage.removeItem( STORAGE_KEY );
 		setPostContent( '' );
 		setEditorKey( ( key ) => key + 1 );
 	};
 
+	const siteId = selectedSiteId || mostRecentlySelectedSiteId || primarySiteId;
+
 	const handleSubmit = () => {
-		if ( ! postContent.trim() || ! selectedSiteId || isSubmitting ) {
+		if ( ! postContent.trim() || ! siteId || isSubmitting ) {
 			return;
 		}
 
 		setIsSubmitting( true );
 
 		wpcom
-			.site( selectedSiteId )
+			.site( siteId )
 			.post()
 			.add( {
 				title:
@@ -190,7 +184,7 @@ function QuickPost( {
 			<div className="quick-post-input__fields">
 				<div className="quick-post-input__site-select-wrapper">
 					<SitesDropdown
-						selectedSiteId={ selectedSiteId || undefined }
+						selectedSiteId={ siteId || undefined }
 						onSiteSelect={ handleSiteSelect }
 						isPlaceholder={ ! hasLoaded }
 					/>
@@ -210,7 +204,7 @@ function QuickPost( {
 							className="quick-post-input__popover"
 						>
 							<PopoverMenuItem
-								href={ selectedSiteId ? `/post/${ selectedSiteId }?type=post` : '/post' }
+								href={ siteId ? `/post/${ siteId }?type=post` : '/post' }
 								target="_blank"
 								rel="noreferrer"
 								onClick={ handleFullEditorClick }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101531

## Proposed Changes

- Sets a `selectedSiteId` to the user's primary blog if it's not present when the page loads
- This should fix the [issue discussed here](https://github.com/Automattic/wp-calypso/pull/101512#issuecomment-2735173454) with the Calypso state preventing the quick edit form from submitting and the "Open Full Editor" button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Improve UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader`
- Clear your IndexedDB
- Reload the page
- Ensure that in the Quick Edit...
  - Your primary site is selected in the dropdown
  - You can make posts
  - The "Open Full Editor" button navigates to site's Gutenberg editor

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
