### PR TITLE
JPMT-15 Support auto trigger of magiclink auth

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -127,13 +127,30 @@ class MagicLogin extends Component {
 	};
 
 	componentDidMount() {
+		const { userEmail, oauth2Client, query } = this.props;
+
 		this.props.recordPageView( '/log-in/link', 'Login > Link' );
 
-		if ( isGravPoweredOAuth2Client( this.props.oauth2Client ) ) {
+		if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 			this.props.recordTracksEvent( 'calypso_gravatar_powered_magic_login_email_form', {
 				client_id: this.props.oauth2Client.id,
 				client_name: this.props.oauth2Client.title,
 			} );
+		}
+
+		// If the auto_trigger query parameter is set to true, automatically trigger the email send.
+		if ( query?.auto_trigger !== undefined ) {
+			if ( userEmail && emailValidator.validate( userEmail ) ) {
+				if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
+					this.handleGravPoweredEmailSubmit( userEmail );
+				} else {
+					this.props.sendEmailLogin( userEmail, {
+						redirectTo: query?.redirect_to,
+						requestLoginEmailFormFlow: true,
+						createAccount: true,
+					} );
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Add `auto_trigger` param that submits email_address query param value automatically, if possible

## Testing Instructions

* Be logged out from WP.com account (no incognito! e.g. new Chrome/Arc profile instead)
* Create JN site, click "Connect User Account"
* When navigated to wordpress.com/log-in/jetpack, switch the host+path to `<calypso_test_env>/log-in/jetpack/link?email_address=<random_email_you_have_access_to>&auto_trigger&<the_rest>`
* You should see "Check your email!" and you should receive the email
* Click the link, and you should be redirected to Jetpack Connect screen, if you didn't have account under this email (e.g. try with aliases +123123) - it will be automatically created
