### PR TITLE
Onboarding style consistency: Remove subheading on the "Use a domain I own" step

### DIFF
--- a/client/components/domains/use-my-domain/domain-input.jsx
+++ b/client/components/domains/use-my-domain/domain-input.jsx
@@ -2,7 +2,7 @@ import { Card, Button, FormInputValidation, Gridicon } from '@automattic/compone
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useId } from 'react';
 import { connect } from 'react-redux';
 import illustration from 'calypso/assets/images/domains/domain.svg';
 import FormButton from 'calypso/components/forms/form-button';
@@ -24,6 +24,7 @@ function UseMyDomainInput( {
 	validationError,
 } ) {
 	const domainNameInput = useRef( null );
+	const inputId = 'use-my-domain-input-' + useId();
 
 	useEffect( () => {
 		shouldSetFocus && domainNameInput.current.focus();
@@ -53,9 +54,10 @@ function UseMyDomainInput( {
 				</div>
 			) }
 			<div className={ baseClassName + '__domain-input' }>
-				<label>{ __( 'Enter the domain you would like to use:' ) }</label>
+				<label htmlFor={ inputId }>{ __( 'Enter the domain you would like to use:' ) }</label>
 				<FormFieldset className={ baseClassName + '__domain-input-fieldset' }>
 					<FormTextInput
+						id={ inputId }
 						placeholder={ __( 'yourgroovydomain.com' ) }
 						value={ domainName }
 						onChange={ onChange }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -126,13 +126,9 @@ const UseMyDomain: StepType< {
 	const shouldHideButtons = isStartWritingFlow( flow );
 
 	if ( shouldUseStepContainerV2( flow ) ) {
-		const [ columnWidth, headingText, subHeadingText ] =
+		const [ columnWidth, headingText ] =
 			useMyDomainMode === 'domain-input'
-				? [
-						4 as const,
-						__( 'Use a domain I own' ),
-						__( 'Enter the domain you would like to use.' ),
-				  ]
+				? [ 4 as const, __( 'Use a domain I own' ) ]
 				: [
 						10 as const,
 						<>
@@ -140,7 +136,6 @@ const UseMyDomain: StepType< {
 							<br />
 							{ getInitialQuery() }
 						</>,
-						undefined,
 				  ];
 
 		return (
@@ -155,7 +150,7 @@ const UseMyDomain: StepType< {
 						/>
 					}
 					columnWidth={ columnWidth }
-					heading={ <Step.Heading text={ headingText } subText={ subHeadingText } /> }
+					heading={ <Step.Heading text={ headingText } /> }
 				>
 					{ getStepContent() }
 				</Step.CenteredColumnLayout>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #101804

## Proposed Changes

* Remove subheading on the "Use a domain I own" step, discussed here p1742799582663609-slack-C08HKNPL2BG
* While I'm here, I improved accessibility of the domain search box on the "Use a domain I own" step by correctly implementing the label

![CleanShot 2025-03-25 at 10 58 54@2x](https://github.com/user-attachments/assets/acb8d9b6-ceb3-4877-aba4-2695be9e5950)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The subheading and the input label had matching text. Which seemed strange. Discussed here:
p1742799582663609-slack-C08HKNPL2BG


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Nav to `/setup/onboarding?flags=onboarding/step-container-v2`
* Click "Use a domain I own"
* Confirm the step has no sub heading
* When inspecting the input box in the a11y tree you see it is now labelled correctly
  * You can also see it's labeled correctly because when you mouse click the label it not focuses the input box

* Test without the feature flag: `/setup/onboarding?flags=-onboarding/step-container-v2`
* Confirm the same lack of subheading and accessibility fix
  * There never used to be a subheading

![CleanShot 2025-03-25 at 10 56 48@2x](https://github.com/user-attachments/assets/16e35dbb-f846-4e33-a318-178d83b73611)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?