### PR TITLE
Onboarding consistency: Use StepContainerV2 in the theme preview screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
@@ -2,6 +2,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	gap: 8px;
+
 	.premium-badge {
 		font-family: $sans;
 		background: var(--studio-black);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -18,7 +18,7 @@ const DesignPickerDesignTitle: FC< Props > = ( {
 	siteSlug,
 } ) => (
 	<div className="design-picker-design-title__container">
-		{ designTitle }
+		<span className="design-picker-design-title__design-title">{ designTitle }</span>
 		<ThemeTierBadge
 			className="design-picker-design-title__theme-tier-badge"
 			isLockedStyleVariation={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -673,6 +673,24 @@ $container-padding-large: 48px;
 		display: flex;
 		flex: 1;
 
+		&__header-design-title {
+			.design-picker-design-title__container {
+				align-items: normal;
+			}
+
+			.design-picker-design-title__design-title {
+				font-size: 0.875rem;
+				font-weight: 500;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			.theme-tier-badge {
+				flex-shrink: 0;
+			}
+		}
+
 		.design-preview.design-preview--is-fullscreen {
 			padding-bottom: var(--step-container-v2-sticky-bottom-bar-height);
 			z-index: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -653,9 +653,53 @@ $container-padding-large: 48px;
 		}
 	}
 }
+
 .step-container-v2--design-picker {
 	.design-picker.design-picker__unified {
 		margin-top: 0;
 		padding-bottom: 0;
 	}
 }
+
+.step-container-v2:has(.step-container-v2--design-picker-preview) {
+	// TODO: Remove most of these customizations once we introduce the FixedColumnOnTheLeftLayout wireframe.
+	.step-container-v2__content-wrapper {
+		@include break-large {
+			padding-top: 0 !important;
+		}
+	}
+
+	.step-container-v2--design-picker-preview {
+		display: flex;
+		flex: 1;
+
+		.design-preview.design-preview--is-fullscreen {
+			padding-bottom: var(--step-container-v2-sticky-bottom-bar-height);
+			z-index: 0;
+		}
+
+		@include break-large {
+			.design-preview {
+				flex: 1;
+				height: auto;
+				gap: 48px;
+
+				.design-preview__sidebar {
+					padding-top: 24px;
+				}
+
+				.design-preview__site-preview {
+					transform: translateY(calc(var(--step-container-v2-top-bar-height) * -1));
+					height: calc(100% + var(--step-container-v2-top-bar-height)) !important;
+					margin-bottom: 0 !important;
+
+					.device-switcher__toolbar {
+						margin-block: 0;
+					}
+				}
+			}
+		}
+	}
+
+}
+

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -895,7 +895,11 @@ const UnifiedDesignPickerStep: StepType< {
 						<Step.StickyBottomBar
 							leftButton={ <Step.BackButton onClick={ handleBackClick } /> }
 							rightButton={ actionButtons }
-						/>
+						>
+							<div className="step-container-v2--design-picker-preview__header-design-title">
+								{ headerDesignTitle }
+							</div>
+						</Step.StickyBottomBar>
 					}
 				>
 					{ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -23,6 +23,7 @@ import {
 } from '@automattic/design-picker';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, ONBOARDING_FLOW, isSiteSetupFlow, Step } from '@automattic/onboarding';
+import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -704,6 +705,9 @@ const UnifiedDesignPickerStep: StepType< {
 		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();
 	}
 
+	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
+	const isDesktopVersion = useViewportMatch( 'large', '>=' );
+
 	function getPrimaryActionButton() {
 		const action = getPrimaryActionButtonAction();
 		const text =
@@ -711,11 +715,15 @@ const UnifiedDesignPickerStep: StepType< {
 				? translate( 'Unlock theme' )
 				: translate( 'Continue' );
 
-		return (
-			<Button className="navigation-link" primary borderless={ false } onClick={ action }>
-				{ text }
-			</Button>
-		);
+		if ( ! isUsingStepContainerV2 ) {
+			return (
+				<Button className="navigation-link" primary borderless={ false } onClick={ action }>
+					{ text }
+				</Button>
+			);
+		}
+
+		return <Step.NextButton label={ text } onClick={ action } />;
 	}
 
 	useEffect( () => {
@@ -753,12 +761,20 @@ const UnifiedDesignPickerStep: StepType< {
 			site_tagline: shouldCustomizeText ? siteDescription : undefined,
 		} );
 
-		const actionButtons = (
-			<>
-				<div className="action-buttons__title">{ headerDesignTitle }</div>
-				<div>{ getPrimaryActionButton() }</div>
-			</>
-		);
+		const getActionButtons = () => {
+			if ( ! isUsingStepContainerV2 ) {
+				return (
+					<>
+						<div className="action-buttons__title">{ headerDesignTitle }</div>
+						<div>{ getPrimaryActionButton() }</div>
+					</>
+				);
+			}
+
+			return getPrimaryActionButton();
+		};
+
+		const actionButtons = getActionButtons();
 
 		const stepContent = (
 			<>
@@ -850,6 +866,43 @@ const UnifiedDesignPickerStep: StepType< {
 			</>
 		);
 
+		if ( isUsingStepContainerV2 ) {
+			// TODO: Create a new wireframe for the design preview. It should be named "FixedColumnOnTheLeftLayout"
+			return (
+				<Step.FullWidthLayout
+					isMediumViewport={ isDesktopVersion }
+					className="step-container-v2--design-picker-preview"
+					topBar={
+						isDesktopVersion ? (
+							<Step.TopBar
+								backButton={
+									shouldHideActionButtons ? undefined : (
+										<Step.BackButton onClick={ handleBackClick } />
+									)
+								}
+								skipButton={
+									! isGoalsAtFrontExperiment ? undefined : (
+										<Step.SkipButton
+											onClick={ () => handleSubmit() }
+											label={ translate( 'Skip setup' ) }
+										/>
+									)
+								}
+							/>
+						) : undefined
+					}
+					stickyBottomBar={
+						<Step.StickyBottomBar
+							leftButton={ <Step.BackButton onClick={ handleBackClick } /> }
+							rightButton={ actionButtons }
+						/>
+					}
+				>
+					{ stepContent }
+				</Step.FullWidthLayout>
+			);
+		}
+
 		return (
 			<StepContainer
 				stepName={ STEP_NAME }
@@ -884,8 +937,6 @@ const UnifiedDesignPickerStep: StepType< {
 	const priorityThemes: Record< string, string > = {
 		education: 'course',
 	};
-
-	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
 
 	const stepContent = (
 		<>

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -1,6 +1,9 @@
 @import '../../mixins';
 
 .step-container-v2 {
+	--step-container-v2-top-bar-height: 56px;
+	--step-container-v2-sticky-bottom-bar-height: 72px;
+
 	width: 100%;
 	min-height: 100vh;
 	margin: 0;

--- a/packages/onboarding/src/step-container-v2/components/StickyBottomBar/StickyBottomBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/StickyBottomBar/StickyBottomBar.tsx
@@ -5,13 +5,17 @@ import './style.scss';
 interface StickyBottomBarProps {
 	leftButton?: ReactNode;
 	rightButton?: ReactNode;
+	children?: ReactNode;
 }
 
-export const StickyBottomBar = ( { leftButton, rightButton }: StickyBottomBarProps ) => {
+export const StickyBottomBar = ( { leftButton, rightButton, children }: StickyBottomBarProps ) => {
 	return (
 		<div className="step-container-v2__sticky-bottom-bar">
 			{ leftButton && (
 				<div className="step-container-v2__sticky-bottom-bar-left-button">{ leftButton }</div>
+			) }
+			{ children && (
+				<div className="step-container-v2__sticky-bottom-bar-content">{ children }</div>
 			) }
 			{ rightButton && (
 				<div className="step-container-v2__sticky-bottom-bar-right-button">{ rightButton }</div>

--- a/packages/onboarding/src/step-container-v2/components/StickyBottomBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StickyBottomBar/style.scss
@@ -11,6 +11,15 @@
 	box-shadow: var(--color-border-subtle) 0 1px 0 inset;
 	background-color: var(--color-surface);
 
+	&-left-button {
+		margin-right: auto;
+	}
+
+	&-content {
+		margin-inline: 2rem;
+		min-width: 0;
+	}
+
 	&-right-button {
 		margin-left: auto;
 	}

--- a/packages/onboarding/src/step-container-v2/components/StickyBottomBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StickyBottomBar/style.scss
@@ -1,5 +1,6 @@
 .step-container-v2__sticky-bottom-bar {
 	position: sticky;
+	height: var(--step-container-v2-sticky-bottom-bar-height);
 	bottom: 0;
 	width: 100%;
 	display: flex;

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -1,7 +1,7 @@
 @import '../../mixins';
 
 .step-container-v2__top-bar {
-	z-index: 1;
+	height: var(--step-container-v2-top-bar-height);
 	box-sizing: border-box;
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101203.

## Proposed Changes

This is far from the state I'd like it to be (using the wireframe), but it's alright for now.

https://github.com/user-attachments/assets/c8ebe14d-ef7e-4c35-adde-f1fb08b5b4a7
