### PR TITLE
Loudly alert users about data loss when site is reset.

### DIFF
--- a/client/components/notice/notice-action.tsx
+++ b/client/components/notice/notice-action.tsx
@@ -7,7 +7,7 @@ import './style.scss';
 interface NoticeActionProps {
 	'aria-label'?: string;
 	href?: string | null;
-	onClick?: () => void;
+	onClick?: ( ( event: React.MouseEvent< HTMLAnchorElement > ) => void ) | ( () => void );
 	external?: boolean;
 	icon?: string;
 	children?: React.ReactNode;

--- a/client/components/notice/notice-action.tsx
+++ b/client/components/notice/notice-action.tsx
@@ -7,7 +7,7 @@ import './style.scss';
 interface NoticeActionProps {
 	'aria-label'?: string;
 	href?: string | null;
-	onClick?: () => void;
+	onClick?: ( event: React.MouseEvent< HTMLAnchorElement > ) => void;
 	external?: boolean;
 	icon?: string;
 	children?: React.ReactNode;

--- a/client/components/notice/notice-action.tsx
+++ b/client/components/notice/notice-action.tsx
@@ -7,7 +7,7 @@ import './style.scss';
 interface NoticeActionProps {
 	'aria-label'?: string;
 	href?: string | null;
-	onClick?: ( event: React.MouseEvent< HTMLAnchorElement > ) => void;
+	onClick?: () => void;
 	external?: boolean;
 	icon?: string;
 	children?: React.ReactNode;

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -10,8 +10,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import { Panel, PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import withP2HubP2Count from 'calypso/data/p2/with-p2-hub-p2-count';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -29,6 +27,7 @@ import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-a
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { FeatureBreadcrumb } from '../../../../hooks/breadcrumbs/use-set-feature-breadcrumb';
+import ExportNotice from '../export-notice';
 import DeleteSiteWarnings from './delete-site-warnings';
 
 import './style.scss';
@@ -52,8 +51,7 @@ class DeleteSite extends Component {
 	};
 
 	renderNotice() {
-		const exportLink = '/export/' + this.props.siteSlug;
-		const { siteDomain } = this.props;
+		const { siteDomain, siteId } = this.props;
 
 		if ( ! siteDomain ) {
 			return null;
@@ -64,11 +62,11 @@ class DeleteSite extends Component {
 		};
 
 		return (
-			<Notice status="is-warning" showDismiss={ false } text={ warningText() }>
-				<NoticeAction onClick={ this._checkSiteLoaded } href={ exportLink }>
-					{ translate( 'Export content' ) }
-				</NoticeAction>
-			</Notice>
+			<ExportNotice
+				siteSlug={ this.props.siteSlug }
+				siteId={ siteId }
+				warningText={ warningText() }
+			/>
 		);
 	}
 
@@ -195,13 +193,6 @@ class DeleteSite extends Component {
 		this.props.getRemoveDuplicateViewsExperimentAssignment();
 	}
 
-	_checkSiteLoaded = ( event ) => {
-		const { siteId } = this.props;
-		if ( ! siteId ) {
-			event.preventDefault();
-		}
-	};
-
 	onConfirmDomainChange = ( event ) => {
 		this.setState( {
 			confirmDomain: event.target.value,
@@ -248,8 +239,8 @@ class DeleteSite extends Component {
 							{ isUntangled && (
 								<PanelCardHeading>{ translate( 'Confirm site deletion' ) }</PanelCardHeading>
 							) }
-							{ this.renderNotice() }
 							{ this.renderBody() }
+							{ this.renderNotice() }
 						</>
 						{ this.renderDeleteSiteCTA() }
 					</PanelCard>

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -62,7 +62,7 @@ class DeleteSite extends Component {
 				siteSlug={ this.props.siteSlug }
 				siteId={ siteId }
 				warningText={ translate(
-					'Before deleting your site, consider exporting its content as a backup'
+					'Before deleting your site, consider exporting your content as a backup.'
 				) }
 			/>
 		);

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -57,15 +57,13 @@ class DeleteSite extends Component {
 			return null;
 		}
 
-		const warningText = () => {
-			return translate( 'Before deleting your site, consider exporting its content as a backup' );
-		};
-
 		return (
 			<ExportNotice
 				siteSlug={ this.props.siteSlug }
 				siteId={ siteId }
-				warningText={ warningText() }
+				warningText={ translate(
+					'Before deleting your site, consider exporting its content as a backup'
+				) }
 			/>
 		);
 	}

--- a/client/sites/settings/administration/tools/export-notice.tsx
+++ b/client/sites/settings/administration/tools/export-notice.tsx
@@ -1,0 +1,28 @@
+import { translate } from 'i18n-calypso';
+import { MouseEvent } from 'react';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+
+export default function ExportNotice( {
+	siteId,
+	siteSlug,
+	warningText,
+}: {
+	siteId: number;
+	siteSlug: string;
+	warningText: string;
+} ) {
+	const checkSiteLoaded = ( event: MouseEvent< HTMLAnchorElement > ) => {
+		if ( ! siteId ) {
+			event.preventDefault();
+		}
+	};
+
+	return (
+		<Notice status="is-warning" showDismiss={ false } text={ warningText }>
+			<NoticeAction onClick={ checkSiteLoaded } href={ `/export/${ siteSlug }` }>
+				{ translate( 'Export content' ) }
+			</NoticeAction>
+		</Notice>
+	);
+}

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -27,6 +27,7 @@ import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selec
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useSetFeatureBreadcrumb } from '../../../../hooks/breadcrumbs/use-set-feature-breadcrumb';
 import { DIFMUpsell } from '../../../components/difm-upsell-banner';
+import ExportNotice from '../export-notice';
 
 import './style.scss';
 
@@ -176,30 +177,22 @@ function SiteResetCard( {
 		}
 	);
 
-	const backupHint = isAtomic
-		? createInterpolateElement(
-				translate(
-					"Having second thoughts? Don't fret, you'll be able to restore your site using the most recent backup in the <a>Activity Log</a>."
-				),
-				{
-					a: <a href={ `/activity-log/${ selectedSiteSlug }` } />,
-				}
-		  )
-		: createInterpolateElement(
-				translate(
-					'To keep a copy of your current site, head to the <a>Export page</a> before starting the reset.'
-				),
-				{
-					a: <a href={ `/settings/export/${ selectedSiteSlug }` } />,
-				}
-		  );
-
 	const isResetInProgress = status?.status === 'in-progress' && isAtomic;
 
 	const ctaText =
 		! isAtomic && isLoading ? translate( 'Resetting site' ) : translate( 'Reset site' );
 
 	const content = contentInfo();
+
+	const renderNotice = () => {
+		const warningText = translate(
+			'Before resetting your site, consider exporting its content as a backup'
+		);
+
+		return (
+			<ExportNotice siteSlug={ selectedSiteSlug } siteId={ siteId } warningText={ warningText } />
+		);
+	};
 
 	const renderBody = () => {
 		if ( resetComplete ) {
@@ -264,6 +257,7 @@ function SiteResetCard( {
 						</>
 					) }
 					<hr />
+					{ ! isAtomic && renderNotice() }
 					<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
 						{ createInterpolateElement(
 							sprintf(
@@ -298,7 +292,18 @@ function SiteResetCard( {
 							{ ctaText }
 						</Button>
 					</div>
-					{ backupHint && <FormSettingExplanation>{ backupHint }</FormSettingExplanation> }
+					{ isAtomic && (
+						<FormSettingExplanation>
+							{ createInterpolateElement(
+								translate(
+									"Having second thoughts? Don't fret, you'll be able to restore your site using the most recent backup in the <a>Activity Log</a>."
+								),
+								{
+									a: <a href={ `/activity-log/${ selectedSiteSlug }` } />,
+								}
+							) }
+						</FormSettingExplanation>
+					) }
 				</PanelCard>
 			</>
 		);

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -252,7 +252,7 @@ function SiteResetCard( {
 							siteSlug={ selectedSiteSlug }
 							siteId={ siteId }
 							warningText={ translate(
-								'Before resetting your site, consider exporting its content as a backup'
+								'Before resetting your site, consider exporting your content as a backup.'
 							) }
 						/>
 					) }

--- a/client/sites/settings/administration/tools/reset-site/index.jsx
+++ b/client/sites/settings/administration/tools/reset-site/index.jsx
@@ -184,16 +184,6 @@ function SiteResetCard( {
 
 	const content = contentInfo();
 
-	const renderNotice = () => {
-		const warningText = translate(
-			'Before resetting your site, consider exporting its content as a backup'
-		);
-
-		return (
-			<ExportNotice siteSlug={ selectedSiteSlug } siteId={ siteId } warningText={ warningText } />
-		);
-	};
-
 	const renderBody = () => {
 		if ( resetComplete ) {
 			const message = createInterpolateElement(
@@ -257,7 +247,15 @@ function SiteResetCard( {
 						</>
 					) }
 					<hr />
-					{ ! isAtomic && renderNotice() }
+					{ ! isAtomic && (
+						<ExportNotice
+							siteSlug={ selectedSiteSlug }
+							siteId={ siteId }
+							warningText={ translate(
+								'Before resetting your site, consider exporting its content as a backup'
+							) }
+						/>
+					) }
 					<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
 						{ createInterpolateElement(
 							sprintf(

--- a/client/sites/settings/administration/tools/test/export-notice.jsx
+++ b/client/sites/settings/administration/tools/test/export-notice.jsx
@@ -21,11 +21,6 @@ describe( 'ExportNotice', () => {
 		expect( screen.getByText( 'This is a warning.' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the export button with the correct text', () => {
-		render( <ExportNotice { ...defaultProps } /> );
-		expect( screen.getByText( 'Export content' ) ).toBeInTheDocument();
-	} );
-
 	it( 'has the correct href for the export link', () => {
 		render( <ExportNotice { ...defaultProps } /> );
 		const link = screen.getByRole( 'link', { name: 'Export content' } );

--- a/client/sites/settings/administration/tools/test/export-notice.jsx
+++ b/client/sites/settings/administration/tools/test/export-notice.jsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExportNotice from '../export-notice';
+
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	translate: jest.fn( ( key ) => key ),
+} ) );
+
+describe( 'ExportNotice', () => {
+	const defaultProps = {
+		siteId: 123,
+		siteSlug: 'example-site',
+		warningText: 'This is a warning.',
+	};
+
+	it( 'renders the warning notice with the correct text', () => {
+		render( <ExportNotice { ...defaultProps } /> );
+		expect( screen.getByText( 'This is a warning.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the export button with the correct text', () => {
+		render( <ExportNotice { ...defaultProps } /> );
+		expect( screen.getByText( 'Export content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'has the correct href for the export link', () => {
+		render( <ExportNotice { ...defaultProps } /> );
+		const link = screen.getByRole( 'link', { name: 'Export content' } );
+		expect( link ).toHaveAttribute( 'href', '/export/example-site' );
+	} );
+
+	it( 'prevents navigation when siteId is missing', () => {
+		render( <ExportNotice { ...defaultProps } siteId={ 0 } /> );
+		const link = screen.getByRole( 'link', { name: 'Export content' } );
+		const clickEvent = fireEvent.click( link );
+		expect( clickEvent ).toBe( false );
+	} );
+
+	it( 'allows navigation when siteId is provided', () => {
+		render( <ExportNotice { ...defaultProps } /> );
+		const link = screen.getByRole( 'link', { name: 'Export content' } );
+		const clickEvent = fireEvent.click( link );
+		expect( clickEvent ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Fixes: #94782 

## Proposed Changes

This PR abstracts and moves the Export notice that we currently have in `client/sites/settings/administration/tools/delete-site/index.jsx` to display that to users when they are resetting their site as well.

Additionally, it moves the notice to what **I think** is a more appropriate place.


### Simple Site: Reset Site

| Before | After |
|--------|--------|
| <img width="747" alt="Screenshot 2025-03-24 at 1 37 59 PM" src="https://github.com/user-attachments/assets/217015f2-1685-4520-8021-d5241c39d4f0" /> | <img width="736" alt="Screenshot 2025-03-26 at 10 26 15 AM" src="https://github.com/user-attachments/assets/057d3587-a62c-4fc5-8d34-e971f0d52e3d" /> | 

### Atomic Site: Reset Site

Since Atomic site recoveries are simple, we leave the view the same.

|  No change |
|--------|
| <img width="733" alt="Screenshot 2025-03-26 at 10 26 22 AM" src="https://github.com/user-attachments/assets/f8485864-a77a-46c3-9957-3da5aeec6102" /> |

### Simple/Atomic Site: Site Delete
| Before | After |
|--------|--------|
| <img width="744" alt="Screenshot 2025-03-24 at 1 36 42 PM" src="https://github.com/user-attachments/assets/b02cfa8f-a329-49a9-aaed-b2a796c7ecd4" /> | <img width="820" alt="Screenshot 2025-03-24 at 11 37 59 AM" src="https://github.com/user-attachments/assets/3ec23724-ccd7-4dec-b68d-480fd1a268c5" /> | 


## Why are these changes being made?

As noted by @masperber in #94782, we don't communicate to simple site users that they will lose site data if they reset.


## Testing Instructions

### Test reset
- Go to `sites/settings/site/{url}/reset-site`
- Expect to see warning, click on "Export Content"

### Test delete
- Go to `sites/settings/site/{url}/delete-site`
- Expect to see warning, click on "Export Content"

### Reset reset on atomic site
- Go to `sites/settings/site/{url}/reset-site`
- Expect to not see the notice
- Expect to see the message below the button.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
