### PR TITLE
A4A: Show a large Woo icon on the checkout page.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/product-info.tsx
@@ -17,6 +17,8 @@ export default function ProductInfo( {
 
 	const { title, product: productInfo } = useLicenseLightboxData( product );
 
+	const isWooCommerceProduct = product.slug.startsWith( 'woocommerce-' );
+
 	let productIcon =
 		productInfo?.productSlug && getProductIcon( { productSlug: productInfo?.productSlug } );
 	let productTitle = title;
@@ -103,9 +105,13 @@ export default function ProductInfo( {
 
 	return (
 		<div className="product-info">
-			<div className="product-info__icon">
-				<img src={ productIcon } alt={ title } />
-			</div>
+			{ isWooCommerceProduct ? (
+				<img className="product-info__icon" src={ productIcon } alt={ title } />
+			) : (
+				<div className="product-info__icon">
+					<img src={ productIcon } alt={ title } />
+				</div>
+			) }
 			<div className="product-info__text-content">
 				<div className="product-info__header">
 					<label htmlFor={ productTitle } className="product-info__label">


### PR DESCRIPTION
This PR updates the checkout page to display a larger Woo icon.

| Before | After |
|--------|--------|
| <img width="305" alt="Screenshot 2025-03-19 at 10 30 40 PM" src="https://github.com/user-attachments/assets/13d1fdc5-feb3-4ec1-9b60-f16d4c198fae" /> | <img width="257" alt="Screenshot 2025-03-19 at 10 30 20 PM" src="https://github.com/user-attachments/assets/d7fa93af-6c8c-4c57-8784-c3086ac50034" /> | 

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1939

## Proposed Changes

* Do not wrap the Woo icon with div.

## Why are these changes being made?
* This is part of the Woo 3rd-party extension phase 2 project.

## Testing Instructions

* Use the A4A live link and navigate to the `/marketplace/products` page.
* Purchase a few Woo products and then proceed to checkout.
* Ensure that on the Checkout page, the Woo icon appears larger now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
