### PR TITLE
Strip zeros from the VIP price

### DIFF
--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -78,7 +78,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 	}
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) ) {
-		const price = formatCurrency( 25000, 'USD' );
+		const price = formatCurrency( 25000, 'USD', { stripZeros: true } );
 
 		return (
 			<div className="plans-grid-next__billing-timeframe-vip-price">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: 3758-gh-Automattic/martech.

## Proposed Changes

* Strips zeros after the decimal point in the hardcoded Entrerprise plan's price.

| BEFORE | AFTER 
| -------- | ------- 
| <img width="822" alt="Screenshot 2025-03-20 at 8 29 22 AM" src="https://github.com/user-attachments/assets/d743e6eb-aaef-4493-98cb-e9ce69fe721c" /> | <img width="1144" alt="Screenshot 2025-03-20 at 8 29 12 AM" src="https://github.com/user-attachments/assets/debb919b-3178-49fc-821a-ba68561f5f22" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In `/setup/onboarding/plans` verify that the zeros after the decimal point are not present in the Enterprise plan's "Starting at US$25,000" price. Check screenshots above.

