### PR TITLE
Site Migration: Add migration key to DIY pending overview

### DIFF
--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -2,7 +2,7 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { Button, ClipboardButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import ConfirmModal from 'calypso/components/confirm-modal';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import Notice from 'calypso/components/notice';
@@ -10,7 +10,6 @@ import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migr
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { addQueryArgs } from 'calypso/lib/url';
 import { getMigrationType } from 'calypso/sites-dashboard/utils';
-import { successNotice } from 'calypso/state/notices/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import Cards from '../cards';
 import { Container, Header } from '../layout';
@@ -50,13 +49,13 @@ const getContinueMigrationUrl = (
 
 export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 	const migrationType = getMigrationType( site );
 	const migrationSourceSiteDomain = useSelector( ( state ) =>
 		getSiteOption( state, site.ID, 'migration_source_site_domain' )
 	);
 	const continueMigrationUrl = getContinueMigrationUrl( site, migrationSourceSiteDomain as string );
-	const [ copied, setCopied ] = useState( false );
+	const [ migrationKeyCopied, setMigrationKeyCopied ] = useState( false );
+	const [ showMigrationKeyCopiedNotice, setShowMigrationKeyCopiedNotice ] = useState( false );
 
 	// Fetch the migration key.
 	const {
@@ -69,16 +68,16 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	} );
 
 	useEffect( () => {
-		if ( ! copied ) {
+		if ( ! migrationKeyCopied ) {
 			return;
 		}
 
 		const timerId = setTimeout( () => {
-			setCopied( () => false );
-		}, 2000 );
+			setMigrationKeyCopied( () => false );
+		}, 3000 );
 
 		return () => clearTimeout( timerId );
-	}, [ copied ] );
+	}, [ migrationKeyCopied ] );
 
 	useEffect( () => {
 		if ( migrationKeyStatus === 'error' ) {
@@ -123,15 +122,9 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	}
 
 	const copyMigrationKey = () => {
-		if ( ! copied ) {
-			setCopied( true );
-			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_clicked' );
-			dispatch(
-				successNotice( translate( 'Migration key copied to clipboard' ), {
-					duration: 3000,
-				} )
-			);
-		}
+		setMigrationKeyCopied( true );
+		setShowMigrationKeyCopiedNotice( true );
+		recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_click' );
 	};
 
 	return (
@@ -156,6 +149,18 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 				</Notice>
 			) }
 
+			{ showMigrationKeyCopiedNotice && (
+				<Notice
+					status="is-success"
+					onDismissClick={ () => {
+						setShowMigrationKeyCopiedNotice( false );
+						recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_dismiss_click' );
+					} }
+				>
+					{ translate( 'Migration key copied successfully' ) }
+				</Notice>
+			) }
+
 			<Header title={ title } subTitle={ subTitle }>
 				{ continueMigrationUrl && (
 					<div className="migration-pending__buttons">
@@ -169,7 +174,7 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 								<>
 									<ClipboardButton
 										style={ {
-											cursor: copied ? 'default' : 'pointer',
+											cursor: migrationKeyCopied ? 'default' : 'pointer',
 											textDecoration: 'underline',
 											margin: 0,
 											padding: 0,

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -1,24 +1,26 @@
-import { useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import { LoadingPlaceholder } from '@automattic/components';
 import { Button, ClipboardButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import ConfirmModal from 'calypso/components/confirm-modal';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import Notice from 'calypso/components/notice';
+import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migration-key';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { addQueryArgs } from 'calypso/lib/url';
 import { getMigrationType } from 'calypso/sites-dashboard/utils';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { getSiteOption } from 'calypso/state/sites/selectors';
 import Cards from '../cards';
 import { Container, Header } from '../layout';
 import useCancelMigration from './use-cancel-migration';
 import type { SiteDetails } from '@automattic/data-stores';
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migration-key';
-import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
-import { PLUGIN_INSTALLATION_COMPLETED } from 'calypso/state/plugins/installed/status/constants';
 
-const getContinueMigrationUrl = ( site: SiteDetails ): string | null => {
+const getContinueMigrationUrl = (
+	site: SiteDetails,
+	migrationSourceSiteDomain?: string
+): string | null => {
 	const migrationType = getMigrationType( site );
 
 	const baseQueryArgs = {
@@ -28,6 +30,15 @@ const getContinueMigrationUrl = ( site: SiteDetails ): string | null => {
 	};
 
 	if ( migrationType === 'diy' ) {
+		if ( migrationSourceSiteDomain ) {
+			return addQueryArgs(
+				{
+					page: 'wpcom-migration',
+				},
+				migrationSourceSiteDomain + '/wp-admin/admin.php'
+			);
+		}
+
 		return addQueryArgs(
 			baseQueryArgs,
 			'/setup/hosted-site-migration/site-migration-instructions'
@@ -39,28 +50,23 @@ const getContinueMigrationUrl = ( site: SiteDetails ): string | null => {
 
 export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	const translate = useTranslate();
-	const migrationType = getMigrationType( site );
-	const continueMigrationUrl = getContinueMigrationUrl( site );
-	const [ copied, setCopied ] = useState( false );
 	const dispatch = useDispatch();
-
-	// Check the wpcom-migration plugin status.
-	const pluginStatus = useSelector( ( state ) =>
-		getStatusForPlugin( state, site.ID, 'wpcom-migration' )
+	const migrationType = getMigrationType( site );
+	const migrationSourceSiteDomain = useSelector( ( state ) =>
+		getSiteOption( state, site.ID, 'migration_source_site_domain' )
 	);
+	const continueMigrationUrl = getContinueMigrationUrl( site, migrationSourceSiteDomain as string );
+	const [ copied, setCopied ] = useState( false );
 
-	console.log( 'pluginStatus', pluginStatus );
 	// Fetch the migration key.
 	const {
 		data: { migrationKey } = {},
 		error: migrationKeyError,
 		status: migrationKeyStatus,
 	} = useSiteMigrationKey( site.ID, {
-		enabled: PLUGIN_INSTALLATION_COMPLETED === pluginStatus,
+		enabled: true,
 		retry: 5,
 	} );
-
-	console.log( 'migrationKey', migrationKey );
 
 	useEffect( () => {
 		if ( ! copied ) {
@@ -109,6 +115,7 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 
 	const copyMigrationKey = () => {
 		if ( ! copied ) {
+			setCopied( true );
 			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_clicked', {
 				siteId: site.ID,
 				siteSlug: site.slug,
@@ -118,22 +125,20 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 		}
 
 		if ( migrationKey && ! migrationKeyError && ! copied ) {
-			setCopied( true );
+			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_success' );
 			dispatch(
 				successNotice( translate( 'Migration key copied to clipboard' ), {
-					duration: 2000,
+					duration: 3000,
 				} )
 			);
 		} else {
 			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_error', {
-				siteId: site.ID,
-				siteSlug: site.slug,
 				status: migrationKeyStatus,
 				error: migrationKeyError,
 			} );
 			dispatch(
 				errorNotice( translate( 'Failed to copy migration key' ), {
-					duration: 2000,
+					duration: 3000,
 				} )
 			);
 		}
@@ -187,9 +192,7 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 										onCopy={ copyMigrationKey }
 										text={ migrationKey }
 									>
-										{ copied
-											? translate( 'Copied migration key!' )
-											: translate( 'Copy migration key' ) }
+										{ translate( 'Copy migration key' ) }
 									</ClipboardButton>
 									{ ' • ' }
 								</>

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -68,6 +68,10 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 		);
 	}
 
+	const copyMigrationKey = () => {
+		console.log( 'copyMigrationKey' );
+	};
+
 	return (
 		<Container>
 			<ConfirmModal
@@ -98,6 +102,15 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 								? translate( 'Complete your migration' )
 								: translate( 'Start your migration' ) }
 						</HostingHeroButton>
+						{ 'diy' === migrationType && (
+							<Button
+								variant="link"
+								className="migration-pending__copy-key-button"
+								onClick={ copyMigrationKey }
+							>
+								{ translate( 'Copy migration key' ) }
+							</Button>
+						) }
 						<Button
 							variant="link"
 							className="migration-pending__cancel-button"

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -170,12 +170,10 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 									<ClipboardButton
 										style={ {
 											cursor: copied ? 'default' : 'pointer',
-											pointerEvents: 'auto',
 											textDecoration: 'underline',
 											margin: 0,
 											padding: 0,
 											boxShadow: 'none',
-											opacity: copied ? 0.5 : 1,
 											outline: 'none',
 										} }
 										className="migration-pending__copy-key-button"

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -10,7 +10,7 @@ import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migr
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { addQueryArgs } from 'calypso/lib/url';
 import { getMigrationType } from 'calypso/sites-dashboard/utils';
-import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { successNotice } from 'calypso/state/notices/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import Cards from '../cards';
 import { Container, Header } from '../layout';
@@ -80,6 +80,15 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 		return () => clearTimeout( timerId );
 	}, [ copied ] );
 
+	useEffect( () => {
+		if ( migrationKeyStatus === 'error' ) {
+			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_error', {
+				migration_key_status: migrationKeyStatus,
+				migration_key_error: migrationKeyError,
+			} );
+		}
+	}, [ migrationKeyStatus ] );
+
 	const title = translate( 'Your WordPress site is ready to be migrated' );
 	const subTitle =
 		'diy' === migrationType
@@ -116,28 +125,9 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	const copyMigrationKey = () => {
 		if ( ! copied ) {
 			setCopied( true );
-			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_clicked', {
-				siteId: site.ID,
-				siteSlug: site.slug,
-				status: migrationKeyStatus,
-				error: migrationKeyError,
-			} );
-		}
-
-		if ( migrationKey && ! migrationKeyError && ! copied ) {
-			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_success' );
+			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_clicked' );
 			dispatch(
 				successNotice( translate( 'Migration key copied to clipboard' ), {
-					duration: 3000,
-				} )
-			);
-		} else {
-			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_error', {
-				status: migrationKeyStatus,
-				error: migrationKeyError,
-			} );
-			dispatch(
-				errorNotice( translate( 'Failed to copy migration key' ), {
 					duration: 3000,
 				} )
 			);

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -90,10 +90,10 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	const subTitle =
 		'diy' === migrationType
 			? translate(
-					'Complete your migration in the {{strong}}Migrate to WordPress.com{{/strong}} plugin and get ready for unmatched WordPress hosting.',
+					'Get ready for unmatched WordPress hosting. Use your migration key to complete your migration in the {{em}}Migrate to WordPress.com{{/em}} plugin.',
 					{
 						components: {
-							strong: <strong />,
+							em: <em />,
 						},
 					}
 			  )

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -58,14 +58,13 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	const [ showMigrationKeyCopiedNotice, setShowMigrationKeyCopiedNotice ] = useState( false );
 
 	// Fetch the migration key.
-	const {
-		data: { migrationKey } = {},
-		error: migrationKeyError,
-		status: migrationKeyStatus,
-	} = useSiteMigrationKey( site.ID, {
-		enabled: true,
-		retry: 5,
-	} );
+	const { data: { migrationKey } = {}, status: migrationKeyStatus } = useSiteMigrationKey(
+		site.ID,
+		{
+			enabled: true,
+			retry: 5,
+		}
+	);
 
 	useEffect( () => {
 		if ( ! migrationKeyCopied ) {
@@ -83,7 +82,6 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 		if ( migrationKeyStatus === 'error' ) {
 			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_error', {
 				migration_key_status: migrationKeyStatus,
-				migration_key_error: migrationKeyError,
 			} );
 		}
 	}, [ migrationKeyStatus ] );
@@ -164,40 +162,34 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 			<Header title={ title } subTitle={ subTitle }>
 				{ continueMigrationUrl && (
 					<div className="migration-pending__buttons">
-						<HostingHeroButton href={ continueMigrationUrl }>
-							{ 'diy' === migrationType
-								? translate( 'Complete your migration' )
-								: translate( 'Start your migration' ) }
-						</HostingHeroButton>
-						<div className="migration-pending__secondary-buttons">
+						<div className="migration-pending__primary-actions">
 							{ 'diy' === migrationType && migrationKey && (
 								<>
 									<ClipboardButton
 										style={ {
 											cursor: migrationKeyCopied ? 'default' : 'pointer',
-											textDecoration: 'underline',
-											margin: 0,
-											padding: 0,
-											boxShadow: 'none',
-											outline: 'none',
 										} }
-										className="migration-pending__copy-key-button"
+										className="migration-pending__copy-key-button components-button is-secondary hosting-hero-button"
 										onCopy={ copyMigrationKey }
 										text={ migrationKey }
 									>
 										{ translate( 'Copy migration key' ) }
 									</ClipboardButton>
-									{ ' • ' }
 								</>
 							) }
-							<Button
-								variant="link"
-								className="migration-pending__cancel-button"
-								onClick={ openCancellationModal }
-							>
-								{ translate( 'Cancel migration' ) }
-							</Button>
+							<HostingHeroButton href={ continueMigrationUrl }>
+								{ 'diy' === migrationType
+									? translate( 'Complete migration' )
+									: translate( 'Start your migration' ) }
+							</HostingHeroButton>
 						</div>
+						<Button
+							variant="link"
+							className="migration-pending__cancel-button"
+							onClick={ openCancellationModal }
+						>
+							{ translate( 'Cancel migration' ) }
+						</Button>
 					</div>
 				) }
 			</Header>

--- a/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-pending/index.tsx
@@ -1,6 +1,9 @@
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { LoadingPlaceholder } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Button, ClipboardButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import ConfirmModal from 'calypso/components/confirm-modal';
 import { HostingHeroButton } from 'calypso/components/hosting-hero';
 import Notice from 'calypso/components/notice';
@@ -10,6 +13,10 @@ import Cards from '../cards';
 import { Container, Header } from '../layout';
 import useCancelMigration from './use-cancel-migration';
 import type { SiteDetails } from '@automattic/data-stores';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migration-key';
+import { getStatusForPlugin } from 'calypso/state/plugins/installed/selectors';
+import { PLUGIN_INSTALLATION_COMPLETED } from 'calypso/state/plugins/installed/status/constants';
 
 const getContinueMigrationUrl = ( site: SiteDetails ): string | null => {
 	const migrationType = getMigrationType( site );
@@ -34,6 +41,38 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	const translate = useTranslate();
 	const migrationType = getMigrationType( site );
 	const continueMigrationUrl = getContinueMigrationUrl( site );
+	const [ copied, setCopied ] = useState( false );
+	const dispatch = useDispatch();
+
+	// Check the wpcom-migration plugin status.
+	const pluginStatus = useSelector( ( state ) =>
+		getStatusForPlugin( state, site.ID, 'wpcom-migration' )
+	);
+
+	console.log( 'pluginStatus', pluginStatus );
+	// Fetch the migration key.
+	const {
+		data: { migrationKey } = {},
+		error: migrationKeyError,
+		status: migrationKeyStatus,
+	} = useSiteMigrationKey( site.ID, {
+		enabled: PLUGIN_INSTALLATION_COMPLETED === pluginStatus,
+		retry: 5,
+	} );
+
+	console.log( 'migrationKey', migrationKey );
+
+	useEffect( () => {
+		if ( ! copied ) {
+			return;
+		}
+
+		const timerId = setTimeout( () => {
+			setCopied( () => false );
+		}, 2000 );
+
+		return () => clearTimeout( timerId );
+	}, [ copied ] );
 
 	const title = translate( 'Your WordPress site is ready to be migrated' );
 	const subTitle =
@@ -69,7 +108,35 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 	}
 
 	const copyMigrationKey = () => {
-		console.log( 'copyMigrationKey' );
+		if ( ! copied ) {
+			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_clicked', {
+				siteId: site.ID,
+				siteSlug: site.slug,
+				status: migrationKeyStatus,
+				error: migrationKeyError,
+			} );
+		}
+
+		if ( migrationKey && ! migrationKeyError && ! copied ) {
+			setCopied( true );
+			dispatch(
+				successNotice( translate( 'Migration key copied to clipboard' ), {
+					duration: 2000,
+				} )
+			);
+		} else {
+			recordTracksEvent( 'calypso_migration_hosting_overview_key_copy_error', {
+				siteId: site.ID,
+				siteSlug: site.slug,
+				status: migrationKeyStatus,
+				error: migrationKeyError,
+			} );
+			dispatch(
+				errorNotice( translate( 'Failed to copy migration key' ), {
+					duration: 2000,
+				} )
+			);
+		}
 	};
 
 	return (
@@ -102,22 +169,39 @@ export const MigrationPending = ( { site }: { site: SiteDetails } ) => {
 								? translate( 'Complete your migration' )
 								: translate( 'Start your migration' ) }
 						</HostingHeroButton>
-						{ 'diy' === migrationType && (
+						<div className="migration-pending__secondary-buttons">
+							{ 'diy' === migrationType && migrationKey && (
+								<>
+									<ClipboardButton
+										style={ {
+											cursor: copied ? 'default' : 'pointer',
+											pointerEvents: 'auto',
+											textDecoration: 'underline',
+											margin: 0,
+											padding: 0,
+											boxShadow: 'none',
+											opacity: copied ? 0.5 : 1,
+											outline: 'none',
+										} }
+										className="migration-pending__copy-key-button"
+										onCopy={ copyMigrationKey }
+										text={ migrationKey }
+									>
+										{ copied
+											? translate( 'Copied migration key!' )
+											: translate( 'Copy migration key' ) }
+									</ClipboardButton>
+									{ ' • ' }
+								</>
+							) }
 							<Button
 								variant="link"
-								className="migration-pending__copy-key-button"
-								onClick={ copyMigrationKey }
+								className="migration-pending__cancel-button"
+								onClick={ openCancellationModal }
 							>
-								{ translate( 'Copy migration key' ) }
+								{ translate( 'Cancel migration' ) }
 							</Button>
-						) }
-						<Button
-							variant="link"
-							className="migration-pending__cancel-button"
-							onClick={ openCancellationModal }
-						>
-							{ translate( 'Cancel migration' ) }
-						</Button>
+						</div>
 					</div>
 				) }
 			</Header>

--- a/client/sites/overview/components/migration-overview/style.scss
+++ b/client/sites/overview/components/migration-overview/style.scss
@@ -18,17 +18,16 @@
 		margin: 0 auto;
 	}
 
-	.migration-pending__secondary-buttons {
+	.migration-pending__primary-actions {
 		display: flex;
 		flex-direction: row;
-		gap: 0.5rem;
+		gap: 0.75rem;
 		width: fit-content;
 		align-items: center;
 		margin: 0 auto;
 	}
 
-	.migration-pending__cancel-button,
-	.migration-pending__copy-key-button {
+	.migration-pending__cancel-button {
 		color: var(--studio-gray-80);
 	}
 

--- a/client/sites/overview/components/migration-overview/style.scss
+++ b/client/sites/overview/components/migration-overview/style.scss
@@ -18,8 +18,17 @@
 		margin: 0 auto;
 	}
 
+	.migration-pending__secondary-buttons {
+		display: flex;
+		flex-direction: row;
+		gap: 0.5rem;
+		width: fit-content;
+		align-items: center;
+		margin: 0 auto;
+	}
 
-	.migration-pending__cancel-button {
+	.migration-pending__cancel-button,
+	.migration-pending__copy-key-button {
 		color: var(--studio-gray-80);
 	}
 

--- a/client/sites/overview/components/migration-overview/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/test/index.tsx
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migration-key';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -114,6 +115,31 @@ describe( 'MigrationOverview', () => {
 			const { getByText } = renderWithProvider( <MigrationOverview site={ site } /> );
 
 			expect( getByText( /Copy migration key/ ) ).toBeVisible();
+		} );
+
+		it( 'shows a success notice if the migration key is copied', async () => {
+			const site = buildMigrationSite( {
+				status: 'pending',
+				how: 'diy',
+				canInstallPlugins: true,
+			} );
+
+			jest.mocked( useSiteMigrationKey ).mockReturnValue( {
+				data: { migrationKey: '123' },
+				isLoading: false,
+				isError: false,
+				error: null,
+				status: 'success',
+			} );
+
+			renderWithProvider( <MigrationOverview site={ site } /> );
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Copy migration key' } ) );
+
+			await waitFor( () => {
+				const notice = screen.getByText( 'Migration key copied successfully' );
+				expect( notice ).toBeInTheDocument();
+			} );
 		} );
 	} );
 

--- a/client/sites/overview/components/migration-overview/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/test/index.tsx
@@ -3,6 +3,7 @@
  */
 import { screen } from '@testing-library/react';
 import React from 'react';
+import { useSiteMigrationKey } from 'calypso/landing/stepper/hooks/use-site-migration-key';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import MigrationOverview from '..';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -34,9 +35,17 @@ jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSelectedSite: jest.fn(),
 } ) );
 
