### PR TITLE
Untangled Plans: show current plan with upgraded term in the plans grid

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -449,6 +449,7 @@ const PlansFeaturesMain = ( {
 		eligibleForFreeHostingTrial,
 		hasRedeemedDomainCredit: currentPlan?.hasRedeemedDomainCredit,
 		hiddenPlans,
+		hideCurrentPlan: isInSiteDashboard,
 		intent,
 		isDisplayingPlansNeededForFeature,
 		isInSignup,
@@ -851,7 +852,6 @@ const PlansFeaturesMain = ( {
 										coupon={ coupon }
 										currentSitePlanSlug={ sitePlanSlug }
 										generatedWPComSubdomain={ resolvedSubdomainName }
-										hideSpotlightPlan={ isInSiteDashboard }
 										gridPlanForSpotlight={ gridPlanForSpotlight }
 										gridPlans={ gridPlansForFeaturesGrid }
 										hideUnavailableFeatures={ hideUnavailableFeatures }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -286,7 +286,7 @@ class PlansComponent extends Component {
 				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
 				showLegacyStorageFeature={ this.props.siteHasLegacyStorage }
 				intent={ plansIntent }
-				isSpotlightOnCurrentPlan={ ! this.props.isDomainAndPlanPackageFlow }
+				isSpotlightOnCurrentPlan={ ! isUntangled && ! this.props.isDomainAndPlanPackageFlow }
 				showPlanTypeSelectorDropdown={ isEnabled( 'onboarding/interval-dropdown' ) }
 			/>
 		);

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -299,7 +299,6 @@ const TabletView = ( {
 const FeaturesGrid = ( {
 	currentSitePlanSlug,
 	generatedWPComSubdomain,
-	hideSpotlightPlan,
 	gridPlanForSpotlight,
 	gridPlans,
 	gridSize,
@@ -317,7 +316,6 @@ const FeaturesGrid = ( {
 }: FeaturesGridProps ) => {
 	const spotlightPlanProps = {
 		currentSitePlanSlug,
-		hideSpotlightPlan,
 		gridPlanForSpotlight,
 		isInSignup,
 		onStorageAddOnClick,
@@ -338,7 +336,7 @@ const FeaturesGrid = ( {
 
 	return (
 		<div className="plans-grid-next-features-grid">
-			{ 'small' !== gridSize && ! hideSpotlightPlan && <SpotlightPlan { ...spotlightPlanProps } /> }
+			{ 'small' !== gridSize && <SpotlightPlan { ...spotlightPlanProps } /> }
 			<div className="plan-features">
 				<div className="plan-features-2023-grid__content">
 					<div>

--- a/packages/plans-grid-next/src/hooks/data-store/types.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/types.ts
@@ -10,6 +10,7 @@ export interface UseGridPlansParams {
 	eligibleForFreeHostingTrial?: boolean;
 	hasRedeemedDomainCredit?: boolean;
 	hiddenPlans?: HiddenPlans;
+	hideCurrentPlan?: boolean;
 	intent?: PlansIntent;
 	isDisplayingPlansNeededForFeature?: boolean;
 	isInSignup?: boolean;

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans-for-features-grid.ts
@@ -10,6 +10,7 @@ const useGridPlansForFeaturesGrid = ( {
 	eligibleForFreeHostingTrial,
 	hasRedeemedDomainCredit,
 	hiddenPlans,
+	hideCurrentPlan,
 	intent,
 	isDisplayingPlansNeededForFeature,
 	isInSignup,
@@ -62,18 +63,21 @@ const useGridPlansForFeaturesGrid = ( {
 		}
 
 		return gridPlans.reduce( ( acc, gridPlan ) => {
-			if ( gridPlan.isVisible ) {
-				return [
-					...acc,
-					{
-						...gridPlan,
-						features: planFeaturesForFeaturesGrid[ gridPlan.planSlug ],
-					},
-				];
+			if ( ! gridPlan.isVisible ) {
+				return acc;
 			}
-			return acc;
+			if ( hideCurrentPlan && gridPlan.current ) {
+				return acc;
+			}
+			return [
+				...acc,
+				{
+					...gridPlan,
+					features: planFeaturesForFeaturesGrid[ gridPlan.planSlug ],
+				},
+			];
 		}, [] as GridPlan[] );
-	}, [ gridPlans, planFeaturesForFeaturesGrid ] );
+	}, [ gridPlans, planFeaturesForFeaturesGrid, hideCurrentPlan ] );
 };
 
 export default useGridPlansForFeaturesGrid;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -123,7 +123,6 @@ export interface FeaturesGridProps extends CommonGridProps {
 	gridPlans: GridPlan[];
 	currentPlanManageHref?: string;
 	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
-	hideSpotlightPlan?: boolean;
 	gridPlanForSpotlight?: GridPlan;
 	isCustomDomainAllowedOnFreePlan: boolean; // indicate when a custom domain is allowed to be used with the Free plan.
 	paidDomainName?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-kcO-p2#comment-67108

## Proposed Changes

Currently, in the untangled Plans page, we do not show the current plan in the plan features grid. In this PR, we want to still show the current plan (with the "Upgrade to xxx" button) if we change the billing term as follows.

|Current: Premium|Change to 2-yearly|
|-|-|
|<img width="1409" alt="image" src="https://github.com/user-attachments/assets/c6f04c83-fc34-4cbf-8d55-099939c94807" />|<img width="1310" alt="image" src="https://github.com/user-attachments/assets/39f21407-0dfd-405b-91a1-e66a4f81f72b" />|

## Implementation Details

- I reverted the addition of `hideSpotlightPlan` from https://github.com/Automattic/wp-calypso/pull/101363. I just realized I can just use the existing `isSpotlightOnCurrentPlan` 🤦 
- Instead, I introduced a new prop `hideCurrentPlan` which I pass for the plan features grid (but not for the plan comparison grid).

## Out of scope

I'll handle hiding the lower plans from the grid in a follow-up PRs (cc: @matt-west) ref: p58i-kiA-p2#comment-67119

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6Xi-p2

## Testing Instructions

1. Go to `/plans/:site?flags=untangling/plans` of a site with a PAID plan.
2. Change the billing term.
3. Verify you can see the current plan with the upgraded term in the plan features grid as shown above.
4. Verify you can also see the above the the comparison grid (click the "Compare plans" below).
5. Smoke-test existing `/plans/:site` page too, for regression testing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?