### PR TITLE
Jetpack Connect: Change error messaging copy

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -111,7 +111,7 @@ export class JetpackConnectNotices extends Component {
 			case NOT_WORDPRESS:
 				noticeValues.icon = 'block';
 				noticeValues.text = translate(
-					"The site doesn't appear to be running WordPress. Please verify you're using the correct URL."
+					"Looks like your site isn't using WordPress. Please make sure you're using the right URL."
 				);
 				return noticeValues;
 

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -69,9 +69,7 @@ export class JetpackConnectNotices extends Component {
 		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
-			text: translate(
-				'The URL you entered appears to be invalid. Please enter a valid WordPress site address.'
-			),
+			text: translate( "Please make sure you're using a valid site address." ),
 			showDismiss: false,
 		};
 
@@ -110,9 +108,7 @@ export class JetpackConnectNotices extends Component {
 
 			case NOT_WORDPRESS:
 				noticeValues.icon = 'block';
-				noticeValues.text = translate(
-					"Looks like your site isn't using WordPress. Please make sure you're using the right URL."
-				);
+				noticeValues.text = translate( 'Please make sure your site is using WordPress.' );
 				return noticeValues;
 
 			case NOT_ACTIVE_JETPACK:
@@ -122,7 +118,7 @@ export class JetpackConnectNotices extends Component {
 			case OUTDATED_JETPACK:
 				noticeValues.icon = 'block';
 				noticeValues.text = translate(
-					'Your Jetpack plugin is outdated. Please update Jetpack to the latest version before connecting.'
+					'Please update to the latest version of Jetpack before connecting.'
 				);
 				return noticeValues;
 
@@ -171,7 +167,7 @@ export class JetpackConnectNotices extends Component {
 
 			case SECRET_EXPIRED:
 				noticeValues.text = translate(
-					'The connection request has expired. Please refresh the page and try connecting again.'
+					'Your connection request expired. Please refresh and try again.'
 				);
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
@@ -222,14 +218,12 @@ export class JetpackConnectNotices extends Component {
 
 			case XMLRPC_ERROR:
 				noticeValues.text = translate(
-					'We had trouble connecting to your site. Please check that your site is accessible and try again.'
+					"We're having trouble connecting to your site. Please check if it's accessible and try again."
 				);
 				return noticeValues;
 
 			case INVALID_CREDENTIALS:
-				noticeValues.text = translate(
-					'The credentials you entered were invalid. Please double-check your username and password and try again.'
-				);
+				noticeValues.text = translate( 'Please check your username and password and try again.' );
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
 				return noticeValues;

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -69,7 +69,7 @@ export class JetpackConnectNotices extends Component {
 		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
-			text: translate( "Please make sure you're using a valid site address." ),
+			text: translate( 'Invalid site address. Enter a valid WordPress URL.' ),
 			showDismiss: false,
 		};
 
@@ -108,7 +108,9 @@ export class JetpackConnectNotices extends Component {
 
 			case NOT_WORDPRESS:
 				noticeValues.icon = 'block';
-				noticeValues.text = translate( 'Please make sure your site is using WordPress.' );
+				noticeValues.text = translate(
+					"This site doesn't appear to use WordPress. Please verify the URL."
+				);
 				return noticeValues;
 
 			case NOT_ACTIVE_JETPACK:
@@ -117,9 +119,7 @@ export class JetpackConnectNotices extends Component {
 
 			case OUTDATED_JETPACK:
 				noticeValues.icon = 'block';
-				noticeValues.text = translate(
-					'Please update to the latest version of Jetpack before connecting.'
-				);
+				noticeValues.text = translate( 'Update Jetpack to the latest version and try again.' );
 				return noticeValues;
 
 			case JETPACK_IS_DISCONNECTED:
@@ -166,9 +166,7 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case SECRET_EXPIRED:
-				noticeValues.text = translate(
-					'Your connection request expired. Please refresh and try again.'
-				);
+				noticeValues.text = translate( 'Connection expired. Refresh the page and try again.' );
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
 				return noticeValues;
@@ -218,12 +216,14 @@ export class JetpackConnectNotices extends Component {
 
 			case XMLRPC_ERROR:
 				noticeValues.text = translate(
-					"We're having trouble connecting to your site. Please check if it's accessible and try again."
+					"Can't connect to your site. Check if it's accessible and try again."
 				);
 				return noticeValues;
 
 			case INVALID_CREDENTIALS:
-				noticeValues.text = translate( 'Please check your username and password and try again.' );
+				noticeValues.text = translate(
+					'Invalid credentials. Check your account information and try again.'
+				);
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
 				return noticeValues;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/100102

## Proposed Changes

This PR further tweaks some copy updates recently done on the Jetpack connect screens. I did my best to try make them shorter while retaining the relevant information. 

Here are the updates (please note that the screenshots don't have the right icons, I mocked these up in the browser to make sure they fit on two lines):

| Before | After|
| ------ | ------ |
| <img width="1365" alt="image" src="https://github.com/user-attachments/assets/c04fc75c-2d7f-4244-b37f-18b9ce097633" /> The URL you entered appears to be invalid. Please enter a valid WordPress site address. | <img width="1365" alt="image" src="https://github.com/user-attachments/assets/88f433e4-809b-4bd7-90bb-b5bda273723b" /> Please make sure you're using a valid site address. |
| <img width="1365" alt="image" src="https://github.com/user-attachments/assets/45d40556-1e1b-4a87-ad53-17fb5c37b335" /> The site doesn't appear to be running WordPress. Please verify you're using the correct URL. | <img width="1840" alt="image" src="https://github.com/user-attachments/assets/5f6807df-4980-4778-8224-d95056dec387" /> This site doesn't appear to use WordPress. Please verify the URL. | 
| <img width="1365" alt="image" src="https://github.com/user-attachments/assets/6ae7c95c-1a73-4d6a-a851-c0b3af37397e" /> Your Jetpack plugin is outdated. Please update Jetpack to the latest version before connecting. | <img width="1840" alt="image" src="https://github.com/user-attachments/assets/11329f44-7be3-42c2-be49-dc5ec84707a3" /> Update Jetpack to the latest version and try again. |
| <img width="1365" alt="image" src="https://github.com/user-attachments/assets/1d2b1fe5-26ec-43e6-a49f-5a4fc52b9f6f" /> The connection request has expired. Please refresh the page and try connecting again. | <img width="1840" alt="image" src="https://github.com/user-attachments/assets/e031f6e9-3c37-49a5-901f-33284664ad87" /> Connection expired. Refresh the page and try again. |
| <img width="1365" alt="image" src="https://github.com/user-attachments/assets/c9a13a69-c3f0-436c-81f4-cbae0af19ff3" /> We had trouble connecting to your site. Please check that your site is accessible and try again. | <img width="1840" alt="image" src="https://github.com/user-attachments/assets/dd5a53bc-8e55-49ab-9739-2eb1b548862b" /> Can't connect to your site. Check if it's accessible and try again. |
| <img width="1365" alt="image" src="https://github.com/user-attachments/assets/639a369f-99c2-4643-a4c3-a9a63823a1bf" /> The credentials you entered were invalid. Please double-check your username and password and try again. | <img width="1840" alt="image" src="https://github.com/user-attachments/assets/f2c5b304-89d6-4751-ad17-19938bf7dbbe" /> Invalid credentials. Check your account information and try again. |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `https://wordpress.com/jetpack/connect` and test different URLs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
