### PR TITLE
Untangled Plans: show correct info for A4A site

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -35,6 +35,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
+import { isPartnerPurchase } from 'calypso/lib/purchases';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import P2PlansMain from 'calypso/my-sites/plans/p2-plans-main';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
@@ -349,7 +350,7 @@ class PlansComponent extends Component {
 		);
 	}
 
-	renderMainContent( { isEcommerceTrial, isBusinessTrial, isWooExpressPlan } ) {
+	renderMainContent( { isEcommerceTrial, isBusinessTrial, isWooExpressPlan, isA4APlan } ) {
 		if ( isEcommerceTrial ) {
 			return this.renderEcommerceTrialPage();
 		}
@@ -358,6 +359,9 @@ class PlansComponent extends Component {
 		}
 		if ( isBusinessTrial ) {
 			return this.renderBusinessTrialPage();
+		}
+		if ( isA4APlan ) {
+			return null;
 		}
 
 		return this.renderPlansMain();
@@ -422,6 +426,7 @@ class PlansComponent extends Component {
 			} );
 
 		const isWooExpressTrial = purchase?.isWooExpressTrial;
+		const isA4APlan = purchase && isPartnerPurchase( purchase );
 
 		// Use the Woo Express subheader text if the current plan has the Performance or trial plans or fallback to the default subheader text.
 		let subHeaderText = null;
@@ -504,6 +509,7 @@ class PlansComponent extends Component {
 									isEcommerceTrial,
 									isBusinessTrial,
 									isWooExpressPlan,
+									isA4APlan,
 								} ) }
 								<PerformanceTrackerStop />
 							</Main>

--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -3,9 +3,11 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import CoreBadge from 'calypso/components/core/badge';
+import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
 import { getMyPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import PlanPricing from 'calypso/sites/components/plan-pricing';
 import PlanStats from 'calypso/sites/components/plan-stats';
+import { isA4AUser } from 'calypso/state/partner-portal/partner/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
@@ -21,15 +23,42 @@ export default function CurrentPlanPanel() {
 	const planPurchaseId = useSelector( ( state: AppState ) =>
 		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )
 	);
+	const isA4APlan = planPurchase && isPartnerPurchase( planPurchase );
 
-	const planName = planDetails?.product_name_short ?? '';
+	const planName = isA4APlan ? purchaseType( planPurchase ) : planDetails?.product_name_short ?? '';
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 
 	const isOwner = planDetails?.user_is_owner;
+	const isA4AOwner = useSelector( isA4AUser );
 
 	const isLoading = ! planDetails || planPurchaseLoading;
 
+	const renderPricing = () => {
+		if ( isFreePlan ) {
+			return null;
+		}
+		if ( isA4APlan ) {
+			return (
+				<p className="plan-price-info">
+					{ translate( 'This site is managed through {{a}}Automattic for Agencies{{/a}}.', {
+						components: {
+							a: isA4AOwner ? (
+								<a href={ `https://agencies.automattic.com/sites/overview/${ site?.slug }` }></a>
+							) : (
+								<strong></strong>
+							),
+						},
+					} ) }
+				</p>
+			);
+		}
+		return <PlanPricing inline />;
+	};
+
 	const renderManageAddOnsButton = () => {
+		if ( isA4APlan ) {
+			return null;
+		}
 		return (
 			<Button variant="tertiary" href={ `/add-ons/${ site?.slug }` }>
 				{ translate( 'Manage add-ons' ) }
@@ -38,7 +67,7 @@ export default function CurrentPlanPanel() {
 	};
 
 	const renderManageBillingButton = () => {
-		if ( ! site || ! isOwner ) {
+		if ( ! site || ! isOwner || isA4APlan ) {
 			return null;
 		}
 		return (
@@ -62,7 +91,7 @@ export default function CurrentPlanPanel() {
 							</>
 						) }
 					</div>
-					{ ! isFreePlan && <PlanPricing inline /> }
+					{ renderPricing() }
 				</div>
 				<div className="manage-buttons">
 					{ ! isLoading && (
@@ -75,7 +104,7 @@ export default function CurrentPlanPanel() {
 			</div>
 
 			<PlanStats />
-			<hr />
+			{ ! isA4APlan && <hr /> }
 		</div>
 	);
 }

--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -87,7 +87,7 @@ export default function CurrentPlanPanel() {
 						) : (
 							<>
 								<h3>{ planName }</h3>
-								<CoreBadge>{ translate( 'Current plan' ) }</CoreBadge>
+								{ ! isA4APlan && <CoreBadge>{ translate( 'Current plan' ) }</CoreBadge> }
 							</>
 						) }
 					</div>


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/10607

## Proposed Changes

This PR renders the "more correct" plan info for an A4A site. This follows what we show in the Overview tab currently:

|Before|After|
|-|-|
|<img width="977" alt="image" src="https://github.com/user-attachments/assets/44b3d5e1-13f3-445f-8562-2fec5c949748" />|<img width="980" alt="image" src="https://github.com/user-attachments/assets/8e200fe4-fe79-4b97-9688-09efe391fd20" />|


## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

1. Create an A4A site.
2. Open `/plans/:siteSlug?flags=untangling/plans`.
3. Verify that you see the minimalistic screen as above screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?