### PR TITLE
Untangled Plans: keep scroll position when changing plan term

### DIFF
--- a/client/layout/hosting-dashboard/item-view/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/index.tsx
@@ -122,7 +122,9 @@ export default function ItemView( {
 					context={ navRef }
 				/>
 			) }
-			<ItemViewContent>{ selectedFeature.preview }</ItemViewContent>
+			<ItemViewContent siteId={ itemData.blogId } featureId={ selectedFeature.id }>
+				{ selectedFeature.preview }
+			</ItemViewContent>
 		</div>
 	);
 }

--- a/client/layout/hosting-dashboard/item-view/item-view-content/index.tsx
+++ b/client/layout/hosting-dashboard/item-view/item-view-content/index.tsx
@@ -3,11 +3,13 @@ import { useEffect, useRef, ReactNode } from 'react';
 import './style.scss';
 
 type Props = {
+	siteId?: number;
+	featureId: string;
 	children?: ReactNode;
 	className?: string;
 };
 
-export default function ItemViewContent( { children }: Props ) {
+export default function ItemViewContent( { siteId, featureId, children }: Props ) {
 	const ref = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
@@ -16,7 +18,7 @@ export default function ItemViewContent( { children }: Props ) {
 				ref.current.scrollTop = 0;
 			}
 		}, 0 );
-	}, [ children ] );
+	}, [ siteId, featureId ] );
 
 	return (
 		<div className="hosting-dashboard-item-view__content" ref={ ref }>


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/10607

## Proposed Changes

This PR keeps the scroll position when we change the plan billing term in the new untangled Plans page.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/4557703b-cc80-4f49-bed1-4b9402088af4">|<video src="https://github.com/user-attachments/assets/6a6315d9-04a8-464f-a045-1f440b6d20ce">|
|<video src="https://github.com/user-attachments/assets/29bd8f5d-e5a9-4934-a6cd-3381d25723a3">|<video src="https://github.com/user-attachments/assets/495a082c-f7bb-4290-82e2-98b67635a8bf">|

## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

1. Go to `/plans/:site?flags=untangling/plans` of a site with a PAID plan.
2. Scroll down and click Compare plans.
3. Change the plan term.
4. Observe that the scroll position stays the same.
5. Re-test https://github.com/Automattic/wp-calypso/pull/90261 (regression test)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?