### PR TITLE
Self Service Downgrades: Fix downgrade button at the user level purchases page

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -101,7 +101,6 @@ export function downgradePurchase( context, next ) {
 					<Downgrade
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 						siteSlug={ context.params.site }
-						getManagePurchaseUrlFor={ managePurchaseUrl }
 					/>
 				</Main>
 			</PurchasesWrapper>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -101,6 +101,7 @@ export function downgradePurchase( context, next ) {
 					<Downgrade
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 						siteSlug={ context.params.site }
+						getManagePurchaseUrlFor={ managePurchaseUrl }
 					/>
 				</Main>
 			</PurchasesWrapper>

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -24,6 +24,7 @@ import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analyt
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
+import { Downgrade } from './downgrade';
 import ManagePurchase from './manage-purchase';
 import { ManagePurchaseByOwnership } from './manage-purchase/manage-purchase-by-ownership';
 import PurchasesList from './purchases-list';
@@ -89,6 +90,24 @@ export function cancelPurchase( context, next ) {
 	} );
 
 	context.primary = <CancelPurchaseWrapper />;
+	next();
+}
+
+export function downgradePurchase( context, next ) {
+	const DowngradePurchaseWrapper = localize( () => {
+		return (
+			<PurchasesWrapper title={ titles.cancelPurchase }>
+				<Main wideLayout className="purchases__cancel">
+					<Downgrade
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	} );
+
+	context.primary = <DowngradePurchaseWrapper />;
 	next();
 }
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -96,7 +96,7 @@ export function cancelPurchase( context, next ) {
 export function downgradePurchase( context, next ) {
 	const DowngradePurchaseWrapper = localize( () => {
 		return (
-			<PurchasesWrapper title={ titles.cancelPurchase }>
+			<PurchasesWrapper title={ titles.downgradeSubscription() }>
 				<Main wideLayout className="purchases__cancel">
 					<Downgrade
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -109,7 +109,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 	const [ isDowngrading, setIsDowngrading ] = useState( false );
 	const loadedFromServer = useSelector( hasLoadedUserPurchasesFromServer );
 	const { ID: siteId, name: siteName } =
-		useSelector( ( state ) => getSite( state, siteSlug ) ) ?? {};
+		useSelector( ( state ) => getSite( state, purchase?.siteId ) ) ?? {};
 
 	const targetPlan = getPlan( downgradePath[ purchase?.productSlug ?? '' ] );
 	const currentPlan = getPlan( purchase?.productSlug ?? '' );

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -50,6 +50,7 @@ import './style.scss';
 interface DowngradeProps {
 	siteSlug: string;
 	purchaseId: number;
+	getManagePurchaseUrlFor: ( siteSlug: string, purchaseId: number ) => string;
 }
 
 const DowngradeFeatureList: React.FC< { features: FeatureObject[]; purchase: Purchase } > = ( {
@@ -130,7 +131,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 			</>
 		);
 	}
-	const purchaseRoot = getManagePurchaseUrlFor( siteSlug, purchaseId );
+	const purchaseRoot = props.getManagePurchaseUrlFor( siteSlug, purchaseId );
 
 	const handleDowngrade = async () => {
 		if (

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -29,10 +29,10 @@ import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import { cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
 import { Purchase } from 'calypso/lib/purchases/types';
+import { managePurchase } from 'calypso/me/purchases/paths';
 import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
 import titles from 'calypso/me/purchases/titles';
 import { isDataLoading } from 'calypso/me/purchases/utils';
-import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
@@ -101,7 +101,7 @@ const downgradePath: Record< string, string > = {
 };
 
 export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
-	const { siteSlug, purchaseId } = props;
+	const { siteSlug, purchaseId, getManagePurchaseUrlFor = managePurchase } = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const purchase = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
@@ -131,7 +131,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 			</>
 		);
 	}
-	const purchaseRoot = props.getManagePurchaseUrlFor( siteSlug, purchaseId );
+	const purchaseRoot = getManagePurchaseUrlFor( siteSlug, purchaseId );
 
 	const handleDowngrade = async () => {
 		if (

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -185,7 +185,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 						<div>
 							<strong>
 								{ translate(
-									'We will change the plan immediately and pro-rate the remaining value from %(currentPlan)s to %(targetPlan)s.',
+									'We will change the plan immediately from %(currentPlan)s to %(targetPlan)s.',
 									{
 										args: {
 											currentPlan: currentPlan?.getTitle() ?? '',

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -115,6 +115,14 @@ export default ( router ) => {
 	);
 
 	router(
+		paths.downgradePurchase( ':site', ':purchaseId' ),
+		sidebar,
+		controller.downgradePurchase,
+		makeLayout,
+		clientRender
+	);
+
+	router(
 		paths.confirmCancelDomain( ':site', ':purchaseId' ),
 		sidebar,
 		siteSelection,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -154,7 +154,7 @@ import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch, IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
-import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
+import { cancelPurchase, downgradePurchase, managePurchase, purchasesRoot } from '../paths';
 import PurchaseSiteHeader from '../purchases-site/header';
 import RemovePurchase from '../remove-purchase';
 import {
@@ -970,7 +970,10 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		const link = this.props.getDowngradeUrlFor?.( this.props.siteSlug, purchase.id );
+		const link = ( this.props.getDowngradeUrlFor ?? downgradePurchase )(
+			this.props.siteSlug,
+			purchase.id
+		);
 
 		return (
 			<CompactCard href={ link }>
@@ -1406,12 +1409,14 @@ class ManagePurchase extends Component<
 						{ ! isJetpackTemporarySitePurchase( purchase ) && this.renderUpgradeNavItem() }
 						{ this.renderEditPaymentMethodNavItem() }
 						{ this.renderReinstall() }
-						{ this.renderCancelPurchaseNavItem() }
-						{ config.isEnabled( 'plans/self-service-downgrade' ) && ! isPersonal( purchase )
-							? this.renderDowngradeNavItem()
-							: null }
-						{ this.renderCancelSurvey() }
-						{ this.renderRemovePurchaseNavItem() }
+						<div className="manage-purchase__downgrade-products">
+							{ config.isEnabled( 'plans/self-service-downgrade' ) && ! isPersonal( purchase )
+								? this.renderDowngradeNavItem()
+								: null }
+							{ this.renderCancelPurchaseNavItem() }
+							{ this.renderRemovePurchaseNavItem() }
+							{ this.renderCancelSurvey() }
+						</div>
 					</>
 				) }
 			</Fragment>

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -1,5 +1,7 @@
 .manage-purchase > button.card,
-.manage-purchase > a.card {
+.manage-purchase > a.card,
+.manage-purchase > div > a.card,
+.manage-purchase > div > button.card{
 	--icon-size: 16px;
 
 	padding-inline-start: calc(var(--icon-size) * 2.5);
@@ -503,4 +505,14 @@
 	color: var(--color-link);
 	text-decoration: underline;
 	line-height: inherit;
+}
+
+.manage-purchase__downgrade-products {
+	margin-top: 16px;
+	margin-bottom: 16px;
+	& > a.card,
+	& > button.card {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
 }

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -47,6 +47,15 @@ export function cancelPurchase( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/cancel';
 }
 
+export function downgradePurchase( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
+	return managePurchase( siteName, purchaseId ) + '/downgrade';
+}
+
 export function confirmCancelDomain( siteName, purchaseId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -192,7 +192,11 @@ export function PurchaseDowngrade( {
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logPurchasesError }
 			>
-				<Downgrade purchaseId={ purchaseId } siteSlug={ siteSlug } />
+				<Downgrade
+					purchaseId={ purchaseId }
+					siteSlug={ siteSlug }
+					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }
+				/>
 			</CheckoutErrorBoundary>
 		</Main>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to #101493
- Related to #100441

## Proposed Changes

* Fixes downgrade button on `/me/purchases` which was initially implemented #101493

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/1162c75b-d2e7-40ef-87cd-4ae82b5e976a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
- Part of an epic to support self service downgrades in wpcom

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Locally there needs to be a feature flag activated plans/self-service-downgrade, flags=plans/self-service-downgrade
- Go to a site with a purchased plan higher than personal
- The downgrade button should be visible `/me/purchases/`
- When clicked should take you to the downgrade page
- Styling on the page should not be broken


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
