### PR TITLE
Reader: Update notification toggles text for consistency

### DIFF
--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -1,6 +1,6 @@
 import './style.scss';
 import { Reader } from '@automattic/data-stores';
-import { Button, ToggleControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Icon, settings } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { find, get } from 'lodash';
@@ -11,6 +11,7 @@ import Settings from 'calypso/assets/images/icons/settings.svg';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormSelect from 'calypso/components/forms/form-select';
 import SVGIcon from 'calypso/components/svg-icon';
+import EmailMeNewCommentsToggle from 'calypso/landing/subscriptions/components/settings/site-settings/email-me-new-comments-toggle';
 import EmailMeNewPostsToggle from 'calypso/landing/subscriptions/components/settings/site-settings/email-me-new-posts-toggle';
 import NotifyMeOfNewPostsToggle from 'calypso/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle';
 import ReaderPopover from 'calypso/reader/components/reader-popover';
@@ -218,14 +219,11 @@ class ReaderSiteNotificationSettings extends Component {
 					) }
 
 					{ ! isEmailBlocked && (
-						<div className="reader-site-notification-settings__popout-toggle">
-							<ToggleControl
-								onChange={ this.toggleNewCommentEmail }
-								checked={ sendNewCommentsByEmail }
-								id="reader-site-notification-settings__email-comments"
-								label={ translate( 'Email me new comments' ) }
-							/>
-						</div>
+						<EmailMeNewCommentsToggle
+							className="reader-site-notification-settings__popout-toggle"
+							value={ sendNewCommentsByEmail }
+							onChange={ this.toggleNewCommentEmail }
+						/>
 					) }
 
 					<NotifyMeOfNewPostsToggle

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -191,11 +191,7 @@ class ReaderSiteNotificationSettings extends Component {
 							isEmailBlocked
 								? translate(
 										'You currently have email delivery turned off. Visit your {{a}}Notification Settings{{/a}} to turn it back on.',
-										{
-											components: {
-												a: <a href="/me/notifications/subscriptions" />,
-											},
-										}
+										{ components: { a: <a href="/me/notifications/subscriptions" /> } }
 								  )
 								: null
 						}
