### PR TITLE
Onboarding consistency: Use StepContainerV2 in checkout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -20,6 +20,7 @@ import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
 import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
@@ -31,6 +32,7 @@ import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { isOffline } from 'calypso/state/application/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
@@ -431,7 +433,8 @@ export default withCurrentRoute(
 			isWpMobileApp() ||
 			isWcMobileApp() ||
 			isJetpackCloud() ||
-			isA8CForAgencies();
+			isA8CForAgencies() ||
+			( sectionName === 'checkout' && shouldUseStepContainerV2( getSignupCompleteFlowName() ) );
 		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 		const isJetpackWooDnaFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -13,6 +13,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import MasterbarLoggedOut from 'calypso/layout/masterbar/logged-out';
 import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
@@ -33,6 +34,7 @@ import {
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getOnboardingUrl as getPatternLibraryOnboardingUrl } from 'calypso/my-sites/patterns/paths';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal, isTwoFactorEnabled } from 'calypso/state/login/selectors';
 import {
@@ -372,7 +374,8 @@ export default withCurrentRoute(
 				! ( currentSection || currentRoute ) ||
 				! masterbarIsVisible( state ) ||
 				noMasterbarForSection ||
-				noMasterbarForRoute;
+				noMasterbarForRoute ||
+				( sectionName === 'checkout' && shouldUseStepContainerV2( getSignupCompleteFlowName() ) );
 			const twoFactorEnabled = isTwoFactorEnabled( state );
 
 			const colorScheme = isWooJPC ? getColorSchemeFromCurrentQuery( currentQuery ) : null;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -1,25 +1,8 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon } from '@automattic/components';
-import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
-import {
-	useProductsCustomOptions,
-	useProductsWithPremiumSupport,
-} from '@automattic/help-center/src/hooks';
-import { useShoppingCart } from '@automattic/shopping-cart';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
-import {
-	useDispatch as useDataStoreDispatch,
-	useSelect as useDataStoreSelect,
-} from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-
-const HELP_CENTER_STORE = HelpCenter.register();
+import { useCheckoutHelpCenter } from 'calypso/my-sites/checkout/src/hooks/use-checkout-help-center';
 
 const ContactContainer = styled.div`
 	display: flex;
@@ -65,53 +48,8 @@ const ContactContainer = styled.div`
 `;
 
 export function DefaultMasterbarContact() {
-	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
 	const translate = useTranslate();
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
-
-	const {
-		hasPremiumSupport,
-		userFieldMessage,
-		userFieldFlowName,
-		helpCenterButtonCopy,
-		helpCenterButtonLink,
-	} = useProductsWithPremiumSupport( responseCart.products, 'checkout' );
-	const helpCenterOptions = useProductsCustomOptions( responseCart.products );
-
-	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
-
-	const isShowingHelpCenter = useDataStoreSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
-		[]
-	);
-	const toggleHelpCenter = () => {
-		recordTracksEvent( `calypso_thank_you_inlinehelp_${ isShowingHelpCenter ? 'close' : 'show' }`, {
-			force_site_id: true,
-			location: 'thank-you-help-center',
-		} );
-
-		if ( hasPremiumSupport ) {
-			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, helpCenterOptions );
-			const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
-				userFieldMessage,
-				userFieldFlowName,
-				siteUrl: siteSlug,
-				siteId,
-			} );
-			setNavigateToRoute( urlWithQueryArgs );
-		} else {
-			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport );
-		}
-	};
-
-	useEffect( () => {
-		return () => {
-			setShowHelpCenter( false );
-		};
-	}, [] );
+	const { helpCenterButtonCopy, helpCenterButtonLink, toggleHelpCenter } = useCheckoutHelpCenter();
 
 	return (
 		<ContactContainer>

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -41,7 +41,6 @@ jest.mock( '../redesign-v2/pages/plan-only', () => () => (
 jest.mock( '../redesign-v2/pages/generic', () => () => (
 	<div data-testid="component--generic-thank-you" />
 ) );
-jest.mock( '@wordpress/api-fetch' );
 
 const translate = ( x ) => x;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -823,21 +823,26 @@ export default function CheckoutMainContent( {
 	}
 
 	return (
-		<Step.FullWidthLayout
-			isMediumViewport={ isMediumViewport }
-			hasContentPadding={ false }
-			topBar={ <Step.TopBar /> }
-		>
-			<StepContainerV2CheckoutFixer isMediumViewport={ isMediumViewport }>
+		<StepContainerV2CheckoutFixer isMediumViewport={ isMediumViewport }>
+			<Step.FullWidthLayout
+				isMediumViewport={ isMediumViewport }
+				hasContentPadding={ false }
+				topBar={ <Step.TopBar backButton={ <Step.BackButton /> } /> }
+			>
 				{ content }
-			</StepContainerV2CheckoutFixer>
-		</Step.FullWidthLayout>
+			</Step.FullWidthLayout>
+		</StepContainerV2CheckoutFixer>
 	);
 }
 
 const StepContainerV2CheckoutFixer = styled.div< { isMediumViewport: boolean } >`
 	.checkout-wrapper {
 		margin-top: calc( var( --step-container-v2-top-bar-height ) * -1 );
+	}
+
+	.step-container-v2__top-bar-wrapper {
+		position: relative;
+		z-index: 1;
 	}
 
 	${ ( props ) =>

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -30,7 +30,7 @@ import {
 	getContactDetailsType,
 	ContactDetailsType,
 } from '@automattic/wpcom-checkout';
-import { keyframes } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
@@ -621,7 +621,11 @@ export default function CheckoutMainContent( {
 			<WPCheckoutMainContent className="checkout-main-content">
 				<CheckoutOrderBanner />
 				{ isStepContainerV2 ? (
-					<Step.Heading text={ translate( 'Checkout' ) } align="left" />
+					<Step.Heading
+						text={ translate( 'Checkout' ) }
+						align="left"
+						size={ ! isMediumViewport ? 'small' : undefined }
+					/>
 				) : (
 					<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
 				) }
@@ -824,73 +828,88 @@ export default function CheckoutMainContent( {
 			hasContentPadding={ false }
 			topBar={ <Step.TopBar /> }
 		>
-			<StepContainerV2CheckoutFixer>{ content }</StepContainerV2CheckoutFixer>
+			<StepContainerV2CheckoutFixer isMediumViewport={ isMediumViewport }>
+				{ content }
+			</StepContainerV2CheckoutFixer>
 		</Step.FullWidthLayout>
 	);
 }
 
-const StepContainerV2CheckoutFixer = styled.div`
+const StepContainerV2CheckoutFixer = styled.div< { isMediumViewport: boolean } >`
 	.checkout-wrapper {
 		margin-top: calc( var( --step-container-v2-top-bar-height ) * -1 );
 	}
 
-	.checkout-sidebar-content {
-		margin-top: var( --step-container-v2-top-bar-height );
-	}
+	${ ( props ) =>
+		! props.isMediumViewport &&
+		css`
+			.checkout-sidebar-content {
+				margin-top: var( --step-container-v2-top-bar-height );
+			}
 
-	.checkout__summary-button {
-		border-bottom: none;
-	}
+			.checkout__summary-button {
+				border-bottom: none;
+			}
 
-	.checkout__summary-body {
-		padding: var( --step-container-v2-content-block-padding )
-			var( --step-container-v2-content-inline-padding );
-		max-width: 100%;
-	}
+			.checkout__summary-body {
+				padding: var( --step-container-v2-content-block-padding )
+					var( --step-container-v2-content-inline-padding );
+				max-width: 100%;
+			}
 
-	.checkout__summary-features {
-		padding: 0;
-		width: 100%;
-	}
+			.checkout__summary-features {
+				padding: 0;
+				width: 100%;
+			}
 
-	.checkout__summary-title {
-		margin: 0;
-		padding: var( --step-container-v2-content-inline-padding );
-		max-width: 100%;
-	}
+			.checkout__summary-title {
+				margin: 0;
+				padding: var( --step-container-v2-content-inline-padding );
+				max-width: 100%;
+			}
 
-	.checkout-sidebar-plan-upsell {
-		margin: 0;
-		max-width: 100%;
-	}
+			.checkout-sidebar-plan-upsell {
+				margin: 0;
+				max-width: 100%;
+			}
 
-	.checkout-main-content {
-		margin-top: 0;
-		padding: var( --step-container-v2-content-block-padding )
-			var( --step-container-v2-content-inline-padding );
-		max-width: 100%;
-	}
+			.checkout-main-content {
+				margin-top: 0;
+				padding: var( --step-container-v2-content-block-padding )
+					var( --step-container-v2-content-inline-padding );
+				max-width: 100%;
+			}
 
-	.wp-checkout__review-order-step,
-	.checkout-contact-form-step,
-	.checkout__payment-method-step,
-	.checkout-terms-and-checkboxes,
-	.checkout-steps__step-content {
-		padding-inline: 0;
-	}
+			.wp-checkout__review-order-step,
+			.checkout-contact-form-step,
+			.checkout__payment-method-step,
+			.checkout-terms-and-checkboxes,
+			.checkout-steps__step-complete-content,
+			.checkout-steps__step-content {
+				padding-inline: 0;
+			}
 
-	.checkout-steps__submit-button-wrapper {
-		max-width: 100%;
-		padding-inline: var( --step-container-v2-content-inline-padding );
+			.checkout-steps__submit-button-wrapper {
+				max-width: 100%;
+				padding-inline: var( --step-container-v2-content-inline-padding );
 
-		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-			padding-inline: 0;
-		}
-	}
+				@media ( ${ props.theme.breakpoints.tabletUp } ) {
+					padding-inline: 0;
+				}
+			}
 
-	.checkout-steps__submit-footer-wrapper {
-		min-height: auto;
-	}
+			.checkout-steps__submit-footer-wrapper {
+				min-height: auto;
+			}
+		` }
+
+	${ ( props ) =>
+		props.isMediumViewport &&
+		css`
+			.checkout__summary-area {
+				transform: translateY( -54px );
+			}
+		` }
 `;
 
 const CheckoutSummary = styled.div`

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -22,6 +22,7 @@ import {
 	useTransactionStatus,
 	TransactionStatus,
 } from '@automattic/composite-checkout';
+import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	styled,
@@ -30,11 +31,13 @@ import {
 	ContactDetailsType,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
+import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import { formatCurrency, useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import Loading from 'calypso/components/loading';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import {
 	hasGoogleApps,
@@ -60,6 +63,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import useOneDollarOfferTrack from 'calypso/my-sites/plans/hooks/use-onedollar-offer-track';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -489,6 +493,9 @@ export default function CheckoutMainContent( {
 
 	useOneDollarOfferTrack( siteId, 'checkout' );
 
+	const isStepContainerV2 = shouldUseStepContainerV2( getSignupCompleteFlowName() );
+	const isMediumViewport = useViewportMatch( 'large', '>=' );
+
 	if ( ! checkoutActions ) {
 		return null;
 	}
@@ -556,9 +563,9 @@ export default function CheckoutMainContent( {
 		return true;
 	};
 
-	return (
-		<WPCheckoutWrapper>
-			<WPCheckoutSidebarContent>
+	const content = (
+		<WPCheckoutWrapper className="checkout-wrapper">
+			<WPCheckoutSidebarContent className="checkout-sidebar-content">
 				{ isLoading && <LoadingSidebarContent /> }
 				{ ! isLoading && (
 					<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
@@ -566,10 +573,15 @@ export default function CheckoutMainContent( {
 							errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
 							onError={ onSummaryError }
 						>
-							<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
-								<CheckoutSummaryTitleContent>
+							<CheckoutSummaryTitleLink
+								className="checkout__summary-button"
+								onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }
+							>
+								<CheckoutSummaryTitleContent className="checkout__summary-title">
 									<CheckoutSummaryTitle>
-										<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
+										{ ! isStepContainerV2 && (
+											<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
+										) }
 										{ translate( 'Purchase Details' ) }
 										<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
 									</CheckoutSummaryTitle>
@@ -606,9 +618,13 @@ export default function CheckoutMainContent( {
 				) }
 			</WPCheckoutSidebarContent>
 
-			<WPCheckoutMainContent>
+			<WPCheckoutMainContent className="checkout-main-content">
 				<CheckoutOrderBanner />
-				<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
+				{ isStepContainerV2 ? (
+					<Step.Heading text={ translate( 'Checkout' ) } align="left" />
+				) : (
+					<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
+				) }
 				<CheckoutStepGroup loadingHeader={ loadingHeader } onStepChanged={ onStepChanged }>
 					<PerformanceTrackerStop />
 					{ infoMessage }
@@ -797,7 +813,85 @@ export default function CheckoutMainContent( {
 			</WPCheckoutMainContent>
 		</WPCheckoutWrapper>
 	);
+
+	if ( ! isStepContainerV2 ) {
+		return content;
+	}
+
+	return (
+		<Step.FullWidthLayout
+			isMediumViewport={ isMediumViewport }
+			hasContentPadding={ false }
+			topBar={ <Step.TopBar /> }
+		>
+			<StepContainerV2CheckoutFixer>{ content }</StepContainerV2CheckoutFixer>
+		</Step.FullWidthLayout>
+	);
 }
+
+const StepContainerV2CheckoutFixer = styled.div`
+	.checkout-wrapper {
+		margin-top: calc( var( --step-container-v2-top-bar-height ) * -1 );
+	}
+
+	.checkout-sidebar-content {
+		margin-top: var( --step-container-v2-top-bar-height );
+	}
+
+	.checkout__summary-button {
+		border-bottom: none;
+	}
+
+	.checkout__summary-body {
+		padding: var( --step-container-v2-content-block-padding )
+			var( --step-container-v2-content-inline-padding );
+		max-width: 100%;
+	}
+
+	.checkout__summary-features {
+		padding: 0;
+		width: 100%;
+	}
+
+	.checkout__summary-title {
+		margin: 0;
+		padding: var( --step-container-v2-content-inline-padding );
+		max-width: 100%;
+	}
+
+	.checkout-sidebar-plan-upsell {
+		margin: 0;
+		max-width: 100%;
+	}
+
+	.checkout-main-content {
+		margin-top: 0;
+		padding: var( --step-container-v2-content-block-padding )
+			var( --step-container-v2-content-inline-padding );
+		max-width: 100%;
+	}
+
+	.wp-checkout__review-order-step,
+	.checkout-contact-form-step,
+	.checkout__payment-method-step,
+	.checkout-terms-and-checkboxes,
+	.checkout-steps__step-content {
+		padding-inline: 0;
+	}
+
+	.checkout-steps__submit-button-wrapper {
+		max-width: 100%;
+		padding-inline: var( --step-container-v2-content-inline-padding );
+
+		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+			padding-inline: 0;
+		}
+	}
+
+	.checkout-steps__submit-footer-wrapper {
+		min-height: auto;
+	}
+`;
 
 const CheckoutSummary = styled.div`
 	box-sizing: border-box;
@@ -992,7 +1086,7 @@ function CheckoutTermsAndCheckboxes( {
 	const translate = useTranslate();
 
 	return (
-		<CheckoutTermsAndCheckboxesWrapper>
+		<CheckoutTermsAndCheckboxesWrapper className="checkout-terms-and-checkboxes">
 			<BeforeSubmitCheckoutHeader />
 
 			{ hasMarketplaceProduct && (

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -21,7 +21,6 @@ import {
 	usePaymentMethod,
 	useTransactionStatus,
 	TransactionStatus,
-	CheckoutModal,
 } from '@automattic/composite-checkout';
 import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -89,6 +88,7 @@ import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import { GoogleDomainsCopy } from './google-transfers-copy';
 import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-sidebar-plan-upsell';
+import { LeaveCheckoutModal, useCheckoutLeaveModal } from './leave-checkout-modal';
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview, { CouponFieldArea } from './wp-checkout-order-review';
@@ -372,10 +372,8 @@ export default function CheckoutMainContent( {
 } ) {
 	const translate = useTranslate();
 	const cartKey = useCartKey();
-	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const {
 		responseCart,
-		replaceProductsInCart,
 		applyCoupon,
 		updateLocation,
 		replaceProductInCart,
@@ -383,6 +381,8 @@ export default function CheckoutMainContent( {
 		removeCoupon,
 		couponStatus,
 	} = useShoppingCart( cartKey );
+
+	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
 
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
@@ -828,53 +828,6 @@ export default function CheckoutMainContent( {
 		return content;
 	}
 
-	const closeAndLeave = ( options?: {
-		userHasClearedCart?: boolean;
-		closedWithoutConfirmation?: boolean;
-	} ) => {
-		const userHasClearedCart = options?.userHasClearedCart ?? false;
-		if ( ! options?.closedWithoutConfirmation ) {
-			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_submitted', {
-				user_has_cleared_cart: userHasClearedCart,
-			} );
-		}
-		leaveCheckout( {
-			siteSlug: siteUrl,
-			forceCheckoutBackUrl,
-			previousPath,
-			tracksEvent: 'calypso_masterbar_close_clicked',
-			userHasClearedCart: userHasClearedCart,
-		} );
-	};
-
-	const shouldClearCartWhenLeaving = ! window.location.pathname.startsWith(
-		'/checkout/failed-purchases'
-	);
-
-	const clickClose = () => {
-		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
-			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
-			setIsModalVisible( true );
-			return;
-		}
-		closeAndLeave( {
-			closedWithoutConfirmation: true,
-		} );
-	};
-
-	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
-	const modalBodyText = translate( 'You can leave the items in the cart or empty the cart.' );
-	/* translators: The label to a button that will exit checkout without removing items from the shopping cart. */
-	const modalPrimaryText = translate( 'Leave items' );
-	/* translators: The label to a button that will remove all items from the shopping cart. */
-	const modalSecondaryText = translate( 'Empty cart' );
-	const clearCartAndLeave = () => {
-		replaceProductsInCart( [] );
-		closeAndLeave( {
-			userHasClearedCart: true,
-		} );
-	};
-
 	return (
 		<StepContainerV2CheckoutFixer isMediumViewport={ isMediumViewport }>
 			<Step.FullWidthLayout
@@ -882,7 +835,7 @@ export default function CheckoutMainContent( {
 				hasContentPadding={ false }
 				topBar={
 					<Step.TopBar
-						backButton={ <Step.BackButton onClick={ clickClose } /> }
+						backButton={ <Step.BackButton onClick={ leaveModalProps.clickClose } /> }
 						skipButton={
 							<span className="checkout-skip-button">
 								<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) } </label>
@@ -897,16 +850,7 @@ export default function CheckoutMainContent( {
 			>
 				{ content }
 			</Step.FullWidthLayout>
-			<CheckoutModal
-				title={ modalTitleText }
-				copy={ modalBodyText }
-				closeModal={ () => setIsModalVisible( false ) }
-				isVisible={ isModalVisible }
-				primaryButtonCTA={ modalPrimaryText }
-				primaryAction={ closeAndLeave }
-				secondaryButtonCTA={ modalSecondaryText }
-				secondaryAction={ clearCartAndLeave }
-			/>
+			<LeaveCheckoutModal { ...leaveModalProps } />
 		</StepContainerV2CheckoutFixer>
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -21,6 +21,7 @@ import {
 	usePaymentMethod,
 	useTransactionStatus,
 	TransactionStatus,
+	CheckoutModal,
 } from '@automattic/composite-checkout';
 import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -370,8 +371,10 @@ export default function CheckoutMainContent( {
 } ) {
 	const translate = useTranslate();
 	const cartKey = useCartKey();
+	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const {
 		responseCart,
+		replaceProductsInCart,
 		applyCoupon,
 		updateLocation,
 		replaceProductInCart,
@@ -822,15 +825,72 @@ export default function CheckoutMainContent( {
 		return content;
 	}
 
+	const closeAndLeave = ( options?: {
+		userHasClearedCart?: boolean;
+		closedWithoutConfirmation?: boolean;
+	} ) => {
+		const userHasClearedCart = options?.userHasClearedCart ?? false;
+		if ( ! options?.closedWithoutConfirmation ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_submitted', {
+				user_has_cleared_cart: userHasClearedCart,
+			} );
+		}
+		leaveCheckout( {
+			siteSlug: siteUrl,
+			forceCheckoutBackUrl,
+			previousPath,
+			tracksEvent: 'calypso_masterbar_close_clicked',
+			userHasClearedCart: userHasClearedCart,
+		} );
+	};
+
+	const shouldClearCartWhenLeaving = ! window.location.pathname.startsWith(
+		'/checkout/failed-purchases'
+	);
+
+	const clickClose = () => {
+		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
+			setIsModalVisible( true );
+			return;
+		}
+		closeAndLeave( {
+			closedWithoutConfirmation: true,
+		} );
+	};
+
+	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
+	const modalBodyText = translate( 'You can leave the items in the cart or empty the cart.' );
+	/* translators: The label to a button that will exit checkout without removing items from the shopping cart. */
+	const modalPrimaryText = translate( 'Leave items' );
+	/* translators: The label to a button that will remove all items from the shopping cart. */
+	const modalSecondaryText = translate( 'Empty cart' );
+	const clearCartAndLeave = () => {
+		replaceProductsInCart( [] );
+		closeAndLeave( {
+			userHasClearedCart: true,
+		} );
+	};
+
 	return (
 		<StepContainerV2CheckoutFixer isMediumViewport={ isMediumViewport }>
 			<Step.FullWidthLayout
 				isMediumViewport={ isMediumViewport }
 				hasContentPadding={ false }
-				topBar={ <Step.TopBar backButton={ <Step.BackButton /> } /> }
+				topBar={ <Step.TopBar backButton={ <Step.BackButton onClick={ clickClose } /> } /> }
 			>
 				{ content }
 			</Step.FullWidthLayout>
+			<CheckoutModal
+				title={ modalTitleText }
+				copy={ modalBodyText }
+				closeModal={ () => setIsModalVisible( false ) }
+				isVisible={ isModalVisible }
+				primaryButtonCTA={ modalPrimaryText }
+				primaryAction={ closeAndLeave }
+				secondaryButtonCTA={ modalSecondaryText }
+				secondaryAction={ clearCartAndLeave }
+			/>
 		</StepContainerV2CheckoutFixer>
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -73,6 +73,7 @@ import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selector
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useUpdateCachedContactDetails } from '../hooks/use-cached-contact-details';
+import { useCheckoutHelpCenter } from '../hooks/use-checkout-help-center';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import { validateContactDetails } from '../lib/contact-validation';
 import { updateCartContactDetailsForCheckout } from '../lib/update-cart-contact-details-for-checkout';
@@ -499,6 +500,8 @@ export default function CheckoutMainContent( {
 	const isStepContainerV2 = shouldUseStepContainerV2( getSignupCompleteFlowName() );
 	const isMediumViewport = useViewportMatch( 'large', '>=' );
 
+	const { helpCenterButtonCopy, helpCenterButtonLink, toggleHelpCenter } = useCheckoutHelpCenter();
+
 	if ( ! checkoutActions ) {
 		return null;
 	}
@@ -877,7 +880,20 @@ export default function CheckoutMainContent( {
 			<Step.FullWidthLayout
 				isMediumViewport={ isMediumViewport }
 				hasContentPadding={ false }
-				topBar={ <Step.TopBar backButton={ <Step.BackButton onClick={ clickClose } /> } /> }
+				topBar={
+					<Step.TopBar
+						backButton={ <Step.BackButton onClick={ clickClose } /> }
+						skipButton={
+							<span className="checkout-skip-button">
+								<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) } </label>
+								<Step.SkipButton
+									onClick={ toggleHelpCenter }
+									label={ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }
+								/>
+							</span>
+						}
+					/>
+				}
 			>
 				{ content }
 			</Step.FullWidthLayout>
@@ -898,6 +914,16 @@ export default function CheckoutMainContent( {
 const StepContainerV2CheckoutFixer = styled.div< { isMediumViewport: boolean } >`
 	.checkout-wrapper {
 		margin-top: calc( var( --step-container-v2-top-bar-height ) * -1 );
+	}
+
+	.checkout-skip-button {
+		label {
+			display: none;
+
+			@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
+				display: inline;
+			}
+		}
 	}
 
 	.step-container-v2__top-bar-wrapper {

--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -1,0 +1,96 @@
+import { CheckoutModal } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getPreviousRoute from '../../../../state/selectors/get-previous-route';
+import useCartKey from '../../use-cart-key';
+import useValidCheckoutBackUrl from '../hooks/use-valid-checkout-back-url';
+import { leaveCheckout } from '../lib/leave-checkout';
+
+export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
+	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const forceCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
+	const cartKey = useCartKey();
+	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
+	const previousPath = useSelector( getPreviousRoute );
+
+	const closeAndLeave = ( options?: {
+		userHasClearedCart?: boolean;
+		closedWithoutConfirmation?: boolean;
+	} ) => {
+		const userHasClearedCart = options?.userHasClearedCart ?? false;
+		if ( ! options?.closedWithoutConfirmation ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_submitted', {
+				user_has_cleared_cart: userHasClearedCart,
+			} );
+		}
+		leaveCheckout( {
+			siteSlug: siteUrl,
+			forceCheckoutBackUrl,
+			previousPath,
+			tracksEvent: 'calypso_masterbar_close_clicked',
+			userHasClearedCart: userHasClearedCart,
+		} );
+	};
+
+	const shouldClearCartWhenLeaving = ! window.location.pathname.startsWith(
+		'/checkout/failed-purchases'
+	);
+
+	const clickClose = () => {
+		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
+			setIsModalVisible( true );
+			return;
+		}
+		closeAndLeave( {
+			closedWithoutConfirmation: true,
+		} );
+	};
+
+	const clearCartAndLeave = () => {
+		replaceProductsInCart( [] );
+		closeAndLeave( {
+			userHasClearedCart: true,
+		} );
+	};
+
+	return {
+		isModalVisible,
+		setIsModalVisible,
+		clickClose,
+		closeAndLeave,
+		clearCartAndLeave,
+	};
+};
+
+export const LeaveCheckoutModal = ( {
+	isModalVisible,
+	setIsModalVisible,
+	closeAndLeave,
+	clearCartAndLeave,
+}: ReturnType< typeof useCheckoutLeaveModal > ) => {
+	const translate = useTranslate();
+
+	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
+	const modalBodyText = translate( 'You can leave the items in the cart or empty the cart.' );
+	/* translators: The label to a button that will exit checkout without removing items from the shopping cart. */
+	const modalPrimaryText = translate( 'Leave items' );
+	/* translators: The label to a button that will remove all items from the shopping cart. */
+	const modalSecondaryText = translate( 'Empty cart' );
+
+	return (
+		<CheckoutModal
+			title={ modalTitleText }
+			copy={ modalBodyText }
+			closeModal={ () => setIsModalVisible( false ) }
+			isVisible={ isModalVisible }
+			primaryButtonCTA={ modalPrimaryText }
+			primaryAction={ closeAndLeave }
+			secondaryButtonCTA={ modalSecondaryText }
+			secondaryAction={ clearCartAndLeave }
+		/>
+	);
+};

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -139,7 +139,7 @@ export function CheckoutSummaryFeaturedList( {
 
 	return (
 		<>
-			<CheckoutSummaryFeatures>
+			<CheckoutSummaryFeatures className="checkout__summary-features">
 				<CheckoutSummaryFeaturesTitle>
 					{ responseCart.is_gift_purchase
 						? translate( 'WordPress.com Gift Subscription' )

--- a/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-help-center.ts
@@ -1,0 +1,73 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
+import {
+	useProductsCustomOptions,
+	useProductsWithPremiumSupport,
+} from '@automattic/help-center/src/hooks';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import {
+	useDispatch as useDataStoreDispatch,
+	useSelect as useDataStoreSelect,
+} from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+export const useCheckoutHelpCenter = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+
+	const {
+		hasPremiumSupport,
+		userFieldMessage,
+		userFieldFlowName,
+		helpCenterButtonCopy,
+		helpCenterButtonLink,
+	} = useProductsWithPremiumSupport( responseCart.products, 'checkout' );
+	const helpCenterOptions = useProductsCustomOptions( responseCart.products );
+
+	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const isShowingHelpCenter = useDataStoreSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const toggleHelpCenter = () => {
+		recordTracksEvent( `calypso_thank_you_inlinehelp_${ isShowingHelpCenter ? 'close' : 'show' }`, {
+			force_site_id: true,
+			location: 'thank-you-help-center',
+		} );
+
+		if ( hasPremiumSupport ) {
+			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport, helpCenterOptions );
+			const urlWithQueryArgs = addQueryArgs( '/odie?provider=zendesk', {
+				userFieldMessage,
+				userFieldFlowName,
+				siteUrl: siteSlug,
+				siteId,
+			} );
+			setNavigateToRoute( urlWithQueryArgs );
+		} else {
+			setShowHelpCenter( ! isShowingHelpCenter, hasPremiumSupport );
+		}
+	};
+
+	useEffect( () => {
+		return () => {
+			setShowHelpCenter( false );
+		};
+	}, [] );
+
+	return {
+		toggleHelpCenter,
+		helpCenterButtonCopy,
+		helpCenterButtonLink,
+	};
+};

--- a/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
+++ b/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
@@ -28,10 +28,6 @@ import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import UpsellNudge, { PROFESSIONAL_EMAIL_UPSELL } from '../index';
 import type { StoredPaymentMethodCard } from '../../../../lib/checkout/payment-methods';
 
-jest.mock( 'wpcom-proxy-request', () => ( {
-	__esModule: true,
-} ) );
-
 jest.mock( '@automattic/calypso-router', () => jest.fn() );
 jest.mock( '@automattic/data-stores', () => ( {
 	...jest.requireActual( '@automattic/data-stores' ),

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -661,7 +661,9 @@ export function CheckoutFormSubmit( {
 					onLoadError={ onSubmitButtonLoadError }
 				/>
 			) }
-			<SubmitFooterWrapper>{ submitButtonFooter || null }</SubmitFooterWrapper>
+			<SubmitFooterWrapper className="checkout-steps__submit-footer-wrapper">
+				{ submitButtonFooter || null }
+			</SubmitFooterWrapper>
 		</SubmitButtonWrapper>
 	);
 }

--- a/packages/data-stores/src/help-center/actions.ts
+++ b/packages/data-stores/src/help-center/actions.ts
@@ -148,27 +148,25 @@ export const setShowHelpCenter = function* (
 	}
 
 	if ( ! isE2ETest() ) {
-		try {
-			if ( canAccessWpcomApis() ) {
-				// Use the promise version to do that action without waiting for the result.
-				wpcomRequestPromise( {
-					path: '/me/preferences',
-					apiNamespace: 'wpcom/v2',
-					method: 'PUT',
-					body: {
-						calypso_preferences: { help_center_open: show },
-					},
-				} );
-			} else {
-				// Use the promise version to do that action without waiting for the result.
-				apiFetchPromise( {
-					global: true,
-					path: '/help-center/open-state',
-					method: 'PUT',
-					data: { help_center_open: show },
-				} as APIFetchOptions );
-			}
-		} catch {}
+		if ( canAccessWpcomApis() ) {
+			// Use the promise version to do that action without waiting for the result.
+			wpcomRequestPromise( {
+				path: '/me/preferences',
+				apiNamespace: 'wpcom/v2',
+				method: 'PUT',
+				body: {
+					calypso_preferences: { help_center_open: show },
+				},
+			} ).catch( () => {} );
+		} else {
+			// Use the promise version to do that action without waiting for the result.
+			apiFetchPromise( {
+				global: true,
+				path: '/help-center/open-state',
+				method: 'PUT',
+				data: { help_center_open: show },
+			} as APIFetchOptions ).catch( () => {} );
+		}
 	}
 
 	if ( ! show ) {

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -4,6 +4,13 @@
 	--step-container-v2-top-bar-height: 56px;
 	--step-container-v2-sticky-bottom-bar-height: 72px;
 
+	--step-container-v2-content-block-padding: 2rem;
+	--step-container-v2-content-inline-padding: 1rem;
+
+	&.medium-viewport {
+		--step-container-v2-content-inline-padding: 3rem;
+	}
+
 	width: 100%;
 	min-height: 100vh;
 	margin: 0;
@@ -24,11 +31,7 @@
 		gap: 3rem;
 
 		&.padding {
-			padding: 2rem 1rem;
-
-			@include step-medium-viewport {
-				padding: 2rem 3rem;
-			}
+			padding: var(--step-container-v2-content-block-padding) var(--step-container-v2-content-inline-padding);
 		}
 
 		&.vertical-align-center {

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -34,6 +34,9 @@
 
 	&-right-button {
 		margin-left: auto;
+		--wp-components-color-accent: var(--color-neutral-100);
+		font-size: 0.875rem;
+		line-height: 1;
 	}
 
 	&-wordpress-logo {

--- a/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/style.scss
@@ -1,6 +1,5 @@
 .step-container-v2__skip-button {
-	--wp-components-color-accent: var(--color-neutral-100);
-	font-size: 0.875rem;
-	line-height: 1;
+	font-size: inherit;
+	line-height: inherit;
 	font-weight: 500;
 }

--- a/packages/onboarding/src/step-container-v2/contexts/StepContainerV2Context.ts
+++ b/packages/onboarding/src/step-container-v2/contexts/StepContainerV2Context.ts
@@ -1,21 +1,15 @@
 import { createContext, useContext } from 'react';
 
-export interface StepContainerV2ContextType {
+export type StepContainerV2ContextType = null | {
 	flowName: string;
 	stepName: string;
 	recordTracksEvent: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
-}
+};
 
-const StepContainerV2Context = createContext< StepContainerV2ContextType | null >( null );
+const StepContainerV2Context = createContext< StepContainerV2ContextType >( null );
 
 export const StepContainerV2Provider = StepContainerV2Context.Provider;
 
 export const useStepContainerV2Context = () => {
-	const context = useContext( StepContainerV2Context );
-
-	if ( ! context ) {
-		throw new Error( 'useStepContainerV2Context must be used within a StepContainerV2Provider' );
-	}
-
-	return context;
+	return useContext( StepContainerV2Context );
 };

--- a/packages/onboarding/src/step-container-v2/helpers/decorateButtonWithTracksEventRecording.ts
+++ b/packages/onboarding/src/step-container-v2/helpers/decorateButtonWithTracksEventRecording.ts
@@ -17,7 +17,7 @@ export const decorateButtonWithTracksEventRecording = (
 	) => {
 		onClick?.( event );
 
-		stepContext.recordTracksEvent?.( tracksEventName, {
+		stepContext?.recordTracksEvent?.( tracksEventName, {
 			flow: stepContext.flowName,
 			step: stepContext.stepName,
 			intent: ( select( Onboard.register() ) as OnboardSelect ).getIntent(),


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/101201.

## Proposed Changes

https://github.com/user-attachments/assets/35e490ca-873b-45e5-aa62-767379c575e0

## Observations

### Not all elements are according to the designs

This PR mostly focuses on getting the basics right, such as using the top bar and correct small viewport margins.

### The page isn't following the `TwoColumnLayout` wireframe

In order to cut scope I ended up using the `FullWidthLayout` and adding the content with its own proportions to make it easier. We can move to the `TwoColumnLayout` in the future.

### The bottom bar on mobile isn't using the `stickyBottomBar` prop

For the same reason above: there's already control over how the bottom bar is displayed in the default checkout styling. We can revisit that later.

## Testing Instructions

Enter `/setup/onboarding?flags=+onboarding/step-container-v2` or `/setup/site-setup?siteSlug=%s&flags=+onboarding/step-container-v2` and add a paid product to the cart.

### StepContainerV2 version

Should match Figma's top bar and page margins (W9xI27S6Swvw5Ku21EbZvn-fi-9588_14434)

### Prod version

Should not have changes.

## Screenshots

### Large screen

Nothing should change apart from the top bar and the "Included with your purchase" label, which is aligned on its baseline with the Checkout heading.

| Before | After |
| ------ | ----- |
| ![large-before](https://github.com/user-attachments/assets/098981ca-41db-4468-b582-53efbe372f06) | ![large-after](https://github.com/user-attachments/assets/752f9957-0a1e-40c1-949b-8576e63b320e) |

### Tablet, above fold

The top bar and purchase details collapsible now look different, with the inside paddings also aligned with the top bar. Also the components within it now stretch.

| Before | After |
| ------ | ----- |
| ![tablet-above-fold-before](https://github.com/user-attachments/assets/c2afec19-9f3d-43a0-a41d-332e16c686cf) | ![tablet-above-fold-after](https://github.com/user-attachments/assets/e02bc6c1-facf-427b-87a5-573cafcd091a) |

### Tablet, below fold

The heading is now smaller and the content is now padded according to StepContainerV2's constraints (16px instead of 24px). Also, the step content within the checkout section are now left aligned to the left instead of aligned to the title of the section.

| Before | After |
| ------ | ----- |
| ![tablet-below-fold-before](https://github.com/user-attachments/assets/2a25da1b-fdf9-4b85-900e-82bdc5e49f40) | ![tablet-below-fold-after](https://github.com/user-attachments/assets/58c6986a-0efc-4101-8544-bf0f9725f4db) |

### Table/mobile footer

Minimal changes, mostly padding alignment.

| Before | After |
| ------ | ----- |
| ![mobile-footer-before](https://github.com/user-attachments/assets/d7ed47a7-5e75-46a7-a032-d52f99d81dbe) | ![mobile-footer-after](https://github.com/user-attachments/assets/aac2545b-4b37-4705-802b-29e61d6b6ae4) |

