### PR TITLE
Explore Calypso state initialisation in testing library helpers

### DIFF
--- a/client/sites/overview/components/test/hosting-overview.tsx
+++ b/client/sites/overview/components/test/hosting-overview.tsx
@@ -10,10 +10,10 @@ import HostingOverview from '../hosting-overview';
 
 describe( 'HostingOverview', () => {
 	it( 'should trigger errors due to limited state tree population', async () => {
-		renderWithProvider( <HostingOverview /> );
+		expect( () => renderWithProvider( <HostingOverview /> ) ).toThrow();
 	} );
 
 	it( 'should work using the stateful provider', async () => {
-		statefulRenderWithProvider( <HostingOverview /> );
+		expect( () => statefulRenderWithProvider( <HostingOverview /> ) ).not.toThrow();
 	} );
 } );

--- a/client/sites/overview/components/test/hosting-overview.tsx
+++ b/client/sites/overview/components/test/hosting-overview.tsx
@@ -169,4 +169,15 @@ describe( 'HostingOverview', () => {
 			} )
 		).not.toThrow();
 	} );
+
+	it( 'should show a warning and ignore initial state from secondary reducers', async () => {
+		expect( () =>
+			statefulRenderWithProvider( <HostingOverview />, {
+				initialState: {
+					...mockInitialState,
+					purchases: {},
+				},
+			} )
+		).not.toThrow();
+	} );
 } );

--- a/client/sites/overview/components/test/hosting-overview.tsx
+++ b/client/sites/overview/components/test/hosting-overview.tsx
@@ -1,19 +1,172 @@
 /**
  * @jest-environment jsdom
  */
+import { MigrationStatus } from '@automattic/data-stores';
 import React from 'react';
+import {
+	PURCHASES_SITE_FETCH,
+	SITE_REQUEST,
+	SITES_REQUEST,
+	SELECTED_SITE_SET,
+} from 'calypso/state/action-types';
 import {
 	renderWithProvider,
 	statefulRenderWithProvider,
 } from 'calypso/test-helpers/testing-library';
 import HostingOverview from '../hosting-overview';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { UnknownAction } from 'redux';
+
+type MockSiteOptions = {
+	mockSiteId: number;
+	is_wpcom_atomic?: boolean;
+	migrationStatus?: MigrationStatus;
+	migrationSticker?: string;
+};
+
+const buildMockSite = ( {
+	mockSiteId,
+	is_wpcom_atomic = false,
+	migrationStatus = MigrationStatus.UNKNOWN,
+	migrationSticker,
+}: MockSiteOptions ): SiteDetails => {
+	return {
+		ID: mockSiteId,
+		slug: 'test-site.wordpress.com',
+		URL: 'https://test-site.wordpress.com',
+		capabilities: {
+			activate_plugins: false,
+			activate_wordads: false,
+			delete_others_posts: true,
+			delete_posts: true,
+			delete_users: true,
+			edit_others_pages: true,
+			edit_others_posts: true,
+			edit_pages: true,
+			edit_posts: true,
+			edit_theme_options: true,
+			edit_users: true,
+			list_users: true,
+			manage_categories: true,
+			manage_options: true,
+			moderate_comments: true,
+			own_site: true,
+			promote_users: true,
+			publish_posts: true,
+			remove_users: true,
+			upload_files: true,
+			update_plugins: false,
+			view_hosting: true,
+			view_stats: true,
+		},
+		description: 'Test site description',
+		domain: 'test-site.wordpress.com',
+		jetpack: true,
+		launch_status: 'launched',
+		locale: 'en_US',
+		is_wpcom_atomic,
+		logo: {
+			id: '123',
+			sizes: [ 'thumbnail', 'medium', 'large' ],
+			url: 'https://test-site.wordpress.com/logo.png',
+		},
+		name: 'Test Site',
+		title: 'Test Site',
+		site_migration: {
+			status: migrationStatus,
+			last_modified: '2025-03-03',
+			migration_status: migrationSticker,
+		},
+	};
+};
 
 describe( 'HostingOverview', () => {
+	const mockSiteId = 123;
+
+	const mockRequestSite: UnknownAction = {
+		type: SITE_REQUEST,
+		siteId: mockSiteId,
+	};
+
+	const mockRequestSites: UnknownAction = {
+		type: SITES_REQUEST,
+	};
+
+	const mockSetSelectedSite: UnknownAction = {
+		type: SELECTED_SITE_SET,
+		siteId: mockSiteId,
+	};
+
+	const mockInitialState = {
+		currentUser: {
+			capabilities: {},
+			flags: [],
+		},
+		sites: {
+			items: {
+				[ mockSiteId ]: buildMockSite( { mockSiteId } ),
+			},
+			plans: {
+				[ mockSiteId ]: {
+					data: null,
+					error: null,
+					hasLoadedFromServer: false,
+					isRequesting: true,
+				},
+			},
+			requesting: {},
+			requestingAll: false,
+		},
+	};
+
 	it( 'should trigger errors due to limited state tree population', async () => {
 		expect( () => renderWithProvider( <HostingOverview /> ) ).toThrow();
 	} );
 
 	it( 'should work using the stateful provider', async () => {
 		expect( () => statefulRenderWithProvider( <HostingOverview /> ) ).not.toThrow();
+	} );
+
+	it( 'should handle the site being fetched using the stateful provider', async () => {
+		const additionalActions: UnknownAction[] = [ mockSetSelectedSite, mockRequestSite ];
+		expect( () =>
+			statefulRenderWithProvider( <HostingOverview />, {
+				initialState: mockInitialState,
+				additionalActions,
+			} )
+		).not.toThrow();
+		// In a real-world test, we'd want to confirm that the code correctly triggered (or not) specific
+		// actions as a result of the loading state
+	} );
+
+	it( 'should handle all sites being fetched using the stateful provider', async () => {
+		const additionalActions: UnknownAction[] = [ mockSetSelectedSite, mockRequestSites ];
+		expect( () =>
+			statefulRenderWithProvider( <HostingOverview />, {
+				initialState: mockInitialState,
+				additionalActions,
+			} )
+		).not.toThrow();
+	} );
+
+	it( 'should handle an additional action for the secondary purchases reducer via the stateful provider', async () => {
+		const mockSitePurchaseFetch: UnknownAction = {
+			type: PURCHASES_SITE_FETCH,
+			siteId: mockSiteId,
+		};
+		// Note that we need the secondary reducers to be pulled in for the purchases action to be handled.
+		// I haven't tested that this actually works, but the goal of the additional actions is to get
+		// the Redux state into a specific starting state.
+		const additionalActions: UnknownAction[] = [
+			mockSetSelectedSite,
+			mockRequestSites,
+			mockSitePurchaseFetch,
+		];
+		expect( () =>
+			statefulRenderWithProvider( <HostingOverview />, {
+				initialState: mockInitialState,
+				additionalActions,
+			} )
+		).not.toThrow();
 	} );
 } );

