### PR TITLE
Line Chart: Use unique chart values to determine Y-axis numTicks

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -71,6 +71,20 @@ function StatsLineChart( {
 		[ chartData ]
 	);
 
+	const yNumTicks = useMemo( () => {
+		const uniqueValues = [
+			...new Set( chartData.flatMap( ( series ) => series.data.map( ( d ) => d.value ) ) ),
+		];
+
+		const maxTicks = uniqueValues.length > 5 ? 5 : uniqueValues.length;
+
+		if ( fixedDomain ) {
+			return maxTicks;
+		}
+
+		return maxTicks - 1;
+	}, [ chartData, fixedDomain ] );
+
 	const yScaleType = useMemo( () => {
 		if ( chartData.length <= 1 ) {
 			return 'linear';
@@ -192,7 +206,7 @@ function StatsLineChart( {
 								y: {
 									orientation: 'right',
 									tickFormat: formatValue,
-									numTicks: maxValue > 4 ? 4 : 1,
+									numTicks: yNumTicks,
 								},
 							},
 						} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101367

## Proposed Changes

* Use unique chart values to determine the Y-axis `numTicks`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Y-axis tick count is more reasonable to correspond to the unique values of the chart data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to Stats > Subscribers page for sites with or without frequent subscriber changes.
* Ensure the chart Y-axis tick count looks reasonable.

#### Site with fewer subscriber changes
|Before|After|
|-|-|
|<img width="1287" alt="截圖 2025-03-24 晚上11 13 29" src="https://github.com/user-attachments/assets/ba4bc476-4c32-4a8e-b7da-96b9a2e3e021" />|<img width="1283" alt="截圖 2025-03-24 晚上11 13 39" src="https://github.com/user-attachments/assets/da8d513c-35fc-48ac-95a2-dd7ceae9cb04" />|

#### Site with frequent subscriber changes
<img width="1278" alt="截圖 2025-03-24 晚上11 26 10" src="https://github.com/user-attachments/assets/e610e32e-f6f3-4a5a-ae88-ec37c45fbc10" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
