### PR TITLE
Revert "Position the current plan in first position if it would otherwise not be visible"

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -31,7 +31,6 @@ import type {
 	FeaturesGridExternalProps,
 	FeaturesGridProps,
 	GridPlan,
-	GridSize,
 	PlanActionOverrides,
 } from '../../types';
 
@@ -395,7 +394,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 
 	const gridBreakpoints = useMemo(
 		() =>
-			new Map< GridSize, number >( [
+			new Map( [
 				[ 'small', 0 ],
 				[ 'medium', 740 ],
 				[ 'large', isInAdmin ? 1180 : 1320 ], // 1320 to fit Enterpreneur plan, 1180 to work in admin

--- a/packages/plans-grid-next/src/hooks/use-grid-size.ts
+++ b/packages/plans-grid-next/src/hooks/use-grid-size.ts
@@ -1,6 +1,5 @@
 import { useLayoutEffect, useState } from '@wordpress/element';
 import ResizeObserver from 'resize-observer-polyfill';
-import { GridSize } from '../types';
 
 interface Props {
 	containerRef: React.MutableRefObject< HTMLDivElement | null >;
@@ -10,7 +9,7 @@ interface Props {
 	 * but they could be used in the future in a containment context.
 	 * The keys are the labels, the values are the minimum widths.
 	 */
-	containerBreakpoints: Map< GridSize, number >;
+	containerBreakpoints: Map< string, number >;
 }
 
 /**
@@ -18,7 +17,7 @@ interface Props {
  * and the breakpoints passed through as props.
  */
 export default function useGridSize( { containerRef, containerBreakpoints }: Props ) {
-	const [ gridSize, setGridSize ] = useState< GridSize | null >( null );
+	const [ gridSize, setGridSize ] = useState< string | null >( null );
 
 	useLayoutEffect( () => {
 		if ( ! containerRef.current ) {

--- a/packages/plans-grid-next/src/lib/sort-plan-properties.ts
+++ b/packages/plans-grid-next/src/lib/sort-plan-properties.ts
@@ -1,0 +1,27 @@
+import type { GridPlan } from '../types';
+
+export function sortPlans(
+	gridPlans: GridPlan[],
+	currentSitePlanProductSlug?: string | null
+): GridPlan[] {
+	// If we don't have plans to sort, return empty array
+	if ( ! gridPlans.length ) {
+		return [];
+	}
+	// If we have a current site plan and we're on mobile, sort to prioritize it
+	if ( currentSitePlanProductSlug ) {
+		return [ ...gridPlans ].sort( ( planA, planB ) => {
+			// If planA is the current plan, it should come first (-1 moves it up)
+			if ( planA.planSlug === currentSitePlanProductSlug ) {
+				return -1;
+			}
+			// If planB is the current plan, it should come first (1 moves planA down)
+			if ( planB.planSlug === currentSitePlanProductSlug ) {
+				return 1;
+			}
+			// Otherwise, maintain original order
+			return 0;
+		} );
+	}
+	return [ ...gridPlans ];
+}

--- a/packages/plans-grid-next/src/lib/test/sort-plan-properties.ts
+++ b/packages/plans-grid-next/src/lib/test/sort-plan-properties.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( '../../hooks/data-store/is-popular-plan', () => ( {
+	isPopularPlan: ( planSlug ) => planSlug === 'value_bundle',
+} ) );
+jest.mock( '@automattic/calypso-products', () => ( {
+	isFreePlan: ( planSlug ) => planSlug === 'free_plan',
+} ) );
+
+import { sortPlans } from '../sort-plan-properties';
+import type { GridPlan } from '../../types';
+
+const planFree = {
+	pricing: { originalPrice: { full: 0, monthly: 0 } },
+	planSlug: 'free_plan',
+} as GridPlan;
+
+const planPersonal = {
+	pricing: { originalPrice: { full: 100, monthly: 0 } },
+	planSlug: 'personal-bundle',
+} as GridPlan;
+
+const planPremium = {
+	pricing: { originalPrice: { full: 200, monthly: 0 } },
+	planSlug: 'value_bundle',
+} as GridPlan;
+
+const planBusiness = {
+	pricing: { originalPrice: { full: 300, monthly: 0 } },
+	planSlug: 'business-bundle',
+} as GridPlan;
+
+const planEcommerce = {
+	pricing: { originalPrice: { full: 500, monthly: 0 } },
+	planSlug: 'ecommerce-bundle',
+} as GridPlan;
+
+const plansInDefaultOrder = [ planFree, planPersonal, planPremium, planBusiness, planEcommerce ];
+
+describe( 'sortPlans', () => {
+	it( 'should return an empty array if no plans are provided', () => {
+		expect( sortPlans( [] ) ).toEqual( [] );
+	} );
+
+	it( 'should return the original order if no current plan is specified', () => {
+		expect( sortPlans( plansInDefaultOrder ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should return the original order if current plan is null', () => {
+		expect( sortPlans( plansInDefaultOrder, null ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should return the original order if current plan is undefined', () => {
+		expect( sortPlans( plansInDefaultOrder, undefined ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should return the original order if current plan is not found in the plans array', () => {
+		expect( sortPlans( plansInDefaultOrder, 'non-existent-plan' ) ).toEqual( plansInDefaultOrder );
+	} );
+
+	it( 'should prioritize the current plan when specified', () => {
+		// When personal plan is current
+		expect( sortPlans( plansInDefaultOrder, 'personal-bundle' ) ).toEqual( [
+			planPersonal,
+			planFree,
+			planPremium,
+			planBusiness,
+			planEcommerce,
+		] );
+
+		// When premium plan is current
+		expect( sortPlans( plansInDefaultOrder, 'value_bundle' ) ).toEqual( [
+			planPremium,
+			planFree,
+			planPersonal,
+			planBusiness,
+			planEcommerce,
+		] );
+
+		// When business plan is current
+		expect( sortPlans( plansInDefaultOrder, 'business-bundle' ) ).toEqual( [
+			planBusiness,
+			planFree,
+			planPersonal,
+			planPremium,
+			planEcommerce,
+		] );
+
+		// When ecommerce plan is current
+		expect( sortPlans( plansInDefaultOrder, 'ecommerce-bundle' ) ).toEqual( [
+			planEcommerce,
+			planFree,
+			planPersonal,
+			planPremium,
+			planBusiness,
+		] );
+
+		// When free plan is current
+		expect( sortPlans( plansInDefaultOrder, 'free_plan' ) ).toEqual( [
+			planFree,
+			planPersonal,
+			planPremium,
+			planBusiness,
+			planEcommerce,
+		] );
+	} );
+
+	it( 'should work with a single plan', () => {
+		const singlePlan = [ planFree ];
+		expect( sortPlans( singlePlan, 'free_plan' ) ).toEqual( [ planFree ] );
+	} );
+
+	it( 'should preserve the original array', () => {
+		const originalArray = [ ...plansInDefaultOrder ];
+		sortPlans( plansInDefaultOrder, 'personal-bundle' );
+		expect( plansInDefaultOrder ).toEqual( originalArray );
+	} );
+} );

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -51,7 +51,7 @@ export interface GridPlan {
  * Grid Component Types:
  ***********************/
 
-export type GridSize = 'small' | 'smedium' | 'medium' | 'large' | 'xlarge';
+export type GridSize = 'small' | 'medium' | 'large';
 
 export type PlansIntent =
 	| 'plans-affiliate'
@@ -116,7 +116,7 @@ export interface CommonGridProps {
 	// only used for comparison grid
 	planTypeSelectorProps?: PlanTypeSelectorProps;
 	gridContainerRef?: React.MutableRefObject< HTMLDivElement | null >;
-	gridSize?: GridSize;
+	gridSize?: string;
 }
 
 export interface FeaturesGridProps extends CommonGridProps {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101278 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

@fushar reported an [issue](https://github.com/Automattic/wp-calypso/pull/101278#issuecomment-2736843227) with plan sorting in the comparison grid. Reverting for now, will investigate and followup.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
