### PR TITLE
A4A: Show WooCommerce product link on all Woo extensions product lightboxes.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hocs/with-product-lightbox.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hocs/with-product-lightbox.tsx
@@ -6,8 +6,8 @@ import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/licen
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getVendorInfo } from '../lib/get-vendor-info';
+import WooCustomFooter from '../product-card/woo-custom-footer';
 import WooPaymentsCustomDescription from '../product-card/woopayments-custom-description';
-import WooPaymentsCustomFooter from '../product-card/woopayments-custom-footer';
 import WooPaymentsRevenueShareNotice from '../product-card/woopayments-revenue-share-notice';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
@@ -105,8 +105,8 @@ function withProductLightbox< T >(
 		}, [ currentProduct.slug ] );
 
 		const customFooter = useMemo( () => {
-			if ( currentProduct.slug === 'woocommerce-woopayments' ) {
-				return <WooPaymentsCustomFooter />;
+			if ( currentProduct.slug.startsWith( 'woocommerce-' ) ) {
+				return <WooCustomFooter productSlug={ currentProduct.slug } />;
 			}
 
 			return undefined;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/lib/get-woo-product-url.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/lib/get-woo-product-url.ts
@@ -1,0 +1,63 @@
+const WOOCOMMERCE_PRODUCT_SLUG_MAP = {
+	'woocommerce-accommodations-bookings': 'woocommerce-accommodation-bookings',
+	'woocommerce-additional-image-variations': 'woocommerce-additional-variation-images',
+	'woocommerce-advanced-notifications': 'advanced-notifications',
+	'woocommerce-all-products-woo-subscriptions': 'all-products-for-woocommerce-subscriptions',
+	'woocommerce-automatewoo': 'automatewoo',
+	'woocommerce-automatewoo-birthdays': 'automatewoo-birthdays',
+	'woocommerce-automatewoo-refer-a-friend': 'automatewoo-refer-a-friend',
+	'woocommerce-back-in-stock-notifications': 'back-in-stock-notifications',
+	'woocommerce-bookings': 'woocommerce-bookings',
+	'woocommerce-bookings-availability': 'woocommerce-bookings-availability',
+	'woocommerce-box-office': 'woocommerce-box-office',
+	'woocommerce-brands': 'brands',
+	'woocommerce-bulk-stock-management': 'bulk-stock-management',
+	'woocommerce-checkout-field-editor': 'woocommerce-checkout-field-editor',
+	'woocommerce-composite-products': 'composite-products',
+	'woocommerce-conditional-shipping-payments': 'conditional-shipping-and-payments',
+	'woocommerce-constellation': 'constellation',
+	'woocommerce-coupon-campaigns': 'woocommerce-coupon-campaigns',
+	'woocommerce-deposits': 'woocommerce-deposits',
+	'woocommerce-distance-rate-shipping': 'woocommerce-distance-rate-shipping',
+	'woocommerce-dynamic-pricing': 'dynamic-pricing',
+	'woocommerce-eu-vat-number': 'eu-vat-number',
+	'woocommerce-flat-rate-box-shipping': 'flat-rate-box-shipping',
+	'woocommerce-gift-cards': 'gift-cards',
+	'woocommerce-gifting-wc-subscriptions': 'woocommerce-subscriptions-gifting',
+	'woocommerce-minmax-quantities': 'minmax-quantities',
+	'woocommerce-one-page-checkout': 'woocommerce-one-page-checkout',
+	'woocommerce-order-barcodes': 'woocommerce-order-barcodes',
+	'woocommerce-per-product-shipping': 'per-product-shipping',
+	'woocommerce-points-and-rewards': 'woocommerce-points-and-rewards',
+	'woocommerce-pre-orders': 'woocommerce-pre-orders',
+	'woocommerce-product-add-ons': 'product-add-ons',
+	'woocommerce-product-bundles': 'product-bundles',
+	'woocommerce-product-csv-import-suite': 'product-csv-import-suite',
+	'woocommerce-product-filters': 'product-filters',
+	'woocommerce-product-recommendations': 'product-recommendations',
+	'woocommerce-product-vendors': 'product-vendors',
+	'woocommerce-purchase-order-gateway': 'woocommerce-gateway-purchase-order',
+	'woocommerce-rental-products': 'rental-products',
+	'woocommerce-returns-warranty-requests': 'warranty-requests',
+	'woocommerce-shipment-tracking': 'shipment-tracking',
+	'woocommerce-shipping': 'shipping',
+	'woocommerce-shipping-multiple-addresses': 'shipping-multiple-addresses',
+	'woocommerce-smart-coupons': 'smart-coupons',
+	'woocommerce-subscription-downloads': 'woocommerce-subscription-downloads',
+	'woocommerce-subscriptions': 'woocommerce-subscriptions',
+	'woocommerce-table-rate-shipping': 'table-rate-shipping',
+	'woocommerce-tax': 'tax',
+	'woocommerce-variation-swatches-and-photos': 'variation-swatches-and-photos',
+	'woocommerce-woopayments': 'woocommerce-payments',
+};
+
+export function getWooProductUrl( productSlug: string ) {
+	const mappedSlug =
+		WOOCOMMERCE_PRODUCT_SLUG_MAP[ productSlug as keyof typeof WOOCOMMERCE_PRODUCT_SLUG_MAP ];
+
+	if ( ! mappedSlug ) {
+		return null;
+	}
+
+	return `https://woocommerce.com/products/${ mappedSlug }/`;
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/woo-custom-footer/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/woo-custom-footer/index.tsx
@@ -4,23 +4,38 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getWooProductUrl } from '../lib/get-woo-product-url';
 
-export default function WooPaymentsCustomFooter() {
+type Props = {
+	productSlug: string;
+};
+
+export default function WooCustomFooter( { productSlug }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const url = getWooProductUrl( productSlug );
 
 	const onViewWooPayments = useCallback( () => {
 		dispatch(
 			recordTracksEvent(
-				'calypso_marketplace_products_overview_view_full_woopayments_details_click'
+				'calypso_marketplace_products_overview_view_full_wooproduct_details_click',
+				{
+					product_slug: productSlug,
+					url: url,
+				}
 			)
 		);
-	}, [ dispatch ] );
+	}, [ dispatch, productSlug, url ] );
+
+	if ( ! url ) {
+		return null;
+	}
 
 	return (
 		<Button
 			variant="secondary"
-			href="https://woocommerce.com/es/products/woopayments/"
+			href={ url }
 			target="_blank"
 			icon={ external }
 			iconPosition="right"

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/woo-custom-footer/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/woo-custom-footer/index.tsx
@@ -32,7 +32,7 @@ export default function WooCustomFooter( { productSlug }: Props ) {
 	}
 
 	return (
-		<Button variant="secondary" href={ url } target="_blank" onCanPlay={ onViewWooPayments }>
+		<Button variant="secondary" href={ url } target="_blank" onClick={ onViewWooPayments }>
 			{ translate( 'View all details on WooCommerce.com ↗' ) }
 		</Button>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/woo-custom-footer/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/woo-custom-footer/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'calypso/state';
@@ -33,15 +32,8 @@ export default function WooCustomFooter( { productSlug }: Props ) {
 	}
 
 	return (
-		<Button
-			variant="secondary"
-			href={ url }
-			target="_blank"
-			icon={ external }
-			iconPosition="right"
-			onCanPlay={ onViewWooPayments }
-		>
-			{ translate( 'View all details on WooCommerce.com' ) }
+		<Button variant="secondary" href={ url } target="_blank" onCanPlay={ onViewWooPayments }>
+			{ translate( 'View all details on WooCommerce.com ↗' ) }
 		</Button>
 	);
 }


### PR DESCRIPTION
This PR modifies the product lightboxes for all Woo products to add a product link in the footer.

<img width="1117" alt="Screenshot 2025-03-19 at 10 40 51 PM" src="https://github.com/user-attachments/assets/57ecc0f1-0b58-4f4f-b054-64b35d58ab75" />


Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1937

## Proposed Changes
* Update the product lightbox to display the product link in the footer for all Woo extensions, as each extension has its own product link.

## Why are these changes being made?

* This is part of the Woo 3rd-party extension phase 2 project.

## Testing Instructions

* Use the A4A live link to navigate to the `/marketplace/products` page.
* Select the 'Woo' category.
* Test all products by clicking 'view details' and verify that all links are working.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
