### PR TITLE
Fix activity log page overlay z-index

### DIFF
--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -78,7 +78,7 @@
 	bottom: 0;
 	left: 0;
 	background: linear-gradient(to bottom, rgba(243, 246, 248, 0.1), #f3f6f8);
-	z-index: 179;
+	z-index: z-index("root", ".main");
 	height: 15%;
 	pointer-events: none;
 }


### PR DESCRIPTION
Related to #[99410](https://github.com/Automattic/wp-calypso/issues/99410)

## Proposed Changes
* Change z-index of activity logs page overlay

## Why are these changes being made?
* To prevent activity logs page overlay show up on top of the navigation menu

## Testing Instructions
* Head to https://wordpress.com/activity-log on a simple site, so that the Jetpack features are gated under a premium banner, and you'll see there's a overlay on top of the navigation. 
**Important note:** you have to have some activity (create a page, write posts, etc.) in your blog in order to see the problem

| Before | After |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/685c34d8-a49c-4208-9843-abde41f01733" />|<img src="https://github.com/user-attachments/assets/782f9d5b-8730-440f-a096-9ac3cc58ca61" />|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
