### PR TITLE
Big Sky: Redirect from /home/

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -10,6 +10,7 @@ import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { isSiteOnWooExpressEcommerceTrial } from 'calypso/state/sites/plans/selectors';
+import isSiteBigSkyTrial from 'calypso/state/sites/plans/selectors/is-site-big-sky-trial';
 import { canCurrentUserUseCustomerHome, getSiteUrl } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSiteSlug,
@@ -72,6 +73,16 @@ export async function maybeRedirect( context, next ) {
 				window.location.replace( siteUrl + '/wp-admin/admin.php?page=wc-admin' );
 				return;
 			}
+		}
+	}
+
+	if ( isSiteBigSkyTrial( state, siteId ) ) {
+		const siteUrl = getSiteUrl( state, siteId );
+		if ( siteUrl !== null ) {
+			window.location.replace(
+				siteUrl + '/wp-admin/site-editor.php?canvas=edit&ai-website-builder-trial=home'
+			);
+			return;
 		}
 	}
 

--- a/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
+++ b/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
@@ -1,0 +1,47 @@
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BUSINESS_3_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_MONTHLY,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PREMIUM_3_YEARS,
+} from '@automattic/calypso-products';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getCurrentPlan } from '.';
+import type { AppState } from 'calypso/types';
+
+export default function isSiteBigSkyTrial( state: AppState, siteId: number ) {
+	const site = getSite( state, siteId );
+	if ( ! site ) {
+		return false;
+	}
+
+	if (
+		site.options?.site_creation_flow !== 'ai-site-builder' ||
+		site.launch_status !== 'unlaunched'
+	) {
+		return false;
+	}
+
+	const currentPlan = getCurrentPlan( state, siteId );
+	const bigSkyPlans = [
+		PLAN_BUSINESS,
+		PLAN_BUSINESS_MONTHLY,
+		PLAN_BUSINESS_2_YEARS,
+		PLAN_BUSINESS_3_YEARS,
+		PLAN_PREMIUM,
+		PLAN_PREMIUM_MONTHLY,
+		PLAN_PREMIUM_2_YEARS,
+		PLAN_PREMIUM_3_YEARS,
+	];
+
+	const productSlug = currentPlan?.productSlug || site?.plan?.product_slug;
+
+	if ( ! productSlug ) {
+		return true;
+	}
+
+	return ! bigSkyPlans.includes( productSlug );
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/big-sky-plugin/issues/2841
Fixes BSKY-191

### What it does

- For sites that are part of `ai-site-builder` onboarding flow
- And on a plan different than one of the plans with Big Sky
- Redirect to a Big Sky modal

### Testing instructions

- Create a site using `setup/ai-site-builder` flow
- Go to https://calypso.localhost:3000/home/siteslug
- Observe being redirected

<img width="1008" alt="Zrzut ekranu 2025-03-20 o 11 06 38" src="https://github.com/user-attachments/assets/9ab652fe-4178-4789-bed8-0e91759b0429" />

The big thing to test is all the sites that are NOT big sky if they are not redirecting by accident
