### PR TITLE
Email Settings: add modal to confirm pausing emails

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,4 +1,4 @@
-import { Card, FormLabel } from '@automattic/components';
+import { Card, FormLabel, Dialog } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
@@ -26,6 +26,10 @@ import { getReaderTeams } from 'calypso/state/teams/selectors';
 import SubscriptionManagementBackButton from '../subscription-management-back-button';
 
 class NotificationSubscriptions extends Component {
+	state = {
+		showConfirmModal: false,
+	};
+
 	handleClickEvent( action ) {
 		return () => this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
 	}
@@ -40,6 +44,32 @@ class NotificationSubscriptions extends Component {
 			this.props.recordGoogleEvent( 'Me', `Clicked ${ action } checkbox`, 'checked', +optionValue );
 		};
 	}
+
+	handleSubmit = ( event ) => {
+		event.preventDefault();
+		const isBlockingEmails = this.props.getSetting( 'subscription_delivery_email_blocked' );
+		const hasNewsletterSubscriptions = true; // You'll need to get this from props or state
+
+		if ( isBlockingEmails && hasNewsletterSubscriptions ) {
+			this.setState( { showConfirmModal: true } );
+			return;
+		}
+
+		this.props.submitForm( event );
+	};
+
+	handleModalCancel = () => {
+		// Create a synthetic event object that matches what updateSetting expects
+		const syntheticEvent = {
+			currentTarget: {
+				name: 'subscription_delivery_email_blocked',
+				value: false,
+			},
+		};
+
+		this.props.updateSetting( syntheticEvent );
+		this.setState( { showConfirmModal: false } );
+	};
 
 	getDeliveryHourLabel( hour ) {
 		return this.props.translate( '%(fromHour)s - %(toHour)s', {
@@ -82,7 +112,7 @@ class NotificationSubscriptions extends Component {
 					<form
 						id="notification-settings"
 						onChange={ this.props.markChanged }
-						onSubmit={ this.props.submitForm }
+						onSubmit={ this.handleSubmit }
 					>
 						<FormSectionHeading>
 							{ this.props.translate( 'Email subscriptions' ) }
@@ -266,6 +296,33 @@ class NotificationSubscriptions extends Component {
 						</FormButton>
 					</form>
 				</Card>
+
+				<Dialog
+					isVisible={ this.state.showConfirmModal }
+					onClose={ () => this.setState( { showConfirmModal: false } ) }
+					buttons={ [
+						{
+							action: 'cancel',
+							label: this.props.translate( 'Cancel' ),
+							onClick: () => this.handleModalCancel(),
+						},
+						{
+							action: 'confirm',
+							label: this.props.translate( 'Confirm' ),
+							onClick: () => {
+								this.setState( { showConfirmModal: false } );
+								this.props.submitForm();
+							},
+							isPrimary: true,
+						},
+					] }
+				>
+					<p>
+						{ this.props.translate(
+							"You have active newsletter subscriptions. Pausing emails means you won't receive any newsletter updates. Are you sure you want to continue?"
+						) }
+					</p>
+				</Dialog>
 			</Main>
 		);
 	}

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -20,6 +20,7 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import withFormBase from 'calypso/me/form-base/with-form-base';
 import Navigation from 'calypso/me/notification-settings/navigation';
 import ReauthRequired from 'calypso/me/reauth-required';
+import { useSiteSubscriptions } from 'calypso/reader/following/use-site-subscriptions';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
@@ -48,9 +49,9 @@ class NotificationSubscriptions extends Component {
 	handleSubmit = ( event ) => {
 		event.preventDefault();
 		const isBlockingEmails = this.props.getSetting( 'subscription_delivery_email_blocked' );
-		const hasNewsletterSubscriptions = true; // You'll need to get this from props or state
+		const { hasSubscriptions } = this.props;
 
-		if ( isBlockingEmails && hasNewsletterSubscriptions ) {
+		if ( isBlockingEmails && hasSubscriptions ) {
 			this.setState( { showConfirmModal: true } );
 			return;
 		}
@@ -311,7 +312,11 @@ class NotificationSubscriptions extends Component {
 							label: this.props.translate( 'Confirm' ),
 							onClick: () => {
 								this.setState( { showConfirmModal: false } );
-								this.props.submitForm();
+								// Create a synthetic event object
+								const syntheticEvent = {
+									preventDefault: () => {},
+								};
+								this.props.submitForm( syntheticEvent );
 							},
 							isPrimary: true,
 						},
@@ -336,10 +341,15 @@ const mapDispatchToProps = {
 	recordGoogleEvent,
 };
 
+const NotificationSubscriptionsWithHooks = ( props ) => {
+	const { hasNonSelfSubscriptions } = useSiteSubscriptions();
+	return <NotificationSubscriptions hasSubscriptions={ hasNonSelfSubscriptions } { ...props } />;
+};
+
 export default compose(
 	connect( mapStateToProps, mapDispatchToProps ),
 	localize,
 	protectForm,
 	withLocalizedMoment,
 	withFormBase
-)( NotificationSubscriptions );
+)( NotificationSubscriptionsWithHooks );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/loop/issues/373

## Proposed Changes

* This will show a confirmation modal if the user has subscriptions and they choose to pause emails

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR locally
* Create a test account - follow/subscribe to no sites
* Go to http://calypso.localhost:3000/me/notifications/subscriptions
* Check the `Pause Emails` setting - confirm you don't see any confirmation modal when saving settings
* Return to `/reader` and subscribe to some sites
* Go to http://calypso.localhost:3000/me/notifications/subscriptions again
* Check the `Pause Emails` setting - confirm you do see a confirmation modal when saving settings

<img width="773" alt="Screenshot 2025-03-29 at 00 02 27" src="https://github.com/user-attachments/assets/87fb4111-71c0-49c7-9ed7-147a711a080a" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
