### PR TITLE
StepContainerV2: Vertically-centered layout doesn't stretch across the screen

### DIFF
--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/StepContainerV2.tsx
@@ -58,7 +58,7 @@ export const StepContainerV2 = ( {
 					'large-viewport': isLargeViewport,
 				} ) }
 			>
-				{ topBar && <div className="step-container-v2__top-bar-wrapper">{ topBar }</div> }
+				{ topBar }
 				<div
 					className={ clsx( 'step-container-v2__content-wrapper', {
 						'vertical-align-center': verticalAlign === 'center',

--- a/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/StepContainerV2/style.scss
@@ -9,12 +9,7 @@
 	margin: 0;
 	display: flex;
 	flex-direction: column;
-
-	&:has(.vertical-align-center) {
-		.step-container-v2__top-bar-wrapper {
-			z-index: 1;
-		}
-	}
+	position: relative;
 
 	&__content-wrapper {
 		flex: 1;
@@ -34,12 +29,10 @@
 		&.vertical-align-center {
 			@include step-medium-viewport {
 				position: absolute;
-				inset: 0;
+				top: 50%;
+				transform: translateY(-50%);
 				width: 100%;
-				height: 100%;
-				padding-block: 1rem;
 				box-sizing: border-box;
-				justify-content: center;
 			}
 		}
 	}


### PR DESCRIPTION
Supersedes https://github.com/Automattic/wp-calypso/pull/101809.

## Proposed Changes

![image](https://github.com/user-attachments/assets/7f2a8ac1-cca9-4875-a95c-43115e809b94)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
