### PR TITLE
PTO: Wait for WooCommerce to be active before redirecting

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
@@ -24,6 +25,8 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 	}
 
 	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) as OnboardSelect, [] );
+
+	const includeWooCommerce = useIsValidWooPartner();
 
 	const handleTransferFailure = ( failureInfo: FailureInfo ) => {
 		recordTracksEvent( 'calypso_woocommerce_dashboard_snag_error', {
@@ -65,7 +68,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 			setProgress( 50 );
 			await waitForFeature();
 			setProgress( 75 );
-			await waitForLatestSiteData();
+			await waitForLatestSiteData( includeWooCommerce );
 			setProgress( 100 );
 
 			return {
@@ -80,7 +83,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 
 		// Only trigger when the siteId changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteId ] );
+	}, [ siteId, includeWooCommerce ] );
 
 	return null;
 };

--- a/client/landing/stepper/hooks/use-is-valid-woo-partner.ts
+++ b/client/landing/stepper/hooks/use-is-valid-woo-partner.ts
@@ -1,12 +1,17 @@
+import { OnboardSelect } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from 'react';
-import { useQuery } from './use-query';
+import { ONBOARD_STORE } from '../stores';
 
 const VALID_WOO_PARTNERS = [ 'square', 'paypal', 'stripe' ];
 
 export const useIsValidWooPartner = () => {
-	const query = useQuery();
-	const queryParams = Object.fromEntries( query );
-	const partnerBundle = queryParams.partnerBundle;
+	const { partnerBundle } = useSelect(
+		( select: ( arg: string ) => OnboardSelect ) => ( {
+			partnerBundle: select( ONBOARD_STORE ).getPartnerBundle(),
+		} ),
+		[]
+	);
 	return useMemo( () => {
 		if ( partnerBundle && VALID_WOO_PARTNERS.includes( partnerBundle ) ) {
 			return true;

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -126,12 +126,13 @@ export const useWaitForAtomic = ( {
 		}
 	};
 
-	const waitForLatestSiteData = async () => {
+	const waitForLatestSiteData = async ( includeWooCommerce = false ) => {
 		while ( true ) {
 			const requestedSite = await reduxDispatch< SiteDetails >( requestSite( siteId ) );
 			if (
 				requestedSite?.options?.is_wpcom_atomic &&
-				requestedSite?.capabilities?.manage_options
+				requestedSite?.capabilities?.manage_options &&
+				( ! includeWooCommerce || requestedSite?.options?.woocommerce_is_active )
 			) {
 				break;
 			}

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -63,6 +63,7 @@ export function register(): typeof STORE_KEY {
 			'planCartItem',
 			'productCartItems',
 			'createWithBigSky',
+			'partnerBundle',
 		],
 	} );
 	isRegistered = true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves DOTOBRD-12-linear-issue

Co-authored with @gavande1 

## Proposed Changes

* When following the PTO flow, wait for the `woocommerce_is_active` option to be true before redirecting
* Retrieve the `partnerBundle` from the `ONBOARD_STORE` instead of using a queryParam to be able to read it from the persisted store
* Persist the `partnerBundle` so it is kept between flows

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix the linked issue when redirecting to `wc-admin` that was not yet ready to be displayed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes
* Navigate to the PTO flow `/setup/new-hosted-site/plans?partnerBundle=square` and create a new site
* Check that after creating the site, the system redirects to `wc-admin` and there are no intermediate errors
* Check it for both plans `Business` and `Commerce` 
![CleanShot 2025-03-21 at 17 20 32@2x](https://github.com/user-attachments/assets/aaf6d2c3-ea15-4a77-b177-e02a6b00e222)

### Regression testing
* Make sure you can create a site without any issues following `/start` flow
* Make sure you can create a site without any issues following `/setup/new-hosted-site` flow without `partnerBundle`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?