### PR TITLE
Onboarding consistency: Use StepContainerV2 in 'Use domain I own' step

### DIFF
--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -102,12 +102,15 @@ export const authCodeStepDefaultDescription = {
 } as const;
 
 export const useMyDomainInputMode = {
-	domainInput: 'domain-input',
-	transferOrConnect: 'transfer-or-connect',
-	ownershipVerification: 'ownership-verification',
-	transferDomain: 'transfer-domain',
-	startPendingTransfer: 'start-pending-transfer',
+	domainInput: 'domain-input' as const,
+	transferOrConnect: 'transfer-or-connect' as const,
+	ownershipVerification: 'ownership-verification' as const,
+	transferDomain: 'transfer-domain' as const,
+	startPendingTransfer: 'start-pending-transfer' as const,
 } as const;
+
+export type UseMyDomainInputMode =
+	( typeof useMyDomainInputMode )[ keyof typeof useMyDomainInputMode ];
 
 export const transferDomainError = {
 	get AUTH_CODE() {

--- a/client/components/domains/use-my-domain/index.jsx
+++ b/client/components/domains/use-my-domain/index.jsx
@@ -52,6 +52,7 @@ function UseMyDomain( props ) {
 		isStepper = false,
 		stepLocation,
 		registerNowAction,
+		hideHeader,
 	} = props;
 
 	const { __ } = useI18n();
@@ -406,6 +407,10 @@ function UseMyDomain( props ) {
 	}, [ domainName, mode, __ ] );
 
 	const renderHeader = () => {
+		if ( hideHeader ) {
+			return null;
+		}
+
 		return (
 			<>
 				{ goBack && (
@@ -476,7 +481,6 @@ UseMyDomain.propTypes = {
 	goBack: PropTypes.func,
 	initialQuery: PropTypes.string,
 	isSignupStep: PropTypes.bool,
-	showHeader: PropTypes.bool,
 	onConnect: PropTypes.func,
 	onTransfer: PropTypes.func,
 	onNextStep: PropTypes.func,
@@ -490,6 +494,7 @@ UseMyDomain.propTypes = {
 	isStepper: PropTypes.bool,
 	stepLocation: PropTypes.object,
 	registerNowAction: PropTypes.func,
+	hideHeader: PropTypes.bool,
 };
 
 export default connect( ( state ) => ( {

--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -3,12 +3,6 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/colors";
 
-.useMyDomain {
-	.domain-transfer-or-connect__content {
-		box-shadow: none;
-	}
-}
-
 .use-my-domain {
 	display: flex;
 	align-items: center;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -90,7 +90,7 @@ button {
 .free,
 .setup-blog,
 .celebration-step,
-.use-my-domain,
+.use-my-domain:not(:has(.step-container-v2)),
 .domain-transfer,
 .update-design,
 .update-options,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -168,7 +168,6 @@ export function DomainFormControl( {
 						initialMode={ inputMode.domainInput }
 						onNextStep={ null }
 						isSignupStep
-						showHeader={ false }
 						onTransfer={ onAddTransfer }
 						onConnect={ ( { domain } ) => onAddMapping( domain ) }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -7,8 +7,7 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement, useState } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg } from '@wordpress/url';
 import { useLocation } from 'react-router';
@@ -135,19 +134,12 @@ const UseMyDomain: StepType< {
 						__( 'Enter the domain you would like to use.' ),
 				  ]
 				: [
-						8 as const,
-						createInterpolateElement(
-							sprintf(
-								/* translators: %(domainName)s - the name of the domain the user will add to their site */
-								__( 'Use a domain I own: <span>%(domainName)s</span>' ),
-								{
-									domainName: getInitialQuery(),
-								}
-							),
-							{
-								span: <span />,
-							}
-						),
+						10 as const,
+						<>
+							{ __( 'Use a domain I own' ) }
+							<br />
+							{ getInitialQuery() }
+						</>,
 						undefined,
 				  ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -7,7 +7,9 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg } from '@wordpress/url';
 import { useLocation } from 'react-router';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -32,6 +34,7 @@ const UseMyDomain: StepType< {
 		shouldSkipSubmitTracking?: boolean;
 	};
 } > = function UseMyDomain( { navigation, flow } ) {
+	const { __ } = useI18n();
 	const { setHideFreePlan, setDomainCartItem } = useDispatch( ONBOARD_STORE );
 	const { goNext, goBack, submit } = navigation;
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
@@ -97,7 +100,6 @@ const UseMyDomain: StepType< {
 					initialQuery={ getInitialQuery() }
 					initialMode={ getInitialMode() }
 					isSignupStep
-					showHeader={ false }
 					onTransfer={ handleOnTransfer }
 					onConnect={ ( { domain } ) => handleOnConnect( domain ) }
 					useMyDomainMode={ useMyDomainMode }
@@ -106,6 +108,7 @@ const UseMyDomain: StepType< {
 					isStepper
 					stepLocation={ location }
 					registerNowAction={ handleGoBack }
+					hideHeader={ shouldUseStepContainerV2( flow ) }
 				/>
 			</CalypsoShoppingCartProvider>
 		);
@@ -124,6 +127,30 @@ const UseMyDomain: StepType< {
 	const shouldHideButtons = isStartWritingFlow( flow );
 
 	if ( shouldUseStepContainerV2( flow ) ) {
+		const [ columnWidth, headingText, subHeadingText ] =
+			useMyDomainMode === 'domain-input'
+				? [
+						4 as const,
+						__( 'Use a domain I own' ),
+						__( 'Enter the domain you would like to use.' ),
+				  ]
+				: [
+						8 as const,
+						createInterpolateElement(
+							sprintf(
+								/* translators: %(domainName)s - the name of the domain the user will add to their site */
+								__( 'Use a domain I own: <span>%(domainName)s</span>' ),
+								{
+									domainName: getInitialQuery(),
+								}
+							),
+							{
+								span: <span />,
+							}
+						),
+						undefined,
+				  ];
+
 		return (
 			<>
 				<QueryProductsList />
@@ -135,7 +162,8 @@ const UseMyDomain: StepType< {
 							}
 						/>
 					}
-					columnWidth={ useMyDomainMode === 'domain-input' ? 4 : 8 }
+					columnWidth={ columnWidth }
+					heading={ <Step.Heading text={ headingText } subText={ subHeadingText } /> }
 				>
 					{ getStepContent() }
 				</Step.CenteredColumnLayout>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -4,23 +4,28 @@ import {
 	ONBOARDING_FLOW,
 	StepContainer,
 	isStartWritingFlow,
+	Step,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
 import { useLocation } from 'react-router';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
+import {
+	useMyDomainInputMode as inputMode,
+	UseMyDomainInputMode,
+} from 'calypso/components/domains/connect-domain-step/constants';
 import UseMyDomainComponent from 'calypso/components/domains/use-my-domain';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainMapping, domainTransfer } from 'calypso/lib/cart-values/cart-items';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import type { Step } from '../../types';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import type { Step as StepType } from '../../types';
 
 import './style.scss';
 
-const UseMyDomain: Step< {
+const UseMyDomain: StepType< {
 	submits: {
 		mode: 'transfer' | 'connect';
 		domain: string;
@@ -32,7 +37,9 @@ const UseMyDomain: Step< {
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 	const location = useLocation();
 
-	const [ useMyDomainMode, setUseMyDomainMode ] = useState( '' );
+	const [ useMyDomainMode, setUseMyDomainMode ] = useState< UseMyDomainInputMode >(
+		inputMode.domainInput
+	);
 
 	const handleGoBack = () => {
 		if ( String( getQueryArg( window.location.search, 'step' ) ?? '' ) === 'transfer-or-connect' ) {
@@ -114,12 +121,34 @@ const UseMyDomain: Step< {
 		}
 	};
 
+	const shouldHideButtons = isStartWritingFlow( flow );
+
+	if ( shouldUseStepContainerV2( flow ) ) {
+		return (
+			<>
+				<QueryProductsList />
+				<Step.CenteredColumnLayout
+					topBar={
+						<Step.TopBar
+							backButton={
+								shouldHideButtons ? undefined : <Step.BackButton onClick={ handleGoBack } />
+							}
+						/>
+					}
+					columnWidth={ useMyDomainMode === 'domain-input' ? 4 : 8 }
+				>
+					{ getStepContent() }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
+
 	return (
 		<>
 			<QueryProductsList />
 			<StepContainer
 				stepName="useMyDomain"
-				shouldHideNavButtons={ isStartWritingFlow( flow ) }
+				shouldHideNavButtons={ shouldHideButtons }
 				goBack={ handleGoBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .step-route.use-my-domain {
 	.start-writing .register-domain-step {
 		box-shadow: none;
@@ -45,16 +48,35 @@
 		}
 
 		.option-content {
-			padding: 24px 0;
+			padding: 48px 0;
 			margin: 0;
+			gap: 24px;
+
+			@include break-small {
+				gap: 48px;
+			}
 
 			&:first-child {
 				padding-top: 0;
 			}
 
+			.option-content__illustration {
+				display: none;
+
+				@include break-small {
+					display: block;
+				}
+			}
+
 			.option-content__main {
 				max-width: unset;
-				margin: 0 48px;
+				margin: 0;
+			}
+
+			.option-content__action:empty {
+				// Ensure the action container doesn't participate in the flex
+				// layout when there's no button.
+				display: none;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
@@ -1,4 +1,15 @@
-.use-my-domain {
+.step-route.use-my-domain {
+	.start-writing .register-domain-step {
+		box-shadow: none;
+		background: none;
+	}
+
+	.domain-transfer-or-connect__content {
+		box-shadow: none;
+	}
+}
+
+.step-route.use-my-domain:not(:has(.step-container-v2)) {
 	padding: 36px 0;
 
 	#choose-a-domain-writer-header {
@@ -9,11 +20,6 @@
 		button {
 			margin-left: 5px;
 		}
-	}
-
-	.start-writing .register-domain-step {
-		box-shadow: none;
-		background: none;
 	}
 
 	.start-writing .register-domain-step__next-page-button {
@@ -27,4 +33,8 @@
 		}
 	}
 
+}
+
+.use-my-domain:has(.step-container-v2) {
+	padding: 0;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
@@ -37,4 +37,25 @@
 
 .use-my-domain:has(.step-container-v2) {
 	padding: 0;
+
+	.domain-transfer-or-connect__content {
+		&.card {
+			padding: 0;
+			margin: 0;
+		}
+
+		.option-content {
+			padding: 24px 0;
+			margin: 0;
+
+			&:first-child {
+				padding-top: 0;
+			}
+
+			.option-content__main {
+				max-width: unset;
+				margin: 0 48px;
+			}
+		}
+	}
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1151,7 +1151,6 @@ export class RenderDomainsStep extends Component {
 					initialMode={ queryObject.step ?? inputMode.domainInput }
 					onNextStep={ this.setCurrentFlowStep }
 					isSignupStep
-					showHeader={ false }
 					onTransfer={ this.handleAddTransfer }
 					onConnect={ this.onUseMyDomainConnect }
 					onSkip={ () => this.handleSkip( undefined, false ) }

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -7,7 +7,7 @@ import {
 import './style.scss';
 
 interface CenteredColumnLayoutProps extends StepContainerV2Props {
-	columnWidth: 4 | 6 | 8;
+	columnWidth: 4 | 6 | 8 | 10;
 }
 
 export const CenteredColumnLayout = ( props: CenteredColumnLayoutProps ) => {

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/style.scss
@@ -17,3 +17,6 @@
 		max-width: 826px;
 	}
 }
+
+// There is no 10 column wide class, the standard step container width is already 10 wide
+// .step-container-v2__content--centered-column-layout-10 {}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101196.

## Proposed Changes

- Adds a "10" column version of the `CenteredColumnLayout`. It's based on the width of the 5+5 cols two column layout
- Removed the `showHeader` prop from `UseMyDomain` component. It was unused
- Added new `hideHeader` prop to `UseMyDomain`. This is so we can render the header using `<Step.Header>` instead. I thought it was better not to reuse the existing `showHeader` prop because I wanted it to be clear the default is `false`.
- Wrap the "Use a domain I own" screens in the `CenteredColumnLayout` wireframe
- Adjust styles so the step paddings follow the mockups.

![CleanShot 2025-03-24 at 21 12 29@2x](https://github.com/user-attachments/assets/a9e15d4e-a1e8-4516-8240-76c39ab9f12d)

![CleanShot 2025-03-24 at 21 13 09@2x](https://github.com/user-attachments/assets/b653aa48-d9c8-43c4-8db6-726d12102fcc)

![CleanShot 2025-03-24 at 21 13 27@2x](https://github.com/user-attachments/assets/5797dab5-7ac8-46eb-9d98-043d4fecb309)

![CleanShot 2025-03-24 at 21 13 44@2x](https://github.com/user-attachments/assets/58ec8517-76be-4da7-bba9-6026e1b67a9a)

![CleanShot 2025-03-24 at 21 14 06@2x](https://github.com/user-attachments/assets/d20b94da-2a11-4e78-ba23-b02ce41cb9b5)

![CleanShot 2025-03-24 at 21 14 23@2x](https://github.com/user-attachments/assets/651a99ca-6d62-4215-84b9-7548ed71940a)


Fix some design inconsistencies:
- [ ] Domain input card has background but no borders, as well as some bottom margin that we can remove

## Testing

There should be no changes unless the `onboarding/step-container-v2` feature flag is enabled.

The `UseMyDomain` component is used in multiple places in the UI. We need to find them and ensure nothing has broken.

The second sub-step in the "Use a domain I own" screen has two variants, where sometimes there's two buttons and sometimes there's only one.
- I used `google.com` to test the case where the domain can not be transferred.
- I used `neopets.com` to test the case where it could be transferred.