### PR TITLE
Subscribers: Add back subscriber details URLs

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -166,6 +166,8 @@ const SubscriberDataViews = ( {
 		} else if ( ! subscriberId && selectedSubscriber ) {
 			setSelectedSubscriber( null );
 		}
+		// We don't need to re-run this effect when selectedSubscriber changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ subscriberId, subscriberDetails, subscribersQueryResult?.subscribers ] );
 
 	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
@@ -446,22 +448,6 @@ const SubscriberDataViews = ( {
 				.map( ( filter ) => filter.value ) as SubscribersFilterBy[] ) ?? [];
 		setFilters( filterValues.length ? filterValues : [ SubscribersFilterBy.All ] );
 	}, [ currentView.search, currentView.filters ] );
-
-	// Handle browser back/forward navigation
-	useEffect( () => {
-		const handleRouteChange = () => {
-			const pathParts = window.location.pathname.split( '/' );
-			const lastPart = pathParts[ pathParts.length - 1 ];
-
-			// If we're back at the main subscribers page (no subscriber ID in URL)
-			if ( lastPart === siteSlug ) {
-				setSelectedSubscriber( null );
-			}
-		};
-
-		window.addEventListener( 'popstate', handleRouteChange );
-		return () => window.removeEventListener( 'popstate', handleRouteChange );
-	}, [ siteSlug ] );
 
 	// Memoize the data and pagination info.
 	const { data, paginationInfo } = useMemo( () => {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -139,11 +139,19 @@ const SubscriberDataViews = ( {
 		}
 	);
 
-	const { data: subscriber, isLoading: isLoadingDetails } = useSubscriberDetailsQuery(
+	// Fetch subscriber details for URL subscriber ID only
+	const { data: subscriberDetails, isLoading: isLoadingDetails } = useSubscriberDetailsQuery(
 		siteId ?? null,
-		selectedSubscriber?.subscription_id,
-		selectedSubscriber?.user_id
+		subscriberId ? parseInt( subscriberId, 10 ) : undefined,
+		undefined
 	);
+
+	// Set initial subscriber from URL if provided
+	useEffect( () => {
+		if ( subscriberDetails && subscriberId ) {
+			setSelectedSubscriber( subscriberDetails );
+		}
+	}, [ subscriberDetails, subscriberId ] );
 
 	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
 		useSubscribedNewsletterCategories( {
@@ -176,7 +184,7 @@ const SubscriberDataViews = ( {
 			if ( Array.isArray( input ) ) {
 				if ( input.length === 0 ) {
 					setSelectedSubscriber( null );
-					page.replace( `/subscribers/${ siteSlug }` );
+					page.show( `/subscribers/${ siteSlug }` );
 					return;
 				}
 				const subscriber = subscribers.find( ( s ) => s.subscription_id.toString() === input[ 0 ] );
@@ -426,20 +434,6 @@ const SubscriberDataViews = ( {
 		setFilters( filterValues.length ? filterValues : [ SubscribersFilterBy.All ] );
 	}, [ currentView.search, currentView.filters ] );
 
-	// Fetch initial subscriber if ID is provided
-	const { data: initialSubscriber } = useSubscriberDetailsQuery(
-		siteId ?? null,
-		subscriberId ? parseInt( subscriberId, 10 ) : undefined,
-		undefined
-	);
-
-	// Update selected subscriber when initialSubscriber changes
-	useEffect( () => {
-		if ( initialSubscriber ) {
-			setSelectedSubscriber( initialSubscriber );
-		}
-	}, [ initialSubscriber ] );
-
 	// Handle browser back/forward navigation
 	useEffect( () => {
 		const handleRouteChange = () => {
@@ -517,10 +511,10 @@ const SubscriberDataViews = ( {
 				siteId &&
 				! isLoadingNewsletterCategories &&
 				! isLoadingDetails &&
-				subscriber && (
+				subscriberDetails && (
 					<section className="subscriber-data-views__details">
 						<SubscriberDetails
-							subscriber={ subscriber }
+							subscriber={ subscriberDetails }
 							siteId={ siteId }
 							subscriptionId={ selectedSubscriber.subscription_id }
 							onClose={ () => {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { Gravatar, TimeSince } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
@@ -10,6 +11,7 @@ import { getCouponsAndGiftsEnabledForSiteId } from 'calypso/state/memberships/se
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscribersFilterBy, SubscribersSortBy, SubscribersStatus } from '../../constants';
 import { useSubscriptionPlans, useUnsubscribeModal } from '../../hooks';
 import {
@@ -36,6 +38,7 @@ type SubscriberDataViewsProps = {
 	siteId: number | null;
 	isUnverified: boolean;
 	onGiftSubscription: ( subscriber: Subscriber ) => void;
+	subscriberId?: string;
 };
 
 const SubscriptionTypeCell = ( { subscriber }: { subscriber: Subscriber } ) => {
@@ -74,12 +77,14 @@ const SubscriberDataViews = ( {
 	siteId,
 	onGiftSubscription,
 	isUnverified,
+	subscriberId,
 }: SubscriberDataViewsProps ) => {
 	const isMobile = useBreakpoint( '<660px' );
 	const recordSubscriberClicked = useRecordSubscriberClicked();
 	const recordSubscriberSearch = useRecordSubscriberSearch();
 	const recordSubscriberFilter = useRecordSubscriberFilter();
 	const recordSubscriberSort = useRecordSubscriberSort();
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ filters, setFilters ] = useState< SubscribersFilterBy[] >( [ SubscribersFilterBy.All ] );
@@ -171,6 +176,7 @@ const SubscriberDataViews = ( {
 			if ( Array.isArray( input ) ) {
 				if ( input.length === 0 ) {
 					setSelectedSubscriber( null );
+					page.replace( `/subscribers/${ siteSlug }` );
 					return;
 				}
 				const subscriber = subscribers.find( ( s ) => s.subscription_id.toString() === input[ 0 ] );
@@ -181,6 +187,7 @@ const SubscriberDataViews = ( {
 						user_id: subscriber.user_id,
 					} );
 					setSelectedSubscriber( subscriber );
+					page.show( `/subscribers/${ siteSlug }/${ subscriber.subscription_id }` );
 				}
 			} else {
 				recordSubscriberClicked( 'row', {
@@ -189,9 +196,10 @@ const SubscriberDataViews = ( {
 					user_id: input.user_id,
 				} );
 				setSelectedSubscriber( input );
+				page.show( `/subscribers/${ siteSlug }/${ input.subscription_id }` );
 			}
 		},
-		[ subscribers, recordSubscriberClicked, siteId ]
+		[ subscribers, recordSubscriberClicked, siteId, siteSlug ]
 	);
 
 	const fields = useMemo(
@@ -418,6 +426,36 @@ const SubscriberDataViews = ( {
 		setFilters( filterValues.length ? filterValues : [ SubscribersFilterBy.All ] );
 	}, [ currentView.search, currentView.filters ] );
 
+	// Fetch initial subscriber if ID is provided
+	const { data: initialSubscriber } = useSubscriberDetailsQuery(
+		siteId ?? null,
+		subscriberId ? parseInt( subscriberId, 10 ) : undefined,
+		undefined
+	);
+
+	// Update selected subscriber when initialSubscriber changes
+	useEffect( () => {
+		if ( initialSubscriber ) {
+			setSelectedSubscriber( initialSubscriber );
+		}
+	}, [ initialSubscriber ] );
+
+	// Handle browser back/forward navigation
+	useEffect( () => {
+		const handleRouteChange = () => {
+			const pathParts = window.location.pathname.split( '/' );
+			const lastPart = pathParts[ pathParts.length - 1 ];
+
+			// If we're back at the main subscribers page (no subscriber ID in URL)
+			if ( lastPart === siteSlug ) {
+				setSelectedSubscriber( null );
+			}
+		};
+
+		window.addEventListener( 'popstate', handleRouteChange );
+		return () => window.removeEventListener( 'popstate', handleRouteChange );
+	}, [ siteSlug ] );
+
 	// Memoize the data and pagination info.
 	const { data, paginationInfo } = useMemo( () => {
 		return {
@@ -485,7 +523,10 @@ const SubscriberDataViews = ( {
 							subscriber={ subscriber }
 							siteId={ siteId }
 							subscriptionId={ selectedSubscriber.subscription_id }
-							onClose={ () => setSelectedSubscriber( null ) }
+							onClose={ () => {
+								setSelectedSubscriber( null );
+								page.show( `/subscribers/${ siteSlug }` );
+							} }
 							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }
 							newsletterCategoriesEnabled={ subscribedNewsletterCategoriesData?.enabled }
 							newsletterCategories={ subscribedNewsletterCategoriesData?.newsletterCategories }

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -139,19 +139,34 @@ const SubscriberDataViews = ( {
 		}
 	);
 
-	// Fetch subscriber details for URL subscriber ID only
+	// Fetch subscriber details.
 	const { data: subscriberDetails, isLoading: isLoadingDetails } = useSubscriberDetailsQuery(
 		siteId ?? null,
 		subscriberId ? parseInt( subscriberId, 10 ) : undefined,
-		undefined
+		selectedSubscriber?.user_id
 	);
 
-	// Set initial subscriber from URL if provided
+	// Single effect to handle all subscriber selection scenarios
 	useEffect( () => {
-		if ( subscriberDetails && subscriberId ) {
-			setSelectedSubscriber( subscriberDetails );
+		// If URL changes or we get new subscriber details, update the selection
+		if ( subscriberId ) {
+			// If we have details and they match the current URL
+			if ( subscriberDetails && subscriberDetails.subscription_id.toString() === subscriberId ) {
+				setSelectedSubscriber( subscriberDetails );
+			}
+			// If we don't have matching details yet, try to find in current list
+			else {
+				const subscriberFromList = subscribersQueryResult?.subscribers.find(
+					( s ) => s.subscription_id.toString() === subscriberId
+				);
+				if ( subscriberFromList ) {
+					setSelectedSubscriber( subscriberFromList );
+				}
+			}
+		} else if ( ! subscriberId && selectedSubscriber ) {
+			setSelectedSubscriber( null );
 		}
-	}, [ subscriberDetails, subscriberId ] );
+	}, [ subscriberId, subscriberDetails, subscribersQueryResult?.subscribers ] );
 
 	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
 		useSubscribedNewsletterCategories( {
@@ -194,7 +209,6 @@ const SubscriberDataViews = ( {
 						subscription_id: subscriber.subscription_id,
 						user_id: subscriber.user_id,
 					} );
-					setSelectedSubscriber( subscriber );
 					page.show( `/subscribers/${ siteSlug }/${ subscriber.subscription_id }` );
 				}
 			} else {
@@ -203,7 +217,6 @@ const SubscriberDataViews = ( {
 					subscription_id: input.subscription_id,
 					user_id: input.user_id,
 				} );
-				setSelectedSubscriber( input );
 				page.show( `/subscribers/${ siteSlug }/${ input.subscription_id }` );
 			}
 		},
@@ -518,7 +531,6 @@ const SubscriberDataViews = ( {
 							siteId={ siteId }
 							subscriptionId={ selectedSubscriber.subscription_id }
 							onClose={ () => {
-								setSelectedSubscriber( null );
 								page.show( `/subscribers/${ siteSlug }` );
 							} }
 							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }

--- a/client/my-sites/subscribers/controller.js
+++ b/client/my-sites/subscribers/controller.js
@@ -1,7 +1,6 @@
 import SubscribersPage from './main';
 
 export function subscribers( context, next ) {
-	context.primary = <SubscribersPage />;
-
+	context.primary = <SubscribersPage subscriberId={ context.params.subscriberId } />;
 	next();
 }

--- a/client/my-sites/subscribers/index.js
+++ b/client/my-sites/subscribers/index.js
@@ -19,4 +19,14 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	page(
+		'/subscribers/:domain/:subscriberId',
+		siteSelection,
+		navigation,
+		redirectIfCurrentUserCannot( 'list_users' ),
+		subscribers,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -13,10 +13,26 @@ import { SubscriberDataViews } from 'calypso/my-sites/subscribers/components/sub
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { Subscriber } from './types';
 
+/**
+ * Props for the SubscribersPage component
+ */
 type Props = {
+	/**
+	 * The ID of the subscriber to display details for.
+	 * When provided and valid, shows the subscriber details view.
+	 * Should be a numeric string matching the subscriber's subscription_id.
+	 */
 	subscriberId?: string;
 };
 
+/**
+ * Renders the subscribers management page.
+ * Handles both the subscribers list view and individual subscriber details view.
+ * The view is determined by the presence of a valid subscriberId in the URL.
+ *
+ * @param {Props} props - Component properties
+ * @param {string} [props.subscriberId] - Optional subscriber ID from URL parameters
+ */
 const SubscribersPage = ( { subscriberId }: Props ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) ?? null;

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -13,10 +13,13 @@ import { SubscriberDataViews } from 'calypso/my-sites/subscribers/components/sub
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { Subscriber } from './types';
 
-const SubscribersPage = () => {
+type Props = {
+	subscriberId?: string;
+};
+
+const SubscribersPage = ( { subscriberId }: Props ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) ?? null;
-	const subscriberId = window.location.pathname.split( '/' ).pop();
 	const isSubscriberIdValid = subscriberId && /^\d+$/.test( subscriberId );
 
 	const initiallyLoadedWithTaskCompletionHash = useRef(

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -16,6 +16,8 @@ import { Subscriber } from './types';
 const SubscribersPage = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) ?? null;
+	const subscriberId = window.location.pathname.split( '/' ).pop();
+	const isSubscriberIdValid = subscriberId && /^\d+$/.test( subscriberId );
 
 	const initiallyLoadedWithTaskCompletionHash = useRef(
 		window.location.hash === '#building-your-audience-task'
@@ -56,6 +58,7 @@ const SubscribersPage = () => {
 						siteId={ siteId }
 						isUnverified={ isUnverified }
 						onGiftSubscription={ onGiftSubscription }
+						subscriberId={ isSubscriberIdValid ? subscriberId : undefined }
 					/>
 
 					{ giftUserId !== 0 && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/589, https://github.com/Automattic/loop/issues/496

## Proposed Changes

* Add subscriber id to the URL when opening the subscriber details panel.
* Update the URL and component when going back or closing the panel.


https://github.com/user-attachments/assets/c1c28cf2-6bf9-4ccc-9c95-b0dc055da9bb



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The URL is needed for better UX and the mobile app.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Click on a subscriber. The URL should change to include the subscriber id.
* Click back in your browser. The URL and component should update to show the list without an id.
* Open another subscriber. Click "Close." The URL and component should update to show the list without an id.
* In a new tab, enter a URL with subscriber id (/subscribers/{site url}/{subscriber id})
* The panel should be open with the selected subscriber visible.
* Test that you can navigate between subscribers with the panel open, and the IDs in the URL change.
* Test in Chrome, Firefox, and Safari.
* Test both Calypso Blue and Jetpack Cloud.

Note that this warning is expected when re-rendering the page:
```
Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17.
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
