### PR TITLE
Replace -rgb color variable usage with color-mix

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -403,7 +403,7 @@ $with-sidebar-min-page-width: 1114px;
 		bottom: 0;
 		overflow: hidden;
 		&:not(.is-note-open) {
-			box-shadow: -3px 1px 10px -2px rgba(var(--color-neutral-70-rgb), 0.075);
+			box-shadow: -3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
 		}
 	}
 
@@ -454,7 +454,7 @@ $with-sidebar-min-page-width: 1114px;
 		}
 
 		.unread {
-			background: rgba(var(--color-primary-rgb), 0.1); // rgba is used to meet AA contrast standard
+			background: color-mix(in srgb, var(--color-primary) 10%, transparent); // rgba is used to meet AA contrast standard
 		}
 
 		.wpnc__traffic_surge .wpnc__note-icon img {
@@ -616,7 +616,7 @@ $with-sidebar-min-page-width: 1114px;
 		height: 100%;
 		left: 0;
 		right: 0;
-		box-shadow: -3px 1px 10px -2px rgba(var(--color-neutral-70-rgb), 0.075);
+		box-shadow: -3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
 
 		@media only screen and (min-width: 480px) {
 			border-left: 1px solid var(--color-neutral-0);

--- a/apps/notifications/src/panel/suggestions/styles.scss
+++ b/apps/notifications/src/panel/suggestions/styles.scss
@@ -8,7 +8,7 @@ $selected-color: var(--color-primary);
 $img-size: 24px;
 $img-border-radius: 50%;
 $border-radius: 3px;
-$box-shadow: 0 5px 6px rgba(var(--color-neutral-10-rgb), 0.5);
+$box-shadow: 0 5px 6px color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 
 .wpnc__suggestions {
 	position: relative;
@@ -55,7 +55,7 @@ $box-shadow: 0 5px 6px rgba(var(--color-neutral-10-rgb), 0.5);
 
 	strong {
 		font-weight: 400;
-		background: rgba(var(--color-primary-light-rgb), 0.25);
+		background: color-mix(in srgb, var(--color-primary-light) 25%, transparent);
 	}
 
 	.wpnc__username {
@@ -83,7 +83,7 @@ $box-shadow: 0 5px 6px rgba(var(--color-neutral-10-rgb), 0.5);
 		strong,
 		.username strong {
 			color: var(--color-text-inverted);
-			background: rgba(var(--color-primary-light-rgb), 0.45);
+			background: color-mix(in srgb, var(--color-primary-light) 45%, transparent);
 		}
 
 		small {

--- a/apps/odyssey-stats/src/widget/mini-chart.scss
+++ b/apps/odyssey-stats/src/widget/mini-chart.scss
@@ -72,7 +72,7 @@ $barDarkColor: var(--color-primary-60);
 	}
 
 	.chart__y-axis-marker {
-		border-color: rgba(var(--color-neutral-5-rgb), 0.5);
+		border-color: color-mix(in srgb, var(--color-neutral-5) 50%, transparent);
 	}
 
 	.chart__y-axis {

--- a/bin/codemods/src/rgb-to-color-mix.js
+++ b/bin/codemods/src/rgb-to-color-mix.js
@@ -17,7 +17,7 @@ const { glob } = require( 'glob' );
 
 function replaceRgbVars( scssContent ) {
 	return scssContent.replace(
-		/rgba\(\s*var\((--[\w-]+)-rgb\)\s*,\s*([\d.]+)\s*\)/g,
+		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+)-rgb\s*\)\s*,\s*([\d.]+)\s*\)/g,
 		( match, varName, alpha ) => {
 			const baseVar = varName.replace( /-rgb$/, '' );
 			return `color-mix(in srgb, var(${ baseVar }) ${ parseFloat( alpha ) * 100 }%, transparent)`;

--- a/bin/codemods/src/rgb-to-color-mix.js
+++ b/bin/codemods/src/rgb-to-color-mix.js
@@ -29,7 +29,9 @@ function replaceRgbVars( scssContent ) {
 	return scssContent.replace(
 		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+?)(?:--rgb|-rgb)\s*\)\s*,\s*([\d.]+)(%?)\s*\)/g,
 		( match, varName, alpha, isPercent ) => {
-			const alphaValue = isPercent ? parseFloat( alpha ) : parseFloat( alpha ) * 100;
+			const alphaValue = isPercent
+				? parseFloat( alpha )
+				: Number( ( parseFloat( alpha ) * 100 ).toPrecision( 10 ) );
 			return `color-mix(in srgb, var(${ varName }) ${ alphaValue }%, transparent)`;
 		}
 	);

--- a/bin/codemods/src/rgb-to-color-mix.js
+++ b/bin/codemods/src/rgb-to-color-mix.js
@@ -5,6 +5,7 @@ const { glob } = require( 'glob' );
  * RGB to color-mix
  *
  * Maps rgba() to color-mix(), e.g. `rgba(var(--color-primary-rgb), 0.04)` is replaced with `color-mix(in srgb, var(--color-primary) 4%, transparent)`.
+ * Maps rgba() to var(), e.g. `rgba(var(--color-primary-rgb))` is replaced with `var(--color-primary)`.
  *
  * ## Usage
  *
@@ -16,6 +17,15 @@ const { glob } = require( 'glob' );
  */
 
 function replaceRgbVars( scssContent ) {
+	// First replace simple rgb() cases
+	scssContent = scssContent.replace(
+		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+)-rgb\s*\)\s*\)/g,
+		( match, varName ) => {
+			return `var(${ varName })`;
+		}
+	);
+
+	// Then handle rgba() cases as before
 	return scssContent.replace(
 		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+)-rgb\s*\)\s*,\s*([\d.]+)\s*\)/g,
 		( match, varName, alpha ) => {

--- a/bin/codemods/src/rgb-to-color-mix.js
+++ b/bin/codemods/src/rgb-to-color-mix.js
@@ -1,0 +1,52 @@
+const fs = require( 'fs' );
+const { glob } = require( 'glob' );
+
+/**
+ * RGB to color-mix
+ *
+ * Maps rgba() to color-mix(), e.g. `rgba(var(--color-primary-rgb), 0.04)` is replaced with `color-mix(in srgb, var(--color-primary) 4%, transparent)`.
+ *
+ * ## Usage
+ *
+ * node ./bin/codemods/src/rgb-to-color-mix.js ~/wp-calypso
+ *
+ * ## Notes:
+ * - Not all rgba() usage is replaced, only those using *-rgb variables are replaced.
+ * - This script does not handle all *-rgb variable replacement, additional changes are required.
+ */
+
+function replaceRgbVars( scssContent ) {
+	return scssContent.replace(
+		/rgba\(\s*var\((--[\w-]+)-rgb\)\s*,\s*([\d.]+)\s*\)/g,
+		( match, varName, alpha ) => {
+			const baseVar = varName.replace( /-rgb$/, '' );
+			return `color-mix(in srgb, var(${ baseVar }) ${ parseFloat( alpha ) * 100 }%, transparent)`;
+		}
+	);
+}
+
+function processScssFiles( rootDir ) {
+	const scssFiles = glob.sync( `${ rootDir }/**/*.scss` );
+
+	console.log( `Processing ${ rootDir }/**/*.scss, found`, scssFiles.length, 'files' );
+
+	scssFiles.forEach( ( filePath ) => {
+		const scssCode = fs.readFileSync( filePath, 'utf8' );
+		const fixedScssCode = replaceRgbVars( scssCode );
+
+		if ( scssCode !== fixedScssCode ) {
+			fs.writeFileSync( filePath, fixedScssCode, 'utf8' );
+			console.log( `Fixed SCSS: ${ filePath }` );
+		}
+	} );
+}
+
+// Run the codemod with a specified directory
+const rootDir = process.argv[ 2 ];
+
+if ( ! rootDir ) {
+	console.error( 'Usage: node fix-scss-rgb.js <scss_directory>' );
+	process.exit( 1 );
+}
+
+processScssFiles( rootDir );

--- a/bin/codemods/src/rgb-to-color-mix.js
+++ b/bin/codemods/src/rgb-to-color-mix.js
@@ -17,9 +17,9 @@ const { glob } = require( 'glob' );
  */
 
 function replaceRgbVars( scssContent ) {
-	// First replace simple rgb() cases
+	// First replace simple rgb() cases (no alpha value)
 	scssContent = scssContent.replace(
-		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+)-rgb\s*\)\s*\)/g,
+		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+?)(?:--rgb|-rgb)\s*\)\s*\)/g,
 		( match, varName ) => {
 			return `var(${ varName })`;
 		}
@@ -27,11 +27,10 @@ function replaceRgbVars( scssContent ) {
 
 	// Handle rgba() cases with both decimal and percentage alpha values
 	return scssContent.replace(
-		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+)-rgb\s*\)\s*,\s*([\d.]+)(%?)\s*\)/g,
+		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+?)(?:--rgb|-rgb)\s*\)\s*,\s*([\d.]+)(%?)\s*\)/g,
 		( match, varName, alpha, isPercent ) => {
-			const baseVar = varName.replace( /-rgb$/, '' );
 			const alphaValue = isPercent ? parseFloat( alpha ) : parseFloat( alpha ) * 100;
-			return `color-mix(in srgb, var(${ baseVar }) ${ alphaValue }%, transparent)`;
+			return `color-mix(in srgb, var(${ varName }) ${ alphaValue }%, transparent)`;
 		}
 	);
 }

