### PR TITLE
Privacy: Rename the section title to Site Visibility

### DIFF
--- a/client/sites/settings/site/privacy/index.tsx
+++ b/client/sites/settings/site/privacy/index.tsx
@@ -69,13 +69,13 @@ const PrivacyForm = ( {
 				onButtonClick={ handleSubmitForm }
 				showButton
 				title={ translate(
-					'Privacy {{infoPopover}} Control who can view your site. {{a}}Learn more{{/a}}. {{/infoPopover}}',
+					'Site Visibility {{infoPopover}} Control who can view your site. {{a}}Learn more{{/a}}. {{/infoPopover}}',
 					{
 						components: {
 							a: <InlineSupportLink showIcon={ false } supportContext="privacy" />,
 							infoPopover: <InfoPopover position="bottom right" />,
 						},
-						comment: 'Privacy Settings header',
+						comment: 'Site Visibility Settings header',
 					}
 				) }
 			/>
@@ -112,7 +112,7 @@ const PrivacyForm = ( {
 	}
 	return (
 		<PanelCard className="settings-site__privacy">
-			<PanelCardHeading>{ translate( 'Privacy' ) }</PanelCardHeading>
+			<PanelCardHeading>{ translate( 'Site Visibility' ) }</PanelCardHeading>
 			<PanelCardDescription>
 				{ translate( 'Control who can view your site. {{a}}Learn more{{/a}}', {
 					components: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/42230#pullrequestreview-2701009783

## Proposed Changes

* Rename the section title to Site Visibility for the consistency

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/332d9a9e-bc51-4b4b-90b4-9ea84eb9ec5a) | ![image](https://github.com/user-attachments/assets/dce86e8a-c1a5-43a3-aa16-cce6ada96e47) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align it with the Site Visibility settings on WP Admin

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick any launched sites
* Switch to Settings tab
* Ensure you can see the Site Visibility card

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
