### PR TITLE
Stepper: Reset new-hosted-site-flow store when mounting the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -199,7 +199,7 @@ const hosting: Flow = {
 
 		useEffect(
 			() => {
-				if ( currentStepSlug === undefined ) {
+				if ( ! currentStepSlug ) {
 					resetOnboardStore();
 				}
 				dispatch( setSelectedSiteId( null ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTOBRD-12-linear-issue

## Proposed Changes

* Refines the condition to reset the `OnboardStore` when mounting the `new-hosted-site-flow`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix an issue with sharing the state when having multiple tabs open at the same time
* The `partnerBundle` piece of state was being read from the new tab when it should not be there for a new flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes and run Calypso locally
* Navigate to the PTO flow `/setup/new-hosted-site/plans?partnerBundle=square`
* Check the partnerBundle is in the state by running `window.wp.data.select('automattic/onboard').getPartnerBundle()` in the Developer Console
* Without closing the tab, open another tab and navigate to the flow without the `partnerBundle`, i.e. `/setup/new-hosted-site` (please note that `/plans` should not be added).
* Check the `partnerBundle` is **not** in the state by running `window.wp.data.select('automattic/onboard').getPartnerBundle()` in the Developer Console
* Complete the flow to create a site without the `partnerBundle` 
* Check the `WooCommerce` plugin is **not** installed
* Complete the flow in the tab with the `partnerBundle`
* Check the system navigates to WooCommerce Launchpad and `Get paid with Square` is displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?