### PR TITLE
Style consistency: Fix regression where it was not possible to buy domains on mobile

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -84,7 +84,7 @@ body.is-section-stepper .domains__step-content,
 		bottom: 0;
 		left: 0;
 		z-index: 99;
-		padding-bottom: 6px !important;
+		padding-bottom: 0 !important;
 		box-shadow: 0 -3px 10px 0 rgba(0, 0, 0, 0.12);
 
 		.foldable-card__main {
@@ -315,6 +315,12 @@ body.is-section-signup {
 		}
 	}
 
+	.featured-domain-suggestions {
+		@include break-mobile {
+			border-top: none;
+		}
+	}
+
 	.domains__step-content {
 		display: flex;
 
@@ -423,6 +429,10 @@ body.is-section-signup {
 			border-bottom: none;
 		}
 
+		.domains__domain-cart-foldable-card .domains__domain-side-content {
+			padding: 0;
+		}
+
 		.register-domain-step {
 			flex: 1;
 		}
@@ -503,6 +513,46 @@ body.is-section-signup {
 		@include break-mobile {
 			padding: 0;
 		}
+	}
+}
 
+.step-route.onboarding.domains:has(.step-container-v2) {
+	padding: 0;
+
+	.register-domain-step__search-card {
+		margin: 0;
+	}
+
+	.featured-domain-suggestions,
+	.domain-suggestion {
+		margin-inline: 0;
+	}
+
+	.register-domain-step__domain-side-content-container-domain-explanation-image {
+		max-width: 100%;
+		margin-bottom: 0;
+	}
+
+	.register-domain-step__example-prompt {
+		margin: 0;
+	}
+
+	.domains__domain-side-content-container {
+		display: flex;
+		margin-top: 0;
+	}
+
+	.domains__domain-side-content {
+		margin: 0;
+		flex: 1;
+		width: 100%;
+
+		@include break-medium {
+			max-width: 290px;
+		}
+	}
+
+	.domains__domain-side-content.fade-out {
+		display: none;
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -84,7 +84,7 @@ body.is-section-stepper .domains__step-content,
 		bottom: 0;
 		left: 0;
 		z-index: 99;
-		padding-bottom: 0 !important;
+		padding-bottom: 6px !important;
 		box-shadow: 0 -3px 10px 0 rgba(0, 0, 0, 0.12);
 
 		.foldable-card__main {
@@ -250,7 +250,7 @@ body.is-section-stepper .domains__step-content,
 }
 
 .onboarding {
-	&.domains:not(:has(.step-container-v2)) {
+	&.domains {
 		&.step-route {
 			padding: 60px 12px 0 12px;
 
@@ -341,6 +341,14 @@ body.is-section-signup {
 
 		.domains__domain-side-content-container {
 			flex-direction: column;
+			margin-top: 40px;
+			display: none;
+
+			@include break-large {
+				margin-top: 0;
+				flex-direction: column;
+				display: flex;
+			}
 
 			&.is-sticky {
 				position: sticky;
@@ -363,7 +371,7 @@ body.is-section-signup {
 			}
 
 			@include break-large {
-				display: none !important;
+				display: none;
 			}
 		}
 
@@ -381,8 +389,23 @@ body.is-section-signup {
 			padding: 20px 0;
 			margin: 0;
 
+			@include break-small {
+				width: 80%;
+				margin: 0 auto;
+			}
+
+			@include break-medium {
+				width: 290px;
+				margin: 0 20px;
+			}
+
 			@include break-large {
+				margin: 0 0 0 40px;
 				padding: 40px 0;
+			}
+
+			@include break-huge {
+				margin: 0 0 0 60px;
 			}
 
 			&.fade-out {
@@ -398,10 +421,6 @@ body.is-section-signup {
 
 		.domains__domain-side-content:last-of-type {
 			border-bottom: none;
-		}
-
-		.domains__domain-cart-foldable-card .domains__domain-side-content {
-			padding: 0;
 		}
 
 		.register-domain-step {
@@ -485,56 +504,5 @@ body.is-section-signup {
 			padding: 0;
 		}
 
-	}
-
-	// In StepContainerV2 the wireframe is responsible for the column
-	// padding. If we're not using this then we need our own column spacing.
-	&:not(:has(.step-container-v2)) {
-		.domains__step-content {
-			.domains__domain-side-content {
-				@include break-small {
-					width: 80%;
-					margin: 0 auto;
-				}
-
-				@include break-medium {
-					width: 290px;
-					margin: 0 20px;
-				}
-
-				@include break-large {
-					margin: 0 0 0 40px;
-				}
-
-				@include break-huge {
-					margin: 0 0 0 60px;
-				}
-			}
-
-			.domains__domain-side-content-container {
-				display: none;
-				margin-top: 40px;
-
-				@include break-large {
-					display: flex;
-					margin-top: 0;
-				}
-			}
-		}
-	}
-
-	&:has(.step-container-v2) {
-		.register-domain-step__search-card {
-			margin: 0;
-		}
-
-		.register-domain-step__domain-side-content-container-domain-explanation-image {
-			max-width: 100%;
-			margin-bottom: 0;
-		}
-
-		.register-domain-step__example-prompt {
-			margin: 0;
-		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101784. Related to https://github.com/Automattic/wp-calypso/pull/101431.

## Proposed Changes

Render bottom bar on mobile.

## Testing instructions

With the feature flag turned on (`onboarding/step-container-v2`) or off, verify you see the bottom bar when a domain is selected:

![image](https://github.com/user-attachments/assets/25987155-5876-4922-b136-1dbd939cee21)

Verify the page is still responsive in all viewports (mobile, tablet, desktop).