### PR TITLE
JPMT-30 Add direct Google auth endpoint for Jetpack

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -265,9 +265,7 @@ export async function jetpackGoogleAuth( context, next ) {
 				callback: () => {},
 			} )
 			.requestCode();
-	} catch ( error ) {
-		/* eslint-disable-next-line no-console */
-		console.error( 'Error initiating Google login:', error );
+	} catch {
 		context.store.dispatch( {
 			type: 'NOTICE_CREATE',
 			notice: {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -9,15 +9,18 @@ import {
 	isWooOAuth2Client,
 	isPartnerPortalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import { login as loginPath } from 'calypso/lib/paths';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wpcom from 'calypso/lib/wp';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { loginSocialUser, rebootAfterLogin } from 'calypso/state/login/actions';
 import { postLoginRequest } from 'calypso/state/login/utils';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import { setRoute } from 'calypso/state/route/actions';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import MagicLogin from './magic-login';
@@ -25,21 +28,6 @@ import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import HandleEmailedLinkFormJetpackConnect from './magic-login/handle-emailed-link-form-jetpack-connect';
 import QrCodeLoginPage from './qr-code-login-page';
 import WPLogin from './wp-login';
-
-// Utility function to generate an authorization nonce
-// Uses a promise to ensure we only request one nonce even if
-// multiple authentication flows are triggered in parallel
-let noncePromise = null;
-const getAuthorizationNonce = () => {
-	if ( ! noncePromise ) {
-		noncePromise = wpcomRequest( {
-			path: '/generate-authorization-nonce',
-			apiNamespace: 'wpcom/v2',
-			method: 'GET',
-		} );
-	}
-	return noncePromise;
-};
 
 const enhanceContextWithLogin = ( context ) => {
 	const {
@@ -224,221 +212,201 @@ export function qrCodeLogin( context, next ) {
 	next();
 }
 
-export function googleAuth( context, next ) {
-	const { query, isServerSide } = context;
+export async function jetpackGoogleAuth( context, next ) {
+	const { query } = context;
+	const redirectUri = `https://${
+		config.isEnabled( 'oauth' ) ? window.location.host : 'wordpress.com'
+	}${ loginPath( { socialService: 'google' } ) }`;
 
-	// Skip processing on server-side render
-	if ( isServerSide ) {
-		next();
-		return;
-	}
+	try {
+		// Get authorization nonce for security
+		let nonce;
+		if ( config.isEnabled( 'oauth' ) ) {
+			// Use the API to get a real nonce in production
+			const response = await wpcomRequest( {
+				path: '/generate-authorization-nonce',
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			} );
+			nonce = response.nonce;
+		} else {
+			// In dev environment, use a random string as nonce
+			nonce = Math.random().toString( 36 ).substring( 2, 15 );
+		}
 
-	// Helper to get the redirect URI for Google OAuth
-	const getRedirectUri = () => `https://${ window.location.host }${ window.location.pathname }`;
+		// Create state object with relevant data
+		const stateObject = {
+			redirect_to: query?.redirect_to || '/',
+			is_jetpack: true,
+			locale: context.params.lang,
+			wpcomNonce: nonce,
+			queryParams: { ...query },
+		};
 
-	// Helper to create authentication parameters and redirect
-	const redirectWithAuthParams = ( accessToken, idToken, redirectTo = '/' ) => {
-		const authParams = new URLSearchParams();
-		authParams.append( 'service', 'google' );
-		authParams.append( 'access_token', accessToken );
-		authParams.append( 'id_token', idToken );
+		// Store nonce in sessionStorage for validation on callback
+		window.sessionStorage.setItem( 'google_oauth_nonce', nonce );
 
-		const redirectUrl = redirectTo.includes( '?' )
-			? `${ redirectTo }&${ authParams.toString() }`
-			: `${ redirectTo }?${ authParams.toString() }`;
+		// Load Google Identity Services API if not already loaded
+		if ( ! window?.google?.accounts?.oauth2 ) {
+			await loadScript( 'https://accounts.google.com/gsi/client' );
+			if ( ! window?.google?.accounts?.oauth2 ) {
+				throw new Error( 'Failed to load Google Identity Services API' );
+			}
+		}
 
-		page.redirect( redirectUrl );
-	};
-
-	// Display an error notice to the user
-	const showErrorNotice = ( message ) => {
+		// Initialize and request authorization code
+		window.google.accounts.oauth2
+			.initCodeClient( {
+				client_id: config( 'google_oauth_client_id' ),
+				scope: 'openid profile email',
+				ux_mode: 'redirect',
+				redirect_uri: redirectUri,
+				state: JSON.stringify( stateObject ),
+				callback: () => {},
+			} )
+			.requestCode();
+	} catch ( error ) {
+		/* eslint-disable-next-line no-console */
+		console.error( 'Error initiating Google login:', error );
 		context.store.dispatch( {
 			type: 'NOTICE_CREATE',
 			notice: {
 				status: 'is-error',
-				text: message,
+				text: 'Error initiating Google login. Please try again.',
 			},
 		} );
-	};
 
-	// Process the response from Google OAuth redirect
-	const handleSocialResponseFromRedirect = async () => {
-		const urlParams = new URLSearchParams( window.location.search );
-		const code = urlParams.get( 'code' );
-		const stateString = urlParams.get( 'state' );
-		const error = urlParams.get( 'error' );
+		// Fall back to regular login form
+		context.primary = (
+			<WPLogin isJetpack path={ context.path } query={ query } locale={ context.params.lang } />
+		);
+		next();
+	}
+}
 
-		// Not a redirect from Google if no code or error present
-		if ( ! code && ! error ) {
-			return false;
+export async function jetpackGoogleAuthCallback( context, next ) {
+	const { query } = context;
+
+	const code = query.code;
+	const stateString = query.state;
+	const error = query.error;
+
+	// Not a redirect from Google if no code or error present
+	if ( ! code && ! error ) {
+		return next();
+	}
+
+	// Handle error from Google
+	if ( error ) {
+		context.store.dispatch( {
+			type: 'NOTICE_CREATE',
+			notice: {
+				status: 'is-error',
+				text: `Error during Google authentication: ${ error }`,
+			},
+		} );
+		return next();
+	}
+
+	try {
+		const storedNonce = window.sessionStorage.getItem( 'google_oauth_nonce' );
+		window.sessionStorage.removeItem( 'google_oauth_nonce' );
+
+		if ( ! storedNonce || ! stateString ) {
+			throw new Error( 'Missing state parameter' );
 		}
 
-		// Handle error from Google
-		if ( error ) {
-			showErrorNotice( `Error during Google authentication: ${ error }` );
-			return true;
-		}
+		let state;
 
 		try {
-			const storedNonce = window.sessionStorage.getItem( 'google_oauth_nonce' );
-			window.sessionStorage.removeItem( 'google_oauth_nonce' );
+			const stateData = JSON.parse( stateString );
 
-			if ( ! storedNonce || ! stateString ) {
-				throw new Error( 'Missing state parameter' );
+			if ( stateData.wpcomNonce !== storedNonce ) {
+				throw new Error();
 			}
 
-			let state;
+			state = {
+				redirect_to: stateData.redirect_to || '/',
+				is_jetpack: stateData.is_jetpack || true,
+				locale: stateData.locale || getLocaleSlug(),
+				wpcomNonce: stateData.wpcomNonce || '',
+				queryParams: stateData.queryParams || {},
+			};
+		} catch {
+			// Not a valid JSON, and not a direct match - state validation fails
+			throw new Error( 'Invalid state parameter' );
+		}
 
-			try {
-				const stateData = JSON.parse( stateString );
+		const redirectUri = `https://${
+			config.isEnabled( 'oauth' ) ? window.location.host : 'wordpress.com'
+		}${ loginPath( { socialService: 'google' } ) }`;
 
-				if ( stateData.wpcomNonce !== storedNonce ) {
-					throw new Error();
-				}
+		// Exchange auth code for tokens
+		const response = await postLoginRequest( 'exchange-social-auth-code', {
+			service: 'google',
+			auth_code: code,
+			redirect_uri: redirectUri,
+			client_id: config( 'wpcom_signup_id' ),
+			client_secret: config( 'wpcom_signup_key' ),
+			state,
+		} );
 
-				state = {
-					redirect_to: stateData.redirect_to || '/',
-					is_jetpack: stateData.is_jetpack || true,
-					locale: stateData.locale || getLocaleSlug(),
-					wpcomNonce: stateData.wpcomNonce || '',
-					queryParams: stateData.queryParams || {},
-				};
-			} catch {
-				// Not a valid JSON, and not a direct match - state validation fails
-				throw new Error( 'Invalid state parameter' );
-			}
+		const { access_token, id_token } = response.body.data;
 
-			// Exchange auth code for tokens
-			const response = await postLoginRequest( 'exchange-social-auth-code', {
+		// Try to create a new WordPress.com account (if it doesn't exist) - then, log in the user
+		try {
+			await wpcom.req.post( '/users/social/new', {
 				service: 'google',
-				auth_code: code,
-				redirect_uri: getRedirectUri(),
+				access_token,
+				id_token,
+				signup_flow_name: 'google-auth-signup',
+				locale: getLocaleSlug(),
 				client_id: config( 'wpcom_signup_id' ),
 				client_secret: config( 'wpcom_signup_key' ),
-				state,
+				tos: JSON.stringify( getToSAcceptancePayload() ),
 			} );
 
-			const { access_token, id_token } = response.body.data;
-
-			// Try to connect Google account to existing WordPress.com account
-			try {
-				// Prepare WPCOM API for authentication
-				require( 'wpcom-proxy-request' ).reloadProxy();
-				wpcom.req.post( { metaAPI: { accessAllUsersBlogs: true } } );
-
-				// Attempt to connect social account
-				const wpcomResponse = await wpcom.req.post( '/me/social-login/connect', {
-					service: 'google',
-					access_token,
-					id_token,
-					redirect_to: state.redirect_to,
-					client_id: config( 'wpcom_signup_id' ),
-					client_secret: config( 'wpcom_signup_key' ),
-				} );
-
-				// Use API-provided redirect if available
-				if ( wpcomResponse.redirect_to ) {
-					page.redirect( wpcomResponse.redirect_to );
-					return true;
-				}
-
-				// Otherwise use default redirect with auth params
-				redirectWithAuthParams( access_token, id_token, state.redirect_to );
-				return true;
-			} catch ( connectError ) {
-				// If connection fails, try creating a new account
-				try {
-					await wpcom.req.post( '/users/social/new', {
+			await context.store.dispatch(
+				loginSocialUser(
+					{
 						service: 'google',
 						access_token,
 						id_token,
-						signup_flow_name: 'google-auth-signup',
-						locale: getLocaleSlug(),
-						client_id: config( 'wpcom_signup_id' ),
-						client_secret: config( 'wpcom_signup_key' ),
-						tos: JSON.stringify( getToSAcceptancePayload() ),
-					} );
-
-					// Redirect with auth params after successful account creation
-					redirectWithAuthParams( access_token, id_token, state.redirect_to );
-					return true;
-				} catch ( createError ) {
-					// If both connection and creation fail, show warning and redirect
-					context.store.dispatch( {
-						type: 'NOTICE_CREATE',
-						notice: {
-							status: 'is-warning',
-							text: 'Could not complete Google login. Falling back to standard flow.',
-						},
-					} );
-
-					// Still redirect with the tokens we have
-					redirectWithAuthParams( access_token, id_token, state.redirect_to );
-					return true;
-				}
-			}
-		} catch ( authError ) {
-			showErrorNotice( 'Error during Google authentication. Please try again.' );
-			return true;
-		}
-	};
-
-	// Initiate Google OAuth flow
-	const initiateGoogleAuth = async () => {
-		try {
-			// Get authorization nonce for security
-			const { nonce } = await getAuthorizationNonce();
-
-			// Create state object with relevant data
-			const stateObject = {
-				redirect_to: query?.redirect_to || '/',
-				is_jetpack: true,
-				locale: context.params.lang,
-				wpcomNonce: nonce,
-				queryParams: { ...query },
-			};
-
-			// Store nonce in sessionStorage for validation on callback
-			window.sessionStorage.setItem( 'google_oauth_nonce', nonce );
-
-			// Load Google Identity Services API if not already loaded
-			if ( ! window?.google?.accounts?.oauth2 ) {
-				await loadScript( 'https://accounts.google.com/gsi/client' );
-				if ( ! window?.google?.accounts?.oauth2 ) {
-					throw new Error( 'Failed to load Google Identity Services API' );
-				}
-			}
-
-			// Initialize and request authorization code
-			window.google.accounts.oauth2
-				.initCodeClient( {
-					client_id: config( 'google_oauth_client_id' ),
-					scope: 'openid profile email',
-					ux_mode: 'redirect',
-					redirect_uri: getRedirectUri(),
-					state: JSON.stringify( stateObject ),
-					callback: () => {},
-				} )
-				.requestCode();
-		} catch ( error ) {
-			/* eslint-disable-next-line no-console */
-			console.error( 'Error initiating Google login:', error );
-			showErrorNotice( 'Error initiating Google login. Please try again.' );
-
-			// Fall back to regular login form
-			context.primary = (
-				<WPLogin isJetpack path={ context.path } query={ query } locale={ context.params.lang } />
+					},
+					state.redirect_to
+				)
 			);
-			next();
-		}
-	};
+			const url = new URL( state.redirect_to );
+			context.store.dispatch(
+				setRoute( url.pathname, Object.fromEntries( url.searchParams.entries() ) )
+			);
 
-	// First check if we're handling a redirect response, otherwise initiate auth
-	handleSocialResponseFromRedirect().then( ( isRedirect ) => {
-		if ( ! isRedirect ) {
-			initiateGoogleAuth();
+			await context.store.dispatch( rebootAfterLogin() );
+			return;
+		} catch ( createError ) {
+			// If both connection and creation fail, show warning and redirect
+			context.store.dispatch( {
+				type: 'NOTICE_CREATE',
+				notice: {
+					status: 'is-warning',
+					text: 'Could not complete Google login. Falling back to standard flow.',
+				},
+			} );
+
+			page.redirect( state.redirect_to );
+			return;
 		}
-	} );
+	} catch {
+		context.store.dispatch( {
+			type: 'NOTICE_CREATE',
+			notice: {
+				status: 'is-error',
+				text: 'Error during Google authentication. Please try again.',
+			},
+		} );
+	}
+
+	return next();
 }
 
 function getHandleEmailedLinkFormComponent( flow ) {
@@ -526,8 +494,8 @@ export function redirectDefaultLocale( context, next ) {
 }
 
 export function redirectJetpack( context, next ) {
-	const { isJetpack } = context.params;
-	const { redirect_to } = context.query;
+	const { isJetpack, socialService } = context.params;
+	const { redirect_to, state } = context.query;
 
 	const isUserComingFromPricingPage =
 		redirect_to?.includes( 'source=jetpack-plans' ) ||
@@ -550,6 +518,18 @@ export function redirectJetpack( context, next ) {
 	if ( pathAlreadyUpdated ) {
 		next();
 		return;
+	}
+
+	// If is_jetpack is set in state (from Google Auth callback), redirect to Jetpack login
+	if ( socialService === 'google' ) {
+		try {
+			const stateData = JSON.parse( state );
+			if ( stateData.is_jetpack === true ) {
+				return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
+			}
+		} catch {
+			// Silently fail
+		}
 	}
 
 	if (

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -20,7 +20,8 @@ import {
 	redirectLostPassword,
 	desktopLogin,
 	desktopLoginFinalize,
-	googleAuth,
+	jetpackGoogleAuthCallback,
+	jetpackGoogleAuth,
 } from './controller';
 import redirectLoggedIn from './redirect-logged-in';
 import { setShouldServerSideRenderLogin, ssrSetupLocaleLogin, setMetaTags } from './ssr';
@@ -121,12 +122,22 @@ export default ( router ) => {
 	);
 
 	router(
-		[ `/log-in/jetpack/google/${ lang }` ],
+		`/log-in/jetpack/google/${ lang }`,
 		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
-		googleAuth,
+		jetpackGoogleAuth,
+		makeLoggedOutLayout
+	);
+
+	router(
+		`/log-in/jetpack/google/callback/${ lang }`,
+		redirectLoggedIn,
+		setLocaleMiddleware(),
+		setMetaTags,
+		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+		jetpackGoogleAuthCallback,
 		makeLoggedOutLayout
 	);
 


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/pull/101427, https://github.com/Automattic/wp-calypso/pull/101508, JPMT-29

## Proposed Changes

- Add /log-in/jetpack/google and /log-in/jetpack/google/callback endpoints
- Handle initialization of Google authentication and exchange of auth tokens for ID token
- Create user if doesn't exist, and initiate the session. Resume the flow by calling `redirect_to`

## Why are these changes being made?

We're building new onboarding flow for Jetpack that will simplify the process for new users. The user will now choose their authentication method directly in Jetpack plugin thus we needed to make some adjustments on Calypso end.

## Testing Instructions

1. Prepare sandbox: 177607-ghe-Automattic/wpcom
2. Create JN site, click "Connect User Account"
3. When navigated to wordpress.com, switch the domain to your calypso local dev (`calypso.localhost:3000`) or Calypso Live link and `log-in/jetpack` to `/log-in/jetpack/google`
4. Continue with the process of logging in with Google account (must be other than a12n!)
5. When landing on wordpress.com, switch the host again to your testing env
6. In the end, you should land on Jetpack Authorize screen

----

There is also maybe no need to test it if it's taking too much time. Same as previous PRs, it just adds a new endpoint and doesn't have a potential to break the existing production code.