### PR TITLE
Plans: Unify Enterprise plan billing info font size

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -282,22 +282,6 @@
 		@include plans-grid-medium-large {
 			margin: 7px 0 10px;
 		}
-
-		.plans-grid-next__billing-timeframe-vip-price {
-			font-size: $font-body;
-			line-height: 24px;
-			font-weight: 400;
-
-			@include plans-grid-medium-large {
-				font-size: $font-body-small;
-				line-height: 20px;
-			}
-
-			@include plans-grid-large {
-				font-size: $font-body-extra-small;
-				line-height: 16px;
-			}
-		}
 	}
 
 	.plans-grid-next-action-button {

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -443,18 +443,6 @@
 		@include plans-grid-medium-large {
 			padding-bottom: 0;
 		}
-
-		.plans-grid-next__billing-timeframe-vip-price {
-			@include plans-grid-medium-large {
-				font-size: $font-body-small;
-				line-height: 20px;
-			}
-
-			@include plans-grid-large {
-				font-size: $font-body-extra-small;
-				line-height: 16px;
-			}
-		}
 	}
 
 	&.popular-plan-parent-class {
@@ -503,12 +491,6 @@
 			font-weight: 400;
 			font-size: $font-body-extra-small;
 			padding: 0 19px 24px 20px;
-
-			.plans-grid-next__billing-timeframe-vip-price {
-				font-size: $font-body;
-				line-height: 24px;
-				font-weight: 400;
-			}
 		}
 
 		&.popular-plan-parent-class {

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -81,7 +81,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		const price = formatCurrency( 25000, 'USD', { stripZeros: true } );
 
 		return (
-			<div className="plans-grid-next__billing-timeframe-vip-price">
+			<div>
 				{ fixMe( {
 					text: 'Starts at {{b}}%(price)s{{/b}} annually',
 					newCopy: translate( 'Starts at {{b}}%(price)s{{/b}} annually', {


### PR DESCRIPTION
## Proposed Changes

Unifies the font size of the Enterprise plan billing info text to be the same as the other plans.

Part of #100296.

## Why are these changes being made?

For consistency, see https://github.com/Automattic/wp-calypso/issues/100296#issuecomment-2743972386

## Testing Instructions

* Go to `/setup/onboarding/plans`
* As you test on different viewport sizes, verify the font size of the Enterprise plan billing info text is the same as for the other plans. Note that sizes are unchanged on Desktop, so I'm not attaching screenshots for that viewport.

## Screenshot

### Tablet (3 plans per row)

|Before|After|
|---|---|
|![Screenshot 2025-03-21 at 19 24 41](https://github.com/user-attachments/assets/72a10268-94b9-44a3-9640-986ac9896a5d)|![Screenshot 2025-03-21 at 19 24 49](https://github.com/user-attachments/assets/ce3be046-6d5c-434a-9921-b5243763f269)|

### Mobile (1 plan per row)

|Before|After|
|---|---|
|![Screenshot 2025-03-21 at 19 26 08](https://github.com/user-attachments/assets/01fff4f2-d3dd-4d4d-ae78-ec9c0ef5e216)|![Screenshot 2025-03-21 at 19 26 00](https://github.com/user-attachments/assets/88c11ce6-0c7c-42c0-97de-2ce46a3144da)|

