### PR TITLE
Subscribers: Invalidate cache for subscribers count query on add and remove

### DIFF
--- a/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
+++ b/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
@@ -63,7 +63,7 @@ export const useAddSubscribersCallback = ( siteId: number | null ) => {
 						)
 					);
 
-					// Invalidate the subscribers query to ensure the new subscribers are fetched
+					// Invalidate the subscribers queries to ensure that the new subscribers are fetched.
 					queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
 					queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
 				}

--- a/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
+++ b/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
@@ -65,6 +65,7 @@ export const useAddSubscribersCallback = ( siteId: number | null ) => {
 
 					// Invalidate the subscribers query to ensure the new subscribers are fetched
 					queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
+					queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
 				}
 			} else {
 				dispatch(

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -205,6 +205,7 @@ const useSubscriberRemoveMutation = (
 			for ( const subscriber of subscribers ) {
 				// Invalidate all subscriber queries to ensure consistency
 				queryClient.invalidateQueries( { queryKey: [ 'subscribers', siteId ] } );
+				queryClient.invalidateQueries( { queryKey: [ 'subscribers', 'count', siteId ] } );
 
 				if ( invalidateDetailsCache ) {
 					const detailsCacheKey = getSubscriberDetailsCacheKey(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/486

## Proposed Changes

* Invalidate cache for the count query when subscribers are imported or removed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The total counts weren't matching the updates to the list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Add a subscriber and check that the total updates.
* Remove a subscriber and check that the total updates.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
