### PR TITLE
Add text-wrap: pretty and fallback to Add New Site Modal

### DIFF
--- a/client/components/sites-add-new-site/style.scss
+++ b/client/components/sites-add-new-site/style.scss
@@ -127,6 +127,8 @@
 	.sites-add-new-site__popover-button-heading {
 		font-size: rem(14px);
 		font-weight: 600;
+		text-wrap: balance; /* Fallback for browsers that don't support pretty. */
+		text-wrap: pretty;
 	}
 
 	.sites-add-new-site__popover-button-description {
@@ -134,6 +136,8 @@
 		font-weight: 400;
 		color: var(--color-text-black);
 		padding-top: 4px;
+		text-wrap: balance; /* Fallback for browsers that don't support pretty. */
+		text-wrap: pretty;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101184

## Proposed Changes

* This PR ensures that we use `text-wrap: pretty;` and a fallback of `text-wrap: balance;` for the content of menu items that we display in the Add New Site modal

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While reviewing https://github.com/Automattic/wp-calypso/pull/101184, I noticed that code using the `MenuItem` component was explicitly calling `preventWidows()` on the text, but the component is using a `div`, so it's not getting the global style rules for text elements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Navigate to `/sites`
* Click on the "Add New Site" button
* Use your browser inspector tools to verify that the header and subheader sections in the modal include `text-wrap: pretty;` and `text-wrap: balance;` rules.
  - `text-wrap: balance;` should only be used by browsers that don't support `pretty`, currently Safari and Firefox

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
