### PR TITLE
Fix individual importer screens' margins

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -12,6 +12,12 @@
 
 	.import__onboarding-page {
 		@include onboarding-block-margin;
+
+		@media ( min-width: $break-medium ) {
+			margin-left: auto;
+			margin-right: auto;
+		}
+
 		.onboarding-progress {
 			min-width: auto;
 			margin: auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101545 and https://github.com/Automattic/wp-calypso/pull/101615

## Proposed Changes

* Fix padding on single-platform import screens in the onboarding flow for wider screens.

**Visuals**

**Before**

<img width="1357" alt="Screenshot 2025-03-20 at 10 17 06 AM" src="https://github.com/user-attachments/assets/c4ffce6c-bbee-4cde-a14b-c9b3f9728541" />

**After**

<img width="1351" alt="Screenshot 2025-03-20 at 10 16 55 AM" src="https://github.com/user-attachments/assets/26950361-cc93-48a8-8ba3-df07012703c2" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes a margins bug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/start` and select import/migrate at the goals step.
* Input a WordPress-based test URL
* Choose Import at the import or migrate step
* Ensure everything is centered and there are margins around the contents on smaller screen widths.
* As you resize your browser window, ensure the content stays centered on all screens.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
