### PR TITLE
A4A: Do not hide marketplace product when volume discount is not supported.

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-tooltip.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-tooltip.tsx
@@ -1,0 +1,40 @@
+import { Tooltip } from '@automattic/components';
+import { ComponentType, useRef, useState } from 'react';
+
+export type WithTooltipProps = {
+	tooltip?: string;
+	tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
+};
+
+export function withTooltip< T extends WithTooltipProps >( WrappedComponent: ComponentType< T > ) {
+	return function WithTooltipWrapper( props: T ) {
+		const { tooltip, tooltipPosition = 'top', ...rest } = props;
+		const elementRef = useRef< HTMLDivElement >( null );
+		const [ isTooltipVisible, setIsTooltipVisible ] = useState( false );
+
+		if ( ! tooltip ) {
+			return <WrappedComponent { ...( rest as T ) } />;
+		}
+
+		return (
+			<>
+				<div
+					className="with-tooltip-wrapper"
+					ref={ elementRef }
+					onMouseEnter={ () => setIsTooltipVisible( true ) }
+					onMouseLeave={ () => setIsTooltipVisible( false ) }
+				>
+					<WrappedComponent { ...( rest as T ) } />
+				</div>
+				<Tooltip
+					context={ elementRef.current }
+					isVisible={ isTooltipVisible }
+					position={ tooltipPosition }
+					showOnMobile
+				>
+					{ tooltip }
+				</Tooltip>
+			</>
+		);
+	};
+}

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/index.tsx
@@ -196,7 +196,7 @@ export function ProductsOverviewV2( {
 			<div
 				className="products-overview-v2__action-panel-wrapper"
 				ref={ actionPanelRef }
-				style={ { top: actionPanelStickyTopOffset } }
+				style={ { top: actionPanelStickyTopOffset, zIndex: 20 } }
 			>
 				<ProductActionPanel
 					searchQuery={ productSearchQuery }

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/index.tsx
@@ -3,6 +3,10 @@ import { check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo } from 'react';
+import {
+	withTooltip,
+	WithTooltipProps,
+} from 'calypso/a8c-for-agencies/components/hoc/with-tooltip';
 import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
 import { useProductDescription } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import getProductShortTitle from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-product-short-title';
@@ -21,6 +25,7 @@ import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types
 import './style.scss';
 
 type Props = WithProductLightboxProps &
+	WithTooltipProps &
 	ProductLightboxActivatorProps & {
 		suggestedProduct?: string | null;
 		hideDiscount?: boolean;
@@ -216,4 +221,4 @@ function ProductCard( props: Props ) {
 	);
 }
 
-export default withProductLightbox( ProductCard );
+export default withProductLightbox( withTooltip( ProductCard ) );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-card/style.scss
@@ -8,6 +8,8 @@ $woocommerce-purple-50: #720EEC;
 	display: flex;
 	justify-content: stretch;
 	min-height: 270px;
+	height: 100%;
+
 	&.disabled {
 		opacity: 0.5;
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -272,6 +272,7 @@ export default function ProductListing( {
 							? translate( 'This product does not support the volume discount.' )
 							: undefined
 					}
+					tooltipPosition="bottom"
 				/>
 			);
 		} );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -267,6 +267,11 @@ export default function ProductListing( {
 					suggestedProduct={ suggestedProduct }
 					quantity={ productDoNotHaveSupportedBundles ? 1 : quantity }
 					withCustomCard={ withCustomCard }
+					tooltip={
+						productDoNotHaveSupportedBundles
+							? translate( 'This product does not support the volume discount.' )
+							: undefined
+					}
 				/>
 			);
 		} );

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -67,7 +67,6 @@ export default function ProductListing( {
 		suggestedProductSlugs,
 	} = useProductAndPlans( {
 		selectedSite,
-		selectedBundleSize: quantity,
 		selectedProductFilters: selectedFilters,
 		productSearchQuery,
 	} );
@@ -221,7 +220,34 @@ export default function ProductListing( {
 		withCustomCard: boolean = false
 	) => {
 		return products.map( ( productOption ) => {
-			const options = Array.isArray( productOption ) ? productOption : [ productOption ];
+			let options;
+
+			if ( Array.isArray( productOption ) ) {
+				options =
+					quantity === 1
+						? productOption
+						: productOption.filter(
+								( option ) =>
+									option.supported_bundles?.some(
+										( bundle: { quantity: number } ) => bundle.quantity === quantity
+									)
+						  );
+			} else {
+				options = [ productOption ];
+			}
+
+			if ( options.length === 0 ) {
+				return null;
+			}
+
+			const productDoNotHaveSupportedBundles =
+				! isSingleLicenseView &&
+				! options.some(
+					( option ) =>
+						option.supported_bundles?.some(
+							( bundle: { quantity: number } ) => bundle.quantity === quantity
+						)
+				);
 
 			return (
 				<ProductCard
@@ -232,13 +258,14 @@ export default function ProductListing( {
 					onVariantChange={ onClickVariantOption }
 					isSelected={ isSelected( options.map( ( { slug } ) => slug ) ) }
 					isDisabled={
+						productDoNotHaveSupportedBundles ||
 						! isReady ||
 						( isIncompatibleProduct( productOption, incompatibleProducts ) &&
 							! isSelected( options.map( ( { slug } ) => slug ) ) )
 					}
 					hideDiscount={ isSingleLicenseView }
 					suggestedProduct={ suggestedProduct }
-					quantity={ quantity }
+					quantity={ productDoNotHaveSupportedBundles ? 1 : quantity }
 					withCustomCard={ withCustomCard }
 				/>
 			);

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/section.tsx
@@ -63,6 +63,7 @@ export default function ProductListingSection( {
 								top: stickyHeadingTopOffset,
 								position: 'sticky',
 								paddingBlock: '16px',
+								zIndex: 10,
 						  }
 						: undefined
 				}


### PR DESCRIPTION
This enhancement updates the Marketplace product page to no longer hide products that do not support the selected volume discount.

<img width="512" alt="Screenshot 2025-03-20 at 5 35 34 PM" src="https://github.com/user-attachments/assets/d07e7456-3ae9-45b1-9b6b-a12bcf8c91b7" />

Closes https://github.com/Automattic/automattic-for-agencies-dev/issues/1938

## Proposed Changes

* The new approach involves disabling the product card for items that do not support the selected volume discount, rather than hiding them. A tooltip appears when the product card is hovered over, providing an explanation for the disabled status.
* **Addition**: The PR also introduces a new `withTooltip` HOC that can be reused in different contexts.

## Why are these changes being made?

* This is part of the Woo 3rd-party extension phase 2 project.

## Testing Instructions

* Open the A4A live link and navigate to the `/marketplace/products` page.
* Choose any bundle size.
* Verify that the third-party Woo products are disabled.
* Ensure that a tooltip appears when hovered over, explaining the disabled state.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
