### PR TITLE
Reader: Fix back button styles on logged out Discover signup flow

### DIFF
--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -242,6 +242,8 @@ body.is-section-accept-invite {
 				display: block;
 				margin: 0 auto;
 				text-underline-offset: 5px;
+				position: relative;
+				top: 0;
 
 				&:hover {
 					color: var(--studio-blue-50, #0675c4);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101584

## Proposed Changes

- Adds styles to override the Reader back button stylesheet

### Before

<img width="772" alt="Image" src="https://github.com/user-attachments/assets/12e5ed99-71db-4c64-937b-60196d1f6d71" />

### After

<img width="516" alt="Screenshot 2025-03-25 at 20 35 48" src="https://github.com/user-attachments/assets/ed90b13f-cc56-4d20-a8ff-c63e153974e6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- The back button styles for the signup page are broken when going through the `/discover` flow because the Reader's styles are being included

## Testing Instructions
- Go to `/discover` while logged out
- On the sign up screen, click 'Email'
- Make sure the back button appears below the email input field as expected

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
