### PR TITLE
Purchases: Move "Add VAT details" link to Billing History dataviews header (Alternative)

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,4 +1,5 @@
-import { CompactCard, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
@@ -67,11 +68,18 @@ function BillingHistory() {
 						},
 					}
 				) }
-			/>
+			>
+				<Button
+					className="billing-history__tax-details-notice"
+					variant="secondary"
+					href={ vatDetailsPath }
+				>
+					{ vatText }
+				</Button>
+			</NavigationHeader>
 			<QueryBillingTransactions transactionType="past" />
 			<PurchasesNavigation section="billingHistory" />
 			<BillingHistoryContent siteId={ null } getReceiptUrlFor={ billingHistoryReceipt } />
-			<CompactCard href={ vatDetailsPath }>{ vatText }</CompactCard>
 		</Main>
 	);
 }

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -300,11 +300,6 @@ li.billing-history__receipt-item-discount--different-term {
 
 
 #purchases {
-	@media (max-width: 600px) {
-		.navigation-header {
-			padding: 1rem 0;
-		}
-	}
 	.navigation-header__main {
 		align-items: center;
 		flex-wrap: wrap;

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -296,3 +296,18 @@ li.billing-history__receipt-item-discount--different-term {
 		font-family: $sans;
 	}
 }
+
+
+
+#purchases {
+	@media (max-width: 600px) {
+		.navigation-header {
+			padding: 1rem 0;
+		}
+	}
+	.navigation-header__main {
+		align-items: center;
+		flex-wrap: wrap;
+		gap: .65rem;
+	}
+}


### PR DESCRIPTION
This resolves the same issue as https://github.com/Automattic/wp-calypso/pull/101123 - but a bit more gracefully. Confirmed [here](https://github.com/Automattic/wp-calypso/pull/101123#issuecomment-2741104793) that it will take precedent (closing other PR for now).

> [!NOTE]
> I removed the left and right padding for the `navigation-header` class on smaller (<600px) screens, since it felt unnecessary here. However, this padding still exists across all of the other sections of `Me` and ~I'm not sure its actually supposed to 🤔 I'll add an issue if I can't find a reason for it to exist in the first place.~
>
> It looks like the default padding on small screens comes from [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/navigation-header/style.scss#L12). While this works on pages where the navigation has no padding or margin set from a parent component, like the Domains page, it doesn't work as well on places like `/me`'s sub sections - awaiting Design input [here](https://github.com/Automattic/wp-calypso/issues/101695) and removing the padding changes from this PR
 
Related to #100552 

## Proposed Changes

* Move the Add Vat Details link from the Me > Purchases > Billing History footer to NavigationHeader for the Billing History tab (only)

## Testing Instructions

* Go to Me > Purchases > Active Upgrades, there **shouldn't** be an Add Vat Details link in the header as depicted above
* Switch to the Billing History tab, you should now see the Add VAT Details link in the header and it should _**only**_ be displayed on this tab
* Resize the screen and see if the layout breaks or obscures any other elements
