### PR TITLE
Do not run Jetpack social auth endpoints on serverside

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -213,8 +213,14 @@ export function qrCodeLogin( context, next ) {
 }
 
 export async function jetpackGoogleAuth( context, next ) {
-	const { query } = context;
-	const redirectUri = `https://${ window?.location?.host ?? 'wordpress.com' }${ loginPath( {
+	const { query, isServerSide } = context;
+
+	// Do not continue if it's server side
+	if ( isServerSide ) {
+		return next();
+	}
+
+	const redirectUri = `https://${ window.location.host }${ loginPath( {
 		socialService: 'google',
 	} ) }`;
 
@@ -276,14 +282,14 @@ export async function jetpackGoogleAuth( context, next ) {
 }
 
 export async function jetpackGoogleAuthCallback( context, next ) {
-	const { query } = context;
+	const { query, isServerSide } = context;
 
 	const code = query.code;
 	const stateString = query.state;
 	const error = query.error;
 
-	// Not a redirect from Google if no code or error present
-	if ( ! code && ! error ) {
+	// Not a redirect from Google if no code or error present, or if it's server side
+	if ( ( ! code && ! error ) || isServerSide ) {
 		return next();
 	}
 
@@ -328,7 +334,7 @@ export async function jetpackGoogleAuthCallback( context, next ) {
 			throw new Error( 'Invalid state parameter' );
 		}
 
-		const redirectUri = `https://${ window?.location?.host ?? 'wordpress.com' }${ loginPath( {
+		const redirectUri = `https://${ window.location.host }${ loginPath( {
 			socialService: 'google',
 		} ) }`;
 
@@ -401,8 +407,14 @@ export async function jetpackGoogleAuthCallback( context, next ) {
 }
 
 export async function jetpackAppleAuth( context, next ) {
-	const { query } = context;
-	const redirectUri = `https://${ window?.location?.host ?? 'wordpress.com' }${ loginPath( {
+	const { query, isServerSide } = context;
+
+	// Do not continue if it's server side
+	if ( isServerSide ) {
+		return next();
+	}
+
+	const redirectUri = `https://${ window.location.host }${ loginPath( {
 		socialService: 'apple',
 	} ) }`;
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -214,7 +214,7 @@ export function qrCodeLogin( context, next ) {
 
 export async function jetpackGoogleAuth( context, next ) {
 	const { query } = context;
-	const redirectUri = `https://${ window.location.host }${ loginPath( {
+	const redirectUri = `https://${ window?.location?.host ?? 'wordpress.com' }${ loginPath( {
 		socialService: 'google',
 	} ) }`;
 
@@ -328,7 +328,7 @@ export async function jetpackGoogleAuthCallback( context, next ) {
 			throw new Error( 'Invalid state parameter' );
 		}
 
-		const redirectUri = `https://${ window.location.host }${ loginPath( {
+		const redirectUri = `https://${ window?.location?.host ?? 'wordpress.com' }${ loginPath( {
 			socialService: 'google',
 		} ) }`;
 
@@ -402,7 +402,7 @@ export async function jetpackGoogleAuthCallback( context, next ) {
 
 export async function jetpackAppleAuth( context, next ) {
 	const { query } = context;
-	const redirectUri = `https://${ window.location.host }${ loginPath( {
+	const redirectUri = `https://${ window?.location?.host ?? 'wordpress.com' }${ loginPath( {
 		socialService: 'apple',
 	} ) }`;
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/101802

## Proposed Changes

Social auth endpoints fail cause part of the request is invoked when window object is not available. It's related to the fact we need to make sure that the endpoint only runs on client side - where all features incl. window object are available.

## Testing Instructions

Open calypso live link, and go to /log-in/jetpack/google and /log-in/jetpack/apple. it should fail (it doesn't work outside production), but it should load the page.
