### PR TITLE
A4A > WooPayments: Implement Overview page

### DIFF
--- a/client/a8c-for-agencies/components/a4a-contact-support-widget/get-default-product.ts
+++ b/client/a8c-for-agencies/components/a4a-contact-support-widget/get-default-product.ts
@@ -2,7 +2,7 @@ import {
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MIGRATIONS_MIGRATE_TO_PRESSABLE_LINK,
 	A4A_MIGRATIONS_MIGRATE_TO_WPCOM_LINK,
-	A4A_WOOPAYMENTS_DASHBOARD_LINK,
+	A4A_WOOPAYMENTS_OVERVIEW_LINK,
 } from '../sidebar-menu/lib/constants';
 
 // This map is used to determine the product when the user is on a specific page to preselect the product in the form.
@@ -10,7 +10,7 @@ const pathToProductMap: Record< string, string > = {
 	[ A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK ]: 'pressable',
 	[ A4A_MIGRATIONS_MIGRATE_TO_PRESSABLE_LINK ]: 'pressable',
 	[ A4A_MIGRATIONS_MIGRATE_TO_WPCOM_LINK ]: 'wpcom',
-	[ A4A_WOOPAYMENTS_DASHBOARD_LINK ]: 'woo',
+	[ A4A_WOOPAYMENTS_OVERVIEW_LINK ]: 'woo',
 };
 
 export default function getDefaultProduct(): string {

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
@@ -1,4 +1,4 @@
-import { category, cog } from '@wordpress/icons';
+import { category, cog, home } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
@@ -8,6 +8,7 @@ import {
 	A4A_WOOPAYMENTS_LINK,
 	A4A_WOOPAYMENTS_DASHBOARD_LINK,
 	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
+	A4A_WOOPAYMENTS_OVERVIEW_LINK,
 } from '../lib/constants';
 import { createItem } from '../lib/utils';
 
@@ -21,6 +22,18 @@ const useWooPaymentsMenuItems = ( path: string ) => {
 
 	const menuItems = useMemo( () => {
 		return [
+			createItem(
+				{
+					icon: home,
+					path: A4A_WOOPAYMENTS_LINK,
+					link: A4A_WOOPAYMENTS_OVERVIEW_LINK,
+					title: translate( 'Overview' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / WooPayments / Overview',
+					},
+				},
+				path
+			),
 			createItem(
 				{
 					icon: category,

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -54,6 +54,7 @@ export const A4A_WOOPAYMENTS_LINK = '/woopayments';
 export const A4A_WOOPAYMENTS_DASHBOARD_LINK = `${ A4A_WOOPAYMENTS_LINK }/dashboard`;
 export const A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK = `${ A4A_WOOPAYMENTS_LINK }/payment-settings`;
 export const A4A_WOOPAYMENTS_SITE_SETUP_LINK = `${ A4A_WOOPAYMENTS_LINK }/site-setup`;
+export const A4A_WOOPAYMENTS_OVERVIEW_LINK = `${ A4A_WOOPAYMENTS_LINK }/overview`;
 
 // Client
 export const A4A_CLIENT_LANDING_LINK = '/client/landing';

--- a/client/a8c-for-agencies/components/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/index.tsx
@@ -20,6 +20,7 @@ interface StepSectionItemProps {
 	iconClassName?: string;
 	isNewLayout?: boolean;
 	stepNumber?: number;
+	children?: React.ReactNode;
 }
 
 export default function StepSectionItem( {
@@ -32,6 +33,7 @@ export default function StepSectionItem( {
 	iconClassName,
 	isNewLayout = false,
 	stepNumber,
+	children,
 }: StepSectionItemProps ) {
 	const status = <StatusBadge statusProps={ statusProps } />;
 
@@ -64,6 +66,7 @@ export default function StepSectionItem( {
 				{ ! isNewLayout && buttonContent }
 			</div>
 			{ isNewLayout ? buttonContent : statusContent }
+			{ children }
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -48,6 +48,7 @@ import {
 	A4A_WOOPAYMENTS_DASHBOARD_LINK,
 	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
 	A4A_WOOPAYMENTS_SITE_SETUP_LINK,
+	A4A_WOOPAYMENTS_OVERVIEW_LINK,
 } from '../components/sidebar-menu/lib/constants';
 import type { Agency } from 'calypso/state/a8c-for-agencies/types';
 
@@ -102,6 +103,7 @@ const MEMBER_ACCESSIBLE_PATHS: Record< string, string[] > = {
 	[ A4A_WOOPAYMENTS_DASHBOARD_LINK ]: [ 'a4a_read_referrals' ],
 	[ A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK ]: [ 'a4a_read_referrals' ],
 	[ A4A_WOOPAYMENTS_SITE_SETUP_LINK ]: [ 'a4a_read_referrals' ],
+	[ A4A_WOOPAYMENTS_OVERVIEW_LINK ]: [ 'a4a_read_referrals' ],
 };
 
 const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {

--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/index.tsx
@@ -1,6 +1,8 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddWooPaymentsToSiteModal from './modal';
@@ -9,12 +11,25 @@ const AddWooPaymentsToSite = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const showModal = getQueryArg( window.location.href, 'add-woopayments-to-site' ) === 'true';
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	const handleOpenModal = () => {
+	const handleOpenModal = useCallback( () => {
 		setIsOpen( true );
 		dispatch( recordTracksEvent( 'calypso_a4a_woopayments_add_site_button_click' ) );
-	};
+	}, [ dispatch ] );
+
+	useEffect( () => {
+		if ( showModal ) {
+			handleOpenModal();
+			page.redirect(
+				removeQueryArgs(
+					window.location.pathname + window.location.search,
+					'add-woopayments-to-site'
+				)
+			);
+		}
+	}, [ handleOpenModal, showModal ] );
 
 	return (
 		<>

--- a/client/a8c-for-agencies/sections/woopayments/controller.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/controller.tsx
@@ -1,9 +1,29 @@
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import WooPaymentsSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/woopayments';
+import SidebarPlaceholder from 'calypso/a8c-for-agencies/components/sidebar-placeholder';
 import ReferralsBankDetails from '../referrals/primary/bank-details';
+import WooPaymentsLanding from './primary/woopayment-landing';
 import WooPaymentsDashboard from './primary/woopayments-dashboard';
+import WooPaymentsOverview from './primary/woopayments-overview';
 import WooPaymentsSiteSetup from './primary/woopayments-site-setup';
+
+export const wooPaymentsLandingContext: Callback = ( context, next ) => {
+	context.primary = <WooPaymentsLanding />;
+	context.secondary = <SidebarPlaceholder />;
+	next();
+};
+
+export const woopaymentsOverviewContext: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker title="WooPayments > Overview" path={ context.path } />
+			<WooPaymentsOverview />
+		</>
+	);
+	context.secondary = <WooPaymentsSidebar path={ context.path } />;
+	next();
+};
 
 export const woopaymentsDashboardContext: Callback = ( context, next ) => {
 	context.primary = (

--- a/client/a8c-for-agencies/sections/woopayments/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/index.tsx
@@ -4,16 +4,26 @@ import {
 	A4A_WOOPAYMENTS_LINK,
 	A4A_WOOPAYMENTS_PAYMENT_SETTINGS_LINK,
 	A4A_WOOPAYMENTS_SITE_SETUP_LINK,
+	A4A_WOOPAYMENTS_OVERVIEW_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
+	wooPaymentsLandingContext,
+	woopaymentsOverviewContext,
 	woopaymentsDashboardContext,
 	woopaymentsPaymentSettingsContext,
 	woopaymentsSiteSetupContext,
 } from './controller';
 
 export default function () {
+	page(
+		A4A_WOOPAYMENTS_OVERVIEW_LINK,
+		requireAccessContext,
+		woopaymentsOverviewContext,
+		makeLayout,
+		clientRender
+	);
 	page(
 		A4A_WOOPAYMENTS_DASHBOARD_LINK,
 		requireAccessContext,
@@ -35,5 +45,5 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
-	page( A4A_WOOPAYMENTS_LINK, () => page.redirect( A4A_WOOPAYMENTS_DASHBOARD_LINK ) );
+	page( A4A_WOOPAYMENTS_LINK, wooPaymentsLandingContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayment-landing/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayment-landing/index.tsx
@@ -1,0 +1,41 @@
+import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import PagePlaceholder from 'calypso/a8c-for-agencies/components/page-placeholder';
+import {
+	A4A_WOOPAYMENTS_DASHBOARD_LINK,
+	A4A_WOOPAYMENTS_OVERVIEW_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchAllLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-all-licenses';
+import {
+	LicenseFilter,
+	LicenseSortField,
+	LicenseSortDirection,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+
+const WooPaymentsLanding = () => {
+	const translate = useTranslate();
+	const title = translate( 'WooPayments Commissions' );
+
+	const { data: licensesWithWooPayments, isFetched } = useFetchAllLicenses(
+		LicenseFilter.Attached,
+		'woopayments',
+		LicenseSortField.IssuedAt,
+		LicenseSortDirection.Descending
+	);
+
+	useEffect( () => {
+		if ( ! isFetched ) {
+			return;
+		}
+		if ( licensesWithWooPayments?.items?.length ) {
+			page.redirect( A4A_WOOPAYMENTS_DASHBOARD_LINK );
+			return;
+		}
+		page.redirect( A4A_WOOPAYMENTS_OVERVIEW_LINK );
+	}, [ licensesWithWooPayments, isFetched ] );
+
+	return <PagePlaceholder title={ title } />;
+};
+
+export default WooPaymentsLanding;

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/empty-state.tsx
@@ -1,14 +1,7 @@
-import { Button } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
-import CopyToClipboardButton from 'calypso/a8c-for-agencies/components/copy-to-clipboard-button';
-import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
-import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
-import { extractStrings } from 'calypso/a8c-for-agencies/lib/translation';
-import backgroundImage1 from 'calypso/assets/images/a8c-for-agencies/woopayments/background-image-1.svg';
-import cartImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cart.png';
-import ccImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cc-image.png';
-import demoImage from 'calypso/assets/images/a8c-for-agencies/woopayments/demo.png';
+import StepSection from 'calypso/a8c-for-agencies/components/step-section';
+import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
 import wooPaymentsLogo from 'calypso/assets/images/a8c-for-agencies/woopayments/logo.svg';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -18,385 +11,41 @@ const WooPaymentsDashboardEmptyState = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const listItems1 = [
-		translate(
-			'WooPayments is available in {{a}}38 countries{{/a}} and accepts payments in 135+ currencies, no other extensions needed.',
-			{
-				components: {
-					a: (
-						<a
-							href="https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_benefits_countries_link_click' )
-								);
-							} }
-						/>
-					),
-				},
-			}
-		),
-		translate(
-			'Get started for free. Pay-as-you-go fees per transaction. There are no monthly fees, either. {{a}}Learn more about WooPayments fees{{/a}}.',
-			{
-				components: {
-					a: (
-						<a
-							href="https://woocommerce.com/document/woopayments/fees-and-debits/fees"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_fees_link_click' ) );
-							} }
-						/>
-					),
-				},
-			}
-		),
-		translate(
-			'Multi-Currency support is built-in. Accept payments in 135+ currencies using WooPayments.'
-		),
-		translate(
-			'Increase conversions by enabling payment methods including {{wooPay}}WooPay{{/wooPay}}, {{applePay}}Apple Pay®{{/applePay}}, {{googlePay}}Google Pay{{/googlePay}}, {{iDeal}}iDeal{{/iDeal}}, {{p24}}P24{{/p24}}, {{eps}}EPS{{/eps}}, and {{bancontact}}Bancontact{{/bancontact}}.',
-			{
-				components: {
-					wooPay: (
-						<a
-							href="https://woocommerce.com/woopay-businesses"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_benefits_wooPay_link_click' )
-								);
-							} }
-						/>
-					),
-					applePay: (
-						<a
-							href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_benefits_applePay_link_click' )
-								);
-							} }
-						/>
-					),
-					googlePay: (
-						<a
-							href="https://woocommerce.com/document/woopayments/payment-methods/google-pay"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_benefits_googlePay_link_click' )
-								);
-							} }
-						/>
-					),
-					iDeal: (
-						<a
-							href="https://woocommerce.com/woocommerce-payments-ideal"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_benefits_iDeal_link_click' )
-								);
-							} }
-						/>
-					),
-					p24: (
-						<a
-							href="https://woocommerce.com/woopayments-p24"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_p24_link_click' ) );
-							} }
-						/>
-					),
-					eps: (
-						<a
-							href="https://woocommerce.com/woocommerce-payments-eps"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_eps_link_click' ) );
-							} }
-						/>
-					),
-					bancontact: (
-						<a
-							href="https://woocommerce.com/woocommerce-payments-bancontact"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_benefits_bancontact_link_click' )
-								);
-							} }
-						/>
-					),
-				},
-			}
-		),
-		translate(
-			'You may be eligible to earn up to {{a}}20% discount on Payment Processing Fees{{/a}}.',
-			{
-				components: {
-					a: (
-						<a
-							href="https://woocommerce.com/terms-conditions/woopayments-promotion"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_benefits_discount_link_click' )
-								);
-							} }
-						/>
-					),
-				},
-			}
-		),
-	];
-
-	const listItems2 = [
-		translate(
-			'Enable buy now, pay later (BNPL) in one click. Sell more and reach new customers with {{a}}top BNPL options{{/a}} built into your dashboard (not available in all geographies).',
-			{
-				components: {
-					a: (
-						<a
-							href="https://woocommerce.com/buy-now-pay-later"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ () => {
-								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_benefits_bnpl_link_click' ) );
-							} }
-						/>
-					),
-				},
-			}
-		),
-		translate(
-			"Simplify your workflow. No more logging into third-party payment processor sites - manage everything from the comfort of your store's dashboard."
-		),
-		translate(
-			'Set a custom payout schedule to get your funds into your bank account as often as you need — daily, weekly, monthly, or even on-demand.'
-		),
-		translate( 'Reduce cart abandonment with a streamlined checkout flow.' ),
-	];
-
 	return (
-		<div>
-			<PageSectionColumns>
-				<PageSectionColumns.Column>
-					<div className="woopayments-dashboard-empty-state__content">
-						<img src={ wooPaymentsLogo } alt="WooPayments" />
-						<div className="woopayments-dashboard-empty-state__content-body">
-							<div className="woopayments-dashboard-empty-state__heading">
-								{ translate( 'Earn revenue share when clients use WooPayments' ) }
-							</div>
-							<div className="woopayments-dashboard-empty-state__description">
-								{ translate(
-									"Accept credit/debit cards and local payment options with no setup or monthly fees. Earn revenue share of 5 basis points on transactions from your clients' sites within Automattic for Agencies."
-								) }
-							</div>
-						</div>
+		<div className="woopayments-dashboard-empty-state__content">
+			<img src={ wooPaymentsLogo } alt="WooPayments" />
+			<div>
+				<div className="woopayments-dashboard-empty-state__heading">
+					{ translate( 'Earn revenue share when clients use WooPayments' ) }
+				</div>
+				<div className="woopayments-dashboard-empty-state__description">
+					{ translate(
+						'When new clients sign up to use the WooPayments gateway on WooCommerce stores that you build or manage for them, you will receive a revenue share of 5 basis points on the Total Payments Volume (“TPV”).'
+					) }
+				</div>
+			</div>
+			<StepSection heading={ translate( 'How do I start?' ) }>
+				<StepSectionItem
+					heading={ translate( 'Add WooPayments to a site for free' ) }
+					description={ translate( 'Start by picking the site' ) }
+				>
+					<div className="woopayments-dashboard-empty-state__button">
 						<AddWooPaymentsToSite />
 					</div>
-				</PageSectionColumns.Column>
-				<PageSectionColumns.Column alignCenter>
-					<img src={ ccImage } alt="WooPayments" />
-				</PageSectionColumns.Column>
-			</PageSectionColumns>
-
-			<PageSectionColumns
-				background={ {
-					isDarkBackground: true,
-					image: backgroundImage1,
-					color: '#720EEC',
-				} }
-			>
-				<PageSectionColumns.Column heading={ translate( 'How to earn revenue share' ) }>
-					<>
-						<div className="woopayments-dashboard-empty-state__description">
-							<div>
-								{ translate(
-									'To qualify for revenue sharing, you must install and connect the Automattic for Agencies plugin and WooPayments extension on your client sites. We recommend using this marketplace to install WooPayments after adding the Automattic for Agencies plugin for easier license and client site management. {{a}}Learn more{{/a}} ↗',
-									{
-										components: {
-											a: (
-												<a
-													href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ () => {
-														dispatch(
-															recordTracksEvent( 'calypso_a4a_woopayments_learn_more_button_click' )
-														);
-													} }
-												/>
-											),
-										},
-									}
-								) }
-							</div>
-							<div>
-								{ translate(
-									'You will receive a revenue share of 5 basis points on new Total Payments Volume (“TPV”) on client sites through June 30, 2025. {{a}}View full terms{{/a}} ↗',
-									{
-										components: {
-											a: (
-												<a
-													href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ () => {
-														dispatch(
-															recordTracksEvent( 'calypso_a4a_woopayments_view_terms_button_click' )
-														);
-													} }
-												/>
-											),
-										},
-									}
-								) }
-							</div>
-						</div>
-						<Button
-							__next40pxDefaultSize
-							href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
-							className="woopayments-dashboard-empty-state__button"
-							onClick={ () => {
-								dispatch( recordTracksEvent( 'calypso_a4a_woopayments_contact_us_button_click' ) );
-							} }
-						>
-							{ translate( 'Have questions? Contact us' ) }
-						</Button>
-					</>
-				</PageSectionColumns.Column>
-			</PageSectionColumns>
-
-			<PageSectionColumns>
-				<PageSectionColumns.Column heading={ translate( 'About WooPayments' ) }>
-					<div className="woopayments-dashboard-empty-state__description">
-						<div>
-							{ translate(
-								"With WooPayments, you can collect payments, track cash flow, handle disputes, and manage recurring revenue directly from your store's dashboard — without needing to log into a third-party platform."
-							) }
-						</div>
-						<div>
-							{ translate(
-								'WooPayments simplifies the payment process for you and your customers, leaving you with more time to focus on growing your business. This fully integrated solution is the only payment method designed exclusively for WooCommerce, by Woo.'
-							) }
-						</div>
-					</div>
-				</PageSectionColumns.Column>
-				<PageSectionColumns.Column alignCenter>
-					<img src={ cartImage } alt="WooPayments" />
-				</PageSectionColumns.Column>
-			</PageSectionColumns>
-
-			<PageSectionColumns
-				heading={
-					<>
-						<span>{ translate( 'Benefits to share with your client' ) }</span>
-						<CopyToClipboardButton
-							textToCopy={ [ ...listItems1, ...listItems2 ]
-								.map( ( item ) => `• ${ extractStrings( item ) }` )
-								.join( '\n' ) }
-							onClick={ () => {
-								dispatch(
-									recordTracksEvent( 'calypso_a4a_woopayments_copy_benefits_button_click' )
-								);
-							} }
-						/>
-					</>
-				}
-				background={ {
-					color: '#F2EDFF',
-				} }
-			>
-				<PageSectionColumns.Column>
-					<SimpleList className="woopayments-dashboard-empty-state__list" items={ listItems1 } />
-				</PageSectionColumns.Column>
-				<PageSectionColumns.Column>
-					<SimpleList className="woopayments-dashboard-empty-state__list" items={ listItems2 } />
-				</PageSectionColumns.Column>
-			</PageSectionColumns>
-
-			<PageSectionColumns>
-				<PageSectionColumns.Column
-					heading={ translate( 'Still undecided if WooPayments is right for your clients?' ) }
+				</StepSectionItem>
+			</StepSection>
+			<StepSection heading={ translate( 'Learn more about the program' ) }>
+				<ExternalLink
+					onClick={ () => {
+						dispatch(
+							recordTracksEvent( 'calypso_a4a_woopayments_learn_more_about_program_click' )
+						);
+					} }
+					href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
 				>
