### PR TITLE
Design Picker: Clean-up unused code

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -45,7 +45,6 @@ import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query'
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
-import { navigate } from 'calypso/lib/navigate';
 import { urlToSlug } from 'calypso/lib/url';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
@@ -69,7 +68,6 @@ import {
 	getDesignEventProps,
 	recordPreviewedDesign,
 	recordSelectedDesign,
-	getVirtualDesignProps,
 } from '../../analytics/record-design';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
@@ -267,13 +265,6 @@ const UnifiedDesignPickerStep: StepType< {
 			'calypso_signup_design_preview_style_variation_preview_click',
 			getEventPropsByDesign( design, { styleVariation } )
 		);
-	}
-
-	function onChangeVariation( design: Design, styleVariation?: StyleVariation ) {
-		recordTracksEvent( 'calypso_signup_design_picker_style_variation_button_click', {
-			...getEventPropsByDesign( design, { styleVariation } ),
-			...getVirtualDesignProps( design ),
-		} );
 	}
 
 	function trackAllDesignsView() {
@@ -874,11 +865,6 @@ const UnifiedDesignPickerStep: StepType< {
 		'One of these homepage options could be great to start with. You can always change later.'
 	);
 
-	function onDesignWithAI() {
-		recordTracksEvent( 'calypso_design_picker_big_sky_button_click', commonFilterProperties );
-		navigate( `/setup/site-setup/launch-big-sky?siteSlug=${ siteSlug }&siteId=${ site?.ID }` );
-	}
-
 	// Use this to prioritize themes in certain categories.
 	// The specified theme will be shown first in the list.
 	const priorityThemes: Record< string, string > = {
@@ -893,9 +879,7 @@ const UnifiedDesignPickerStep: StepType< {
 				designs={ designs }
 				priorityThemes={ priorityThemes }
 				locale={ locale }
-				onDesignWithAI={ onDesignWithAI }
 				onPreview={ previewDesign }
-				onChangeVariation={ onChangeVariation }
 				onViewAllDesigns={ trackAllDesignsView }
 				heading={
 					! isUsingStepContainerV2 ? (
@@ -908,7 +892,6 @@ const UnifiedDesignPickerStep: StepType< {
 				}
 				categorization={ categorization }
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
-				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 				// TODO: Update the ThemeCard component once the new design is rolled out completely
 				// to avoid passing the getBadge and getOptionsMenu prop conditionally down the component tree.
 				getBadge={ isUpdatedBadgeDesign ? undefined : getBadge }

--- a/packages/design-picker/src/components/design-preview-image/index.tsx
+++ b/packages/design-picker/src/components/design-preview-image/index.tsx
@@ -2,7 +2,7 @@ import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import photon from 'photon';
 import { getDesignPreviewUrl, getMShotOptions } from '../../utils';
-import type { Design } from '../../types';
+import type { Design, StyleVariation } from '../../types';
 import type { FC } from 'react';
 
 const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name__${ slug }`;
@@ -11,12 +11,14 @@ interface DesignPreviewImageProps {
 	design: Design;
 	imageOptimizationExperiment?: boolean;
 	locale?: string;
+	styleVariation?: StyleVariation;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 }
 
 const DesignPreviewImage: FC< DesignPreviewImageProps > = ( {
 	design,
 	locale,
+	styleVariation,
 	oldHighResImageLoading,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
@@ -52,6 +54,7 @@ const DesignPreviewImage: FC< DesignPreviewImageProps > = ( {
 		<MShotsImage
 			url={ getDesignPreviewUrl( design, {
 				use_screenshot_overrides: true,
+				style_variation: styleVariation,
 				...( locale && { language: locale } ),
 			} ) }
 			aria-labelledby={ makeOptionId( design ) }

--- a/packages/design-picker/src/components/design-preview-image/index.tsx
+++ b/packages/design-picker/src/components/design-preview-image/index.tsx
@@ -2,7 +2,7 @@ import { MShotsImage } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
 import photon from 'photon';
 import { getDesignPreviewUrl, getMShotOptions } from '../../utils';
-import type { Design, StyleVariation } from '../../types';
+import type { Design } from '../../types';
 import type { FC } from 'react';
 
 const makeOptionId = ( { slug }: Design ): string => `design-picker__option-name__${ slug }`;
@@ -11,14 +11,12 @@ interface DesignPreviewImageProps {
 	design: Design;
 	imageOptimizationExperiment?: boolean;
 	locale?: string;
-	styleVariation?: StyleVariation;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 }
 
 const DesignPreviewImage: FC< DesignPreviewImageProps > = ( {
 	design,
 	locale,
-	styleVariation,
 	oldHighResImageLoading,
 } ) => {
 	const isMobile = useViewportMatch( 'small', '<' );
@@ -54,7 +52,6 @@ const DesignPreviewImage: FC< DesignPreviewImageProps > = ( {
 		<MShotsImage
 			url={ getDesignPreviewUrl( design, {
 				use_screenshot_overrides: true,
-				style_variation: styleVariation,
 				...( locale && { language: locale } ),
 			} ) }
 			aria-labelledby={ makeOptionId( design ) }

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -2,7 +2,6 @@ import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { forwardRef, useMemo } from 'react';
-import type { StyleVariation } from '../../types';
 import type { Ref } from 'react';
 import './style.scss';
 
@@ -14,16 +13,12 @@ interface ThemeCardProps {
 	imageActionLabel?: string;
 	banner?: React.ReactNode;
 	badge?: React.ReactNode;
-	styleVariations: StyleVariation[];
-	selectedStyleVariation?: StyleVariation;
 	optionsMenu?: React.ReactNode;
 	isActive?: boolean;
 	isLoading?: boolean;
 	isSoftLaunched?: boolean;
 	onClick?: () => void;
 	onImageClick?: () => void;
-	onStyleVariationClick?: ( styleVariation: StyleVariation ) => void;
-	onStyleVariationMoreClick?: () => void;
 }
 
 const ActiveBadge = () => {
@@ -58,7 +53,6 @@ const ThemeCard = forwardRef(
 			imageActionLabel,
 			banner,
 			badge,
-			styleVariations = [],
 			optionsMenu,
 			isActive,
 			isLoading,
@@ -74,11 +68,6 @@ const ThemeCard = forwardRef(
 		const themeClasses = clsx( 'theme-card', {
 			'theme-card--is-active': isActive,
 			'theme-card--is-actionable': isActionable,
-		} );
-
-		const themeInfoClasses = clsx( 'theme-card__info', {
-			// Only show style variations when there is both a badge and variations.
-			'theme-card__info--has-style-variations': badge && styleVariations.length > 0,
 		} );
 
 		return (
@@ -120,7 +109,7 @@ const ThemeCard = forwardRef(
 							</div>
 						</div>
 					) }
-					<div className={ themeInfoClasses }>
+					<div className="theme-card__info">
 						<h2 className="theme-card__info-title">
 							<span>{ name }</span>
 						</h2>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -12,12 +12,7 @@ import {
 } from '../constants';
 import { useDesignTiers, useDesignPickerFilters } from '../hooks/use-design-picker-filters';
 import { useFilteredDesignsByGroup } from '../hooks/use-filtered-designs';
-import {
-	isDefaultGlobalStylesVariationSlug,
-	isFeatureCategory,
-	isLockedStyleVariation,
-	shuffleDesigns,
-} from '../utils';
+import { isFeatureCategory, shuffleDesigns } from '../utils';
 import DesignPickerCategoryFilter from './design-picker-category-filter';
 import DesignPreviewImage from './design-preview-image';
 import NoResults from './no-results';
@@ -111,8 +106,6 @@ interface DesignCardProps {
 	locale: string;
 	category?: string | null;
 	isPremiumThemeAvailable?: boolean;
-	shouldLimitGlobalStyles?: boolean;
-	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
@@ -125,55 +118,30 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	locale,
 	category,
 	isPremiumThemeAvailable,
-	shouldLimitGlobalStyles,
-	onChangeVariation,
 	onPreview,
 	getBadge,
 	getOptionsMenu,
 	oldHighResImageLoading,
 	isActive,
 } ) => {
-	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation >();
-
-	const { style_variations = [] } = design;
 	const trackingDivRef = useTrackDesignView( { category, design, isPremiumThemeAvailable } );
-	const isDefaultVariation = isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug );
 
-	const isLocked = isLockedStyleVariation( {
-		isPremiumTheme: design?.design_tier === 'premium',
-		styleVariationSlug: selectedStyleVariation?.slug,
-		shouldLimitGlobalStyles,
-	} );
-
-	const conditionalProps =
-		! isLocked && isActive
-			? {}
-			: { onImageClick: () => onPreview( design, selectedStyleVariation ) };
+	const conditionalProps = isActive ? {} : { onImageClick: () => onPreview( design ) };
 
 	return (
 		<ThemeCard
 			className="design-button-container"
 			ref={ trackingDivRef }
-			name={
-				isDefaultVariation ? design.title : `${ design.title } – ${ selectedStyleVariation?.title }`
-			}
+			name={ design.title }
 			image={
 				<DesignPreviewImage
 					design={ design }
 					locale={ locale }
-					styleVariation={ selectedStyleVariation }
 					oldHighResImageLoading={ oldHighResImageLoading }
 				/>
 			}
-			optionsMenu={ getOptionsMenu && getOptionsMenu( design.slug, isLocked ) }
-			badge={ getBadge && getBadge( design.slug, isLocked ) }
-			styleVariations={ style_variations }
-			selectedStyleVariation={ selectedStyleVariation }
-			onStyleVariationClick={ ( variation ) => {
-				onChangeVariation( design, variation );
-				setSelectedStyleVariation( variation );
-			} }
-			onStyleVariationMoreClick={ () => onPreview( design ) }
+			optionsMenu={ getOptionsMenu && getOptionsMenu( design.slug, false ) }
+			badge={ getBadge && getBadge( design.slug, false ) }
 			isActive={ isActive && ! isLocked }
 			{ ...conditionalProps }
 		/>
@@ -187,12 +155,10 @@ interface DesignCardGroup {
 	category?: string | null;
 	categoryName?: string;
 	isPremiumThemeAvailable?: boolean;
-	shouldLimitGlobalStyles?: boolean;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test.
 	showActiveThemeBadge?: boolean;
 	siteActiveTheme?: string | null;
 	showNoResults?: boolean;
-	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
@@ -205,12 +171,10 @@ const DesignCardGroup = ( {
 	categoryName,
 	locale,
 	isPremiumThemeAvailable,
-	shouldLimitGlobalStyles,
 	oldHighResImageLoading,
 	showActiveThemeBadge = false,
 	siteActiveTheme,
 	showNoResults,
-	onChangeVariation,
 	onPreview,
 	getBadge,
 	getOptionsMenu,
@@ -262,8 +226,6 @@ const DesignCardGroup = ( {
 						design={ design }
 						locale={ locale }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
-						shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-						onChangeVariation={ onChangeVariation }
 						onPreview={ onPreview }
 						getBadge={ getBadge }
 						getOptionsMenu={ getOptionsMenu }
@@ -335,13 +297,10 @@ const DesignPickerFilterGroup: React.FC< DesignPickerFilterGroupProps > = ( {
 
 interface DesignPickerProps {
 	locale: string;
-	onDesignWithAI?: () => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	designs: Design[];
 	categorization?: Categorization;
 	isPremiumThemeAvailable?: boolean;
-	shouldLimitGlobalStyles?: boolean;
 	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
@@ -354,13 +313,10 @@ interface DesignPickerProps {
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
-	//onDesignWithAI,
 	onPreview,
-	onChangeVariation,
 	designs,
 	categorization,
 	isPremiumThemeAvailable,
-	shouldLimitGlobalStyles,
 	getBadge,
 	getOptionsMenu,
 	oldHighResImageLoading,
@@ -400,8 +356,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	const designCardProps = {
 		locale,
 		isPremiumThemeAvailable,
-		shouldLimitGlobalStyles,
-		onChangeVariation,
 		onPreview,
 		getBadge,
 		getOptionsMenu,
@@ -438,21 +392,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					</DesignPickerFilterGroup>
 				) }
-				{ /* isBigSkyEligible && (
-					<DesignPickerFilterGroup>
-						<Button
-							className={ clsx(
-								'design-picker__design-your-own-button',
-								'design-picker__design-with-ai'
-							) }
-							onClick={ () => {
-								onDesignWithAI && onDesignWithAI();
-							} }
-						>
-							{ translate( 'Design with AI' ) }
-						</Button>
-					</DesignPickerFilterGroup>
-				) */ }
 			</div>
 
 			{ isMultiFilterEnabled && selectedCategoriesWithoutDesignTier.length > 1 && (
@@ -495,15 +434,12 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 
 export interface UnifiedDesignPickerProps {
 	locale: string;
-	onDesignWithAI?: () => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
-	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onViewAllDesigns: () => void;
 	designs: Design[];
 	categorization?: Categorization;
 	heading?: React.ReactNode;
 	isPremiumThemeAvailable?: boolean;
-	shouldLimitGlobalStyles?: boolean;
 	getBadge?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	getOptionsMenu?: ( themeId: string, isLockedStyleVariation: boolean ) => React.ReactNode;
 	oldHighResImageLoading?: boolean; // Temporary for A/B test
@@ -516,15 +452,12 @@ export interface UnifiedDesignPickerProps {
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	locale,
-	onDesignWithAI,
 	onPreview,
-	onChangeVariation,
 	onViewAllDesigns,
 	designs,
 	heading,
 	categorization,
 	isPremiumThemeAvailable,
-	shouldLimitGlobalStyles,
 	getBadge,
 	getOptionsMenu,
 	oldHighResImageLoading,
@@ -546,13 +479,10 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 			<div className="unified-design-picker__designs">
 				<DesignPicker
 					locale={ locale }
-					onDesignWithAI={ onDesignWithAI }
 					onPreview={ onPreview }
-					onChangeVariation={ onChangeVariation }
 					designs={ designs }
 					categorization={ categorization }
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
-					shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 					getBadge={ getBadge }
 					getOptionsMenu={ getOptionsMenu }
 					oldHighResImageLoading={ oldHighResImageLoading }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -125,7 +125,6 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	isActive,
 } ) => {
 	const trackingDivRef = useTrackDesignView( { category, design, isPremiumThemeAvailable } );
-
 	const conditionalProps = isActive ? {} : { onImageClick: () => onPreview( design ) };
 
 	return (
@@ -142,7 +141,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 			}
 			optionsMenu={ getOptionsMenu && getOptionsMenu( design.slug, false ) }
 			badge={ getBadge && getBadge( design.slug, false ) }
-			isActive={ isActive && ! isLocked }
+			isActive={ isActive }
 			{ ...conditionalProps }
 		/>
 	);


### PR DESCRIPTION
## Proposed Changes

Just removing unused code.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke-test Design Picker. And the Theme Showcase.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
