### PR TITLE
Subscribers: Use new helper library

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -61,14 +61,14 @@ const useNewHelper = config.isEnabled( 'subscribers-helper-library' );
 
 const getSubscriptionId = ( subscriber: Subscriber ): number => {
 	if ( useNewHelper ) {
-		return subscriber.wpcom_subscription_id || subscriber.email_subscription_id || 0;
+		return subscriber.email_subscription_id || subscriber.wpcom_subscription_id || 0;
 	}
 	return subscriber.subscription_id || 0;
 };
 
 const getSubscriptionIdString = ( subscriber: Subscriber ): string => {
 	if ( useNewHelper ) {
-		return String( subscriber.wpcom_subscription_id || subscriber.email_subscription_id || '' );
+		return String( subscriber.email_subscription_id || subscriber.wpcom_subscription_id || '' );
 	}
 	return String( subscriber.subscription_id || '' );
 };
@@ -168,8 +168,14 @@ const SubscriberDataViews = ( {
 	// Fetch subscriber details.
 	const { data: subscriberDetails, isLoading: isLoadingDetails } = useSubscriberDetailsQuery(
 		siteId ?? null,
-		subscriberId ? parseInt( subscriberId, 10 ) : undefined,
-		selectedSubscriber?.user_id
+		// Only pass subscriberId if it's a valid number
+		subscriberId && ! isNaN( parseInt( subscriberId, 10 ) )
+			? parseInt( subscriberId, 10 )
+			: undefined,
+		// Only pass user_id if it's a valid number (WordPress.com user)
+		typeof selectedSubscriber?.user_id === 'number' && ! isNaN( selectedSubscriber.user_id )
+			? selectedSubscriber.user_id
+			: undefined
 	);
 
 	// Single effect to handle all subscriber selection scenarios

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Gravatar, TimeSince } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -56,16 +57,27 @@ const SubscriberName = ( { displayName, email }: { displayName: string; email: s
 	</div>
 );
 
+const useNewHelper = config.isEnabled( 'subscribers-helper-library' );
+
 const getSubscriptionId = ( subscriber: Subscriber ): number => {
-	return subscriber.wpcom_subscription_id || subscriber.email_subscription_id || 0;
+	if ( useNewHelper ) {
+		return subscriber.wpcom_subscription_id || subscriber.email_subscription_id || 0;
+	}
+	return subscriber.subscription_id || 0;
 };
 
 const getSubscriptionIdString = ( subscriber: Subscriber ): string => {
-	return String( subscriber.wpcom_subscription_id || subscriber.email_subscription_id || '' );
+	if ( useNewHelper ) {
+		return String( subscriber.wpcom_subscription_id || subscriber.email_subscription_id || '' );
+	}
+	return String( subscriber.subscription_id || '' );
 };
 
 const getSubscriptionDate = ( subscriber: Subscriber ): string => {
-	return subscriber.wpcom_date_subscribed || subscriber.email_date_subscribed || '';
+	if ( useNewHelper ) {
+		return subscriber.wpcom_date_subscribed || subscriber.email_date_subscribed || '';
+	}
+	return subscriber.date_subscribed || '';
 };
 
 const defaultView: View = {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -56,6 +56,18 @@ const SubscriberName = ( { displayName, email }: { displayName: string; email: s
 	</div>
 );
 
+const getSubscriptionId = ( subscriber: Subscriber ): number => {
+	return subscriber.wpcom_subscription_id || subscriber.email_subscription_id || 0;
+};
+
+const getSubscriptionIdString = ( subscriber: Subscriber ): string => {
+	return String( subscriber.wpcom_subscription_id || subscriber.email_subscription_id || '' );
+};
+
+const getSubscriptionDate = ( subscriber: Subscriber ): string => {
+	return subscriber.wpcom_date_subscribed || subscriber.email_date_subscribed || '';
+};
+
 const defaultView: View = {
 	type: 'table',
 	titleField: 'name',
@@ -153,13 +165,13 @@ const SubscriberDataViews = ( {
 		// If URL changes or we get new subscriber details, update the selection
 		if ( subscriberId ) {
 			// If we have details and they match the current URL
-			if ( subscriberDetails && subscriberDetails.subscription_id.toString() === subscriberId ) {
+			if ( subscriberDetails && subscriberId === getSubscriptionIdString( subscriberDetails ) ) {
 				setSelectedSubscriber( subscriberDetails );
 			}
 			// If we don't have matching details yet, try to find in current list
 			else {
 				const subscriberFromList = subscribersQueryResult?.subscribers.find(
-					( s ) => s.subscription_id.toString() === subscriberId
+					( s ) => subscriberId === getSubscriptionIdString( s )
 				);
 				if ( subscriberFromList ) {
 					setSelectedSubscriber( subscriberFromList );
@@ -175,7 +187,7 @@ const SubscriberDataViews = ( {
 	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
 		useSubscribedNewsletterCategories( {
 			siteId: siteId as number,
-			subscriptionId: selectedSubscriber?.subscription_id,
+			subscriptionId: selectedSubscriber ? getSubscriptionId( selectedSubscriber ) : undefined,
 			userId: selectedSubscriber?.user_id,
 			enabled: !! selectedSubscriber,
 		} );
@@ -206,22 +218,22 @@ const SubscriberDataViews = ( {
 					page.show( `/subscribers/${ siteSlug }` );
 					return;
 				}
-				const subscriber = subscribers.find( ( s ) => s.subscription_id.toString() === input[ 0 ] );
+				const subscriber = subscribers.find( ( s ) => getSubscriptionIdString( s ) === input[ 0 ] );
 				if ( subscriber ) {
 					recordSubscriberClicked( 'list', {
 						site_id: siteId,
-						subscription_id: subscriber.subscription_id,
+						subscription_id: getSubscriptionId( subscriber ),
 						user_id: subscriber.user_id,
 					} );
-					page.show( `/subscribers/${ siteSlug }/${ subscriber.subscription_id }` );
+					page.show( `/subscribers/${ siteSlug }/${ getSubscriptionIdString( subscriber ) }` );
 				}
 			} else {
 				recordSubscriberClicked( 'row', {
 					site_id: siteId,
-					subscription_id: input.subscription_id,
+					subscription_id: getSubscriptionId( input ),
 					user_id: input.user_id,
 				} );
-				page.show( `/subscribers/${ siteSlug }/${ input.subscription_id }` );
+				page.show( `/subscribers/${ siteSlug }/${ getSubscriptionIdString( input ) }` );
 			}
 		},
 		[ subscribers, recordSubscriberClicked, siteId, siteSlug ]
@@ -311,8 +323,10 @@ const SubscriberDataViews = ( {
 			{
 				id: 'date_subscribed',
 				label: translate( 'Since' ),
-				getValue: ( { item }: { item: Subscriber } ) => item.date_subscribed,
-				render: ( { item }: { item: Subscriber } ) => <TimeSince date={ item.date_subscribed } />,
+				getValue: ( { item }: { item: Subscriber } ) => getSubscriptionDate( item ),
+				render: ( { item }: { item: Subscriber } ) => (
+					<TimeSince date={ getSubscriptionDate( item ) } />
+				),
 				enableHiding: false,
 				enableSorting: true,
 			},
@@ -515,14 +529,14 @@ const SubscriberDataViews = ( {
 							isItemClickable={ () => true }
 							onChangeView={ handleViewChange }
 							selection={
-								selectedSubscriber ? [ selectedSubscriber.subscription_id.toString() ] : undefined
+								selectedSubscriber ? [ getSubscriptionIdString( selectedSubscriber ) ] : undefined
 							}
 							onChangeSelection={
 								currentView.type === 'list' ? handleSubscriberSelection : undefined
 							}
 							isLoading={ isLoading }
 							paginationInfo={ paginationInfo }
-							getItemId={ ( item: Subscriber ) => item.subscription_id.toString() }
+							getItemId={ ( item: Subscriber ) => getSubscriptionIdString( item ) }
 							defaultLayouts={ selectedSubscriber ? { list: {} } : { table: {} } }
 							actions={ actions }
 							search
@@ -540,7 +554,7 @@ const SubscriberDataViews = ( {
 						<SubscriberDetails
 							subscriber={ subscriberDetails }
 							siteId={ siteId }
-							subscriptionId={ selectedSubscriber.subscription_id }
+							subscriptionId={ getSubscriptionId( selectedSubscriber ) }
 							onClose={ () => {
 								page.show( `/subscribers/${ siteSlug }` );
 							} }

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -99,7 +99,7 @@ const SubscriberDetails = ( {
 					siteId={ siteId }
 					subscriptionId={ subscriptionId }
 					userId={ userId }
-					dateSubscribed={ new Date( date_subscribed ) }
+					dateSubscribed={ date_subscribed ? new Date( date_subscribed ) : new Date() }
 				/>
 			) }
 			<div className="subscriber-details__content">
@@ -111,11 +111,13 @@ const SubscriberDetails = ( {
 						<div className="subscriber-details__content-label">
 							{ translate( 'Subscription date' ) }
 						</div>
-						<TimeSince
-							className="subscriber-details__content-value"
-							date={ date_subscribed }
-							dateFormat="LL"
-						/>
+						{ date_subscribed && (
+							<TimeSince
+								className="subscriber-details__content-value"
+								date={ date_subscribed }
+								dateFormat="LL"
+							/>
+						) }
 					</div>
 					{ newsletterCategoriesEnabled && (
 						<div className="subscriber-details__content-column">

--- a/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/subscriber-details.tsx
@@ -6,14 +6,14 @@ import { useMemo } from 'react';
 import { NewsletterCategory } from 'calypso/data/newsletter-categories/types';
 import { useSubscriptionPlans } from '../../hooks';
 import { SubscriptionPlanData } from '../../hooks/use-subscription-plans';
-import { Subscriber } from '../../types';
+import { Subscriber, SubscriberDetails as SubscriberDetailsType } from '../../types';
 import { SubscriberProfile } from '../subscriber-profile';
 import { SubscriberStats } from '../subscriber-stats';
 
 import './styles.scss';
 
 type SubscriberDetailsProps = {
-	subscriber: Subscriber;
+	subscriber: SubscriberDetailsType;
 	siteId: number;
 	subscriptionId?: number;
 	userId?: number;
@@ -99,7 +99,7 @@ const SubscriberDetails = ( {
 					siteId={ siteId }
 					subscriptionId={ subscriptionId }
 					userId={ userId }
-					dateSubscribed={ date_subscribed ? new Date( date_subscribed ) : new Date() }
+					dateSubscribed={ new Date( date_subscribed ) }
 				/>
 			) }
 			<div className="subscriber-details__content">

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -8,6 +8,7 @@ const getSubscribersCacheKey = ( {
 	sortTerm,
 	filters,
 	sortOrder,
+	use_new_helper,
 }: {
 	siteId: number | undefined | null;
 	page?: number;
@@ -16,7 +17,18 @@ const getSubscribersCacheKey = ( {
 	sortTerm?: string;
 	filters?: SubscribersFilterBy[];
 	sortOrder?: 'asc' | 'desc';
-} ) => [ 'subscribers', siteId, page, perPage, search, sortTerm, filters, sortOrder ];
+	use_new_helper?: boolean;
+} ) => [
+	'subscribers',
+	siteId,
+	page,
+	perPage,
+	search,
+	sortTerm,
+	filters,
+	sortOrder,
+	use_new_helper,
+];
 
 const getSubscriberDetailsCacheKey = (
 	siteId: number | undefined | null,

--- a/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
@@ -1,7 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { getSubscriberDetailsCacheKey, getSubscriberDetailsType } from '../helpers';
-import type { Subscriber } from '../types';
+import type { SubscriberDetails } from '../types';
 
 const useSubscriberDetailsQuery = (
 	siteId: number | null,
@@ -10,7 +10,7 @@ const useSubscriberDetailsQuery = (
 ) => {
 	const type = getSubscriberDetailsType( userId );
 
-	return useQuery< Subscriber >( {
+	return useQuery< SubscriberDetails >( {
 		queryKey: getSubscriberDetailsCacheKey( siteId, subscriptionId, userId, type ),
 		queryFn: () =>
 			wpcom.req.get( {

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
@@ -26,8 +27,9 @@ const useSubscribersQuery = ( {
 	sortTerm = SubscribersSortBy.DateSubscribed,
 	sortOrder,
 	filters = [],
-	use_new_helper = true,
 }: SubscriberQueryParams ) => {
+	const use_new_helper = config.isEnabled( 'subscribers-helper-library' );
+
 	const query = useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( {
 			siteId,

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -15,6 +15,7 @@ type SubscriberQueryParams = {
 	filters?: SubscribersFilterBy[];
 	timestamp?: number;
 	limitData?: boolean;
+	use_new_helper?: boolean;
 };
 
 const useSubscribersQuery = ( {
@@ -25,6 +26,7 @@ const useSubscribersQuery = ( {
 	sortTerm = SubscribersSortBy.DateSubscribed,
 	sortOrder,
 	filters = [],
+	use_new_helper = true,
 }: SubscriberQueryParams ) => {
 	const query = useQuery< SubscriberEndpointResponse >( {
 		queryKey: getSubscribersCacheKey( {
@@ -35,11 +37,13 @@ const useSubscribersQuery = ( {
 			sortTerm,
 			filters,
 			sortOrder,
+			use_new_helper,
 		} ),
 		queryFn: () => {
 			const params = new URLSearchParams( {
 				per_page: perPage.toString(),
 				page: page.toString(),
+				use_new_helper: use_new_helper.toString(),
 				...( search && { search } ),
 				...( sortTerm && { sort: sortTerm } ),
 				...( sortOrder && { sort_order: sortOrder } ),

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -49,7 +49,6 @@ const useSubscribersQuery = ( {
 				...( search && { search } ),
 				...( sortTerm && { sort: sortTerm } ),
 				...( sortOrder && { sort_order: sortOrder } ),
-				no_cache: 'true',
 			} );
 
 			filters.forEach( ( filter ) => {

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -49,6 +49,7 @@ const useSubscribersQuery = ( {
 				...( search && { search } ),
 				...( sortTerm && { sort: sortTerm } ),
 				...( sortOrder && { sort_order: sortOrder } ),
+				no_cache: 'true',
 			} );
 
 			filters.forEach( ( filter ) => {

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -26,8 +26,10 @@ export type SubscriptionPlan = {
 
 export type Subscriber = {
 	user_id: number;
-	subscription_id: number;
-	date_subscribed: string;
+	email_subscription_id?: number;
+	wpcom_subscription_id?: number;
+	wpcom_date_subscribed?: string;
+	email_date_subscribed?: string;
 	subscription_status: string;
 	email_address: string;
 	avatar: string;

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -26,10 +26,15 @@ export type SubscriptionPlan = {
 
 export type Subscriber = {
 	user_id: number;
+	// Fields for new helper library
 	email_subscription_id?: number;
 	wpcom_subscription_id?: number;
 	wpcom_date_subscribed?: string;
 	email_date_subscribed?: string;
+	// Fields for old format
+	subscription_id?: number;
+	date_subscribed?: string;
+	// Common fields
 	subscription_status: string;
 	email_address: string;
 	avatar: string;

--- a/client/my-sites/subscribers/types/index.ts
+++ b/client/my-sites/subscribers/types/index.ts
@@ -49,6 +49,10 @@ export type Subscriber = {
 	url?: string;
 };
 
+export type SubscriberDetails = Omit< Subscriber, 'date_subscribed' > & {
+	date_subscribed: string;
+};
+
 export type SubscriberQueryParams = {
 	page: number;
 	perPage?: number;

--- a/config/development.json
+++ b/config/development.json
@@ -194,6 +194,7 @@
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
 		"subscriber-importer": true,
+		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/premium": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -77,6 +77,7 @@
 		"purchases/new-payment-methods": true,
 		"realtime-site-count": true,
 		"site-indicator": false,
+		"subscribers-helper-library": true,
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/567

## Proposed Changes

* Behind the feature flag `subscribers-helper-library`, add a param to use the new subscribers library: `use_new_helper`.
* Also behind the flag, update the subscription ids and dates to match the library responses.
* Add `use_new_helper` to the cache key.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To use the more performant helper library.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /subscribers/{site url}
- Smoke test:
    - The subscribers load without errors (on the sandbox or in the console).
    - The correct data displays in the table.
    - You can sort by all sortable columns.
    - You can filter by all filters.
    - You can combine filters.
    - Deleted subscribers are filtered out.
    - You can click on a subscriber and see the correct URL and details.
    - Pagination works correctly.
    - Import new subscriber(s) and check there's no lag in updating the list. You'll need to turn on write access and sandbox the job (import_subscribers).
    - Remove new subscriber(s) and check there's no lag in updating the list. You'll need to turn on write access.
    - Export subscribers.
- Regression test that subscribers still loads correctly without the library (you can turn off the flag in the dev environment or use calypso live). And that you can delete users and load subscriber details.
- Regression test Jetpack Cloud without the library.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?