### PR TITLE
Multi-Site: Domains:  Fix alignment on large screens.

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -175,17 +175,6 @@
 					padding-inline: 48px;
 				}
 			}
-
-			@include break-huge {
-				max-width: 100%;
-
-				.bulk-domains-empty-state__main {
-					box-sizing: border-box;
-					max-width: 1400px;
-					margin: 0 auto;
-					padding-inline: 48px;
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
Related to #96626

## Proposed Changes

This PR removes CSS styles that center the multi-site no domains state when the screen width is larger than `1710px`. 

This code was added in #96626 when the multi-site header had a `max-width`. It no longer does. (I couldn't find where that changed)

| Before | After |
|--------|--------|
| <img width="1919" alt="Screenshot 2025-03-25 at 12 01 36 PM" src="https://github.com/user-attachments/assets/65c6bb0e-89f6-49da-bc29-96f6dcc069a1" /> | <img width="1920" alt="Screenshot 2025-03-25 at 12 01 48 PM" src="https://github.com/user-attachments/assets/1f76f8da-c74d-4940-9a94-de293f3bedcf" /> | 

## Why are these changes being made?

It doesn't align on large desktops.

## Testing Instructions

With an account with no domain on a large monitor.
 - Go to `/domains/manage`
 - Expect the content to be left-aligned.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
