### PR TITLE
FormSelect: Make disabled styling consistent with FormTextInput's styling

### DIFF
--- a/client/assets/stylesheets/shared/_extends-forms.scss
+++ b/client/assets/stylesheets/shared/_extends-forms.scss
@@ -1,5 +1,23 @@
 // SASS placeholder selectors for form styles
 
+%form-field-disabled {
+	&:disabled {
+		background-color: var(--color-neutral-0);
+		border-color: var(--color-neutral-0);
+		color: var(--color-neutral-20);
+		opacity: 1;
+		-webkit-text-fill-color: var(--color-neutral-20);
+
+		&:hover {
+			cursor: default;
+		}
+
+		&::placeholder {
+			color: var(--color-neutral-20);
+		}
+	}
+}
+
 %form-field {
 	margin: 0;
 	padding: 7px 14px;
@@ -50,21 +68,7 @@
 		}
 	}
 
-	&:disabled {
-		background: var(--color-neutral-0);
-		border-color: var(--color-neutral-0);
-		color: var(--color-neutral-20);
-		opacity: 1;
-		-webkit-text-fill-color: var(--color-neutral-20);
-
-		&:hover {
-			cursor: default;
-		}
-
-		&::placeholder {
-			color: var(--color-neutral-20);
-		}
-	}
+	@extend %form-field-disabled;
 
 	&.is-valid {
 		border-color: var(--color-success);

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -1,3 +1,5 @@
+@import "../../../assets/stylesheets/shared/extends-forms";
+
 .form-select {
 	background:
 		var(--color-surface)
@@ -43,11 +45,14 @@
 		}
 	}
 
+	@extend %form-field-disabled;
+
 	&:disabled,
 	&:hover:disabled {
-		background:
-			url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1IDYuNzUwMDFMOSAxMi43NUwzIDYuNzUwMDFMNC4wNjA1IDUuNjg5NTFMOSAxMC42MjlMMTMuOTM5NSA1LjY4OTUxTDE1IDYuNzUwMDFaIiBmaWxsPSIjQzNDNEM3Ii8+Cjwvc3ZnPgo=)
-			no-repeat right 10px center;
+		background-image:
+			url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAxOCAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE1IDYuNzUwMDFMOSAxMi43NUwzIDYuNzUwMDFMNC4wNjA1IDUuNjg5NTFMOSAxMC42MjlMMTMuOTM5NSA1LjY4OTUxTDE1IDYuNzUwMDFaIiBmaWxsPSIjQzNDNEM3Ii8+Cjwvc3ZnPgo=);
+		background-repeat: no-repeat;
+		background-position: right 10px center;
 	}
 
 	// A smaller variant that works well when presented inline with text

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 @import "../../../assets/stylesheets/shared/extends-forms";
 
 .form-select {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100554.

## Proposed Changes

* Extract `disabled` form field styles into a reusable placeholder selector (`%form-field-disabled`) for use in both `FormTextInput` and `FormSelect`.
* Use specific background properties for the arrow background image.

|Before|After|
|-|-|
|<img width="708" alt="image" src="https://github.com/user-attachments/assets/66580495-808a-4348-87b7-ebd3bed319dc" />|<img width="703" alt="image" src="https://github.com/user-attachments/assets/b4f0e47f-6a5d-43da-9359-91002c5e0b64" />|

## Why are these changes being made?

The style of the disabled `FormSelect` was inconsistent with `FormTextInput`'s styling.

The changes improve the maintainability and reusability of the styles by:
1. Centralizing disabled state styles into a single, reusable placeholder selector.
2. Fixing a resulting style conflict where the `background` shorthand property was overriding desired background colors.
3. Ensuring consistent disabled state styling across form components.

## Testing Instructions

1. Navigate to `/me/purchases/vat-details`.
2. Add invalid data to the form (e.g. any country, ID `123`, `Test`, and `Test`).
3. Click the save button and verify that:
   - The background color, text color, and border of the country dropdown match that of the Name and Address fields.
   - The dropdown arrow icon is still visible and properly positioned.

**Note:** There appears to be a similar issue with the VAT ID input — we'll check if this needs fixing.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?