### PR TITLE
Purchase Management: Set up feature flags for using DataViews in `Active upgrades`

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { localize, useTranslate } from 'i18n-calypso';
@@ -27,9 +28,12 @@ import ConfirmCancelDomain from './confirm-cancel-domain';
 import ManagePurchase from './manage-purchase';
 import { ManagePurchaseByOwnership } from './manage-purchase/manage-purchase-by-ownership';
 import PurchasesList from './purchases-list';
+import PurchasesListDataView from './purchases-list-in-dataviews';
 import titles from './titles';
 import VatInfoPage from './vat-info';
 import useVatDetails from './vat-info/use-vat-details';
+
+const useDataViewPurchasesList = config.isEnabled( 'purchases/purchase-list-dataview' );
 
 function useLogPurchasesError( message ) {
 	return useCallback(
@@ -120,7 +124,11 @@ export function list( context, next ) {
 	const ListWrapper = localize( () => {
 		return (
 			<PurchasesWrapper>
-				<PurchasesList noticeType={ context.params.noticeType } />
+				{ useDataViewPurchasesList ? (
+					<PurchasesListDataView noticeType={ context.params.noticeType } />
+				) : (
+					<PurchasesList noticeType={ context.params.noticeType } />
+				) }
 			</PurchasesWrapper>
 		);
 	} );

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { localize, useTranslate } from 'i18n-calypso';
@@ -28,12 +27,9 @@ import ConfirmCancelDomain from './confirm-cancel-domain';
 import ManagePurchase from './manage-purchase';
 import { ManagePurchaseByOwnership } from './manage-purchase/manage-purchase-by-ownership';
 import PurchasesList from './purchases-list';
-import PurchasesListDataView from './purchases-list-in-dataviews';
 import titles from './titles';
 import VatInfoPage from './vat-info';
 import useVatDetails from './vat-info/use-vat-details';
-
-const useDataViewPurchasesList = config.isEnabled( 'purchases/purchase-list-dataview' );
 
 function useLogPurchasesError( message ) {
 	return useCallback(
@@ -124,11 +120,7 @@ export function list( context, next ) {
 	const ListWrapper = localize( () => {
 		return (
 			<PurchasesWrapper>
-				{ useDataViewPurchasesList ? (
-					<PurchasesListDataView noticeType={ context.params.noticeType } />
-				) : (
-					<PurchasesList noticeType={ context.params.noticeType } />
-				) }
+				<PurchasesList noticeType={ context.params.noticeType } />
 			</PurchasesWrapper>
 		);
 	} );

--- a/config/development.json
+++ b/config/development.json
@@ -160,6 +160,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": true,
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,6 +100,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": false,
 		"reader": true,
 		"reader/quick-post": true,
 		"reader/recommended-blogs-list": false,

--- a/config/production.json
+++ b/config/production.json
@@ -128,6 +128,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": false,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -126,6 +126,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": false,
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -133,6 +133,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
+		"purchases/purchase-list-dataview": false,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/quick-post": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add feature flags for development and testing of converting the purchases list in `Active ugrades` to DataViews.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To help simplify development PRs which require this feature flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
