### PR TITLE
Migrating import flow to StepContainerV2

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -1,6 +1,6 @@
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Onboard, type SiteSelect, type UserSelect } from '@automattic/data-stores';
-import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
+import { isHostedSiteMigrationFlow, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -26,10 +26,8 @@ import { AssertConditionState } from '../../internals/types';
 import { goToImporter } from '../../migration/helpers';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from '../../internals/types';
 
-const FLOW_NAME = 'site-migration';
-
 const siteMigration: Flow = {
-	name: FLOW_NAME,
+	name: SITE_MIGRATION_FLOW,
 	isSignupFlow: false,
 	__experimentalUseSessions: true,
 	__experimentalUseBuiltinAuth: true,
@@ -66,7 +64,7 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
 		];
 
-		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
+		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? SITE_MIGRATION_FLOW )
 			? [ STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ]
 			: [];
 
@@ -80,7 +78,7 @@ const siteMigration: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const flowPath = this.variantSlug ?? FLOW_NAME;
+		const flowPath = this.variantSlug ?? SITE_MIGRATION_FLOW;
 
 		useEffect( () => {
 			if ( isAdmin === false ) {
@@ -534,9 +532,9 @@ const siteMigration: Flow = {
 							platform: providedDependencies.platform as ImporterPlatform,
 							siteId: siteId!.toString(),
 							siteSlug,
-							backToFlow: `${ FLOW_NAME }/${ STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT.slug }`,
+							backToFlow: `${ SITE_MIGRATION_FLOW }/${ STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT.slug }`,
 							from: fromQueryParam,
-							ref: FLOW_NAME,
+							ref: SITE_MIGRATION_FLOW,
 						} );
 					}
 

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -9,3 +9,10 @@ export const shouldUseStepContainerV2 = ( flow: string ) => {
 		FLOWS_USING_STEP_CONTAINER_V2.includes( flow )
 	);
 };
+
+export const shouldUseStepContainerV2MigrationFlow = ( flow: string ) => {
+	return (
+		configApi.isEnabled( 'onboarding/step-container-v2-migration-flow' ) &&
+		FLOWS_USING_STEP_CONTAINER_V2.includes( flow )
+	);
+};

--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -1,7 +1,7 @@
 import configApi from '@automattic/calypso-config';
