### PR TITLE
Remove redundant migration screen.

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -419,12 +419,7 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip' ) {
-						return exitFlow(
-							addQueryArgs(
-								{ ref: 'site-migration', siteId, from: from || fromQueryParam, siteSlug },
-								`/overview/${ siteSlug }`
-							)
-						);
+						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 					}
 
 					if ( action === 'already-wpcom' ) {
@@ -473,52 +468,19 @@ const siteMigration: Flow = {
 						);
 					}
 
-					return exitFlow(
-						addQueryArgs(
-							{
-								ref: 'site-migration',
-								siteId,
-								from: from || fromQueryParam,
-								siteSlug,
-								preventTicketCreation: true,
-							},
-							`/overview/${ siteSlug }`
-						)
-					);
+					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 				}
 
 				case STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug: {
-					const { action, from } = providedDependencies as {
+					const { action } = providedDependencies as {
 						action: 'skip' | 'submit';
 						from: string;
 					};
 
 					if ( action === 'skip' ) {
-						return exitFlow(
-							addQueryArgs(
-								{
-									ref: 'site-migration',
-									siteId,
-									from: from || fromQueryParam,
-									siteSlug,
-									preventTicketCreation: true,
-								},
-								`/overview/${ siteSlug }`
-							)
-						);
+						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 					}
-					return exitFlow(
-						addQueryArgs(
-							{
-								ref: 'site-migration',
-								siteId,
-								from: from || fromQueryParam,
-								siteSlug,
-								preventTicketCreation: true,
-							},
-							`/overview/${ siteSlug }`
-						)
-					);
+					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 				}
 
 				case STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug: {
@@ -550,7 +512,7 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug: {
-					const { action, authorizationUrl, from } = providedDependencies as {
+					const { action, authorizationUrl } = providedDependencies as {
 						action: string;
 						from: string;
 						authorizationUrl: string;
@@ -578,18 +540,7 @@ const siteMigration: Flow = {
 					}
 
 					//TODO: Add a skip flag to track the user is having trouble to share the credentials.
-					return exitFlow(
-						addQueryArgs(
-							{
-								ref: 'site-migration',
-								siteId,
-								from: from || fromQueryParam,
-								siteSlug,
-								preventTicketCreation: true,
-							},
-							`/overview/${ siteSlug }`
-						)
-					);
+					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -422,7 +422,7 @@ const siteMigration: Flow = {
 					if ( action === 'skip' ) {
 						return exitFlow(
 							addQueryArgs(
-								{ ref: 'site-migration', iteId, from: from || fromQueryParam, siteSlug },
+								{ ref: 'site-migration', siteId, from: from || fromQueryParam, siteSlug },
 								`/overview/${ siteSlug }`
 							)
 						);

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -57,7 +57,6 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
 			STEPS.SITE_MIGRATION_INSTRUCTIONS,
 			STEPS.ERROR,
-			//STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
 			STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS,
 			STEPS.SITE_MIGRATION_CREDENTIALS,
 			STEPS.SITE_MIGRATION_ALREADY_WPCOM,
@@ -426,14 +425,6 @@ const siteMigration: Flow = {
 								`/overview/${ siteSlug }`
 							)
 						);
-						/*
-						return navigate(
-							addQueryArgs(
-								{ siteId, from: from || fromQueryParam, siteSlug },
-								STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
-							)
-						);
-						*/
 					}
 
 					if ( action === 'already-wpcom' ) {
@@ -494,14 +485,6 @@ const siteMigration: Flow = {
 							`/overview/${ siteSlug }`
 						)
 					);
-					/*
-					return navigate(
-						addQueryArgs(
-							{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
-							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
-						)
-					);
-					*/
 				}
 
 				case STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug: {
@@ -523,14 +506,6 @@ const siteMigration: Flow = {
 								`/overview/${ siteSlug }`
 							)
 						);
-						/*
-						return navigate(
-							addQueryArgs(
-								{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
-								STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
-							)
-						);
-						*/
 					}
 					return exitFlow(
 						addQueryArgs(
@@ -544,34 +519,7 @@ const siteMigration: Flow = {
 							`/overview/${ siteSlug }`
 						)
 					);
-					/*
-					//TODO: Check if both conditions are needed.
-					return navigate(
-						addQueryArgs(
-							{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
-							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
-						)
-					);
-					*/
 				}
-
-				/*
-				// TODO: Do we need to handle this elsewhere?
-				case STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug: {
-					const { hasError } = providedDependencies as {
-						hasError?: 'ticket-creation';
-					};
-
-					if ( hasError === 'ticket-creation' ) {
-						return navigate(
-							addQueryArgs(
-								{ siteId, siteSlug, from: fromQueryParam, error: hasError },
-								STEPS.SITE_MIGRATION_CREDENTIALS.slug
-							)
-						);
-					}
-				}
-					*/
 
 				case STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug: {
 					return navigate(
@@ -642,14 +590,6 @@ const siteMigration: Flow = {
 							`/overview/${ siteSlug }`
 						)
 					);
-					/*
-					return navigate(
-						addQueryArgs(
-							{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
-							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
-						)
-					);
-					*/
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -57,7 +57,7 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
 			STEPS.SITE_MIGRATION_INSTRUCTIONS,
 			STEPS.ERROR,
-			STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+			//STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
 			STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS,
 			STEPS.SITE_MIGRATION_CREDENTIALS,
 			STEPS.SITE_MIGRATION_ALREADY_WPCOM,
@@ -420,12 +420,20 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip' ) {
+						return exitFlow(
+							addQueryArgs(
+								{ ref: 'site-migration', iteId, from: from || fromQueryParam, siteSlug },
+								`/overview/${ siteSlug }`
+							)
+						);
+						/*
 						return navigate(
 							addQueryArgs(
 								{ siteId, from: from || fromQueryParam, siteSlug },
 								STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
 							)
 						);
+						*/
 					}
 
 					if ( action === 'already-wpcom' ) {
@@ -474,12 +482,26 @@ const siteMigration: Flow = {
 						);
 					}
 
+					return exitFlow(
+						addQueryArgs(
+							{
+								ref: 'site-migration',
+								siteId,
+								from: from || fromQueryParam,
+								siteSlug,
+								preventTicketCreation: true,
+							},
+							`/overview/${ siteSlug }`
+						)
+					);
+					/*
 					return navigate(
 						addQueryArgs(
 							{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
 							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
 						)
 					);
+					*/
 				}
 
 				case STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug: {
@@ -489,13 +511,40 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip' ) {
+						return exitFlow(
+							addQueryArgs(
+								{
+									ref: 'site-migration',
+									siteId,
+									from: from || fromQueryParam,
+									siteSlug,
+									preventTicketCreation: true,
+								},
+								`/overview/${ siteSlug }`
+							)
+						);
+						/*
 						return navigate(
 							addQueryArgs(
 								{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
 								STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
 							)
 						);
+						*/
 					}
+					return exitFlow(
+						addQueryArgs(
+							{
+								ref: 'site-migration',
+								siteId,
+								from: from || fromQueryParam,
+								siteSlug,
+								preventTicketCreation: true,
+							},
+							`/overview/${ siteSlug }`
+						)
+					);
+					/*
 					//TODO: Check if both conditions are needed.
 					return navigate(
 						addQueryArgs(
@@ -503,8 +552,11 @@ const siteMigration: Flow = {
 							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
 						)
 					);
+					*/
 				}
 
+				/*
+				// TODO: Do we need to handle this elsewhere?
 				case STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug: {
 					const { hasError } = providedDependencies as {
 						hasError?: 'ticket-creation';
@@ -519,6 +571,7 @@ const siteMigration: Flow = {
 						);
 					}
 				}
+					*/
 
 				case STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug: {
 					return navigate(
@@ -577,12 +630,26 @@ const siteMigration: Flow = {
 					}
 
 					//TODO: Add a skip flag to track the user is having trouble to share the credentials.
+					return exitFlow(
+						addQueryArgs(
+							{
+								ref: 'site-migration',
+								siteId,
+								from: from || fromQueryParam,
+								siteSlug,
+								preventTicketCreation: true,
+							},
+							`/overview/${ siteSlug }`
+						)
+					);
+					/*
 					return navigate(
 						addQueryArgs(
 							{ siteId, from: from || fromQueryParam, siteSlug, preventTicketCreation: true },
 							STEPS.SITE_MIGRATION_ASSISTED_MIGRATION.slug
 						)
 					);
+					*/
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -531,7 +531,6 @@ const siteMigration: Flow = {
 						);
 					}
 
-					//TODO: Add a skip flag to track the user is having trouble to share the credentials.
 					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 				}
 			}

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -472,14 +472,6 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug: {
-					const { action } = providedDependencies as {
-						action: 'skip' | 'submit';
-						from: string;
-					};
-
-					if ( action === 'skip' ) {
-						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
-					}
 					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 				}
 

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -506,7 +506,6 @@ const siteMigration: Flow = {
 				case STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug: {
 					const { action, authorizationUrl } = providedDependencies as {
 						action: string;
-						from: string;
 						authorizationUrl: string;
 					};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -7,8 +7,11 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useDispatch } from 'calypso/state';
+import { resetSite } from 'calypso/state/sites/actions';
 import Authorization from './components/authorization';
 import useStoreApplicationPassword from './hooks/use-store-application-password';
 import type { Step } from '../../types';
@@ -22,6 +25,8 @@ const SiteMigrationApplicationPasswordsAuthorization: Step< {
 } > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlugParam();
+	const siteId = parseInt( useSiteIdParam() ?? '' );
+	const dispatch = useDispatch();
 
 	const source = useQuery().get( 'from' ) ?? '';
 	const authorizationUrl = useQuery().get( 'authorizationUrl' ) ?? undefined;
@@ -55,9 +60,10 @@ const SiteMigrationApplicationPasswordsAuthorization: Step< {
 
 	useEffect( () => {
 		if ( isStoreApplicationPasswordSuccess ) {
+			dispatch( resetSite( siteId ) );
 			navigation?.submit?.( { action: 'migration-started' } );
 		}
-	}, [ isStoreApplicationPasswordSuccess, navigation ] );
+	}, [ isStoreApplicationPasswordSuccess, navigation, dispatch, siteId ] );
 
 	const navigateToFallbackCredentials = () => {
 		navigation?.submit?.( { action: 'fallback-credentials', authorizationUrl } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -60,7 +60,7 @@ const SiteMigrationApplicationPasswordsAuthorization: Step< {
 
 	useEffect( () => {
 		if ( isStoreApplicationPasswordSuccess ) {
-			dispatch( resetSite( siteId ) );
+			siteId && dispatch( resetSite( siteId ) );
 			navigation?.submit?.( { action: 'migration-started' } );
 		}
 	}, [ isStoreApplicationPasswordSuccess, navigation, dispatch, siteId ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -70,7 +70,6 @@ const SiteMigrationCredentials: Step< {
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
-	const shouldPreventTicketCreationInSkip = useQuery().get( 'preventTicketCreation' ) === 'true';
 	const { sendTicket } = useSubmitMigrationTicket( {
 		onSuccess: () => {
 			recordTracksEvent( 'calypso_migration_credentials_ticket_submit_success', {
@@ -110,15 +109,12 @@ const SiteMigrationCredentials: Step< {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
 			automated_migration: true,
-			prevent_ticket_creation: shouldPreventTicketCreationInSkip,
 		} );
-		if ( ! shouldPreventTicketCreationInSkip ) {
-			sendTicket( {
-				locale,
-				from_url: fromUrl,
-				blog_url: siteSlug,
-			} );
-		}
+		sendTicket( {
+			locale,
+			from_url: fromUrl,
+			blog_url: siteSlug,
+		} );
 
 		return navigation.submit?.( {
 			action: 'skip',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -66,7 +66,7 @@ const SiteMigrationCredentials: Step< {
 		applicationPasswordsInfo?: ApplicationPasswordsInfo
 	) => {
 		const action = getAction( siteInfo, applicationPasswordsInfo );
-		dispatch( resetSite( siteId ) );
+		siteId && dispatch( resetSite( siteId ) );
 		return navigation.submit?.( {
 			action,
 			from: siteInfo?.url,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -6,7 +7,10 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { useSubmitMigrationTicket } from 'calypso/landing/stepper/hooks/use-submit-migration-ticket';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
@@ -53,6 +57,7 @@ const SiteMigrationCredentials: Step< {
 		from?: string;
 		platform?: ImporterPlatform;
 		authorizationUrl?: string;
+		hasError?: 'ticket-creation';
 	};
 } > = function ( { navigation } ) {
 	const translate = useTranslate();
@@ -60,6 +65,32 @@ const SiteMigrationCredentials: Step< {
 	const dispatch = useDispatch();
 
 	const { mutate: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
+
+	const locale = useLocale();
+	const siteSlugParam = useSiteSlugParam();
+	const fromUrl = useQuery().get( 'from' ) || '';
+	const siteSlug = siteSlugParam ?? '';
+	const shouldPreventTicketCreation = useQuery().get( 'preventTicketCreation' ) === 'true';
+	const { sendTicket } = useSubmitMigrationTicket( {
+		onSuccess: () => {
+			recordTracksEvent( 'calypso_migration_credentials_ticket_submit_success', {
+				blog_url: siteSlug,
+				from_url: fromUrl,
+			} );
+		},
+		onError: ( error ) => {
+			recordTracksEvent( 'calypso_migration_credentials_ticket_submit_error', {
+				blog_url: siteSlug,
+				from_url: fromUrl,
+				error: error.message,
+			} );
+			navigation.submit?.( {
+				action: 'skip',
+				hasError: 'ticket-creation',
+				from: fromUrl,
+			} );
+		},
+	} );
 
 	const handleSubmit = (
 		siteInfo?: UrlData | undefined,
@@ -76,6 +107,19 @@ const SiteMigrationCredentials: Step< {
 	};
 
 	const handleSkip = () => {
+		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
+			path: window.location.pathname,
+			automated_migration: true,
+			prevent_ticket_creation: shouldPreventTicketCreation,
+		} );
+		if ( ! shouldPreventTicketCreation ) {
+			sendTicket( {
+				locale,
+				from_url: fromUrl,
+				blog_url: siteSlug,
+			} );
+		}
+
 		return navigation.submit?.( {
 			action: 'skip',
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -70,7 +70,7 @@ const SiteMigrationCredentials: Step< {
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
-	const shouldPreventTicketCreation = useQuery().get( 'preventTicketCreation' ) === 'true';
+	const shouldPreventTicketCreationInSkip = useQuery().get( 'preventTicketCreation' ) === 'true';
 	const { sendTicket } = useSubmitMigrationTicket( {
 		onSuccess: () => {
 			recordTracksEvent( 'calypso_migration_credentials_ticket_submit_success', {
@@ -110,9 +110,9 @@ const SiteMigrationCredentials: Step< {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
 			automated_migration: true,
-			prevent_ticket_creation: shouldPreventTicketCreation,
+			prevent_ticket_creation: shouldPreventTicketCreationInSkip,
 		} );
-		if ( ! shouldPreventTicketCreation ) {
+		if ( ! shouldPreventTicketCreationInSkip ) {
 			sendTicket( {
 				locale,
 				from_url: fromUrl,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -8,6 +8,8 @@ import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useDispatch } from 'calypso/state';
+import { resetSite } from 'calypso/state/sites/actions';
 import { CredentialsForm } from './components/credentials-form';
 import { NeedHelpLink } from './components/need-help-link';
 import { ApplicationPasswordsInfo } from './types';
@@ -55,6 +57,7 @@ const SiteMigrationCredentials: Step< {
 } > = function ( { navigation } ) {
 	const translate = useTranslate();
 	const siteId = parseInt( useSiteIdParam() ?? '' );
+	const dispatch = useDispatch();
 
 	const { mutate: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
@@ -63,6 +66,7 @@ const SiteMigrationCredentials: Step< {
 		applicationPasswordsInfo?: ApplicationPasswordsInfo
 	) => {
 		const action = getAction( siteInfo, applicationPasswordsInfo );
+		dispatch( resetSite( siteId ) );
 		return navigation.submit?.( {
 			action,
 			from: siteInfo?.url,
@@ -79,7 +83,7 @@ const SiteMigrationCredentials: Step< {
 
 	useEffect( () => {
 		if ( siteId ) {
-			updateMigrationStatus( { status: MigrationStatus.PENDING_DIFM } );
+			updateMigrationStatus( { status: MigrationStatus.STARTED_DIFM } );
 		}
 	}, [ siteId, updateMigrationStatus ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -153,7 +153,6 @@ describe( 'SiteMigrationCredentials', () => {
 		await userEvent.click( skipButton() );
 
 		expect( submit ).toHaveBeenCalledWith( { action: 'skip' } );
-		expect( wpcomRequest ).not.toHaveBeenCalled();
 	} );
 
 	it( 'shows errors on the required fields when the user does not fill the fields when user select credentials option', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -140,7 +140,7 @@ describe( 'SiteMigrationCredentials', () => {
 			expect( wp.req.post ).toHaveBeenCalledWith(
 				expect.objectContaining( {
 					path: '/sites/123/site-migration-status-sticker',
-					body: { status_sticker: MigrationStatus.PENDING_DIFM },
+					body: { status_sticker: MigrationStatus.STARTED_DIFM },
 				} )
 			);
 		} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -710,8 +710,6 @@ describe( 'Site Migration Flow', () => {
 					path: '/overview/example.wordpress.com',
 					query: {
 						ref: 'site-migration',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
 					},
 				} );
 			} );
@@ -731,9 +729,6 @@ describe( 'Site Migration Flow', () => {
 					path: '/overview/example.wordpress.com',
 					query: {
 						ref: 'site-migration',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-						preventTicketCreation: true,
 					},
 				} );
 			} );
@@ -888,9 +883,6 @@ describe( 'Site Migration Flow', () => {
 					path: '/overview/example.wordpress.com',
 					query: {
 						ref: 'site-migration',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-						preventTicketCreation: true,
 					},
 				} );
 			} );
@@ -909,9 +901,6 @@ describe( 'Site Migration Flow', () => {
 					path: '/overview/example.wordpress.com',
 					query: {
 						ref: 'site-migration',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-						preventTicketCreation: true,
 					},
 				} );
 			} );
@@ -1034,9 +1023,6 @@ describe( 'Site Migration Flow', () => {
 					path: '/overview/example.wordpress.com',
 					query: {
 						ref: 'site-migration',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-						preventTicketCreation: true,
 					},
 				} );
 			} );
@@ -1081,9 +1067,6 @@ describe( 'Site Migration Flow', () => {
 					path: '/overview/example.wordpress.com',
 					query: {
 						ref: 'site-migration',
-						siteId: 123,
-						from: 'http://oldsite.com',
-						preventTicketCreation: true,
 					},
 				} );
 			} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -692,56 +692,9 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		describe( 'SITE_MIGRATION_ASSISTED_MIGRATION', () => {
-			it( 'redirects back to SITE_MIGRATION_CREDENTIALS step when failing to create the ticket', () => {
-				const destination = runNavigation( {
-					from: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
-					dependencies: {
-						hasError: 'ticket-creation',
-					},
-					query: {
-						siteSlug: 'example.wordpress.com',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-					},
-				} );
-
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_CREDENTIALS,
-					query: {
-						siteSlug: 'example.wordpress.com',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-						error: 'ticket-creation',
-					},
-				} );
-			} );
-		} );
-
 		describe( 'SITE_MIGRATION_CREDENTIALS', () => {
-			it( 'redirects the user to SITE_MIGRATION_ASSISTED_MIGRATION step when the user submits the credentials', () => {
-				const destination = runNavigation( {
-					from: STEPS.SITE_MIGRATION_CREDENTIALS,
-					dependencies: {},
-					query: {
-						siteSlug: 'example.wordpress.com',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-					},
-				} );
-
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
-					query: {
-						siteSlug: 'example.wordpress.com',
-						siteId: 123,
-						from: 'https://site-to-be-migrated.com',
-					},
-				} );
-			} );
-
-			it( 'redirects to SITE_MIGRATION_ASSISTED_MIGRATION step when the user skips the form and enables ticket creation', () => {
-				const destination = runNavigation( {
+			it( 'redirects to site overview when the user skips', () => {
+				runNavigation( {
 					from: STEPS.SITE_MIGRATION_CREDENTIALS,
 					dependencies: {
 						action: 'skip',
@@ -753,22 +706,20 @@ describe( 'Site Migration Flow', () => {
 					},
 				} );
 
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+				expect( window.location.assign ).toMatchURL( {
+					path: '/overview/example.wordpress.com',
 					query: {
-						siteSlug: 'example.wordpress.com',
+						ref: 'site-migration',
 						siteId: 123,
 						from: 'https://site-to-be-migrated.com',
 					},
 				} );
 			} );
 
-			it( 'redirects to SITE_MIGRATION_ASSISTED_MIGRATION step while skipping ticket creation', () => {
-				const destination = runNavigation( {
+			it( 'redirects to site overview when submitting credentials', () => {
+				runNavigation( {
 					from: STEPS.SITE_MIGRATION_CREDENTIALS,
-					dependencies: {
-						action: 'continue',
-					},
+					dependencies: {},
 					query: {
 						siteSlug: 'example.wordpress.com',
 						siteId: 123,
@@ -776,18 +727,18 @@ describe( 'Site Migration Flow', () => {
 					},
 				} );
 
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+				expect( window.location.assign ).toMatchURL( {
+					path: '/overview/example.wordpress.com',
 					query: {
-						siteSlug: 'example.wordpress.com',
+						ref: 'site-migration',
 						siteId: 123,
 						from: 'https://site-to-be-migrated.com',
-						preventTicketCreation: 'true',
+						preventTicketCreation: true,
 					},
 				} );
 			} );
 
-			it( 'redirects to SITE_MIGRATION_ALREADY_WPCOM step when the user is already on WPCOM', () => {
+			it( 'redirects to SITE_MIGRATION_FALLBACK_CREDENTIALS when the user is already on WPCOM', () => {
 				const destination = runNavigation( {
 					from: STEPS.SITE_MIGRATION_CREDENTIALS,
 					dependencies: {
@@ -920,8 +871,8 @@ describe( 'Site Migration Flow', () => {
 		} );
 
 		describe( 'SITE_MIGRATION_FALLBACK_CREDENTIALS', () => {
-			it( 'redirects to SITE_MIGRATION_ASSISTED_MIGRATION when the user skips the form and enables ticket creation', () => {
-				const destination = runNavigation( {
+			it( 'redirects to site overview when the user skips', () => {
+				runNavigation( {
 					from: STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS,
 					dependencies: {
 						action: 'skip',
@@ -933,19 +884,19 @@ describe( 'Site Migration Flow', () => {
 					},
 				} );
 
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+				expect( window.location.assign ).toMatchURL( {
+					path: '/overview/example.wordpress.com',
 					query: {
-						siteSlug: 'example.wordpress.com',
+						ref: 'site-migration',
 						siteId: 123,
 						from: 'https://site-to-be-migrated.com',
-						preventTicketCreation: 'true',
+						preventTicketCreation: true,
 					},
 				} );
 			} );
 
-			it( 'redirects to SITE_MIGRATION_ASSISTED_MIGRATION while disabling ticket creation', () => {
-				const destination = runNavigation( {
+			it( 'redirects to site overview when submitting credentials', () => {
+				runNavigation( {
 					from: STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS,
 					query: {
 						siteSlug: 'example.wordpress.com',
@@ -954,13 +905,13 @@ describe( 'Site Migration Flow', () => {
 					},
 				} );
 
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+				expect( window.location.assign ).toMatchURL( {
+					path: '/overview/example.wordpress.com',
 					query: {
-						siteSlug: 'example.wordpress.com',
+						ref: 'site-migration',
 						siteId: 123,
 						from: 'https://site-to-be-migrated.com',
-						preventTicketCreation: 'true',
+						preventTicketCreation: true,
 					},
 				} );
 			} );
@@ -1066,30 +1017,26 @@ describe( 'Site Migration Flow', () => {
 		} );
 
 		describe( 'SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION', () => {
-			it( 'redirects to the site authorization url when the user authorizes the application password', () => {
-				const currentURL = `https://calypso/setup/${ STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug }`;
-				window.location.href = currentURL;
-
+			it( 'redirects to site overview when the user skips', () => {
 				runNavigation( {
 					from: STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION,
+					dependencies: {
+						action: 'skip',
+					},
 					query: {
 						siteSlug: 'example.wordpress.com',
 						siteId: 123,
-						from: 'http://oldsite.com',
-					},
-					dependencies: {
-						action: 'authorization',
-						authorizationUrl:
-							'https://oldsite.com/wp-admin/authorize-application.php?app_name=Migrate+to+WordPress.com&app_id=c95b5f6a-b93f-4ece-96c2-a6660bfcb6d2',
+						from: 'https://site-to-be-migrated.com',
 					},
 				} );
 
 				expect( window.location.assign ).toMatchURL( {
-					path: 'https://oldsite.com/wp-admin/authorize-application.php',
+					path: '/overview/example.wordpress.com',
 					query: {
-						app_id: 'c95b5f6a-b93f-4ece-96c2-a6660bfcb6d2',
-						app_name: 'Migrate to WordPress.com',
-						success_url: currentURL,
+						ref: 'site-migration',
+						siteId: 123,
+						from: 'https://site-to-be-migrated.com',
+						preventTicketCreation: true,
 					},
 				} );
 			} );
@@ -1117,8 +1064,8 @@ describe( 'Site Migration Flow', () => {
 				} );
 			} );
 
-			it( 'redirects to SITE_MIGRATION_ASSISTED_MIGRATION when the user ask for help', () => {
-				const destination = runNavigation( {
+			it( 'redirects to the overview when the user ask for help', () => {
+				runNavigation( {
 					from: STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION,
 					dependencies: {
 						action: 'skip',
@@ -1130,12 +1077,13 @@ describe( 'Site Migration Flow', () => {
 					},
 				} );
 
-				expect( destination ).toMatchDestination( {
-					step: STEPS.SITE_MIGRATION_ASSISTED_MIGRATION,
+				expect( window.location.assign ).toMatchURL( {
+					path: '/overview/example.wordpress.com',
 					query: {
-						siteSlug: 'example.wordpress.com',
+						ref: 'site-migration',
 						siteId: 123,
 						from: 'http://oldsite.com',
+						preventTicketCreation: true,
 					},
 				} );
 			} );

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -1,4 +1,4 @@
-import { globe, group, Icon, scheduled, envelope } from '@wordpress/icons';
+import { globe, group, Icon, scheduled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
 import { Container, Header } from './layout';
@@ -30,7 +30,7 @@ export const MigrationStartedDIFM = () => {
 
 	const title = translate( "We've received your migration request" );
 	const subTitle = translate(
-		"Our team has received your details. We will review your site to make sure we have everything we need. Here's what you can expect next:"
+		"We will review your site to make sure we have everything we need. Here's what you can expect next:"
 	) as string;
 
 	return (
@@ -39,12 +39,6 @@ export const MigrationStartedDIFM = () => {
 			<div className="migration-started-difm">
 				<h2 className="migration-started-difm__title">{ translate( 'What to expect' ) }</h2>
 				<MigrationStartedList>
-					<MigrationStartedItem
-						icon={ envelope }
-						text={ translate(
-							"We'll send you an email with more details on the process and we'll let you know when we start the migration."
-						) }
-					/>
 					<MigrationStartedItem
 						icon={ group }
 						text={ translate(

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { globe, group, Icon, scheduled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
@@ -27,11 +28,18 @@ const MigrationStartedItem = ( { icon, text }: MigrationStartedItemProps ) => (
 
 export const MigrationStartedDIFM = () => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const title = translate( "We've received your migration request" );
-	const subTitle = translate(
+	const subTitle = hasEnTranslation(
 		"We will review your site to make sure we have everything we need. Here's what you can expect next:"
-	) as string;
+	)
+		? translate(
+				"We will review your site to make sure we have everything we need. Here's what you can expect next:"
+		  )
+		: translate(
+				"Our team has received your details. We will review your site to make sure we have everything we need. Here's what you can expect next:"
+		  );
 
 	return (
 		<Container>

--- a/client/sites/overview/components/migration-overview/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/test/index.tsx
@@ -128,7 +128,7 @@ describe( 'MigrationOverview', () => {
 			expect( getByText( /We've received your migration request/ ) ).toBeVisible();
 			expect(
 				getByText(
-					/Our team has received your details. We will review your site to make sure we have everything we need. Here's what you can expect next:/
+					/We will review your site to make sure we have everything we need. Here's what you can expect next:/
 				)
 			).toBeVisible();
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101017

## Proposed Changes

This updates the site-migration-flow so that we go directly from the "authorize application" or "share credentials screen" to `/overview/:siteSlug`. Previously, we went to the `importer-migrate-message` step which showed essentially the same message as `/overview`.

Note that it's necessary to reset site data when redirecting to the overview or you get weird behavior. See https://github.com/Automattic/wp-calypso/pull/101614 and https://github.com/Automattic/wp-calypso/pull/101156 for more details.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This helps streamline the migration flow and gives the user fewer steps to go through.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll need to use the calypso.live url. Testing the "authorize application" process won't work running Calypso locally.

**Using authorize application**
* Go to `/start`.
* Go through the steps and select "Import or migrate" on the goals step.
* Make sure you select a DIFM (assisted migration).
* When you get to the "Get ready for blazing fast speeds", click "Authorize access".
* When redirected, allow access to the app from your source site.
* After authorizing, you should be redirected to the site overview and see the screen shown below.

**Using share credentials**
* Go to `/start`.
* Go through the steps and select "Import or migrate" on the goals step.
* Make sure you select a DIFM (assisted migration).
* When you get to the "Get ready for blazing fast speeds", click "Share credentials instead".
* Enter your source site credentials.
* After sharing, you should be redirected to the site overview and see the screen shown below.

![CleanShot 2025-03-26 at 11 36 40](https://github.com/user-attachments/assets/3f9cf758-8a4f-4109-956c-871679b745fa)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
