### PR TITLE
Self Service Downgrades: Adds the downgrade call on CTA submit

### DIFF
--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -160,7 +160,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 			// Wait for the notice to be displayed
 			await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
 
-			page.redirect( purchaseRoot );
+			page( purchaseRoot );
 
 			// Show success notification after data is refreshed
 		} catch ( error: unknown ) {
@@ -205,15 +205,15 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 					<DowngradeFeatureList features={ features } purchase={ purchase } />
 
 					<div className="downgrade__confirm-buttons">
-						<Button variant="secondary" isBusy={ isDowngrading } onClick={ handleDowngrade }>
+						<Button variant="primary" isBusy={ isDowngrading } onClick={ handleDowngrade }>
 							{ translate( 'Downgrade to %(targetPlan)s', {
 								args: { targetPlan: targetPlan?.getTitle() ?? '' },
 							} ) }
 						</Button>
 						<Button
-							variant="primary"
+							variant="secondary"
 							disabled={ isDowngrading }
-							href={ getManagePurchaseUrlFor( siteSlug, purchaseId ) }
+							onClick={ () => page( getManagePurchaseUrlFor( siteSlug, purchaseId ) ) }
 						>
 							{ translate( 'Keep %(currentPlan)s', {
 								args: { currentPlan: currentPlan?.getTitle() ?? '' },

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -22,10 +22,10 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card, Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import FormButton from 'calypso/components/forms/form-button';
 import HeaderCake from 'calypso/components/header-cake';
 import { cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
 import { Purchase } from 'calypso/lib/purchases/types';
@@ -150,18 +150,19 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 				type: 'downgrade',
 				to_product_id: targetPlan.getProductId(),
 			} );
+			await Promise.all( [
+				dispatch( refreshSitePlans( siteId! ) ),
+				dispatch( clearPurchases() ),
+			] );
 
-			// Refresh site plans and purchases first to ensure UI consistency
-			if ( siteId ) {
-				await Promise.all( [
-					dispatch( refreshSitePlans( siteId ) ),
-					dispatch( clearPurchases() ),
-				] );
-				page.redirect( purchaseRoot );
-			}
+			dispatch( successNotice( response.message, { duration: 5000 } ) );
+
+			// Wait for the notice to be displayed
+			await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+
+			page.redirect( purchaseRoot );
 
 			// Show success notification after data is refreshed
-			dispatch( successNotice( response.message, { duration: 5000 } ) );
 		} catch ( error: unknown ) {
 			if ( error instanceof Error ) {
 				dispatch( errorNotice( error.message, { duration: 5000 } ) );
@@ -204,24 +205,20 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 					<DowngradeFeatureList features={ features } purchase={ purchase } />
 
 					<div className="downgrade__confirm-buttons">
-						<FormButton
-							primary
-							onClick={ handleDowngrade }
-							isSubmitting={ isDowngrading }
-							disabled={ isDowngrading }
-						>
+						<Button variant="secondary" isBusy={ isDowngrading } onClick={ handleDowngrade }>
 							{ translate( 'Downgrade to %(targetPlan)s', {
 								args: { targetPlan: targetPlan?.getTitle() ?? '' },
 							} ) }
-						</FormButton>
-						<FormButton
-							isPrimary={ false }
+						</Button>
+						<Button
+							variant="primary"
+							disabled={ isDowngrading }
 							href={ getManagePurchaseUrlFor( siteSlug, purchaseId ) }
 						>
 							{ translate( 'Keep %(currentPlan)s', {
 								args: { currentPlan: currentPlan?.getTitle() ?? '' },
 							} ) }
-						</FormButton>
+						</Button>
 					</div>
 					<SupportLink usage="downgrade" purchase={ purchase } />
 				</div>

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -20,22 +20,27 @@ import {
 	getFeatureByKey,
 	FeatureObject,
 } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
 import { Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useState } from 'react';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import FormButton from 'calypso/components/forms/form-button';
 import HeaderCake from 'calypso/components/header-cake';
+import { cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
 import { Purchase } from 'calypso/lib/purchases/types';
 import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 import titles from 'calypso/me/purchases/titles';
 import { isDataLoading } from 'calypso/me/purchases/utils';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { clearPurchases } from 'calypso/state/purchases/actions';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
+import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import SupportLink from '../cancel-purchase-support-link/support-link';
 import DowngradeLoadingPlaceholder from './downgrade-placeholder';
@@ -97,8 +102,10 @@ const downgradePath: Record< string, string > = {
 export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 	const { siteSlug, purchaseId } = props;
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const purchase = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
 	const hasLoadedSites = useSelector( ( state ) => ! isRequestingSites( state ) );
+	const [ isDowngrading, setIsDowngrading ] = useState( false );
 	const loadedFromServer = useSelector( hasLoadedUserPurchasesFromServer );
 	const { ID: siteId, name: siteName } =
 		useSelector( ( state ) => getSite( state, siteSlug ) ) ?? {};
@@ -124,6 +131,47 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 		);
 	}
 	const purchaseRoot = getManagePurchaseUrlFor( siteSlug, purchaseId );
+
+	const handleDowngrade = async () => {
+		if (
+			! purchaseId ||
+			! currentPlan?.getProductId() ||
+			! targetPlan?.getStoreSlug() ||
+			isDowngrading
+		) {
+			return;
+		}
+
+		setIsDowngrading( true );
+
+		try {
+			const response = await cancelAndRefundPurchaseAsync( purchaseId, {
+				product_id: currentPlan.getProductId(),
+				type: 'downgrade',
+				to_product_id: targetPlan.getProductId(),
+			} );
+
+			// Refresh site plans and purchases first to ensure UI consistency
+			if ( siteId ) {
+				await Promise.all( [
+					dispatch( refreshSitePlans( siteId ) ),
+					dispatch( clearPurchases() ),
+				] );
+				page.redirect( purchaseRoot );
+			}
+
+			// Show success notification after data is refreshed
+			dispatch( successNotice( response.message, { duration: 5000 } ) );
+		} catch ( error: unknown ) {
+			if ( error instanceof Error ) {
+				dispatch( errorNotice( error.message, { duration: 5000 } ) );
+			} else {
+				dispatch( errorNotice( translate( 'An unknown error occurred' ), { duration: 5000 } ) );
+			}
+		} finally {
+			setIsDowngrading( false );
+		}
+	};
 	return (
 		<>
 			<HeaderCake backHref={ purchaseRoot }>
@@ -158,9 +206,9 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 					<div className="downgrade__confirm-buttons">
 						<FormButton
 							primary
-							onClick={ () => {
-								alert( 'Downgrade not implemented' );
-							} }
+							onClick={ handleDowngrade }
+							isSubmitting={ isDowngrading }
+							disabled={ isDowngrading }
 						>
 							{ translate( 'Downgrade to %(targetPlan)s', {
 								args: { targetPlan: targetPlan?.getTitle() ?? '' },

--- a/client/me/purchases/downgrade/style.scss
+++ b/client/me/purchases/downgrade/style.scss
@@ -1,15 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-@keyframes loading-button-animation {
-	from {
-		background-position: 100% 0;
-	}
-	to {
-		background-position: -100% 0;
-	}
-}
-
 .downgrade__wrapper-card {
 	.downgrade__content{
 		margin-bottom: 18px
@@ -84,24 +75,8 @@
 	display: flex;
 	margin-top: 24px;
 
-	.form-button {
-		margin-right: 8px;
-
-		&[disabled] {
-			animation: loading-button-animation 1.6s infinite linear;
-			background-color: var( --color-neutral-10 );
-			background-image: linear-gradient(
-				-45deg,
-				var( --color-neutral-10 ) 28%,
-				var( --color-neutral-0 ) 28%,
-				var( --color-neutral-0 ) 72%,
-				var( --color-neutral-10 ) 72%
-			);
-			background-size: 50% 100%;
-			background-repeat: repeat-x;
-			border-color: var( --color-neutral-5 );
-			pointer-events: none;
-		}
+	button {
+		margin-right: 18px;
 	}
 }
 

--- a/client/me/purchases/downgrade/style.scss
+++ b/client/me/purchases/downgrade/style.scss
@@ -1,6 +1,15 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+@keyframes loading-button-animation {
+	from {
+		background-position: 100% 0;
+	}
+	to {
+		background-position: -100% 0;
+	}
+}
+
 .downgrade__wrapper-card {
 	.downgrade__content{
 		margin-bottom: 18px
@@ -77,6 +86,22 @@
 
 	.form-button {
 		margin-right: 8px;
+
+		&[disabled] {
+			animation: loading-button-animation 1.6s infinite linear;
+			background-color: var( --color-neutral-10 );
+			background-image: linear-gradient(
+				-45deg,
+				var( --color-neutral-10 ) 28%,
+				var( --color-neutral-0 ) 28%,
+				var( --color-neutral-0 ) 72%,
+				var( --color-neutral-10 ) 72%
+			);
+			background-size: 50% 100%;
+			background-repeat: repeat-x;
+			border-color: var( --color-neutral-5 );
+			pointer-events: none;
+		}
 	}
 }
 
@@ -185,3 +210,5 @@
 		}
 	}
 }
+
+


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100150

- Related to https://github.com/Automattic/wp-calypso/issues/100441
- Related to pau2Xa-6Mk-p2
- Follow up to https://github.com/Automattic/wp-calypso/pull/101493

## Proposed Changes

* Adds call to. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of an epic to support self service downgrades in wpcom 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Sandbox the backend with the instructions from 177621-ghe-Automattic/wpcom
* Select a site with a paid plan, other than Personal
* Locally there needs to be a feature flag activated `plans/self-service-downgrade`, `flags=plans/self-service-downgrade`
* Go to the /purchases/subscriptions/{SITE_ID}
* Select the Site plan purchase
* Select the `Downgrade plan` option
* In the Downgrade screen click on `Downgrade to {TARGET_PLAN}` button
* The button should become disabled while a request to `wpcom/v2/purchases/{SITE_ID}/cancel` is sent
* When finished, a notification should be shown and be redirected back to the purchases list (or site list if reverted from Atomic)
* The new plan should match the TARGET_PLAN



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?