### PR TITLE
Plans: Unify plan billing info text contrast

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -287,7 +287,6 @@
 			font-size: $font-body;
 			line-height: 24px;
 			font-weight: 400;
-			color: var(--studio-gray-80);
 
 			@include plans-grid-medium-large {
 				font-size: $font-body-small;

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -506,7 +506,6 @@
 				font-size: $font-body;
 				line-height: 24px;
 				font-weight: 400;
-				color: var(--studio-gray-80);
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

Updates the contrast of the Enterprise plan billing info text.

Part of #100296.

## Why are these changes being made?

For consistency https://github.com/Automattic/wp-calypso/issues/100296#issuecomment-2743806669

## Testing Instructions

* Go to `/setup/onboarding/plans`
* Verify the contrast of the Enterprise plan billing info text is the same as for the other plans.

## Screenshot

|Before|After|
|---|---|
|![Screenshot 2025-03-21 at 18 14 14](https://github.com/user-attachments/assets/48744f26-a86d-4082-a253-508b12a0d937)|![Screenshot 2025-03-21 at 18 14 21](https://github.com/user-attachments/assets/44a88f15-dcd0-40b8-afa4-0fec01b5e5a2)|



