### PR TITLE
Update JITMs to use new v3 endpoint

### DIFF
--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -60,6 +60,8 @@ export const queueRequest =
 		const { responseType } = options || {};
 		const fetcher = get( options, 'options.fetcher', 'wpcom' );
 
+		const isLocalApiCall = options?.isLocalApiCall;
+
 		const onStreamRecord =
 			rawOnStreamRecord &&
 			( ( record ) => {
@@ -73,9 +75,10 @@ export const queueRequest =
 			fetcher
 		)(
 			...[
-				{ path, formData, onStreamRecord, responseType },
+				{ path, formData, onStreamRecord, responseType, isLocalApiCall },
 				{ ...query }, // wpcom mutates the query so hand it a copy
 				method === 'POST' && body,
+
 				( error, data, headers ) => {
 					debug( 'callback fn by Req method: error=%o data=%o headers=%o', error, data, headers );
 

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -76,7 +76,6 @@ export const queueRequest =
 				{ path, formData, onStreamRecord, responseType, isLocalApiCall },
 				{ ...query }, // wpcom mutates the query so hand it a copy
 				method === 'POST' && body,
-
 				( error, data, headers ) => {
 					debug( 'callback fn by Req method: error=%o data=%o headers=%o', error, data, headers );
 

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -57,10 +57,8 @@ export const queueRequest =
 			path,
 			query = {},
 		} = action;
-		const { responseType } = options || {};
+		const { responseType, isLocalApiCall } = options || {};
 		const fetcher = get( options, 'options.fetcher', 'wpcom' );
-
-		const isLocalApiCall = options?.isLocalApiCall;
 
 		const onStreamRecord =
 			rawOnStreamRecord &&

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -11,7 +11,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import schema from './schema.json';
 
 const noop = () => {};
-const jitmSchema = schema;
+
 const isRunningInJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
 
 /**
@@ -126,7 +126,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 			fetch: doFetchJITM,
 			onSuccess: receiveJITM,
 			onError: failedJITM,
-			fromApi: makeJsonSchemaParser( jitmSchema, transformApiRequest ),
+			fromApi: makeJsonSchemaParser( schema, transformApiRequest ),
 		} ),
 	],
 

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -28,10 +28,6 @@ const unescapeDecimalEntities = ( str ) =>
  * @returns {Object} The transformed data to display
  */
 export const transformApiRequest = ( jitms ) => {
-	// Different shape of date between Calypso and Jetpack.
-	if ( jitms && jitms.data ) {
-		jitms = jitms.data;
-	}
 	return jitms.map( ( jitm ) => ( {
 		message: unescapeDecimalEntities( jitm.content.message || '' ),
 		description: unescapeDecimalEntities( jitm.content.description || '' ),

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -78,6 +78,8 @@ export const doFetchJITM = ( action ) =>
 	);
 
 /**
+ * Dismisses a JITM. It returns nothing useful and will return no useful error, so we'll
+ * fail and succeed silently.
  * Dismisses a jitm
  * @param {Object} action The dismissal action
  * @returns {Object} The HTTP fetch action

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -12,8 +12,6 @@ import schema from './schema.json';
 
 const noop = () => {};
 
-const isRunningInJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
-
 /**
  * Existing libraries do not escape decimal encoded entities that php encodes, this handles that.
  * @param {string} str The string to decode
@@ -63,13 +61,15 @@ export const doFetchJITM = ( action ) =>
 		{
 			method: 'GET',
 			apiNamespace: 'wpcom/v3',
-			path: isRunningInJetpackSite ? `/jitm` : `/sites/${ action.siteId }/jitm`,
+			path: config.isEnabled( 'is_running_in_jetpack_site' )
+				? '/jitm'
+				: `/sites/${ action.siteId }/jitm`,
 			query: {
 				message_path: action.messagePath,
 				query: action.searchQuery,
 				locale: action.locale,
 			},
-			isLocalApiCall: true, // stop `jetpack_site_xhr_wrapper` from modifying the apiNamespace
+			isLocalApiCall: true, // required to use the wpcom/v3 namespace
 		},
 		{ ...action }
 	);
@@ -84,12 +84,14 @@ export const doDismissJITM = ( action ) =>
 		{
 			method: 'POST',
 			apiNamespace: 'wpcom/v3',
-			path: isRunningInJetpackSite ? `/jitm` : `/sites/${ action.siteId }/jitm`,
+			path: config.isEnabled( 'is_running_in_jetpack_site' )
+				? '/jitm'
+				: `/sites/${ action.siteId }/jitm`,
 			body: {
 				feature_class: action.featureClass,
 				id: action.id,
 			},
-			isLocalApiCall: true, // stop `jetpack_site_xhr_wrapper` from modifying the apiNamespace
+			isLocalApiCall: true, // required to use the wpcom/v3 namespace
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import moment from 'moment/moment';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
 import { JITM_DISMISS, JITM_FETCH } from 'calypso/state/action-types';
@@ -11,8 +10,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import schema from './schema.json';
 
 const noop = () => {};
-const isRunningInJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
-const jitmSchema = isRunningInJetpackSite ? { ...schema, ...schema.properties.data } : schema;
+const jitmSchema = schema;
 
 /**
  * Existing libraries do not escape decimal encoded entities that php encodes, this handles that.
@@ -78,9 +76,7 @@ export const doFetchJITM = ( action ) =>
 	);
 
 /**
- * Dismisses a JITM. It returns nothing useful and will return no useful error, so we'll
- * fail and succeed silently.
- * Dismisses a jitm
+ * Dismisses a JITM
  * @param {Object} action The dismissal action
  * @returns {Object} The HTTP fetch action
  */
@@ -94,36 +90,6 @@ export const doDismissJITM = ( action ) =>
 				feature_class: action.featureClass,
 				id: action.id,
 			},
-		},
-		action
-	);
-
-const doJetpackFetchJITM = ( action ) =>
-	http(
-		{
-			method: 'GET',
-			apiNamespace: 'jetpack/v4',
-			path: '/jitm',
-			query: {
-				message_path: action.messagePath,
-				query: action.searchQuery,
-			},
-			locale: action.locale,
-		},
-		{ ...action }
-	);
-
-const doJetpackDismissJITM = ( action ) =>
-	http(
-		{
-			method: 'POST',
-			apiNamespace: 'jetpack/v4',
-			path: '/jitm',
-			body: JSON.stringify( {
-				feature_class: action.featureClass,
-				id: action.id,
-			} ),
-			json: false,
 		},
 		action
 	);
@@ -157,7 +123,7 @@ export const failedJITM = ( action ) => ( dispatch, getState ) => {
 registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 	[ JITM_FETCH ]: [
 		dispatchRequest( {
-			fetch: isRunningInJetpackSite ? doJetpackFetchJITM : doFetchJITM,
+			fetch: doFetchJITM,
 			onSuccess: receiveJITM,
 			onError: failedJITM,
 			fromApi: makeJsonSchemaParser( jitmSchema, transformApiRequest ),
@@ -166,7 +132,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/jitm/index.js', {
 
 	[ JITM_DISMISS ]: [
 		dispatchRequest( {
-			fetch: isRunningInJetpackSite ? doJetpackDismissJITM : doDismissJITM,
+			fetch: doDismissJITM,
 			onSuccess: noop,
 			onError: noop,
 		} ),

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -88,7 +88,7 @@ export const doDismissJITM = ( action ) =>
 		{
 			method: 'POST',
 			apiNamespace: 'wpcom/v3',
-			path: `/sites/${ action.siteId }/jitm`,
+			path: isRunningInJetpackSite ? `/jitm` : `/sites/${ action.siteId }/jitm`,
 			body: {
 				feature_class: action.featureClass,
 				id: action.id,

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -66,22 +66,19 @@ export const doFetchJITM = ( action ) =>
 	http(
 		{
 			method: 'GET',
-			path: `/jetpack-blogs/${ action.siteId }/rest-api/`,
+			apiNamespace: 'wpcom/v3',
+			path: `/sites/${ action.siteId }/jitm`,
 			query: {
-				path: '/jetpack/v4/jitm',
-				query: JSON.stringify( {
-					message_path: action.messagePath,
-					query: action.searchQuery,
-				} ),
-				http_envelope: 1,
+				message_path: action.messagePath,
+				query: action.searchQuery,
 				locale: action.locale,
 			},
 		},
 		{ ...action }
 	);
+
 /**
- * Dismisses a jitm on the jetpack site, it returns nothing useful and will return no useful error, so we'll
- * fail and succeed silently.
+ * Dismisses a jitm
  * @param {Object} action The dismissal action
  * @returns {Object} The HTTP fetch action
  */
@@ -89,15 +86,11 @@ export const doDismissJITM = ( action ) =>
 	http(
 		{
 			method: 'POST',
-			path: `/jetpack-blogs/${ action.siteId }/rest-api/`,
-			query: {
-				path: '/jetpack/v4/jitm',
-				body: JSON.stringify( {
-					feature_class: action.featureClass,
-					id: action.id,
-				} ),
-				http_envelope: 1,
-				json: false,
+			apiNamespace: 'wpcom/v3',
+			path: `/sites/${ action.siteId }/jitm`,
+			body: {
+				feature_class: action.featureClass,
+				id: action.id,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import moment from 'moment/moment';
 import makeJsonSchemaParser from 'calypso/lib/make-json-schema-parser';
 import { JITM_DISMISS, JITM_FETCH } from 'calypso/state/action-types';
@@ -11,6 +12,7 @@ import schema from './schema.json';
 
 const noop = () => {};
 const jitmSchema = schema;
+const isRunningInJetpackSite = config.isEnabled( 'is_running_in_jetpack_site' );
 
 /**
  * Existing libraries do not escape decimal encoded entities that php encodes, this handles that.
@@ -65,12 +67,13 @@ export const doFetchJITM = ( action ) =>
 		{
 			method: 'GET',
 			apiNamespace: 'wpcom/v3',
-			path: `/sites/${ action.siteId }/jitm`,
+			path: isRunningInJetpackSite ? `/jitm` : `/sites/${ action.siteId }/jitm`,
 			query: {
 				message_path: action.messagePath,
 				query: action.searchQuery,
 				locale: action.locale,
 			},
+			isLocalApiCall: true, // stop `jetpack_site_xhr_wrapper` from modifying the apiNamespace
 		},
 		{ ...action }
 	);
@@ -90,6 +93,7 @@ export const doDismissJITM = ( action ) =>
 				feature_class: action.featureClass,
 				id: action.id,
 			},
+			isLocalApiCall: true, // stop `jetpack_site_xhr_wrapper` from modifying the apiNamespace
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/sites/jitm/schema.json
+++ b/client/state/data-layer/wpcom/sites/jitm/schema.json
@@ -1,91 +1,87 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
-	"properties": {
-		"data": {
-			"items": {
+	"type": "array",
+	"items": {
+		"type": "object",
+		"properties": {
+			"CTA": {
+				"type": "object",
 				"properties": {
-					"CTA": {
-						"properties": {
-							"hook": {
-								"type": [ "string", "null" ]
-							},
-							"message": {
-								"type": "string"
-							},
-							"primary": {
-								"type": "boolean"
-							},
-							"newWindow": {
-								"type": "boolean"
-							}
-						},
-						"type": "object"
+					"hook": {
+						"type": [ "string", "null" ]
 					},
-					"content": {
-						"properties": {
-							"classes": {
-								"type": "string"
-							},
-							"description": {
-								"type": "string"
-							},
-							"icon": {
-								"type": [ "string", "null" ]
-							},
-							"message": {
-								"type": "string"
-							},
-							"list": {
-								"items": {
-									"properties": {
-										"item": {
-											"type": "string"
-										},
-										"url": {
-											"type": [ "string", "null" ]
-										}
-									}
-								},
-								"type": "array"
-							}
-						},
-						"type": "object"
-					},
-					"expires": {
-						"type": "integer"
-					},
-					"feature_class": {
+					"message": {
 						"type": "string"
 					},
-					"id": {
-						"type": "string"
+					"primary": {
+						"type": "boolean"
 					},
-					"jitm_stats_url": {
-						"type": "string"
-					},
-					"template": {
-						"type": "string"
-					},
-					"ttl": {
-						"type": "integer"
-					},
-					"url": {
-						"type": "string"
-					},
-					"tracks": {
-						"type": "object"
-					},
-					"action": {
-						"type": "object"
-					},
-					"is_dismissible": {
+					"newWindow": {
 						"type": "boolean"
 					}
-				},
+				}
+			},
+			"content": {
+				"type": "object",
+				"properties": {
+					"classes": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"icon": {
+						"type": [ "string", "null" ]
+					},
+					"message": {
+						"type": "string"
+					},
+					"list": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"item": {
+									"type": "string"
+								},
+								"url": {
+									"type": [ "string", "null" ]
+								}
+							}
+						}
+					}
+				}
+			},
+			"expires": {
+				"type": "integer"
+			},
+			"feature_class": {
+				"type": "string"
+			},
+			"id": {
+				"type": "string"
+			},
+			"jitm_stats_url": {
+				"type": "string"
+			},
+			"template": {
+				"type": "string"
+			},
+			"ttl": {
+				"type": "integer"
+			},
+			"url": {
+				"type": "string"
+			},
+			"tracks": {
 				"type": "object"
 			},
-			"type": "array"
+			"action": {
+				"type": "object"
+			},
+			"is_dismissible": {
+				"type": "boolean"
+			}
 		}
-	},
-	"type": "object"
+	}
 }

--- a/client/state/data-layer/wpcom/sites/jitm/test/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/test/index.js
@@ -20,6 +20,7 @@ describe( 'jitms', () => {
 							query: undefined,
 							locale: undefined,
 						},
+						isLocalApiCall: true, // required to use the wpcom/v3 namespace
 					},
 					action
 				)
@@ -44,6 +45,7 @@ describe( 'jitms', () => {
 							feature_class: featureClass,
 							id: messageId,
 						},
+						isLocalApiCall: true, // required to use the wpcom/v3 namespace
 					},
 					action
 				)

--- a/client/state/data-layer/wpcom/sites/jitm/test/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/test/index.js
@@ -1,10 +1,22 @@
+import config from '@automattic/calypso-config';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { fetchJITM, dismissJITM } from 'calypso/state/jitm/actions';
 import { doFetchJITM, doDismissJITM } from '..';
 
+jest.mock( '@automattic/calypso-config' );
+
+const configMock = ( values ) => ( key ) => values[ key ];
+
 describe( 'jitms', () => {
 	describe( '#doFetchJITM', () => {
-		test( 'should dispatch a get action with the site id and the message path', () => {
+		test.each( [
+			[ false, '/sites/123/jitm', 'should include sites/{siteId} in the path when not in Jetpack' ],
+			[ true, '/jitm', 'should not include sites/{siteId} in the path when in Jetpack' ],
+		] )( 'when is_running_in_jetpack_site is %p, %s', ( isJetpack, expectedPath ) => {
+			config.isEnabled.mockImplementation(
+				configMock( { is_running_in_jetpack_site: isJetpack } )
+			);
+
 			const siteId = 123;
 			const messagePath = 'test:foo:bar';
 			const action = fetchJITM( siteId, messagePath );
@@ -14,7 +26,7 @@ describe( 'jitms', () => {
 					{
 						method: 'GET',
 						apiNamespace: 'wpcom/v3',
-						path: `/sites/${ siteId }/jitm`,
+						path: expectedPath,
 						query: {
 							message_path: messagePath,
 							query: undefined,
@@ -29,7 +41,14 @@ describe( 'jitms', () => {
 	} );
 
 	describe( '#doDismissJITM', () => {
-		test( 'should dispatch a post action with the message id and the feature class', () => {
+		test.each( [
+			[ false, '/sites/123/jitm', 'should include sites/{siteId} in the path when not in Jetpack' ],
+			[ true, '/jitm', 'should not include sites/{siteId} in the path when in Jetpack' ],
+		] )( 'when is_running_in_jetpack_site is %p, %s', ( isJetpack, expectedPath ) => {
+			config.isEnabled.mockImplementation(
+				configMock( { is_running_in_jetpack_site: isJetpack } )
+			);
+
 			const siteId = 123;
 			const messageId = 'upsell-nudge-testing';
 			const featureClass = 'retention-marketing';
@@ -40,7 +59,7 @@ describe( 'jitms', () => {
 					{
 						method: 'POST',
 						apiNamespace: 'wpcom/v3',
-						path: `/sites/${ siteId }/jitm`,
+						path: expectedPath,
 						body: {
 							feature_class: featureClass,
 							id: messageId,

--- a/client/state/data-layer/wpcom/sites/jitm/test/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/test/index.js
@@ -8,15 +8,12 @@ jest.mock( '@automattic/calypso-config' );
 const configMock = ( values ) => ( key ) => values[ key ];
 
 describe( 'jitms', () => {
-	describe( '#doFetchJITM', () => {
-		test.each( [
-			[ false, '/sites/123/jitm', 'should include sites/{siteId} in the path when not in Jetpack' ],
-			[ true, '/jitm', 'should not include sites/{siteId} in the path when in Jetpack' ],
-		] )( 'when is_running_in_jetpack_site is %p, %s', ( isJetpack, expectedPath ) => {
-			config.isEnabled.mockImplementation(
-				configMock( { is_running_in_jetpack_site: isJetpack } )
-			);
+	beforeAll( () => {
+		config.isEnabled.mockImplementation( configMock( { is_running_in_jetpack_site: false } ) );
+	} );
 
+	describe( '#doFetchJITM', () => {
+		test( 'should dispatch a get action with the site id and the message path', () => {
 			const siteId = 123;
 			const messagePath = 'test:foo:bar';
 			const action = fetchJITM( siteId, messagePath );
@@ -26,7 +23,7 @@ describe( 'jitms', () => {
 					{
 						method: 'GET',
 						apiNamespace: 'wpcom/v3',
-						path: expectedPath,
+						path: `/sites/${ siteId }/jitm`,
 						query: {
 							message_path: messagePath,
 							query: undefined,
@@ -41,14 +38,7 @@ describe( 'jitms', () => {
 	} );
 
 	describe( '#doDismissJITM', () => {
-		test.each( [
-			[ false, '/sites/123/jitm', 'should include sites/{siteId} in the path when not in Jetpack' ],
-			[ true, '/jitm', 'should not include sites/{siteId} in the path when in Jetpack' ],
-		] )( 'when is_running_in_jetpack_site is %p, %s', ( isJetpack, expectedPath ) => {
-			config.isEnabled.mockImplementation(
-				configMock( { is_running_in_jetpack_site: isJetpack } )
-			);
-
+		test( 'should dispatch a post action with the message id and the feature class', () => {
 			const siteId = 123;
 			const messageId = 'upsell-nudge-testing';
 			const featureClass = 'retention-marketing';
@@ -59,7 +49,7 @@ describe( 'jitms', () => {
 					{
 						method: 'POST',
 						apiNamespace: 'wpcom/v3',
-						path: expectedPath,
+						path: `/sites/${ siteId }/jitm`,
 						body: {
 							feature_class: featureClass,
 							id: messageId,
@@ -70,5 +60,37 @@ describe( 'jitms', () => {
 				)
 			);
 		} );
+	} );
+
+	describe( 'path modification based on running in Jetpack', () => {
+		const siteId = 123;
+		const actions = [
+			{
+				name: 'fetchJITM',
+				action: fetchJITM( siteId, 'test:path' ),
+				handler: doFetchJITM,
+			},
+			{
+				name: 'dismissJITM',
+				action: dismissJITM( siteId, 'test-id', 'test-class' ),
+				handler: doDismissJITM,
+			},
+		];
+
+		test.each( actions )(
+			'$name should use /jitm path when in Jetpack',
+			( { action, handler } ) => {
+				config.isEnabled.mockImplementation( configMock( { is_running_in_jetpack_site: true } ) );
+				expect( handler( action ).path ).toBe( '/jitm' );
+			}
+		);
+
+		test.each( actions )(
+			'$name should use /sites/{siteId}/jitm path when not in Jetpack',
+			( { action, handler } ) => {
+				config.isEnabled.mockImplementation( configMock( { is_running_in_jetpack_site: false } ) );
+				expect( handler( action ).path ).toBe( `/sites/${ siteId }/jitm` );
+			}
+		);
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/jitm/test/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/test/index.js
@@ -13,13 +13,12 @@ describe( 'jitms', () => {
 				http(
 					{
 						method: 'GET',
-						path: `/jetpack-blogs/${ siteId }/rest-api/`,
+						apiNamespace: 'wpcom/v3',
+						path: `/sites/${ siteId }/jitm`,
 						query: {
-							path: '/jetpack/v4/jitm',
-							query: JSON.stringify( {
-								message_path: messagePath,
-							} ),
-							http_envelope: 1,
+							message_path: messagePath,
+							query: undefined,
+							locale: undefined,
 						},
 					},
 					action
@@ -39,15 +38,11 @@ describe( 'jitms', () => {
 				http(
 					{
 						method: 'POST',
-						path: `/jetpack-blogs/${ siteId }/rest-api/`,
-						query: {
-							path: '/jetpack/v4/jitm',
-							body: JSON.stringify( {
-								feature_class: featureClass,
-								id: messageId,
-							} ),
-							http_envelope: 1,
-							json: false,
+						apiNamespace: 'wpcom/v3',
+						path: `/sites/${ siteId }/jitm`,
+						body: {
+							feature_class: featureClass,
+							id: messageId,
 						},
 					},
 					action


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Use the new `wpcom/v3/jitm` endpoint on the Public API directly for non-Jetpack requests (see PCYsg-OT6-p2 for scenarios where Calypso code might run in a "Jetpack context").

**Note**: JP contexts continue to use the Jetpack endpoint. ~We can update that in a followup PR.~ Actually we can't because we're modifying the `schema.json` in this PR which would break those contexts. So we need to fix it!

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As part of p58i-kwy-p2 JITMs received a new endpoint in 177578-ghe-Automattic/wpcom. 

This endpoint is available on the Public API and thus calling it directly avoids the additional network hops involved in calling the endpoint on the _Jetpack_ site.

The current route for the request is: Calypso request -> Proxy request to JP site -> `jetpack/v4/jitm` -> Public API JITM endpoint

The proposed new route for the request is: Calypso request --> Public API JITM v3 endpoint.

The new v3 endpoint on the Public API routes all JITM requests [via the Jetpack mechanics](https://github.com/Automattic/jetpack/blob/f66a482cf3a893e83d84e606a41e5762448ba5cb/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-jitm.php#L121-L125).

This change should improve the speed at which JITMs load in Calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update your SB
* Add the following to `0-sandbox.php` - 3774b-pb/#php
* Check out this Calypso PR.
* Build
* In Calypso visit `/home/` for a Simple site.
* You should see the test JITM at the top fo the screen (see screenshot) below.
* You should see the `Free domain with an annual plan` JITM in the sidebar.
* Open `Network` in dev tools. Filter by `jitm`. Reload. Check that you can see requests going to Public API `wpcom/v3/jitm`. 
* Now **test you can dismiss the JITM** using the `X` icon on the JITM message in the UI. When clicked you should see a `POST` network request to the JITM endpoint with [the response being `true`](https://github.com/Automattic/jetpack/blob/45a208ffdb312ed27c74b36a4687aeceb785e7c5/projects/packages/jitm/src/class-post-connection-jitm.php#L224). 

## Testing Odyssey stats:
* Build get both Jetpack and Calypso running
* Use a tunnel to connect to your Jetpack site
* Add the following to `0-sandbox.php` - 3774c-pb/#php
* Ensure that your Jetpack site is connecting to your wpcom sandbox using the JETPACK__SANDBOX_DOMAIN const
* `cd ~/Sites/wp-calypso/apps/odyssey-stats`
* STATS_PACKAGE_PATH=~/Sites/jetpack/projects/packages/stats-admin yarn dev
* Open the Stats page: /wp-admin/admin.php?page=stats
* Dismiss the message that asks you if you're enjoying Stats
* Confirm you see a JITM
* Open your console and go to the network tab
* Filter for JITM
* Confirm that request is to the v3 endpoint

## Screenshots
<img width="2990" alt="Screen Shot 2025-03-24 at 15 59 33" src="https://github.com/user-attachments/assets/6d1eab66-de2a-4b53-8f3f-2c12554b7ab7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?