### PR TITLE
New hosted site flow: handle `plan` query param in Plans step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -5,10 +5,10 @@ import {
 	StepContainer,
 } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useQuery } from '../../../../hooks/use-query';
 import PlansWrapper from './plans-wrapper';
 import type { Step } from '../../types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-
 /**
  * @deprecated Use `unified-plans` instead. This step is deprecated and will be removed in the future.
  */
@@ -20,6 +20,10 @@ const plans: Step< {
 } > = function Plans( { navigation, flow } ) {
 	const { goBack, submit } = navigation;
 
+	const query = useQuery();
+	const queryParams = Object.fromEntries( query );
+	const plan = queryParams.plan;
+
 	const handleSubmit = ( plan: MinimalRequestCartProduct | null ) => {
 		const providedDependencies = {
 			plan,
@@ -28,6 +32,12 @@ const plans: Step< {
 
 		submit?.( providedDependencies );
 	};
+
+	// If we have a plan from URL params, submit it immediately and don't render anything
+	if ( plan ) {
+		handleSubmit( { product_slug: plan } );
+		return null;
+	}
 
 	const isAllowedToGoBack = isDomainUpsellFlow( flow ) || isNewHostedSiteCreationFlow( flow );
 


### PR DESCRIPTION
Add the respective plan to cart and skip the plans step.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/10592
Related to https://linear.app/a8c/issue/DOTOBRD-6/pto-square-change-the-landing-page-to-include-the-new-prices

## Proposed Changes

* add a `plan` URL parameter to the plans step of the `new-hosted-site` flow
* if the plan is present, skip rendering the plan step and submit immediately with the selected plan

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

In https://linear.app/a8c/issue/DOTOBRD-6/pto-square-change-the-landing-page-to-include-the-new-prices the intention is to update a [landing page](https://wordpress.com/start-with-square-test/) with plan choices, and the respective CTAs would go to a URL that preselects the plan on the `/setup/new-hosted-site` flow:

<img width="823" alt="image" src="https://github.com/user-attachments/assets/597aeb01-8fdf-443e-a8aa-c1cecef79253" />

We need to alter the existing flow so that the plan can be pre-selected via the URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On this branch, navigate to the URLs for the respective plans:
    * Business: `/setup/new-hosted-site/plans?partnerBundle=square&coupon=SWS50&plan=business-bundle`
    * Ecommerce: `/setup/new-hosted-site/plans?partnerBundle=square&coupon=SWS50&plan=ecommerce-bundle`
* Check that the plans page is skipped and the correct plan is added to the cart
* Check the URL without the `plan` for regressions: `/setup/new-hosted-site/plans?partnerBundle=square&coupon=SWS50`
