### PR TITLE
Revert "Avoid navigating to launchpad step when Focused Launchpad should be shown"

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/00-example-flow/example.ts
+++ b/client/landing/stepper/declarative-flow/flows/00-example-flow/example.ts
@@ -79,7 +79,7 @@ const newsletter: Flow = {
 
 		const createSite = useCreateSite();
 
-		const { getPostFlowUrl } = useLaunchpadDecider( {
+		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -131,6 +131,10 @@ const newsletter: Flow = {
 					const site = get( 'site' );
 					if ( site ) {
 						const { siteId, siteSlug } = site;
+						initializeLaunchpadState( {
+							siteId: siteId,
+							siteSlug: siteSlug,
+						} );
 
 						if ( providedDependencies?.goToHome ) {
 							return window.location.replace(

--- a/client/landing/stepper/declarative-flow/flows/build/build.ts
+++ b/client/landing/stepper/declarative-flow/flows/build/build.ts
@@ -66,7 +66,7 @@ const build: Flow = {
 
 		triggerGuidesForStep( flowName, _currentStep );
 
-		const { postFlowNavigator } = useLaunchpadDecider( {
+		const { postFlowNavigator, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -82,6 +82,11 @@ const build: Flow = {
 							} )
 						);
 					}
+
+					initializeLaunchpadState( {
+						siteId,
+						siteSlug: ( providedDependencies?.siteSlug ?? siteSlug ) as string,
+					} );
 
 					return postFlowNavigator( { siteId, siteSlug } );
 				case 'launchpad': {

--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -65,7 +65,7 @@ const newsletter: Flow = {
 		const { exitFlow } = useExitFlow();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
 
-		const { getPostFlowUrl } = useLaunchpadDecider( {
+		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -123,6 +123,11 @@ const newsletter: Flow = {
 							) }?redirect_to=${ encodeURIComponent( launchpadUrl ) }&signup=1`
 						);
 					}
+
+					initializeLaunchpadState( {
+						siteId: providedDependencies?.siteId as number,
+						siteSlug: providedDependencies?.siteSlug as string,
+					} );
 
 					return window.location.assign(
 						getPostFlowUrl( {

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -221,6 +221,7 @@ const siteSetupFlow: FlowV1 = {
 					if ( isLaunchpadIntent( siteIntent ) ) {
 						redirectionUrl = addQueryArgs(
 							{
+								showLaunchpad: true,
 								...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
 								...( skippedCheckout && { skippedCheckout: 1 } ),
 							},
@@ -265,7 +266,7 @@ const siteSetupFlow: FlowV1 = {
 			clearSignupDestinationCookie();
 		};
 
-		const { getPostFlowUrl } = useLaunchpadDecider( {
+		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -317,6 +318,7 @@ const siteSetupFlow: FlowV1 = {
 					}
 
 					if ( isLaunchpadIntent( intent ) ) {
+						initializeLaunchpadState( { siteId, siteSlug } );
 						const url = getPostFlowUrl( { flow: intent, siteId, siteSlug } );
 						return exitFlow( url );
 					}

--- a/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
@@ -59,7 +59,7 @@ const startWriting: Flow = {
 			}
 		}, [ siteSlug, setIntentOnSite, isSiteLaunched ] );
 
-		const { getPostFlowUrl, postFlowNavigator } = useLaunchpadDecider( {
+		const { getPostFlowUrl, postFlowNavigator, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -114,6 +114,11 @@ const startWriting: Flow = {
 								launchpad_screen: 'full',
 							} ),
 						] );
+
+						initializeLaunchpadState( {
+							siteId: providedDependencies?.siteId as number,
+							siteSlug: providedDependencies?.siteSlug as string,
+						} );
 
 						const siteOrigin = window.location.origin;
 

--- a/client/landing/stepper/declarative-flow/flows/update-design/update-design.ts
+++ b/client/landing/stepper/declarative-flow/flows/update-design/update-design.ts
@@ -51,7 +51,7 @@ const updateDesign: Flow = {
 			return navigate( 'processing' );
 		};
 
-		const { getPostFlowUrl } = useLaunchpadDecider( {
+		const { getPostFlowUrl, initializeLaunchpadState } = useLaunchpadDecider( {
 			exitFlow,
 			navigate,
 		} );
@@ -61,6 +61,11 @@ const updateDesign: Flow = {
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
 				case 'processing': {
+					initializeLaunchpadState( {
+						siteId,
+						siteSlug: ( providedDependencies?.siteSlug ?? siteSlug ) as string,
+					} );
+
 					const processingResult = providedDependencies.processingResult as ProcessingResult;
 
 					if ( processingResult === ProcessingResult.FAILURE ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -15,6 +15,7 @@ import { urlToSlug } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -92,6 +93,11 @@ const Launchpad: Step = ( { navigation, flow } ) => {
 
 	if ( launchpadScreenOption === 'skipped' ) {
 		window.location.assign( `/home/${ siteSlug }` );
+		return null;
+	}
+
+	if ( shouldShowLaunchpadFirst( site ) ) {
+		window.location.replace( `/home/${ siteSlug }` );
 		return null;
 	}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101745

Users are being sent back to the full screen launchpad in the "Publish a blog" onboarding flow.

Steps:
- New free blog
- Choose "Publish a blog" on the goals screen
- Once you land on the focused launchpad choose the "Write your first post" task
- Publish your first post
- The celebration modal appears. Choose **Next steps**

At this point you're taken to the fullscreen launchpad. But you should have gone to the focused launchpad.