### PR TITLE
PTO Square: Use wait-for-plugins step when checking if WooCommerce is installed

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
@@ -189,9 +189,10 @@ const entrepreneurFlow: Flow = {
 		return { goBack, submit };
 	},
 
-	useSideEffect() {
+	useSideEffect( currentStepSlug ) {
 		const isLoggedIn = useSelector( isUserLoggedIn );
 
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		useEffect( () => {
 			// We need to store the anonymous user ID in localStorage because
 			// we need to pass it to the server on site creation, i.e. after the user signs up or logs in.
@@ -200,6 +201,13 @@ const entrepreneurFlow: Flow = {
 				anonIdCache.store( anonymousUserId );
 			}
 		}, [ isLoggedIn ] );
+
+		useEffect( () => {
+			// We only need to reset the store when the flow is mounted.
+			if ( ! currentStepSlug ) {
+				resetOnboardStore();
+			}
+		}, [ currentStepSlug, resetOnboardStore ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -3,7 +3,6 @@ import config from '@automattic/calypso-config';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
@@ -25,8 +24,6 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 	}
 
 	const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) as OnboardSelect, [] );
-
-	const includeWooCommerce = useIsValidWooPartner();
 
 	const handleTransferFailure = ( failureInfo: FailureInfo ) => {
 		recordTracksEvent( 'calypso_woocommerce_dashboard_snag_error', {
@@ -68,7 +65,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 			setProgress( 50 );
 			await waitForFeature();
 			setProgress( 75 );
-			await waitForLatestSiteData( includeWooCommerce );
+			await waitForLatestSiteData();
 			setProgress( 100 );
 
 			return {
@@ -83,7 +80,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 
 		// Only trigger when the siteId changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteId, includeWooCommerce ] );
+	}, [ siteId ] );
 
 	return null;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -24,6 +24,11 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data } 
 		[]
 	);
 
+	const pendingActionsPromise = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPendingAction(),
+		[]
+	);
+
 	const siteId = data?.siteId;
 	const siteSlug = data?.siteSlug;
 
@@ -99,7 +104,13 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data } 
 				backoffTime *= 2;
 			}
 
-			return { pluginsInstalled: true, siteSlug, siteId };
+			// Add potential pending actions from other steps.
+			let pendingActions = {};
+			if ( typeof pendingActionsPromise === 'function' ) {
+				pendingActions = await pendingActionsPromise();
+			}
+
+			return { ...pendingActions, pluginsInstalled: true, siteSlug, siteId };
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -105,12 +105,13 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data } 
 			}
 
 			// Add potential pending actions from other steps.
-			let pendingActions = {};
+			let redirectTo = null;
 			if ( typeof pendingActionsPromise === 'function' ) {
-				pendingActions = await pendingActionsPromise();
+				const pendingActions = await pendingActionsPromise();
+				redirectTo = pendingActions?.redirectTo;
 			}
 
-			return { ...pendingActions, pluginsInstalled: true, siteSlug, siteId };
+			return { redirectTo, pluginsInstalled: true, siteSlug, siteId };
 		} );
 
 		submit?.();

--- a/client/landing/stepper/declarative-flow/test/transferring-hosted-site-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/transferring-hosted-site-flow.tsx
@@ -9,12 +9,19 @@ import { getFlowLocation, renderFlow } from './helpers';
 const originalLocation = window.location;
 let mockIsAdminInterfaceWPAdminMock = true;
 const mockSiteId = 123;
+const mockSite = {
+	ID: mockSiteId,
+	URL: 'https://mysite.com',
+	options: {
+		admin_url: 'https://mysite.com/wp-admin',
+	},
+};
 
 jest.mock( 'calypso/state/sites/selectors', () => ( {
 	isAdminInterfaceWPAdmin: jest.fn( () => mockIsAdminInterfaceWPAdminMock ),
 } ) );
-jest.mock( '../../hooks/use-site-id-param', () => ( {
-	useSiteIdParam: jest.fn( () => mockSiteId ),
+jest.mock( '../../hooks/use-site', () => ( {
+	useSite: jest.fn( () => mockSite ),
 } ) );
 
 jest.mock( '@wordpress/data', () => {

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -126,13 +126,12 @@ export const useWaitForAtomic = ( {
 		}
 	};
 
-	const waitForLatestSiteData = async ( includeWooCommerce = false ) => {
+	const waitForLatestSiteData = async () => {
 		while ( true ) {
 			const requestedSite = await reduxDispatch< SiteDetails >( requestSite( siteId ) );
 			if (
 				requestedSite?.options?.is_wpcom_atomic &&
-				requestedSite?.capabilities?.manage_options &&
-				( ! includeWooCommerce || requestedSite?.options?.woocommerce_is_active )
+				requestedSite?.capabilities?.manage_options
 			) {
 				break;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://linear.app/a8c/issue/DOTOBRD-34/pto-square-check-if-woocommerce-is-active-is-taking-too-long

## Proposed Changes

* Use the existing `wait-for-plugin-install` step when checking if `WooCommerce` plugin is installed
* Remove the existing check of the `woocommerce_is_active` option

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Checking the option `woocommerce_is_active` takes too long as it requires the option to be synchronized to the cached database
* Using the existing step `wait-for-plugin-install` is faster as it does not depend on synchronization steps

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change
* Execute the PTO flow by navigating to `/setup/new-hosted-site/plans?partnerBundle=square`
* Create a `Business` site and follow the checkout 
* Confirm that after creating the site, the flow redirects to the WooCommerce Launchpad and you can see the `Get paid with Square` in one of the Launchpad steps.
* Repeat for the `Commerce` site and confirm the flow redirects to the WooCommerce Launchpad too as in the previous step 
![CleanShot 2025-03-24 at 16 47 53@2x](https://github.com/user-attachments/assets/167f9794-1b67-4817-ae82-cf356d449d9c)

### Regression testing
#### `new-hosted-site` flow without `partnerBundle`
* Create a site by following the flow starting with https://wordpress.com/hosting/ and clicking `Create a site` or navigating to `/setup/new-hosted-site`
* Ensure there are no unexpected errors and the sites can be created successfully.
 
#### `entrepreneur` flow
* Create a site by following the flow starting with https://wordpress.com/ecommerce/ and clicking `Get Started with Commerce` or navigating to `/setup/entrepreneur`
* Follow all the flow
* Ensure there are no unexpected errors and the site can be created successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
