### PR TITLE
Help Center: Fix options undefined 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -72,7 +72,7 @@ const DIFMStartingPoint: StepType< {
 							skipButton={
 								shouldRenderHelpCenter ? (
 									<HelpCenterStepButton
-										flowName={ flow }
+										flowName={ DIFM_FLOW }
 										enabledGeos={ [ 'US' ] }
 										helpCenterButtonCopy={ translate( 'Questions?' ) }
 										helpCenterButtonLink={ translate( 'Contact our site building team' ) }

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -159,7 +159,7 @@ export const setShowHelpCenter = function* (
 		yield setShowMessagingWidget( false );
 	}
 
-	yield setMessage( options.searchTerm );
+	yield setMessage( options?.searchTerm || '' );
 	yield setIsMinimized( false );
 
 	if ( allowPremiumSupport ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-31k-p2#comment-3084


## Proposed Changes

Recently we introduce the use of a search term that is possible to pass to the Help Center to set the context.
There is a bug though, we didn't catch a possible undefined in the code. This fixes it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start from /start/do-it-for-me/new-or-existing-site?flags=signup/help-center-link
* Reach after checkout and in the difmStartingPoint try to open the Help Center, it should not break but open

