### PR TITLE
Imports: Remove routing for onboarding flow query param

### DIFF
--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { BrowserRouter } from 'react-router-dom';
-import CaptureScreen from 'calypso/blocks/import/capture';
 import ImporterList from 'calypso/blocks/import/list';
 import { getFinalImporterUrl } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
@@ -37,37 +36,9 @@ export function importSite( context, next ) {
 		page.replace( path );
 	};
 
-	switch ( context.query?.flow ) {
-		case 'onboarding': {
-			context.primary = (
-				<BrowserRouter>
-					<div className="import__onboarding-page">
-						<CaptureScreen
-							onValidFormSubmit={ ( { url } ) => {
-								const importerPath = `${ onboardingFlowRoute }/import?siteSlug=${ siteSlug }&from=${ encodeURIComponent(
-									url || ''
-								) }&flow=onboarding`;
-
-								page( importerPath );
-							} }
-							onImportListClick={ () => {
-								page( `/import/list/${ siteSlug }` );
-							} }
-						/>
-					</div>
-				</BrowserRouter>
-			);
-			break;
-		}
-		default:
-			context.primary = (
-				<SectionImport
-					engine={ engine }
-					fromSite={ fromSite }
-					afterStartImport={ afterStartImport }
-				/>
-			);
-	}
+	context.primary = (
+		<SectionImport engine={ engine } fromSite={ fromSite } afterStartImport={ afterStartImport } />
+	);
 	next();
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101382

## Proposed Changes

* Remove extra routing that shows the onboarding importer rather than the regular importer within Calypso.

**Visual**

**Before**

<img width="1368" alt="Screenshot 2025-03-19 at 11 53 31 AM" src="https://github.com/user-attachments/assets/06889301-6ecf-4eb3-b60f-37c80cae8916" />

**After**

<img width="1369" alt="Screenshot 2025-03-19 at 11 53 22 AM" src="https://github.com/user-attachments/assets/801bd23c-2a9e-48d9-a115-d1f9e96278d5" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/101382 - we've confirmed this particular flow variation is not used and removing it reduces user confusion (and code).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/import/{siteslug}?flow=onboarding
* You should see the following import screen rather than the onboarding-themed as in the screenshots above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
