### PR TITLE
Odyssey Stats: Query site features for Simple site WPAdmin on all pages

### DIFF
--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import Main, { MainProps } from 'calypso/components/main';
 import useWPAdminTheme from 'calypso/my-sites/stats/hooks/use-wp-admin-theme';
 import StatsUpsellModal from 'calypso/my-sites/stats/stats-upsell-modal';
@@ -8,6 +10,7 @@ import { getUpsellModalView } from 'calypso/state/stats/paid-stats-upsell/select
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export default function StatsMain( { children, className, ...props }: MainProps ) {
+	const isWPAdminAndNotSimpleSite = config.isEnabled( 'is_running_in_jetpack_site' );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) as number;
 	const isSiteJetpack = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } )
@@ -19,6 +22,7 @@ export default function StatsMain( { children, className, ...props }: MainProps 
 
 	return (
 		<Main { ...props } className={ clsx( 'stats-main', 'color-scheme', customTheme, className ) }>
+			{ ! isWPAdminAndNotSimpleSite && <QuerySiteFeatures siteIds={ [ siteId ] } /> }
 			{ children }
 			{ upsellModalView && <StatsUpsellModal siteId={ siteId } /> }
 		</Main>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -17,7 +17,6 @@ import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
-import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import { useShortcuts } from 'calypso/components/date-range/use-shortcuts';
 import EmptyContent from 'calypso/components/empty-content';
@@ -855,9 +854,6 @@ const StatsSite = ( props ) => {
 
 	return (
 		<Main fullWidthLayout ariaLabel={ STATS_PRODUCT_NAME }>
-			{ config.isEnabled( 'stats/paid-wpcom-v2' ) && ! isOdysseyStats && (
-				<QuerySiteFeatures siteIds={ [ siteId ] } />
-			) }
 			{ /* Odyssey: Google Business Profile pages are currently unsupported. */ }
 			{ ! isOdysseyStats && (
 				<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/354

## Proposed Changes

* Fetch Simple site features for WP-Admin on all Stats pages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Site features for Simple site WP-Admin were only fetched on the Traffic page, which should be moved to a wrapper for all pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase the `Premium` plan for a Simple site.
* Change the `Admin Interface Style` to `Classic style` for accessing WP-Admin.
* Follow `Option 2` to sync changes for Odyssey Stats and sandbox `widgets.wp.com` : `PCYsg-Pp7-p2#option-2`.
* Ensure the UTM module is enabled on the Traffic page.
* Click on a post with a view count on the `Posts & pages` module.
* Ensure the UTM module is available on the Post details page.
* Reload the page.
* Ensure the UTM module is still available.

https://github.com/user-attachments/assets/1e9529b5-a30f-402e-8bf9-8e0bd95f6c87

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?