### PR TITLE
Ask for new layout data only after saving the new launchpad skipped setting

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -159,8 +159,8 @@ const HomeContent = ( {
 			<FullScreenLaunchpad
 				onClose={ async () => {
 					setFocusedLaunchpadDismissed( true );
-					skipCurrentView( null, true );
 					await updateLaunchpadSettings( siteId, { launchpad_screen: 'skipped' } );
+					skipCurrentView( null, true );
 				} }
 				onSiteLaunch={ () => {
 					setCelebrateLaunchModalIsOpen( true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/101485

## Proposed Changes

* We're only loading the new home Layout components after saving the `skipped` data in our backend

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Here's the explanation: 177765-ghe-Automattic/wpcom

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this backend PR: 177765-ghe-Automattic/wpcom
* Make sure after skipping a Focused Launchpad screen, we don't see a blank Calypso home