--- a/bin/codemods/src/rgb-to-color-mix.js
+++ b/bin/codemods/src/rgb-to-color-mix.js
@@ -37,7 +37,9 @@ function replaceRgbVars( scssContent ) {
 }
 
 function processScssFiles( rootDir ) {
-	const scssFiles = glob.sync( `${ rootDir }/**/*.scss` );
+	const scssFiles = glob.sync( `${ rootDir }/**/*.scss`, {
+		ignore: [ '**/node_modules/**' ],
+	} );
 
 	console.log( `Processing ${ rootDir }/**/*.scss, found`, scssFiles.length, 'files' );
 

--- a/bin/codemods/src/rgb-to-color-mix.js
+++ b/bin/codemods/src/rgb-to-color-mix.js
@@ -25,12 +25,13 @@ function replaceRgbVars( scssContent ) {
 		}
 	);
 
-	// Then handle rgba() cases as before
+	// Handle rgba() cases with both decimal and percentage alpha values
 	return scssContent.replace(
-		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+)-rgb\s*\)\s*,\s*([\d.]+)\s*\)/g,
-		( match, varName, alpha ) => {
+		/rgba\s*\(\s*var\s*\(\s*(--[\w-]+)-rgb\s*\)\s*,\s*([\d.]+)(%?)\s*\)/g,
+		( match, varName, alpha, isPercent ) => {
 			const baseVar = varName.replace( /-rgb$/, '' );
-			return `color-mix(in srgb, var(${ baseVar }) ${ parseFloat( alpha ) * 100 }%, transparent)`;
+			const alphaValue = isPercent ? parseFloat( alpha ) : parseFloat( alpha ) * 100;
+			return `color-mix(in srgb, var(${ baseVar }) ${ alphaValue }%, transparent)`;
 		}
 	);
 }

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -73,8 +73,8 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 	border: 1px solid var(--color-accent-0);
 	border-radius: 4px;
 	box-shadow:
-		0 4px 6px rgba(var(--color-accent-100-rgb), 0.1),
-		0 1px 2px rgba(var(--color-accent-100-rgb), 0.1);
+		0 4px 6px color-mix(in srgb, var(--color-accent-100) 10%, transparent),
+		0 1px 2px color-mix(in srgb, var(--color-accent-100) 10%, transparent);
 	list-style-type: none;
 
 	@include a4a-font-body-md;

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-filter/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-filter/style.scss
@@ -68,7 +68,7 @@
 		box-shadow: inset 0 0 0 1px var(--color-neutral-20);
 		color: var(--color-accent-60);
 		fill: var(--color-accent-60);
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background: color-mix(in srgb, var(--wp-admin-theme-color) 4%, transparent);
 	}
 }
 

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/style.scss
@@ -24,7 +24,7 @@
 	}
 
 	.dataviews-wrapper ul.dataviews-view-list li:has(.is-site-selected) .dataviews-view-list__item-wrapper {
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background-color: color-mix(in srgb, var(--wp-admin-theme-color) 4%, transparent);
 	}
 
 	.dataviews-view-list li.is-selected.is-selected + li {

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -10,7 +10,7 @@
 	right: 0;
 	padding: 6px;
 	color: var(--color-text-inverted);
-	background: rgba(var(--color-neutral-70-rgb), 0.8);
+	background: color-mix(in srgb, var(--color-neutral-70) 80%, transparent);
 	text-align: center;
 	z-index: z-index("root", ".wpcom-site__global-noscript");
 }