+jest.mock( 'calypso/landing/stepper/hooks/use-site-migration-key', () => ( {
+	useSiteMigrationKey: jest.fn(),
+} ) );
+
 const render = ( ui: React.ReactElement ) => renderWithProvider( ui );
 
 describe( 'MigrationOverview', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	const getStartDIYMigrationLink = () => {
 		return screen.queryByRole( 'link', { name: 'Complete your migration' } );
 	};
@@ -49,7 +58,15 @@ describe( 'MigrationOverview', () => {
 		it( 'shows the migration pending instructions', () => {
 			const site = buildMigrationSite( { status: 'pending', how: 'diy' } );
 
-			const { getByText } = render( <MigrationOverview site={ site } /> );
+			jest.mocked( useSiteMigrationKey ).mockReturnValue( {
+				data: { migrationKey: '123' },
+				isLoading: false,
+				isError: false,
+				error: null,
+				status: 'success',
+			} );
+
+			const { getByText } = renderWithProvider( <MigrationOverview site={ site } /> );
 
 			expect( getByText( /Complete your migration in the/ ) ).toBeVisible();
 		} );
@@ -61,7 +78,15 @@ describe( 'MigrationOverview', () => {
 				canInstallPlugins: true,
 			} );
 
-			render( <MigrationOverview site={ site } /> );
+			jest.mocked( useSiteMigrationKey ).mockReturnValue( {
+				data: { migrationKey: '123' },
+				isLoading: false,
+				isError: false,
+				error: null,
+				status: 'success',
+			} );
+
+			renderWithProvider( <MigrationOverview site={ site } /> );
 
 			const link = getStartDIYMigrationLink();
 
@@ -69,6 +94,26 @@ describe( 'MigrationOverview', () => {
 				'href',
 				'/setup/hosted-site-migration/site-migration-instructions?siteId=123&siteSlug=example.com&ref=hosting-migration-overview'
 			);
+		} );
+
+		it( 'shows a link to copy the migration key if we have a migration key', () => {
+			const site = buildMigrationSite( {
+				status: 'pending',
+				how: 'diy',
+				canInstallPlugins: true,
+			} );
+
+			jest.mocked( useSiteMigrationKey ).mockReturnValue( {
+				data: { migrationKey: '123' },
+				isLoading: false,
+				isError: false,
+				error: null,
+				status: 'success',
+			} );
+
+			const { getByText } = renderWithProvider( <MigrationOverview site={ site } /> );
+
+			expect( getByText( /Copy migration key/ ) ).toBeVisible();
 		} );
 	} );
 

