### PR TITLE
i18n: Convert translate calls to getters in collection definitions

### DIFF
--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -30,39 +30,53 @@ export const THEME_TIER_FREE = 'free';
  */
 export const THEME_TIERS = {
 	free: {
-		label: translate( 'Free' ),
+		get label() {
+			return translate( 'Free' );
+		},
 		minimumUpsellPlan: PLAN_FREE,
 		isFilterable: true,
 	},
 	personal: {
-		label: getIncludedWithLabel( PLAN_PERSONAL ),
+		get label() {
+			return getIncludedWithLabel( PLAN_PERSONAL );
+		},
 		minimumUpsellPlan: PLAN_PERSONAL,
 		isFilterable: true,
 	},
 	[ THEME_TIER_PREMIUM ]: {
-		label: getIncludedWithLabel( PLAN_PREMIUM ),
+		get label() {
+			return getIncludedWithLabel( PLAN_PREMIUM );
+		},
 		minimumUpsellPlan: PLAN_PREMIUM,
 		isFilterable: true,
 	},
 	[ THEME_TIER_PARTNER ]: {
-		label: translate( 'Partner', {
-			context: 'This theme is developed and supported by a theme partner',
-		} ),
+		get label() {
+			return translate( 'Partner', {
+				context: 'This theme is developed and supported by a theme partner',
+			} );
+		},
 		minimumUpsellPlan: PLAN_BUSINESS,
 		isFilterable: true,
 	},
 	woocommerce: {
-		label: translate( 'WooCommerce' ),
+		get label() {
+			return translate( 'WooCommerce' );
+		},
 		minimumUpsellPlan: PLAN_BUSINESS,
 		isFilterable: true,
 	},
 	sensei: {
-		label: translate( 'Sensei LMS' ),
+		get label() {
+			return translate( 'Sensei LMS' );
+		},
 		minimumUpsellPlan: PLAN_BUSINESS,
 		isFilterable: false,
 	},
 	community: {
-		label: translate( 'Community' ),
+		get label() {
+			return translate( 'Community' );
+		},
 		minimumUpsellPlan: PLAN_BUSINESS,
 		isFilterable: false,
 	},

--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -26,10 +26,16 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: 'marketplace',
 		},
-		title: translate( 'Partner Themes' ),
-		fullTitle: translate( 'Partner Themes' ),
+		get title() {
+			return translate( 'Partner Themes' );
+		},
+		get fullTitle() {
+			return translate( 'Partner Themes' );
+		},
 		collectionSlug: 'partner-themes',
-		description: translate( 'Professional themes designed and developed by our partners.' ),
+		get description() {
+			return translate( 'Professional themes designed and developed by our partners.' );
+		},
 		seeAllLink: '/themes/marketplace',
 	},
 	partner: {
@@ -41,10 +47,16 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: 'partner',
 		},
-		title: translate( 'Partner Themes' ),
-		fullTitle: translate( 'Partner Themes' ),
+		get title() {
+			return translate( 'Partner Themes' );
+		},
+		get fullTitle() {
+			return translate( 'Partner Themes' );
+		},
 		collectionSlug: 'partner-themes',
-		description: translate( 'Professional themes designed and developed by our partners.' ),
+		get description() {
+			return translate( 'Professional themes designed and developed by our partners.' );
+		},
 		seeAllLink: '/themes/partner',
 	},
 };

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -152,15 +152,21 @@ class ThemeShowcase extends Component {
 		return {
 			MYTHEMES: {
 				key: STATIC_FILTERS.MYTHEMES,
-				text: translate( 'My Themes' ),
+				get text() {
+					return translate( 'My Themes' );
+				},
 			},
 			RECOMMENDED: {
 				key: STATIC_FILTERS.RECOMMENDED,
-				text: translate( 'Recommended' ),
+				get text() {
+					return translate( 'Recommended' );
+				},
 			},
 			ALL: {
 				key: STATIC_FILTERS.ALL,
-				text: translate( 'All' ),
+				get text() {
+					return translate( 'All' );
+				},
 			},
 		};
 	}
@@ -222,7 +228,15 @@ class ThemeShowcase extends Component {
 			];
 		}, [] );
 
-		return [ { value: 'all', label: translate( 'All' ) }, ...tiers ];
+		return [
+			{
+				value: 'all',
+				get label() {
+					return translate( 'All' );
+				},
+			},
+			...tiers,
+		];
 	};
 
 	findTabFilter = ( tabFilters, filterKey ) =>


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/i18n-issues#966

## Proposed Changes
Convert direct `translate()` calls to getter properties for better translation handling.

This ensures translations are computed on-demand when properties are accessed

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

```
The first time you visit https://wordpress.com/themes/, there are a few places where text is in English:

- the heading and text in the "Partner Themes" section isn't translated. This section appears if you scroll down a little in the theme showcase.
- the words "Partner" and "Included with" in the dropdown filter.

This text stays untranslated unless you refresh your browser window. Then the translations show up.
```
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
