### PR TITLE
Big Sky: Open Calypso flow for everybody

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -23,6 +23,7 @@
 		"100-year-plan/vip": true,
 		"ad-tracking": true,
 		"a4a-dev-sites": true,
+		"calypso/ai-site-builder-flow": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"automated-migration/application-password": true,
 		"calypso/ai-blogging-prompts": false,


### PR DESCRIPTION
Fixes BSKY-214

This opens up the calypso big sky flow for everybody.

### Testing instructions

There was a CFT already on staging where it is open, so this should not be necessary.