### PR TITLE
WIP: Redirect tools->export to wp-admin in all cases

### DIFF
--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -1,69 +1,42 @@
 import { localize } from 'i18n-calypso';
-import { Fragment } from 'react';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
-import ExporterContainer from 'calypso/my-sites/exporter/container';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const SectionExport = ( { isJetpack, canUserExport, site, translate } ) => {
-	let sectionContent;
+const SectionExport = ( { canUserExport, site, translate } ) => {
+	useEffect( () => {
+		// Auto-redirect to wp-admin if the user has permission and site data is loaded
+		if ( canUserExport && site && site.options?.admin_url ) {
+			window.location.href = `${ site.options.admin_url }export.php`;
+		}
+	}, [ canUserExport, site ] );
 
 	if ( ! canUserExport ) {
-		sectionContent = (
-			<EmptyContent
-				illustration="/calypso/images/illustrations/illustration-404.svg"
-				title={ translate( 'You are not authorized to view this page' ) }
-			/>
-		);
-	} else if ( isJetpack ) {
-		sectionContent = (
-			<EmptyContent
-				illustration="/calypso/images/illustrations/illustration-jetpack.svg"
-				title={ translate( 'Want to export your site?' ) }
-				line={ translate( "Visit your site's wp-admin for all your import and export needs." ) }
-				action={ translate( 'Export %(siteTitle)s', { args: { siteTitle: site.title } } ) }
-				actionURL={ site.options?.admin_url + 'export.php' }
-				actionTarget="_blank"
-			/>
-		);
-	} else {
-		sectionContent = (
-			<Fragment>
-				<NavigationHeader
-					navigationItems={ [] }
-					title={ translate( 'Export Content' ) }
-					subtitle={ translate(
-						'Back up or move your content to another site or platform. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="export" showIcon={ false } />,
-							},
-						}
-					) }
+		return (
+			<Main>
+				<ScreenOptionsTab wpAdminPath="export.php" />
+				<DocumentHead title={ translate( 'Export' ) } />
+				<EmptyContent
+					illustration="/calypso/images/illustrations/illustration-404.svg"
+					title={ translate( 'You are not authorized to view this page' ) }
 				/>
-				<ExporterContainer />
-			</Fragment>
+			</Main>
 		);
 	}
 
+	// This will briefly show while redirecting
 	return (
 		<Main>
 			<ScreenOptionsTab wpAdminPath="export.php" />
 			<DocumentHead title={ translate( 'Export' ) } />
-			{ sectionContent }
+			<div></div>
 		</Main>
 	);
 };
@@ -73,9 +46,7 @@ export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		isJetpack: isJetpackSite( state, siteId ),
 		site,
-		siteSlug: getSelectedSiteSlug( state ),
 		canUserExport: canCurrentUser( state, siteId, 'manage_options' ),
 	};
 } )( localize( SectionExport ) );

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -517,7 +517,7 @@ export default function buildFallbackResponse( {
 					slug: 'tools-export',
 					title: translate( 'Export' ),
 					type: 'submenu-item',
-					url: `/export/${ siteDomain }`,
+					url: `https://${ siteDomain }/wp-admin/export.php`,
 				},
 				{
 					parent: 'tools.php',


### PR DESCRIPTION
## WIP

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
