### PR TITLE
MARTECH-42 Various Jetpack direct auth improvements and fixes

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -215,7 +215,7 @@ export function qrCodeLogin( context, next ) {
 export async function jetpackGoogleAuth( context, next ) {
 	const { query, isServerSide } = context;
 
-	// Do not continue if it's server side
+	// Don't run authentication if it's server side
 	if ( isServerSide ) {
 		return next();
 	}
@@ -409,7 +409,7 @@ export async function jetpackGoogleAuthCallback( context, next ) {
 export async function jetpackAppleAuth( context, next ) {
 	const { query, isServerSide } = context;
 
-	// Do not continue if it's server side
+	// Don't run authentication if it's server side
 	if ( isServerSide ) {
 		return next();
 	}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -553,8 +553,14 @@ export async function jetpackAppleAuthCallback( context, next ) {
 }
 
 export async function jetpackGitHubAuth( context, next ) {
-	const { query } = context;
-	const redirectUri = `${ window.location.origin }/log-in/jetpack/github/callback`;
+	const { query, isServerSide } = context;
+
+	// Do not continue if it's server side
+	if ( isServerSide ) {
+		return next();
+	}
+
+	const redirectUri = `https://${ window.location.host }/log-in/jetpack/github/callback`;
 	try {
 		// Store redirect_to in sessionStorage for use on callback
 		window.sessionStorage.setItem( 'github_redirect_to', query?.redirect_to || '/' );
@@ -586,13 +592,13 @@ export async function jetpackGitHubAuth( context, next ) {
 }
 
 export async function jetpackGitHubAuthCallback( context, next ) {
-	const { query } = context;
+	const { query, isServerSide } = context;
 
 	const code = query.code;
 	const service = query.service;
 
 	// Not a redirect from GitHub if no code or error present
-	if ( ! code || service !== 'github' ) {
+	if ( ! code || service !== 'github' || isServerSide ) {
 		return next();
 	}
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -555,7 +555,7 @@ export async function jetpackAppleAuthCallback( context, next ) {
 export async function jetpackGitHubAuth( context, next ) {
 	const { query, isServerSide } = context;
 
-	// Do not continue if it's server side
+	// Don't run authentication if it's server side
 	if ( isServerSide ) {
 		return next();
 	}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -168,10 +168,10 @@ export function desktopLoginFinalize( context, next ) {
 export async function magicLogin( context, next ) {
 	const {
 		path,
-		query: { gravatar_flow, client_id, redirect_to },
+		query: { gravatar_flow, client_id, redirect_to, auto_trigger },
 	} = context;
 
-	if ( isUserLoggedIn( context.store.getState() ) ) {
+	if ( isUserLoggedIn( context.store.getState() ) && auto_trigger === undefined ) {
 		return login( context, next );
 	}
 
@@ -830,4 +830,10 @@ export function redirectLostPassword( context, next ) {
 	}
 
 	next();
+}
+
+export function redirectJetpackDirectAuthError( context ) {
+	const queryString = new URLSearchParams( context.query ).toString();
+	const redirectUrl = queryString ? `/log-in/jetpack/?${ queryString }` : '/log-in/jetpack/';
+	return context.redirect( 301, redirectUrl );
 }

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -26,6 +26,7 @@ import {
 	jetpackGoogleAuth,
 	jetpackGitHubAuth,
 	jetpackGitHubAuthCallback,
+	redirectJetpackDirectAuthError,
 } from './controller';
 import redirectLoggedIn from './redirect-logged-in';
 import { setShouldServerSideRenderLogin, ssrSetupLocaleLogin, setMetaTags } from './ssr';
@@ -96,8 +97,18 @@ export default ( router ) => {
 
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(
-			[ `/log-in/link/use/${ lang }`, `/log-in/jetpack/link/use/${ lang }` ],
+			[ `/log-in/link/use/${ lang }` ],
 			redirectLoggedIn,
+			setLocaleMiddleware(),
+			setMetaTags,
+			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
+			magicLoginUse,
+			makeLoggedOutLayout
+		);
+
+		// For Jetpack link use, we don't want to stop when the user is logged in
+		router(
+			[ `/log-in/jetpack/link/use/${ lang }` ],
 			setLocaleMiddleware(),
 			setMetaTags,
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -127,62 +127,56 @@ export default ( router ) => {
 
 	router(
 		`/log-in/jetpack/google/${ lang }`,
-		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		jetpackGoogleAuth,
-		makeLoggedOutLayout
+		redirectJetpackDirectAuthError
 	);
 
 	router(
 		`/log-in/jetpack/google/callback/${ lang }`,
-		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		jetpackGoogleAuthCallback,
-		makeLoggedOutLayout
+		redirectJetpackDirectAuthError
 	);
 
 	router(
 		`/log-in/jetpack/apple/${ lang }`,
-		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		jetpackAppleAuth,
-		makeLoggedOutLayout
+		redirectJetpackDirectAuthError
 	);
 
 	router(
 		`/log-in/jetpack/apple/callback/${ lang }`,
-		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		jetpackAppleAuthCallback,
-		makeLoggedOutLayout
+		redirectJetpackDirectAuthError
 	);
 
 	router(
 		`/log-in/jetpack/github/${ lang }`,
-		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		jetpackGitHubAuth,
-		makeLoggedOutLayout
+		redirectJetpackDirectAuthError
 	);
 
 	router(
 		`/log-in/jetpack/github/callback/${ lang }`,
-		redirectLoggedIn,
 		setLocaleMiddleware(),
 		setMetaTags,
 		setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 		jetpackGitHubAuthCallback,
-		makeLoggedOutLayout
+		redirectJetpackDirectAuthError
 	);
 
 	router(

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -70,7 +70,9 @@ function redirectToCalypso( request, response, next ) {
 		originalUrlPath = originalUrlPath.replace( 'log-in', 'log-in/jetpack' );
 	}
 
-	response.redirect( originalUrlPath + '?' + state.queryString + '#' + hashString );
+	response.redirect(
+		originalUrlPath + '?' + encodeURIComponent( state.queryString ?? '' ) + '#' + hashString
+	);
 }
 
 export default function ( app ) {

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -71,7 +71,7 @@ function redirectToCalypso( request, response, next ) {
 	}
 
 	response.redirect(
-		originalUrlPath + '?' + encodeURIComponent( state.queryString ?? '' ) + '#' + hashString
+		`${ originalUrlPath }?${ encodeURIComponent( state.queryString ?? '' ) }#${ hashString }`
 	);
 }
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/101672 

## Proposed Changes

- **Do not run GitHub endpoints server-side**
- **Fix param encoding in Apple auth redirect**
- **For social auth, override the current user, redirect to login page in case of error**
- **For magic link auth, override current user**

## Why are these changes being made?

we're introducing direct auth flow for Jetpack (for purposes of the new onboarding flow), when testing flows (they work only on production), we found several issues and we provide fixes for them.

## Testing Instructions

- Do not run GitHub endpoints server-side
  - Not testable 
- Fix param encoding in Apple auth redirect
  - Not testable 
- For social auth, override the current user, redirect to login page in case of error
  - Not testable 
- For magic link auth, override current user
  - Log in to wordpress.com
  - Go to `wordpress.com/log-in/jetpack/link?email_address=<>&auto_trigger`
  - You should be able to create a new account and be logged into it