### PR TITLE
[Site Admin]: Add Link component with stateful navigation (ARC-24)

### DIFF
--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Initial release of the site-admin package providing a framework for building modern WordPress admin interfaces.
 
-## Core Components
+### Components
 
 - `SidebarButton`: Base button component for sidebar interactions
 - `SidebarContent`: Main sidebar layout component with navigation context
@@ -10,12 +10,12 @@ Initial release of the site-admin package providing a framework for building mod
 - `SidebarNavigationScreen`: Screen container for sidebar navigation
 - `SiteIcon`: Site icon display component
 
-## Routing System
+### Routing System
 - `RoutesContext`: Context provider for current matched route
 - `ConfigContext`: Context for router configuration and settings
 - `browserHistory`: Browser history instance for navigation state
 
-### Router Hooks
+#### Router Hooks
 - `useHistory`: Hook for navigation and history management
 - `useLink`: Hook for handling link navigation
 - `useLocation`: Hook for accessing current route location
@@ -23,5 +23,7 @@ Initial release of the site-admin package providing a framework for building mod
 
 ## Next
 
+### Components
 - `SiteHub`: Site navigation and context switcher
 - Add `history` package dependency
+- `Link`: Router component providing declarative navigation

--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -11,11 +11,13 @@ Initial release of the site-admin package providing a framework for building mod
 - `SiteIcon`: Site icon display component
 
 ### Routing System
+
 - `RoutesContext`: Context provider for current matched route
 - `ConfigContext`: Context for router configuration and settings
 - `browserHistory`: Browser history instance for navigation state
 
 #### Router Hooks
+
 - `useHistory`: Hook for navigation and history management
 - `useLink`: Hook for handling link navigation
 - `useLocation`: Hook for accessing current route location

--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -25,7 +25,8 @@ Initial release of the site-admin package providing a framework for building mod
 
 ## Next
 
+- Add `history` package dependency
+
 ### Components
 - `SiteHub`: Site navigation and context switcher
-- Add `history` package dependency
 - `Link`: Router component providing declarative navigation

--- a/packages/site-admin/README.md
+++ b/packages/site-admin/README.md
@@ -155,8 +155,8 @@ The `RouterProvider` manages the navigation state and provides
 the necessary context for the navigation elements to work correctly.
 
 ```tsx
-<SidebarContent>
-    <RouterProvider routes={ appRoutes } pathArg="page">
+<RouterProvider routes={ appRoutes } pathArg="page">
+    <SidebarContent>
         <SidebarNavigationScreen
             isRoot
             title={ __( 'Home', 'a8c-site-admin' ) }
@@ -168,8 +168,8 @@ the necessary context for the navigation elements to work correctly.
             {/* Here we can use a component that displays content based on the current route */}
             <MainContent />
         </div>
-    </RouterProvider>
-</SidebarContent>
+    </SidebarContent>
+</RouterProvider>
 ```
 
 ### 2.4 Component to Display Active Route Content

--- a/packages/site-admin/src/index.ts
+++ b/packages/site-admin/src/index.ts
@@ -1,6 +1,7 @@
 /**
  * Components
  */
+export { Link } from './router';
 export { SidebarContent, SidebarNavigationItem, SidebarNavigationScreen } from './components/';
 
 /**

--- a/packages/site-admin/src/router/components/link/index.tsx
+++ b/packages/site-admin/src/router/components/link/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { useLink } from '../../hooks';
+import { type NavigationOptions } from '../../types';
+
+export function Link( {
+	to,
+	options,
+	children,
+	...props
+}: {
+	to: string;
+	options?: NavigationOptions;
+	children: React.ReactNode;
+} ) {
+	const { href, onClick } = useLink( to, options );
+
+	return (
+		<a href={ href } onClick={ onClick } { ...props }>
+			{ children }
+		</a>
+	);
+}

--- a/packages/site-admin/src/router/components/link/index.tsx
+++ b/packages/site-admin/src/router/components/link/index.tsx
@@ -4,7 +4,7 @@
 import { useLink } from '../../hooks';
 import { type NavigationOptions } from '../../types';
 
-type LinkProps = React.ComponentPropsWithoutRef< 'a' > & {
+type LinkProps = Omit< React.ComponentPropsWithoutRef< 'a' >, 'href' | 'onClick' > & {
 	to: string;
 	options?: NavigationOptions;
 	children: React.ReactNode;
@@ -14,7 +14,7 @@ export function Link( { to, options, children, ...props }: LinkProps ) {
 	const { href, onClick } = useLink( to, options );
 
 	return (
-		<a href={ href } onClick={ onClick } { ...props }>
+		<a { ...props } href={ href } onClick={ onClick }>
 			{ children }
 		</a>
 	);

--- a/packages/site-admin/src/router/components/link/index.tsx
+++ b/packages/site-admin/src/router/components/link/index.tsx
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { useCallback } from '@wordpress/element';
-/**
  * Internal dependencies
  */
 import { useLink } from '../../hooks';
