### PR TITLE
Posts: Navigate max pages notice to `/sites`

### DIFF
--- a/client/my-sites/post-type-list/max-pages-notice.jsx
+++ b/client/my-sites/post-type-list/max-pages-notice.jsx
@@ -1,62 +1,39 @@
-import { localize } from 'i18n-calypso';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 
 import './max-pages-notice.scss';
 
-class PostTypeListMaxPagesNotice extends Component {
-	static propTypes = {
-		displayedPosts: PropTypes.number,
-		totalPosts: PropTypes.number,
-	};
+function PostTypeListMaxPagesNotice( { displayedPosts, totalPosts } ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
 
-	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_post_type_list_max_pages_view' );
-	}
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_post_type_list_max_pages_view' ) );
+	}, [ dispatch ] );
 
-	focusSiteSelector = ( event ) => {
-		event.preventDefault();
-
-		this.props.setLayoutFocus( 'sites' );
-	};
-
-	render() {
-		const { displayedPosts, totalPosts, translate } = this.props;
-
-		return (
-			<div className="post-type-list__max-pages-notice">
-				{ translate(
-					'Showing %(displayedPosts)d post of %(totalPosts)d.',
-					'Showing %(displayedPosts)d posts of %(totalPosts)d.',
-					{
-						count: displayedPosts,
-						args: {
-							displayedPosts,
-							totalPosts,
-						},
-					}
-				) }
-				<br />
-				{ translate( 'To view more posts, {{a}}switch to a specific site{{/a}}.', {
-					components: {
-						a: (
-							/* eslint-disable jsx-a11y/anchor-is-valid,jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
-							<a
-								className="post-type-list__max-pages-notice-link"
-								onClick={ this.focusSiteSelector }
-							/>
-							/* eslint-enable jsx-a11y/anchor-is-valid,jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
-						),
+	return (
+		<div className="post-type-list__max-pages-notice">
+			{ translate(
+				'Showing %(displayedPosts)d post of %(totalPosts)d.',
+				'Showing %(displayedPosts)d posts of %(totalPosts)d.',
+				{
+					count: displayedPosts,
+					args: {
+						displayedPosts,
+						totalPosts,
 					},
-				} ) }
-			</div>
-		);
-	}
+				}
+			) }
+			<br />
+			{ translate( 'To view more posts, {{a}}switch to a specific site{{/a}}.', {
+				components: {
+					a: <a className="post-type-list__max-pages-notice-link" href="/sites" />,
+				},
+			} ) }
+		</div>
+	);
 }
 
-export default connect( null, { recordTracksEvent, setLayoutFocus } )(
-	localize( PostTypeListMaxPagesNotice )
-);
+export default PostTypeListMaxPagesNotice;


### PR DESCRIPTION
## Proposed Changes

Updates `PostTypeListMaxPagesNotice` to no longer set layout focus to `sites`, but to rather navigate to the new sites selector on `/sites`.

I'm also using the opportunity to refactor the component to a functional one.

## Why are these changes being made?

To remove one of the last instances where we're setting layout focus to `sites`, which unblocks us from removing the old site picker which we're not using almost anywhere anymore. 

We're unifying site selection code as part of improving the multisite dashboard experience. 

We're removing the old site picker in #101844 and we removed a few unused related pieces in https://github.com/Automattic/wp-calypso/pull/101835 and https://github.com/Automattic/wp-calypso/pull/101837.

## Testing Instructions

* Make sure your `remove_duplicate_views_experiment_assignment_160125` preference is set to `control`.
* Go to `/posts`
* If you don't have enough posts in that list, in React DevTools set `PostTypeList`'s `totalPageCount` prop to `99` as shown on the screenshot:

![Screenshot 2025-03-25 at 17 37 37](https://github.com/user-attachments/assets/ec1f59bb-6711-48b1-8067-ca154dcf016e)

* Verify that clicking the "switch to a specific site" link leads to `/sites`. 