### PR TITLE
Remove style variation description on theme showcase

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -2,9 +2,7 @@ import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import {
 	FEATURE_UPLOAD_THEMES,
-	PLAN_BUSINESS,
 	WPCOM_FEATURES_INSTALL_PLUGINS,
-	getPlan,
 	FEATURE_INSTALL_THEMES,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
@@ -728,7 +726,6 @@ class ThemeSheet extends Component {
 		return (
 			styleVariations.length > 0 && (
 				<ThemeStyleVariations
-					description={ this.getStyleVariationDescription() }
 					splitDefaultVariation={ shouldSplitDefaultVariation || needsUpgrade }
 					selectedVariation={ this.getSelectedStyleVariation() }
 					variations={ styleVariations }
@@ -1103,28 +1100,6 @@ class ThemeSheet extends Component {
 
 	onAtomicThemeActiveFailure = ( message ) => {
 		this.props.errorNotice( message );
-	};
-
-	getStyleVariationDescription = () => {
-		const { defaultOption, isActive, isWpcomTheme, themeId, shouldLimitGlobalStyles, translate } =
-			this.props;
-		if ( isActive && defaultOption.getUrl ) {
-			return translate( 'Open the {{a}}site editor{{/a}} to change your site’s style.', {
-				components: {
-					a: (
-						<a href={ defaultOption.getUrl( themeId ) } target="_blank" rel="noopener noreferrer" />
-					),
-				},
-			} );
-		}
-
-		if ( ! shouldLimitGlobalStyles || isWpcomTheme ) {
-			return;
-		}
-
-		return translate( 'Additional styles require the %(businessPlanName)s plan or higher.', {
-			args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-		} );
 	};
 
 	renderSheet = () => {

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -1,11 +1,9 @@
 import AsyncLoad from 'calypso/components/async-load';
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
-import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
 
 interface ThemeStyleVariationsProps {
-	description: TranslateResult;
 	selectedVariation: StyleVariation;
 	variations: StyleVariation[];
 	splitDefaultVariation: boolean;
@@ -14,7 +12,6 @@ interface ThemeStyleVariationsProps {
 }
 
 const ThemeStyleVariations = ( {
-	description,
 	selectedVariation,
 	variations,
 	splitDefaultVariation,
@@ -24,8 +21,6 @@ const ThemeStyleVariations = ( {
 	const isGlobalStylesOnPersonal = useSiteGlobalStylesOnPersonal();
 	return (
 		<div className="theme__sheet-style-variations">
-			{ !! description && <p>{ description }</p> }
-
 			<div className="theme__sheet-style-variations-previews">
 				<AsyncLoad
 					require="@automattic/global-styles/src/components/global-styles-variations"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100354

## Proposed Changes

Remove the style variation description. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The style variation description for the active theme links people to the site editor to make changes. This is redundant with the big blue Customize Site button.

Additionally I've removed the concept of the description altogether - the remaining case isn't possible to reach - a description isn't displayed for non-active wpcom themes, and we don't display style variations for non-wpcom themes at all. It's also redundant with other information on that page.

Here's what the description would look like if it was forced to appear:

<img src="https://github.com/user-attachments/assets/3cf0b388-5e8a-44ec-acf2-eb24e84af79a" width="400">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test using the calypso.live link below

1. Go to /themes without a site selected
2. Select a theme that has style variations
3. You should notice no difference between this and live

1. Select a free site and then go to /themes
2. Select a theme that has style variations
3. You should notice no difference between this and live
4. Activate the theme
5. Go back to the theme showcase and select the theme you just activated on the site you just activated it on.
6. Notice that the ‘Open the site editor to change your site’s stye’ paragraph has been removed.

Before | After
-------|------
<img width="1369" alt="Screenshot 2025-03-20 at 15 24 10" src="https://github.com/user-attachments/assets/38215b28-5058-4871-a355-6c3aa4ed4f21" /> | <img width="1369" alt="Screenshot 2025-03-20 at 15 24 37" src="https://github.com/user-attachments/assets/1c4bd3bc-e2e1-4d82-a771-e1a96810f7bb" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
