### PR TITLE
Rewrite/step container v2

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -130,10 +130,10 @@ const UserStepComponent: StepType = function UserStep( {
 
 		const topBar = (
 			<Step.TopBar
-				backButton={
+				leftButton={
 					navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
 				}
-				skipButton={ <Step.SkipButton href={ loginLink } label={ translate( 'Log in' ) } /> }
+				rightButton={ <Step.SkipButton href={ loginLink } label={ translate( 'Log in' ) } /> }
 			/>
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -133,7 +133,9 @@ const UserStepComponent: StepType = function UserStep( {
 				leftButton={
 					navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
 				}
-				rightButton={ <Step.SkipButton href={ loginLink } label={ translate( 'Log in' ) } /> }
+				rightButton={
+					<Step.SkipButton href={ loginLink }>{ translate( 'Log in' ) }</Step.SkipButton>
+				}
 			/>
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -204,7 +204,7 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 					} ) }
 					topBar={
 						<Step.TopBar
-							backButton={
+							leftButton={
 								navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
 							}
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -866,12 +866,12 @@ const UnifiedDesignPickerStep: StepType< {
 					topBar={
 						isDesktopVersion ? (
 							<Step.TopBar
-								backButton={
+								leftButton={
 									shouldHideActionButtons ? undefined : (
 										<Step.BackButton onClick={ handleBackClick } />
 									)
 								}
-								skipButton={
+								rightButton={
 									! isGoalsAtFrontExperiment ? undefined : (
 										<Step.SkipButton
 											onClick={ () => handleSubmit() }
@@ -988,8 +988,8 @@ const UnifiedDesignPickerStep: StepType< {
 				className="step-container-v2--design-picker"
 				topBar={
 					<Step.TopBar
-						backButton={ backButton ? <Step.BackButton onClick={ backButton } /> : undefined }
-						skipButton={
+						leftButton={ backButton ? <Step.BackButton onClick={ backButton } /> : undefined }
+						rightButton={
 							hideSkip ? undefined : (
 								<Step.SkipButton onClick={ () => handleSubmit() } label={ skipLabelText } />
 							)

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -714,7 +714,7 @@ const UnifiedDesignPickerStep: StepType< {
 			);
 		}
 
-		return <Step.PrimaryButton label={ text } onClick={ action } />;
+		return <Step.PrimaryButton onClick={ action }>{ text }</Step.PrimaryButton>;
 	}
 
 	useEffect( () => {
@@ -873,10 +873,9 @@ const UnifiedDesignPickerStep: StepType< {
 								}
 								rightButton={
 									! isGoalsAtFrontExperiment ? undefined : (
-										<Step.SkipButton
-											onClick={ () => handleSubmit() }
-											label={ translate( 'Skip setup' ) }
-										/>
+										<Step.SkipButton onClick={ () => handleSubmit() }>
+											{ translate( 'Skip setup' ) }
+										</Step.SkipButton>
 									)
 								}
 							/>
@@ -991,7 +990,9 @@ const UnifiedDesignPickerStep: StepType< {
 						leftButton={ backButton ? <Step.BackButton onClick={ backButton } /> : undefined }
 						rightButton={
 							hideSkip ? undefined : (
-								<Step.SkipButton onClick={ () => handleSubmit() } label={ skipLabelText } />
+								<Step.SkipButton onClick={ () => handleSubmit() }>
+									{ skipLabelText }
+								</Step.SkipButton>
 							)
 						}
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -714,7 +714,7 @@ const UnifiedDesignPickerStep: StepType< {
 			);
 		}
 
-		return <Step.NextButton label={ text } onClick={ action } />;
+		return <Step.PrimaryButton label={ text } onClick={ action } />;
 	}
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -43,20 +43,19 @@ const DIFMStartingPoint: StepType< {
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		const primaryButton = showNewOrExistingSiteChoice ? (
-			<Step.NextButton
+			<Step.PrimaryButton
 				onClick={ () => onSubmit( 'existing-site' ) }
 				label={ translate( 'Use an existing site' ) }
 			/>
 		) : (
-			<Step.NextButton
+			<Step.PrimaryButton
 				onClick={ () => onSubmit( 'new-site' ) }
 				label={ translate( 'Get started' ) }
 			/>
 		);
 
 		const secondaryButton = showNewOrExistingSiteChoice ? (
-			<Step.NextButton
-				variant="secondary"
+			<Step.SecondaryButton
 				onClick={ () => onSubmit( 'new-site' ) }
 				label={ translate( 'Start a new site' ) }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -43,22 +43,19 @@ const DIFMStartingPoint: StepType< {
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		const primaryButton = showNewOrExistingSiteChoice ? (
-			<Step.PrimaryButton
-				onClick={ () => onSubmit( 'existing-site' ) }
-				label={ translate( 'Use an existing site' ) }
-			/>
+			<Step.PrimaryButton onClick={ () => onSubmit( 'existing-site' ) }>
+				{ translate( 'Use an existing site' ) }
+			</Step.PrimaryButton>
 		) : (
-			<Step.PrimaryButton
-				onClick={ () => onSubmit( 'new-site' ) }
-				label={ translate( 'Get started' ) }
-			/>
+			<Step.PrimaryButton onClick={ () => onSubmit( 'new-site' ) }>
+				{ translate( 'Get started' ) }
+			</Step.PrimaryButton>
 		);
 
 		const secondaryButton = showNewOrExistingSiteChoice ? (
-			<Step.SecondaryButton
-				onClick={ () => onSubmit( 'new-site' ) }
-				label={ translate( 'Start a new site' ) }
-			/>
+			<Step.SecondaryButton onClick={ () => onSubmit( 'new-site' ) }>
+				{ translate( 'Start a new site' ) }
+			</Step.SecondaryButton>
 		) : undefined;
 
 		return (
@@ -77,10 +74,9 @@ const DIFMStartingPoint: StepType< {
 										helpCenterButtonLink={ translate( 'Contact our site building team' ) }
 									/>
 								) : (
-									<Step.SkipButton
-										onClick={ goNext }
-										label={ translate( 'No Thanks, I’ll Build It' ) }
-									/>
+									<Step.SkipButton onClick={ goNext }>
+										{ translate( 'No Thanks, I’ll Build It' ) }
+									</Step.SkipButton>
 								)
 							}
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -67,8 +67,8 @@ const DIFMStartingPoint: StepType< {
 				<StepContainerV2DIFMStartingPoint
 					topBar={
 						<Step.TopBar
-							backButton={ goBack ? <Step.BackButton onClick={ goBack } /> : undefined }
-							skipButton={
+							leftButton={ goBack ? <Step.BackButton onClick={ goBack } /> : undefined }
+							rightButton={
 								shouldRenderHelpCenter ? (
 									<HelpCenterStepButton
 										flowName={ DIFM_FLOW }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -200,7 +200,7 @@ const GoalsStep: StepType< {
 
 	const getStep = () => {
 		if ( shouldUseStepContainerV2( flow ) ) {
-			const nextButton = <Step.NextButton onClick={ handleNext } />;
+			const nextButton = <Step.PrimaryButton onClick={ handleNext } />;
 
 			return (
 				<Step.CenteredColumnLayout

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -206,7 +206,7 @@ const GoalsStep: StepType< {
 				<Step.CenteredColumnLayout
 					columnWidth={ 6 }
 					className="step-container-v2--goals"
-					topBar={ <Step.TopBar skipButton={ <Step.SkipButton onClick={ handleSkip } /> } /> }
+					topBar={ <Step.TopBar leftButton={ <Step.SkipButton onClick={ handleSkip } /> } /> }
 					heading={ <Step.Heading text={ whatAreYourGoalsText } subText={ subHeaderText } /> }
 					stickyBottomBar={ <Step.StickyBottomBar rightButton={ nextButton } /> }
 				>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/step-container-v2-plans.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/step-container-v2-plans.tsx
@@ -22,7 +22,7 @@ const StepContainerV2Plans = ( {
 			className="step-container-v2--plans"
 			topBar={
 				<Step.TopBar
-					backButton={
+					leftButton={
 						goBack ? <Step.BackButton onClick={ goBack } label={ backLabelText } /> : undefined
 					}
 				/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/step-container-v2-plans.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/step-container-v2-plans.tsx
@@ -23,7 +23,9 @@ const StepContainerV2Plans = ( {
 			topBar={
 				<Step.TopBar
 					leftButton={
-						goBack ? <Step.BackButton onClick={ goBack } label={ backLabelText } /> : undefined
+						goBack ? (
+							<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>
+						) : undefined
 					}
 				/>
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -144,7 +144,7 @@ const UseMyDomain: StepType< {
 				<Step.CenteredColumnLayout
 					topBar={
 						<Step.TopBar
-							backButton={
+							leftButton={
 								shouldHideButtons ? undefined : <Step.BackButton onClick={ handleGoBack } />
 							}
 						/>

--- a/client/signup/steps/domains/async-domain-step-wrapper.tsx
+++ b/client/signup/steps/domains/async-domain-step-wrapper.tsx
@@ -32,8 +32,9 @@ export default function AsyncDomainStepWrapper( props: AsyncDomainStepWrapperPro
 			href={ backUrl }
 			rel={ isExternalBackUrl ? 'external' : '' }
 			onClick={ goBack }
-			label={ backLabelText }
-		/>
+		>
+			{ backLabelText }
+		</Step.BackButton>
 	);
 
 	return (

--- a/client/signup/steps/domains/async-domain-step-wrapper.tsx
+++ b/client/signup/steps/domains/async-domain-step-wrapper.tsx
@@ -40,7 +40,7 @@ export default function AsyncDomainStepWrapper( props: AsyncDomainStepWrapperPro
 		<Step.TwoColumnLayout
 			firstColumnWidth={ 7 }
 			secondColumnWidth={ 3 }
-			topBar={ <Step.TopBar backButton={ ! hideBack && backButton } /> }
+			topBar={ <Step.TopBar leftButton={ ! hideBack && backButton } /> }
 			heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
 			className={ className }
 		>

--- a/packages/onboarding/src/step-container-v2/README.md
+++ b/packages/onboarding/src/step-container-v2/README.md
@@ -12,7 +12,7 @@ The new version focuses on modularity and composition instead of overrides throu
 
 This version, however, provides several "slots" that allow the developer to declare _which_ parts of the step will be rendered, instead of imperatively specifying _what_ to render. `topBar`, `heading`, `stickyBottomBar`, and `footer` are example of slots.
 
-It also provides the elements to be used within these slots, such as `TopBar`, `Heading`, `StickyBottomBar`, and `Footer`, as well as their internal elements, such as buttons like `NextButton`, `SkipButton`, and `BackButton`.
+It also provides the elements to be used within these slots, such as `TopBar`, `Heading`, `StickyBottomBar`, and `Footer`, as well as their internal elements, such as buttons like `PrimaryButton`, `SkipButton`, and `BackButton`.
 
 Here's an example:
 
@@ -20,7 +20,7 @@ Here's an example:
 import { Step } from '@automattic/onboarding';
 
 const MyStep = () => {
-	const nextButton = <Step.NextButton onClick={ navigation.submit } />;
+	const nextButton = <Step.PrimaryButton onClick={ navigation.submit } />;
 
 	return (
 		<Step.StepContainerV2
@@ -177,7 +177,7 @@ Et voilà, we've created a new wireframe. Here's how to use it:
 	imageUrl={ imageUrl }
 >
 	<p>Here comes the content rendered in the right column of the step.</p>
-	<Step.NextButton onClick={ navigation.submit } />
+	<Step.PrimaryButton onClick={ navigation.submit } />
 </Step.HorizontalLayout>
 ```
 

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -5,11 +5,11 @@ import { useStepContainerV2InternalContext } from '../../contexts/StepContainerV
 import './style.scss';
 
 interface TopBarProps {
-	backButton?: ReactNode;
-	skipButton?: ReactNode;
+	leftButton?: ReactNode;
+	rightButton?: ReactNode;
 }
 
-export const TopBar = ( { backButton, skipButton }: TopBarProps ) => {
+export const TopBar = ( { leftButton, rightButton }: TopBarProps ) => {
 	const { isMediumViewport } = useStepContainerV2InternalContext();
 
 	return (
@@ -23,14 +23,14 @@ export const TopBar = ( { backButton, skipButton }: TopBarProps ) => {
 				<WordPressLogo size={ 21 } className="step-container-v2__top-bar-wordpress-logo" />
 			) }
 
-			{ backButton && (
+			{ leftButton && (
 				<>
 					<div className="step-container-v2__top-bar-divider" />
-					<div className="step-container-v2__top-bar-left-button">{ backButton }</div>
+					<div className="step-container-v2__top-bar-left-button">{ leftButton }</div>
 				</>
 			) }
-			{ skipButton && (
-				<div className="step-container-v2__top-bar-right-button">{ skipButton }</div>
+			{ rightButton && (
+				<div className="step-container-v2__top-bar-right-button">{ rightButton }</div>
 			) }
 		</div>
 	);

--- a/packages/onboarding/src/step-container-v2/components/buttons/BackButton/BackButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/BackButton/BackButton.tsx
@@ -13,7 +13,7 @@ export const BackButton = ( originalProps: ButtonProps ) => {
 	const stepContext = useStepContainerV2Context();
 
 	const backButtonProps = normalizeButtonProps( originalProps, {
-		label: __( 'Back', __i18n_text_domain__ ),
+		children: __( 'Back', __i18n_text_domain__ ),
 		className: 'step-container-v2__back-button',
 		icon: chevronLeft,
 	} );

--- a/packages/onboarding/src/step-container-v2/components/buttons/PrimaryButton/PrimaryButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/PrimaryButton/PrimaryButton.tsx
@@ -5,13 +5,13 @@ import { ButtonProps } from '../../../types';
 
 import './style.scss';
 
-export const NextButton = ( originalProps: ButtonProps ) => {
+export const PrimaryButton = ( originalProps: ButtonProps ) => {
 	const { __ } = useI18n();
 
-	const nextButtonProps = normalizeButtonProps( originalProps, {
+	const primaryButtonProps = normalizeButtonProps( originalProps, {
 		label: __( 'Next', __i18n_text_domain__ ),
-		className: 'step-container-v2__next-button',
+		className: 'step-container-v2__primary-button',
 	} );
 
-	return <Button __next40pxDefaultSize variant="primary" { ...nextButtonProps } />;
+	return <Button __next40pxDefaultSize variant="primary" { ...primaryButtonProps } />;
 };

--- a/packages/onboarding/src/step-container-v2/components/buttons/PrimaryButton/PrimaryButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/PrimaryButton/PrimaryButton.tsx
@@ -9,7 +9,7 @@ export const PrimaryButton = ( originalProps: ButtonProps ) => {
 	const { __ } = useI18n();
 
 	const primaryButtonProps = normalizeButtonProps( originalProps, {
-		label: __( 'Next', __i18n_text_domain__ ),
+		children: __( 'Next', __i18n_text_domain__ ),
 		className: 'step-container-v2__primary-button',
 	} );
 

--- a/packages/onboarding/src/step-container-v2/components/buttons/PrimaryButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/PrimaryButton/style.scss
@@ -1,4 +1,4 @@
-.step-container-v2__content-wrapper .step-container-v2__next-button {
+.step-container-v2__content-wrapper .step-container-v2__primary-button {
 	padding: 0.5rem 3rem;
 	font-size: 0.875rem;
 	line-height: 1;

--- a/packages/onboarding/src/step-container-v2/components/buttons/SecondaryButton/SecondaryButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SecondaryButton/SecondaryButton.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { normalizeButtonProps } from '../../../helpers/normalizeButtonProps';
+import { ButtonProps } from '../../../types';
+
+import './style.scss';
+
+export const SecondaryButton = ( originalProps: ButtonProps ) => {
+	const { __ } = useI18n();
+
+	const secondaryButtonProps = normalizeButtonProps( originalProps, {
+		label: __( 'Secondary', __i18n_text_domain__ ),
+		className: 'step-container-v2__secondary-button',
+	} );
+
+	return <Button __next40pxDefaultSize variant="secondary" { ...secondaryButtonProps } />;
+};

--- a/packages/onboarding/src/step-container-v2/components/buttons/SecondaryButton/SecondaryButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SecondaryButton/SecondaryButton.tsx
@@ -9,7 +9,7 @@ export const SecondaryButton = ( originalProps: ButtonProps ) => {
 	const { __ } = useI18n();
 
 	const secondaryButtonProps = normalizeButtonProps( originalProps, {
-		label: __( 'Secondary', __i18n_text_domain__ ),
+		children: __( 'Secondary', __i18n_text_domain__ ),
 		className: 'step-container-v2__secondary-button',
 	} );
 

--- a/packages/onboarding/src/step-container-v2/components/buttons/SecondaryButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SecondaryButton/style.scss
@@ -1,0 +1,6 @@
+.step-container-v2__content-wrapper .step-container-v2__secondary-button {
+	padding: 0.5rem 3rem;
+	font-size: 0.875rem;
+	line-height: 1;
+	justify-content: center;
+}

--- a/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
@@ -12,7 +12,7 @@ export const SkipButton = ( originalProps: ButtonProps ) => {
 	const stepContext = useStepContainerV2Context();
 
 	const skipButtonProps = normalizeButtonProps( originalProps, {
-		label: __( 'Skip', __i18n_text_domain__ ),
+		children: __( 'Skip', __i18n_text_domain__ ),
 		className: 'step-container-v2__skip-button',
 	} );
 

--- a/packages/onboarding/src/step-container-v2/helpers/normalizeButtonProps.ts
+++ b/packages/onboarding/src/step-container-v2/helpers/normalizeButtonProps.ts
@@ -11,14 +11,12 @@ export const normalizeButtonProps = < T extends ComponentProps< typeof Button > 
 		return {
 			...standardProps,
 			onClick: button.onClick,
-			children: standardProps.label,
 		};
 	}
 
 	return {
 		...standardProps,
 		...button,
-		children: button.label ?? standardProps.label,
 		className: clsx( standardProps.className, button.className ),
 	};
 };

--- a/packages/onboarding/src/step-container-v2/index.tsx
+++ b/packages/onboarding/src/step-container-v2/index.tsx
@@ -7,7 +7,8 @@
 export { StepContainerV2Provider } from './contexts/StepContainerV2Context';
 
 export { BackButton } from './components/buttons/BackButton/BackButton';
-export { NextButton } from './components/buttons/NextButton/NextButton';
+export { PrimaryButton } from './components/buttons/PrimaryButton/PrimaryButton';
+export { SecondaryButton } from './components/buttons/SecondaryButton/SecondaryButton';
 export { SkipButton } from './components/buttons/SkipButton/SkipButton';
 export { Heading } from './components/Heading/Heading';
 export { TopBar } from './components/TopBar/TopBar';

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.stories.tsx
@@ -1,5 +1,5 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { Heading, TopBar, BackButton, NextButton, StickyBottomBar, SkipButton } from '../..';
+import { Heading, TopBar, BackButton, PrimaryButton, StickyBottomBar, SkipButton } from '../..';
 import { WireframePlaceholder } from '../../helpers/wireframe-placeholder';
 import { withStepContainerV2ContextDecorator } from '../../helpers/withStepContainerV2ContextDecorator';
 import { CenteredColumnLayout } from './CenteredColumnLayout';
@@ -15,13 +15,13 @@ export default meta;
 
 export const FourColumnsCenteredLayout = () => {
 	const backButton = <BackButton />;
-	const nextButton = <NextButton />;
+	const nextButton = <PrimaryButton />;
 	const skipButton = <SkipButton />;
 
 	return (
 		<CenteredColumnLayout
 			columnWidth={ 4 }
-			topBar={ <TopBar backButton={ backButton } skipButton={ skipButton } /> }
+			topBar={ <TopBar leftButton={ backButton } rightButton={ skipButton } /> }
 			heading={
 				<Heading
 					text="Four Columns Centered Layout"
@@ -42,13 +42,13 @@ export const FourColumnsCenteredLayout = () => {
 
 export const SixColumnsCenteredLayout = () => {
 	const backButton = <BackButton />;
-	const nextButton = <NextButton />;
+	const nextButton = <PrimaryButton />;
 	const skipButton = <SkipButton />;
 
 	return (
 		<CenteredColumnLayout
 			columnWidth={ 6 }
-			topBar={ <TopBar backButton={ backButton } skipButton={ skipButton } /> }
+			topBar={ <TopBar leftButton={ backButton } rightButton={ skipButton } /> }
 			heading={
 				<Heading
 					text="Six Columns Centered Layout"
@@ -69,13 +69,13 @@ export const SixColumnsCenteredLayout = () => {
 
 export const EightColumnsCenteredLayout = () => {
 	const backButton = <BackButton />;
-	const nextButton = <NextButton />;
+	const nextButton = <PrimaryButton />;
 	const skipButton = <SkipButton />;
 
 	return (
 		<CenteredColumnLayout
 			columnWidth={ 8 }
-			topBar={ <TopBar backButton={ backButton } skipButton={ skipButton } /> }
+			topBar={ <TopBar leftButton={ backButton } rightButton={ skipButton } /> }
 			heading={
 				<Heading
 					text="Eight Columns Centered Layout"

--- a/packages/onboarding/src/step-container-v2/wireframes/FullWidthLayout/FullWidthLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/FullWidthLayout/FullWidthLayout.stories.tsx
@@ -2,7 +2,7 @@ import { Badge } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { chevronLeft } from '@wordpress/icons';
-import { Heading, StickyBottomBar, TopBar, BackButton, NextButton } from '../..';
+import { Heading, StickyBottomBar, TopBar, BackButton, PrimaryButton } from '../..';
 import { WireframePlaceholder } from '../../helpers/wireframe-placeholder';
 import { withStepContainerV2ContextDecorator } from '../../helpers/withStepContainerV2ContextDecorator';
 import { FullWidthLayout } from './FullWidthLayout';
@@ -27,7 +27,7 @@ export const ThemePreview = () => {
 	return (
 		<FullWidthLayout
 			className="theme-preview"
-			topBar={ <TopBar backButton={ backButton } /> }
+			topBar={ <TopBar leftButton={ backButton } /> }
 			isMediumViewport={ isMediumViewport }
 			isLargeViewport={ isLargeViewport }
 		>
@@ -57,13 +57,13 @@ export const ThemePreviewFonts = () => {
 	const isMediumViewport = useViewportMatch( 'large', '>=' );
 
 	const backButton = <BackButton label="Back" />;
-	const nextButton = <NextButton label="Save fonts" />;
+	const nextButton = <PrimaryButton label="Save fonts" />;
 
 	return (
 		<FullWidthLayout
 			className="theme-preview"
 			isMediumViewport={ isMediumViewport }
-			topBar={ isMediumViewport ? <TopBar backButton={ backButton } /> : <FontsBar /> }
+			topBar={ isMediumViewport ? <TopBar leftButton={ backButton } /> : <FontsBar /> }
 			stickyBottomBar={ <StickyBottomBar leftButton={ backButton } rightButton={ nextButton } /> }
 			hasContentPadding={ isMediumViewport }
 		>

--- a/packages/onboarding/src/step-container-v2/wireframes/FullWidthLayout/FullWidthLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/FullWidthLayout/FullWidthLayout.stories.tsx
@@ -22,7 +22,7 @@ export const ThemePreview = () => {
 	const isMediumViewport = useViewportMatch( 'small', '>=' );
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
-	const backButton = <BackButton label="Back" />;
+	const backButton = <BackButton>Back</BackButton>;
 
 	return (
 		<FullWidthLayout
@@ -56,8 +56,8 @@ const FontsBar = () => {
 export const ThemePreviewFonts = () => {
 	const isMediumViewport = useViewportMatch( 'large', '>=' );
 
-	const backButton = <BackButton label="Back" />;
-	const nextButton = <PrimaryButton label="Save fonts" />;
+	const backButton = <BackButton>Back</BackButton>;
+	const nextButton = <PrimaryButton>Save fonts</PrimaryButton>;
 
 	return (
 		<FullWidthLayout

--- a/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/TwoColumnLayout/TwoColumnLayout.stories.tsx
@@ -1,5 +1,5 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { Heading, TopBar, BackButton, NextButton, StickyBottomBar } from '../..';
+import { Heading, TopBar, BackButton, PrimaryButton, StickyBottomBar } from '../..';
 import { WireframePlaceholder } from '../../helpers/wireframe-placeholder';
 import { withStepContainerV2ContextDecorator } from '../../helpers/withStepContainerV2ContextDecorator';
 import { TwoColumnLayout } from './TwoColumnLayout';
@@ -17,7 +17,7 @@ export const ThreeColumnsOnRightLayout = () => (
 	<TwoColumnLayout
 		firstColumnWidth={ 2 }
 		secondColumnWidth={ 1 }
-		topBar={ <TopBar backButton={ <BackButton /> } /> }
+		topBar={ <TopBar leftButton={ <BackButton /> } /> }
 		heading={
 			<Heading
 				text="Three Columns on the Right"
@@ -29,7 +29,7 @@ export const ThreeColumnsOnRightLayout = () => (
 				) }
 			/>
 		}
-		stickyBottomBar={ <StickyBottomBar rightButton={ <NextButton /> } /> }
+		stickyBottomBar={ <StickyBottomBar rightButton={ <PrimaryButton /> } /> }
 	>
 		<WireframePlaceholder height={ 616 }>Main</WireframePlaceholder>
 		<WireframePlaceholder height={ 616 }>Sidebar</WireframePlaceholder>
@@ -40,7 +40,7 @@ export const EqualTwoColumnLayout = () => (
 	<TwoColumnLayout
 		firstColumnWidth={ 1 }
 		secondColumnWidth={ 1 }
-		topBar={ <TopBar backButton={ <BackButton /> } /> }
+		topBar={ <TopBar leftButton={ <BackButton /> } /> }
 		heading={
 			<Heading
 				text="Two Equal Columns"
@@ -52,7 +52,7 @@ export const EqualTwoColumnLayout = () => (
 				) }
 			/>
 		}
-		stickyBottomBar={ <StickyBottomBar rightButton={ <NextButton /> } /> }
+		stickyBottomBar={ <StickyBottomBar rightButton={ <PrimaryButton /> } /> }
 	>
 		<WireframePlaceholder height={ 616 }>Content 1</WireframePlaceholder>
 		<WireframePlaceholder height={ 616 }>Content 2</WireframePlaceholder>
@@ -63,7 +63,7 @@ export const WithRenderProp = () => (
 	<TwoColumnLayout
 		firstColumnWidth={ 1 }
 		secondColumnWidth={ 1 }
-		topBar={ <TopBar backButton={ <BackButton /> } /> }
+		topBar={ <TopBar leftButton={ <BackButton /> } /> }
 		heading={
 			<Heading
 				text="Columns Rendered with Render Prop"
@@ -75,7 +75,7 @@ export const WithRenderProp = () => (
 				) }
 			/>
 		}
-		stickyBottomBar={ <StickyBottomBar rightButton={ <NextButton /> } /> }
+		stickyBottomBar={ <StickyBottomBar rightButton={ <PrimaryButton /> } /> }
 	>
 		{ ( { isMediumViewport, isLargeViewport } ) => (
 			<>

--- a/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.stories.tsx
@@ -1,5 +1,5 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { Heading, TopBar, BackButton, NextButton, StickyBottomBar } from '../..';
+import { Heading, TopBar, BackButton, PrimaryButton, StickyBottomBar } from '../..';
 import { WireframePlaceholder } from '../../helpers/wireframe-placeholder';
 import { withStepContainerV2ContextDecorator } from '../../helpers/withStepContainerV2ContextDecorator';
 import { WideLayout } from './WideLayout';
@@ -15,7 +15,7 @@ export default meta;
 
 export const Default = () => (
 	<WideLayout
-		topBar={ <TopBar backButton={ <BackButton /> } /> }
+		topBar={ <TopBar leftButton={ <BackButton /> } /> }
 		heading={
 			<Heading
 				text="Wide layout"
@@ -27,7 +27,7 @@ export const Default = () => (
 				) }
 			/>
 		}
-		stickyBottomBar={ <StickyBottomBar rightButton={ <NextButton /> } /> }
+		stickyBottomBar={ <StickyBottomBar rightButton={ <PrimaryButton /> } /> }
 	>
 		<WireframePlaceholder height={ 616 }>Main</WireframePlaceholder>
 	</WideLayout>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

- [ ] Figure out vertically centered screens
- [ ] Improve wireframes composition
- [ ] Rethink header `max-width`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
