### PR TITLE
Stats: Disable CSV downloads for email module

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -293,6 +293,11 @@ class StatsModule extends Component {
 		const isAllTime = this.isAllTimeList();
 
 		const renderDownloadCsv = () => {
+			// Disable for the email module as it doesn't work correctly.
+			if ( statType === 'statsEmailsSummary' ) {
+				return null;
+			}
+
 			if ( gateDownloads ) {
 				return <DownloadCsvUpsell siteId={ siteId } borderless />;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Recent changes enabled the CSV download button on the email module where it was previously hidden. In my testing, the button doesn't return useful data nor does it match the table as it only includes one of the two columns. This PR hides the button again.

If we wish to enable it, we'll need to do the following:

- Update the call sites to provide a `summary` prop indicating if this is the Summary page (full view with download option) or a limited view of the module (like on the Subscribers page where it shows ten results).
- Update styling to account for the button as it currently doesn't render as expected.
- Update data mapping so that all three columns are in the CSV file.

### With unexpected download link
<img width="712" alt="SCR-20250319-tgmp" src="https://github.com/user-attachments/assets/d04918f2-75cc-4ffe-a744-c9ff213bd398" />

### Without download link
<img width="712" alt="SCR-20250319-tgpb" src="https://github.com/user-attachments/assets/12919524-016a-4cb4-9cb5-1add7aaef786" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We don't want to show the CSV until it's working correctly. This PR just maintains the previous behaviours.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View the Calypso Live link.
* Visit the Stats → Subscribers page.
* Confirm the Emails module does not have a download link.
* Click the "View all" link to go to the Summary page.
* Confirm the module does not have a download link here either.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
