### PR TITLE
Center domain name sugestions vertically when they have a badge

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -265,7 +265,7 @@ class DomainRegistrationSuggestion extends Component {
 		};
 	}
 
-	renderDomain() {
+	renderDomain( hasBadges = false ) {
 		const {
 			showHstsNotice,
 			showDotGayNotice,
@@ -274,6 +274,9 @@ class DomainRegistrationSuggestion extends Component {
 
 		const { name, tld } = this.getDomainParts( domain );
 
+		const wrapperClassName = clsx( 'domain-registration-suggestion__title-info', {
+			'has-badges': hasBadges,
+		} );
 		const titleWrapperClassName = clsx( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain':
 				this.props.showStrikedOutPrice && ! this.props.isFeatured,
@@ -281,7 +284,7 @@ class DomainRegistrationSuggestion extends Component {
 		} );
 
 		return (
-			<div className="domain-registration-suggestion__title-info">
+			<div className={ wrapperClassName }>
 				<div className={ titleWrapperClassName }>
 					<h3 className="domain-registration-suggestion__title">
 						<div className="domain-registration-suggestion__domain-title">
@@ -437,6 +440,8 @@ class DomainRegistrationSuggestion extends Component {
 			'is-unavailable': isUnavailableDomain,
 		} );
 
+		const badges = this.renderBadges();
+
 		return (
 			<DomainSuggestion
 				extraClasses={ extraClasses }
@@ -453,8 +458,8 @@ class DomainRegistrationSuggestion extends Component {
 				showStrikedOutPrice={ showStrikedOutPrice }
 				hideMatchReasons={ hideMatchReasons }
 			>
-				{ this.renderBadges() }
-				{ this.renderDomain() }
+				{ badges }
+				{ this.renderDomain( !! badges ) }
 				{ ! hideMatchReasons && isFeatured && this.renderMatchReason() }
 			</DomainSuggestion>
 		);

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -172,6 +172,11 @@
 	@include breakpoint-deprecated( ">800px" ) {
 		max-width: 55%;
 	}
+
+	&.has-badges {
+		display: flex;
+    	align-items: center;
+	}
 }
 
 .domain-registration-suggestion__title-wrapper {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101599

## Proposed Changes

* Center domain name sugestions vertically when they have a badge

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `Domains > Add new Domain` or `/start/domain/domain-only`
* Search for a generic word (e.g. `food`)
* Check that the domain name on suggestions with a badge (`Sale`, `Premium domain`) is vertically centered

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/56fc8ddd-b926-4bd5-8248-7f26d3a1f6a9)|![image](https://github.com/user-attachments/assets/82d6c51c-072e-493a-a7f9-c3050cb8ec65)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