-					<>
-						<div className="woopayments-dashboard-empty-state__description">
-							{ translate(
-								"Explore all of WooPayments' benefits, browse the technical documentation, and {{a}}try the demo{{/a}} ↗ to see it in action.",
-								{
-									components: {
-										a: (
-											<a
-												className="woopayments-dashboard-empty-state__demo-link"
-												href="https://woocommerce.com/products/woopayments"
-												target="_blank"
-												rel="noopener noreferrer"
-												onClick={ () => {
-													dispatch(
-														recordTracksEvent( 'calypso_a4a_woopayments_try_demo_button_click' )
-													);
-												} }
-											/>
-										),
-									},
-								}
-							) }
-						</div>
-						<div className="woopayments-dashboard-empty-state__buttons">
-							<Button
-								__next40pxDefaultSize
-								variant="primary"
-								href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
-								onClick={ () => {
-									dispatch(
-										recordTracksEvent(
-											'calypso_a4a_woopayments_contact_us_to_learn_more_button_click'
-										)
-									);
-								} }
-							>
-								{ translate( 'Contact us to learn more' ) }
-							</Button>
-							<Button
-								__next40pxDefaultSize
-								variant="secondary"
-								href="https://woocommerce.com/products/woopayments"
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ () => {
-									dispatch(
-										recordTracksEvent(
-											'calypso_a4a_woopayments_explore_on_woocommerce_button_click'
-										)
-									);
-								} }
-							>
-								{ translate( 'Explore on WooCommerce.com ↗' ) }
-							</Button>
-						</div>
-					</>
-				</PageSectionColumns.Column>
-				<PageSectionColumns.Column alignCenter>
-					<img src={ demoImage } alt="WooPayments" />
-				</PageSectionColumns.Column>
-			</PageSectionColumns>
+					{ translate( 'Checkout the full details in the Knowledge Base' ) }
+				</ExternalLink>
+			</StepSection>
 		</div>
 	);
 };

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
@@ -14,13 +14,11 @@ $woocommerce-purple-50: #720EEC;
 
 	&.is-empty {
 		.hosting-dashboard-layout__body-wrapper {
-			max-width: unset;
-			padding-inline: 0;
-			margin: 0;
+			max-width: 900px;
+			padding-block-start: calc(24px + 48px);
 		}
 	}
 }