--- a/client/sites/overview/components/migration-overview/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/test/index.tsx
@@ -69,7 +69,11 @@ describe( 'MigrationOverview', () => {
 
 			const { getByText } = renderWithProvider( <MigrationOverview site={ site } /> );
 
-			expect( getByText( /Complete your migration in the/ ) ).toBeVisible();
+			expect(
+				getByText(
+					/Get ready for unmatched WordPress hosting. Use your migration key to complete your migration in the/
+				)
+			).toBeVisible();
 		} );
 
 		it( 'shows a link to the instructions page', () => {

--- a/client/sites/overview/components/migration-overview/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/test/index.tsx
@@ -48,7 +48,7 @@ describe( 'MigrationOverview', () => {
 	} );
 
 	const getStartDIYMigrationLink = () => {
-		return screen.queryByRole( 'link', { name: 'Complete your migration' } );
+		return screen.queryByRole( 'link', { name: 'Complete migration' } );
 	};
 
 	const getStartDIFMMigrationLink = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100879#issuecomment-2737142860

## Proposed Changes

* To make this screen more useful, we're adding a button to copy the migration key for pending DIY migrations rather than sending them back to the site migration instructions screen.
* Show a Notice upon copying if successful.
* Only show the link to copy the migration key if we have fetched a migration key from the API
* Only link to the source site domain's plugin page if we have a source site.

<img width="1484" alt="Screenshot 2025-03-27 at 4 22 29 PM" src="https://github.com/user-attachments/assets/fa50a8e5-dd56-41a7-a7ef-8f4be125b92e" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/100879#issuecomment-2737142860

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/start`
* At the goals step, choose Import/Migrate
* Input your WordPress-based test site URL and choose "I'll do it myself"
* Checkout. You'll be brought to the site migration instructions screen and the site transfer/plugin installation will begin.
* Go to `/overview/{newsiteslug}`
* Once the site transfer is completed and the plugin is installed, you should see the "Copy migration key" link appear underneath the "Complete your migration" button.
* Clicking the "Copy migration key" button should show a success notice that fades out after 3s and the key should be successfully copied to the clipboard. The button itself will not be clickable again for 2s.
* If the site's source site has been retained during the transfer, clicking the button should take you to `{sourcesiteurl}/wp-admin/?page=wpcom-migration`. If not, you'll be brought back to the site migration instructions screen.
* Ensure the screen still looks correct (no link to copy migration key) when a DIFM migration is requested.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
