### PR TITLE
Onboarding Copy Polish: Update design picker subtitle

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -919,7 +919,7 @@ const UnifiedDesignPickerStep: StepType< {
 		: translate( 'Pick a design' );
 
 	const subHeaderText = translate(
-		'One of these homepage options could be great to start with. You can always change later.'
+		'Choose a homepage design that works for you. You can always change it later.'
 	);
 
 	// Use this to prioritize themes in certain categories.

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -1,3 +1,4 @@
+import { PLAN_PERSONAL, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
 import {
 	__unstableComposite as Composite,
@@ -31,6 +32,7 @@ interface ColorPaletteVariationsProps {
 	selectedColorPaletteVariation: GlobalStylesObject | null;
 	onSelect: ( colorPaletteVariation: GlobalStylesObject | null ) => void;
 	limitGlobalStyles?: boolean;
+	isGlobalStylesOnPersonal?: boolean;
 }
 
 const ColorPaletteVariation = ( {
@@ -87,10 +89,18 @@ const ColorPaletteVariations = ( {
 	selectedColorPaletteVariation,
 	onSelect,
 	limitGlobalStyles,
+	isGlobalStylesOnPersonal = window.isGlobalStylesOnPersonal ?? false,
 }: ColorPaletteVariationsProps ) => {
 	const { base } = useContext( GlobalStylesContext );
 	const colorPaletteVariations = useColorPaletteVariations( stylesheet ) ?? [];
 	const composite = useCompositeState();
+
+	const upgradeToPlan = isGlobalStylesOnPersonal ? PLAN_PERSONAL : PLAN_PREMIUM;
+
+	const variationDescription = translate(
+		'Preview our style variations for free or pick your own fonts and colors with the %(planName)s plan later on.',
+		{ args: { planName: getPlan( upgradeToPlan )?.getTitle() ?? '' } }
+	);
 
 	return (
 		<Composite
@@ -124,6 +134,7 @@ const ColorPaletteVariations = ( {
 						}
 					/>
 				</h3>
+				<p className="global-styles-variations__group-description">{ variationDescription }</p>
 				<div className="color-palette-variations">
 					{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (
 						<ColorPaletteVariation

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -1,4 +1,6 @@
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .color-palette-variations {
 	display: grid;
@@ -69,4 +71,18 @@
 
 .global-styles-variations__group-title-actual {
 	white-space: nowrap;
+}
+
+.global-styles-variations__group-description {
+	color: var(--color-neutral-60);
+	font-size: 0.875rem;
+	letter-spacing: -0.15px;
+	padding: 6px 0 6px 0;
+	line-height: 20px;
+	margin: 0;
+
+	display: none;
+	@include break-large {
+		display: block;
+	}
 }

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -115,7 +115,7 @@ const GlobalStylesVariations = ( {
 
 	const variationDescription = needsUpgrade
 		? translate(
-				'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
+				'Preview our style variations for free or pick your own fonts and colors with the %(planName)s plan later on.',
 				{ args: { planName: getPlan( upgradeToPlan )?.getTitle() ?? '' } }
 		  )
 		: translate( 'You can change your style at any time.' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

closes https://github.com/Automattic/wp-calypso/issues/98843
closes https://github.com/Automattic/wp-calypso/issues/98844
## Proposed Changes

* Update design picker subtitle to new copy

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to setup/onboarding and go through to the design picker
* Verify the copies are correct. Subtitle and Style variations

![image](https://github.com/user-attachments/assets/32b3797d-2556-497f-9b32-dbe46b692a7f)
![image](https://github.com/user-attachments/assets/f78eb3e1-83cc-41b1-b4b0-d331093515ce)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
