### PR TITLE
Jetpack Cloud: Remove old site selection triggers

### DIFF
--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -1,90 +1,32 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import AllSites from 'calypso/blocks/all-sites';
+import { useSelector } from 'react-redux';
 import Site from 'calypso/blocks/site';
 import { SidebarV2Header as SidebarHeader } from 'calypso/layout/sidebar-v2';
-import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
-import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import { AppState } from 'calypso/types';
 import JetpackLogo from './jetpack-logo.svg';
 import ProfileDropdown from './profile-dropdown';
 
-type Props = {
-	forceAllSitesView?: boolean;
-};
-
-const AllSitesIcon = () => (
-	<img
-		className="jetpack-cloud-sidebar__all-sites-icon"
-		src={ JetpackLogo }
-		alt=""
-		role="presentation"
-	/>
-);
-
-// NOTE: This hook is a little hacky, to get around the "outside click"
-// close behavior that happens inside `<SiteSelector />`. Instead of
-// using the `getCurrentLayoutFocus` selector, we use internal state to
-// derive whether or not the site selector should be visible.
-const useShowSiteSelector = ( {
-	forceAllSitesView,
-	selectedSiteId,
-}: {
-	forceAllSitesView: boolean;
-	selectedSiteId: number | null;
-} ) => {
-	const SITES_FOCUS = 'sites';
-
-	const isSiteSelectorVisible = useSelector(
-		( state: AppState ) => getCurrentLayoutFocus( state ) === SITES_FOCUS
-	);
-	const dispatch = useDispatch();
-
-	return useCallback( () => {
-		dispatch(
-			forceAllSitesView
-				? recordTracksEvent( 'calypso_jetpack_sidebar_switch_site_all_click' )
-				: recordTracksEvent( 'calypso_jetpack_sidebar_switch_site_single_click', {
-						site_id: selectedSiteId,
-				  } )
-		);
-
-		// NOTE: If the selector is visible, dismissal will happen automatically
-		// when the user clicks outside the bounds of its root element
-		if ( ! isSiteSelectorVisible ) {
-			dispatch( setLayoutFocus( SITES_FOCUS ) );
-		}
-	}, [ dispatch, forceAllSitesView, isSiteSelectorVisible, selectedSiteId ] );
-};
-
-const Header = ( { forceAllSitesView = false }: Props ) => {
+const AllSitesHeader = () => {
 	const translate = useTranslate();
-	const selectedSiteId = useSelector( getSelectedSiteId );
+	return (
+		<div className="jetpack-cloud-sidebar__all-sites">
+			<img
+				className="jetpack-cloud-sidebar__all-sites-icon"
+				src={ JetpackLogo }
+				alt=""
+				role="presentation"
+			/>
+			<span className="jetpack-cloud-sidebar__all-sites-label">{ translate( 'All Sites' ) }</span>
+		</div>
+	);
+};
 
-	const showSiteSelector = useShowSiteSelector( { forceAllSitesView, selectedSiteId } );
+const Header = () => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	return (
 		<SidebarHeader className="jetpack-cloud-sidebar__header">
-			{ forceAllSitesView ? (
-				<AllSites
-					showIcon
-					showChevronDownIcon
-					showCount={ false }
-					icon={ <AllSitesIcon /> }
-					title={ translate( 'All Sites' ) }
-					onSelect={ showSiteSelector }
-				/>
-			) : (
-				<Site
-					showChevronDownIcon
-					className="jetpack-cloud-sidebar__selected-site"
-					siteId={ selectedSiteId }
-					onSelect={ showSiteSelector }
-				/>
-			) }
+			{ selectedSiteId ? <Site siteId={ selectedSiteId } /> : <AllSitesHeader /> }
 			<ProfileDropdown />
 		</SidebarHeader>
 	);

--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -105,3 +105,21 @@ a.jetpack-cloud-sidebar__external-link {
 		right: 16px;
 	}
 }
+
+.jetpack-cloud-sidebar__all-sites {
+    display: flex;
+    flex: 1 0 auto;
+    justify-content: flex-start;
+    align-items: center;
+}
+
+.jetpack-cloud-sidebar__all-sites-icon {
+	margin-inline-end: 12px;
+}
+
+.jetpack-cloud-sidebar__all-sites-label {
+	font-size: .875rem;
+	font-weight: 500;
+	line-height: 1.3;
+	display: inline-flex;
+}

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -88,7 +88,7 @@ const JetpackCloudSidebar = ( {
 
 	return (
 		<Sidebar className={ clsx( 'jetpack-cloud-sidebar', className ) }>
-			<SidebarHeader forceAllSitesView={ isJetpackManage } />
+			<SidebarHeader />
 
 			<SidebarMain>
 				<SidebarNavigator initialPath={ path }>


### PR DESCRIPTION
## Proposed Changes

We're removing the old site selection triggers in favor of the `/sites` screen that allows selection. 

## Why are these changes being made?

In all environments (Jetpack Cloud, Automattic for Agencies, WordPress.com) we already use `/sites` for selecting the current site. The old site selection picker is obsolete and only appears in a few awkward places. It is time to retire it for consistency.

This is part of a bigger initiative - unifying multisite dashboard experiences. 

This step is one of the last pre-requisites to removing the old picker, which I'm addressing in #101844.

## Testing Instructions

* Open Jetpack Cloud with a partner account.
* "All sites" at the top of the sidebar shouldn't be clickable anymore. The corresponding chevron down has also been removed.
* Go to `/sites`
* Select a site by clicking on it.
* The site name at the top of the sidebar shouldn't be clickable anymore. The corresponding chevron down has also been removed.

### Screenshots

Without a selected site:

|Before|After|
|---|---|
|![Screenshot 2025-03-25 at 18 24 40](https://github.com/user-attachments/assets/64740eaf-e6c8-4584-b988-53b8f30a9053)|![Screenshot 2025-03-25 at 18 24 34](https://github.com/user-attachments/assets/4e85ef07-4401-4189-8892-341aa8319ebb)|

With a selected site:

|Before|After|
|---|---|
|![Screenshot 2025-03-25 at 18 23 47](https://github.com/user-attachments/assets/cafa6cf0-d535-4880-a9bc-0b90036a722a)|![Screenshot 2025-03-25 at 18 23 40](https://github.com/user-attachments/assets/9f33b94a-1a9f-4796-a161-3938f15162a3)|



