### PR TITLE
isMigrationInProgress checks for cancelled migrations

### DIFF
--- a/client/sites-dashboard/test/utils.js
+++ b/client/sites-dashboard/test/utils.js
@@ -5,6 +5,7 @@ describe( 'isMigrationInProgress', () => {
 		{ site: {} },
 		{ site: { site_migration: { migration_status: 'migration-completed-diy' } } },
 		{ site: { site_migration: { migration_status: 'migration-completed-difm' } } },
+		{ site: { site_migration: { migration_status: 'migration-cancelled-difm' } } },
 	] )( 'returns false when the migration is not in progress', ( { site } ) => {
 		expect( isMigrationInProgress( site ) ).toBe( false );
 	} );

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -73,7 +73,10 @@ export const isMigrationInProgress = ( site: SiteExcerptData ): boolean => {
 		return false;
 	}
 
-	return ! migrationStatus.startsWith( 'migration-completed' );
+	return (
+		! migrationStatus.startsWith( 'migration-completed' ) &&
+		! migrationStatus.startsWith( 'migration-cancelled' )
+	);
 };
 
 export const getMigrationStatus = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #101791

## Proposed Changes

Previously we still returned true if the migration was cancelled. Now we return false if the migration is completed or cancelled

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

For sites marked as `migration-cancelled-difm` via the BlogRC, those users were still seeing this screen on the site overview.

![CleanShot 2025-03-24 at 13 36 10](https://github.com/user-attachments/assets/a1ab79b3-271e-4675-b24a-380b315a4c90)

Now they'll see the normal site overview when the migration is cancelled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual inspection should be enough since the tests are updated and pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
