### PR TITLE
A4A > WooPayments: Fix empty state link color

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/style.scss
@@ -54,6 +54,7 @@ $woocommerce-purple-50: #720EEC;
 	text-decoration: underline;
 	color: var(--color-text);
 
+	&:active,
 	&:hover,
 	&:focus,
 	&:focus-visible {


### PR DESCRIPTION
## Proposed Changes

* Resolves an issue with the empty state link color when it is active.

## Testing Instructions

* Open the A4A live link
* Go to WooPayments: Dashboard > Verify the link color stays intact when it is active in the empty state view.

Open the dev too > Select the element > Right click > Force state > Select `:active`

<img width="1333" alt="Screenshot 2025-03-24 at 8 56 38 AM" src="https://github.com/user-attachments/assets/5b02c69c-9d50-48ab-a72d-51615b87bfa0" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
