### PR TITLE
Stats: Improves video page styling - part 2

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -6,6 +6,7 @@ import { numberFormat, localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import InfoPopover from 'calypso/components/info-popover';
 import SectionHeader from 'calypso/components/section-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -152,18 +153,29 @@ class VideoPressStatsModule extends Component {
 			<div>
 				{ summary && (
 					<div className="stats-module__date-picker-header">
-						<DatePicker
-							period={ period.period }
-							date={ period.startOf }
-							path={ path }
-							query={ query }
-							summary
-						/>
+						<h3>
+							<DatePicker
+								period={ period.period }
+								date={ period.startOf }
+								path={ path }
+								query={ query }
+								summary
+							/>
+						</h3>
 					</div>
 				) }
 				<SectionHeader
 					className={ headerClass }
-					label={ moduleStrings.title }
+					label={
+						<div className="stats-card-header__title" role="heading" aria-level="4">
+							<div>{ moduleStrings.title }</div>
+							<div className="stats-card-header__title-nodes">
+								<InfoPopover className="stats-info-area__popover" iconSize={ 24 } position="top">
+									{ translate( 'View detailed statistics about your videos.' ) }
+								</InfoPopover>
+							</div>
+						</div>
+					}
 					href={ ! summary ? summaryLink : null }
 				>
 					{ summary && (

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -79,7 +79,3 @@
 		background-color: var(--color-neutral-0);
 	}
 }
-
-.stats-module__date-picker-header {
-	margin-bottom: 16px;
-}

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -3,10 +3,16 @@
 @import "@automattic/components/src/styles/typography";
 
 .stats-module__date-picker-header {
-	margin: 32px 0 16px;
-	font-family: $brand-serif;
-	font-size: $font-title-medium;
-	line-height: 1.5;
+	margin: 20px 0;
+
+	h3 {
+		color: var(--studio-gray-100);
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: 2rem;
+		font-weight: 400;
+		line-height: 40px;
+		margin: 0;
+	}
 
 	@media (max-width: $break-medium) {
 		margin: 24px 0 16px;
@@ -28,54 +34,114 @@
 	color: var(--color-text);
 	min-width: 100%;
 	width: fit-content;
-}
 
-@media screen and (max-width: 450px) {
-	.videopress-stats-module__grid {
+	@media screen and (max-width: 450px) {
 		grid-template-columns: 40% auto auto auto auto;
 	}
-}
 
-.videopress-stats-module__grid-header {
-	font-weight: 600;
-	color: var(--color-text-subtle);
-	line-height: 20px;
-}
-
-.videopress-stats-module__grid-metric {
-	text-align: right;
-	padding-right: 8px;
-}
-
-.videopress-stats-module__grid-cell span {
-	cursor: pointer;
-}
-.videopress-stats-module__grid-cell span:hover {
-	text-decoration: underline;
-}
-
-.videopress-stats-module__grid-link {
-	color: var(--color-primary);
-	overflow-x: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.videopress-stats-module__row-wrapper,
-.videopress-stats-module__header-row-wrapper {
-	display: contents;
-
-	div:first-of-type {
-		padding-left: 24px;
+	.videopress-stats-module__grid-header {
+		font-weight: 600;
+		color: var(--color-text-subtle);
+		line-height: 20px;
 	}
 
-	div:last-of-type {
-		padding-right: 24px;
+	.videopress-stats-module__grid-metric {
+		text-align: right;
+		padding-right: 8px;
+	}
+
+	.videopress-stats-module__grid-cell {
+		span {
+			cursor: pointer;
+			
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	.videopress-stats-module__grid-link {
+		color: var(--color-primary);
+		overflow-x: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
+
+	.videopress-stats-module__row-wrapper,
+	.videopress-stats-module__header-row-wrapper {
+		display: contents;
+
+		div:first-of-type {
+			padding-left: 24px;
+		}
+
+		div:last-of-type {
+			padding-right: 24px;
+		}
+	}
+
+	.videopress-stats-module__row-wrapper {
+		&:hover div {
+			background-color: var(--color-neutral-0);
+		}
 	}
 }
 
-.videopress-stats-module__row-wrapper {
-	&:hover div {
-		background-color: var(--color-neutral-0);
+.card.is-compact {
+	padding: 0;
+	
+	.videopress-stats-module__grid {
+		margin: 0;
+	}
+}
+
+.section-header {
+	&.stats-module__header {
+		margin: 0;
+		padding: 24px 24px;
+		border-bottom: 1px solid var(--color-border-subtle);
+		
+		.section-header__label {
+			font-family: $font-sf-pro-display;
+			font-size: $font-body;
+			line-height: 40px;
+			font-weight: 500;
+			color: var(--color-text);
+		}
+
+		.stats-card-header__title {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			font-size: $font-body;
+			font-weight: 500;
+			color: var(--color-text);
+
+			.stats-card-header__title-nodes {
+				display: flex;
+				align-items: center;
+
+				.stats-info-area__popover {
+					margin-left: 8px;
+				}
+			}
+		}
+
+		.stats-download-csv {
+			color: var(--color-link);
+
+			&:hover {
+				color: var(--color-link-dark);
+			}
+		}
+	}
+}
+
+.stats-module {
+	&.is-loading,
+	&.has-no-data {
+		.videopress-stats-module__grid {
+			display: none;
+		}
 	}
 }

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -79,3 +79,7 @@
 		background-color: var(--color-neutral-0);
 	}
 }
+
+.stats-module__date-picker-header {
+	margin-bottom: 16px;
+}

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -103,7 +103,7 @@
 		
 		.section-header__label {
 			font-family: $font-sf-pro-display;
-			font-size: $font-body;
+			font-size: $font-title-small;
 			line-height: 40px;
 			font-weight: 500;
 			color: var(--color-text);
@@ -113,7 +113,7 @@
 			display: flex;
 			align-items: center;
 			justify-content: space-between;
-			font-size: $font-body;
+			font-size: $font-title-small;
 			font-weight: 500;
 			color: var(--color-text);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101634

## Proposed Changes

* This PR makes the following style updates to align with the other page headers:
     - Updates the download CSV link color and hover color
     - Updates the padding and margins around the headings and titles
     - Adjusts font weight, colour, style of the headings
     - Refactors SCSS to be more readable and functional

* **note:** this is not the final design. Adjusting incrementally, there will be more PRs to come. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align the video press stats page with the other pages
* This is a followup from #101634 and is being compared to that PR. So it needs to merge first before this one. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live branch
* Navigate to `/stats/day/videoplays/jetpack.com` (or any site with video plays)
* Check that the styling matched below

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/b5b26c81-4dd7-4ec5-b1bd-10565d18d76a)  | ![image](https://github.com/user-attachments/assets/fb27876f-ce3f-4212-a47d-2d0cf3372a72) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
