### PR TITLE
Handle site selection correctly in domain transfer page

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -63,11 +63,13 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		);
 	};
 
-	handleSiteSelect = ( targetSiteId: number ): void => {
+	handleSiteSelect = ( targetSiteId: number ) => {
 		this.setState( {
 			targetSiteId,
 			showConfirmationDialog: true,
 		} );
+		// Return true to let the site selector know we'll take care of the navigation
+		return true;
 	};
 
 	handleConfirmTransfer = (


### PR DESCRIPTION
Fix https://github.com/Automattic/wp-calypso/issues/101772

## Proposed Changes

The domain transfer page depends on the site selector to select a site, but the site selector handles navigation automatically unless the host returns `true` in the event handler. 

The host page didn't return true, causing a disruptive redirect. 
