### PR TITLE
Use global color scheme for notifications panel in calypso

### DIFF
--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -457,7 +457,7 @@ class Layout extends Component {
 			// element itself. There may be better ways to handle this, but
 			// let's disable eslint here for now to avoid refactoring older code.
 			// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-			<div onClick={ this.props.interceptLinks }>
+			<div className="color-scheme is-global" onClick={ this.props.interceptLinks }>
 				{ this.props.error && <AppError error={ this.props.error } /> }
 
 				{ ! this.props.error && (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/101288
Fixes https://linear.app/a8c/issue/DOTCOM-464/color-scheme-application-in-notifications-slider-is-inconsistent

Props @arthur791004 for [this one](https://github.com/Automattic/wp-calypso/pull/101652/files/069ef11df3909d8996f0a618bc9d4c2434424a20#diff-27374a70c13059756839dabb3fedf4c59c75444f93497261a45b2804e989cc89).

## Proposed Changes

Applies the global color scheme directly to the notification panel preventing user color scheme from applying at in the site level.

## Why are these changes being made?

* See issue discussion for context

## Testing Instructions

* Test the notification panel in:
  * Reader
  * SMP pages
  * Home
  * WP-Admin (sandboxed)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