--- a/client/assets/stylesheets/shared/_extends.scss
+++ b/client/assets/stylesheets/shared/_extends.scss
@@ -25,7 +25,7 @@
 }
 
 %mobile-link-element {
-	-webkit-tap-highlight-color: rgba(var(--color-surface-rgb), 0.4); // Until we capture ontouch events in JS this is better than :active
+	-webkit-tap-highlight-color: color-mix(in srgb, var(--color-surface) 40%, transparent); // Until we capture ontouch events in JS this is better than :active
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;

--- a/client/assets/stylesheets/shared/mixins/_elevation.scss
+++ b/client/assets/stylesheets/shared/mixins/_elevation.scss
@@ -7,53 +7,53 @@
 	}
 	@else if $dp==1 {
 		box-shadow:
-			0 1px 1px 0 rgba(var(--color-neutral-100-rgb), 0.14),
-			0 2px 1px -1px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 1px 3px 0 rgba(var(--color-neutral-100-rgb), 0.2);
+			0 1px 1px 0 color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 2px 1px -1px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 1px 3px 0 color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==2 {
 		box-shadow:
-			0 2px 2px 0 rgba(var(--color-neutral-100-rgb), 0.14),
-			0 3px 1px -2px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 1px 5px 0 rgba(var(--color-neutral-100-rgb), 0.2);
+			0 2px 2px 0 color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 3px 1px -2px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 1px 5px 0 color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==3 {
 		box-shadow:
-			0 3px 4px 0 rgba(var(--color-neutral-100-rgb), 0.14),
-			0 3px 3px -2px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 1px 8px 0 rgba(var(--color-neutral-100-rgb), 0.2);
+			0 3px 4px 0 color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 3px 3px -2px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 1px 8px 0 color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==4 {
 		box-shadow:
-			0 4px 5px 0 rgba(var(--color-neutral-100-rgb), 0.14),
-			0 1px 10px 0 rgba(var(--color-neutral-100-rgb), 0.12),
-			0 2px 4px -1px rgba(var(--color-neutral-100-rgb), 0.2);
+			0 4px 5px 0 color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 1px 10px 0 color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 2px 4px -1px color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==6 {
 		box-shadow:
-			0 6px 10px 0 rgba(var(--color-neutral-100-rgb), 0.14),
-			0 1px 18px 0 rgba(var(--color-neutral-100-rgb), 0.12),
-			0 3px 5px -1px rgba(var(--color-neutral-100-rgb), 0.2);
+			0 6px 10px 0 color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 1px 18px 0 color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 3px 5px -1px color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==8 {
 		box-shadow:
-			0 8px 10px 1px rgba(var(--color-neutral-100-rgb), 0.14),
-			0 3px 14px 2px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 5px 5px -3px rgba(var(--color-neutral-100-rgb), 0.2);
+			0 8px 10px 1px color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 3px 14px 2px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 5px 5px -3px color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==9 {
 		box-shadow:
-			0 9px 12px 1px rgba(var(--color-neutral-100-rgb), 0.14),
-			0 3px 16px 2px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 5px 6px -3px rgba(var(--color-neutral-100-rgb), 0.2);
+			0 9px 12px 1px color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 3px 16px 2px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 5px 6px -3px color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==12 {
 		box-shadow:
-			0 12px 17px 2px rgba(var(--color-neutral-100-rgb), 0.14),
-			0 5px 22px 4px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 7px 8px -4px rgba(var(--color-neutral-100-rgb), 0.2);
+			0 12px 17px 2px color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 5px 22px 4px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 7px 8px -4px color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==16 {
 		box-shadow:
-			0 16px 24px 2px rgba(var(--color-neutral-100-rgb), 0.14),
-			0 6px 30px 5px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 8px 10px -5px rgba(var(--color-neutral-100-rgb), 0.2);
+			0 16px 24px 2px color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 6px 30px 5px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 8px 10px -5px color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	} @else if $dp==24 {
 		box-shadow:
-			0 24px 38px 3px rgba(var(--color-neutral-100-rgb), 0.14),
-			0 9px 46px 8px rgba(var(--color-neutral-100-rgb), 0.12),
-			0 11px 15px -7px rgba(var(--color-neutral-100-rgb), 0.2);
+			0 24px 38px 3px color-mix(in srgb, var(--color-neutral-100) 14%, transparent),
+			0 9px 46px 8px color-mix(in srgb, var(--color-neutral-100) 12%, transparent),
+			0 11px 15px -7px color-mix(in srgb, var(--color-neutral-100) 20%, transparent);
 	}
 }

--- a/client/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/client/assets/stylesheets/shared/mixins/_mixins.scss
@@ -19,7 +19,7 @@
 // Copied _extends rules that are used in @media
 //======================================================
 @mixin mobile-link-element {
-	-webkit-tap-highlight-color: rgba(var(--color-surface-rgb), 0.4); // Until we capture ontouch events in JS this is better than :active
+	-webkit-tap-highlight-color: color-mix(in srgb, var(--color-surface) 40%, transparent); // Until we capture ontouch events in JS this is better than :active
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -4,7 +4,7 @@
 	width: 100%;
 	top: 0;
 	left: 0;
-	background: rgba(var(--studio-black-rgb), 0.6);
+	background: color-mix(in srgb, var(--studio-black) 60%, transparent);
 	touch-action: none;
 
 	/* Needed for banner to appear in front of notifications panel. */

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -12,7 +12,7 @@
 		position: absolute;
 		top: 0;
 		left: 0;
-		background-color: rgba(var(--color-neutral-70-rgb), 0.5);
+		background-color: color-mix(in srgb, var(--color-neutral-70) 50%, transparent);
 		border-radius: 50%;
 		height: 150px;
 		width: 150px;
@@ -164,7 +164,7 @@
 }
 
 .edit-gravatar .spinner__border {
-	fill: rgba(var(--color-neutral-70-rgb), 0.5);
+	fill: color-mix(in srgb, var(--color-neutral-70) 50%, transparent);
 }
 
 .edit-gravatar__explanation {

--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -31,7 +31,7 @@
 }
 
 .image-editor__toolbar-button {
-	background: rgba(var(--color-surface-rgb), 0);
+	background: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	border: none;
 	color: var(--color-text-inverted);
 	margin: 0 10px;

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -49,7 +49,7 @@ $section-border: solid 1px var(--color-neutral-5);
 
 .post-share__wrapper.is-placeholder {
 	padding-bottom: 24px;
-	border-bottom: 1px solid rgba(var(--color-neutral-10-rgb), 0.5);
+	border-bottom: 1px solid color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 }
 
 .post-share__placeholder {

--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -28,7 +28,7 @@
 }
 
 .product-purchase-features-list__item .happiness-support {
-	box-shadow: 0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5), 0 1px 2px var(--color-neutral-0);
+	box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent), 0 1px 2px var(--color-neutral-0);
 	box-sizing: border-box;
 	color: var(--color-text-subtle);
 	padding: 37px;

--- a/client/blocks/reader-full-post/carousel.scss
+++ b/client/blocks/reader-full-post/carousel.scss
@@ -51,7 +51,7 @@
 
 		.entry-wrapper {
 			bottom: 0;
-			background-color: rgba(var(--color-text-rgb), 0.5);
+			background-color: color-mix(in srgb, var(--color-text) 50%, transparent);
 			color: var(--studio-white);
 			left: 0;
 			padding: 1.5em;

--- a/client/blocks/reader-full-post/tiled-gallery.scss
+++ b/client/blocks/reader-full-post/tiled-gallery.scss
@@ -25,7 +25,7 @@ $tiled-gallery-max-rounded-corners: 20;
 		align-self: inherit;
 
 		> img {
-			background-color: rgba(var(--color-text-rgb), 0.1);
+			background-color: color-mix(in srgb, var(--color-text) 10%, transparent);
 		}
 
 		> a,

--- a/client/blocks/reader-join-conversation/style.scss
+++ b/client/blocks/reader-join-conversation/style.scss
@@ -70,5 +70,5 @@
 
 .dialog__backdrop,
 .dialog__backdrop.card {
-	background-color: rgba(var(--color-neutral-70-rgb), 0.8) !important;
+	background-color: color-mix(in srgb, var(--color-neutral-70) 80%, transparent) !important;
 }

--- a/client/blocks/reader-suggested-follows/style.scss
+++ b/client/blocks/reader-suggested-follows/style.scss
@@ -143,5 +143,5 @@
 
 .dialog__backdrop,
 .dialog__backdrop.card {
-	background-color: rgba(var(--color-neutral-70-rgb), 0.8) !important;
+	background-color: color-mix(in srgb, var(--color-neutral-70) 80%, transparent) !important;
 }

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -24,10 +24,10 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba(var(--color-surface-rgb), 0.75);
+	background-color: color-mix(in srgb, var(--color-surface) 75%, transparent);
 }
 
 .site-icon__img {
-	background: rgba(var(--color-surface-rgb), 0);
+	background: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	position: relative;
 }

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -1,13 +1,13 @@
 .taxonomy-manager {
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 }
 
 .taxonomy-manager__header {
 	display: flex;
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 	background: var(--color-surface);
 }

--- a/client/blocks/user-mentions/suggestion.scss
+++ b/client/blocks/user-mentions/suggestion.scss
@@ -35,5 +35,5 @@ $user-mentions-avatar-margin: 10px;
 
 .user-mentions__highlight {
 	font-weight: 400;
-	background: rgba(var(--color-primary-light-rgb), 0.25);
+	background: color-mix(in srgb, var(--color-primary-light) 25%, transparent);
 }

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -156,7 +156,7 @@ $heading-font-body-small: 15px;
 	}
 
 	&.dialog__backdrop {
-		background-color: rgba(var(--color-neutral-100-rgb), 0.6);
+		background-color: color-mix(in srgb, var(--color-neutral-100) 60%, transparent);
 
 		.dialog.card {
 			max-width: 480px;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -38,7 +38,7 @@ $year-bar-chart-border-radius: 4px;
 	top: 0;
 	width: 100%;
 	height: 1px;
-	border-top: 1px solid rgba(var(--color-neutral-0-rgb), 0.1);
+	border-top: 1px solid color-mix(in srgb, var(--color-neutral-0) 10%, transparent);
 }
 
 .chart__bar-marker,
@@ -77,7 +77,7 @@ $y-axis-padding: 0 20px;
 
 // For forcing the width of y-axis to the width of the label
 .chart__y-axis-width-fix {
-	color: rgba(var(--color-surface-rgb), 0);
+	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 }
 
 // X-axis
@@ -119,7 +119,7 @@ $y-axis-padding: 0 20px;
 }
 
 .chart__x-axis-width-spacer {
-	color: rgba(var(--color-surface-rgb), 0);
+	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	padding: $y-axis-padding;
 	right: 0;
 
@@ -165,12 +165,12 @@ $y-axis-padding: 0 20px;
 
 	&:hover {
 		cursor: pointer;
-		background-color: rgba(var(--color-neutral-rgb), 0.1);
+		background-color: color-mix(in srgb, var(--color-neutral) 10%, transparent);
 	}
 
 	&.is-selected {
 		cursor: default;
-		background-color: rgba(var(--color-primary-rgb), 0.1);
+		background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
 	}
 }
 
@@ -483,7 +483,7 @@ $y-axis-padding: 0 20px;
 		background-color: transparent;
 
 		.chart__bar-section {
-			background-color: rgba(var(--color-neutral-0-rgb), 0.5);
+			background-color: color-mix(in srgb, var(--color-neutral-0) 50%, transparent);
 		}
 	}
 }

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -207,7 +207,7 @@ $date-picker_nav_button_size: 20px;
 	line-height: 24px;
 	border-radius: 50%;
 	cursor: pointer;
-	border: 1px solid rgba(var(--color-surface-rgb), 0);
+	border: 1px solid color-mix(in srgb, var(--color-surface) 0%, transparent);
 	color: var(--color-neutral-70);
 	text-align: center;
 	margin: 0 auto;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -259,7 +259,7 @@ $date-range-mobile-layout-switch: $break-small;
 
 
 .date-range__picker {
-	--date-range-picker-highlight-color: rgba(var(--color-primary-light-rgb), 0.4);
+	--date-range-picker-highlight-color: color-mix(in srgb, var(--color-primary-light) 40%, transparent);
 
 	.DayPicker-Day,
 	.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -191,7 +191,7 @@
 
 	// from components/card/style.scss
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 
 	// from components/domains/domain-suggestion/style

--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -15,7 +15,7 @@
 	border: 6px solid var(--color-primary-dark);
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
 
-	background-color: rgba(var(--color-primary-rgb), 0.8);
+	background-color: color-mix(in srgb, var(--color-primary) 80%, transparent);
 
 	&.is-active {
 		opacity: 1;
@@ -24,7 +24,7 @@
 	}
 
 	&.is-dragging-over-element {
-		background-color: rgba(var(--color-primary-rgb), 0.8);
+		background-color: color-mix(in srgb, var(--color-primary) 80%, transparent);
 	}
 
 	&.is-full-screen {

--- a/client/components/feature-example/style.scss
+++ b/client/components/feature-example/style.scss
@@ -11,6 +11,6 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background: linear-gradient(to bottom, rgba(var(--color-surface-backdrop-rgb), 0.4), rgba(var(--color-surface-backdrop-rgb), 1));
+	background: linear-gradient(to bottom, color-mix(in srgb, var(--color-surface-backdrop) 40%, transparent), color-mix(in srgb, var(--color-surface-backdrop) 100%, transparent));
 	z-index: z-index("root", ".feature-example__gradient");
 }

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -8,7 +8,7 @@
 	background-size: cover;
 	border-radius: 2px;
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 	transition: all 100ms ease-in-out;
 	overflow: hidden;

--- a/client/components/input-chrono/style.scss
+++ b/client/components/input-chrono/style.scss
@@ -11,7 +11,7 @@
 	padding: 0 10px;
 	border: 1px solid var(--color-neutral-0);
 	box-sizing: border-box;
-	background-color: rgba(var(--color-surface-rgb), 0);
+	background-color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	color: var(--color-text-subtle);
 	font-size: $font-body-extra-small;
 	text-align: left;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -125,7 +125,7 @@
 	}
 
 	&__get-started {
-		background-color: rgba(var(--studio-jetpack-green-10-rgb), 0.2);
+		background-color: color-mix(in srgb, var(--studio-jetpack-green-10) 20%, transparent);
 	}
 
 	&__from {

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -23,7 +23,7 @@
 .licensing-prompt-dialog {
 	// Add ".dialog__backdrop" to override the default dialog backdrop
 	&__backdrop.dialog__backdrop {
-		background-color: rgba(var(--color-neutral-100-rgb), 0.6);
+		background-color: color-mix(in srgb, var(--color-neutral-100) 60%, transparent);
 	}
 }
 

--- a/client/components/jetpack/profile-dropdown/style.scss
+++ b/client/components/jetpack/profile-dropdown/style.scss
@@ -55,8 +55,8 @@
 		background: var(--color-surface);
 		border: 1px solid var(--studio-gray-20);
 		box-shadow:
-			0 4px 6px rgba(var(--studio-gray-100-rgb), 0.1),
-			0 1px 2px rgba(var(--studio-gray-100-rgb), 0.1);
+			0 4px 6px color-mix(in srgb, var(--studio-gray-100) 10%, transparent),
+			0 1px 2px color-mix(in srgb, var(--studio-gray-100) 10%, transparent);
 		list-style-type: none;
 
 		font-size: $font-body-small;

--- a/client/components/jetpack/sidebar/style.scss
+++ b/client/components/jetpack/sidebar/style.scss
@@ -74,7 +74,7 @@
 		}
 
 		&:active {
-			background-color: rgba ( var ( --color-sidebar-menu-selected-text-rgb ), 0.075);
+			background-color: color-mix(in srgb, var(--color-sidebar-menu-selected-text) 7.5%, transparent);
 
 			.sidebar__menu-icon {
 				fill: var(--color-sidebar-menu-selected-gridicon-fill);

--- a/client/components/logged-out-form/links.scss
+++ b/client/components/logged-out-form/links.scss
@@ -7,7 +7,7 @@
 		content: "";
 		display: block;
 		width: 80px;
-		background: rgba(var(--color-surface-rgb), 0.3);
+		background: color-mix(in srgb, var(--color-surface) 30%, transparent);
 		height: 2px;
 		margin: 0 auto 8px;
 	}

--- a/client/components/marked-lines/style.scss
+++ b/client/components/marked-lines/style.scss
@@ -9,7 +9,7 @@
 }
 
 .marked-lines__marked-line {
-	background-color: rgba(var(--color-error-rgb), 0.2);
+	background-color: color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .marked-lines__line-numbers {
@@ -24,7 +24,7 @@
 	color: var(--color-text-subtle);
 
 	&.marked-lines__marked-line {
-		background-color: rgba(var(--color-error-rgb), 0.15);
+		background-color: color-mix(in srgb, var(--color-error) 15%, transparent);
 	}
 }
 

--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -31,7 +31,7 @@
 			right: 0;
 			width: 50%;
 			height: 24px;
-			background: linear-gradient(to right, rgba(var(--studio-white-rgb), 0), var(--studio-white) 50%);
+			background: linear-gradient(to right, color-mix(in srgb, var(--studio-white) 0%, transparent), var(--studio-white) 50%);
 
 			@include breakpoint-deprecated( "<480px" ) {
 				height: 22px;

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -212,7 +212,7 @@
 
 	&.is-selected {
 		// Matches the feature highlight on the plans tables
-		background-color: rgba(var(--color-primary-rgb), 0.1);
+		background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
 		border-color: var(--color-primary);
 	}
 

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -1,6 +1,6 @@
 .purchase-detail {
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 	box-sizing: border-box;
 	color: var(--color-text-subtle);

--- a/client/components/readme-viewer/style.scss
+++ b/client/components/readme-viewer/style.scss
@@ -17,7 +17,7 @@
 
 		th,
 		td {
-			border-bottom: 1px solid rgba(var(--color-neutral-10-rgb), 0.5);
+			border-bottom: 1px solid color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 			text-align: left;
 		}
 

--- a/client/components/scrollable-horizontal-navigation/styles.scss
+++ b/client/components/scrollable-horizontal-navigation/styles.scss
@@ -42,12 +42,12 @@
 	.scrollable-horizontal-navigation__right-button-wrapper {
 		right: 0;
 		padding-left: 30px;
-		background: linear-gradient(270deg, rgba(var(--color-surface-rgb), 1) 30%, rgba(var(--color-surface-rgb), 0.7) 40%, rgba(var(--color-surface-rgb), 0) 100%);
+		background: linear-gradient(270deg, color-mix(in srgb, var(--color-surface) 100%, transparent) 30%, color-mix(in srgb, var(--color-surface) 70%, transparent) 40%, color-mix(in srgb, var(--color-surface) 0%, transparent) 100%);
 	}
 	.scrollable-horizontal-navigation__left-button-wrapper {
 		left: 0;
 		padding-right: 30px;
-		background: linear-gradient(90deg, rgba(var(--color-surface-rgb), 1) 30%, rgba(var(--color-surface-rgb), 0.7) 40%, rgba(var(--color-surface-rgb), 0) 100%);
+		background: linear-gradient(90deg, color-mix(in srgb, var(--color-surface) 100%, transparent) 30%, color-mix(in srgb, var(--color-surface) 70%, transparent) 40%, color-mix(in srgb, var(--color-surface) 0%, transparent) 100%);
 	}
 
 	.scrollable-horizontal-navigation__tabs {

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -9,7 +9,7 @@
 	background: var(--color-surface);
 	box-sizing: border-box;
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 
 	&.is-empty .section-nav__panel {

--- a/client/components/site-icon-with-picker/style.scss
+++ b/client/components/site-icon-with-picker/style.scss
@@ -231,7 +231,7 @@ button.components-button.site-icon-with-picker__upload-button {
 		top: 0;
 		left: 50%;
 		transform: translateX(-50%);
-		background-color: rgba(var(--color-primary-rgb));
+		background-color: var(--color-primary);
 		border: 1px solid var(--studio-gray-10);
 		border-radius: $icon-border-radius;
 		transition: ease 1s;

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -143,7 +143,7 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	color: rgba(var(--color-surface-rgb), 0.4);
+	color: color-mix(in srgb, var(--color-surface) 40%, transparent);
 
 	.gridicon {
 		position: absolute;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -160,7 +160,7 @@ $theme-info-height: 54px;
 		font-weight: 600;
 
 		.is-active & {
-			color: rgba(var(--color-surface-rgb), 0.2);
+			color: color-mix(in srgb, var(--color-surface) 20%, transparent);
 		}
 
 		.accessible-focus &:focus {
@@ -174,11 +174,11 @@ $theme-info-height: 54px;
 	}
 
 	&.is-active {
-		border-left-color: rgba(var(--color-neutral-0-rgb), 0.7);
+		border-left-color: color-mix(in srgb, var(--color-neutral-0) 70%, transparent);
 	}
 
 	&:hover {
-		background-color: rgba(var(--color-neutral-0-rgb), 0.7);
+		background-color: color-mix(in srgb, var(--color-neutral-0) 70%, transparent);
 
 		.gridicon {
 			color: var(--color-primary);

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -123,7 +123,7 @@
 @include breakpoint-deprecated( ">480px" ) {
 	.tile-grid__item-copy {
 		padding: 15px;
-		border-top: 1px solid rgba(var(--color-neutral-10-rgb), 0.5);
+		border-top: 1px solid color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -37,13 +37,13 @@
 	right: 0;
 	bottom: 0;
 	display: block;
-	background: rgba(var(--color-neutral-0-rgb), 0.8);
+	background: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
 }
 
 .web-preview__content {
 	display: flex;
 	flex-direction: column;
-	box-shadow: 0 0 0 1px rgba(var(--color-neutral-light-rgb), 0.5);
+	box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-neutral-light) 50%, transparent);
 	background: var(--color-neutral-0);
 	border-radius: 2px 2px 0 0;
 	position: absolute;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -38,7 +38,7 @@ $devdocs-max-width: 720px;
 		margin-top: 4px;
 
 		mark {
-			background: rgba(var(--color-primary-light-rgb), 0.4);
+			background: color-mix(in srgb, var(--color-primary-light) 40%, transparent);
 			padding: 2px;
 			border-radius: 2px;
 		}
@@ -94,7 +94,7 @@ $devdocs-max-width: 720px;
 	padding: 3px 6px;
 	margin: 0 6px 4px 0;
 	font-family: $code;
-	box-shadow: 0 1px 2px rgba(var(--color-neutral-70-rgb), 0.05);
+	box-shadow: 0 1px 2px color-mix(in srgb, var(--color-neutral-70) 5%, transparent);
 }
 
 .design__illustrations-illustrations {
@@ -119,7 +119,7 @@ $devdocs-max-width: 720px;
 	box-sizing: border-box;
 	background: var(--color-surface);
 	box-shadow: 0 1px 2px var(--color-neutral-0);
-	border: 1px solid rgba(var(--color-neutral-10-rgb), 0.65);
+	border: 1px solid color-mix(in srgb, var(--color-neutral-10) 65%, transparent);
 	margin: 0 auto 24px;
 	position: relative;
 
@@ -127,7 +127,7 @@ $devdocs-max-width: 720px;
 		font-family: $code;
 		font-size: $font-title-small;
 		letter-spacing: 1px;
-		border-bottom: 1px solid rgba(var(--color-neutral-10-rgb), 0.65);
+		border-bottom: 1px solid color-mix(in srgb, var(--color-neutral-10) 65%, transparent);
 
 		a,
 		a:visited {
@@ -429,7 +429,7 @@ $devdocs-max-width: 720px;
 	}
 
 	pre > code {
-		background-color: rgba(var(--color-surface-rgb), 0);
+		background-color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 		padding: 2px 0;
 	}
 

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -142,15 +142,14 @@ $devdocs-max-width: 720px;
 	.docs-example__wrapper-content {
 		background: var(--color-surface-backdrop);
 		padding: 16px;
-		--docs-example-grid: var(--color-neutral-70-rgb);
-		box-shadow: inset 0 2px 1px rgba(var(--docs-example-grid), 0.075);
+		box-shadow: inset 0 2px 1px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
 
 		// Grid background
 		background-image:
-			linear-gradient(rgba(var(--docs-example-grid), 0.05) 1px, transparent 1px),
-			linear-gradient(90deg, rgba(var(--docs-example-grid), 0.05) 1px, transparent 1px),
-			linear-gradient(rgba(var(--docs-example-grid), 0.025) 1px, transparent 1px),
-			linear-gradient(90deg, rgba(var(--docs-example-grid), 0.025) 1px, transparent 1px);
+			linear-gradient(color-mix(in srgb, var(--color-neutral-70) 5%, transparent) 1px, transparent 1px),
+			linear-gradient(90deg, color-mix(in srgb, var(--color-neutral-70) 5%, transparent) 1px, transparent 1px),
+			linear-gradient(color-mix(in srgb, var(--color-neutral-70) 2.5%, transparent) 1px, transparent 1px),
+			linear-gradient(90deg, color-mix(in srgb, var(--color-neutral-70) 2.5%, transparent) 1px, transparent 1px);
 		background-size: 32px 32px, 32px 32px, 8px 8px, 8px 8px;
 		background-position: -1px -1px, -1px -1px, -1px -1px, -1px -1px;
 

--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -50,8 +50,8 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 	border: 1px solid var(--studio-gray-0);
 	border-radius: 2px;
 	box-shadow:
-		0 4px 6px rgba(var(--studio-gray-100-rgb), 0.1),
-		0 1px 2px rgba(var(--studio-gray-100-rgb), 0.1);
+		0 4px 6px color-mix(in srgb, var(--studio-gray-100) 10%, transparent),
+		0 1px 2px color-mix(in srgb, var(--studio-gray-100) 10%, transparent);
 	list-style-type: none;
 
 	font-size: $font-body-small;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -337,7 +337,7 @@ $colophon-height: 50px;
 	margin: 0;
 	line-height: 0;
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 }
 
@@ -1413,7 +1413,7 @@ $colophon-height: 50px;
 	.jetpack-connect__authorize-form {
 		.jetpack-connect__site.card {
 			.site-icon {
-				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.15);
+				background-color: color-mix(in srgb, var(--wp-admin-theme-color) 15%, transparent);
 
 				svg {
 					fill: var(--wp-admin-theme-color);

--- a/client/landing/subscriptions/components/settings/site-settings/styles.scss
+++ b/client/landing/subscriptions/components/settings/site-settings/styles.scss
@@ -33,7 +33,7 @@
 		&:hover,
 		&:focus {
 			color: var(--color-primary);
-			background: rgba(var(--color-primary-light-rgb), 1);
+			background: color-mix(in srgb, var(--color-primary-light) 100%, transparent);
 
 			.reader-export-button__label {
 				color: var(--color-text-inverted);

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -6,7 +6,7 @@
 	background: var(--color-neutral-90);
 	box-shadow:
 		0 0 0 1px rgbs(255, 255, 255, 0.6),
-		0 2px 24px 0 rgba(var(--color-neutral-80-rgb), 0.5);
+		0 2px 24px 0 color-mix(in srgb, var(--color-neutral-80) 50%, transparent);
 	border-radius: 2px;
 	padding-top: 19px;
 	margin-left: 5px;
@@ -133,7 +133,7 @@
 	a.button {
 		color: var(--color-neutral-10);
 		background: none;
-		border: 1px rgba(var(--color-surface-rgb), 0.2) solid;
+		border: 1px color-mix(in srgb, var(--color-surface) 20%, transparent) solid;
 	}
 
 	a.button {
@@ -142,7 +142,7 @@
 
 		&:hover,
 		&:focus {
-			border-color: rgba(var(--color-surface-rgb), 0.3);
+			border-color: color-mix(in srgb, var(--color-surface) 30%, transparent);
 		}
 
 		.gridicon {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -98,11 +98,11 @@
 	}
 
 	.progress-bar {
-		background-color: rgba(var(--color-sidebar-text-rgb), 0.4);
+		background-color: color-mix(in srgb, var(--color-sidebar-text) 40%, transparent);
 		height: 6px;
 
 		.selected & {
-			background-color: rgba(var(--color-sidebar-menu-selected-text-rgb), 0.4);
+			background-color: color-mix(in srgb, var(--color-sidebar-menu-selected-text) 40%, transparent);
 		}
 
 		.progress-bar__progress {
@@ -134,7 +134,7 @@
 
 	// I think this is some voodoo to change the color
 	// of a link when tapped on iOS.
-	-webkit-tap-highlight-color: rgba(var(--color-neutral-700-rgb), 0.2);
+	-webkit-tap-highlight-color: color-mix(in srgb, var(--color-neutral-700) 20%, transparent);
 
 	&:hover {
 		background-color: var(--color-sidebar-menu-hover-background);

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -191,7 +191,7 @@ $image-height: 47px;
 	}
 
 	.wp-login__site-return-link::after {
-		background: linear-gradient(to right, rgba(var(--color-surface-backdrop-rgb), 0), var(--color-surface-backdrop) 90%);
+		background: linear-gradient(to right, color-mix(in srgb, var(--color-surface-backdrop) 0%, transparent), var(--color-surface-backdrop) 90%);
 	}
 }
 

--- a/client/my-sites/activity/activity-log-tasklist/style.scss
+++ b/client/my-sites/activity/activity-log-tasklist/style.scss
@@ -21,7 +21,7 @@
 
 .card.activity-log-tasklist__task {
 	align-items: center;
-	box-shadow: 0 -1px 0 rgba(var(--color-neutral-10-rgb), 0.5);
+	box-shadow: 0 -1px 0 color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 	display: flex;
 	justify-content: flex-end;
 	padding: 16px 0;
@@ -79,7 +79,7 @@
 .activity-log-tasklist__footer {
 	display: flex;
 	justify-content: space-between;
-	box-shadow: 0 -1px 0 rgba(var(--color-neutral-10-rgb), 0.5);
+	box-shadow: 0 -1px 0 color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 	padding: 16px 0;
 	color: var(--color-text-subtle);
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -296,7 +296,7 @@
 				color: var(--color-text);
 				background-color: var(--color-surface);
 				box-shadow:
-					0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+					0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 					0 1px 2px var(--color-neutral-0);
 			}
 		}
@@ -305,7 +305,7 @@
 	.thank-you-card__header {
 		color: var(--color-text);
 		background-color: var(--color-surface);
-		box-shadow: 0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5);
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 	}
 
 	.thank-you-card__description {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -9,7 +9,7 @@
 	// Nested comment at max depth
 	&.is-at-max-depth {
 		margin-bottom: 0;
-		box-shadow: 0 -1px rgba(var(--color-neutral-10-rgb), 0.5);
+		box-shadow: 0 -1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 	}
 
 	.accessible-focus &:focus {
@@ -21,7 +21,7 @@
 		background: var(--color-surface);
 		box-shadow:
 			inset 4px 0 0 0 var(--color-warning),
-			0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+			0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 			0 1px 2px var(--color-neutral-0);
 	}
 
@@ -279,7 +279,7 @@
 	position: relative;
 
 	&::after {
-		background: linear-gradient(to right, rgba(var(--color-surface-rgb), 0), rgba(var(--color-surface-rgb), 1) 50%);
+		background: linear-gradient(to right, color-mix(in srgb, var(--color-surface) 0%, transparent), color-mix(in srgb, var(--color-surface) 100%, transparent) 50%);
 		content: "";
 		height: 20px;
 		position: absolute;
@@ -289,7 +289,7 @@
 	}
 }
 .comment.is-pending .comment__content-preview::after {
-	background: linear-gradient(to right, rgba(var(--color-warning-0-rgb), 0), rgba(var(--color-warning-0-rgb), 1) 50%);
+	background: linear-gradient(to right, color-mix(in srgb, var(--color-warning-0) 0%, transparent), color-mix(in srgb, var(--color-warning-0) 100%, transparent) 50%);
 }
 
 @supports ( -webkit-line-clamp: 2 ) {

--- a/client/my-sites/media-library/list-item-video.scss
+++ b/client/my-sites/media-library/list-item-video.scss
@@ -15,7 +15,7 @@
 	left: 0;
 	right: 0;
 	content: "";
-	background: rgba(var(--color-netural-30-rgb), 0.25);
+	background: color-mix(in srgb, var(--color-netural-30) 25%, transparent);
 }
 
 .media-library__list-item-video .media-library__list-item-icon {

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -15,7 +15,7 @@
 		height: 28px;
 		padding: 0;
 		transition: color 90ms ease;
-		box-shadow: 0 0 8px rgba(var(--color-neutral-70-rgb), 0.4);
+		box-shadow: 0 0 8px color-mix(in srgb, var(--color-neutral-70) 40%, transparent);
 		background: var(--color-accent);
 		border-radius: 50%;
 		font-size: $font-body-small;
@@ -81,7 +81,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba(var(--color-surface-rgb), 0.75);
+	background-color: color-mix(in srgb, var(--color-surface) 75%, transparent);
 	border-radius: 0;
 	z-index: z-index(".media-library__list-item", ".media-library__list-item.is-transient .media-library__list-item-figure::after");
 }

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -90,7 +90,7 @@
 		display: none;
 		margin-bottom: 9px;
 		box-shadow:
-			0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+			0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 			0 1px 2px var(--color-neutral-0);
 		background-color: var(--color-surface);
 		padding-left: 24px;
@@ -122,7 +122,7 @@
 
 	.media-library__datasource {
 		box-shadow:
-			0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+			0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 			0 1px 2px var(--color-neutral-0);
 		background-color: var(--color-surface);
 		box-sizing: border-box;

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -23,6 +23,6 @@
 	background-color: var(--color-surface);
 	box-sizing: border-box;
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 }

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -14,7 +14,7 @@
 .pages__page-list-header {
 	background: var(--color-neutral-0);
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 	color: var(--color-neutral-light);
 	font-size: $font-body-extra-small;
@@ -83,7 +83,7 @@
 	left: 0;
 	height: 100%;
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 
 	&.is-indented {
@@ -182,7 +182,7 @@
 	top: 0;
 	bottom: 0;
 	z-index: z-index("root", ".page__shadow-notice-cover");
-	background-color: rgba(var(--color-neutral-0-rgb), 0.8);
+	background-color: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
 	display: flex;
 	align-items: center;
 	overflow: hidden;

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -3,7 +3,7 @@
 }
 
 .current-plan__dialog.dialog__backdrop {
-	background-color: rgba(var(--color-neutral-dark-rgb), 0.85);
+	background-color: color-mix(in srgb, var(--color-neutral-dark) 85%, transparent);
 	box-shadow: none;
 	margin: 0;
 
@@ -23,7 +23,7 @@
 	padding: 14px 32px;
 	background-color: var(--color-surface);
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 
 	&-main {

--- a/client/my-sites/plans/doughnut-chart/style.scss
+++ b/client/my-sites/plans/doughnut-chart/style.scss
@@ -8,10 +8,10 @@
 	}
 	--width: 80px;
 	--line-width: 9px;
-	--main-color: var(--color-accent-rgb);
+	--main-color: var(--color-accent);
 
 	&.blue {
-		--main-color: var(--studio-blue-60-rgb);
+		--main-color: var(--studio-blue-60);
 	}
 
 	background-color: var(--color-surface);
@@ -24,7 +24,7 @@
 	font-size: $font-title-medium;
 	border-radius: 50%;
 	box-shadow:
-		inset 0 0 0 var(--line-width) rgba(var(--main-color), 0.1),
+		inset 0 0 0 var(--line-width) color-mix(in srgb, var(--main-color) 10%, transparent),
 		inset 0 0 0 10px var(--color-surface);
 
 	&::before,
@@ -37,15 +37,15 @@
 	&::before {
 		inset: 0;
 		background:
-			radial-gradient(farthest-side, rgb(var(--main-color)) 98%, transparent) top/var(--line-width) var(--line-width) no-repeat,
-			conic-gradient(rgb(var(--main-color)) calc(var(--percentage) * 1%), transparent 0);
+			radial-gradient(farthest-side, var(--main-color) 98%, transparent) top/var(--line-width) var(--line-width) no-repeat,
+			conic-gradient(var(--main-color) calc(var(--percentage) * 1%), transparent 0);
 		-webkit-mask: radial-gradient(farthest-side, transparent calc(99% - var(--line-width)), var(--studio-black) calc(100% - var(--line-width)));
 		mask: radial-gradient(farthest-side, transparent calc(99% - var(--line-width)), var(--studio-black) calc(100% - var(--line-width)));
 	}
 
 	&::after {
 		inset: calc(50% - var(--line-width) / 2);
-		background: rgb(var(--main-color));
+		background: var(--main-color);
 		transform: rotate(calc(var(--percentage) * 3.6deg)) translateY(calc(50% - var(--width) / 2));
 
 		.rtl & {

--- a/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
+++ b/client/my-sites/plans/jetpack-plans/more-info-box/style.scss
@@ -23,7 +23,7 @@
 
 .is-section-jetpack-cloud-pricing {
 	.more-info-box__more-container {
-		background-color: rgba(var(--studio-jetpack-green-10-rgb), 0.1);
+		background-color: color-mix(in srgb, var(--studio-jetpack-green-10) 10%, transparent);
 	}
 
 	.more-info-box__more-button.button {

--- a/client/my-sites/plans/trials/trial-banner/style.scss
+++ b/client/my-sites/plans/trials/trial-banner/style.scss
@@ -3,7 +3,7 @@
 .trial-banner {
 	display: flex;
 	padding: 40px;
-	background-color: rgba(var(--color-neutral-0-rgb), 0.8);
+	background-color: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
 	box-shadow: none;
 
 	@media (max-width: $break-mobile) {

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -52,7 +52,7 @@ body.is-section-plans.is-woo-express-plan {
 		}
 
 		&.woo-express-plans-page__price-card-for-grid {
-			background-color: rgba(var(--color-neutral-0-rgb), 0.8);
+			background-color: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
 			box-shadow: none;
 
 			.woo-express-plans-page__price-card-text .woo-express-plans-page__price-card-label {
@@ -147,7 +147,7 @@ body.is-section-plans.is-woo-express-plan {
 		display: none;
 
 		padding: 40px;
-		background-color: rgba(var(--color-neutral-0-rgb), 0.8);
+		background-color: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
 		box-shadow: none;
 		margin: 60px 0;
 

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -5,7 +5,7 @@
 }
 
 .plugin-details-cta__modal-overlay.dialog__backdrop {
-	background-color: rgba(var(--color-neutral-100-rgb), 0.7);
+	background-color: color-mix(in srgb, var(--color-neutral-100) 70%, transparent);
 }
 
 .plugin-details-cta__dialog-content {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -204,7 +204,7 @@ body.is-section-plugins.theme-default.color-scheme {
 }
 
 .plugins__main-header .section-nav {
-	border: 1px solid rgba(var(--color-neutral-10-rgb), 0.5);
+	border: 1px solid color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 	box-shadow: none;
 	flex: auto;
 	margin: 0;

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -72,7 +72,7 @@
 
 	.progress-bar__progress {
 		background-color: var(--color-primary);
-		box-shadow: 0 2px 6px rgba(var(--color-primary-rgb), 0.25);
+		box-shadow: 0 2px 6px color-mix(in srgb, var(--color-primary) 25%, transparent);
 	}
 }
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -20,7 +20,7 @@ $brand-text: "SF Pro Text", $sans;
 		// Resetting these colors to prevent bleeding from dashboard color schemes
 		--color-sidebar-text: var(--studio-gray-80);
 		--color-sidebar-text-alternative: var(--studio-gray-40);
-		--color-sidebar-text-alternative-selected: rgba(var(--studio-white-rgb), 0.7);
+		--color-sidebar-text-alternative-selected: color-mix(in srgb, var(--studio-white) 70%, transparent);
 		--color-sidebar-menu-selected-background: #e3e8fc;
 		--color-sidebar-menu-selected-text: var(--color-accent);
 		--color-sidebar-menu-hover-text: var(--studio-gray-80);

--- a/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
@@ -15,13 +15,13 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-		background-color: rgba(var(--color-surface-rgb), 0.75);
+		background-color: color-mix(in srgb, var(--color-surface) 75%, transparent);
 	}
 }
 
 .podcast-cover-image-setting__img {
 	align-self: center;
-	background: rgba(var(--color-surface-rgb), 0);
+	background: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	position: relative;
 	max-height: 100%;
 	max-width: 100%;

--- a/client/my-sites/stats/features/modules/shared/stats-card-skeleton.scss
+++ b/client/my-sites/stats/features/modules/shared/stats-card-skeleton.scss
@@ -9,7 +9,7 @@
 	// use separate animation to match the cycle actoss card
 	.stats-card-skeleton__placeholder {
 		animation: stats-skeleton-card 2.5s ease-in-out infinite;
-		background-color: rgba(var(--color-neutral-5-rgb), 0.8);
+		background-color: color-mix(in srgb, var(--color-neutral-5) 80%, var(--color-neutral-0));
 		border-radius: 4px;
 	}
 
@@ -63,7 +63,10 @@
 }
 
 @keyframes stats-skeleton-card {
-	50% {
-		background-color: var(--color-neutral-0);
-	}
+    0%, 100% {
+        background-color: color-mix(in srgb, var(--color-neutral-5) 80%, var(--color-neutral-0));
+    }
+    50% {
+        background-color: var(--color-neutral-0);
+    }
 }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -33,7 +33,7 @@
 		}
 	}
 
-	border-top: 1px solid rgba(var(--color-surface-rgb), 0);
+	border-top: 1px solid color-mix(in srgb, var(--color-surface) 0%, transparent);
 
 	// Increase touch targets on mobile
 	@include breakpoint-deprecated( "<480px" ) {
@@ -41,7 +41,7 @@
 		border-top: 1px solid var(--color-neutral-0);
 
 		&:first-child {
-			border-top-color: rgba(var(--color-surface-rgb), 0);
+			border-top-color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 		}
 
 		// Darken color for sublists
@@ -125,7 +125,7 @@
 		}
 
 		.module-content-list-item-right::before {
-			background-image: linear-gradient(to right, rgba(var(--color-neutral-0-rgb), 0) 0%, var(--color-neutral-0) 90%);
+			background-image: linear-gradient(to right, color-mix(in srgb, var(--color-neutral-0) 0%, transparent) 0%, var(--color-neutral-0) 90%);
 		}
 
 		// Display hidden actions
@@ -159,7 +159,7 @@
 	}
 
 	.module-content-list-item-right::before {
-		background-image: linear-gradient(to right, rgba(var(--color-neutral-0-rgb), 0) 0%, var(--color-neutral-0) 90%);
+		background-image: linear-gradient(to right, color-mix(in srgb, var(--color-neutral-0) 0%, transparent) 0%, var(--color-neutral-0) 90%);
 	}
 
 	// Display hidden actions
@@ -321,7 +321,7 @@
 
 	// Fade out value if long
 	&::before {
-		@include stats-fade-text( rgba( var( --color-surface-rgb ), 0 ), var( --color-surface ) );
+		@include stats-fade-text( color-mix(in srgb, var(--color-surface) 0%, transparent), var( --color-surface ) );
 	}
 }
 
@@ -791,7 +791,7 @@ ul.module-content-list-legend {
 	}
 
 	> .stats-list__module-content-list-item-wrapper .module-content-list-item-right::before {
-		background-image: linear-gradient(to right, rgba(var(--color-neutral-0-rgb), 0) 0%, var(--color-neutral-0) 90%);
+		background-image: linear-gradient(to right, color-mix(in srgb, var(--color-neutral-0) 0%, transparent) 0%, var(--color-neutral-0) 90%);
 	}
 
 	// Rotate toggle icon
@@ -806,7 +806,7 @@ ul.module-content-list-legend {
 
 	// Hide the top border of an active sub-list
 	> .module-content-list-item {
-		border-top-color: rgba(var(--color-surface-rgb), 0);
+		border-top-color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	}
 
 	// Hover changes
@@ -819,7 +819,7 @@ ul.module-content-list-legend {
 			}
 
 			span.module-content-list-item-right::before {
-				background-image: linear-gradient(to right, rgba(var(--color-surface-rgb), 0) 0%, var(--color-surface) 90%);
+				background-image: linear-gradient(to right, color-mix(in srgb, var(--color-surface) 0%, transparent) 0%, var(--color-surface) 90%);
 			}
 		}
 	}
@@ -846,7 +846,7 @@ ul.module-content-list-legend {
 	}
 
 	.module-content-list-item-right::before {
-		background-image: linear-gradient(to right, rgba(var(--color-neutral-rgb), 0) 0%, var(--color-neutral-0) 90%);
+		background-image: linear-gradient(to right, color-mix(in srgb, var(--color-neutral) 0%, transparent) 0%, var(--color-neutral-0) 90%);
 	}
 
 	// Hover changes
@@ -860,7 +860,7 @@ ul.module-content-list-legend {
 			}
 
 			span.module-content-list-item-right::before {
-				background-image: linear-gradient(to right, rgba(var(--color-surface-rgb), 0) 0%, var(--color-surface) 90%);
+				background-image: linear-gradient(to right, color-mix(in srgb, var(--color-surface) 0%, transparent) 0%, var(--color-surface) 90%);
 			}
 		}
 	}

--- a/client/my-sites/stats/stats-module/placeholder.scss
+++ b/client/my-sites/stats/stats-module/placeholder.scss
@@ -50,7 +50,7 @@
 	.module-header-title,
 	ul.module-content-tabs li:hover .label,
 	ul.module-content-tabs li.module-tab.is-selected:hover .label {
-		color: rgba(var(--color-surface-rgb), 0);
+		color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	}
 }
 

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -168,7 +168,7 @@ ul.module-header-actions {
 
 	// Fade really long module titles
 	&::before {
-		@include stats-fade-text( rgba( var( --color-surface-rgb ), 0 ), var( --color-surface ) );
+		@include stats-fade-text( color-mix(in srgb, var(--color-surface) 0%, transparent), var( --color-surface ) );
 	}
 
 	.module-header-action {

--- a/client/my-sites/stats/stats-plan-usage/style.scss
+++ b/client/my-sites/stats/stats-plan-usage/style.scss
@@ -39,7 +39,7 @@
 
 	&.is-over-limit {
 		.plan-usage-progress-bar {
-			background-color: rgba(var(--studio-red-40-rgb), 0.15);
+			background-color: color-mix(in srgb, var(--studio-red-40) 15%, transparent);
 		}
 	}
 
@@ -47,7 +47,7 @@
 		position: absolute;
 		left: 0;
 		height: 100%;
-		background-color: rgba(var(--studio-jetpack-green-40-rgb), 0.15);
+		background-color: color-mix(in srgb, var(--studio-jetpack-green-40) 15%, transparent);
 		border-radius: 2px;
 	}
 }

--- a/client/my-sites/stats/stats-post-summary/style.scss
+++ b/client/my-sites/stats/stats-post-summary/style.scss
@@ -2,9 +2,9 @@
 	margin-bottom: 0;
 	padding: 16px 0;
 	box-shadow:
-		0 -1px 0 0 rgba(var(--color-neutral-10-rgb), 0.5),
-		-1px -1px 0 0 rgba(var(--color-neutral-10-rgb), 0.5),
-		1px -1px 0 0 rgba(var(--color-neutral-10-rgb), 0.5);
+		0 -1px 0 0 color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
+		-1px -1px 0 0 color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
+		1px -1px 0 0 color-mix(in srgb, var(--color-neutral-10) 50%, transparent);
 	z-index: z-index(".stats-post-summary", ".section-nav");
 	.segmented-control {
 		margin: 0 auto;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -139,7 +139,7 @@ $button-padding: 8px 32px;
 		// On holding thumb styling
 		.jp-components-pricing-slider--is-holding {
 			.jp-components-pricing-slider__thumb {
-				box-shadow: 0 6px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04), 0 0 0 3px rgba(var(--color-primary-rgb), 0.25);
+				box-shadow: 0 6px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04), 0 0 0 3px color-mix(in srgb, var(--color-primary) 25%, transparent);
 			}
 		}
 	}

--- a/client/my-sites/stats/stats-site-overview/style.scss
+++ b/client/my-sites/stats/stats-site-overview/style.scss
@@ -27,7 +27,7 @@
 
 		// Fade out value if text is very long
 		&::before {
-			@include stats-fade-text( rgba( var( --color-surface-rgb ), 0 ), var( --color-surface ) );
+			@include stats-fade-text( color-mix(in srgb, var(--color-surface) 0%, transparent), var( --color-surface ) );
 		}
 
 		.gridicon {

--- a/client/my-sites/store/components/table/style.scss
+++ b/client/my-sites/store/components/table/style.scss
@@ -79,7 +79,7 @@
 			overflow: hidden;
 
 			&::after {
-				background-image: linear-gradient(to right, rgba(var(--color-surface-rgb), 0) 0%, var(--color-surface) 90%);
+				background-image: linear-gradient(to right, color-mix(in srgb, var(--color-surface) 0%, transparent) 0%, var(--color-surface) 90%);
 				position: absolute;
 				z-index: 1;
 				right: 0;
@@ -104,7 +104,7 @@
 				position: absolute;
 				right: -12px;
 				top: 0;
-				background: radial-gradient(ellipse at center, rgba(var(--color-neutral-70-rgb), 0.125) 0%, rgba(var(--color-surface-rgb), 0) 75%, rgba(var(--color-surface-rgb), 0) 90%);
+				background: radial-gradient(ellipse at center, color-mix(in srgb, var(--color-neutral-70) 12.5%, transparent) 0%, color-mix(in srgb, var(--color-surface) 0%, transparent) 75%, color-mix(in srgb, var(--color-surface) 0%, transparent) 90%);
 			}
 
 			@include breakpoint-deprecated( ">660px" ) {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -442,7 +442,7 @@ $button-border: 4px;
 			bottom: 0;
 			width: 100%;
 			height: 30%;
-			background: linear-gradient(to bottom, transparent 0, rgba(var(--color-neutral-0-rgb), 0.5) 40%, var(--color-neutral-0) 93%);
+			background: linear-gradient(to bottom, transparent 0, color-mix(in srgb, var(--color-neutral-0) 50%, transparent) 40%, var(--color-neutral-0) 93%);
 		}
 	}
 
@@ -460,7 +460,7 @@ $button-border: 4px;
 			cursor: pointer;
 			box-shadow:
 				0 0 0 1px var(--color-neutral-light),
-				0 2px 10px 0 rgba(var(--color-neutral-dark-rgb), 0.5);
+				0 2px 10px 0 color-mix(in srgb, var(--color-neutral-dark) 50%, transparent);
 		}
 	}
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -198,7 +198,7 @@
 		}
 
 		.keyed-suggestions__value.is-selected {
-			background-color: rgba(var(--studio-blue-rgb), 0.1);
+			background-color: color-mix(in srgb, var(--studio-blue) 10%, transparent);
 		}
 	}
 
@@ -219,7 +219,7 @@
 			color: var(--studio-blue-90);
 
 			&:hover::before {
-				background-color: rgba(var(--studio-blue-rgb), 0.1);
+				background-color: color-mix(in srgb, var(--studio-blue) 10%, transparent);
 			}
 		}
 
@@ -298,7 +298,7 @@
 
 			.select-dropdown__item:not(.is-selected):hover {
 				color: var(--studio-blue-90);
-				background-color: rgba(var(--studio-blue-rgb), 0.1);
+				background-color: color-mix(in srgb, var(--studio-blue) 10%, transparent);
 			}
 		}
 	}

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -215,7 +215,7 @@ div.reader-notifications__panel {
 			background-color: unset;
 
 			.wpnc__note-list:not(.is-note-open) {
-				box-shadow: 3px 1px 10px -2px rgba(var(--color-neutral-70-rgb), 0.075);
+				box-shadow: 3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
 			}
 
 			.wpnc__single-view {

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -18,7 +18,7 @@
 	position: relative;
 	border-bottom: 1px solid var(--color-neutral-10);
 	background-color: var(--color-neutral-0);
-	box-shadow: inset 0 0 2px 2px rgba(var(--color-neutral-20-rgb), 0.1);
+	box-shadow: inset 0 0 2px 2px color-mix(in srgb, var(--color-neutral-20) 10%, transparent);
 
 	@include breakpoint-deprecated( ">660px" ) {
 		flex: 2 0 0%;
@@ -73,7 +73,7 @@
 	width: 46px;
 	height: 46px;
 	transform: translateY(-50%);
-	background-color: rgba(var(--color-neutral-70-rgb), 0.85);
+	background-color: color-mix(in srgb, var(--color-neutral-70) 85%, transparent);
 	border-radius: 24px; /* stylelint-disable-line scales/radii */
 	color: var(--color-text-inverted);
 	cursor: pointer;
@@ -83,7 +83,7 @@
 	}
 
 	&:hover {
-		background-color: rgba(var(--color-neutral-50-rgb), 0.9);
+		background-color: color-mix(in srgb, var(--color-neutral-50) 90%, transparent);
 	}
 }
 

--- a/client/reader/list-gap/style.scss
+++ b/client/reader/list-gap/style.scss
@@ -26,7 +26,7 @@
 	}
 
 	&::before {
-		background: linear-gradient(-135deg, var(--color-neutral-0) 8px, rgba(var(--color-neutral-0-rgb), 0) 0) 0 8px, linear-gradient(135deg, var(--color-neutral-0) 8px, rgba(var(--color-neutral-0-rgb), 0) 0) 0 8px;
+		background: linear-gradient(-135deg, var(--color-neutral-0) 8px, color-mix(in srgb, var(--color-neutral-0) 0%, transparent) 0) 0 8px, linear-gradient(135deg, var(--color-neutral-0) 8px, color-mix(in srgb, var(--color-neutral-0) 0%, transparent) 0) 0 8px;
 		background-position: top left;
 		background-repeat: repeat-x;
 		background-size: 16px 16px;
@@ -35,7 +35,7 @@
 	}
 
 	&::after {
-		background: linear-gradient(-135deg, var(--color-surface) 8px, rgba(var(--color-surface-rgb), 0) 0) 0 8px, linear-gradient(135deg, var(--color-surface) 8px, rgba(var(--color-surface-rgb), 0) 0) 0 8px;
+		background: linear-gradient(-135deg, var(--color-surface) 8px, color-mix(in srgb, var(--color-surface) 0%, transparent) 0) 0 8px, linear-gradient(135deg, var(--color-surface) 8px, color-mix(in srgb, var(--color-surface) 0%, transparent) 0) 0 8px;
 		background-position: top left;
 		background-repeat: repeat-x;
 		background-size: 16px 16px;
@@ -52,6 +52,6 @@
 	z-index: z-index("root", ".reader-list-gap__button");
 
 	&:hover {
-		color: rgba(var(--color-surface-rgb), 0.8);
+		color: color-mix(in srgb, var(--color-surface) 80%, transparent);
 	}
 }

--- a/client/reader/list-manage/style.scss
+++ b/client/reader/list-manage/style.scss
@@ -54,7 +54,7 @@
 }
 
 .list-item__img {
-	background: rgba(var(--color-surface-rgb), 0);
+	background: color-mix(in srgb, var(--color-surface) 0%, transparent);
 }
 
 .list-item__info {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -402,8 +402,8 @@ body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .bac
 	left: -16px;
 	margin-bottom: 16px;
 	border-bottom: 1px solid var( --color-neutral-10 );
-	box-shadow: inset 0 0 2px 2px rgba( var( --color-neutral-20-rgb ), 0.1 );
-	background: rgba( var( --color-neutral-0-rgb ), 0.3 );
+	box-shadow: inset 0 0 2px 2px color-mix(in srgb, var(--color-neutral-20) 10%, transparent);
+	background: color-mix(in srgb, var(--color-neutral-0) 30%, transparent);
 
 	@include breakpoint-deprecated( '>480px' ) {
 		left: -24px;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -228,7 +228,7 @@ body.is-section-reader {
 		font-weight: 600;
 		line-height: 1.6;
 		border-top: 1px solid var(--color-neutral-10);
-		background: linear-gradient(to bottom, rgba(var(--color-neutral-0-rgb), 1) 0%, rgba(var(--color-neutral-0-rgb), 0) 100%);
+		background: linear-gradient(to bottom, color-mix(in srgb, var(--color-neutral-0) 100%, transparent) 0%, color-mix(in srgb, var(--color-neutral-0) 0%, transparent) 100%);
 
 		.avatar {
 			display: none;

--- a/client/reader/update-notice/style.scss
+++ b/client/reader/update-notice/style.scss
@@ -4,7 +4,7 @@
 	position: fixed;
 	right: 16px;
 	top: calc(var(--masterbar-height) + 16px);
-	background: rgba(var(--color-accent-rgb), 0.96);
+	background: color-mix(in srgb, var(--color-accent) 96%, transparent);
 	padding: 8px 18px 8px 34px;
 	border-radius: 24px; /* stylelint-disable-line scales/radii */
 	color: var(--color-text-inverted);

--- a/client/signup/steps/clone-point/style.scss
+++ b/client/signup/steps/clone-point/style.scss
@@ -28,7 +28,7 @@
 		bottom: 0;
 		height: 16px;
 		z-index: -1;
-		background: linear-gradient(rgba(var(--color-neutral-0-rgb), 1), var(--color-neutral-0));
+		background: linear-gradient(color-mix(in srgb, var(--color-neutral-0) 100%, transparent), var(--color-neutral-0));
 	}
 }
 

--- a/client/sites/marketing/style.scss
+++ b/client/sites/marketing/style.scss
@@ -611,7 +611,7 @@
 	padding: 20px 24px;
 	background: var(--color-surface);
 	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
+		0 0 0 1px color-mix(in srgb, var(--color-neutral-10) 50%, transparent),
 		0 1px 2px var(--color-neutral-0);
 }
 
@@ -753,7 +753,7 @@
 	cursor: pointer;
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 2px;
-	box-shadow: 0 0 8px rgba(var(--color-neutral-70-rgb), 0.04);
+	box-shadow: 0 0 8px color-mix(in srgb, var(--color-neutral-70) 4%, transparent);
 	background-color: var(--color-surface);
 	color: var(--color-primary);
 
@@ -1035,7 +1035,7 @@
 	background: var(--color-surface);
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 2px;
-	box-shadow: 0 0 8px rgba(var(--color-neutral-70-rgb), 0.04);
+	box-shadow: 0 0 8px color-mix(in srgb, var(--color-neutral-70) 4%, transparent);
 
 	&::before {
 		content: "";

--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -3,7 +3,7 @@
 
 .dialog__backdrop,
 .dialog__backdrop.card {
-	background-color: rgba(var(--color-neutral-0-rgb), 0.8);
+	background-color: color-mix(in srgb, var(--color-neutral-0) 80%, transparent);
 	align-items: center;
 	bottom: 0;
 	left: 0;

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -41,7 +41,7 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 
 .highlight-cards a.highlight-cards-heading-wrapper {
 	color: var(--color-text);
-	text-decoration: underline solid rgba(var(--color-link-rgb), 0);
+	text-decoration: underline solid color-mix(in srgb, var(--color-link) 0%, transparent);
 	transition: color 100ms linear, text-decoration-color 100ms linear;
 	&:focus,
 	&:hover {

--- a/packages/components/src/horizontal-bar-list/style.scss
+++ b/packages/components/src/horizontal-bar-list/style.scss
@@ -83,7 +83,7 @@
 			height: 100%;
 			content: "";
 			border-radius: 2px;
-			background-color: rgba(var(--color-primary-rgb), 15%);
+			background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
 			position: absolute;
 			left: 0;
 			z-index: 0;

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -133,7 +133,7 @@ $theme-card-info-margin-top: 16px;
 
 .theme-card__loading {
 	bottom: $theme-card-info-height + $theme-card-info-margin-top;
-	background: rgba(var(--color-neutral-dark-rgb), 0.5);
+	background: color-mix(in srgb, var(--color-neutral-dark) 50%, transparent);
 	left: 0;
 	position: absolute;
 	top: 0;

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -456,7 +456,7 @@ main.domains-overview main.domains-overview__list .hosting-dashboard-layout-colu
 	}
 
 	.domains-table__row.is-selected > td {
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		background-color: color-mix(in srgb, var(--wp-admin-theme-color) 4%, transparent);
 		color: var(--theme-base-color);
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/101281

Relates to DOTCOM-457

## Proposed Changes

- Adds rgb-to-color-mix.js which:
  - Maps rgba() to color-mix(), e.g. `rgba(var(--color-primary-rgb), 0.04)` is replaced with `color-mix(in srgb, var(--color-primary) 4%, transparent)`.
  - Maps rgba() to var(), e.g. `rgba(var(--color-primary-rgb))` is replaced with `var(--color-primary)`.
- Manual updates to:
  - `client/my-sites/plans/doughnut-chart/style.scss`
  - `.docs-example__wrapper-content` in `client/devdocs/style.scss`
  - `client/my-sites/stats/features/modules/shared/stats-card-skeleton.scss` for handling fading animation

## Why are these changes being made?

* We'd like to remove the `*-rgb` color variants from the calypso color schemes package as these values are relatively rarely used and can be derived from other color values.
* See pbxlJb-6Yq-p2

## Testing Instructions

* Smoke test, should be no changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?