### PR TITLE
Site picker: arrows didn't have any fill

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -404,9 +404,5 @@ button {
 
 	.step-container.site-picker .step-container__content {
 		max-width: 100%;
-
-		svg {
-			fill: none;
-		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/98994

## Proposed Changes

Remove css rule that set the svg fill to none in the sitePicker.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The offending rule was added in [this PR](https://github.com/Automattic/wp-calypso/pull/90892) to prevent the search icon to have a blue fill, but it wasn't specific enough.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch locally (or use the calypso.live link below if you have more than 96 sites)
* If testing locally, add this change to force show the pagination
```diff
diff --git a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
index 66821bc8b1b..e79676f814f 100644
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -32,7 +32,7 @@ const SitePicker = function SitePicker( props: Props ) {
        const { __ } = useI18n();
        const {
                page,
-               perPage = 96,
+               perPage = 8,
                search,
                status,
                onSelectSite,
```
* Navigate to `/setup/hosted-site-migration/sitePicker`
* Verify you don't see a blue search icon: <img width="775" alt="image" src="https://github.com/user-attachments/assets/939f3888-1472-4a86-ab0a-2eb84ba54bed" />
* Verify the arrows in the pagination are visible: <img width="434" alt="image" src="https://github.com/user-attachments/assets/2faff5d6-354e-4504-8b39-6f71a0201a4d" />
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
