### PR TITLE
Subscribers: Show removal success notice after navigation

### DIFF
--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -45,7 +45,9 @@ const useUnsubscribeModal = (
 		) {
 			mutate( subscribers, {
 				onSuccess: () => {
-					// Show success notice.
+					resetSubscribers();
+					onSuccess?.();
+					// Show success notice after navigation
 					dispatch(
 						successNotice(
 							subscribers.length === 1
@@ -66,11 +68,9 @@ const useUnsubscribeModal = (
 											comment: 'Shows when multiple subscribers are removed, using the count',
 										}
 								  ),
-							{ duration: 5000 }
+							{ duration: 5000, displayOnNextPage: true }
 						)
 					);
-					resetSubscribers();
-					onSuccess?.();
 				},
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Show removal success notice after navigating back to the list.

<img width="637" alt="Screenshot 2025-03-24 at 2 36 09 PM" src="https://github.com/user-attachments/assets/899330b6-d930-4a2e-887a-fc9f4e9b6bcd" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The notice was trying to show on an unmounted component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Click on a subscriber
* Click Delete subscriber
* The panel should close
* A success notice should show

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
