### PR TITLE
Playground onboarding predefined blueprints

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -15,7 +15,35 @@ const DEFAULT_BLUEPRINT: Blueprint = {
 	login: true,
 };
 
+const PREDEFINED_BLUEPRINTS: Record< string, Blueprint > = {
+	woocommerce: {
+		...DEFAULT_BLUEPRINT,
+		steps: [
+			{
+				step: 'installPlugin',
+				pluginData: {
+					resource: 'wordpress.org/plugins',
+					slug: 'woocommerce',
+				},
+				options: {
+					activate: true,
+				},
+			},
+		],
+	},
+	// Add more predefined blueprints here as needed
+};
+
 function getBlueprintFromUrl(): Blueprint {
+	const url = new URL( window.location.href );
+	const predefinedBlueprintName = url.searchParams.get( 'blueprint' );
+
+	// If a predefined blueprint is specified and exists, use it
+	if ( predefinedBlueprintName && predefinedBlueprintName in PREDEFINED_BLUEPRINTS ) {
+		return PREDEFINED_BLUEPRINTS[ predefinedBlueprintName ];
+	}
+
+	// Otherwise, try to get blueprint from hash
 	try {
 		const blueprint = JSON.parse( decodeURIComponent( window.location.hash.slice( 1 ) ) );
 		return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -3,6 +3,7 @@ import { Blueprint } from '@wp-playground/blueprints';
 import { MountDescriptor, PlaygroundClient, startPlaygroundWeb } from '@wp-playground/client';
 import { logToLogstash } from 'calypso/lib/logstash';
 
+const OPFS_PATH_PREFIX = '/wpcom-onboarding';
 const DEFAULT_BLUEPRINT: Blueprint = {
 	preferredVersions: {
 		php: '8.3',
@@ -48,7 +49,7 @@ export async function initializeWordPressPlayground(
 		const mountDescriptor: MountDescriptor = {
 			device: {
 				type: 'opfs',
-				path: `/sites/${ playgroundId }/`,
+				path: `${ OPFS_PATH_PREFIX }/${ playgroundId }/`,
 			},
 			mountpoint: '/wordpress',
 			initialSyncDirection: 'opfs-to-memfs',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -61,10 +61,12 @@ export async function initializeWordPressPlayground(
 	iframe: HTMLIFrameElement
 ): Promise< PlaygroundClient > {
 	let isWordPressInstalled = false;
+	let firstRun = false;
 
 	const url = new URL( window.location.href );
 	let playgroundId = url.searchParams.get( 'playground' );
 	if ( ! playgroundId ) {
+		firstRun = true;
 		playgroundId = crypto.randomUUID();
 		url.searchParams.set( 'playground', playgroundId );
 		window.history.replaceState( {}, '', url.toString() );
@@ -87,7 +89,7 @@ export async function initializeWordPressPlayground(
 		const client = await startPlaygroundWeb( {
 			iframe,
 			remoteUrl: 'https://playground.wordpress.net/remote.html',
-			blueprint,
+			blueprint: firstRun ? blueprint : DEFAULT_BLUEPRINT,
 			shouldInstallWordPress: ! isWordPressInstalled,
 			mounts: [ mountDescriptor ],
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -61,12 +61,10 @@ export async function initializeWordPressPlayground(
 	iframe: HTMLIFrameElement
 ): Promise< PlaygroundClient > {
 	let isWordPressInstalled = false;
-	let firstRun = false;
 
 	const url = new URL( window.location.href );
 	let playgroundId = url.searchParams.get( 'playground' );
 	if ( ! playgroundId ) {
-		firstRun = true;
 		playgroundId = crypto.randomUUID();
 		url.searchParams.set( 'playground', playgroundId );
 		window.history.replaceState( {}, '', url.toString() );
@@ -76,7 +74,6 @@ export async function initializeWordPressPlayground(
 	}
 
 	try {
-		const blueprint = getBlueprintFromUrl();
 		const mountDescriptor: MountDescriptor = {
 			device: {
 				type: 'opfs',
@@ -89,7 +86,7 @@ export async function initializeWordPressPlayground(
 		const client = await startPlaygroundWeb( {
 			iframe,
 			remoteUrl: 'https://playground.wordpress.net/remote.html',
-			blueprint: firstRun ? blueprint : DEFAULT_BLUEPRINT,
+			blueprint: ! isWordPressInstalled ? getBlueprintFromUrl() : DEFAULT_BLUEPRINT,
 			shouldInstallWordPress: ! isWordPressInstalled,
 			mounts: [ mountDescriptor ],
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -15,6 +15,20 @@ const DEFAULT_BLUEPRINT: Blueprint = {
 	login: true,
 };
 
+function getBlueprintFromUrl(): Blueprint {
+	try {
+		const blueprint = JSON.parse( decodeURIComponent( window.location.hash.slice( 1 ) ) );
+		return {
+			...DEFAULT_BLUEPRINT,
+			...blueprint,
+			steps: [ ...( DEFAULT_BLUEPRINT.steps || [] ), ...( blueprint.steps || [] ) ],
+		};
+	} catch ( error ) {
+		// If the blueprint is invalid or missing, use the default one
+		return DEFAULT_BLUEPRINT;
+	}
+}
+
 export async function initializeWordPressPlayground(
 	iframe: HTMLIFrameElement
 ): Promise< PlaygroundClient > {
@@ -32,20 +46,7 @@ export async function initializeWordPressPlayground(
 	}
 
 	try {
-		// get blueprint json from the hash
-		let blueprint: Blueprint | null = null;
-		try {
-			blueprint = JSON.parse( decodeURIComponent( window.location.hash.slice( 1 ) ) );
-			blueprint = {
-				...DEFAULT_BLUEPRINT,
-				...blueprint,
-			};
-			blueprint.steps = [ ...( DEFAULT_BLUEPRINT.steps || [] ), ...( blueprint.steps || [] ) ];
-		} catch ( error ) {
-			// If the blueprint is invalid, use the default one
-			blueprint = DEFAULT_BLUEPRINT;
-		}
-
+		const blueprint = getBlueprintFromUrl();
 		const mountDescriptor: MountDescriptor = {
 			device: {
 				type: 'opfs',


### PR DESCRIPTION
## Proposed Changes

* Support a `blueprint` GET param that can execute a pre-defined blueprint
* When not specified, blueprint specified in `hash` property of url executes
* When nothing is specified, run the default blueprint
* When its a subsequent playground boot, only run the default blueprint
* Changed OPFS path from `/sites` to `/wpcom-onboarding`
