### PR TITLE
Plans: Balance text wrap to avoid widows

### DIFF
--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -222,6 +222,7 @@
 		line-height: 16px;
 		padding-bottom: 8px;
 		min-height: 50px;
+		text-wrap: balance;
 	}
 }
 
@@ -349,6 +350,7 @@
 		font-weight: 400;
 		line-height: 20px;
 		overflow-wrap: break-word;
+		text-wrap: balance;
 		margin: 0;
 		flex: 1 0 0;
 		width: 100%;


### PR DESCRIPTION
## Proposed Changes

This PR suggests balancing the widows of plan descriptions and features.

Part of #100296.

## Why are these changes being made?

Right now we have a few widows in descriptions and plan features, and that's not ideal.

Note that #101724 changes the plan descriptions.

## Testing Instructions

* Go to `/setup/onboarding/plans`
* Test on different viewport widths and verify there are no widows on the plan descriptions and plan features. 

## Screenshots

|Before|After|
|---|---|
|![Screenshot 2025-03-21 at 17 14 59](https://github.com/user-attachments/assets/a12133a3-00c3-41af-9221-92a2290ca202)|![Screenshot 2025-03-21 at 17 14 53](https://github.com/user-attachments/assets/d87dc61f-4b0c-4ed2-978c-0a74fe2041aa)|