--- a/client/sites/overview/components/test/hosting-overview.tsx
+++ b/client/sites/overview/components/test/hosting-overview.tsx
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import {
+	renderWithProvider,
+	statefulRenderWithProvider,
+} from 'calypso/test-helpers/testing-library';
+import HostingOverview from '../hosting-overview';
+
+describe( 'HostingOverview', () => {
+	it( 'should trigger errors due to limited state tree population', async () => {
+		renderWithProvider( <HostingOverview /> );
+	} );
+
+	it( 'should work using the stateful provider', async () => {
+		statefulRenderWithProvider( <HostingOverview /> );
+	} );
+} );

--- a/client/test-helpers/testing-library/index.js
+++ b/client/test-helpers/testing-library/index.js
@@ -4,7 +4,9 @@ import { Fragment } from 'react';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import { thunk as thunkMiddleware } from 'redux-thunk';
+import { createReduxStore } from 'calypso/state';
 import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
 
 export const renderWithProvider = (
 	ui,
@@ -22,6 +24,41 @@ export const renderWithProvider = (
 		}
 
 		store = createStore( reducer, initialState, applyMiddleware( thunkMiddleware ) );
+	}
+
+	const Wrapper = ( { children } ) => (
+		<QueryClientProvider client={ queryClient }>
+			<Provider store={ store }>{ children }</Provider>
+		</QueryClientProvider>
+	);
+
+	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
+};
+
+export const statefulRenderWithProvider = (
+	ui,
+	{ initialState, store = null, additionalActions = [], reducers, ...renderOptions } = {}
+) => {
+	const queryClient = new QueryClient();
+
+	if ( ! store ) {
+		let reducer = initialReducer;
+
+		if ( typeof reducers === 'object' ) {
+			for ( const key in reducers ) {
+				reducer = reducer.addReducer( [ key ], reducers[ key ] );
+			}
+		}
+
+		store = createReduxStore( initialState, reducer );
+
+		setStore( store );
+
+		if ( additionalActions && additionalActions.length > 0 ) {
+			additionalActions.forEach( ( action ) => {
+				store.dispatch( action );
+			} );
+		}
 	}
 
 	const Wrapper = ( { children } ) => (

--- a/client/test-helpers/testing-library/index.js
+++ b/client/test-helpers/testing-library/index.js
@@ -37,37 +37,27 @@ export const renderWithProvider = (
 
 export const statefulRenderWithProvider = (
 	ui,
-	{ initialState, store = null, additionalActions = [], reducers, ...renderOptions } = {}
+	{ initialState, additionalActions = [], reducers, ...renderOptions } = {}
 ) => {
-	const queryClient = new QueryClient();
+	let reducer = initialReducer;
 
-	if ( ! store ) {
-		let reducer = initialReducer;
-
-		if ( typeof reducers === 'object' ) {
-			for ( const key in reducers ) {
-				reducer = reducer.addReducer( [ key ], reducers[ key ] );
-			}
-		}
-
-		store = createReduxStore( initialState, reducer );
-
-		setStore( store );
-
-		if ( additionalActions && additionalActions.length > 0 ) {
-			additionalActions.forEach( ( action ) => {
-				store.dispatch( action );
-			} );
+	if ( typeof reducers === 'object' ) {
+		for ( const key in reducers ) {
+			reducer = reducer.addReducer( [ key ], reducers[ key ] );
 		}
 	}
 
-	const Wrapper = ( { children } ) => (
-		<QueryClientProvider client={ queryClient }>
-			<Provider store={ store }>{ children }</Provider>
-		</QueryClientProvider>
-	);
+	const store = createReduxStore( initialState, reducer );
 
-	return rtlRender( ui, { wrapper: Wrapper, ...renderOptions } );
+	setStore( store );
+
+	if ( additionalActions && additionalActions.length > 0 ) {
+		additionalActions.forEach( ( action ) => {
+			store.dispatch( action );
+		} );
+	}
+
+	return renderWithProvider( ui, { store, ...renderOptions } );
 };
 
 export const renderHookWithProvider = ( hookContainer, options = {} ) => {

--- a/client/test-helpers/testing-library/index.js
+++ b/client/test-helpers/testing-library/index.js
@@ -10,7 +10,7 @@ import { setStore } from 'calypso/state/redux-store';
 
 export const renderWithProvider = (
 	ui,
-	{ initialState, store = null, reducers, ...renderOptions } = {}
+	{ initialState, store = null, reducers, additionalActions = [], ...renderOptions } = {}
 ) => {
 	const queryClient = new QueryClient();
 
@@ -24,6 +24,14 @@ export const renderWithProvider = (
 		}
 
 		store = createStore( reducer, initialState, applyMiddleware( thunkMiddleware ) );
+	}
+
+	setStore( store );
+
+	if ( additionalActions && additionalActions.length > 0 ) {
+		additionalActions.forEach( ( action ) => {
+			store.dispatch( action );
+		} );
 	}
 
 	const Wrapper = ( { children } ) => (
@@ -49,6 +57,7 @@ export const statefulRenderWithProvider = (
 
 	const store = createReduxStore( initialState, reducer );
 
+	/*
 	setStore( store );
 
 	if ( additionalActions && additionalActions.length > 0 ) {
@@ -56,8 +65,9 @@ export const statefulRenderWithProvider = (
 			store.dispatch( action );
 		} );
 	}
+	*/
 
-	return renderWithProvider( ui, { store, ...renderOptions } );
+	return renderWithProvider( ui, { store, additionalActions, ...renderOptions } );
 };
 
 export const renderHookWithProvider = ( hookContainer, options = {} ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR explores a way to create a fuller state tree for testing higher-level Calypso components that depend on reducers that are registered via side-effects on their packages, and the dependency on the code under test may be very indirect
* The PR also makes it possible to pass in some initial Redux actions via `additionalActions` to modify the state in a particular way -- this is particularly important for parts of the store that have these secondary reducers, as they won't be populated from the initial state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While I was working on tests for the `HostingOverview` component in https://github.com/Automattic/wp-calypso/pull/101371, I needed to test interactions with Calypso state to make sure that my code was handling various cases correctly. When I used the `renderWithProvider()` helper, I got exceptions due to un-initialised parts of the state tree, which were in some nested component of the component I wanted to test.
  - When I explored further, I realised it was because all the side-effectful loading of reducers wasn't actually being set up - the way `registerReducer()` is implemented involves queuing up reducers 
  - I also realised that while I _could_ manually set up the relevant reducers directly, that was a lot of work that was generally unrelated to what I was actually testing

I then explored putting together a local helper that fully initialises the Calypso store, ensures that all loaded reducers are added to the store (by calling `setStore()`), and then allows the code to proceed.

You can see the difference in the test cases I've included in the PR. The existing helper falls over in the first case.

### Concerns and Discussion

* We probably don't want the entire state tree to be initialised for all tests, as it seems to be pretty slow.
* As above, many unit tests and tests for components with limited dependencies _should not_ depend on too much state. It feels like higher-level tests that are more towards integration tests may need this
* Given the above concerns (and there are likely more!), I am not sure what the right API for such a state-heavy helper should be, if we even think we should add it.
  - My initial approach here is a wrapper function that creates the store and then calls `renderWithProvider()` - I don't like the naming, but it's enough to get us rolling!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally - `git checkout try/calypso-test-render-state-improvements`
* Run the supplied tests: `yarn test-client client/sites/overview/components/test/hosting-overview.tsx`
* Play with the code more to explore what is going on

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
