### PR TITLE
Reader share - make facebook popup wider to accomodate login, open in new tab if users window is smaller than popup.

### DIFF
--- a/client/blocks/reader-share/social.jsx
+++ b/client/blocks/reader-share/social.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { getWindowInnerWidth } from '@automattic/viewport';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuItemClipboard from 'calypso/components/popover-menu/item-clipboard';
@@ -33,36 +34,49 @@ const actionMap = {
 		} );
 		baseUrl.search = params.toString();
 
+		const viewportWidth = getWindowInnerWidth();
+
 		const xUrl = baseUrl.href;
 		const width = 550;
 		const height = 420;
 		const { left, top } = getWindowCenterPosition( width, height );
 
-		window.open(
-			xUrl,
-			'x',
-			`width=${ width },height=${ height },left=${ left },top=${ top },resizable,scrollbars`
-		);
+		if ( viewportWidth > width ) {
+			window.open(
+				xUrl,
+				'x',
+				`width=${ width },height=${ height },left=${ left },top=${ top },resizable,scrollbars`
+			);
+		} else {
+			window.open( xUrl, '_blank' );
+		}
 	},
 	facebook( post ) {
-		const baseUrl = new URL( 'https://www.facebook.com/sharer.php' );
+		const baseUrl = new URL( 'https://m.facebook.com/sharer.php' );
 		const params = new URLSearchParams( {
 			u: post.URL,
 			app_id: config( 'facebook_api_key' ),
 		} );
 		baseUrl.search = params.toString();
 
+		const viewportWidth = getWindowInnerWidth();
 		const facebookUrl = baseUrl.href;
 
-		const width = 626;
+		// This must be wide enough to accomodate facebook's login redirect screen, which
+		// unfortunately is not responsive to smaller viewports.
+		const width = 1000;
 		const height = 436;
 		const { left, top } = getWindowCenterPosition( width, height );
 
-		window.open(
-			facebookUrl,
-			'facebook',
-			`width=${ width },height=${ height },left=${ left },top=${ top },resizable,scrollbars`
-		);
+		if ( viewportWidth > width ) {
+			window.open(
+				facebookUrl,
+				'facebook',
+				`width=${ width },height=${ height },left=${ left },top=${ top },resizable,scrollbars`
+			);
+		} else {
+			window.open( facebookUrl, '_blank' );
+		}
 	},
 	copy_link() {},
 };

--- a/client/blocks/reader-share/social.jsx
+++ b/client/blocks/reader-share/social.jsx
@@ -52,7 +52,7 @@ const actionMap = {
 		}
 	},
 	facebook( post ) {
-		const baseUrl = new URL( 'https://m.facebook.com/sharer.php' );
+		const baseUrl = new URL( 'https://www.facebook.com/sharer.php' );
 		const params = new URLSearchParams( {
 			u: post.URL,
 			app_id: config( 'facebook_api_key' ),

--- a/client/blocks/reader-share/social.jsx
+++ b/client/blocks/reader-share/social.jsx
@@ -65,7 +65,8 @@ const actionMap = {
 		// This must be wide enough to accomodate facebook's login redirect screen, which
 		// unfortunately is not responsive to smaller viewports.
 		const width = 1000;
-		const height = 436;
+		// Facebook resizes to about 850px, so this prevents jumpyness after opening the window.
+		const height = 850;
 		const { left, top } = getWindowCenterPosition( width, height );
 
 		if ( viewportWidth > width ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/596

## Proposed Changes

Resolves an issue with the facebook sharing popup being too small and looking bad for logged out facebook users.

* Updates the facebook popups window width to 1000px to accomodate the facebook login screen that is redirected to if the user is not logged in. unfortunately this login screen by facebook is not device responsive.
    * This makes the current sharing window larger for logged in facebook users, but it still feels good on my end.
* Updates both X and Facebook sharing links to open in a new tab instead of a new window, if the new window would be wider than their current browser window.

The alternative to this could be to leave things the way they are. If a user is sharing to another platform, chances are they are logged into that platform. If the increased width for logged in facebook sharing feels too large, leaving it the way it was could be a tradeoff as most users should not experience the issue and those that do shouldn't experience it anymore after they are logged into their platform. Thoughts?

BEFORE
<img width="1243" alt="Screenshot 2025-03-25 at 1 45 03 PM" src="https://github.com/user-attachments/assets/82cb9154-a7f2-460b-8fc2-4e23740f093f" />


AFTER
<img width="1325" alt="Screenshot 2025-03-25 at 1 38 06 PM" src="https://github.com/user-attachments/assets/304933e8-0566-4554-a202-16f426be6d16" />


 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* A poor popup experience for logged out facebook users, due to facebooks lack of responsive web design 🙃 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch, logged out of facebook.
* Have your browser >1000px width.
* Go to the reader, click "share" and select facebook.
* Verify the login screen from facebook is more visible and feels less broken.
* Decrease the browser screen width to less than 1000px and try again.
* Verify the login screen opens in a new tab.
* Test with logged-in facebook as well, verify it works as expected.
* Test sharing with X - note instead of 1000px for X, the cutoff for window vs. tab for X sharing is 550px width.
* Verify this works as expected.
* Consider - is this better? Is this worth the tradeoff or should we go back to the smaller width for facebook considering that most users should be logged in, or likely only have to login once if not (? 🤔 )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
