### PR TITLE
Design style consistency: Update Design Choice Screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -71,7 +71,7 @@ button {
 .site-setup:not(:has(.step-container-v2)),
 .onboarding.goals,
 .onboarding.design-setup,
-.onboarding.design-choices,
+.onboarding.design-choices:not(:has(.step-container-v2)),
 .onboarding.difm-starting-point,
 .site-migration,
 .migration,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
@@ -1,9 +1,21 @@
 @import "@automattic/typography/styles/fonts";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
 
 .design-choice {
 	display: flex;
 	flex-direction: column;
-	width: 380px;
+	width: 100%;
+	align-items: center;
+
+	@include break-small {
+		max-width: 380px;
+	}
+
+	@include break-medium {
+		align-self: stretch;
+	}
+
 	padding: 36px 36px 60px;
 	border-radius: 4px;
 	outline: var(--studio-gray-5) solid 1px;
@@ -31,7 +43,11 @@
 	.design-choice__image-container {
 		display: flex;
 		position: relative; // Allows the price badge to be positioned absolutely
-		width: 308px;
+
+		@include break-small {
+			max-width: 308px;
+		}
+
 		min-height: 226px;
 		transition: transform ease-in 0.15s;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -2,7 +2,7 @@ import { PLAN_PERSONAL } from '@automattic/calypso-products';
 import { OnboardSelect, ProductsList } from '@automattic/data-stores';
 import { themesIllustrationImage } from '@automattic/design-picker';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { StepContainer, isOnboardingFlow } from '@automattic/onboarding';
+import { Step, StepContainer, isOnboardingFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -13,6 +13,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useIsBigSkyEligible } from '../../../../hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from '../../../../stores';
 import kebabCase from '../../../../utils/kebabCase';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { useBigSkyBeforePlans } from '../../../helpers/use-bigsky-before-plans-experiment';
 import bigSkyBg from './big-sky-bg.png';
 import bigSkyFg from './big-sky-fg.png';
@@ -20,19 +21,21 @@ import hiBigSky from './big-sky-no-text.svg';
 import DesignChoice from './design-choice';
 import GoalsFirstDesignChoice from './goals-first-design-choice';
 import themeChoiceFg from './theme-choice-fg.png';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
+
 import './style.scss';
 
 /**
  * The design choices step
  */
-const DesignChoicesStep: Step< { submits: { destination: string } } > = ( {
+const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 	navigation,
 	flow,
 	stepName,
 } ) => {
 	const [ , isBigSkyBeforePlansExperiment ] = useBigSkyBeforePlans(); // If the experiment hasn't loaded yet, then it must mean we're ineligible anyway
 	const isGoalsFirstVariation = isOnboardingFlow( flow ) && isBigSkyBeforePlansExperiment;
+	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
 
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
@@ -128,6 +131,94 @@ const DesignChoicesStep: Step< { submits: { destination: string } } > = ( {
 		return undefined;
 	};
 
+	const stepContent = (
+		<>
+			{ ! isGoalsFirstVariation ? (
+				<DesignChoice
+					title={ translate( 'Choose a theme' ) }
+					description={ translate( 'Choose one of our professionally designed themes.' ) }
+					imageSrc={ themesIllustrationImage }
+					destination="design-setup"
+					onSelect={ handleSubmit }
+				/>
+			) : (
+				<GoalsFirstDesignChoice
+					title={ translate( 'Start with a theme' ) }
+					description={ translate( 'Choose a professionally designed theme and make it yours.' ) }
+					fgImageSrc={ themeChoiceFg }
+					destination="design-setup"
+					onSelect={ handleSubmit }
+				/>
+			) }
+			{ ! isLoading && isEligible && ! isGoalsFirstVariation && (
+				<DesignChoice
+					className="design-choices__try-big-sky"
+					title={ translate( 'Create your site with AI' ) }
+					description={ translate( 'Tell our AI what you need, and watch it come to life.' ) }
+					bgImageSrc={ hiBigSky }
+					destination="launch-big-sky"
+					onSelect={ ( destination ) => {
+						recordTracksEvent( 'calypso_big_sky_choose', {
+							flow,
+							step: stepName,
+						} );
+						handleSubmit( destination );
+					} }
+				/>
+			) }
+			{ ! isLoading && isEligible && isGoalsFirstVariation && (
+				<GoalsFirstDesignChoice
+					title={ getCreateWithAILabel() }
+					ariaLabel={ translate( 'Create with AI (BETA)' ) }
+					description={
+						hasEnTranslation(
+							'Use our AI Website Builder to quickly and easily create the site of your dreams.'
+						)
+							? translate(
+									'Use our AI Website Builder to quickly and easily create the site of your dreams.'
+							  )
+							: translate(
+									'Use our AI website builder to easily and quickly build the site of your dreams.'
+							  )
+					}
+					badgeLabel={ bigSkyBadgeLabel() }
+					bgImageSrc={ bigSkyBg }
+					fgImageSrc={ bigSkyFg }
+					destination="launch-big-sky"
+					onSelect={ ( destination ) => {
+						handleSubmit( destination );
+					} }
+				/>
+			) }
+		</>
+	);
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ documentHeaderText } />
+				<Step.TwoColumnLayout
+					firstColumnWidth={ 0 }
+					secondColumnWidth={ 0 }
+					width="standard"
+					className={ clsx( 'design-choices__body', {
+						'is-goals-first': isGoalsFirstVariation,
+					} ) }
+					topBar={
+						<Step.TopBar
+							backButton={
+								navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
+							}
+						/>
+					}
+					heading={ <Step.Heading text={ documentHeaderText } subText={ subHeaderText } /> }
+				>
+					{ stepContent }
+				</Step.TwoColumnLayout>
+			</>
+		);
+	}
+
 	return (
 		<>
 			<DocumentHead title={ documentHeaderText } />
@@ -139,75 +230,13 @@ const DesignChoicesStep: Step< { submits: { destination: string } } > = ( {
 					<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 				}
 				stepContent={
-					<>
-						<div
-							className={ clsx( 'design-choices__body', {
-								'is-goals-first': isGoalsFirstVariation,
-							} ) }
-						>
-							{ ! isGoalsFirstVariation ? (
-								<DesignChoice
-									title={ translate( 'Choose a theme' ) }
-									description={ translate( 'Choose one of our professionally designed themes.' ) }
-									imageSrc={ themesIllustrationImage }
-									destination="design-setup"
-									onSelect={ handleSubmit }
-								/>
-							) : (
-								<GoalsFirstDesignChoice
-									title={ translate( 'Start with a theme' ) }
-									description={ translate(
-										'Choose a professionally designed theme and make it yours.'
-									) }
-									fgImageSrc={ themeChoiceFg }
-									destination="design-setup"
-									onSelect={ handleSubmit }
-								/>
-							) }
-							{ ! isLoading && isEligible && ! isGoalsFirstVariation && (
-								<DesignChoice
-									className="design-choices__try-big-sky"
-									title={ translate( 'Create your site with AI' ) }
-									description={ translate(
-										'Tell our AI what you need, and watch it come to life.'
-									) }
-									bgImageSrc={ hiBigSky }
-									destination="launch-big-sky"
-									onSelect={ ( destination ) => {
-										recordTracksEvent( 'calypso_big_sky_choose', {
-											flow,
-											step: stepName,
-										} );
-										handleSubmit( destination );
-									} }
-								/>
-							) }
-							{ ! isLoading && isEligible && isGoalsFirstVariation && (
-								<GoalsFirstDesignChoice
-									title={ getCreateWithAILabel() }
-									ariaLabel={ translate( 'Create with AI (BETA)' ) }
-									description={
-										hasEnTranslation(
-											'Use our AI Website Builder to quickly and easily create the site of your dreams.'
-										)
-											? translate(
-													'Use our AI Website Builder to quickly and easily create the site of your dreams.'
-											  )
-											: translate(
-													'Use our AI website builder to easily and quickly build the site of your dreams.'
-											  )
-									}
-									badgeLabel={ bigSkyBadgeLabel() }
-									bgImageSrc={ bigSkyBg }
-									fgImageSrc={ bigSkyFg }
-									destination="launch-big-sky"
-									onSelect={ ( destination ) => {
-										handleSubmit( destination );
-									} }
-								/>
-							) }
-						</div>
-					</>
+					<div
+						className={ clsx( 'design-choices__body', {
+							'is-goals-first': isGoalsFirstVariation,
+						} ) }
+					>
+						{ stepContent }
+					</div>
 				}
 				goBack={ goBack }
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -197,10 +197,8 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 		return (
 			<>
 				<DocumentHead title={ documentHeaderText } />
-				<Step.TwoColumnLayout
-					firstColumnWidth={ 0 }
-					secondColumnWidth={ 0 }
-					width="standard"
+				<Step.CenteredColumnLayout
+					columnWidth={ 8 }
 					className={ clsx( 'design-choices__body', {
 						'is-goals-first': isGoalsFirstVariation,
 					} ) }
@@ -214,7 +212,7 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 					heading={ <Step.Heading text={ documentHeaderText } subText={ subHeaderText } /> }
 				>
 					{ stepContent }
-				</Step.TwoColumnLayout>
+				</Step.CenteredColumnLayout>
 			</>
 		);
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .step-container.design-choices {
 	.step-container__header {
 		margin-top: 96px;
@@ -14,8 +17,16 @@
 .step-container-v2 {
 	.design-choices__body {
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
 		align-items: center;
+	}
+
+	@include break-medium {
+		.design-choices__body {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
@@ -11,6 +11,14 @@
 	}
 }
 
+.step-container-v2 {
+	.design-choices__body {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+	}
+}
+
 .design-choice__image-container {
 	flex-direction: column;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
@@ -14,22 +14,6 @@
 	}
 }
 
-.step-container-v2 {
-	.design-choices__body {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-	}
-
-	@include break-medium {
-		.design-choices__body {
-			display: flex;
-			flex-direction: row;
-			align-items: center;
-		}
-	}
-}
-
 .design-choice__image-container {
 	flex-direction: column;
 
@@ -44,12 +28,24 @@
 	}
 }
 
+.design-choices:not(:has(.step-container-v2)) {
+	.design-choices__body {
+		padding-inline: 24px;
+	}
+}
+
 
 .design-choices__body {
 	display: flex;
-	flex-direction: row;
-	justify-content: center;
-	gap: 43px;
+	flex-direction: column;
+	align-items: center;
+	gap: 48px;
+
+	@include break-medium {
+		flex-direction: row;
+		justify-content: center;
+		gap: 64px;
+	}
 
 	&.is-goals-first {
 		gap: 16px;

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.stories.tsx
@@ -66,3 +66,30 @@ export const SixColumnsCenteredLayout = () => {
 		</CenteredColumnLayout>
 	);
 };
+
+export const EightColumnsCenteredLayout = () => {
+	const backButton = <BackButton />;
+	const nextButton = <NextButton />;
+	const skipButton = <SkipButton />;
+
+	return (
+		<CenteredColumnLayout
+			columnWidth={ 8 }
+			topBar={ <TopBar backButton={ backButton } skipButton={ skipButton } /> }
+			heading={
+				<Heading
+					text="Eight Columns Centered Layout"
+					subText={ createInterpolateElement(
+						'An example of the <code>CenteredColumnLayout</code> wireframe layout.',
+						{
+							code: <code />,
+						}
+					) }
+				/>
+			}
+			stickyBottomBar={ <StickyBottomBar rightButton={ nextButton } /> }
+		>
+			<WireframePlaceholder height={ 500 }>Content</WireframePlaceholder>
+		</CenteredColumnLayout>
+	);
+};

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -7,7 +7,7 @@ import {
 import './style.scss';
 
 interface CenteredColumnLayoutProps extends StepContainerV2Props {
-	columnWidth: 4 | 6;
+	columnWidth: 4 | 6 | 8;
 }
 
 export const CenteredColumnLayout = ( props: CenteredColumnLayoutProps ) => {

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
@@ -17,3 +17,9 @@
 		max-width: 615px;
 	}
 }
+
+.step-container-v2__content--centered-column-layout-8 {
+	@include step-medium-viewport {
+		max-width: 826px;
+	}
+}

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
@@ -1,11 +1,5 @@
 @import '../../mixins';
 
-.step-container-v2__content--centered-column-layout {
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
-}
-
 .step-container-v2__content--centered-column-layout-4 {
 	@include step-medium-viewport {
 		max-width: 404px;

--- a/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.tsx
@@ -37,13 +37,13 @@ export const TwoColumnLayout = ( props: TwoColumnLayoutProps ) => {
 					childElements = childElements.props.children;
 				}
 
-				return Children.map( childElements, ( child, index ) => {
-					if ( ! isValidElement( child ) ) {
-						return null;
-					}
-
-					return <div style={ { flex: getChildFlexGrow( index ) } }>{ child }</div>;
-				} );
+				return Children.toArray( childElements )
+					.filter( isValidElement )
+					.map( ( child, index ) => (
+						<div style={ { flex: getChildFlexGrow( index ) } } key={ index }>
+							{ child }
+						</div>
+					) );
 			} }
 		</StepContainerV2>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101197

## Proposed Changes

* We're adding support to the new StepContainerV2 to Design Choice Screen
* Also adding mobile support on that page:

https://github.com/user-attachments/assets/4fddc12c-82b2-4787-b8dd-65f391955eb9



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding) (dev environment only)
* Buy a paid plan, and you'll be redirected to the Design Choice
* Make sure it works as expected
* Make sure the default Step Container also works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
