### PR TITLE
Domain connect or transfer: open inline help center

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -138,9 +138,9 @@ function DomainTransferOrConnect( {
 				{ ! isFetching && (
 					<div className={ baseClassName + '__support-link' }>
 						{ createInterpolateElement(
-							__( "Not sure what's best for you? <button>We're happy to help!</button>" ),
+							__( "Not sure what's best for you? <a>We're happy to help!</a>" ),
 							{
-								button: createElement( 'button', {
+								a: createElement( 'button', {
 									onClick: () => setShowHelpCenter( true ),
 								} ),
 							}

--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { CALYPSO_HELP_WITH_HELP_CENTER } from '@automattic/urls';
+import { useDispatch } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -50,6 +51,8 @@ function DomainTransferOrConnect( {
 		domainInboundTransferStatusInfo
 	);
 	const [ isFetching, setIsFetching ] = useState( false );
+
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
 
 	const handleConnect = () => {
 		recordMappingButtonClickInUseYourDomain( domain );
@@ -135,11 +138,10 @@ function DomainTransferOrConnect( {
 				{ ! isFetching && (
 					<div className={ baseClassName + '__support-link' }>
 						{ createInterpolateElement(
-							__( "Not sure what's best for you? <a>We're happy to help!</a>" ),
+							__( "Not sure what's best for you? <button>We're happy to help!</button>" ),
 							{
-								a: createElement( 'a', {
-									target: '_blank',
-									href: CALYPSO_HELP_WITH_HELP_CENTER,
+								button: createElement( 'button', {
+									onClick: () => setShowHelpCenter( true ),
 								} ),
 							}
 						) }

--- a/client/components/domains/use-my-domain/transfer-or-connect/style.scss
+++ b/client/components/domains/use-my-domain/transfer-or-connect/style.scss
@@ -15,7 +15,7 @@
 		// Specificity increase to override Card background color loaded later in the cascade.
 		&.domain-transfer-or-connect__content {
 			background-color: transparent;
-		}	
+		}
 
 		.option-content {
 			+ .option-content {
@@ -205,6 +205,21 @@
 
 		@include break-mobile {
 			margin: 24px 0;
+		}
+
+		button {
+			color: var(--color-link);
+			cursor: pointer;
+
+			&:hover,
+			&:focus,
+			&:active {
+				color: var(--color-link-dark);
+			}
+
+			&:focus {
+				outline: thin dotted;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100243

## Proposed Changes

Chance the "We're happy to help" text in domain transfer screens, from opening a link to `/wordpress.com/help`, to opening the inline help center

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Keep the users on the current page instead of interrupting their flow

## Testing Instructions

In WP Admin:
 - Visit `/domains/add/use-my-domain/{SITE_SLUG}?initialQuery=wptavern.com`
 - Make sure that the "We're happy to help" text at the bottom looks as on `trunk`
 - Make sure that, when the text is clicked, the inline help center shows


https://github.com/user-attachments/assets/77fc9f5c-1a5b-433f-8bb6-ee72c2e4655b

In onboarding flows:
 - Visit `/setup/onboarding` and navigate to the domain step
 - Select the "Use a domain I own" option
 - Enter a valid URL for the domain you'd like to use and submit the form
 - In the new screen:
   - Make sure that the "We're happy to help" text at the bottom looks as on `trunk`
   - Make sure that, when the text is clicked, the inline help center shows


https://github.com/user-attachments/assets/b2451df2-31e8-45d1-a7dc-477cc75eee3f



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
