### PR TITLE
Reader - revert 60 day following cutoff

### DIFF
--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -275,7 +275,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				{ ! ( selectedItem && getPostFromItem( selectedItem ) ) && isLoading && (
 					<RecentPostSkeleton />
 				) }
-				{ ! isLoading && data?.items.length === 0 && <FollowingEmptyContent /> }
+				{ ! isLoading && data?.items.length === 0 && <FollowingEmptyContent view="recent" /> }
 				{ data?.items.length > 0 && selectedItem && getPostFromItem( selectedItem ) && (
 					<>
 						<AsyncLoad

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -27,14 +27,19 @@ class FollowingEmptyContent extends Component {
 	};
 
 	render() {
-		const { selectedFeedId, translate } = this.props;
+		const { selectedFeedId, translate, view } = this.props;
 		const isFullSiteFeed = !! selectedFeedId;
+		const isRecentView = view === 'recent';
 
 		return (
 			<EmptyContent
 				className="stream__empty"
 				title={ translate( "You're all caught up." ) }
-				line={ translate( 'No new posts in the last 60 days.' ) }
+				line={
+					isRecentView
+						? translate( 'No new posts in the last 60 days.' )
+						: translate( 'No new posts.' )
+				}
 				action={
 					isFullSiteFeed
 						? translate( 'Visit the Full Site Feed' )

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -744,25 +744,7 @@ class ReaderStream extends Component {
 				{ this.props.children }
 				{ showingStream && items.length ? this.props.intro?.() : null }
 				{ body }
-				{ showingStream && !! items.length && ! isRequesting && (
-					<>
-						<ListEnd />
-						{ streamKey.startsWith( 'following' ) && (
-							<div className="stream__caught-up">
-								<p>{ translate( "You've seen all new posts from the past 60 days." ) }</p>
-								<p>
-									{ this.props.selectedFeedId
-										? translate( "Visit {{link}}this site's feed{{/link}} to view older posts.", {
-												components: {
-													link: <a href={ `/read/feeds/${ this.props.selectedFeedId }` } />,
-												},
-										  } )
-										: translate( 'Visit the individual site to view older posts.' ) }
-								</p>
-							</div>
-						) }
-					</>
-				) }
+				{ showingStream && items.length && ! isRequesting ? <ListEnd /> : null }
 			</TopLevel>
 		);
 	}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -47,15 +47,6 @@
 }
 
 .following {
-	.stream__caught-up {
-		text-align: center;
-		color: var( --color-text-subtle );
-		font-size: $font-body-small;
-
-		p {
-			margin: 0 0 0.5em;
-		}
-	}
 
 	@include breakpoint-deprecated( '<660px' ) {
 		-webkit-perspective: none;

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -193,21 +193,6 @@ const streamApis = {
 	following: {
 		path: () => '/read/following',
 		dateProperty: 'date',
-		query: ( extras ) => {
-			// Filter out undefined values from extras
-			const filteredExtras = Object.fromEntries(
-				Object.entries( extras ).filter( ( [ , value ] ) => value !== undefined )
-			);
-
-			// If no after param is provided, default to 60 days ago
-			if ( ! filteredExtras.after && ! filteredExtras.pageHandle?.after ) {
-				const sixtyDaysAgo = new Date();
-				sixtyDaysAgo.setDate( sixtyDaysAgo.getDate() - 60 );
-				filteredExtras.after = sixtyDaysAgo.toISOString().split( '.' )[ 0 ] + 'Z';
-			}
-
-			return getQueryString( filteredExtras );
-		},
 	},
 	recent: {
 		path: () => '/read/streams/following',

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -33,6 +33,7 @@ describe( 'streams', () => {
 					method: 'GET',
 					path: '/read/following',
 					apiVersion: '1.2',
+					query,
 					onSuccess: action,
 					onFailure: action,
 				} )
@@ -67,6 +68,7 @@ describe( 'streams', () => {
 						method: 'GET',
 						path: '/read/following',
 						apiVersion: '1.2',
+						query,
 					},
 				},
 				{

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -17,7 +17,6 @@ jest.mock( '@wordpress/warning', () => () => {} );
 
 describe( 'streams', () => {
 	const action = deepfreeze( requestPageAction( { streamKey: 'following', page: 2 } ) );
-	const ISO_DATE_MATCHER = expect.stringMatching( /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/ );
 
 	describe( 'requestPage', () => {
 		const query = {
@@ -34,10 +33,6 @@ describe( 'streams', () => {
 					method: 'GET',
 					path: '/read/following',
 					apiVersion: '1.2',
-					query: {
-						...query,
-						after: ISO_DATE_MATCHER,
-					},
 					onSuccess: action,
 					onFailure: action,
 				} )
@@ -72,10 +67,6 @@ describe( 'streams', () => {
 						method: 'GET',
 						path: '/read/following',
 						apiVersion: '1.2',
-						query: {
-							...query,
-							after: ISO_DATE_MATCHER,
-						},
 					},
 				},
 				{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/634 

## Proposed Changes

* Removes the 60 day default cutoff for the following feed recently added in https://github.com/Automattic/wp-calypso/pull/98944/files 
* Also updates the default empty content component that was updated in https://github.com/Automattic/wp-calypso/pull/99132 to only use the "60 day" blurb for the recent (dataviews) view.

BEFORE
<img width="1108" alt="Screenshot 2025-03-24 at 10 09 27 AM" src="https://github.com/user-attachments/assets/820b9ce6-58d2-46ad-8d08-c18370e5b576" />


AFTER
<img width="1297" alt="Screenshot 2025-03-24 at 10 09 43 AM" src="https://github.com/user-attachments/assets/366df2f3-8ba8-40c2-bdcb-cf4649a4158e" />



BELOW - For empty content in following (non-dataview) - this appears for sites that have not posted in a very long time (1.5-2years ish).

BEFORE
<img width="835" alt="Screenshot 2025-03-24 at 10 10 16 AM" src="https://github.com/user-attachments/assets/d8f33296-e7de-4643-9cc8-04c51072cafa" />


AFTER
<img width="775" alt="Screenshot 2025-03-24 at 10 10 30 AM" src="https://github.com/user-attachments/assets/b4d48dfc-9454-4333-9f74-cbe2a99f6d44" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  https://github.com/Automattic/loop/issues/634 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the following feed at /reader
* turn dataviews (recent view) toggle off.
* Select a site in the recent dropdown that has no new posts in the last 60 days, but does have new posts in the last year or so.
* Verify without dataviews view seleceted we see a feed in following.
* Select a site in recent dropdown that has no new posts in 1.5-2years+. Verify the empty content message reads "No new posts" and doesn't mention 60 days.
* Test the recent view for regressions, the "60 day" message should still be seen and is relevant there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
