### PR TITLE
A4A: add referral error status

### DIFF
--- a/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
@@ -3,7 +3,7 @@ export const getSubscriptionStatus = (
 	translate: ( key: string ) => string
 ): {
 	children: string | undefined;
-	type: 'success' | 'warning' | 'info' | undefined;
+	type: 'success' | 'warning' | 'info' | 'error' | undefined;
 } => {
 	switch ( status ) {
 		case 'pending':
@@ -15,6 +15,11 @@ export const getSubscriptionStatus = (
 			return {
 				children: translate( 'Active' ),
 				type: 'success',
+			};
+		case 'error':
+			return {
+				children: translate( 'Error' ),
+				type: 'error',
 			};
 		case 'canceled':
 			return {

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -28,7 +28,7 @@ export const getEstimatedCommission = (
 		}
 		for ( const purchase of referral.purchases ) {
 			// We go over 'active' and 'cancelled' subscriptions
-			if ( ! purchase || purchase.status === 'pending' ) {
+			if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
 				continue;
 			}
 			// Find corresponding product for price

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -28,6 +28,10 @@ function getPurchaseStatus(
 		return [ 'info', translate( 'Canceled' ) ];
 	}
 
+	if ( purchase.status === 'error' ) {
+		return [ 'error', translate( 'Error' ) ];
+	}
+
 	return [ 'warning', translate( 'Awaiting payment' ) ];
 }
 

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
@@ -67,6 +67,11 @@ export default function SubscriptionStatus( { item }: { item: Referral } ): Reac
 					status: translate( 'Canceled' ),
 					type: 'info',
 				};
+			case 'error':
+				return {
+					status: translate( 'Error' ),
+					type: 'error',
+				};
 			case 'archived':
 				return {
 					status: translate( 'Archived' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1928

## Proposed Changes

Following 177540-ghe-Automattic/wpcom we are adding error states to referral products to clearly showcase these to users. 
**These should show up in Agency referrals:**
<img width="828" alt="Screenshot 2025-03-19 at 10 52 19 AM" src="https://github.com/user-attachments/assets/18a42060-b8ea-495b-ac4d-80d629cea70d" />

**And client subscriptions:**
<img width="1079" alt="Screenshot 2025-03-19 at 10 55 57 AM" src="https://github.com/user-attachments/assets/3e3c6799-0d10-4966-a3af-e5bff1054ffa" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Follow instructions for broken flows here: 177540-ghe-Automattic/wpcom
- Verify you see correct statuses as in description

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?