### PR TITLE
Revert "Site Migration: Standardize mobile padding"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/style.scss
@@ -1,20 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
-@import "@automattic/onboarding/styles/mixins";
 $blueberry-color: #3858e9;
 
-.step-container.site-migration-credentials {
-	@include onboarding-block-margin;
-
-	@media ( max-width: $break-small ) {
-		.formatted-header__title {
-			padding: 0;
-		}
-
-		.formatted-header__subtitle {
-			padding: 0;
-		}
-	}
-
+.site-migration-credentials {
 	#site-migration-credentials-header {
 		.formatted-header__subtitle {
 			text-align: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/style.scss
@@ -1,25 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "@automattic/onboarding/styles/mixins";
 
 .how-to-migrate {
-	@include onboarding-block-margin;
-
 	max-width: 620px;
-
-	@media ( max-width: $break-small ) {
-		.step-container__header {
-			margin-bottom: 16px;
-
-			.formatted-header__title {
-				padding: 0;
-			}
-
-			.formatted-header__subtitle {
-				padding: 0;
-			}
-		}
-	}
+	padding: 0 12px;
 
 	.onboarding-title {
 		font-size: 2.75rem;
@@ -80,7 +64,7 @@
 	}
 
 	.how-to-migrate__process-details {
-		margin: 40px auto 0;
+		margin: 40px auto 0 auto;
 		max-width: 350px;
 
 		&-title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -1,5 +1,4 @@
 @import "@wordpress/base-styles/breakpoints";
-@import "@automattic/onboarding/styles/mixins";
 
 .import__capture-container {
 	max-width: 368px;
@@ -75,7 +74,6 @@
 }
 
 .import__capture-wrapper {
-	@include onboarding-block-margin;
 	margin-bottom: 60px;
 
 	@media (min-width: $break-small) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -1,20 +1,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "@automattic/onboarding/styles/mixins";
 
 .import-or-migrate {
-	@include onboarding-block-margin;
-	max-width: 502px;
-
-	@media ( max-width: $break-small ) {
-		.formatted-header__title {
-			padding: 0;
-		}
-
-		.formatted-header__subtitle {
-			padding: 0;
-		}
-	}
+	max-width: 602px;
 
 	.onboarding-title {
 		font-size: 2.75rem;
@@ -35,8 +23,6 @@
 		flex-direction: column;
 
 		@include break-mobile {
-			margin-left: 1em;
-			margin-right: 1em;
 			padding-bottom: revert;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -1,23 +1,12 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
-@import "@automattic/onboarding/styles/mixins";
 
 .step-route.site-migration-instructions {
-	@include onboarding-block-margin;
-
 	.step-container {
 		padding: 0 0 60px;
 
 		@include break-large {
 			padding: 0;
-		}
-	}
-
-	@media ( max-width: $break-small ) {
-		.launchpad-container__sidebar,
-		.launchpad-container__main-content {
-			padding-left: 0;
-			padding-right: 0;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/style.scss
@@ -1,31 +1,21 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@automattic/onboarding/styles/mixins";
 
 :root .site-migration-upgrade-plan .is-step-site-migration-upgrade-plan-with-variants {
-	@include onboarding-block-margin;
-	
 	padding-bottom: 5rem;
 
 	@media ( min-width: 1040px ) {
 		padding-bottom: 3rem;
 	}
 
-	@media ( max-width: $break-small ) {
-		.formatted-header__title {
-			padding: 0;
-		}
-
-		.formatted-header__subtitle {
-			padding: 0;
-		}
-	}
-
 	&.step-container .step-container__header {
 		margin-left: auto;
 		margin-right: auto;
 		margin-bottom: 1rem;
+		padding-left: 1rem;
+		padding-right: 1rem;
 		@media ( min-width: 720px ) {
 			max-width: 616px;
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 	.import-upgrade-plan-skeleton {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101545 as it broke the full-width layout.