### PR TITLE
Avoid navigating to launchpad step when Focused Launchpad should be shown

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/00-example-flow/example.ts
+++ b/client/landing/stepper/declarative-flow/flows/00-example-flow/example.ts
@@ -79,7 +79,7 @@ const newsletter: Flow = {
 
 		const createSite = useCreateSite();
 
-		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
+		const { getPostFlowUrl } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -131,10 +131,6 @@ const newsletter: Flow = {
 					const site = get( 'site' );
 					if ( site ) {
 						const { siteId, siteSlug } = site;
-						initializeLaunchpadState( {
-							siteId: siteId,
-							siteSlug: siteSlug,
-						} );
 
 						if ( providedDependencies?.goToHome ) {
 							return window.location.replace(

--- a/client/landing/stepper/declarative-flow/flows/build/build.ts
+++ b/client/landing/stepper/declarative-flow/flows/build/build.ts
@@ -66,7 +66,7 @@ const build: Flow = {
 
 		triggerGuidesForStep( flowName, _currentStep );
 
-		const { postFlowNavigator, initializeLaunchpadState } = useLaunchpadDecider( {
+		const { postFlowNavigator } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -82,11 +82,6 @@ const build: Flow = {
 							} )
 						);
 					}
-
-					initializeLaunchpadState( {
-						siteId,
-						siteSlug: ( providedDependencies?.siteSlug ?? siteSlug ) as string,
-					} );
 
 					return postFlowNavigator( { siteId, siteSlug } );
 				case 'launchpad': {

--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -65,7 +65,7 @@ const newsletter: Flow = {
 		const { exitFlow } = useExitFlow();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
 
-		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
+		const { getPostFlowUrl } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -123,11 +123,6 @@ const newsletter: Flow = {
 							) }?redirect_to=${ encodeURIComponent( launchpadUrl ) }&signup=1`
 						);
 					}
-
-					initializeLaunchpadState( {
-						siteId: providedDependencies?.siteId as number,
-						siteSlug: providedDependencies?.siteSlug as string,
-					} );
 
 					return window.location.assign(
 						getPostFlowUrl( {

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -221,7 +221,6 @@ const siteSetupFlow: FlowV1 = {
 					if ( isLaunchpadIntent( siteIntent ) ) {
 						redirectionUrl = addQueryArgs(
 							{
-								showLaunchpad: true,
 								...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
 								...( skippedCheckout && { skippedCheckout: 1 } ),
 							},
@@ -266,7 +265,7 @@ const siteSetupFlow: FlowV1 = {
 			clearSignupDestinationCookie();
 		};
 
-		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
+		const { getPostFlowUrl } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -318,7 +317,6 @@ const siteSetupFlow: FlowV1 = {
 					}
 
 					if ( isLaunchpadIntent( intent ) ) {
-						initializeLaunchpadState( { siteId, siteSlug } );
 						const url = getPostFlowUrl( { flow: intent, siteId, siteSlug } );
 						return exitFlow( url );
 					}

--- a/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
@@ -59,7 +59,7 @@ const startWriting: Flow = {
 			}
 		}, [ siteSlug, setIntentOnSite, isSiteLaunched ] );
 
-		const { getPostFlowUrl, postFlowNavigator, initializeLaunchpadState } = useLaunchpadDecider( {
+		const { getPostFlowUrl, postFlowNavigator } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -114,11 +114,6 @@ const startWriting: Flow = {
 								launchpad_screen: 'full',
 							} ),
 						] );
-
-						initializeLaunchpadState( {
-							siteId: providedDependencies?.siteId as number,
-							siteSlug: providedDependencies?.siteSlug as string,
-						} );
 
 						const siteOrigin = window.location.origin;
 

--- a/client/landing/stepper/declarative-flow/flows/update-design/update-design.ts
+++ b/client/landing/stepper/declarative-flow/flows/update-design/update-design.ts
@@ -51,7 +51,7 @@ const updateDesign: Flow = {
 			return navigate( 'processing' );
 		};
 
-		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
+		const { getPostFlowUrl } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -61,11 +61,6 @@ const updateDesign: Flow = {
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
 				case 'processing': {
-					initializeLaunchpadState( {
-						siteId,
-						siteSlug: ( providedDependencies?.siteSlug ?? siteSlug ) as string,
-					} );
-
 					const processingResult = providedDependencies.processingResult as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -27,7 +27,8 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) as OnboardSelect, [] );
 	const intent = getIntent();
 	const site = useSite();
-
+	// The site_intent option is not set until we exit site setup flow so we set the client value with data from the onboarding store
+	// as it is used in shouldShowLaunchpadFirst.
 	const showCustomerHome =
 		site &&
 		shouldShowLaunchpadFirst( { ...site, options: { ...site.options, site_intent: intent } } );

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,4 +1,3 @@
-import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -6,6 +5,7 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { getSessionId } from 'calypso/landing/stepper/utils/use-session-id';
 import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import type { Navigate, StepperStep } from '../../types';
+import type { OnboardSelect } from '@automattic/data-stores';
 
 interface Props {
 	exitFlow: ( path: string ) => void;
@@ -28,7 +28,9 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 	const intent = getIntent();
 	const site = useSite();
 	// site intent is not set until we exit site setup flow so we set it here with onboarding store
-	// as it is used in shouldShowLaunchpadFirst
+	// as it is used in shouldShowLaunchpadFirst. Note that we are not setting the site intent
+	// here to be saved server-side, we are only setting client-side so that we can use it in
+	// shouldShowLaunchpadFirst.
 	if ( site && site.options && site.options.site_intent === '' ) {
 		site.options.site_intent = intent;
 	}
@@ -45,7 +47,6 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 				siteSlug,
 				siteId,
 				sessionId,
-				showLaunchpad: true,
 			} );
 		},
 		postFlowNavigator: ( { siteId, siteSlug }: SiteProps ) => {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -27,10 +27,8 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) as OnboardSelect, [] );
 	const intent = getIntent();
 	const site = useSite();
-	// site intent is not set until we exit site setup flow so we set it here with onboarding store
-	// as it is used in shouldShowLaunchpadFirst. Note that we are not setting the site intent
-	// here to be saved server-side, we are only setting client-side so that we can use it in
-	// shouldShowLaunchpadFirst.
+	// The site_intent option is not set until we exit site setup flow so we set the client value with data from the onboarding store
+	// as it is used in shouldShowLaunchpadFirst.
 	if ( site && site.options && site.options.site_intent === '' ) {
 		site.options.site_intent = intent;
 	}

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -27,12 +27,11 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) as OnboardSelect, [] );
 	const intent = getIntent();
 	const site = useSite();
-	// The site_intent option is not set until we exit site setup flow so we set the client value with data from the onboarding store
-	// as it is used in shouldShowLaunchpadFirst.
-	if ( site && site.options && site.options.site_intent === '' ) {
-		site.options.site_intent = intent;
-	}
-	const showCustomerHome = site && shouldShowLaunchpadFirst( site );
+
+	const showCustomerHome =
+		site &&
+		shouldShowLaunchpadFirst( { ...site, options: { ...site.options, site_intent: intent } } );
+
 	const sessionId = getSessionId();
 
 	return {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,9 +1,11 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { OnboardSelect } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { getSessionId } from 'calypso/landing/stepper/utils/use-session-id';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import type { Navigate, StepperStep } from '../../types';
-
-export const LAUNCHPAD_EXPERIMENT_NAME = 'calypso_onboarding_launchpad_removal_test_2024_08';
 
 interface Props {
 	exitFlow: ( path: string ) => void;
@@ -22,19 +24,16 @@ interface SiteProps {
 }
 
 export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
-	// placeholder field for the experiment assignment
-	const showCustomerHome = false;
-	const sessionId = getSessionId();
-	let launchpadStateOnSkip: null | 'skipped' = null;
-	if ( showCustomerHome ) {
-		launchpadStateOnSkip = 'skipped';
+	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) as OnboardSelect, [] );
+	const intent = getIntent();
+	const site = useSite();
+	// site intent is not set until we exit site setup flow so we set it here with onboarding store
+	// as it is used in shouldShowLaunchpadFirst
+	if ( site && site.options && site.options.site_intent === '' ) {
+		site.options.site_intent = intent;
 	}
-
-	const setLaunchpadSkipState = ( siteIdOrSlug: string | number | null ) => {
-		if ( siteIdOrSlug && launchpadStateOnSkip ) {
-			updateLaunchpadSettings( siteIdOrSlug, { launchpad_screen: launchpadStateOnSkip } );
-		}
-	};
+	const showCustomerHome = site && shouldShowLaunchpadFirst( site );
+	const sessionId = getSessionId();
 
 	return {
 		getPostFlowUrl: ( { flow, siteId, siteSlug }: PostFlowUrlProps ) => {
@@ -42,22 +41,20 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 				return `/home/${ siteSlug || siteId }`;
 			}
 
-			return addQueryArgs( `/setup/${ flow }/launchpad`, { siteSlug, siteId, sessionId } );
+			return addQueryArgs( `/setup/${ flow }/launchpad`, {
+				siteSlug,
+				siteId,
+				sessionId,
+				showLaunchpad: true,
+			} );
 		},
 		postFlowNavigator: ( { siteId, siteSlug }: SiteProps ) => {
 			if ( showCustomerHome ) {
-				setLaunchpadSkipState( siteId || siteSlug );
-
 				exitFlow( '/home/' + siteSlug );
 				return;
 			}
 
 			navigate( `launchpad?siteSlug=${ siteSlug }&siteId=${ siteId }` );
-		},
-		initializeLaunchpadState: ( { siteId, siteSlug }: SiteProps ) => {
-			if ( showCustomerHome ) {
-				setLaunchpadSkipState( siteId || siteSlug );
-			}
 		},
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -15,7 +15,6 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
-import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -96,10 +95,10 @@ const Launchpad: Step = ( { navigation, flow } ) => {
 		return null;
 	}
 
-	if ( shouldShowLaunchpadFirst( site ) ) {
-		window.location.replace( `/home/${ siteSlug }` );
-		return null;
-	}
+	// if ( shouldShowLaunchpadFirst( site ) ) {
+	// 	window.location.replace( `/home/${ siteSlug }` );
+	// 	return null;
+	// }
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -95,11 +95,6 @@ const Launchpad: Step = ( { navigation, flow } ) => {
 		return null;
 	}
 
-	// if ( shouldShowLaunchpadFirst( site ) ) {
-	// 	window.location.replace( `/home/${ siteSlug }` );
-	// 	return null;
-	// }
-
 	return (
 		<>
 			<DocumentHead title={ almostReadyToLaunchText } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/101706

## Proposed Changes
This PR fixes the issue where events are being recorded for `fullscreen launchpad` even though we are not showing that launchpad. This happens because we fist navigate to the `Launchpad` step before deciding if we should navigate to `/home` to show the focused launchpad. 

This PR removes the decision from in the Launchpad step and repurpose the `useLaunchpadDecider` to decide if the launchpad step should be shown or we go directly to `/home` if the focused launchpad should be shown.

* update `useLaunchpadDecider` to check if site should show focused launchpad using `shouldShowLaunchpadFirst`
* * Cleanup other references to unused `initialiseLaunchpadState` from the `useLaunchpadDecider`


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prevent tracks from being recorded incorrectly. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding` and go through the flow
* In network tab chose `img` and filter by `calypso_signup_step_start`
* After going through the flow the focused launchpad should be shown in my home and event `calypso_signup_step_start` with `step=launchpad` should not be fired.

**Non onboarding test**
* Go to `/start/free` and go through the flow
* In network tab chose `img` and filter by `calypso_signup_step_start`
* Verify you see the fullscreen launchpad
* Verify `calypso_signup_step_start` with `step=launchpad`  is fired

**Network tab**
![image](https://github.com/user-attachments/assets/aaa73f2f-44d7-4afb-9343-6b834a8bcd7d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
