### PR TITLE
Subscribers: Use margin auto instead of float to preserve button margin

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/style.scss
@@ -74,7 +74,8 @@
 	}
 
 	.add-subscriber__form-submit-btn {
-		float: right;
+		display: block;
+		margin-left: auto;
 		min-width: auto;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/604

## Proposed Changes

* This PR uses `margin-left: auto` to move the "Add subscribers" button to the right of the modal instead of `float: right`. This preserves the padding of the modal content container and gives some margin below the button.

Before | After
--|--
<video src="https://github.com/user-attachments/assets/2632fc84-6f3b-4be5-8183-30abccf86a0b" /> | <video src="https://github.com/user-attachments/assets/f7e38ff9-b39b-4a64-9010-df6ba39d8b84" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The effects of this PR are a little subtle. You need to size your browser height so that the modal cuts off just underneath the "Add subscribers" button, and then you need to try scrolling to see if the margin exists. See the videos above for an example.
* Use Calypso Live and go to /subscribers/{site_slug}
* Click "+ Add subscribers" in the upper right
* Select "Use a CSV file"
* Adjust the height of your browser to ensure that there is a margin underneath the "Add subscribers" button.
* Try a range of browser heights and try viewing in mobile and make sure it looks good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
