### PR TITLE
composite-checkout: Add useMakeStepActive hook to steps

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -147,6 +147,7 @@ This component's props are:
 - `isCompleteCallback: () => boolean | Promise<boolean>`. Used to determine if a step is complete for purposes of validation. Note that this is not called for the last step!
 - `editButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Edit" button if one exists.
 - `nextStepButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Continue" button if one exists.
+- `canEditStep?: boolean`. If false, the step will never show an "Edit" button. Defaults to true.
 - `editButtonText?: string`. Used in place of "Edit" on the edit step button.
 - `nextStepButtonText?: string`. Used in place of "Continue" on the next step button.
 - `validatingButtonText?: string`. Used in place of "Please wait…" on the next step button when `isCompleteCallback` returns an unresolved Promise.

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -288,6 +288,10 @@ A React Hook that returns all the payment processor functions in a Record.
 
 A React Hook that will return the `onClick` function passed to each [payment method's submitButton component](#payment-methods). The hook requires a payment processor ID. Call the returned function with data for the payment processor and it will begin the transaction.
 
+### useMakeStepActive
+
+A React Hook that will return a function to set a step to be the active step. Only works within a step. The returned function looks like `( stepId: string ) => Promise< boolean >;`. Calling this function is similar to pressing the "Edit" button on the specified step. Note that this is risky! It will make the previous active step inactive, but **will not complete** that step, so if the previous step has any `isCompleteCallback` behavior, that behavior will not be triggered. It will also ignore the `canEditStep` prop of `CheckoutStep`.
+
 ### useSetStepComplete
 
 A React Hook that will return a function to set a step to "complete". Only works within a step but it does not have to be the targeted step. The returned function looks like `( stepId: string ) => Promise< boolean >;`. Calling this function is similar to pressing the "Continue" button on the specified step; it will call the `isCompleteCallback` prop of the step and only succeed if the callback succeeds. In addition, all previous incomplete steps will be marked as complete in the same way, and the process will fail and stop at the first step whose `isCompleteCallback` fails. The resolved Promise will return true if all the requested steps were completed and false if any of them failed.

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -35,6 +35,7 @@ import type {
 	CheckoutStepCompleteStatus,
 	CheckoutStepGroupStore,
 	StepChangedCallback,
+	MakeStepActive,
 } from '../types';
 import type { ReactNode, HTMLAttributes, PropsWithChildren, ReactElement } from 'react';
 
@@ -65,6 +66,7 @@ const CheckoutStepGroupContext = createContext< CheckoutStepGroupStore >( {
 		stepCompleteCallbackMap: {},
 	},
 	actions: {
+		makeStepActive: noop,
 		setStepComplete: noop,
 		setActiveStepNumber: noop,
 		setStepCompleteStatus: noop,
@@ -175,6 +177,16 @@ function createCheckoutStepGroupActions(
 		);
 	};
 
+	const makeStepActive = async ( stepId: string ) => {
+		debug( `attempting to set step active: '${ stepId }'` );
+		const stepNumber = getStepNumberFromId( stepId );
+		if ( ! stepNumber ) {
+			throw new Error( `Cannot find step with id '${ stepId }' when trying to set step active.` );
+		}
+		setActiveStepNumber( stepNumber );
+		return true;
+	};
+
 	const setStepComplete = async ( stepId: string ) => {
 		debug( `attempting to set step complete: '${ stepId }'` );
 		const stepNumber = getStepNumberFromId( stepId );
@@ -205,6 +217,7 @@ function createCheckoutStepGroupActions(
 		getStepCompleteCallback,
 		setTotalSteps,
 		setStepComplete,
+		makeStepActive,
 	};
 }
 
@@ -868,6 +881,11 @@ export function useIsStepComplete(): boolean {
 export function useSetStepComplete(): SetStepComplete {
 	const store = useContext( CheckoutStepGroupContext );
 	return store.actions.setStepComplete;
+}
+
+export function useMakeStepActive(): MakeStepActive {
+	const store = useContext( CheckoutStepGroupContext );
+	return store.actions.makeStepActive;
 }
 
 const StepTitle = styled.span< StepTitleProps & HTMLAttributes< HTMLSpanElement > >`

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -12,6 +12,7 @@ import {
 	useIsStepActive,
 	useIsStepComplete,
 	useSetStepComplete,
+	useMakeStepActive,
 	createCheckoutStepGroupStore,
 } from './components/checkout-steps';
 import useProcessPayment from './components/use-process-payment';
@@ -68,4 +69,5 @@ export {
 	useSetStepComplete,
 	useTogglePaymentMethod,
 	useTransactionStatus,
+	useMakeStepActive,
 };

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -271,6 +271,8 @@ export type StepCompleteCallbackMap = Record< string, StepCompleteCallback >;
 
 export type SetStepComplete = ( stepId: string ) => Promise< boolean >;
 
+export type MakeStepActive = ( stepId: string ) => Promise< boolean >;
+
 export type CheckoutStepCompleteStatus = Record< string, boolean >;
 
 export interface CheckoutStepGroupStore {
@@ -291,6 +293,7 @@ export interface CheckoutStepGroupActions {
 	setActiveStepNumber: ( stepNumber: number ) => void;
 	setStepCompleteStatus: ( newStatus: CheckoutStepCompleteStatus ) => void;
 	setStepComplete: SetStepComplete;
+	makeStepActive: MakeStepActive;
 	getStepNumberFromId: ( stepId: string ) => number | undefined;
 	setStepCompleteCallback: (
 		stepNumber: number,

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -8,7 +8,6 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createContext, useState, useContext } from 'react';
-import { useMakeStepActive } from '../src/components/checkout-steps';
 import {
 	CheckoutProvider,
 	CheckoutStep,
@@ -21,6 +20,7 @@ import {
 	useSetStepComplete,
 	useTogglePaymentMethod,
 	makeErrorResponse,
+	useMakeStepActive,
 } from '../src/public-api';
 import { PaymentProcessorFunction, PaymentProcessorResponseType } from '../src/types';
 import { DefaultCheckoutSteps } from './utils/default-checkout-steps';

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -8,6 +8,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createContext, useState, useContext } from 'react';
+import { useMakeStepActive } from '../src/components/checkout-steps';
 import {
 	CheckoutProvider,
 	CheckoutStep,
@@ -420,6 +421,41 @@ describe( 'Checkout', () => {
 			await waitFor( () => {
 				expect( firstStepContent ).toHaveStyle( 'display: none' );
 			} );
+		} );
+
+		it( 'does change steps if useMakeStepActive is used', async () => {
+			function ManualStepChangeButton( { stepId } ) {
+				const setActiveStep = useMakeStepActive();
+				return <button onClick={ () => setActiveStep( stepId ) }>Change step</button>;
+			}
+			const stepOne = {
+				...steps[ 1 ],
+				id: 'step-will-pass',
+				className: 'step-will-pass',
+			};
+			const stepTwo = {
+				...steps[ 1 ],
+				activeStepContent: (
+					<div>
+						<span>Custom Step - Summary Active</span>
+						<ManualStepChangeButton stepId={ steps[ 1 ].id } />
+					</div>
+				),
+			};
+			const { container, getAllByText } = render( <MyCheckout steps={ [ stepOne, stepTwo ] } /> );
+			const manualContinue = getAllByText( 'Change step' )[ 0 ];
+			const firstStep = container.querySelector( '.' + stepOne.className );
+			const secondStep = container.querySelector( '.' + stepTwo.className );
+			const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
+			const secondStepContent = secondStep.querySelector( '.checkout-steps__step-content' );
+			expect( firstStepContent ).toHaveStyle( 'display: block' );
+			expect( secondStepContent ).toHaveStyle( 'display: none' );
+			const user = userEvent.setup();
+			await user.click( manualContinue );
+			await waitFor( () => {
+				expect( firstStepContent ).toHaveStyle( 'display: none' );
+			} );
+			expect( secondStepContent ).toHaveStyle( 'display: block' );
 		} );
 
 		it( 'does change steps if useSetStepComplete is used and the step becomes complete after a Promise resolves', async () => {


### PR DESCRIPTION
## Proposed Changes

This PR adds a new React hook to the `@automattic/composite-checkout` package called `useMakeStepActive`. It returns a function that can be used to change the currently active step in a `CheckoutStepGroup`.

This behavior has not been exposed before because it's risky; it bypasses all the guards around editable steps and also skips step callbacks. So if one step is active and this function is called, it will change the active step without calling the `isCompleteCallback` of the current step. That step will remain incomplete but will become inactive.

## Why are these changes being made?

https://github.com/Automattic/wp-calypso/pull/101555/ adds a button to the payment method step that needs to be able to activate the contact info step, as if the user had pressed the "Edit" button on that step. Currently there's no easy way to do this, so we must expose a mechanism.

## Testing Instructions

Automated tests are included.
