### PR TITLE
Re-enable the cancel purchase button for non-plan purchases

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -914,7 +914,7 @@ class ManagePurchase extends Component<
 		}
 		const { id } = purchase;
 
-		if ( ! canAutoRenewBeTurnedOff( purchase ) || ! isPlan( purchase ) ) {
+		if ( ! canAutoRenewBeTurnedOff( purchase ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
The cancel purchase link was hidden for non-plans in #101493. If this is a necessary as part of the self-service plan downgrades feature, then the logic will need to be updated to include a check for the `plans/self-service-downgrade` feature flag.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Bug reported p1742704745899799-slack-C02FMH4G8
Related to https://github.com/Automattic/wp-calypso/pull/101493
Fixes https://github.com/Automattic/wp-calypso/issues/101756

| **Before** | **After** |
|---|---|
| ![CleanShot 2025-03-24 at 10 21 57@2x](https://github.com/user-attachments/assets/6ff8e027-dd78-4244-99cc-fbaef979e8a0) | ![CleanShot 2025-03-24 at 10 21 35@2x](https://github.com/user-attachments/assets/36304210-1a79-4c68-8a26-490f8dcba43b) |


## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/101493 hid the cancel purchase button for all non-plan purchases.

This looks unintentional, users should still be able to cancel their domain purchases, email subscriptions, etc.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The purchase screen is on `/purchases/subscriptions/{{ site }}` and `/me/purchases`
* The "Cancel domain" or "Cancel subscription" link should now appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?