### PR TITLE
Cleanup and remove fixMe()

### DIFF
--- a/client/my-sites/importer/newsletter/content.tsx
+++ b/client/my-sites/importer/newsletter/content.tsx
@@ -4,7 +4,6 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import i18n from 'i18n-calypso';
 import { useEffect } from 'react';
 import exportSubstackDataImg from 'calypso/assets/images/importer/export-substack-content.png';
 import importerConfig from 'calypso/lib/importer/importer-config';
@@ -122,24 +121,20 @@ export default function Content( {
 					<hr />
 					<h2>{ __( 'Step 2: Import your content to WordPress.com' ) }</h2>
 					<p>
-						{ i18n.fixMe( {
-							text: 'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to Reading Settings, and change "Your homepage displays" to a static page.',
-							newCopy: createInterpolateElement(
-								__(
-									'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a static page.'
-								),
-								{
-									a: (
-										<a
-											href={ `${ selectedSite.URL }/wp-admin/options-reading.php` }
-											target="_blank"
-											rel="noreferrer noopener"
-										/>
-									),
-								}
+						{ createInterpolateElement(
+							__(
+								'Your posts may be added to your homepage by default. If you prefer your posts to load on a separate page, first go to <a>Reading Settings</a>, and change "Your homepage displays" to a static page.'
 							),
-							oldCopy: __( '' ),
-						} ) }
+							{
+								a: (
+									<a
+										href={ `${ selectedSite.URL }/wp-admin/options-reading.php` }
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+							}
+						) }
 					</p>
 				</>
 			) }

--- a/client/my-sites/importer/newsletter/select-newsletter-form.tsx
+++ b/client/my-sites/importer/newsletter/select-newsletter-form.tsx
@@ -61,15 +61,9 @@ export default function SelectNewsletterForm( {
 			) }
 			{ ! hasError && (
 				<p className="select-newsletter-form__help">
-					{ i18n.fixMe( {
-						text: "Enter your Substack URL. We'll create a link where you can download your newsletter content.",
-						newCopy: i18n.translate(
-							"Enter your Substack URL. We'll create a link where you can download your newsletter content."
-						),
-						oldCopy: i18n.translate(
-							'Enter the URL of the Substack newsletter that you wish to import.'
-						),
-					} ) }
+					{ i18n.translate(
+						"Enter your Substack URL. We'll create a link where you can download your newsletter content."
+					) }
 				</p>
 			) }
 		</Card>

--- a/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/step-initial.tsx
@@ -3,9 +3,8 @@ import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef } from 'react';
 import exportSubstackSubscribersImg from 'calypso/assets/images/importer/export-substack-subscribers.png';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -42,35 +41,24 @@ export default function StepInitial( {
 		<Card>
 			<h2>{ translate( 'Step 1: Export your subscribers from Substack' ) }</h2>
 			<p>
-				{ i18n.fixMe( {
-					text: 'Generate a CSV of your Substack subscribers. In Substack, go to Subscribers, click Export under "All subscribers," then upload the CSV in the next step. On the free plan, you can import up to 100 subscribers.',
-					newCopy: translate(
-						'Generate a CSV of your Substack subscribers. In Substack, go to {{strong}}Subscribers{{/strong}}, click {{strong}}Export{{/strong}} under "All subscribers," then upload the CSV in the next step. On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
-						{
-							components: {
-								strong: <strong />,
-								supportLink: (
-									<InlineSupportLink
-										noWrap={ false }
-										showIcon={ false }
-										supportLink={ localizeUrl(
-											'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
-										) }
-										supportPostId={ 220199 }
-									/>
-								),
-							},
-						}
-					),
-					oldCopy: createInterpolateElement(
-						translate(
-							'Generate a CSV file of all your Substack subscribers. On Substack, go to the <strong>Subscribers</strong> tab and click the <strong>Export</strong> button you’ll find on top of the table. Then, upload the downloaded CSV in the next step.'
-						),
-						{
+				{ translate(
+					'Generate a CSV of your Substack subscribers. In Substack, go to {{strong}}Subscribers{{/strong}}, click {{strong}}Export{{/strong}} under "All subscribers," then upload the CSV in the next step. On the free plan, {{supportLink}}you can import up to 100 subscribers.{{/supportLink}}',
+					{
+						components: {
 							strong: <strong />,
-						}
-					),
-				} ) }
+							supportLink: (
+								<InlineSupportLink
+									noWrap={ false }
+									showIcon={ false }
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/import-subscribers-to-a-newsletter/#troubleshooting-subscriber-imports'
+									) }
+									supportPostId={ 220199 }
+								/>
+							),
+						},
+					}
+				) }
 			</p>
 			<img
 				src={ exportSubstackSubscribersImg }

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-categories-section/newsletter-categories-toggle.tsx
@@ -1,5 +1,5 @@
 import { ToggleControl } from '@wordpress/components';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 
@@ -27,25 +27,14 @@ const NewsletterCategoriesToggle = ( {
 				label={ translate( 'Enable newsletter categories' ) }
 			/>
 			<FormSettingExplanation>
-				{ i18n.fixMe( {
-					text: "Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the subscribe block.",
-					newCopy: translate(
-						"Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the {{link}}subscribe block{{/link}}.",
-						{
-							components: {
-								link: <InlineSupportLink showIcon={ false } supportContext="subscribe-block" />,
-							},
-						}
-					),
-					oldCopy:
-						translate(
-							'Newsletter categories allow visitors to subscribe only to specific topics.'
-						) +
-						' ' +
-						translate(
-							'When enabled, only posts published under the categories selected below will be emailed to your subscribers.'
-						),
-				} ) }
+				{ translate(
+					"Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the {{link}}subscribe block{{/link}}.",
+					{
+						components: {
+							link: <InlineSupportLink showIcon={ false } supportContext="subscribe-block" />,
+						},
+					}
+				) }
 			</FormSettingExplanation>
 		</div>
 	);

--- a/packages/calypso-products/src/features-list.tsx
+++ b/packages/calypso-products/src/features-list.tsx
@@ -1655,30 +1655,16 @@ const FEATURES_LIST: FeatureList = {
 	[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: {
 		getSlug: () => FEATURE_COMMISSION_FEE_STANDARD_FEATURES,
 		getTitle: () =>
-			/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
-			i18n.fixMe( {
-				text: 'Transaction fee for standard payments (+\u00A0standard processing\u00A0fee)',
-				newCopy: i18n.translate(
-					'Transaction fee for standard payments (+\u00A0standard processing\u00A0fee)'
-				),
-				oldCopy: i18n.translate(
-					'Commission fee for standard payment features (plus standard processing\u00A0fee)'
-				),
-			} ),
+			i18n.translate(
+				'Transaction fee for standard payments (+\u00A0standard processing\u00A0fee)'
+			),
 	},
 	[ FEATURE_COMMISSION_FEE_WOO_FEATURES ]: {
 		getSlug: () => FEATURE_COMMISSION_FEE_WOO_FEATURES,
 		getTitle: () =>
-			/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
-			i18n.fixMe( {
-				text: 'Transaction fee for standard WooCommerce payments (+ standard processing\u00A0fee)',
-				newCopy: i18n.translate(
-					'Transaction fee for standard WooCommerce payments (+ standard processing\u00A0fee)'
-				),
-				oldCopy: i18n.translate(
-					'Commission fee for standard WooCommerce payment features (plus standard processing\u00A0fee)'
-				),
-			} ),
+			i18n.translate(
+				'Transaction fee for standard WooCommerce payments (+ standard processing\u00A0fee)'
+			),
 	},
 	[ FEATURE_PAYMENT_TRANSACTION_FEES_10 ]: {
 		getSlug: () => FEATURE_PAYMENT_TRANSACTION_FEES_10,
@@ -2266,13 +2252,7 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_ES_SEARCH_JP ]: {
 		getSlug: () => FEATURE_ES_SEARCH_JP,
-		getTitle: () =>
-			/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
-			i18n.fixMe( {
-				text: 'Jetpack Search',
-				newCopy: i18n.translate( 'Jetpack Search' ),
-				oldCopy: i18n.translate( 'Built-in Elasticsearch' ),
-			} ),
+		getTitle: () => i18n.translate( 'Jetpack Search' ),
 		getDescription: () =>
 			i18n.translate( 'Make surfacing your content simple with built-in premium site search.' ),
 	},
@@ -2284,30 +2264,17 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_SITE_ACTIVITY_LOG_JP ]: {
 		getSlug: () => FEATURE_SITE_ACTIVITY_LOG_JP,
-		getTitle: () =>
-			/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
-			i18n.fixMe( {
-				text: 'Site activity log',
-				newCopy: i18n.translate( 'Site activity log' ),
-				oldCopy: i18n.translate( 'Unlimited site activity log' ),
-			} ),
+		getTitle: () => i18n.translate( 'Site activity log' ),
 		getDescription: () =>
 			i18n.translate( 'Keep an administrative eye on activity across your site.' ),
 	},
 	[ FEATURE_DONATIONS_AND_TIPS_JP ]: {
 		getSlug: () => FEATURE_DONATIONS_AND_TIPS_JP,
 		getTitle: () => i18n.translate( 'Donations and tips' ),
-		/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
 		getDescription: () =>
-			i18n.fixMe( {
-				text: 'Allow your audience to support your work easily with charitable donations and tips.',
-				newCopy: i18n.translate(
-					'Allow your audience to support your work easily with charitable donations and tips.'
-				),
-				oldCopy: i18n.translate(
-					'Allow your audience to support your work easily with donations and tips.'
-				),
-			} ),
+			i18n.translate(
+				'Allow your audience to support your work easily with charitable donations and tips.'
+			),
 	},
 	[ FEATURE_PAYPAL_JP ]: {
 		getSlug: () => FEATURE_PAYPAL_JP,
@@ -2453,20 +2420,8 @@ const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_SUPPORT_FROM_EXPERTS ]: {
 		getSlug: () => FEATURE_SUPPORT_FROM_EXPERTS,
-		getTitle: () =>
-			/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
-			i18n.fixMe( {
-				text: 'Support from our expert\u00A0team',
-				newCopy: i18n.translate( 'Support from our expert\u00A0team' ),
-				oldCopy: i18n.translate( 'Fast support from our expert\u00A0team' ),
-			} ),
-		/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
-		getDescription: () =>
-			i18n.fixMe( {
-				text: 'Get support from our expert, friendly Happiness team',
-				newCopy: i18n.translate( 'Get support from our expert, friendly Happiness team' ),
-				oldCopy: i18n.translate( 'Prompt support from our expert, friendly Happiness team' ),
-			} ),
+		getTitle: () => i18n.translate( 'Support from our expert\u00A0team' ),
+		getDescription: () => i18n.translate( 'Get support from our expert, friendly Happiness team' ),
 	},
 	[ FEATURE_FAST_SUPPORT_FROM_EXPERTS ]: {
 		getSlug: () => FEATURE_FAST_SUPPORT_FROM_EXPERTS,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -836,17 +836,12 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 			: baseFeatures;
 	},
 	getStorageFeature: () => FEATURE_6GB_STORAGE,
-	/* @ts-expect-error - fixMe method is not typed in the package. Once types are added upstream, remove this. */
 	getPlanComparisonFeatureLabels: () => {
 		const baseFeatures = {
 			[ FEATURE_PREMIUM_THEMES ]: i18n.translate( 'Dozens of premium themes' ),
 			[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: i18n.translate( '%d shares per month', { args: [ 30 ] } ),
 			[ FEATURE_COMMISSION_FEE_STANDARD_FEATURES ]: i18n.translate( '8%' ),
-			[ FEATURE_SUPPORT ]: i18n.fixMe( {
-				text: 'Support from our expert\u00A0team',
-				newCopy: i18n.translate( 'Support from our expert\u00A0team' ),
-				oldCopy: i18n.translate( 'Fast support from our expert\u00A0team' ),
-			} ),
+			[ FEATURE_SUPPORT ]: i18n.translate( 'Support from our expert\u00A0team' ),
 		};
 
 		return isStatsFeatureTranslated()


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Remove fixMe() calls

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We don't want to leave fixMe() in the code after the translations are complete. Cleaning up and removing fixMe() calls improves the experience for non-Mag16 locales, since these locales are not officially translated and visible english strings can enable translators to add new translations.

I've verified that the strings modified in the PR have translations across the Mag16:

* https://translate.wordpress.com/projects/wpcom/-all-translated/974353/
* https://translate.wordpress.com/projects/wpcom/-all-translated/974354/
* https://translate.wordpress.com/projects/wpcom/-all-translated/974352/
* https://translate.wordpress.com/projects/wpcom/-all-translated/860572/
* https://translate.wordpress.com/projects/wpcom/-all-translated/973107/
* https://translate.wordpress.com/projects/wpcom/-all-translated/973106/
* https://translate.wordpress.com/projects/wpcom/-all-translated/971823/
* https://translate.wordpress.com/projects/wpcom/-all-translated/973058/
* https://translate.wordpress.com/projects/wpcom/-all-translated/973884/
* https://translate.wordpress.com/projects/wpcom/-all-translated/973883/