-import { SITE_SETUP_FLOW, ONBOARDING_FLOW } from '@automattic/onboarding';
+import { SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 
-const FLOWS_USING_STEP_CONTAINER_V2 = [ SITE_SETUP_FLOW, ONBOARDING_FLOW ];
+const FLOWS_USING_STEP_CONTAINER_V2 = [ SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW ];
 
 export const shouldUseStepContainerV2 = ( flow: string ) => {
 	return (

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -79,7 +79,7 @@ button {
 .onboarding.design-setup:not(:has(.step-container-v2)),
 .onboarding.design-choices:not(:has(.step-container-v2)),
 .onboarding.difm-starting-point:not(:has(.step-container-v2)),
-.site-migration,
+.site-migration:not(:has(.step-container-v2)),
 .migration,
 .plugin-bundle,
 .newsletter-setup,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
@@ -4,6 +4,9 @@
 	text-decoration: underline;
 }
 
-.step-container-v2 .how-to-migrate__experiment-diy {
-	font-size: 0.875rem;
+.site-migration {
+	.step-container-v2__heading {
+		max-width: 620px;
+		margin: 0 auto;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
@@ -1,5 +1,9 @@
-.how-to-migrate__experiment-diy {
+.how-to-migrate__experiment-diy:not(.step-container-v2 *) {
 	color: var(--studio-gray-90);
 	font-weight: 500;
 	text-decoration: underline;
+}
+
+.step-container-v2 .how-to-migrate__experiment-diy {
+	font-size: 0.875rem;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/diy-option/style.scss
@@ -1,12 +1,5 @@
-.how-to-migrate__experiment-diy:not(.step-container-v2 *) {
+.how-to-migrate__experiment-diy {
 	color: var(--studio-gray-90);
 	font-weight: 500;
 	text-decoration: underline;
-}
-
-.site-migration {
-	.step-container-v2__heading {
-		max-width: 620px;
-		margin: 0 auto;
-	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -147,7 +147,12 @@ const SiteMigrationHowToMigrate: StepType< {
 					topBar={
 						<Step.TopBar
 							backButton={ <Step.BackButton onClick={ goBack } /> }
-							skipButton={ <DIYOption onClick={ handleClick } /> }
+							skipButton={
+								<Step.SkipButton
+									onClick={ () => handleClick( HOW_TO_MIGRATE_OPTIONS.DO_IT_MYSELF ) }
+									label={ translate( "I'll do it myself" ) }
+								/>
+							}
 						/>
 					}
 					heading={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -159,6 +159,7 @@ const SiteMigrationHowToMigrate: StepType< {
 						<Step.Heading
 							text={ headerText ?? translate( 'Let us migrate your site' ) }
 							subText={ subHeaderText || renderSubHeaderText() }
+							maxWidth="615px"
 						/>
 					}
 				>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -10,7 +10,7 @@ import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
-import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
 import { DIYOption } from './diy-option';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -29,7 +29,7 @@ const SiteMigrationHowToMigrate: StepType< {
 	const translate = useTranslate();
 	const site = useSite();
 	const { mutate: cancelMigration } = useMigrationCancellation( site?.ID );
-	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
+	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	usePresalesChat( 'wpcom' );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -1,5 +1,5 @@
 import { PLAN_BUSINESS, getPlan, isWpComBusinessPlan } from '@automattic/calypso-products';
-import { NextButton, StepContainer } from '@automattic/onboarding';
+import { NextButton, Step, StepContainer } from '@automattic/onboarding';
 import { Icon, copy, globe, lockOutline, scheduled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
@@ -10,11 +10,12 @@ import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { DIYOption } from './diy-option';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import './style.scss';
 
-const SiteMigrationHowToMigrate: Step< {
+const SiteMigrationHowToMigrate: StepType< {
 	accepts: {
 		headerText?: string;
 		subHeaderText?: string;
@@ -24,10 +25,11 @@ const SiteMigrationHowToMigrate: Step< {
 		destination: string;
 	};
 } > = ( props ) => {
-	const { navigation, headerText, stepName, subHeaderText } = props;
+	const { navigation, headerText, stepName, subHeaderText, flow } = props;
 	const translate = useTranslate();
 	const site = useSite();
 	const { mutate: cancelMigration } = useMigrationCancellation( site?.ID );
+	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
 
 	usePresalesChat( 'wpcom' );
 
@@ -134,6 +136,32 @@ const SiteMigrationHowToMigrate: Step< {
 			</div>
 		);
 	};
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ translate( 'Let us migrate your site' ) } />
+				<Step.CenteredColumnLayout
+					className="how-to-migrate-v2"
+					columnWidth={ 6 }
+					topBar={
+						<Step.TopBar
+							backButton={ <Step.BackButton onClick={ goBack } /> }
+							skipButton={ <DIYOption onClick={ handleClick } /> }
+						/>
+					}
+					heading={
+						<Step.Heading
+							text={ headerText ?? translate( 'Let us migrate your site' ) }
+							subText={ subHeaderText || renderSubHeaderText() }
+						/>
+					}
+				>
+					{ renderStepContent() }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -61,9 +61,15 @@ interface Props {
 	onSkip: () => void;
 	hideImporterListLink: boolean;
 	flowName: string;
+	onVisibilityChange: ( isVisible: boolean ) => void;
 }
 
-export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
+export const Analyzer: FC< Props > = ( {
+	onComplete,
+	onSkip,
+	onVisibilityChange,
+	hideImporterListLink = false,
+} ) => {
 	const translate = useTranslate();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 	const {
@@ -80,8 +86,11 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 	}, [ onComplete, siteInfo ] );
 
 	if ( isFetching || ( isFetched && ! hasError ) ) {
+		onVisibilityChange?.( false );
 		return <ScanningStep />;
 	}
+
+	onVisibilityChange?.( true );
 
 	const hostingDetailItems = {
 		'blazing-fast-speed': {
@@ -161,6 +170,8 @@ const SiteMigrationIdentify: StepType< {
 		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideIfBackToIsSet;
 	};
 
+	const [ isVisible, setIsVisible ] = useState( false );
+
 	const stepContent = (
 		<Analyzer
 			onComplete={ ( { platform, url } ) => handleSubmit( 'continue', { platform, from: url } ) }
@@ -169,6 +180,9 @@ const SiteMigrationIdentify: StepType< {
 				handleSubmit( 'skip_platform_identification' );
 			} }
 			flowName={ flow }
+			onVisibilityChange={ ( isVisible ) => {
+				setIsVisible( isVisible );
+			} }
 		/>
 	);
 
@@ -188,10 +202,12 @@ const SiteMigrationIdentify: StepType< {
 						/>
 					}
 					heading={
-						<Step.Heading
-							text={ translate( 'Let’s find your site' ) }
-							subText={ translate( 'Enter your current site address below to get started.' ) }
-						/>
+						isVisible ? (
+							<Step.Heading
+								text={ translate( 'Let’s find your site' ) }
+								subText={ translate( 'Enter your current site address below to get started.' ) }
+							/>
+						) : undefined
 					}
 				>
 					{ stepContent }
@@ -216,12 +232,14 @@ const SiteMigrationIdentify: StepType< {
 				isFullLayout
 				stepContent={
 					<div className="import__capture-wrapper">
-						<div className="import__heading import__heading-center">
-							<Title>{ translate( 'Let’s find your site' ) }</Title>
-							<SubTitle>
-								{ translate( 'Enter your current site address below to get started.' ) }
-							</SubTitle>
-						</div>
+						{ isVisible && (
+							<div className="import__heading import__heading-center">
+								<Title>{ translate( 'Let’s find your site' ) }</Title>
+								<SubTitle>
+									{ translate( 'Enter your current site address below to get started.' ) }
+								</SubTitle>
+							</div>
+						) }
 						{ stepContent }
 					</div>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -15,7 +15,7 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
 import type { Step as StepType } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
@@ -135,7 +135,7 @@ const SiteMigrationIdentify: StepType< {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const { createScreenshots } = useSitePreviewMShotImageHandler();
-	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
+	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const handleSubmit = useCallback(
 		async ( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,4 +1,10 @@
-import { StepContainer, Title, SubTitle, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import {
+	StepContainer,
+	Title,
+	SubTitle,
+	HOSTED_SITE_MIGRATION_FLOW,
+	Step,
+} from '@automattic/onboarding';
 import { Icon, next, published, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { type FC, ReactElement, useEffect, useState, useCallback } from 'react';
@@ -9,8 +15,9 @@ import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-q
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
 
 import './style.scss';
@@ -94,13 +101,7 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 	};
 
 	return (
-		<div className="import__capture-wrapper">
-			<div className="import__heading import__heading-center">
-				<Title>{ translate( 'Let’s find your site' ) }</Title>
-				<SubTitle>
-					{ translate( 'Enter your current site address below to get started.' ) }
-				</SubTitle>
-			</div>
+		<>
 			<div className="import__capture-container">
 				<CaptureInput
 					onInputEnter={ setSiteURL }
@@ -118,13 +119,13 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 				/>
 			</div>
 			<HostingDetailsWithIcons items={ Object.values( hostingDetailItems ) } />
-		</div>
+		</>
 	);
 };
 
 export type SiteMigrationIdentifyAction = 'continue' | 'skip_platform_identification';
 
-const SiteMigrationIdentify: Step< {
+const SiteMigrationIdentify: StepType< {
 	submits: {
 		action: SiteMigrationIdentifyAction;
 		platform?: string;
@@ -134,6 +135,7 @@ const SiteMigrationIdentify: Step< {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const { createScreenshots } = useSitePreviewMShotImageHandler();
+	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
 
 	const handleSubmit = useCallback(
 		async ( action: SiteMigrationIdentifyAction, data?: { platform: string; from: string } ) => {
@@ -159,6 +161,45 @@ const SiteMigrationIdentify: Step< {
 		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideIfBackToIsSet;
 	};
 
+	const stepContent = (
+		<Analyzer
+			onComplete={ ( { platform, url } ) => handleSubmit( 'continue', { platform, from: url } ) }
+			hideImporterListLink={ urlQueryParams.get( 'hide_importer_link' ) === 'true' }
+			onSkip={ () => {
+				handleSubmit( 'skip_platform_identification' );
+			} }
+			flowName={ flow }
+		/>
+	);
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ translate( 'Import your site content' ) } />
+				<Step.CenteredColumnLayout
+					columnWidth={ 6 }
+					topBar={
+						<Step.TopBar
+							backButton={
+								shouldHideBackButton() ? undefined : (
+									<Step.BackButton onClick={ navigation.goBack } />
+								)
+							}
+						/>
+					}
+					heading={
+						<Step.Heading
+							text={ translate( 'Let’s find your site' ) }
+							subText={ translate( 'Enter your current site address below to get started.' ) }
+						/>
+					}
+				>
+					{ stepContent }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Import your site content' ) } />
@@ -174,16 +215,15 @@ const SiteMigrationIdentify: Step< {
 				goNext={ navigation?.submit }
 				isFullLayout
 				stepContent={
-					<Analyzer
-						onComplete={ ( { platform, url } ) =>
-							handleSubmit( 'continue', { platform, from: url } )
-						}
-						hideImporterListLink={ urlQueryParams.get( 'hide_importer_link' ) === 'true' }
-						onSkip={ () => {
-							handleSubmit( 'skip_platform_identification' );
-						} }
-						flowName={ flow }
-					/>
+					<div className="import__capture-wrapper">
+						<div className="import__heading import__heading-center">
+							<Title>{ translate( 'Let’s find your site' ) }</Title>
+							<SubTitle>
+								{ translate( 'Enter your current site address below to get started.' ) }
+							</SubTitle>
+						</div>
+						{ stepContent }
+					</div>
 				}
 				recordTracksEvent={ recordTracksEvent }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -177,7 +177,7 @@ const SiteMigrationIdentify: StepType< {
 			<>
 				<DocumentHead title={ translate( 'Import your site content' ) } />
 				<Step.CenteredColumnLayout
-					columnWidth={ 6 }
+					columnWidth={ 4 }
 					topBar={
 						<Step.TopBar
 							backButton={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -4,7 +4,6 @@
 .import__capture-container {
 	max-width: 368px;
 	margin: 0 auto;
-	width: 100%;
 }
 
 .import__capture {
@@ -170,5 +169,16 @@
 	&-description {
 		color: var(--studio-black);
 		line-height: 1.66666667;
+	}
+}
+
+.step-container-v2 {
+	.import__capture-container {
+		max-width: 100%;
+		margin: unset;
+	}
+
+	.import__site-identify-hosting-details-experiment {
+		max-width: 100%;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/style.scss
@@ -4,6 +4,7 @@
 .import__capture-container {
 	max-width: 368px;
 	margin: 0 auto;
+	width: 100%;
 }
 
 .import__capture {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -1,6 +1,6 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { BadgeType } from '@automattic/components';
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import { canInstallPlugins } from '@automattic/sites';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -12,15 +12,16 @@ import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-mig
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import FlowCard from '../components/flow-card';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import './style.scss';
 
-const SiteMigrationImportOrMigrate: Step< {
+const SiteMigrationImportOrMigrate: StepType< {
 	submits: {
 		destination: 'migrate' | 'import' | 'upgrade';
 	};
-} > = function ( { navigation } ) {
+} > = function ( { navigation, flow } ) {
 	const translate = useTranslate();
 	const site = useSite();
 	const importSiteQueryParam = getQueryArg( window.location.href, 'from' )?.toString() || '';
@@ -28,6 +29,7 @@ const SiteMigrationImportOrMigrate: Step< {
 	const { mutate: cancelMigration } = useMigrationCancellation( site?.ID );
 	const siteCanInstallPlugins = canInstallPlugins( site );
 	const isUpgradeRequired = ! siteCanInstallPlugins;
+	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
 
 	const options = useMemo( () => {
 		const upgradeRequiredLabel = translate( '50% off %(planName)s', {
@@ -93,9 +95,34 @@ const SiteMigrationImportOrMigrate: Step< {
 		</>
 	);
 
+	const pageTitle = translate( 'What do you want to do?' );
+	const pageSubTitle = shouldDisplayHostIdentificationMessage
+		? translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {
+				args: { hostingProviderName },
+		  } )
+		: '';
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ pageTitle } />
+				<Step.CenteredColumnLayout
+					columnWidth={ 6 }
+					topBar={
+						<Step.TopBar backButton={ <Step.BackButton onClick={ navigation.goBack } /> } />
+					}
+					heading={ <Step.Heading text={ pageTitle } subText={ pageSubTitle } /> }
+					className="import-or-migrate-v2"
+				>
+					{ stepContent }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
+
 	return (
 		<>
-			<DocumentHead title={ translate( 'What do you want to do?' ) } />
+			<DocumentHead title={ pageTitle } />
 			<StepContainer
 				stepName="site-migration-import-or-migrate"
 				className="import-or-migrate"
@@ -104,14 +131,8 @@ const SiteMigrationImportOrMigrate: Step< {
 				formattedHeader={
 					<FormattedHeader
 						id="how-to-migrate-header"
-						headerText={ translate( 'What do you want to do?' ) }
-						subHeaderText={
-							shouldDisplayHostIdentificationMessage
-								? translate( 'Your WordPress site is hosted with %(hostingProviderName)s.', {
-										args: { hostingProviderName },
-								  } )
-								: ''
-						}
+						headerText={ pageTitle }
+						subHeaderText={ pageSubTitle }
 						align="center"
 					/>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -107,7 +107,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 			<>
 				<DocumentHead title={ pageTitle } />
 				<Step.CenteredColumnLayout
-					columnWidth={ 6 }
+					columnWidth={ 5 }
 					topBar={
 						<Step.TopBar backButton={ <Step.BackButton onClick={ navigation.goBack } /> } />
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -12,7 +12,7 @@ import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-mig
 import { useHostingProviderUrlDetails } from 'calypso/data/site-profiler/use-hosting-provider-url-details';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
 import FlowCard from '../components/flow-card';
 import type { Step as StepType } from '../../types';
 import './style.scss';
@@ -29,7 +29,7 @@ const SiteMigrationImportOrMigrate: StepType< {
 	const { mutate: cancelMigration } = useMigrationCancellation( site?.ID );
 	const siteCanInstallPlugins = canInstallPlugins( site );
 	const isUpgradeRequired = ! siteCanInstallPlugins;
-	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
+	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const options = useMemo( () => {
 		const upgradeRequiredLabel = translate( '50% off %(planName)s', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -79,6 +79,7 @@
 
 		.flow-question {
 			max-width: none;
+			margin: 0 0 18px;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -71,3 +71,14 @@
 		color: var(--studio-gray-60);
 	}
 }
+
+.import-or-migrate-v2 {
+	.import-or-migrate__list {
+		display: flex;
+		flex-direction: column;
+
+		.flow-question {
+			max-width: none;
+		}
+	}
+}

--- a/config/development.json
+++ b/config/development.json
@@ -139,6 +139,7 @@
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
 		"onboarding/step-container-v2": true,
+		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,

--- a/packages/onboarding/src/step-container-v2/components/Heading/Heading.tsx
+++ b/packages/onboarding/src/step-container-v2/components/Heading/Heading.tsx
@@ -8,15 +8,17 @@ interface HeadingProps {
 	subText?: ReactNode;
 	align?: 'left' | 'center';
 	size?: 'small';
+	maxWidth?: string;
 }
 
-export const Heading = ( { text, subText, align, size }: HeadingProps ) => {
+export const Heading = ( { text, subText, align, size, maxWidth }: HeadingProps ) => {
 	return (
 		<div
 			className={ clsx( 'step-container-v2__heading', {
 				left: align === 'left',
 				center: align === 'center',
 			} ) }
+			style={ maxWidth ? { maxWidth } : undefined }
 		>
 			<h1
 				className={ clsx( 'wp-brand-font', {

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -7,7 +7,7 @@ import {
 import './style.scss';
 
 interface CenteredColumnLayoutProps extends StepContainerV2Props {
-	columnWidth: 4 | 6 | 8 | 10;
+	columnWidth: 4 | 5 | 6 | 8 | 10;
 }
 
 export const CenteredColumnLayout = ( props: CenteredColumnLayoutProps ) => {

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
@@ -7,6 +7,12 @@
 	}
 }
 
+.step-container-v2__content--centered-column-layout-5 {
+	@include step-medium-viewport {
+		max-width: 509px;
+	}
+}
+
 .step-container-v2__content--centered-column-layout-6 {
 	@include break-small {
 		max-width: 615px;

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
@@ -8,7 +8,7 @@
 }
 
 .step-container-v2__content--centered-column-layout-5 {
-	@include step-medium-viewport {
+	@include break-small {
 		max-width: 509px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101191

## Proposed Changes

* Added support to the new stepper flow v2 on import screen

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f468ab78-af64-4f00-b5b5-d84f4a8b46a5) | ![image](https://github.com/user-attachments/assets/bf258882-a6f1-4c5b-bff5-5e14ca8e3d18) |
| ![image](https://github.com/user-attachments/assets/a20eabd0-d68b-4c7a-ac94-8b3c1b4c99ca) | ![image](https://github.com/user-attachments/assets/281f936c-9664-4c2e-9705-8b27ad2b46cc) |
| ![image](https://github.com/user-attachments/assets/16fa6173-bea5-497a-8920-eace4857fca3) | ![image](https://github.com/user-attachments/assets/992757f9-f31f-45d6-a8f7-958481e9a0ac) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [the /setup/onboarding flow](http://calypso.localhost:3000/setup/onboarding) locally or use the feature flag `?flags=onboarding/step-container-v2-migration-flow` in testing servers.
* Advance until you're at the Goals screen
* Select `Import or migrate an existing site`

### This work is partial

To make our reviews easier, I split the work into another three extra steps:

- https://github.com/Automattic/wp-calypso/pull/101798
- https://github.com/Automattic/wp-calypso/issues/101910
- https://github.com/Automattic/wp-calypso/issues/101912