### PR TITLE
Remove useGoalsFirstExperiment from onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -33,7 +33,6 @@ import {
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
-import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import type { Step } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './styles.scss';
@@ -67,7 +66,6 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 		siteUrl,
 		progress,
 		partnerBundle,
-		siteGoals,
 	} = useSelect(
 		( select: ( arg: string ) => OnboardSelect ) => ( {
 			domainItem: select( ONBOARD_STORE ).getSelectedDomain(),
@@ -85,8 +83,6 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	);
 
 	const { mutateAsync: addEcommerceTrial } = useAddEcommerceTrialMutation( partnerBundle );
-	const [ , isGoalsFirstExperiment ] = useGoalsFirstExperiment();
-
 	/**
 	 * Support singular and multiple domain cart items.
 	 */
@@ -94,8 +90,6 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 	if ( domainCartItem ) {
 		mergedDomainCartItems.push( domainCartItem );
 	}
-
-	const shouldSaveSiteGoals = isOnboardingFlow( flow ) && isGoalsFirstExperiment;
 
 	const username = useSelector( getCurrentUserName );
 
@@ -187,8 +181,7 @@ const CreateSite: Step = function CreateSite( { navigation, flow, data } ) {
 			siteUrl,
 			domainItem,
 			sourceSlug,
-			siteIntent,
-			shouldSaveSiteGoals ? siteGoals : undefined
+			siteIntent
 		);
 
 		if ( isEntrepreneurFlow( flow ) && site ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -6,7 +6,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { type ReactNode, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { useGoalsFirstExperiment } from 'calypso/landing/stepper/declarative-flow/helpers/use-goals-first-experiment';
 import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -68,7 +67,6 @@ const GoalsStep: StepType< {
 	const { setGoals, setIntent, resetIntent } = useDispatch( ONBOARD_STORE );
 	const refParameter = getQueryArgs()?.ref as string;
 
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 	const isIntentCreateCourseGoalEnabled = useCreateCourseGoalFeature();
 
 	useEffect( () => {
@@ -165,7 +163,7 @@ const GoalsStep: StepType< {
 		if ( isValidRef && goals.length === 0 ) {
 			setGoals( refGoals[ refParameter ] );
 		}
-		// Delibirately not including all deps in the deps array
+		// Deliberately not including all deps in the deps array
 		// This hook is only meant to be executed when either refParameter, refGoals change in value
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ refParameter, refGoals ] );
@@ -182,16 +180,14 @@ const GoalsStep: StepType< {
 				<Button variant="link" onClick={ handleDIFMClick } className="select-goals__link">
 					{ translate( 'Let us build a custom site for you' ) }
 				</Button>
-				{ ! isGoalsAtFrontExperiment && (
-					<Button
-						variant="link"
-						onClick={ handleDashboardClick }
-						className="select-goals__link select-goals__dashboard-button"
-					>
-						<DashboardIcon />
-						{ translate( 'Skip to dashboard' ) }
-					</Button>
-				) }
+				<Button
+					variant="link"
+					onClick={ handleDashboardClick }
+					className="select-goals__link select-goals__dashboard-button"
+				>
+					<DashboardIcon />
+					{ translate( 'Skip to dashboard' ) }
+				</Button>
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -111,10 +111,7 @@ const GoalsStep: StepType< {
 
 	const recordNavigationSelectTracksEvent = ( intent: Onboard.SiteIntent, action: string ) => {
 		recordTracksEvent( 'calypso_signup_intent_select', { intent } );
-		recordTracksEvent( 'calypso_signup_goals_nav_click', {
-			action,
-			is_goals_first: isGoalsAtFrontExperiment,
-		} );
+		recordTracksEvent( 'calypso_signup_goals_nav_click', { action } );
 	};
 
 	const getStepSubmissionHandler = ( action: string ) => () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-domains/index.tsx
@@ -30,7 +30,6 @@ import { fetchUsernameSuggestion } from 'calypso/state/signup/optional-dependenc
 import { removeStep } from 'calypso/state/signup/progress/actions';
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
-import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import { useIsManagedSiteFlowProps } from './use-is-managed-site-flow';
 import type { ProvidedDependencies, Step } from '../../types';
 
@@ -103,7 +102,6 @@ const DomainsStep: Step< { submits: DomainStepSubmittedTypes } > = ( props ) => 
 	const [ stepState, setStepState ] =
 		useStepPersistedState< ProvidedDependencies >( 'domains-step' );
 	const managedSiteFlowProps = useIsManagedSiteFlowProps();
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 
 	return (
 		<CalypsoShoppingCartProvider>
@@ -126,7 +124,6 @@ const DomainsStep: Step< { submits: DomainStepSubmittedTypes } > = ( props ) => 
 				} }
 				step={ stepState }
 				flowName={ props.flow }
-				goBack={ isGoalsAtFrontExperiment ? props.navigation.goBack : undefined }
 				useStepperWrapper
 			/>
 		</CalypsoShoppingCartProvider>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/101759
This is the first of multiple PRs that will remove GoalsFirst code.

## Proposed Changes

* Removing references to `useGoalsFirstExperiment` 
* Steps included:
  * goals
  * create-site
  * unified-domains

## Why are these changes being made?

Leadership has confirmed we will not be resurrecting the Goals First onboarding flow. We can remove all traces of this flow. 
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