@@ -230,7 +226,6 @@ class ReaderSiteNotificationSettings extends Component {
 						className="reader-site-notification-settings__popout-toggle"
 						value={ sendNewPostsByNotification }
 						onChange={ this.toggleNewPostNotification }
-						showHint
 					/>
 
 					{ subscriptionId && (

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -1,3 +1,4 @@
+import './style.scss';
 import { Reader } from '@automattic/data-stores';
 import { Button, ToggleControl } from '@wordpress/components';
 import { Icon, settings } from '@wordpress/icons';
@@ -10,6 +11,7 @@ import Settings from 'calypso/assets/images/icons/settings.svg';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormSelect from 'calypso/components/forms/form-select';
 import SVGIcon from 'calypso/components/svg-icon';
+import EmailMeNewPostsToggle from 'calypso/landing/subscriptions/components/settings/site-settings/email-me-new-posts-toggle';
 import NotifyMeOfNewPostsToggle from 'calypso/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle';
 import ReaderPopover from 'calypso/reader/components/reader-popover';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -24,8 +26,6 @@ import {
 } from 'calypso/state/reader/follows/actions';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
-
-import './style.scss';
 
 class ReaderSiteNotificationSettings extends Component {
 	static displayName = 'ReaderSiteNotificationSettings';
@@ -179,38 +179,28 @@ class ReaderSiteNotificationSettings extends Component {
 					position="bottom left"
 					className="reader-site-notification-settings__popout"
 				>
-					<div
+					<EmailMeNewPostsToggle
 						className={
 							isEmailBlocked
 								? 'reader-site-notification-settings__popout-instructions'
 								: 'reader-site-notification-settings__popout-toggle'
 						}
-					>
-						{ ! isEmailBlocked && (
-							<ToggleControl
-								onChange={ this.toggleNewPostEmail }
-								checked={ sendNewPostsByEmail }
-								id="reader-site-notification-settings__email-posts"
-								label={ translate( 'Email me new posts' ) }
-							/>
-						) }
-
-						{ isEmailBlocked && (
-							<div>
-								{ translate( 'Email me new posts' ) }
-								<p className="reader-site-notification-settings__popout-instructions-hint">
-									{ translate(
+						value={ sendNewPostsByEmail }
+						hintText={
+							isEmailBlocked
+								? translate(
 										'You currently have email delivery turned off. Visit your {{a}}Notification Settings{{/a}} to turn it back on.',
 										{
 											components: {
 												a: <a href="/me/notifications/subscriptions" />,
 											},
 										}
-									) }
-								</p>
-							</div>
-						) }
-					</div>
+								  )
+								: null
+						}
+						isDisabled={ isEmailBlocked }
+						onChange={ this.toggleNewPostEmail }
+					/>
 
 					{ ! isEmailBlocked && sendNewPostsByEmail && (
 						<div className="reader-site-notification-settings__popout-select">

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -10,6 +10,7 @@ import Settings from 'calypso/assets/images/icons/settings.svg';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import FormSelect from 'calypso/components/forms/form-select';
 import SVGIcon from 'calypso/components/svg-icon';
+import NotifyMeOfNewPostsToggle from 'calypso/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle';
 import ReaderPopover from 'calypso/reader/components/reader-popover';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -178,17 +179,6 @@ class ReaderSiteNotificationSettings extends Component {
 					position="bottom left"
 					className="reader-site-notification-settings__popout"
 				>
-					<div className="reader-site-notification-settings__popout-toggle">
-						<ToggleControl
-							onChange={ this.toggleNewPostNotification }
-							checked={ sendNewPostsByNotification }
-							id="reader-site-notification-settings__notifications"
-							label={ translate( 'Notify me of new posts' ) }
-						/>
-						<p className="reader-site-notification-settings__popout-hint">
-							{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
-						</p>
-					</div>
 					<div
 						className={
 							isEmailBlocked
@@ -247,6 +237,13 @@ class ReaderSiteNotificationSettings extends Component {
 							/>
 						</div>
 					) }
+
+					<NotifyMeOfNewPostsToggle
+						className="reader-site-notification-settings__popout-toggle"
+						value={ sendNewPostsByNotification }
+						onChange={ this.toggleNewPostNotification }
+						showHint
+					/>
 
 					{ subscriptionId && (
 						<Button

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -64,12 +64,6 @@
 		top: 1px;
 	}
 
-	.reader-site-notification-settings__popout-toggle:nth-child(2),
-	.reader-site-notification-settings__popout-toggle:nth-child(3),
-	.reader-site-notification-settings__popout-toggle:nth-child(4) {
-		display: flex;
-	}
-
 	.components-base-control.components-toggle-control {
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		line-height: 1.25rem;
@@ -95,19 +89,19 @@
 	}
 }
 
-.new-posts-notify-toggle__hint,
-.reader-site-notification-settings__popout-instructions-hint {
+.notify-new-posts-toggle__hint,
+.email-new-posts-toggle__hint {
 	color: var(--color-text-subtle);
 	font-size: $font-body-extra-small;
 	margin-bottom: -2px;
 	margin-top: 5px;
 }
 
-.new-posts-notify-toggle__hint {
+.notify-new-posts-toggle__hint {
 	width: 220px;
 }
 
-.reader-site-notification-settings__popout-instructions-hint {
+.email-new-posts-toggle__hint {
 	margin-top: 4px;
 	width: 250px;
 }

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -95,15 +95,15 @@
 	}
 }
 
-.reader-site-notification-settings__popout-hint,
+.new-posts-notify-toggle__hint,
 .reader-site-notification-settings__popout-instructions-hint {
 	color: var(--color-text-subtle);
 	font-size: $font-body-extra-small;
 	margin-bottom: -2px;
-	margin-top: 10px;
+	margin-top: 5px;
 }
 
-.reader-site-notification-settings__popout-hint {
+.new-posts-notify-toggle__hint {
 	width: 220px;
 }
 

--- a/client/landing/subscriptions/components/settings/comment-settings/comment-settings.tsx
+++ b/client/landing/subscriptions/components/settings/comment-settings/comment-settings.tsx
@@ -32,7 +32,7 @@ const CommentSettings = ( {
 					<NotifyMeOfNewCommentsToggle
 						value={ notifyMeOfNewComments }
 						onChange={ onNotifyMeOfNewCommentsChange }
-						isUpdating={ updatingNotifyMeOfNewComments }
+						isDisabled={ updatingNotifyMeOfNewComments }
 					/>
 				</div>
 			) }

--- a/client/landing/subscriptions/components/settings/comment-settings/notify-me-of-new-comments-toggle.tsx
+++ b/client/landing/subscriptions/components/settings/comment-settings/notify-me-of-new-comments-toggle.tsx
@@ -3,13 +3,13 @@ import { useTranslate } from 'i18n-calypso';
 
 type NotifyMeOfNewCommentsToggleProps = {
 	value: boolean;
-	isUpdating: boolean;
+	isDisabled: boolean;
 	onChange: ( value: boolean ) => void;
 };
 
 const NotifyMeOfNewCommentsToggle = ( {
 	value = false,
-	isUpdating = false,
+	isDisabled = false,
 	onChange,
 }: NotifyMeOfNewCommentsToggleProps ) => {
 	const translate = useTranslate();
@@ -20,7 +20,7 @@ const NotifyMeOfNewCommentsToggle = ( {
 				label={ translate( 'Notify me of new comments' ) }
 				onChange={ () => onChange( ! value ) }
 				checked={ value }
-				disabled={ isUpdating }
+				disabled={ isDisabled }
 			/>
 			<p className="setting-item__hint">
 				{ translate( 'Receive web and mobile notifications for new comments from this post.' ) }

--- a/client/landing/subscriptions/components/settings/site-settings/email-me-new-comments-toggle.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/email-me-new-comments-toggle.tsx
@@ -1,26 +1,29 @@
 import { ToggleControl } from '@wordpress/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 
 type EmailMeNewCommentsToggleProps = {
+	className?: string;
 	value: boolean;
-	isUpdating: boolean;
+	isDisabled: boolean;
 	onChange: ( value: boolean ) => void;
 };
 
 const EmailMeNewCommentsToggle = ( {
+	className = '',
 	value = false,
-	isUpdating = false,
+	isDisabled = false,
 	onChange,
 }: EmailMeNewCommentsToggleProps ) => {
 	const translate = useTranslate();
 
 	return (
-		<div className="setting-item email-me-new-comments-toggle">
+		<div className={ clsx( 'email-me-new-comments-toggle', className ) }>
 			<ToggleControl
-				label={ translate( 'Receive new comment emails' ) }
+				label={ translate( 'Email me new comments' ) }
 				onChange={ () => onChange( ! value ) }
 				checked={ value }
-				disabled={ isUpdating }
+				disabled={ isDisabled }
 			/>
 		</div>
 	);

--- a/client/landing/subscriptions/components/settings/site-settings/email-me-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/email-me-new-posts-toggle.tsx
@@ -20,12 +20,7 @@ const EmailMeNewPostsToggle = ( {
 	const translate = useTranslate();
 
 	return (
-		<div
-			className={ clsx( className, {
-				'setting-item email-me-new-posts-toggle': ! className,
-				'is-enabled': value,
-			} ) }
-		>
+		<div className={ clsx( 'email-me-new-posts-toggle', className, { 'is-enabled': value } ) }>
 			<ToggleControl
 				label={ translate( 'Email me new posts' ) }
 				onChange={ () => onChange( ! value ) }

--- a/client/landing/subscriptions/components/settings/site-settings/email-me-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/email-me-new-posts-toggle.tsx
@@ -3,26 +3,36 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 
 type EmailMeNewPostsToggleProps = {
+	className?: string;
+	isDisabled?: boolean;
+	hintText?: boolean;
 	value: boolean;
-	isUpdating: boolean;
 	onChange: ( value: boolean ) => void;
 };
 
 const EmailMeNewPostsToggle = ( {
+	className = '',
+	isDisabled = false,
+	hintText = false,
 	value = false,
-	isUpdating = false,
 	onChange,
 }: EmailMeNewPostsToggleProps ) => {
 	const translate = useTranslate();
 
 	return (
-		<div className={ clsx( 'setting-item', 'email-me-new-posts-toggle', { 'is-enabled': value } ) }>
+		<div
+			className={ clsx( className, {
+				'setting-item email-me-new-posts-toggle': ! className,
+				'is-enabled': value,
+			} ) }
+		>
 			<ToggleControl
-				label={ translate( 'Receive emails' ) }
+				label={ translate( 'Email me new posts' ) }
 				onChange={ () => onChange( ! value ) }
 				checked={ value }
-				disabled={ isUpdating }
+				disabled={ isDisabled }
 			/>
+			{ hintText && <div className="email-new-posts-toggle__hint">{ hintText }</div> }
 		</div>
 	);
 };

--- a/client/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -3,27 +3,39 @@ import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 
 type NotifyMeOfNewPostsToggleProps = {
+	className?: string;
+	isUpdating?: boolean;
+	showHint?: boolean;
+	showJetpackAppHint?: boolean;
+	toggleId?: string;
 	value: boolean;
-	isUpdating: boolean;
 	onChange: ( value: boolean ) => void;
 };
 
 const NotifyMeOfNewPostsToggle = ( {
-	value = false,
+	className = '',
 	isUpdating = false,
+	showHint = false,
+	showJetpackAppHint = false,
+	value,
 	onChange,
 }: NotifyMeOfNewPostsToggleProps ) => {
 	const translate = useTranslate();
 
 	return (
-		<div className="setting-item setting-item__last">
+		<div className={ className }>
 			<ToggleControl
-				label={ translate( 'Receive web and mobile notifications' ) }
+				label={ translate( 'Notify me of new posts' ) }
 				onChange={ () => onChange( ! value ) }
 				checked={ value }
 				disabled={ isUpdating }
 			/>
-			{ value && (
+			{ showHint && (
+				<p className="new-posts-notify-toggle__hint">
+					{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
+				</p>
+			) }
+			{ showJetpackAppHint && value && (
 				<div className="setting-item__app-hint">
 					<JetpackLogo size={ 20 } />
 					<p>

--- a/client/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -4,7 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 
 type NotifyMeOfNewPostsToggleProps = {
 	className?: string;
-	isUpdating?: boolean;
+	isDisabled?: boolean;
 	showHint?: boolean;
 	showJetpackAppHint?: boolean;
 	toggleId?: string;
@@ -14,7 +14,7 @@ type NotifyMeOfNewPostsToggleProps = {
 
 const NotifyMeOfNewPostsToggle = ( {
 	className = '',
-	isUpdating = false,
+	isDisabled = false,
 	showHint = false,
 	showJetpackAppHint = false,
 	value,
@@ -28,10 +28,10 @@ const NotifyMeOfNewPostsToggle = ( {
 				label={ translate( 'Notify me of new posts' ) }
 				onChange={ () => onChange( ! value ) }
 				checked={ value }
-				disabled={ isUpdating }
+				disabled={ isDisabled }
 			/>
 			{ showHint && (
-				<p className="new-posts-notify-toggle__hint">
+				<p className="notify-new-posts-toggle__hint">
 					{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
 				</p>
 			) }

--- a/client/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 type NotifyMeOfNewPostsToggleProps = {
 	className?: string;
 	isDisabled?: boolean;
-	showHint?: boolean;
 	showJetpackAppHint?: boolean;
 	toggleId?: string;
 	value: boolean;
@@ -15,7 +14,6 @@ type NotifyMeOfNewPostsToggleProps = {
 const NotifyMeOfNewPostsToggle = ( {
 	className = '',
 	isDisabled = false,
-	showHint = false,
 	showJetpackAppHint = false,
 	value,
 	onChange,
@@ -30,11 +28,9 @@ const NotifyMeOfNewPostsToggle = ( {
 				checked={ value }
 				disabled={ isDisabled }
 			/>
-			{ showHint && (
-				<p className="notify-new-posts-toggle__hint">
-					{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
-				</p>
-			) }
+			<p className="notify-new-posts-toggle__hint">
+				{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
+			</p>
 			{ showJetpackAppHint && value && (
 				<div className="setting-item__app-hint">
 					<JetpackLogo size={ 20 } />

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -63,9 +63,10 @@ const SiteSettings = ( {
 			) }
 			{ isLoggedIn && (
 				<EmailMeNewCommentsToggle
+					className="setting-item"
 					value={ emailMeNewComments }
 					onChange={ onEmailMeNewCommentsChange }
-					isUpdating={ updatingEmailMeNewComments }
+					isDisabled={ updatingEmailMeNewComments }
 				/>
 			) }
 			{ isLoggedIn && (

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -70,6 +70,7 @@ const SiteSettings = ( {
 			) }
 			{ isLoggedIn && (
 				<NotifyMeOfNewPostsToggle
+					className="setting-item setting-item__last"
 					value={ notifyMeOfNewPosts }
 					onChange={ onNotifyMeOfNewPostsChange }
 					isUpdating={ updatingNotifyMeOfNewPosts }

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -51,7 +51,7 @@ const SiteSettings = ( {
 				<EmailMeNewPostsToggle
 					value={ emailMeNewPosts }
 					onChange={ onEmailMeNewPostsChange }
-					isUpdating={ updatingEmailMeNewPosts }
+					isDisabled={ updatingEmailMeNewPosts }
 				/>
 			) }
 			{ emailMeNewPosts && (
@@ -73,7 +73,7 @@ const SiteSettings = ( {
 					className="setting-item setting-item__last"
 					value={ notifyMeOfNewPosts }
 					onChange={ onNotifyMeOfNewPostsChange }
-					isUpdating={ updatingNotifyMeOfNewPosts }
+					isDisabled={ updatingNotifyMeOfNewPosts }
 				/>
 			) }
 		</div>

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -49,6 +49,7 @@ const SiteSettings = ( {
 		<div className="settings site-settings">
 			{ isLoggedIn && (
 				<EmailMeNewPostsToggle
+					className="setting-item"
 					value={ emailMeNewPosts }
 					onChange={ onEmailMeNewPostsChange }
 					isDisabled={ updatingEmailMeNewPosts }

--- a/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/site-settings.tsx
@@ -76,6 +76,7 @@ const SiteSettings = ( {
 					value={ notifyMeOfNewPosts }
 					onChange={ onNotifyMeOfNewPostsChange }
 					isDisabled={ updatingNotifyMeOfNewPosts }
+					showJetpackAppHint
 				/>
 			) }
 		</div>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -94,7 +94,7 @@ class NotificationSubscriptions extends Component {
 									components: {
 										readerLink: (
 											<a
-												href="/following/edit"
+												href="/reader/subscriptions"
 												onClick={ this.handleClickEvent( 'Edit Subscriptions in Reader Link' ) }
 											/>
 										),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/97575

## Proposed Changes

In Reader, we currently display notification toggles using both dedicated components and `ToggleControl`. This pull request extends our existing dedicated components to enable their consistent use throughout the app.

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/0a8e2a11-1bb0-41a9-96d3-65657903e3fe) | ![image](https://github.com/user-attachments/assets/94942a99-39b4-459d-bf84-72e42a3ad059) |
| ![image](https://github.com/user-attachments/assets/328be76d-c1d4-4fa5-a0aa-e9e43f6cdf06) | No visual change |
| ![image](https://github.com/user-attachments/assets/6bdbf6a0-2534-4e12-87bb-e5d4c7f68857)| ![image](https://github.com/user-attachments/assets/306aa249-9e33-4403-aed6-e205d83404b1)|
| ![image](https://github.com/user-attachments/assets/734f0c8a-30fb-4e4d-8098-d06dd4b9b21e) | ![image](https://github.com/user-attachments/assets/3bffeabf-ba3c-4b12-89ca-0e316ae130eb) |



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To enhance clarity and improve consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/reader/subscriptions`. Click on ellipsis menu of any subscription and verify the toggles.
* Go to `subscriptions/comments`. Click on ellipsis menu of any subscription and verify the toggles.
* Go to `/reader/subscriptions/[SUBS_ID]`. Verify the toggles.
* Go to `/reader/recent/[FEEDID]`. Open settings menu and verify the toggles.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
