### PR TITLE
WP VIP plan: Add fixMe call to preserve previous translations

### DIFF
--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -5,7 +5,7 @@ import {
 	isFreePlan,
 } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
-import { useTranslate, formatCurrency } from 'i18n-calypso';
+import { useTranslate, formatCurrency, fixMe } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import usePlanBillingDescription from '../../../hooks/data-store/use-plan-billing-description';
 import type { GridPlan } from '../../../types';
@@ -82,6 +82,19 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 
 		return (
 			<div className="plans-grid-next__billing-timeframe-vip-price">
+				{ fixMe( {
+					text: 'Starts at {{b}}%(price)s{{/b}} annually',
+					newCopy: translate( 'Starts at {{b}}%(price)s{{/b}} annually', {
+						args: { price },
+						components: { b: <b /> },
+						comment: 'Translators: the price is in US dollars for all users (US$25,000)',
+					} ),
+					oldCopy: translate( 'Starts at {{b}}%(price)s{{/b}} yearly', {
+						args: { price },
+						components: { b: <b /> },
+						comment: 'Translators: the price is in US dollars for all users (US$25,000)',
+					} ),
+				} ) }
 				{ translate( 'Starts at {{b}}%(price)s{{/b}} annually', {
 					args: { price },
 					components: { b: <b /> },

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -95,11 +95,6 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 						comment: 'Translators: the price is in US dollars for all users (US$25,000)',
 					} ),
 				} ) }
-				{ translate( 'Starts at {{b}}%(price)s{{/b}} annually', {
-					args: { price },
-					components: { b: <b /> },
-					comment: 'Translators: the price is in US dollars for all users (US$25,000)',
-				} ) }
 			</div>
 		);
 	}


### PR DESCRIPTION
## Proposed Changes

* Updates the WP VIP copy to use `fixMe`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The newly introduced copy is not yet fully translated, using `fixMe` allows international users to see the previous translation until the new copy is translated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
