### PR TITLE
StepContainerV2: Make sure top bar is above vertically-centered content

### DIFF
--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
@@ -58,7 +58,7 @@ export const StepContainerV2 = ( {
 					'large-viewport': isLargeViewport,
 				} ) }
 			>
-				{ topBar }
+				{ topBar && <div className="step-container-v2__top-bar-wrapper">{ topBar }</div> }
 				<div
 					className={ clsx( 'step-container-v2__content-wrapper', {
 						'vertical-align-center': verticalAlign === 'center',

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -10,6 +10,12 @@
 	display: flex;
 	flex-direction: column;
 
+	&:has(.vertical-align-center) {
+		.step-container-v2__top-bar-wrapper {
+			z-index: 1;
+		}
+	}
+
 	&__content-wrapper {
 		flex: 1;
 		display: flex;


### PR DESCRIPTION
Fixes p1742863696447989-slack-C03N25JPCE4.

## Proposed Changes

The vertically-centered content variant stays on top of the top bar of the step. This PR makes it so the top bar has a higher z-index value, thus making the bar buttons' clickable.

This PR is a temporary fix; with time (and the refactor of `StepContainerV2`), we will revisit this.

## Testing Instructions

Enter `/setup/onboarding` with the feature flag on (`onboarding/step-container-v2`) and verify you can click the "Log in" button.