### PR TITLE
open facebook and x sharing in new tab

### DIFF
--- a/client/blocks/reader-share/social.jsx
+++ b/client/blocks/reader-share/social.jsx
@@ -10,13 +10,6 @@ import { useDispatch } from 'calypso/state';
 import { infoNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
-const getWindowCenterPosition = ( targetWidth, targetHeight ) => {
-	return {
-		left: window.screenX + ( window.innerWidth / 2 - targetWidth / 2 ),
-		top: window.screenY + ( window.innerHeight / 2 - targetHeight / 2 ),
-	};
-};
-
 /**
  * Local variables
  */
@@ -33,16 +26,7 @@ const actionMap = {
 		} );
 		baseUrl.search = params.toString();
 
-		const xUrl = baseUrl.href;
-		const width = 550;
-		const height = 420;
-		const { left, top } = getWindowCenterPosition( width, height );
-
-		window.open(
-			xUrl,
-			'x',
-			`width=${ width },height=${ height },left=${ left },top=${ top },resizable,scrollbars`
-		);
+		window.open( baseUrl.href, '_blank' );
 	},
 	facebook( post ) {
 		const baseUrl = new URL( 'https://www.facebook.com/sharer.php' );
@@ -52,17 +36,7 @@ const actionMap = {
 		} );
 		baseUrl.search = params.toString();
 
-		const facebookUrl = baseUrl.href;
-
-		const width = 626;
-		const height = 436;
-		const { left, top } = getWindowCenterPosition( width, height );
-
-		window.open(
-			facebookUrl,
-			'facebook',
-			`width=${ width },height=${ height },left=${ left },top=${ top },resizable,scrollbars`
-		);
+		window.open( baseUrl.href, '_blank' );
 	},
 	copy_link() {},
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

just a test idea for - https://github.com/Automattic/loop/issues/596, to see what it feels like to open facebook and x sharing links in a new tab.

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
