### PR TITLE
Reader Quick Edit: Add buttons to initial toolbar state

### DIFF
--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -26,6 +26,11 @@
 			top: 32px;
 		}
 
+		.editor__header-toolbar {
+			display: flex;
+			align-items: center;
+		}
+
 		.editor__header-wrapper {
 			display: flex;
 			overflow: hidden;

--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { getCompatibilityStyles } from '@wordpress/block-editor/build-module/components/iframe/get-compatibility-styles';
 import { createBlock, serialize, type BlockInstance } from '@wordpress/blocks';
-import { Popover, SlotFillProvider, KeyboardShortcuts } from '@wordpress/components';
+import { Popover, SlotFillProvider, KeyboardShortcuts, Button } from '@wordpress/components';
 import { useStateWithHistory, useResizeObserver } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import React, { useState, useEffect, useCallback } from '@wordpress/element';
@@ -126,6 +126,8 @@ export const Editor: FC< EditorProps > = ( {
 					<div className={ clsx( 'editor__header', { 'is-editing': isEditing } ) }>
 						<div className="editor__header-wrapper">
 							<div className="editor__header-toolbar">
+								<Button>Undo</Button>
+								<Button>Redo</Button>
 								<BlockToolbar hideDragHandle />
 							</div>
 							{ /* @ts-expect-error - Slot type missing */ }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/514, https://github.com/Automattic/wp-calypso/pull/100969#top

## Proposed Changes

This is a draft PR to discuss the appearance of the Quick Edit toolbar.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Placeholders to get an idea of what we want to put here:

### State Without Focus

<img width="782" alt="Screenshot 2025-03-24 at 12 15 09" src="https://github.com/user-attachments/assets/9ac31cd3-8d49-4641-9e8a-3045a2163ce1" />

### State With Focus

<img width="775" alt="Screenshot 2025-03-24 at 12 14 27" src="https://github.com/user-attachments/assets/b5e6997e-63ae-498e-838b-c2dd3312fda9" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/reader/`
* Open the Quick Edit
* See the new default placeholder buttons in the toolbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
