### PR TITLE
Global Styles: LoTS can now be used for running cross login boundary cross platform AB Experiments

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -2,7 +2,6 @@ import { ExperimentAssignment } from '@automattic/explat-client';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -36,37 +35,10 @@ if ( typeof window !== 'undefined' ) {
 		.catch( () => {} );
 }
 
-function shouldRunGlobalStylesOnPersonalExperiment(
-	siteId: number | null,
-	userLoggedIn: boolean
-): boolean {
-	// Do not run it on SSR contexts.
-	if ( typeof window === 'undefined' ) {
-		return false;
-	}
+const shouldRunGlobalStylesOnPersonalExperiment = (): boolean => typeof window !== 'undefined';
 
-	// Always run it if a site has been selected.
-	if ( siteId !== null ) {
-		return true;
-	}
-
-	// Do not run it on the logged-out theme showcase.
-	if ( ! userLoggedIn && window.location.pathname.startsWith( '/theme' ) ) {
-		return false;
-	}
-
-	// Run it by default. Ideally, we should not run it if the user is logged out, but
-	// we cannot rely on the `isUserLoggedIn` selector for users who just signed up
-	// (see pbxNRc-2HR-p2#comment-4607). So, we assume that this hook is not used in
-	// any logged-out context apart from the theme showcase.
-	return true;
-}
-
-const getGlobalStylesInfoForSite = (
-	siteId: number | null,
-	userLoggedIn: boolean = false
-): Promise< GlobalStylesStatus > => {
-	if ( ! shouldRunGlobalStylesOnPersonalExperiment( siteId, userLoggedIn ) ) {
+const getGlobalStylesInfoForSite = ( siteId: number | null ): Promise< GlobalStylesStatus > => {
+	if ( ! shouldRunGlobalStylesOnPersonalExperiment() ) {
 		return Promise.resolve( {
 			shouldLimitGlobalStyles: true,
 			globalStylesInUse: false,
@@ -101,7 +73,6 @@ export function useSiteGlobalStylesStatus(
 	siteIdOrSlug: number | string | null = null
 ): GlobalStylesStatus {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const userLoggedIn = useSelector( isUserLoggedIn );
 
 	// When site id is null it means that the site hasn't been created yet.
 	const siteId = useSelector( ( state ) => {
@@ -116,7 +87,7 @@ export function useSiteGlobalStylesStatus(
 
 	const { data: globalStylesInfo } = useQuery( {
 		queryKey: [ 'globalStylesInfo', siteId ],
-		queryFn: () => getGlobalStylesInfoForSite( siteId, userLoggedIn ),
+		queryFn: () => getGlobalStylesInfoForSite( siteId ),
 		placeholderData: DEFAULT_GLOBAL_STYLES_INFO,
 		refetchOnWindowFocus: false,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We removed a check that prevented the LoTS from being part of AB experiments that crossed the login boundary.

![Screenshot 2025-03-20 at 13 20 33](https://github.com/user-attachments/assets/991b5b31-1953-405e-84e3-d53300485b85)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to provide a consistent experience for our users that participate in the Global Styles AB experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the instructions found here: https://github.com/Automattic/jetpack/pull/42585
* Then clear assignment, log out, and test starting the flow from wordpress.com/themes to access the LoTS
* Make sure the assignment gets carried over if there is no previous logged-in user assignment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
