### PR TITLE
A4A > WooPayments: Update empty state content

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -339,23 +339,58 @@ const WooPaymentsDashboardEmptyState = () => {
 					<>
 						<div className="woopayments-dashboard-empty-state__description">
 							{ translate(
-								"Explore all of WooPayments' benefits, browse the technical documentation, and try the demo to see it in action."
+								"Explore all of WooPayments' benefits, browse the technical documentation, and {{a}}try the demo{{/a}} ↗ to see it in action.",
+								{
+									components: {
+										a: (
+											<a
+												className="woopayments-dashboard-empty-state__demo-link"
+												href="https://woocommerce.com/products/woopayments"
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={ () => {
+													dispatch(
+														recordTracksEvent( 'calypso_a4a_woopayments_try_demo_button_click' )
+													);
+												} }
+											/>
+										),
+									},
+								}
 							) }
 						</div>
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							href="https://woocommerce.com/products/woopayments/"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_explore_woocommerce_button_click' )
-								);
-							} }
-						>
-							{ translate( 'Explore WooPayments on WooCommerce.com ↗' ) }
-						</Button>
+						<div className="woopayments-dashboard-empty-state__buttons">
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent(
+											'calypso_a4a_woopayments_contact_us_to_learn_more_button_click'
+										)
+									);
+								} }
+							>
+								{ translate( 'Contact us to learn more' ) }
+							</Button>
+							<Button
+								__next40pxDefaultSize
+								variant="secondary"
+								href="https://woocommerce.com/products/woopayments"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent(
+											'calypso_a4a_woopayments_explore_on_woocommerce_button_click'
+										)
+									);
+								} }
+							>
+								{ translate( 'Explore on WooCommerce.com ↗' ) }
+							</Button>
+						</div>
 					</>
 				</PageSectionColumns.Column>
 				<PageSectionColumns.Column alignCenter>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
@@ -49,9 +49,16 @@ $woocommerce-purple-50: #720EEC;
 	}
 }
 
-.woopayments-dashboard-empty-state__list a {
+.woopayments-dashboard-empty-state__list a,
+.woopayments-dashboard-empty-state__demo-link {
 	text-decoration: underline;
 	color: var(--color-text);
+
+	&:hover,
+	&:focus,
+	&:focus-visible {
+		color: var(--color-text);
+	}
 }
 
 a.components-button.woopayments-dashboard-empty-state__button {
@@ -85,5 +92,24 @@ a.components-button.woopayments-dashboard-empty-state__button {
 
 	svg {
 		margin: 0
+	}
+}
+
+.woopayments-dashboard-empty-state__buttons {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	a.components-button {
+		width: 100%;
+		text-wrap: balance;
+	}
+
+	@include break-wide {
+		flex-direction: row;
+
+		a.components-button {
+			width: auto;
+		}
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1945

## Proposed Changes

This PR updates the empty state content for WooPayments Commissions.

## Why are these changes being made?

* To update the empty state content as per CFT feedback. Design: iyNspimFpNJSlBxaatQEoC-fi-6698_32085

## Testing Instructions

* Open the A4A live link > Go to WooPayments: Dashboard > Verify the empty state content for the last section is updated as shown below. Verify the links work as expected.

Try demo: Should redirected to https://woocommerce.com/products/woopayments
Contact us: Should open the contact form with Woo pre-loaded
Explore on WooCommerce.com ↗: Should redirected to https://woocommerce.com/products/woopayments

<img width="1632" alt="Screenshot 2025-03-20 at 9 58 56 AM" src="https://github.com/user-attachments/assets/d16aabd2-dad1-4038-b957-618b18bade51" />
<img width="691" alt="Screenshot 2025-03-20 at 10 00 00 AM" src="https://github.com/user-attachments/assets/aeef465f-83e1-4c01-a097-1fed6f486625" />
<img width="343" alt="Screenshot 2025-03-20 at 10 00 22 AM" src="https://github.com/user-attachments/assets/5802b68f-b3b7-4d1b-82d6-e1f96144c2eb" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?