### PR TITLE
Stats: Improves video header title

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -59,16 +59,6 @@ class VideoPressStatsModule extends Component {
 		}
 	}
 
-	getModuleLabel() {
-		if ( ! this.props.summary ) {
-			return this.props.moduleStrings.title;
-		}
-		const { period, startOf } = this.props.period;
-		const { path, query } = this.props;
-
-		return <DatePicker period={ period } date={ startOf } path={ path } query={ query } summary />;
-	}
-
 	getHref() {
 		const { summary, period, path, siteSlug } = this.props;
 
@@ -160,9 +150,20 @@ class VideoPressStatsModule extends Component {
 
 		return (
 			<div>
+				{ summary && (
+					<div className="stats-module__date-picker-header">
+						<DatePicker
+							period={ period.period }
+							date={ period.startOf }
+							path={ path }
+							query={ query }
+							summary
+						/>
+					</div>
+				) }
 				<SectionHeader
 					className={ headerClass }
-					label={ this.getModuleLabel() }
+					label={ moduleStrings.title }
 					href={ ! summary ? summaryLink : null }
 				>
 					{ summary && (

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -1,3 +1,23 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@automattic/components/src/styles/typography";
+
+.stats-module__date-picker-header {
+	margin: 32px 0 16px;
+	font-family: $brand-serif;
+	font-size: $font-title-medium;
+	line-height: 1.5;
+
+	@media (max-width: $break-medium) {
+		margin: 24px 0 16px;
+		padding: 0 16px;
+	}
+
+	@media (max-width: $break-mobile) {
+		margin: 16px 0;
+	}
+}
+
 .videopress-stats-module__grid {
 	display: grid;
 	grid-template-columns: 50% auto auto auto auto;
@@ -58,8 +78,4 @@
 	&:hover div {
 		background-color: var(--color-neutral-0);
 	}
-}
-
-.stats-module__date-picker-header {
-	margin-bottom: 16px;
 }

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -59,3 +59,7 @@
 		background-color: var(--color-neutral-0);
 	}
 }
+
+.stats-module__date-picker-header {
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100506

## Proposed Changes

* This PR moves the date range header (eg. `Stats for Mar 13 - Mar 19`) from inside the card to above it
* It replaces the previous header location with the title `videos`
* **note:** this is not the final design. Adjusting incrementally, there will be more PRs to come. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align the video press stats page with the other pages

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live branch
* Navigate to `/stats/day/videoplays/jetpack.com` (or any site with video plays)
* Check that the date range header is now above the card border

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/29f04f08-5876-45f3-b2ff-ecb11b59d649) | ![image](https://github.com/user-attachments/assets/b5b26c81-4dd7-4ec5-b1bd-10565d18d76a)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
