### PR TITLE
Stats: Improves video page styling - part 3

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -164,31 +164,31 @@ class VideoPressStatsModule extends Component {
 						</h3>
 					</div>
 				) }
-				<SectionHeader
-					className={ headerClass }
-					label={
-						<div className="stats-card-header__title" role="heading" aria-level="4">
-							<div>{ moduleStrings.title }</div>
-							<div className="stats-card-header__title-nodes">
-								<InfoPopover className="stats-info-area__popover" iconSize={ 24 } position="top">
-									{ translate( 'View detailed statistics about your videos.' ) }
-								</InfoPopover>
-							</div>
-						</div>
-					}
-					href={ ! summary ? summaryLink : null }
-				>
-					{ summary && (
-						<DownloadCsv
-							statType={ statType }
-							data={ csvData }
-							query={ query }
-							path={ path }
-							period={ period }
-						/>
-					) }
-				</SectionHeader>
 				<Card compact className={ cardClasses }>
+					<SectionHeader
+						className={ headerClass }
+						label={
+							<div className="stats-card-header__title" role="heading" aria-level="4">
+								<div>{ moduleStrings.title }</div>
+								<div className="stats-card-header__title-nodes">
+									<InfoPopover className="stats-info-area__popover" iconSize={ 24 } position="top">
+										{ translate( 'View detailed statistics about your videos.' ) }
+									</InfoPopover>
+								</div>
+							</div>
+						}
+						href={ ! summary ? summaryLink : null }
+					>
+						{ summary && (
+							<DownloadCsv
+								statType={ statType }
+								data={ csvData }
+								query={ query }
+								path={ path }
+								period={ period }
+							/>
+						) }
+					</SectionHeader>
 					<div className="videopress-stats-module__grid">
 						<div className="videopress-stats-module__header-row-wrapper">
 							<div className="videopress-stats-module__grid-header">{ translate( 'Title' ) }</div>

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -109,7 +109,8 @@
 	&.stats-module__header {
 		margin: 0;
 		padding: 24px 24px;
-		border-bottom: 1px solid var(--color-border-subtle);
+		border-bottom: none;
+		box-shadow: none;
 		
 		.section-header__label {
 			font-family: $font-sf-pro-display;

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -145,3 +145,7 @@
 		}
 	}
 }
+
+.stats-module__date-picker-header {
+	margin-bottom: 16px;
+}

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -37,7 +37,7 @@
 .videopress-stats-module__grid {
 	display: grid;
 	grid-template-columns: 50% auto auto auto auto;
-	padding: 0.5em 0;
+	padding: 0 0 0.5em;
 	line-height: 40px;
 	font-size: 0.875rem;
 
@@ -95,6 +95,11 @@
 			background-color: var(--color-neutral-0);
 		}
 	}
+
+	.videopress-stats-module__header-row-wrapper {
+		display: contents;
+		padding-bottom: 12px;
+	}
 }
 
 .card.is-compact {
@@ -108,7 +113,7 @@
 .section-header {
 	&.stats-module__header {
 		margin: 0;
-		padding: 24px 24px;
+		padding: 24px 24px 12px;
 		border-bottom: none;
 		box-shadow: none;
 		

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -145,7 +145,3 @@
 		}
 	}
 }
-
-.stats-module__date-picker-header {
-	margin-bottom: 16px;
-}

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -13,6 +13,16 @@
 		line-height: 40px;
 		margin: 0;
 	}
+	margin: 20px 0;
+
+	h3 {
+		color: var(--studio-gray-100);
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: 2rem;
+		font-weight: 400;
+		line-height: 40px;
+		margin: 0;
+	}
 
 	@media (max-width: $break-medium) {
 		margin: 24px 0 16px;

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -13,16 +13,6 @@
 		line-height: 40px;
 		margin: 0;
 	}
-	margin: 20px 0;
-
-	h3 {
-		color: var(--studio-gray-100);
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: 2rem;
-		font-weight: 400;
-		line-height: 40px;
-		margin: 0;
-	}
 
 	@media (max-width: $break-medium) {
 		margin: 24px 0 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101634

## Proposed Changes

* This PR makes the following style updates to align with the other page headers:
     - Combines the two card components into one
     - Removes box shadows creating divider line between heading and table
     - Small tweaks to padding and spacing to align with other similar pages. 

* **note:** this is not the final design. Adjusting incrementally, there will be more PRs to come. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align the video press stats page with the other pages
* This is a followup from #101659 and is being compared to that PR. So it needs to merge first before this one. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live branch
* Navigate to `/stats/day/videoplays/jetpack.com` (or any site with video plays)
* Check that the styling matched below

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/fb27876f-ce3f-4212-a47d-2d0cf3372a72) | ![image](https://github.com/user-attachments/assets/e51cbd01-6109-409c-817c-94ef4186b38c) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
