### PR TITLE
Stats: Force the tabs in devices stats card to be 100% on mobile devices

### DIFF
--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -99,6 +99,13 @@
 		flex-wrap: wrap;
 		// Add padding to wrapped elements in narrow viewports.
 		row-gap: 16px;
+
+		@media (max-width: $break-mobile) {
+			.stats-card-header--main__left,
+			.stats-card-header--main__right {
+				flex-grow: 1;
+			}
+		}
 	}
 
 	.stats-card-header__additional {

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -79,7 +79,11 @@ const StatsCard = ( props: StatsCardProps ) => {
 	// (main item, optional additional columns and value)
 	const splitHeaderNode = (
 		<div
-			className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
+			className={ clsx(
+				`${ BASE_CLASS_NAME }-header`,
+				headerClassName,
+				`${ BASE_CLASS_NAME }-header--split`
+			) }
 		>
 			<div className={ `${ BASE_CLASS_NAME }-header--main` }>
 				<div className={ `${ BASE_CLASS_NAME }-header--main__left` }>

--- a/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-hero-card.tsx
@@ -69,7 +69,11 @@ const StatsHeroCard = ( {
 			} ) }
 		>
 			<div
-				className={ `${ BASE_CLASS_NAME }-header ${ headerClassName } ${ BASE_CLASS_NAME }-header--split` }
+				className={ clsx(
+					`${ BASE_CLASS_NAME }-header`,
+					headerClassName,
+					`${ BASE_CLASS_NAME }-header--split`
+				) }
 			>
 				<div className={ `${ BASE_CLASS_NAME }-header--main` }>
 					<div className={ `${ BASE_CLASS_NAME }-header--main__left` }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/red-team/issues/349

## Proposed Changes

* Force the tabs in the device stats card to be 100% width on mobile devices

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Let the tabs take all the available width on mobile width

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open stats with /stats/day/<site>
* Scroll to the devices section
* Reduce the screen width to mobile
* The tabs in the device stats would be 100%

Before/After screenshot below

![Arc -2025-03-24 at 15 47 56@2x](https://github.com/user-attachments/assets/3ee09fec-59e3-4b5d-b4b4-5893c5c50d8d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
