### PR TITLE
Signup: Fix Jetpack colophon spacing

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -339,7 +339,7 @@
 
 body.is-section-stepper:not(:has(.step-container-v2)),
 body.is-section-signup:not(:has(.step-container-v2)) {
-	svg {
+	svg:not(.jetpack-logo) {
 		padding-top: 0;
 		margin-right: 0;
 	}


### PR DESCRIPTION
## Proposed Changes

Fixes the spacing of the Jetpack Colophon on signup/onboarding.

Part of #101825.

## Why are these changes being made?

Just fixing spacing.

## Testing Instructions

* Go to `/setup/newsletter/newsletterSetup`
* Verify spacing of the "Powered by Jetpack" looks good.

## Screenshots


|Before|After|
|---|---|
|![Screenshot 2025-03-25 at 13 21 06](https://github.com/user-attachments/assets/4e8bcbd4-8be3-4791-922f-baa6f26b4443)|![Screenshot 2025-03-25 at 13 20 53](https://github.com/user-attachments/assets/509df465-d965-4e08-864d-0733bcc9b226)|
