### PR TITLE
Mobile domains: Show ellipsis during price calculation

### DIFF
--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -161,10 +161,12 @@ export class DomainsMiniCart extends Component {
 						} ) }
 					</div>
 					<div key="rowtotalprice" className="domains__domain-cart-total-price">
-						{ formatCurrency(
-							this.props.domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
-							this.props.domainsInCart?.[ 0 ]?.currency ?? userCurrency
-						) }
+						{ this.props.domainsInCart.some( ( domain ) => domain.temporary )
+							? '...'
+							: formatCurrency(
+									this.props.domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
+									this.props.domainsInCart?.[ 0 ]?.currency ?? userCurrency
+							  ) }
 					</div>
 				</div>
 				<Button


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/101823.

## Proposed Changes

https://github.com/user-attachments/assets/5521954b-ad6d-41bb-a619-152cb91e54a0

## Why are these changes being made?

Consistency with the desktop version.

## Testing Instructions

Both the feature-flagged and prod versions should show the ellipsis on mobile when the domains cart is loading.