### PR TITLE
Revert "Remove the primary domain selector from top of bulk domain list page"

### DIFF
--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/index.tsx
@@ -1,0 +1,216 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import { Card } from '@automattic/components';
+import { Substitution, useTranslate } from 'i18n-calypso';
+import { useState, ChangeEvent, useEffect, FormEvent } from 'react';
+import CardHeading from 'calypso/components/card-heading';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormSelect from 'calypso/components/forms/form-select';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { useSelector } from 'calypso/state';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
+import type { DomainData, SiteDetails } from '@automattic/data-stores';
+
+import './style.scss';
+
+type PrimaryDomainSelectorProps = {
+	domains: undefined | DomainData[];
+	site: undefined | null | SiteDetails;
+	onSetPrimaryDomain: ( domain: string, onComplete: () => void, type: string ) => void;
+};
+
+const PrimaryDomainSelector = ( {
+	domains,
+	site,
+	onSetPrimaryDomain,
+}: PrimaryDomainSelectorProps ) => {
+	const [ selectedDomain, setSelectedDomain ] = useState< string >( '' );
+	const [ primaryDomain, setPrimaryDomain ] = useState< string >( '' );
+	const [ isSettingPrimaryDomain, setIsSettingPrimaryDomain ] = useState< boolean >( false );
+
+	const translate = useTranslate();
+
+	const primaryWithPlanOnly = useSelector( ( state ) =>
+		currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+	);
+
+	useEffect( () => {
+		if ( domains?.length ) {
+			const primary = domains.find( ( domain ) => {
+				return domain.primary_domain;
+			} );
+			if ( primary ) {
+				setPrimaryDomain( primary.domain );
+				setSelectedDomain( '' );
+			}
+		}
+	}, [ domains ] );
+
+	if ( ! domains || ! site ) {
+		return null;
+	}
+
+	const isOnFreePlan = site?.plan?.is_free ?? false;
+	const canUserSetPrimaryDomainOnThisSite = ! ( primaryWithPlanOnly && isOnFreePlan );
+
+	const shouldUpgradeToMakeDomainPrimary = ( domain: DomainData ): boolean => {
+		return (
+			! canUserSetPrimaryDomainOnThisSite &&
+			( domain.type === 'registered' || domain.type === 'mapping' ) &&
+			! domain.current_user_can_create_site_from_domain_only &&
+			! domain.wpcom_domain &&
+			! domain.is_wpcom_staging_domain &&
+			( site?.plan?.features?.active.includes( FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ) ?? false )
+		);
+	};
+
+	// All domains that can be set as primary, except the current primary domain
+	let otherValidPrimaryDomains = domains.filter( ( domain ) => {
+		return (
+			domain.can_set_as_primary &&
+			! domain.aftermarket_auction &&
+			! shouldUpgradeToMakeDomainPrimary( domain ) &&
+			! domain.primary_domain
+		);
+	} );
+
+	const hasWpcomStagingDomain = domains.find( ( domain ) => domain.is_wpcom_staging_domain );
+
+	if ( hasWpcomStagingDomain ) {
+		otherValidPrimaryDomains = otherValidPrimaryDomains.filter( ( domain ) => {
+			if ( domain.wpcom_domain ) {
+				return domain.is_wpcom_staging_domain;
+			}
+
+			return true;
+		} );
+	}
+
+	const onSelectChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
+		setSelectedDomain( event.target.value );
+	};
+
+	const onSubmit = ( event: FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+
+		const domain = domains.find( ( d ) => d.domain === selectedDomain );
+		if ( ! domain || ! selectedDomain ) {
+			return;
+		}
+
+		setIsSettingPrimaryDomain( true );
+		onSetPrimaryDomain(
+			selectedDomain,
+			() => {
+				setIsSettingPrimaryDomain( false );
+				setSelectedDomain( '' );
+			},
+			domain.type
+		);
+	};
+
+	const trackUpgradeClick = ( isPlanUpgrade: boolean = false ) => {
+		recordTracksEvent( 'calypso_primary_site_address_nudge_cta_click', {
+			cta_name: isPlanUpgrade ? 'buy_a_plan' : 'add_custom_domain',
+		} );
+	};
+
+	let message: Substitution;
+
+	if ( ! canUserSetPrimaryDomainOnThisSite ) {
+		// The user can't set a primary domain on this site because they need to upgrade their plan
+		message = translate(
+			"Your site plan doesn't allow to set a custom domain as a primary site address. {{planUpgradeLink}}Upgrade your plan{{/planUpgradeLink}} and get a free one-year domain registration or transfer with any annual paid plan. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
+			{
+				components: {
+					planUpgradeLink: (
+						<a href={ '/plans/' + primaryDomain } onClick={ () => trackUpgradeClick( true ) } />
+					),
+					learnMoreLink: (
+						<InlineSupportLink supportContext="primary-site-address" showIcon={ false } />
+					),
+				},
+			}
+		);
+	} else if ( otherValidPrimaryDomains.length < 1 ) {
+		// The user can't set a primary domain because they don't have any other valid domains
+		message = translate(
+			'Before changing your primary site address you must {{domainSearchLink}}register{{/domainSearchLink}} or {{mapDomainLink}}connect{{/mapDomainLink}} a new custom domain. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				components: {
+					domainSearchLink: (
+						<a
+							href={ '/domains/add/' + primaryDomain }
+							onClick={ () => trackUpgradeClick( false ) }
+						/>
+					),
+					mapDomainLink: (
+						<a
+							href={ '/domains/add/use-my-domain/' + primaryDomain }
+							onClick={ () => trackUpgradeClick( false ) }
+						/>
+					),
+					learnMoreLink: (
+						<InlineSupportLink supportContext="primary-site-address" showIcon={ false } />
+					),
+				},
+			}
+		);
+	} else {
+		// The user has at least one domain that can be set as primary and the site is on a plan that allows it
+		message = translate(
+			'The current primary address set for this site is: {{strong}}%(selectedDomain)s{{/strong}}. You can change it by selecting a different address from the list below. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+			{
+				args: { selectedDomain: primaryDomain as string },
+				components: {
+					strong: <strong />,
+					learnMoreLink: (
+						<InlineSupportLink supportContext="primary-site-address" showIcon={ false } />
+					),
+				},
+			}
+		);
+	}
+
+	return (
+		<Card className="domains-set-primary-address">
+			<CardHeading className="domains-set-primary-address__title" isBold size={ 16 } tagName="h2">
+				{ translate( 'Primary site address' ) }
+			</CardHeading>
+			<>
+				<p className="domains-set-primary-address__subtitle">{ message }</p>
+				{ otherValidPrimaryDomains.length > 0 && canUserSetPrimaryDomainOnThisSite && (
+					<FormFieldset className="domains-set-primary-address__fieldset">
+						<FormSelect
+							className="domains-set-primary-address__select"
+							disabled={ isSettingPrimaryDomain }
+							id="primary-domain-selector"
+							onChange={ onSelectChange }
+							value={ selectedDomain }
+						>
+							<option value="">{ translate( 'Select a domain' ) }</option>
+							{ otherValidPrimaryDomains.map( ( domain ) => (
+								<option key={ domain.domain } value={ domain.domain }>
+									{ domain.domain }
+								</option>
+							) ) }
+						</FormSelect>
+						<FormButton
+							className="domains-set-primary-address__submit"
+							primary
+							busy={ isSettingPrimaryDomain }
+							disabled={ isSettingPrimaryDomain || ! selectedDomain }
+							onClick={ onSubmit }
+						>
+							{ translate( 'Set as primary' ) }
+						</FormButton>
+					</FormFieldset>
+				) }
+			</>
+		</Card>
+	);
+};
+
+export default PrimaryDomainSelector;

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/style.scss
@@ -1,0 +1,33 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.domains-set-primary-address {
+	&__title {
+		margin-top: 0;
+	}
+	&__subtitle {
+		color: var(--color-text-subtle);
+		margin-bottom: 0;
+		font-size: 0.875rem;
+	}
+	&__fieldset.form-fieldset {
+		margin-top: 0.875rem;
+		margin-bottom: 0;
+	}
+	&__select.form-select {
+		max-width: 100%;
+		width: 100%;
+		@media (min-width: $break-large) {
+			width: auto;
+		}
+	}
+	&__submit {
+		margin-right: 0;
+		margin-top: 12px;
+		display: block;
+		@media (min-width: $break-large) {
+			display: inline-block;
+			margin-top: 0;
+			margin-left: 12px;
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/components/primary-domain-selector/test/index.tsx
+++ b/client/my-sites/domains/domain-management/components/primary-domain-selector/test/index.tsx
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { FEATURE_SET_PRIMARY_CUSTOM_DOMAIN } from '@automattic/calypso-products';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import PrimaryDomainSelector from '../index';
+
+// Mock dependencies
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+jest.mock( 'calypso/components/inline-support-link' );
+
+const mockStore = configureMockStore();
+
+describe( 'PrimaryDomainSelector', () => {
+	const defaultProps = {
+		onSetPrimaryDomain: jest.fn(),
+		domains: [
+			{
+				domain: 'primary.com',
+				primary_domain: true,
+				can_set_as_primary: true,
+				type: 'registered',
+			},
+			{
+				domain: 'secondary.com',
+				primary_domain: false,
+				can_set_as_primary: true,
+				type: 'registered',
+			},
+			{
+				domain: 'cannot-be-primary.com',
+				primary_domain: false,
+				can_set_as_primary: false,
+				type: 'registered',
+			},
+		],
+		site: {
+			plan: {
+				is_free: false,
+				features: {
+					active: [ FEATURE_SET_PRIMARY_CUSTOM_DOMAIN ],
+				},
+			},
+		},
+	};
+
+	const renderComponent = ( props = {}, storeState = {} ) => {
+		const store = mockStore( {
+			currentUser: {
+				flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS ],
+			},
+			...storeState,
+		} );
+
+		return render(
+			<Provider store={ store }>
+				<PrimaryDomainSelector { ...defaultProps } { ...props } />
+			</Provider>
+		);
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the primary domain message', () => {
+		renderComponent();
+		expect(
+			screen.getByText( /The current primary address set for this site is:/i )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'primary.com' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the domain selector with valid options', () => {
+		renderComponent();
+		const select = screen.getByRole( 'combobox' );
+		expect( select ).toBeInTheDocument();
+		expect( screen.getByText( 'secondary.com' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'cannot-be-primary.com' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'enables the submit button only when a domain is selected', () => {
+		renderComponent();
+		const submitButton = screen.getByRole( 'button', { name: /set as primary/i } );
+		expect( submitButton ).toBeDisabled();
+
+		const select = screen.getByRole( 'combobox' );
+		fireEvent.change( select, { target: { value: 'secondary.com' } } );
+
+		expect( submitButton ).toBeEnabled();
+	} );
+
+	it( 'calls onSetPrimaryDomain when form is submitted', () => {
+		renderComponent();
+		const select = screen.getByRole( 'combobox' );
+		const submitButton = screen.getByRole( 'button', { name: /set as primary/i } );
+
+		fireEvent.change( select, { target: { value: 'secondary.com' } } );
+		fireEvent.click( submitButton );
+
+		expect( defaultProps.onSetPrimaryDomain ).toHaveBeenCalledWith(
+			'secondary.com',
+			expect.any( Function ),
+			'registered'
+		);
+	} );
+
+	it( 'shows upgrade message for free plan users', () => {
+		renderComponent(
+			{
+				site: {
+					plan: {
+						is_free: true,
+					},
+				},
+			},
+			{
+				currentUser: {
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS ],
+				},
+			}
+		);
+
+		expect(
+			screen.getByText(
+				/Your site plan doesn't allow to set a custom domain as a primary site address/i
+			)
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows add domain message when no valid domains are available', () => {
+		renderComponent( {
+			domains: [
+				{
+					domain: 'primary.com',
+					primary_domain: true,
+					can_set_as_primary: true,
+					type: 'registered',
+				},
+			],
+		} );
+
+		expect(
+			screen.getByText( /Before changing your primary site address you must/i )
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'tracks upgrade click events', () => {
+		renderComponent(
+			{
+				site: {
+					plan: {
+						is_free: true,
+					},
+				},
+			},
+			{
+				currentUser: {
+					flags: [ NON_PRIMARY_DOMAINS_TO_FREE_USERS ],
+				},
+			}
+		);
+
+		const upgradeLink = screen.getByText( 'Upgrade your plan' );
+		fireEvent.click( upgradeLink );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_primary_site_address_nudge_cta_click',
+			{
+				cta_name: 'buy_a_plan',
+			}
+		);
+	} );
+
+	it( 'handles staging domains correctly', () => {
+		renderComponent( {
+			domains: [
+				{
+					domain: 'staging.wordpress.com',
+					primary_domain: false,
+					can_set_as_primary: true,
+					type: 'wpcom',
+					is_wpcom_staging_domain: true,
+					wpcom_domain: true,
+				},
+				{
+					domain: 'regular.wordpress.com',
+					primary_domain: false,
+					can_set_as_primary: true,
+					type: 'wpcom',
+					wpcom_domain: true,
+				},
+				{
+					domain: 'custom.com',
+					primary_domain: false,
+					can_set_as_primary: true,
+					type: 'registered',
+				},
+			],
+		} );
+
+		const options = screen.getAllByRole( 'option' );
+
+		// Should only show staging domain and custom domain, not regular wpcom domain
+		expect( options ).toHaveLength( 3 ); // Including the "Select a domain" option
+		expect( screen.queryByText( 'regular.wordpress.com' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'custom.com' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -12,7 +12,7 @@ import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector, useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
 import {
@@ -27,6 +27,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { domainManagementList } from '../../paths';
 import DomainHeader from '../components/domain-header';
 import PointToWpcomDialog from '../components/point-to-wpcom-dialog';
+import PrimaryDomainSelector from '../components/primary-domain-selector';
 import {
 	createBulkAction,
 	deleteBulkActionStatus,
@@ -91,6 +92,39 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	const [ changeSiteAddressSourceDomain, setChangeSiteAddressSourceDomain ] =
 		useState< ResponseDomain | null >( null );
 
+	const onSetPrimaryDomain = async (
+		domain: string,
+		onComplete: () => void,
+		type: string
+	): Promise< void > => {
+		if ( site ) {
+			dispatch(
+				recordGoogleEvent(
+					'Domain Management',
+					'Changed Primary Domain in Site Domains',
+					'Domain Name',
+					domain
+				)
+			);
+			dispatch(
+				recordTracksEvent( 'calypso_domain_management_settings_change_primary_domain_dropdown', {
+					section: type,
+					mode: 'dropdown',
+				} )
+			);
+			try {
+				await dispatch( setPrimaryDomain( site.ID, domain ) );
+				dispatch( showUpdatePrimaryDomainSuccessNotice( domain ) );
+				page.replace( domainManagementList( domain ) );
+				await refetch();
+			} catch ( error ) {
+				dispatch( showUpdatePrimaryDomainErrorNotice( ( error as Error ).message ) );
+			} finally {
+				onComplete();
+			}
+		}
+	};
+
 	const onPointToWpcom = async ( domain: string ) => {
 		if ( ! domain ) {
 			return;
@@ -129,6 +163,11 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 				/>
 				<DomainHeader items={ [ item ] } buttons={ buttons } mobileButtons={ buttons } />
 				{ ! isLoading && <GoogleDomainOwnerBanner /> }
+				<PrimaryDomainSelector
+					domains={ data?.domains }
+					site={ site }
+					onSetPrimaryDomain={ onSetPrimaryDomain }
+				/>
 				<DomainsTable
 					isLoadingDomains={ isLoading }
 					domains={ data?.domains }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101121


Brings back the primary domain selector removed in  #101121

There is a conversation in Slack about this having affected the perception of value on users after getting a domain. 

p1742482614591059/1742477737.082189-slack-C06FCT6EEHH

![image](https://github.com/user-attachments/assets/ee232f23-6500-4e49-a455-6f4f6b8a319f)


