### PR TITLE
Normalize `/sites` sidebar animation on desktop.

### DIFF
--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -23,12 +23,16 @@ function getSiteDashboardRoutes( state: AppState ) {
 		...( isPlansPageUntangled( state ) ? [ '/plans' ] : [] ),
 
 		// Domain Management
+		'/domains/manage',
 		'/domains/manage/all/overview',
 		'/domains/manage/all/email',
 		'/domains/manage/all/contact-info',
 
 		// Bulk Plugins management
 		'/plugins/manage/sites',
+
+		// Themes
+		'/themes',
 	];
 }
 

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -23,17 +23,21 @@ function getSiteDashboardRoutes( state: AppState ) {
 		...( isPlansPageUntangled( state ) ? [ '/plans' ] : [] ),
 
 		// Domain Management
-		'/domains/manage',
 		'/domains/manage/all/overview',
 		'/domains/manage/all/email',
 		'/domains/manage/all/contact-info',
 
 		// Bulk Plugins management
 		'/plugins/manage/sites',
-
-		// Themes
-		'/themes',
 	];
+}
+
+/**
+ * There routes are used in both 'sites' and 'sites-dashboard' sections.
+ * @returns A list of routes.
+ */
+function tangledBasePaths() {
+	return [ '/domains/manage', '/themes' ];
 }
 
 function isInRoute( state: AppState, routes: string[] ) {
@@ -47,6 +51,7 @@ function shouldShowSitesDashboard( state: AppState ) {
 		'/setup',
 		'/start',
 		...getSiteDashboardRoutes( state ),
+		...tangledBasePaths(),
 	] );
 }
 

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -33,7 +33,7 @@ function getSiteDashboardRoutes( state: AppState ) {
 }
 
 /**
- * There routes are used in both 'sites' and 'sites-dashboard' sections.
+ * These routes are used in both 'sites' and 'sites-dashboard' sections.
  * @returns A list of routes.
  */
 function tangledBasePaths() {

--- a/client/state/global-sidebar/test/selectors.ts
+++ b/client/state/global-sidebar/test/selectors.ts
@@ -1,0 +1,92 @@
+import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
+import isScheduledUpdatesMultisiteRoute from 'calypso/state/selectors/is-scheduled-updates-multisite-route';
+import { shouldShowSiteDashboard, getShouldShowGlobalSidebar } from '../selectors';
+import type { AppState } from 'calypso/types';
+
+jest.mock( 'calypso/lib/plans/untangling-plans-experiment', () => ( {
+	isPlansPageUntangled: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/selectors/is-scheduled-updates-multisite-route', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	isScheduledUpdatesMultisiteCreateRoute: jest.fn(),
+	isScheduledUpdatesMultisiteEditRoute: jest.fn(),
+} ) );
+
+describe( 'Global Sidebar Selectors', () => {
+	const createMockState = ( path: string ): AppState =>
+		( {
+			route: {
+				path: {
+					current: path,
+				},
+			},
+		} ) as AppState;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'shouldShowSiteDashboard', () => {
+		it( 'should return false when siteId is null', () => {
+			const state = createMockState( '/setup' );
+			expect( shouldShowSiteDashboard( state, null ) ).toBe( false );
+		} );
+
+		it( 'should return true for setup route with valid siteId', () => {
+			const state = createMockState( '/setup' );
+			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( true );
+		} );
+
+		it( 'should return true for start route with valid siteId', () => {
+			const state = createMockState( '/start' );
+			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( true );
+		} );
+
+		it( 'should return true for site dashboard routes with valid siteId', () => {
+			const state = createMockState( '/domains/manage' );
+			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( true );
+		} );
+
+		it( 'should return false for non-dashboard routes', () => {
+			const state = createMockState( '/some-other-route' );
+			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( false );
+		} );
+
+		it( 'should include plans route when plans page is untangled', () => {
+			const state = createMockState( '/plans' );
+			( isPlansPageUntangled as jest.Mock ).mockReturnValue( true );
+			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( true );
+		} );
+
+		it( 'should not include plans route when plans page is not untangled', () => {
+			const state = createMockState( '/plans' );
+			( isPlansPageUntangled as jest.Mock ).mockReturnValue( false );
+			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getShouldShowGlobalSidebar', () => {
+		it( 'should return true for me section', () => {
+			const state = createMockState( '/me' );
+			expect( getShouldShowGlobalSidebar( state, null, 'me' ) ).toBe( true );
+		} );
+
+		it( 'should return true for reader section', () => {
+			const state = createMockState( '/reader' );
+			expect( getShouldShowGlobalSidebar( state, null, 'reader' ) ).toBe( true );
+		} );
+
+		it( 'should return true for sites section with no siteId', () => {
+			const state = createMockState( '/sites' );
+			expect( getShouldShowGlobalSidebar( state, null, 'sites' ) ).toBe( true );
+		} );
+
+		it( 'should handle scheduled updates multisite route', () => {
+			const state = createMockState( '/plugins' );
+			( isScheduledUpdatesMultisiteRoute as jest.Mock ).mockReturnValue( true );
+			expect( getShouldShowGlobalSidebar( state, 123, 'sites' ) ).toBe( true );
+		} );
+	} );
+} );

--- a/client/state/global-sidebar/test/selectors.ts
+++ b/client/state/global-sidebar/test/selectors.ts
@@ -44,11 +44,6 @@ describe( 'Global Sidebar Selectors', () => {
 			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( true );
 		} );
 
-		it( 'should return true for site dashboard routes with valid siteId', () => {
-			const state = createMockState( '/domains/manage' );
-			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( true );
-		} );
-
 		it( 'should return false for non-dashboard routes', () => {
 			const state = createMockState( '/some-other-route' );
 			expect( shouldShowSiteDashboard( state, 123 ) ).toBe( false );
@@ -81,6 +76,16 @@ describe( 'Global Sidebar Selectors', () => {
 		it( 'should return true for sites section with no siteId', () => {
 			const state = createMockState( '/sites' );
 			expect( getShouldShowGlobalSidebar( state, null, 'sites' ) ).toBe( true );
+		} );
+
+		it( 'should return false for tangled routes in the sites section', () => {
+			const state = createMockState( '/domains/manage' );
+			expect( getShouldShowGlobalSidebar( state, 123, 'sites' ) ).toBe( false );
+		} );
+
+		it( 'should return true for tangled routes in the sites-dashboard section', () => {
+			const state = createMockState( '/domains/manage' );
+			expect( getShouldShowGlobalSidebar( state, 123, 'sites-dashboard' ) ).toBe( true );
 		} );
 
 		it( 'should handle scheduled updates multisite route', () => {


### PR DESCRIPTION
Related to #92911

## Why are these changes being made?

When you click through the sidebar items, you'll get differing animations in the sidebar. 

## Proposed Changes

At face value, this seems like a problem with the transition and, it kinda is I guess. 

We switch out `--sidebar-width-max` from `272px` to `295px` once we add [.is-global-sidebar-visible](https://github.com/Automattic/wp-calypso/blob/b1f6370587d155dc14b40ef89d5b7a46f56a946f/client/my-sites/sidebar/style.scss#L15) in [client/layout/index.jsx](https://github.com/Automattic/wp-calypso/blob/b1f6370587d155dc14b40ef89d5b7a46f56a946f/client/layout/index.jsx#L258).

With Domains and Themes there is a delay in `isGlobalSidebarVisible` being said to true. That delay is why we see the transition. 

The solution in this PR is to add the routes to `getSiteDashboardRoutes` which is used by [shouldShowSitesDashboard]( https://github.com/Automattic/wp-calypso/blob/b1f6370587d155dc14b40ef89d5b7a46f56a946f/client/state/global-sidebar/selectors.ts#L39) to determine (earlier) that we are viewing a page with the global sidebar.


## Considerations

I don't completely understand the implication of adding the routes here. The comment suggests that apart from affecting this layout, the presence of those routes will determine where they should up. Reading through the associated p2 also leaves things unclear for me. 

Maybe you can confirm or provide better context @fushar? (Updated [here](https://github.com/Automattic/wp-calypso/pull/101154/files#diff-33316ee02ed424c6862ab81c9792fd225a851305558dca401c9029a2dc2f94fbR12)).  


### Screenshots

| Before | After |
|--------|--------|
| ![Screen Capture on 2025-03-26 at 11-20-33](https://github.com/user-attachments/assets/21bf1a0c-e439-42bb-9247-802ee371ac2c) | ![Screen Capture on 2025-03-26 at 11-22-09](https://github.com/user-attachments/assets/cc6bc355-9e70-4559-a886-e91c265863c0) | 

## Testing Instructions
- Go to `/sites`
- Click on "Domains" & "Themes"
- You should not see any width transition in the sidebar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
