### PR TITLE
Fix site setup perf

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -38,6 +38,7 @@ const SiteIntent = Onboard.SiteIntent;
 
 type ExitFlowOptions = {
 	skipLaunchpad?: boolean;
+	replaceHistory?: boolean;
 };
 
 function isLaunchpadIntent( intent: string ) {
@@ -179,70 +180,69 @@ const siteSetupFlow: FlowV1 = {
 		};
 
 		const exitFlow = ( to: string, options: ExitFlowOptions = {} ) => {
-			setPendingAction( () => {
-				/**
-				 * This implementation seems very hacky.
-				 * The new Promise returned is never resolved or rejected.
-				 *
-				 * If we were to resolve the promise when all pending actions complete,
-				 * I found out this results in setIntentOnSite and setGoalsOnSite being called multiple times
-				 * because the exitFlow itself is called more than once on actual flow exits.
-				 */
-				return new Promise( () => {
-					if ( ! siteSlug ) {
-						return;
-					}
-					const siteId = site?.ID;
-					const siteIntent = getIntent();
+			function getPendingActions() {
+				if ( ! siteSlug ) {
+					return { pendingActions: [], redirectionUrl: to };
+				}
+				const siteId = site?.ID;
+				const siteIntent = getIntent();
 
-					const settings = {
-						site_intent: siteIntent,
-						...( goals.length && { site_goals: goals } ),
-						launchpad_screen: undefined as string | undefined,
-					};
+				const settings = {
+					site_intent: siteIntent,
+					...( goals.length && { site_goals: goals } ),
+					launchpad_screen: undefined as string | undefined,
+				};
 
-					const formData: string[][] = [];
-					const pendingActions = [];
+				const formData: string[][] = [];
+				const pendingActions = [];
 
-					if ( siteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
-						pendingActions.push(
-							setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN, { enableThemeSetup: true } )
-						);
-					}
+				if ( siteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
+					pendingActions.push(
+						setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN, { enableThemeSetup: true } )
+					);
+				}
 
-					// Update Launchpad option based on site intent
-					if ( typeof siteId === 'number' ) {
-						settings.launchpad_screen = getLaunchpadScreenValue(
-							siteIntent,
-							options.skipLaunchpad ?? false
-						);
-					}
+				// Update Launchpad option based on site intent
+				if ( typeof siteId === 'number' ) {
+					settings.launchpad_screen = getLaunchpadScreenValue(
+						siteIntent,
+						options.skipLaunchpad ?? false
+					);
+				}
 
-					let redirectionUrl = to;
+				let redirectionUrl = to;
 
-					// Forcing cache invalidation to retrieve latest launchpad_screen option value
-					if ( isLaunchpadIntent( siteIntent ) ) {
-						redirectionUrl = addQueryArgs(
-							{
-								showLaunchpad: true,
-								...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
-								...( skippedCheckout && { skippedCheckout: 1 } ),
-							},
-							to
-						);
-					}
+				// Forcing cache invalidation to retrieve latest launchpad_screen option value
+				if ( isLaunchpadIntent( siteIntent ) ) {
+					redirectionUrl = addQueryArgs(
+						{
+							showLaunchpad: true,
+							...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
+							...( skippedCheckout && { skippedCheckout: 1 } ),
+						},
+						to
+					);
+				}
 
+				if (
+					settings.launchpad_screen !== site?.options?.launchpad_screen ||
+					settings.site_intent !== site?.options?.site_intent ||
+					( settings.site_goals?.length ?? 0 ) !== site?.options?.site_goals?.length
+				) {
+					// Only update the settings if they have changed
 					formData.push( [ 'settings', JSON.stringify( settings ) ] );
+				}
 
-					const enableFeaturesForGoals = getEnableFeaturesForGoals();
+				const enableFeaturesForGoals = getEnableFeaturesForGoals();
 
-					if ( enableFeaturesForGoals ) {
-						formData.push( [
-							'enable_features_for_goals',
-							JSON.stringify( enableFeaturesForGoals ),
-						] );
-					}
+				if ( enableFeaturesForGoals ) {
+					formData.push( [
+						'enable_features_for_goals',
+						JSON.stringify( enableFeaturesForGoals ),
+					] );
+				}
 
+				if ( formData.length > 0 ) {
 					pendingActions.push(
 						wpcomRequest( {
 							path: `/sites/${ siteId }/onboarding-customization`,
@@ -251,16 +251,38 @@ const siteSetupFlow: FlowV1 = {
 							formData,
 						} )
 					);
+				}
 
-					Promise.all( pendingActions )
-						// Refetch the site to get the latest data, including the new intent.
-						.then( () => dispatch( requestSite( siteSlug ) ) )
-						.then( () => window.location.assign( redirectionUrl ) );
+				// Refetch the site to get the latest data, including the new intent.
+				dispatch( requestSite( siteSlug ) );
+				return { pendingActions, redirectionUrl };
+			}
+
+			// Determine the pending actions and the redirection URL early to avoid going to the processing step unless needed.
+			const { pendingActions, redirectionUrl } = getPendingActions();
+			if ( pendingActions.length > 0 ) {
+				setPendingAction( () => {
+					/**
+					 * This implementation seems very hacky.
+					 * The new Promise returned is never resolved or rejected.
+					 *
+					 * If we were to resolve the promise when all pending actions complete,
+					 * I found out this results in setIntentOnSite and setGoalsOnSite being called multiple times
+					 * because the exitFlow itself is called more than once on actual flow exits.
+					 */
+					Promise.all( pendingActions ).then( () =>
+						options.replaceHistory
+							? window.location.replace( redirectionUrl )
+							: window.location.assign( redirectionUrl )
+					);
 				} );
-			} );
 
-			navigate( 'processing' );
-
+				navigate( 'processing' );
+			} else {
+				options.replaceHistory
+					? window.location.replace( redirectionUrl )
+					: window.location.assign( redirectionUrl );
+			}
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
 			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent', 'skipGoals' ] );
 
@@ -305,7 +327,7 @@ const siteSetupFlow: FlowV1 = {
 					if ( intent === 'sell' && storeType === 'power' ) {
 						dispatch( recordTracksEvent( 'calypso_woocommerce_dashboard_redirect' ) );
 
-						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
+						return exitFlow( `${ adminUrl }admin.php?page=wc-admin`, { replaceHistory: true } );
 					}
 
 					// Check current theme: Does it have a plugin bundled?
@@ -317,16 +339,18 @@ const siteSetupFlow: FlowV1 = {
 						isPluginBundleEligible &&
 						siteSlug
 					) {
-						return exitFlow( `/setup/plugin-bundle/?siteSlug=${ siteSlug }` );
+						return exitFlow( `/setup/plugin-bundle/?siteSlug=${ siteSlug }`, {
+							replaceHistory: true,
+						} );
 					}
 
 					if ( isLaunchpadIntent( intent ) ) {
 						initializeLaunchpadState( { siteId, siteSlug } );
 						const url = getPostFlowUrl( { flow: intent, siteId, siteSlug } );
-						return exitFlow( url );
+						return exitFlow( url, { replaceHistory: true } );
 					}
 
-					return exitFlow( `/home/${ siteId ?? siteSlug }` );
+					return exitFlow( `/home/${ siteId ?? siteSlug }`, { replaceHistory: true } );
 				}
 
 				case 'bloggerStartingPoint': {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