-import { type NavigationOptions } from '../../types';
+import type { NavigationOptions } from '../../types';
 
 type LinkProps = Omit< React.ComponentPropsWithoutRef< 'a' >, 'href' > & {
 	to: string;
@@ -17,13 +13,10 @@ type LinkProps = Omit< React.ComponentPropsWithoutRef< 'a' >, 'href' > & {
 export function Link( { to, options, children, onClick: onClickProp, ...props }: LinkProps ) {
 	const { href, onClick } = useLink( to, options );
 
-	const handleClickEvent = useCallback(
-		( event: React.MouseEvent< HTMLAnchorElement > ) => {
-			onClickProp?.( event );
-			onClick?.( event );
-		},
-		[ onClick, onClickProp ]
-	);
+	const handleClickEvent = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
+		onClickProp?.( event );
+		onClick( event );
+	};
 
 	return (
 		<a { ...props } href={ href } onClick={ handleClickEvent }>

--- a/packages/site-admin/src/router/components/link/index.tsx
+++ b/packages/site-admin/src/router/components/link/index.tsx
@@ -1,20 +1,32 @@
 /**
+ * External dependencies
+ */
+import { useCallback } from '@wordpress/element';
+/**
  * Internal dependencies
  */
 import { useLink } from '../../hooks';
 import { type NavigationOptions } from '../../types';
 
-type LinkProps = Omit< React.ComponentPropsWithoutRef< 'a' >, 'href' | 'onClick' > & {
+type LinkProps = Omit< React.ComponentPropsWithoutRef< 'a' >, 'href' > & {
 	to: string;
 	options?: NavigationOptions;
 	children: React.ReactNode;
 };
 
-export function Link( { to, options, children, ...props }: LinkProps ) {
+export function Link( { to, options, children, onClick: onClickProp, ...props }: LinkProps ) {
 	const { href, onClick } = useLink( to, options );
 
+	const handleClickEvent = useCallback(
+		( event: React.MouseEvent< HTMLAnchorElement > ) => {
+			onClickProp?.( event );
+			onClick?.( event );
+		},
+		[ onClick, onClickProp ]
+	);
+
 	return (
-		<a { ...props } href={ href } onClick={ onClick }>
+		<a { ...props } href={ href } onClick={ handleClickEvent }>
 			{ children }
 		</a>
 	);

--- a/packages/site-admin/src/router/components/link/index.tsx
+++ b/packages/site-admin/src/router/components/link/index.tsx
@@ -4,16 +4,13 @@
 import { useLink } from '../../hooks';
 import { type NavigationOptions } from '../../types';
 
-export function Link( {
-	to,
-	options,
-	children,
-	...props
-}: {
+type LinkProps = React.ComponentPropsWithoutRef< 'a' > & {
 	to: string;
 	options?: NavigationOptions;
 	children: React.ReactNode;
-} ) {
+};
+
+export function Link( { to, options, children, ...props }: LinkProps ) {
 	const { href, onClick } = useLink( to, options );
 
 	return (

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -42,15 +42,20 @@ export const Default: Story = {
 };
 
 type HistoryState = {
+	/**
+	 * The current lucky number.
+	 */
 	luckyNumber: number;
-	init: boolean;
-	history: number[];
+
+	/**
+	 * The previous lucky numbers from the history state.
+	 */
+	prevLuckyNumbers: number[];
 };
 
 const INITIAL_HISTORY_STATE: HistoryState = {
 	luckyNumber: 0,
-	init: true,
-	history: [],
+	prevLuckyNumbers: [],
 };
 
 /**
@@ -71,31 +76,34 @@ export const PassCustomState: Story = {
 		 */
 		useLocation();
 
-		// Pick the location state from the browser history state
-		const { init, history } =
+		/*
+		 * pick the previous lucky numbers from the history state
+		 * or initialize the state if it's the first render
+		 */
+		const { prevLuckyNumbers } =
 			( browserHistory.location.state as HistoryState ) || INITIAL_HISTORY_STATE;
 
-		let newLuckyNumber = 0;
+		let newLuckyNumber = 0; // zero is not a lucky number. This is not a roulette.
 
-		// Create a new lucky number only when the init flag is false.
-		if ( ! init && browserHistory.action !== 'POP' ) {
+		// Create a new lucky number only when the pushing a new state
+		if ( browserHistory.action !== 'POP' ) {
 			newLuckyNumber = ( ( Math.random() * 100 ) | 0 ) + 1;
 		}
 
-		// Crate the state to pass to the `<Link />` instance
+		// Create the state object to pass to the `<Link />` instance
 		const state = {
 			luckyNumber: newLuckyNumber,
-			init: false,
-			history: newLuckyNumber > 0 ? [ ...history, newLuckyNumber ] : history,
+			prevLuckyNumbers:
+				newLuckyNumber > 0 ? [ ...prevLuckyNumbers, newLuckyNumber ] : prevLuckyNumbers,
 		};
 
 		return (
 			<VStack>
 				<Link { ...args } options={ { state } } className="story-link" />
 
-				{ ! init && (
+				{ prevLuckyNumbers.length && (
 					<div>
-						Previous lucky numbers: <strong>[ { history.join( ', ' ) } ]</strong>
+						Previous lucky numbers: <strong>[ { prevLuckyNumbers.join( ', ' ) } ]</strong>
 					</div>
 				) }
 

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -124,6 +124,7 @@ export const PassCustomState: Story = {
 export const WithCustomOnClick: Story = {
 	args: {
 		to: '/home',
+		className: 'story-link',
 		children: 'Click to call the onClick()!',
 		onClick: fn(),
 	},

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -1,0 +1,19 @@
+import { Link } from '../';
+import type { Meta, StoryObj } from '@storybook/react';
+import './style.stories.scss';
+
+const meta: Meta< typeof Link > = {
+	title: 'Components/Link',
+	component: Link,
+};
+
+export default meta;
+
+type Story = StoryObj< typeof Link >;
+
+export const Default: Story = {
+	args: {
+		to: '/',
+		children: 'Home page',
+	},
+};

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -53,6 +53,10 @@ export const PassCustomState: Story = {
 	},
 
 	render: function Template( args ) {
+		/*
+		 * Force re-render on location changes to sync
+		 * with browserHistory.location.state
+		 */
 		useLocation();
 
 		// Pick the location state from the browser history state

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -29,36 +29,27 @@ export default meta;
 
 type Story = StoryObj< typeof Link >;
 
+/**
+ * The Link component enables navigation between routes in the application,<br />
+ * maintaining state and avoiding full page reloads.
+ */
 export const Default: Story = {
 	args: {
 		to: '/home',
 		children: 'Homepage',
 		className: 'story-link',
 	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The Link component enables navigation between routes in the application, maintaining state and avoiding full page reloads.',
-			},
-		},
-	},
 };
 
+/**
+ * This story shows how to pass custom state to the Link component using the options prop.<br />
+ * Each time the user clicks the link, a new _lucky number_ is generated and passed along.<br />
+ * You can see how the state is preserved when navigating back and forth.
+ */
 export const PassCustomState: Story = {
 	args: {
 		to: '/home',
 		children: 'Request lucky number!',
-	},
-
-	parameters: {
-		docs: {
-			description: {
-				story: `This story shows how to pass custom state to the Link component using the options prop.<br />
-Each time the user clicks the link, a new _lucky number_ is generated and passed along.<br />
-You can see how the state is preserved when navigating back and forth.`,
-			},
-		},
 	},
 
 	render: function Template( args ) {

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -1,10 +1,23 @@
+/**
+ * Internal dependencies
+ */
 import { Link } from '../';
+import { RouterProvider } from '../../../';
 import type { Meta, StoryObj } from '@storybook/react';
 import './style.stories.scss';
 
 const meta: Meta< typeof Link > = {
 	title: 'Components/Link',
 	component: Link,
+	decorators: [
+		function WithRouterProvider( Story ) {
+			return (
+				<RouterProvider routes={ [] }>
+					<Story />
+				</RouterProvider>
+			);
+		},
+	],
 };
 
 export default meta;
@@ -13,7 +26,7 @@ type Story = StoryObj< typeof Link >;
 
 export const Default: Story = {
 	args: {
-		to: '/',
-		children: 'Home page',
+		to: '/home',
+		children: 'Homepage',
 	},
 };

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -41,6 +41,18 @@ export const Default: Story = {
 	},
 };
 
+type HistoryState = {
+	luckyNumber: number;
+	init: boolean;
+	history: number[];
+};
+
+const INITIAL_HISTORY_STATE: HistoryState = {
+	luckyNumber: 0,
+	init: true,
+	history: [],
+};
+
 /**
  * This story shows how to pass custom state to the Link component using the options prop.<br />
  * Each time the user clicks the link, a new _lucky number_ is generated and passed along.<br />
@@ -60,15 +72,8 @@ export const PassCustomState: Story = {
 		useLocation();
 
 		// Pick the location state from the browser history state
-		const { init, history } = ( browserHistory.location.state || {
-			luckyNumber: 0,
-			init: true,
-			history: [],
-		} ) as unknown as {
-			luckyNumber: number;
-			init: boolean;
-			history: number[];
-		};
+		const { init, history } =
+			( browserHistory.location.state as HistoryState ) || INITIAL_HISTORY_STATE;
 
 		let newLuckyNumber = 0;
 

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -68,9 +68,7 @@ export const PassCustomState: Story = {
 
 		let newLuckyNumber = 0;
 
-		/*
-		 * Create a new lucky number only when the user clicks on the link.
-		 */
+		// Create a new lucky number only when the init flag is false.
 		if ( ! init && browserHistory.action !== 'POP' ) {
 			newLuckyNumber = ( ( Math.random() * 100 ) | 0 ) + 1;
 		}
@@ -88,9 +86,7 @@ export const PassCustomState: Story = {
 
 				{ ! init && (
 					<div>
-						<span>
-							Previous lucky numbers: <strong>[ { history.join( ', ' ) } ]</strong>
-						</span>
+						Previous lucky numbers: <strong>[ { history.join( ', ' ) } ]</strong>
 					</div>
 				) }
 

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta< typeof Link > = {
 	decorators: [
 		function WithRouterProvider( Story ) {
 			return (
-				<RouterProvider routes={ [] } pathArg="p">
+				<RouterProvider>
 					<Story />
 				</RouterProvider>
 			);

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import { __experimentalVStack as VStack } from '@wordpress/components';
+/**
  * Internal dependencies
  */
 import { Link } from '../';
-import { RouterProvider } from '../../../';
+import { browserHistory, RouterProvider, useLocation } from '../../../';
 import type { Meta, StoryObj } from '@storybook/react';
 import './style.stories.scss';
 
@@ -28,5 +32,59 @@ export const Default: Story = {
 	args: {
 		to: '/home',
 		children: 'Homepage',
+	},
+};
+
+export const PassCustomState: Story = {
+	args: {
+		to: '/home',
+		children: 'Request lucky number!',
+	},
+
+	render: function Template( args ) {
+		useLocation();
+
+		// Pick the location state from the browser history singleton
+		const { luckyNumber, clicked } = ( browserHistory.location.state || {
+			luckyNumber: 0,
+			clicked: false,
+		} ) as unknown as {
+			luckyNumber: number;
+			clicked: boolean;
+		};
+
+		// The new lucky number is initially zero
+		let newLuckyNumber: number = 0;
+
+		/*
+		 * Create a new lucky number only when the user clicks on the link.
+		 * `clicked` is useful to detect if the user has clicked
+		 * on the `<Link />` instance.
+		 * It's defined into its options state object
+		 */
+		if ( clicked ) {
+			newLuckyNumber = ( ( Math.random() * 100 ) | 0 ) + 1;
+		}
+
+		// Crate the state to pass to the `<Link />` instance
+		const state = { luckyNumber: newLuckyNumber, clicked: true };
+
+		return (
+			<VStack>
+				<Link { ...args } options={ { state } } />
+
+				{ newLuckyNumber && (
+					<div>
+						Your lucky number is <strong>{ newLuckyNumber }.</strong>
+					</div>
+				) }
+
+				{ luckyNumber && (
+					<div>
+						Your previous lucky number was <strong>{ luckyNumber }.</strong>
+					</div>
+				) }
+			</VStack>
+		);
 	},
 };

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -64,44 +64,48 @@ You can see how the state is preserved when navigating back and forth.`,
 	render: function Template( args ) {
 		useLocation();
 
-		// Pick the location state from the browser history singleton
-		const { luckyNumber, clicked } = ( browserHistory.location.state || {
+		// Pick the location state from the browser history state
+		const { init, history } = ( browserHistory.location.state || {
 			luckyNumber: 0,
-			clicked: false,
+			init: true,
+			history: [],
 		} ) as unknown as {
 			luckyNumber: number;
-			clicked: boolean;
+			init: boolean;
+			history: number[];
 		};
 
-		// The new lucky number is initially zero
-		let newLuckyNumber: number = 0;
+		let newLuckyNumber = 0;
 
 		/*
 		 * Create a new lucky number only when the user clicks on the link.
-		 * `clicked` is useful to detect if the user has clicked
-		 * on the `<Link />` instance.
-		 * It's defined into its options state object
 		 */
-		if ( clicked ) {
+		if ( ! init && browserHistory.action !== 'POP' ) {
 			newLuckyNumber = ( ( Math.random() * 100 ) | 0 ) + 1;
 		}
 
 		// Crate the state to pass to the `<Link />` instance
-		const state = { luckyNumber: newLuckyNumber, clicked: true };
+		const state = {
+			luckyNumber: newLuckyNumber,
+			init: false,
+			history: newLuckyNumber > 0 ? [ ...history, newLuckyNumber ] : history,
+		};
 
 		return (
 			<VStack>
 				<Link { ...args } options={ { state } } className="story-link" />
 
-				{ newLuckyNumber && (
+				{ ! init && (
 					<div>
-						Your lucky number is <strong>{ newLuckyNumber }.</strong>
+						<span>
+							Previous lucky numbers: <strong>[ { history.join( ', ' ) } ]</strong>
+						</span>
 					</div>
 				) }
 
-				{ luckyNumber && (
+				{ newLuckyNumber && (
 					<div>
-						Your previous lucky number was <strong>{ luckyNumber }.</strong>
+						Your lucky number is <strong>{ newLuckyNumber }</strong>
 					</div>
 				) }
 			</VStack>

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -13,6 +13,7 @@ import './style.stories.scss';
 const meta: Meta< typeof Link > = {
 	title: 'Components/Link',
 	component: Link,
+	tags: [ 'autodocs' ],
 	decorators: [
 		function WithRouterProvider( Story ) {
 			return (
@@ -34,12 +35,30 @@ export const Default: Story = {
 		children: 'Homepage',
 		className: 'story-link',
 	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The Link component enables navigation between routes in the application, maintaining state and avoiding full page reloads.',
+			},
+		},
+	},
 };
 
 export const PassCustomState: Story = {
 	args: {
 		to: '/home',
 		children: 'Request lucky number!',
+	},
+
+	parameters: {
+		docs: {
+			description: {
+				story: `This story shows how to pass custom state to the Link component using the options prop.<br />
+Each time the user clicks the link, a new _lucky number_ is generated and passed along.<br />
+You can see how the state is preserved when navigating back and forth.`,
+			},
+		},
 	},
 
 	render: function Template( args ) {

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta< typeof Link > = {
 	decorators: [
 		function WithRouterProvider( Story ) {
 			return (
-				<RouterProvider routes={ [] }>
+				<RouterProvider routes={ [] } pathArg="p">
 					<Story />
 				</RouterProvider>
 			);
@@ -32,6 +32,7 @@ export const Default: Story = {
 	args: {
 		to: '/home',
 		children: 'Homepage',
+		className: 'story-link',
 	},
 };
 
@@ -71,7 +72,7 @@ export const PassCustomState: Story = {
 
 		return (
 			<VStack>
-				<Link { ...args } options={ { state } } />
+				<Link { ...args } options={ { state } } className="story-link" />
 
 				{ newLuckyNumber && (
 					<div>

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -30,7 +31,7 @@ export default meta;
 type Story = StoryObj< typeof Link >;
 
 /**
- * The Link component enables navigation between routes in the application,<br />
+ * The Link component enables navigation between routes in the application,
  * maintaining state and avoiding full page reloads.
  */
 export const Default: Story = {
@@ -45,7 +46,7 @@ type HistoryState = {
 	/**
 	 * The current lucky number.
 	 */
-	luckyNumber: number;
+	luckyNumber?: number;
 
 	/**
 	 * The previous lucky numbers from the history state.
@@ -54,13 +55,13 @@ type HistoryState = {
 };
 
 const INITIAL_HISTORY_STATE: HistoryState = {
-	luckyNumber: 0,
+	luckyNumber: undefined,
 	prevLuckyNumbers: [],
 };
 
 /**
- * This story shows how to pass custom state to the Link component using the options prop.<br />
- * Each time the user clicks the link, a new _lucky number_ is generated and passed along.<br />
+ * This story shows how to pass custom state to the Link component using the options prop.
+ * Each time the user clicks the link, a new _lucky number_ is generated and passed along.
  * You can see how the state is preserved when navigating back and forth.
  */
 export const PassCustomState: Story = {
@@ -76,30 +77,29 @@ export const PassCustomState: Story = {
 		 */
 		useLocation();
 
+		const [ newLuckyNumber, setNewLuckyNumber ] = useState< number | undefined >();
+
 		/*
-		 * pick the previous lucky numbers from the history state
+		 * Pick the previous lucky numbers from the history state
 		 * or initialize the state if it's the first render
 		 */
 		const { prevLuckyNumbers } =
 			( browserHistory.location.state as HistoryState ) || INITIAL_HISTORY_STATE;
 
-		let newLuckyNumber = 0; // zero is not a lucky number. This is not a roulette.
-
-		// Create a new lucky number only when the pushing a new state
-		if ( browserHistory.action !== 'POP' ) {
-			newLuckyNumber = ( ( Math.random() * 100 ) | 0 ) + 1;
-		}
-
 		// Create the state object to pass to the `<Link />` instance
 		const state = {
 			luckyNumber: newLuckyNumber,
-			prevLuckyNumbers:
-				newLuckyNumber > 0 ? [ ...prevLuckyNumbers, newLuckyNumber ] : prevLuckyNumbers,
+			prevLuckyNumbers: newLuckyNumber ? [ ...prevLuckyNumbers, newLuckyNumber ] : prevLuckyNumbers,
 		};
 
 		return (
 			<VStack>
-				<Link { ...args } options={ { state } } className="story-link" />
+				<Link
+					{ ...args }
+					options={ { state } }
+					className="story-link"
+					onClick={ () => setNewLuckyNumber( ( ( Math.random() * 10 ) | 0 ) + 1 ) }
+				/>
 
 				{ prevLuckyNumbers.length && (
 					<div>

--- a/packages/site-admin/src/router/components/link/stories/index.stories.tsx
+++ b/packages/site-admin/src/router/components/link/stories/index.stories.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { fn } from '@storybook/test';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 /**
@@ -114,5 +115,16 @@ export const PassCustomState: Story = {
 				) }
 			</VStack>
 		);
+	},
+};
+
+/**
+ * This story shows how to pass a custom onClick handler to the Link component.
+ */
+export const WithCustomOnClick: Story = {
+	args: {
+		to: '/home',
+		children: 'Click to call the onClick()!',
+		onClick: fn(),
 	},
 };

--- a/packages/site-admin/src/router/components/link/stories/style.stories.scss
+++ b/packages/site-admin/src/router/components/link/stories/style.stories.scss
@@ -1,0 +1,9 @@
+.custom-icon-styles {
+	width: 130px;
+	
+	& > img {
+		background-color: transparent;
+		aspect-ratio: 1 / 1;
+		object-fit: contain;
+	}
+}

--- a/packages/site-admin/src/router/components/link/stories/style.stories.scss
+++ b/packages/site-admin/src/router/components/link/stories/style.stories.scss
@@ -1,9 +1,10 @@
-.custom-icon-styles {
-	width: 130px;
-	
-	& > img {
-		background-color: transparent;
-		aspect-ratio: 1 / 1;
-		object-fit: contain;
+.story-link {
+	color: #4e4;
+	&:hover {
+		color: #8f8;
 	}
+}
+
+strong {
+	color: #9acd32;
 }

--- a/packages/site-admin/src/router/components/link/stories/style.stories.scss
+++ b/packages/site-admin/src/router/components/link/stories/style.stories.scss
@@ -1,10 +1,9 @@
+@import '@wordpress/base-styles/colors';
+
 .story-link {
-	color: #4e4;
-	&:hover {
-		color: #8f8;
-	}
+	color: $alert-green;
 }
 
 strong {
-	color: #9acd32;
+	color: $alert-red;
 }

--- a/packages/site-admin/src/router/index.ts
+++ b/packages/site-admin/src/router/index.ts
@@ -24,6 +24,9 @@ export const RoutesContext = createContext< Match | null >( null );
  */
 export const ConfigContext = createContext< Config >( { pathArg: 'p' } );
 
+// Export Router components
+export * from './components/link';
+
 // Export hooks related to routing
 export * from './hooks';
 

--- a/packages/site-admin/src/router/providers/index.tsx
+++ b/packages/site-admin/src/router/providers/index.tsx
@@ -52,8 +52,8 @@ function getLocationWithQuery(): LocationWithQuery {
  * ```
  */
 export function RouterProvider( {
-	routes,
-	pathArg,
+	routes = [],
+	pathArg = 'p',
 	beforeNavigate,
 	children,
 }: RouterProviderProps ): JSX.Element {
@@ -62,6 +62,7 @@ export function RouterProvider( {
 		getLocationWithQuery,
 		getLocationWithQuery
 	);
+
 	const matcher = useMemo( () => {
 		const ret = new RouteRecognizer();
 		routes.forEach( ( route ) => {

--- a/packages/site-admin/src/router/types.ts
+++ b/packages/site-admin/src/router/types.ts
@@ -107,13 +107,15 @@ export interface Route {
 export interface RouterProviderProps {
 	/**
 	 * List of available routes.
+	 * @default []
 	 */
-	routes: Route[];
+	routes?: Route[];
 
 	/**
-	 * Argument used for path identification.
+	 * Defines the URL query parameter that stores the current path.
+	 * @default 'p'
 	 */
-	pathArg: string;
+	pathArg?: string;
 
 	/**
 	 * Optional navigation behavior modifier.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR adds a `<Link />` component built on top of the internal `useLink()` hook to handle client-side navigation while preserving the navigation state. It simplifies usage and avoids repeating logic in multiple places.

Two stories were added to the Storybook:
* A basic usage example.
* One that shows how to pass a custom state


Related to #

## Proposed Changes

* [Site Admin]: Add Link component with stateful navigation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the Site Admin Storybook application
```sh
yarn workspace @automattic/site-admin run storybook
```
2. Go to the Link stories
3. Use the Pass Custom State story to confirm how the state is preserved during navigation.

![site-admin-link-component-2](https://github.com/user-attachments/assets/f88362e9-c6f8-444a-8696-6526b280cb0b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
