### PR TITLE
Untangled Plans: add manage billing & add-ons button in the header

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1481,7 +1481,10 @@ class ManagePurchase extends Component<
 					<QueryCanonicalTheme siteId={ siteId } themeId={ purchase?.meta ?? '' } />
 				) }
 
-				<HeaderCake backHref={ this.props.purchaseListUrl ?? purchasesRoot }>
+				<HeaderCake
+					backText={ translate( 'Purchases' ) }
+					backHref={ this.props.purchaseListUrl ?? purchasesRoot }
+				>
 					{ this.props.cardTitle || titles.managePurchase }
 				</HeaderCake>
 				{ showExpiryNotice ? (

--- a/client/my-sites/purchases/paths.ts
+++ b/client/my-sites/purchases/paths.ts
@@ -3,6 +3,11 @@ export const getManagePurchaseUrlFor = (
 	targetPurchaseId: string | number
 ): string => `/purchases/subscriptions/${ targetSiteSlug }/${ targetPurchaseId }`;
 
+export const getMyPurchaseUrlFor = (
+	targetSiteSlug: string,
+	targetPurchaseId: string | number
+): string => `/me/purchases/${ targetSiteSlug }/${ targetPurchaseId }`;
+
 export const getConfirmCancelDomainUrlFor = (
 	targetSiteSlug: string,
 	targetPurchaseId: string | number

--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -37,13 +37,13 @@ export default function CurrentPlanPanel() {
 		);
 	};
 
-	const renderManagePlanButton = () => {
+	const renderManageBillingButton = () => {
 		if ( ! site || ! isOwner ) {
 			return null;
 		}
 		return (
 			<Button variant="secondary" href={ getMyPurchaseUrlFor( site.slug, planPurchaseId ?? 0 ) }>
-				{ translate( 'Manage plan' ) }
+				{ translate( 'Manage billing' ) }
 			</Button>
 		);
 	};
@@ -67,7 +67,7 @@ export default function CurrentPlanPanel() {
 				<div className="manage-buttons">
 					{ ! isLoading && (
 						<>
-							{ renderManagePlanButton() }
+							{ renderManageBillingButton() }
 							{ renderManageAddOnsButton() }
 						</>
 					) }

--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -1,10 +1,14 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import CoreBadge from 'calypso/components/core/badge';
+import { getMyPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import PlanPricing from 'calypso/sites/components/plan-pricing';
 import PlanStats from 'calypso/sites/components/plan-stats';
+import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
+import { AppState } from 'calypso/types';
 
 import './style.scss';
 
@@ -14,25 +18,62 @@ export default function CurrentPlanPanel() {
 	const planDetails = site?.plan;
 	const isFreePlan = planDetails?.is_free;
 	const planPurchase = useSelector( getSelectedPurchase );
+	const planPurchaseId = useSelector( ( state: AppState ) =>
+		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )
+	);
 
 	const planName = planDetails?.product_name_short ?? '';
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
+
+	const isOwner = planDetails?.user_is_owner;
+
 	const isLoading = ! planDetails || planPurchaseLoading;
+
+	const renderManageAddOnsButton = () => {
+		return (
+			<Button variant="tertiary" href={ `/add-ons/${ site?.slug }` }>
+				{ translate( 'Manage add-ons' ) }
+			</Button>
+		);
+	};
+
+	const renderManagePlanButton = () => {
+		if ( ! site || ! isOwner ) {
+			return null;
+		}
+		return (
+			<Button variant="secondary" href={ getMyPurchaseUrlFor( site.slug, planPurchaseId ?? 0 ) }>
+				{ translate( 'Manage plan' ) }
+			</Button>
+		);
+	};
 
 	return (
 		<div className="current-plan-panel">
-			<div className="current-plan-name">
-				{ isLoading ? (
-					<LoadingPlaceholder width="200px" height="24px" />
-				) : (
-					<>
-						<h3>{ planName }</h3>
-						<CoreBadge>{ translate( 'Current plan' ) }</CoreBadge>
-					</>
-				) }
+			<div className="current-plan-heading">
+				<div className="current-plan-info">
+					<div className="current-plan-name">
+						{ isLoading ? (
+							<LoadingPlaceholder width="200px" height="24px" />
+						) : (
+							<>
+								<h3>{ planName }</h3>
+								<CoreBadge>{ translate( 'Current plan' ) }</CoreBadge>
+							</>
+						) }
+					</div>
+					{ ! isFreePlan && <PlanPricing inline /> }
+				</div>
+				<div className="manage-buttons">
+					{ ! isLoading && (
+						<>
+							{ renderManagePlanButton() }
+							{ renderManageAddOnsButton() }
+						</>
+					) }
+				</div>
 			</div>
 
-			{ ! isFreePlan && <PlanPricing inline /> }
 			<PlanStats />
 			<hr />
 		</div>

--- a/client/sites/plan/components/current-plan-panel/style.scss
+++ b/client/sites/plan/components/current-plan-panel/style.scss
@@ -4,10 +4,36 @@
 @import "@wordpress/base-styles/variables";
 
 .current-plan-panel {
+	.current-plan-heading {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+
+		@include break-medium {
+			display: flex;
+			flex-direction: row;
+			align-items: flex-start;
+		}
+	}
+
+	.current-plan-info {
+		flex: 1;
+	}
+
 	.current-plan-name {
 		display: flex;
+		flex: 1;
 		gap: 8px;
 		margin-bottom: 8px;
+	}
+
+	.manage-buttons {
+		display: flex;
+		gap: 4px;
+
+		@include break-medium {
+			flex-direction: row-reverse;
+		}
 	}
 
 	h3 {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/10607

## Proposed Changes

This PR implements the `Manage add-ons` and `Manage billing` buttons as per Figma kyrhgvUpBQak3Qww1560PK-fi-461_8867

<img width="989" alt="image" src="https://github.com/user-attachments/assets/2c1b6d8f-6d63-4b04-b472-d0ee0b03298a" />


Note that there's a discussion about the button copy here: p58i-kcO-p2#comment-67294 (cc: @matt-west)


## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

1. Go to `/plans/:site?flags=untangling/plans` on a Free site
   - Verify you see the `Manage add-ons` button.
2. Go to `/plans/:site?flags=untangling/plans` as an owner of a site with a paid plan
   - Verify you see the `Manage add-ons` and `Manage billing` buttons.
   - Verify you can click the buttons and they take you to the correct pages:

|Manage add-ons|Manage billing|
|-|-|
|<img width="1192" alt="image" src="https://github.com/user-attachments/assets/0e40ae59-85f3-4239-a7d2-c03dd6becff5" />|<img width="1198" alt="image" src="https://github.com/user-attachments/assets/08ed8466-18ba-4f8b-bc14-a71e16c22641" />|

(Note that the `Manage add-ons` destination page is temporary; it will be replaced with a modal, soon.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?