### PR TITLE
Improve copy in site-migration-popup

### DIFF
--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { WordPressLogo, JetpackLogo } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -56,6 +56,7 @@ const offerClick = () => {
 
 export const Content = () => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	return (
 		<>
 			<Column heading={ translate( 'Add a new site' ) }>
@@ -85,7 +86,9 @@ export const Content = () => {
 					icon={ <Icon icon={ reusableBlock } size={ 18 } /> }
 					heading="Migrate"
 					description={ preventWidows(
-						translate( 'Bring your theme, plugins, and content to WordPress.com.' )
+						hasEnTranslation( 'Bring your entire WordPress site to WordPress.com.' )
+							? translate( 'Bring your entire WordPress site to WordPress.com.' )
+							: translate( 'Bring your theme, plugins, and content to WordPress.com.' )
 					) }
 					buttonProps={ {
 						onClick: migrateClick,
@@ -95,7 +98,9 @@ export const Content = () => {
 					icon={ <Icon icon={ download } size={ 18 } /> }
 					heading="Import"
 					description={ preventWidows(
-						translate( 'Use a backup file to import your content into a new site.' )
+						hasEnTranslation( 'Use a backup to only import content from other platforms.' )
+							? translate( 'Use a backup to only import content from other platforms.' )
+							: translate( 'Use a backup file to import your content into a new site.' )
 					) }
 					buttonProps={ {
 						onClick: importClick,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/101559

## Proposed Changes

Improve copy in create-site-modal for better Migrate vs Import distinction.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The Migrate and Import options in the Add new sites dropdown are not distinct enough from each other.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or go to the calypso.live link below
* Navigate to `/sites`
* Open the modal and verify the copy of the Import and Migrate actions read like this:
  * Migrate: `Bring your entire WordPress site to WordPress.com.`
  * Import: `Use a backup to only import content from other platforms.`
<img width="932" alt="image" src="https://github.com/user-attachments/assets/c71dfb7f-ee87-40eb-8e5b-2171201ba63e" />

* Set your account to a different language and verify the new copy is not shown in English and the previous copy (translated) is shown.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
