### PR TITLE
Launch site: Keep the button always in blueberry (modern scheme)

### DIFF
--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -31,6 +31,8 @@ interface MasterbarItemProps {
 	disabled?: boolean;
 	subItems?: Array< Array< MasterbarSubItemProps > >;
 	hasGlobalBorderStyle?: boolean;
+	as?: React.ComponentType;
+	variant?: string;
 }
 
 class MasterbarItem extends Component< MasterbarItemProps > {
@@ -47,6 +49,8 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 		alwaysShowContent: PropTypes.bool,
 		subItems: PropTypes.array,
 		hasGlobalBorderStyle: PropTypes.bool,
+		as: PropTypes.elementType,
+		variant: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -231,6 +235,8 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 				ref={ this.wrapperRef }
 			>
 				<MenuItem
+					as={ this.props.as }
+					variant={ this.props.variant }
 					url={ this.props.url }
 					innerRef={ this.props.innerRef }
 					{ ...attributes }
@@ -252,9 +258,14 @@ export default forwardRef< HTMLButtonElement | HTMLAnchorElement, MasterbarItemP
 type MenuItemProps< R > = {
 	url?: string;
 	innerRef?: R;
+	as?: React.ComponentType;
 } & React.HTMLAttributes< HTMLElement >;
 
-function MenuItem< R >( { url, innerRef, ...props }: MenuItemProps< R > ) {
+function MenuItem< R >( { url, innerRef, as: Component, ...props }: MenuItemProps< R > ) {
+	if ( Component ) {
+		return <Component ref={ innerRef } { ...props } { ...( url ? { url } : {} ) } />;
+	}
+
 	return url ? (
 		<a href={ url } ref={ innerRef as LegacyRef< HTMLAnchorElement > } { ...props } />
 	) : (

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -259,11 +259,18 @@ type MenuItemProps< R > = {
 	url?: string;
 	innerRef?: R;
 	as?: React.ComponentType;
+	variant?: string;
 } & React.HTMLAttributes< HTMLElement >;
 
 function MenuItem< R >( { url, innerRef, as: Component, ...props }: MenuItemProps< R > ) {
 	if ( Component ) {
-		return <Component ref={ innerRef } { ...props } { ...( url ? { url } : {} ) } />;
+		return (
+			<Component
+				{ ...props }
+				{ ...( innerRef ? { ref: innerRef } : {} ) }
+				{ ...( url ? { url } : {} ) }
+			/>
+		);
 	}
 
 	return url ? (

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -2,6 +2,8 @@ import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products/src';
 import page from '@automattic/calypso-router';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
@@ -525,7 +527,10 @@ class MasterbarLoggedIn extends Component {
 
 		return (
 			<Item
-				className="masterbar__item-launch-site"
+				as={ Button }
+				variant="primary"
+				// Keep the Launch button always in blueberry (default scheme: modern) like in wp-admin.
+				className={ clsx( 'masterbar__item-launch-site', 'color-scheme', 'is-global' ) }
 				icon={
 					<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<path

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -682,7 +682,6 @@ body.is-mobile-app-view {
 .masterbar__item-launch-site {
 	gap: 6px;
 	cursor: pointer;
-	background-color: var(--wp-admin-theme-color);
 	@media only screen and (max-width: 480px) {
 		display: none;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101284

## Proposed Changes

* Keep the button always in blueberry (modern scheme) like in wp-admin

**Calypso**
| | Before | After |
| - | - | - |
| Default | <img width="363" alt="Image" src="https://github.com/user-attachments/assets/0c833917-f8cf-4441-9b5a-789724e6d309" /> | ![image](https://github.com/user-attachments/assets/c59bcf5a-b413-4639-afd7-011fc57cb2e1) |
| Hover | <img width="361" alt="Image" src="https://github.com/user-attachments/assets/b9956737-5e22-44b8-bba4-b37cbc9c1a95" /> | ![image](https://github.com/user-attachments/assets/3d2fb8a0-5f72-4a31-a234-e058eb00f015) |

**/sites**

| | Before | After |
| - | - | - |
| Default | <img width="370" alt="Image" src="https://github.com/user-attachments/assets/38a6cd48-e0f0-47aa-97d6-dc31498b61d7" /> | ![image](https://github.com/user-attachments/assets/7e2408a6-4755-400a-8f56-5a1f5404f31c) |
| Hover | <img width="364" alt="Image" src="https://github.com/user-attachments/assets/6c5f8db1-9843-4e45-8163-069e3cc29ae9" /> | ![image](https://github.com/user-attachments/assets/dd0944e8-804c-42c6-8a70-e9d6a81c97e0) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Color consistency

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Pick any un-launched site that has non-modern color scheme
* Ensure the “Launch site” button on the masterbar is in blueberry
* Click “My Home” to go to the Home of your site
* Ensure the “Launch site” button on the masterbar is still in blueberry

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