-
 
 .woopayments-dashboard-empty-state__content {
 	display: flex;
@@ -29,6 +27,10 @@ $woocommerce-purple-50: #720EEC;
 
 	img {
 		width: max-content;
+	}
+
+	a.components-external-link {
+		@include body-medium;
 	}
 }
 
@@ -96,21 +98,22 @@ a.components-button.woopayments-dashboard-empty-state__button {
 	}
 }
 
-.woopayments-dashboard-empty-state__buttons {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
+.woopayments-dashboard-empty-state__button {
+	margin-block-start: 16px;
+	margin-inline-start: auto;
 
-	a.components-button {
+	button {
 		width: 100%;
-		text-wrap: balance;
+		height: 40px;
+
+		@include break-large {
+			min-width: 100px;
+			width: auto;
+			height: inherit;
+		}
 	}
 
-	@include break-wide {
-		flex-direction: row;
-
-		a.components-button {
-			width: auto;
-		}
+	@include break-large {
+		margin-block-start: 0;
 	}
 }

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -1,0 +1,465 @@
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo, useCallback } from 'react';
+import { CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import CopyToClipboardButton from 'calypso/a8c-for-agencies/components/copy-to-clipboard-button';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_WOOPAYMENTS_DASHBOARD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import { extractStrings } from 'calypso/a8c-for-agencies/lib/translation';
+import backgroundImage1 from 'calypso/assets/images/a8c-for-agencies/woopayments/background-image-1.svg';
+import cartImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cart.png';
+import ccImage from 'calypso/assets/images/a8c-for-agencies/woopayments/cc-image.png';
+import demoImage from 'calypso/assets/images/a8c-for-agencies/woopayments/demo.png';
+import wooPaymentsLogo from 'calypso/assets/images/a8c-for-agencies/woopayments/logo.svg';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+	LayoutHeaderActions as Actions,
+} from 'calypso/layout/hosting-dashboard/header';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+import './style.scss';
+
+const WooPaymentsOverview = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const title = translate( 'WooPayments Commissions' );
+
+	const listItems1 = useMemo(
+		() => [
+			translate(
+				'WooPayments is available in {{a}}38 countries{{/a}} and accepts payments in 135+ currencies, no other extensions needed.',
+				{
+					components: {
+						a: (
+							<a
+								href="https://woocommerce.com/document/woopayments/compatibility/countries/#supported-countries"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_countries_link_click' )
+									);
+								} }
+							/>
+						),
+					},
+				}
+			),
+			translate(
+				'Get started for free. Pay-as-you-go fees per transaction. There are no monthly fees, either. {{a}}Learn more about WooPayments fees{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href="https://woocommerce.com/document/woopayments/fees-and-debits/fees"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_fees_link_click' )
+									);
+								} }
+							/>
+						),
+					},
+				}
+			),
+			translate(
+				'Multi-Currency support is built-in. Accept payments in 135+ currencies using WooPayments.'
+			),
+			translate(
+				'Increase conversions by enabling payment methods including {{wooPay}}WooPay{{/wooPay}}, {{applePay}}Apple Pay®{{/applePay}}, {{googlePay}}Google Pay{{/googlePay}}, {{iDeal}}iDeal{{/iDeal}}, {{p24}}P24{{/p24}}, {{eps}}EPS{{/eps}}, and {{bancontact}}Bancontact{{/bancontact}}.',
+				{
+					components: {
+						wooPay: (
+							<a
+								href="https://woocommerce.com/woopay-businesses"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_wooPay_link_click' )
+									);
+								} }
+							/>
+						),
+						applePay: (
+							<a
+								href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_applePay_link_click' )
+									);
+								} }
+							/>
+						),
+						googlePay: (
+							<a
+								href="https://woocommerce.com/document/woopayments/payment-methods/google-pay"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_googlePay_link_click' )
+									);
+								} }
+							/>
+						),
+						iDeal: (
+							<a
+								href="https://woocommerce.com/woocommerce-payments-ideal"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_iDeal_link_click' )
+									);
+								} }
+							/>
+						),
+						p24: (
+							<a
+								href="https://woocommerce.com/woopayments-p24"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_p24_link_click' )
+									);
+								} }
+							/>
+						),
+						eps: (
+							<a
+								href="https://woocommerce.com/woocommerce-payments-eps"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_eps_link_click' )
+									);
+								} }
+							/>
+						),
+						bancontact: (
+							<a
+								href="https://woocommerce.com/woocommerce-payments-bancontact"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_bancontact_link_click' )
+									);
+								} }
+							/>
+						),
+					},
+				}
+			),
+			translate(
+				'You may be eligible to earn up to {{a}}20% discount on Payment Processing Fees{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href="https://woocommerce.com/terms-conditions/woopayments-promotion"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_discount_link_click' )
+									);
+								} }
+							/>
+						),
+					},
+				}
+			),
+		],
+		[ dispatch, translate ]
+	);
+
+	const listItems2 = useMemo(
+		() => [
+			translate(
+				'Enable buy now, pay later (BNPL) in one click. Sell more and reach new customers with {{a}}top BNPL options{{/a}} built into your dashboard (not available in all geographies).',
+				{
+					components: {
+						a: (
+							<a
+								href="https://woocommerce.com/buy-now-pay-later"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_benefits_bnpl_link_click' )
+									);
+								} }
+							/>
+						),
+					},
+				}
+			),
+			translate(
+				"Simplify your workflow. No more logging into third-party payment processor sites - manage everything from the comfort of your store's dashboard."
+			),
+			translate(
+				'Set a custom payout schedule to get your funds into your bank account as often as you need — daily, weekly, monthly, or even on-demand.'
+			),
+			translate( 'Reduce cart abandonment with a streamlined checkout flow.' ),
+		],
+		[ dispatch, translate ]
+	);
+
+	const handleAddWooPaymentsToSite = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_woopayments_add_site_button_click' ) );
+		page.redirect(
+			addQueryArgs( { 'add-woopayments-to-site': 'true' }, A4A_WOOPAYMENTS_DASHBOARD_LINK )
+		);
+	}, [ dispatch ] );
+
+	const addWooPaymentsToSite = useMemo( () => {
+		return (
+			<Button __next40pxDefaultSize variant="primary" onClick={ handleAddWooPaymentsToSite }>
+				{ translate( 'Add WooPayments to site' ) }
+			</Button>
+		);
+	}, [ translate, handleAddWooPaymentsToSite ] );
+
+	return (
+		<Layout className="woopayments-overview" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title }</Title>
+					<Actions>
+						<MobileSidebarNavigation />
+						{ addWooPaymentsToSite }
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<PageSectionColumns>
+					<PageSectionColumns.Column>
+						<div className="woopayments-overview__content">
+							<img src={ wooPaymentsLogo } alt="WooPayments" />
+							<div>
+								<div className="woopayments-overview__heading">
+									{ translate( 'Earn revenue share when clients use WooPayments' ) }
+								</div>
+								<div className="woopayments-overview__description">
+									{ translate(
+										"Accept credit/debit cards and local payment options with no setup or monthly fees. Earn revenue share of 5 basis points on transactions from your clients' sites within Automattic for Agencies."
+									) }
+								</div>
+							</div>
+							{ addWooPaymentsToSite }
+						</div>
+					</PageSectionColumns.Column>
+					<PageSectionColumns.Column alignCenter>
+						<img src={ ccImage } alt="WooPayments" />
+					</PageSectionColumns.Column>
+				</PageSectionColumns>
+
+				<PageSectionColumns
+					background={ {
+						isDarkBackground: true,
+						image: backgroundImage1,
+						color: '#720EEC',
+					} }
+				>
+					<PageSectionColumns.Column heading={ translate( 'How to earn revenue share' ) }>
+						<>
+							<div className="woopayments-overview__description">
+								<div>
+									{ translate(
+										'To qualify for revenue sharing, you must install and connect the Automattic for Agencies plugin and WooPayments extension on your client sites. We recommend using this marketplace to install WooPayments after adding the Automattic for Agencies plugin for easier license and client site management. {{a}}Learn more{{/a}} ↗',
+										{
+											components: {
+												a: (
+													<a
+														href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
+														target="_blank"
+														rel="noopener noreferrer"
+														onClick={ () => {
+															dispatch(
+																recordTracksEvent(
+																	'calypso_a4a_woopayments_learn_more_button_click'
+																)
+															);
+														} }
+													/>
+												),
+											},
+										}
+									) }
+								</div>
+								<div>
+									{ translate(
+										'You will receive a revenue share of 5 basis points on new Total Payments Volume (“TPV”) on client sites through June 30, 2025. {{a}}View full terms{{/a}} ↗',
+										{
+											components: {
+												a: (
+													<a
+														href="https://agencieshelp.automattic.com/knowledge-base/earn-revenue-share-when-clients-use-woopayments/"
+														target="_blank"
+														rel="noopener noreferrer"
+														onClick={ () => {
+															dispatch(
+																recordTracksEvent(
+																	'calypso_a4a_woopayments_view_terms_button_click'
+																)
+															);
+														} }
+													/>
+												),
+											},
+										}
+									) }
+								</div>
+							</div>
+							<Button
+								__next40pxDefaultSize
+								href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
+								className="woopayments-overview__button"
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_contact_us_button_click' )
+									);
+								} }
+							>
+								{ translate( 'Have questions? Contact us' ) }
+							</Button>
+						</>
+					</PageSectionColumns.Column>
+				</PageSectionColumns>
+
+				<PageSectionColumns>
+					<PageSectionColumns.Column heading={ translate( 'About WooPayments' ) }>
+						<div className="woopayments-overview__description">
+							<div>
+								{ translate(
+									"With WooPayments, you can collect payments, track cash flow, handle disputes, and manage recurring revenue directly from your store's dashboard — without needing to log into a third-party platform."
+								) }
+							</div>
+							<div>
+								{ translate(
+									'WooPayments simplifies the payment process for you and your customers, leaving you with more time to focus on growing your business. This fully integrated solution is the only payment method designed exclusively for WooCommerce, by Woo.'
+								) }
+							</div>
+						</div>
+					</PageSectionColumns.Column>
+					<PageSectionColumns.Column alignCenter>
+						<img src={ cartImage } alt="WooPayments" />
+					</PageSectionColumns.Column>
+				</PageSectionColumns>
+
+				<PageSectionColumns
+					heading={
+						<>
+							<span>{ translate( 'Benefits to share with your client' ) }</span>
+							<CopyToClipboardButton
+								textToCopy={ [ ...listItems1, ...listItems2 ]
+									.map( ( item ) => `• ${ extractStrings( item ) }` )
+									.join( '\n' ) }
+								onClick={ () => {
+									dispatch(
+										recordTracksEvent( 'calypso_a4a_woopayments_copy_benefits_button_click' )
+									);
+								} }
+							/>
+						</>
+					}
+					background={ {
+						color: '#F2EDFF',
+					} }
+				>
+					<PageSectionColumns.Column>
+						<SimpleList className="woopayments-overview__list" items={ listItems1 } />
+					</PageSectionColumns.Column>
+					<PageSectionColumns.Column>
+						<SimpleList className="woopayments-overview__list" items={ listItems2 } />
+					</PageSectionColumns.Column>
+				</PageSectionColumns>
+
+				<PageSectionColumns>
+					<PageSectionColumns.Column
+						heading={ translate( 'Still undecided if WooPayments is right for your clients?' ) }
+					>
+						<>
+							<div className="woopayments-overview__description">
+								{ translate(
+									"Explore all of WooPayments' benefits, browse the technical documentation, and {{a}}try the demo{{/a}} ↗ to see it in action.",
+									{
+										components: {
+											a: (
+												<a
+													className="woopayments-overview__demo-link"
+													href="https://woocommerce.com/products/woopayments"
+													target="_blank"
+													rel="noopener noreferrer"
+													onClick={ () => {
+														dispatch(
+															recordTracksEvent( 'calypso_a4a_woopayments_try_demo_button_click' )
+														);
+													} }
+												/>
+											),
+										},
+									}
+								) }
+							</div>
+							<div className="woopayments-overview__buttons-container">
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									href={ CONTACT_URL_HASH_FRAGMENT_WITH_PRODUCT }
+									onClick={ () => {
+										dispatch(
+											recordTracksEvent(
+												'calypso_a4a_woopayments_contact_us_to_learn_more_button_click'
+											)
+										);
+									} }
+								>
+									{ translate( 'Contact us to learn more' ) }
+								</Button>
+								<Button
+									__next40pxDefaultSize
+									variant="secondary"
+									href="https://woocommerce.com/products/woopayments"
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ () => {
+										dispatch(
+											recordTracksEvent(
+												'calypso_a4a_woopayments_explore_on_woocommerce_button_click'
+											)
+										);
+									} }
+								>
+									{ translate( 'Explore on WooCommerce.com ↗' ) }
+								</Button>
+							</div>
+						</>
+					</PageSectionColumns.Column>
+					<PageSectionColumns.Column alignCenter>
+						<img src={ demoImage } alt="WooPayments" />
+					</PageSectionColumns.Column>
+				</PageSectionColumns>
+			</LayoutBody>
+		</Layout>
+	);
+};
+
+export default WooPaymentsOverview;

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/style.scss
@@ -1,0 +1,91 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+$woocommerce-purple-50: #720EEC;
+
+.woopayments-overview {
+	.hosting-dashboard-layout__header-actions {
+		display: flex;
+		flex-direction: column;
+		align-items: normal;
+		justify-content: normal;
+	}
+
+	.hosting-dashboard-layout__body-wrapper {
+		max-width: unset;
+		padding-inline: 0;
+		margin: 0;
+	}
+}
+
+.woopayments-overview__content {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+
+	img {
+		width: max-content;
+	}
+}
+
+.woopayments-overview__heading {
+	@include heading-2x-large;
+	margin-block-end: 8px;
+}
+
+.woopayments-overview__description {
+	@include body-large;
+
+	> div {
+		margin-block-end: 16px;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+}
+
+a.components-button.woopayments-overview__button {
+	&,
+	&:hover,
+	&:focus,
+	&:focus-visible {
+		color: $woocommerce-purple-50;
+		background-color: var(--color-surface);
+		border: none;
+		outline: none;
+		box-shadow: none;
+	}
+}
+
+.woopayments-overview__list a,
+.woopayments-overview__demo-link {
+	text-decoration: underline;
+	color: var(--color-text);
+
+	&:hover,
+	&:focus,
+	&:focus-visible {
+		color: var(--color-text);
+	}
+}
+
+.woopayments-overview__buttons-container {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	a.components-button {
+		width: 100%;
+		text-wrap: balance;
+	}
+
+	@include break-wide {
+		flex-direction: row;
+
+		a.components-button {
+			width: auto;
+		}
+	}
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -892,6 +892,7 @@ const sections = [
 		name: 'a8c-for-agencies-woopayments',
 		paths: [
 			'/woopayments',
+			'/woopayments/overview',
 			'/woopayments/dashboard',
 			'/woopayments/payment-settings',
 			'/woopayments/site-setup',


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1933

## Proposed Changes

This PR implements: 
- Overview page for the WooPayments Commissions.
- Empty state view for the Dashboard

## Why are these changes being made?

* To show the original empty state always because of the value it adds.

## Testing Instructions

* Open the A4A live link
* Go to Licenses and delete all the WooPayments licenses assigned to a site
* Go to WooPayments > Verify you are redirected to the Overview page, and the empty state looks fine by comparing it with staging.

![screencapture-agencies-localhost-3000-woopayments-overview-2025-03-20-12_30_05](https://github.com/user-attachments/assets/6995719c-34a0-43b2-b50e-0babf11ecd23)

* Click the `Add WooPayments to site` button on the Layout top-right corner or on the first section > Verify you are redirected to Dashboard and a modal is shown after you are redirected > Close the modal > Verify the Dashboard empty state is displayed as shown below. Verify the buttons and links work as expected. 

![screencapture-agencies-localhost-3000-woopayments-dashboard-2025-03-20-12_30_35](https://github.com/user-attachments/assets/c430a084-4290-43c5-9c92-451a7cacef67)

* Click the `Add WooPayments to site` button > Select a site and add WooPayments to a site and install/activate the plugin > Go to Dashboard and verify the site is displayed. 
* Visit Overview and click the WooPayments menu > Verify you are now redirected to the Dashboard instead of the Overview page > Also verify that you can view the Overview page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
