### PR TITLE
MARTECH-32 Implement GitHub authentication endpoint

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -24,6 +24,8 @@ import {
 	jetpackAppleAuthCallback,
 	jetpackGoogleAuthCallback,
 	jetpackGoogleAuth,
+	jetpackGitHubAuth,
+	jetpackGitHubAuthCallback,
 } from './controller';
 import redirectLoggedIn from './redirect-logged-in';
 import { setShouldServerSideRenderLogin, ssrSetupLocaleLogin, setMetaTags } from './ssr';
@@ -160,6 +162,26 @@ export default ( router ) => {
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		jetpackAppleAuthCallback,
+		makeLoggedOutLayout
+	);
+
+	router(
+		`/log-in/jetpack/github/${ lang }`,
+		redirectLoggedIn,
+		setLocaleMiddleware(),
+		setMetaTags,
+		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+		jetpackGitHubAuth,
+		makeLoggedOutLayout
+	);
+
+	router(
+		`/log-in/jetpack/github/callback/${ lang }`,
+		redirectLoggedIn,
+		setLocaleMiddleware(),
+		setMetaTags,
+		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+		jetpackGitHubAuthCallback,
 		makeLoggedOutLayout
 	);
 


### PR DESCRIPTION
Related to 177769-ghe-Automattic/wpcom

## Proposed Changes

* Add auth endpoint and callback handling for direct GitHub authentication with redirect_to param

## Why are these changes being made?
We're building new onboarding flow for Jetpack that will simplify the process for new users. The user will now choose their authentication method directly in Jetpack plugin thus we needed to make some adjustments on Calypso end.

## Testing Instructions

1. You need this change (177607-ghe-Automattic/wpcom) on your sandbox and point `wordpress.com` to your sandbox
2. You also need this 177769-ghe-Automattic/wpcom
3. Then it's quite easy
4. Be logged out and go to `calypso.localhost:3000/log-in/jetpack/github?redirect_to=/success`
5. You should be able to go through github authentication and land on `calypso.localhost:3000/success`
6. Otherwise, you should land on `calypso.localhost:3000/log-in/jetpack?redirect_to=/success`