### PR TITLE
Stats: Improves video page styling - part 4

### DIFF
--- a/client/my-sites/stats/videopress-stats-module/index.jsx
+++ b/client/my-sites/stats/videopress-stats-module/index.jsx
@@ -78,6 +78,31 @@ class VideoPressStatsModule extends Component {
 		}
 	}
 
+	getMaxValue( data, field ) {
+		if ( ! data || ! data.length ) {
+			return 0;
+		}
+		return Math.max( ...data.map( ( item ) => item[ field ] || 0 ) );
+	}
+
+	renderTitleCell( title, views, maxViews, onClick, onKeyUp ) {
+		const fillPercentage = maxViews > 0 ? ( views / maxViews ) * 100 : 0;
+		return (
+			<div className="videopress-stats-module__grid-cell videopress-stats-module__grid-link">
+				<div className="videopress-stats-module__bar-wrapper">
+					<div
+						className="videopress-stats-module__bar"
+						style={ { '--bar-fill-percentage': `${ fillPercentage }%` } }
+					>
+						<span onClick={ onClick } onKeyUp={ onKeyUp } tabIndex="0" role="button">
+							{ title }
+						</span>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
 	render() {
 		const {
 			className,
@@ -149,6 +174,9 @@ class VideoPressStatsModule extends Component {
 			...completeVideoStats,
 		];
 
+		// Calculate max views only
+		const maxViews = this.getMaxValue( completeVideoStats, 'views' );
+
 		return (
 			<div>
 				{ summary && (
@@ -210,16 +238,13 @@ class VideoPressStatsModule extends Component {
 								key={ 'videopress-stats-row-' + index }
 								className="videopress-stats-module__row-wrapper"
 							>
-								<div className="videopress-stats-module__grid-cell videopress-stats-module__grid-link">
-									<span
-										onClick={ () => editVideo( row.post_id ) }
-										onKeyUp={ () => editVideo( row.post_id ) }
-										tabIndex="0"
-										role="button"
-									>
-										{ row.title }
-									</span>
-								</div>
+								{ this.renderTitleCell(
+									row.title,
+									row.views,
+									maxViews,
+									() => editVideo( row.post_id ),
+									() => editVideo( row.post_id )
+								) }
 								<div className="videopress-stats-module__grid-cell videopress-stats-module__grid-metric">
 									<span
 										onClick={ () => showStat( 'impressions', row ) }

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -26,7 +26,7 @@
 
 .videopress-stats-module__grid {
 	display: grid;
-	grid-template-columns: minmax(200px, 50%) repeat(4, minmax(100px, 1fr));
+	grid-template-columns: minmax(200px, 50%) repeat(4, minmax(120px, 1fr));
 	grid-auto-rows: min-content;
 	gap: 3px;
 	padding: 0 0 0.5em;
@@ -40,10 +40,13 @@
 	}
 
 	.videopress-stats-module__grid-header {
-		font-weight: 600;
-		color: var(--color-text-subtle);
+		font-weight: 500;
+		color: var(--studio-gray-100);
 		line-height: 20px;
-		padding: 12px 8px;
+		padding: 12px;
+		display: flex;
+		align-items: center;
+		white-space: nowrap;
 
 		&:first-child {
 			padding-left: 24px;
@@ -52,12 +55,13 @@
 		&.videopress-stats-module__grid-metric {
 			text-align: right;
 			padding-right: 24px;
+			justify-content: flex-end;
 		}
 	}
 
 	.videopress-stats-module__grid-metric {
 		text-align: right;
-		padding: 0 24px 0 8px;
+		padding: 0 24px 0 12px;
 
 		span {
 			cursor: pointer;
@@ -69,7 +73,7 @@
 	.videopress-stats-module__grid-link {
 		color: var(--color-primary);
 		overflow: hidden;
-		padding: 0 8px 0 24px;
+		padding: 0 12px 0 24px;
 
 		.videopress-stats-module__bar-wrapper {
 			height: 100%;

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -27,8 +27,9 @@
 .videopress-stats-module__grid {
 	display: grid;
 	grid-template-columns: minmax(200px, 50%) repeat(4, minmax(100px, 1fr));
+	grid-auto-rows: min-content;
+	gap: 3px;
 	padding: 0 0 0.5em;
-	line-height: 40px;
 	font-size: 0.875rem;
 	color: var(--color-text);
 	min-width: 100%;
@@ -75,7 +76,7 @@
 		padding: 0 8px 0 24px;
 
 		.videopress-stats-module__bar-wrapper {
-			height: 40px;
+			height: 100%;
 		}
 
 		.videopress-stats-module__bar {
@@ -117,7 +118,9 @@
 
 	.videopress-stats-module__row-wrapper,
 	.videopress-stats-module__header-row-wrapper {
-		display: contents;
+		display: grid;
+		grid-template-columns: subgrid;
+		grid-column: 1 / -1;
 	}
 
 	.videopress-stats-module__row-wrapper {
@@ -189,59 +192,12 @@
 	}
 }
 
-.videopress-stats-module__bar-wrapper {
-	position: relative;
-	width: 100%;
-	height: 100%;
-	display: flex;
-	align-items: center;
-}
-
-.videopress-stats-module__bar {
-	position: relative;
-	width: 100%;
-	height: 100%;
-	display: flex;
-	align-items: center;
-	padding-left: 10px;
-
-	&::before {
-		content: "";
-		position: absolute;
-		left: 0;
-		top: 0;
-		height: 100%;
-		width: var(--bar-fill-percentage, 0%);
-		background-color: rgba(var(--color-primary-rgb), 15%);
-		border-radius: 2px;
-		transition: width 0.2s ease-out;
-		z-index: 0;
-	}
-}
-
-.videopress-stats-module__bar-value {
-	position: relative;
-	z-index: 1;
-	cursor: pointer;
-
-	&:hover {
-		color: var(--color-primary);
-	}
-}
-
 .videopress-stats-module__grid-cell {
+	height: 36px;
+
 	&.videopress-stats-module__grid-metric {
-		padding: 8px 16px;
-		min-height: 36px;
+		padding: 0 24px 0 8px;
 		display: flex;
 		align-items: center;
-	}
-}
-
-.videopress-stats-module__row-wrapper {
-	&:hover {
-		.videopress-stats-module__bar::before {
-			background-color: rgba(var(--color-primary-rgb), 25%);
-		}
 	}
 }

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -26,33 +26,42 @@
 
 .videopress-stats-module__grid {
 	display: grid;
-	grid-template-columns: 50% auto auto auto auto;
+	grid-template-columns: minmax(200px, 50%) repeat(4, minmax(100px, 1fr));
 	padding: 0 0 0.5em;
 	line-height: 40px;
 	font-size: 0.875rem;
-
 	color: var(--color-text);
 	min-width: 100%;
 	width: fit-content;
 
 	@media screen and (max-width: 450px) {
-		grid-template-columns: 40% auto auto auto auto;
+		grid-template-columns: minmax(150px, 40%) repeat(4, minmax(80px, 1fr));
 	}
 
 	.videopress-stats-module__grid-header {
 		font-weight: 600;
 		color: var(--color-text-subtle);
 		line-height: 20px;
+		padding: 12px 8px;
+
+		&:first-child {
+			padding-left: 24px;
+		}
+
+		&.videopress-stats-module__grid-metric {
+			text-align: right;
+			padding-right: 24px;
+		}
 	}
 
 	.videopress-stats-module__grid-metric {
 		text-align: right;
-		padding-right: 8px;
-	}
+		padding: 0 24px 0 8px;
 
-	.videopress-stats-module__grid-cell {
 		span {
 			cursor: pointer;
+			display: block;
+			width: 100%;
 			
 			&:hover {
 				text-decoration: underline;
@@ -62,33 +71,61 @@
 
 	.videopress-stats-module__grid-link {
 		color: var(--color-primary);
-		overflow-x: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
+		overflow: hidden;
+		padding: 0 8px 0 24px;
+
+		.videopress-stats-module__bar-wrapper {
+			height: 40px;
+		}
+
+		.videopress-stats-module__bar {
+			position: relative;
+			width: 100%;
+			height: 100%;
+			display: flex;
+			align-items: center;
+			
+			span {
+				overflow: hidden;
+				white-space: nowrap;
+				text-overflow: ellipsis;
+				display: block;
+				width: 100%;
+				cursor: pointer;
+				position: relative;
+				z-index: 1;
+
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+
+			&::before {
+				content: "";
+				position: absolute;
+				left: 0;
+				top: 0;
+				height: 100%;
+				width: var(--bar-fill-percentage, 0%);
+				background-color: rgba(var(--color-primary-rgb), 8%);
+				border-radius: 2px;
+				transition: width 0.2s ease-out;
+				z-index: 0;
+			}
+		}
 	}
 
 	.videopress-stats-module__row-wrapper,
 	.videopress-stats-module__header-row-wrapper {
 		display: contents;
-
-		div:first-of-type {
-			padding-left: 24px;
-		}
-
-		div:last-of-type {
-			padding-right: 24px;
-		}
 	}
 
 	.videopress-stats-module__row-wrapper {
-		&:hover div {
-			background-color: var(--color-neutral-0);
+		&:hover {
+			.videopress-stats-module__bar::before {
+				background-color: rgba(var(--color-primary-rgb), 12%);
+			}
 		}
-	}
-
-	.videopress-stats-module__header-row-wrapper {
-		display: contents;
-		padding-bottom: 12px;
 	}
 }
 
@@ -148,6 +185,63 @@
 	&.has-no-data {
 		.videopress-stats-module__grid {
 			display: none;
+		}
+	}
+}
+
+.videopress-stats-module__bar-wrapper {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+}
+
+.videopress-stats-module__bar {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	padding-left: 10px;
+
+	&::before {
+		content: "";
+		position: absolute;
+		left: 0;
+		top: 0;
+		height: 100%;
+		width: var(--bar-fill-percentage, 0%);
+		background-color: rgba(var(--color-primary-rgb), 15%);
+		border-radius: 2px;
+		transition: width 0.2s ease-out;
+		z-index: 0;
+	}
+}
+
+.videopress-stats-module__bar-value {
+	position: relative;
+	z-index: 1;
+	cursor: pointer;
+
+	&:hover {
+		color: var(--color-primary);
+	}
+}
+
+.videopress-stats-module__grid-cell {
+	&.videopress-stats-module__grid-metric {
+		padding: 8px 16px;
+		min-height: 36px;
+		display: flex;
+		align-items: center;
+	}
+}
+
+.videopress-stats-module__row-wrapper {
+	&:hover {
+		.videopress-stats-module__bar::before {
+			background-color: rgba(var(--color-primary-rgb), 25%);
 		}
 	}
 }

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -151,7 +151,3 @@
 		}
 	}
 }
-
-.stats-module__date-picker-header {
-	margin-bottom: 16px;
-}

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -36,7 +36,7 @@
 	width: fit-content;
 
 	@media screen and (max-width: 450px) {
-		grid-template-columns: minmax(150px, 40%) repeat(4, minmax(80px, 1fr));
+		grid-template-columns: 40% auto auto auto auto;
 	}
 
 	.videopress-stats-module__grid-header {

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -63,10 +63,6 @@
 			cursor: pointer;
 			display: block;
 			width: 100%;
-			
-			&:hover {
-				text-decoration: underline;
-			}
 		}
 	}
 
@@ -96,10 +92,9 @@
 				cursor: pointer;
 				position: relative;
 				z-index: 1;
-
-				&:hover {
-					text-decoration: underline;
-				}
+				color: var(--color-text);
+				font-size: $font-body-small;
+				font-weight: 500;
 			}
 
 			&::before {
@@ -109,9 +104,9 @@
 				top: 0;
 				height: 100%;
 				width: var(--bar-fill-percentage, 0%);
-				background-color: rgba(var(--color-primary-rgb), 8%);
+				background-color: rgba(var(--color-primary-rgb), 15%);
 				border-radius: 2px;
-				transition: width 0.2s ease-out;
+				transition: background-color 0.2s ease-out;
 				z-index: 0;
 			}
 		}
@@ -126,8 +121,15 @@
 
 	.videopress-stats-module__row-wrapper {
 		&:hover {
+			background-color: var(--theme-highlight-color);
+
 			.videopress-stats-module__bar::before {
-				background-color: rgba(var(--color-primary-rgb), 12%);
+				background-color: rgba(var(--color-primary-rgb), 15%);
+			}
+
+			.videopress-stats-module__grid-metric span,
+			.videopress-stats-module__bar span {
+				color: var(--color-text-inverted);
 			}
 		}
 	}

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -85,6 +85,7 @@
 			height: 100%;
 			display: flex;
 			align-items: center;
+			padding-left: 10px;
 			
 			span {
 				overflow: hidden;

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -151,3 +151,7 @@
 		}
 	}
 }
+
+.stats-module__date-picker-header {
+	margin-bottom: 16px;
+}

--- a/client/my-sites/stats/videopress-stats-module/style.scss
+++ b/client/my-sites/stats/videopress-stats-module/style.scss
@@ -43,7 +43,7 @@
 		font-weight: 500;
 		color: var(--studio-gray-100);
 		line-height: 20px;
-		padding: 12px;
+		padding: 0 12px;
 		display: flex;
 		align-items: center;
 		white-space: nowrap;
@@ -141,6 +141,8 @@
 
 .card.is-compact {
 	padding: 0;
+	border-radius: 4px;
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
 	
 	.videopress-stats-module__grid {
 		margin: 0;
@@ -182,6 +184,7 @@
 
 		.stats-download-csv {
 			color: var(--color-link);
+			padding-right: 0;
 
 			&:hover {
 				color: var(--color-link-dark);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101634

## Proposed Changes

* This PR makes the following style updates to align with the other page headers:
     -  Adds the horizontal bar styling and logic
     - Numerous other small styling tweaks and changes to match the other similar pages


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To align the video press stats page with the other pages
* This is a followup from #101663 and is being compared to that PR. So it needs to merge first before this one. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live branch
* Navigate to `/stats/day/videoplays/jetpack.com` (or any site with video plays)
* Check that the styling matches below

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/e51cbd01-6109-409c-817c-94ef4186b38c) | ![image](https://github.com/user-attachments/assets/fbc979f3-e438-4a5c-97f3-1b9f8a3691b2) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
