### PR TITLE
Fix empty siteId and sessionId when leaving update-design flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -42,7 +42,11 @@ export const useLaunchpadDecider = ( { exitFlow, navigate }: Props ) => {
 				return `/home/${ siteSlug || siteId }`;
 			}
 
-			return addQueryArgs( `/setup/${ flow }/launchpad`, { siteSlug, siteId, sessionId } );
+			return addQueryArgs( `/setup/${ flow }/launchpad`, {
+				siteSlug: siteSlug || undefined,
+				siteId: siteId || undefined,
+				sessionId: sessionId || undefined,
+			} );
 		},
 		postFlowNavigator: ( { siteId, siteSlug }: SiteProps ) => {
 			if ( showCustomerHome ) {

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/test/user-launchpad-decider.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/test/user-launchpad-decider.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useLaunchpadDecider } from '..';
+
+test( 'appends siteId and sitdSlug to the post-flow url', () => {
+	const exitFlow = jest.fn();
+	const navigate = jest.fn();
+
+	const { result } = renderHook( () => useLaunchpadDecider( { exitFlow, navigate } ) );
+
+	const postFlowUrl = result.current.getPostFlowUrl( {
+		flow: 'flow-name',
+		siteId: '1234',
+		siteSlug: 'site.wordpress.com',
+	} );
+
+	expect( postFlowUrl ).toBe(
+		'/setup/flow-name/launchpad?siteSlug=site.wordpress.com&siteId=1234'
+	);
+} );
+
+test( "doesn't append empty siteId to the post-flow url", () => {
+	const exitFlow = jest.fn();
+	const navigate = jest.fn();
+
+	const { result } = renderHook( () => useLaunchpadDecider( { exitFlow, navigate } ) );
+
+	const nullSiteIdUrl = result.current.getPostFlowUrl( {
+		flow: 'flow-name',
+		siteSlug: 'site.wordpress.com',
+		siteId: null,
+	} );
+	expect( nullSiteIdUrl ).toBe( '/setup/flow-name/launchpad?siteSlug=site.wordpress.com' );
+
+	const emptySiteId = result.current.getPostFlowUrl( {
+		flow: 'flow-name',
+		siteSlug: 'site.wordpress.com',
+		siteId: '',
+	} );
+	expect( emptySiteId ).toBe( '/setup/flow-name/launchpad?siteSlug=site.wordpress.com' );
+
+	const zeroSiteId = result.current.getPostFlowUrl( {
+		flow: 'flow-name',
+		siteSlug: 'site.wordpress.com',
+		siteId: 0,
+	} );
+	expect( zeroSiteId ).toBe( '/setup/flow-name/launchpad?siteSlug=site.wordpress.com' );
+} );
+
+test( "doesn't append empty siteSlug to the post-flow url", () => {
+	const exitFlow = jest.fn();
+	const navigate = jest.fn();
+
+	const { result } = renderHook( () => useLaunchpadDecider( { exitFlow, navigate } ) );
+
+	const emptySiteSlug = result.current.getPostFlowUrl( {
+		flow: 'flow-name',
+		siteSlug: '',
+		siteId: '1234',
+	} );
+	expect( emptySiteSlug ).toBe( '/setup/flow-name/launchpad?siteId=1234' );
+} );

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -14,7 +14,7 @@ export function useSite( siteFragment?: number | string ) {
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
 	const createdSiteID = useFlowState().get( 'site' )?.siteId;
-	const siteIdOrSlug = siteFragment ?? siteIdParam ?? siteSlug ?? createdSiteID;
+	const siteIdOrSlug = siteFragment || siteIdParam || siteSlug || createdSiteID;
 
 	const site = useSelect(
 		( select ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101822

## Proposed Changes

* Prevent the `update-design` flow from appending empty `siteId` and `sessionId` query params when it navigates to the full screen launchpad
* As an extra measure, prevent empty `siteId` query params from causing a WSOD in the full screen launchpad.

The fix here is that `addQueryArgs()` will only ignore `undefined` values. `null`s or empty strings get added as query args.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This bug was introduced by #99676 when [the `getPostFlowUrl()` function was updated to include `sessionId`](https://github.com/Automattic/wp-calypso/pull/99676/files#diff-41c7ebbf73cb6ed1a4e5271644dd34a6f301a45fc0b4a00b73ef0ddac3b96e5cR44).

CC @alshakero @agrullon95 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create new site using a flow that ends in the full screen launchpad
  - e.g. `/setup/free`
2. Proceed through flow, everything can be free
3. After arriving in the fullscreen launchpad, choose to update your design selection
4. Choose a different design
5. WSOD when you land back on the fullscreen launchpad

https://github.com/user-attachments/assets/2e09cafe-dac1-4412-abf3-4ed02c88c6a2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [ ] ~Have you checked for TypeScript, React or other console errors?~
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
    - [ ] ~For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. ~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?~
