### PR TITLE
StepContainerV2: Make viewport mixins internal

### DIFF
--- a/packages/onboarding/src/step-container-v2/components/Heading/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/Heading/style.scss
@@ -1,6 +1,6 @@
 @import '@automattic/typography';
 
-@import '../../../../styles/mixins';
+@import '../../mixins';
 
 .step-container-v2__heading {
 	width: 100%;

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -1,4 +1,4 @@
-@import '../../../../styles/mixins';
+@import '../../mixins';
 
 .step-container-v2 {
 	width: 100%;

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -1,4 +1,4 @@
-@import '../../../../styles/mixins';
+@import '../../mixins';
 
 .step-container-v2__top-bar {
 	z-index: 1;

--- a/packages/onboarding/src/step-container-v2/mixins.scss
+++ b/packages/onboarding/src/step-container-v2/mixins.scss
@@ -1,0 +1,11 @@
+@mixin step-medium-viewport {
+	.step-container-v2.medium-viewport & {
+		@content;
+	}
+}
+
+@mixin step-large-viewport {
+	.step-container-v2.large-viewport & {
+		@content;
+	}
+}

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
@@ -1,4 +1,4 @@
-@import '../../../../styles/mixins';
+@import '../../mixins';
 
 .step-container-v2__content--centered-column-layout {
 	display: flex;

--- a/packages/onboarding/src/step-container-v2/wireframes/FullWidthLayout/style.stories.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/FullWidthLayout/style.stories.scss
@@ -1,7 +1,4 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-
-@import '../../../../styles/mixins';
+@import '../../mixins';
 
 .theme-preview {
 	display: flex;

--- a/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/style.scss
@@ -1,4 +1,4 @@
-@import '../../../../styles/mixins';
+@import '../../mixins';
 
 .step-container-v2__content--two-column-layout {
 	display: flex;

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -260,17 +260,3 @@
 	white-space: nowrap;
 	border-width: 0;
 }
-
-$step-container: '.step-container-v2';
-
-@mixin step-medium-viewport {
-	#{$step-container}.medium-viewport & {
-		@content;
-	}
-}
-
-@mixin step-large-viewport {
-	#{$step-container}.large-viewport & {
-		@content;
-	}
-}


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/98648.

## Proposed Changes

After some thought, I came to the conclusion that it doesn't make sense to expose this as part of the public API.

If the user declares medium and large viewports externally, they can use the same breakpoints in SCSS (assuming they're using it vs. CSS-in-JS, which is another can of worms.)