### PR TITLE
Hosting Features: Update CTA label

### DIFF
--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -215,7 +215,9 @@ const HostingFeatures = ( { showAsTools }: HostingFeaturesProps ) => {
 					dispatch( recordTracksEvent( 'calypso_hosting_features_upgrade_plan_click' ) )
 				}
 			>
-				{ translate( 'Upgrade now' ) }
+				{ translate( 'Upgrade to %(planName)s', {
+					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+				} ) }
 			</HostingHeroButton>
 		);
 	}


### PR DESCRIPTION
## Proposed Changes

Updates the label of the "Upgrade now" CTA in the Hosting Features panel.

Fixes #101530.

## Why are these changes being made?

See #101530.

## Testing Instructions

* Go to `/hosting-features/:site` where `:site` is a simple site on a Free plan.
* Verify you can see the new button label.

## Screenshots

|Before|After|
|---|---|
|![Screenshot 2025-03-20 at 17 00 34](https://github.com/user-attachments/assets/ee26f140-8fe2-41cb-92d4-38a61d33dd69)|![Screenshot 2025-03-20 at 17 00 29](https://github.com/user-attachments/assets/55dc346d-f2ba-4f04-88a7-84a75928ddf4)|
