### PR TITLE
MARTECH-45: Authorization page: Detect when coming 'from' the 'jetpack-onboarding' flow & explicitly redirect.

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -323,6 +323,10 @@ export class JetpackAuthorize extends Component {
 				this.isSso()
 			);
 			this.externalRedirectOnce( redirectAfterAuth );
+		} else if ( this.isFromJetpackOnboarding() ) {
+			debug( `Redirecting to My Jetpack page with 'from' url query arg: ${ redirectAfterAuth }` );
+			// Adding the `&from=jetpack-onboarding` query arg here to the url so Jetpack can know the user is coming directly from the Jetpack onboarding flow.
+			this.externalRedirectOnce( addQueryArgs( { from }, redirectAfterAuth ) );
 		} else if ( this.isFromMyJetpackConnectAfterCheckout() ) {
 			debug( `Redirecting to Calypso product license activation page: ${ redirectAfterAuth }` );
 			navigate(
@@ -496,6 +500,11 @@ export class JetpackAuthorize extends Component {
 	isFromMyJetpackConnectAfterCheckout( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'connect-after-checkout' );
+	}
+
+	isFromJetpackOnboarding( props = this.props ) {
+		const { from } = props.authQuery;
+		return startsWith( from, 'jetpack-onboarding' );
 	}
 
 	getCompanyName() {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -314,6 +314,30 @@ describe( 'JetpackAuthorize', () => {
 		} );
 	} );
 
+	describe( 'isFromJetpackOnboardingFlow', () => {
+		const isFromJetpackOnboarding = new JetpackAuthorize().isFromJetpackOnboarding;
+
+		test( 'is from jetpack onboarding', () => {
+			const props = {
+				authQuery: {
+					from: 'jetpack-onboarding',
+				},
+			};
+
+			expect( isFromJetpackOnboarding( props ) ).toBe( true );
+		} );
+
+		test( 'is not from jetpack onboarding', () => {
+			const props = {
+				authQuery: {
+					from: 'not-jetpack-onboarding',
+				},
+			};
+
+			expect( isFromJetpackOnboarding( props ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'isFromJetpackBackupPlugin', () => {
 		const isFromJetpackBackupPlugin = new JetpackAuthorize().isFromJetpackBackupPlugin;
 


### PR DESCRIPTION
After successful authorization, this PR detects when the user has arrived from the Jetpack onboarding flow and then explicitly redirects the user to My Jetpack (with a url query param `from=jetpack-onboarding`).

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/jetpack-marketing/issues/1234


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When coming from the new Jetpack onboarding flow (after successful authorization) the user should redirect to My Jetpack on their site.  We should also include a url query param (from=jetpack-onboarding) so that we know specifically when the user has just connected via the Jetpack onboarding flow (this will be useful for displaying the popout carousel that shows during the onboarding flow).

## Testing Instructions

*** ~~Before testing this PR, PR [MARTECH-41: Allow passing a 'from' property value to the magic-link connection authorization url/flow](https://github.com/Automattic/jetpack/pull/42708#top) needs to be merged first.~~

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and `yarn start`.
- From a Jurassic Ninja site (using Jetpack Beta on Bleeding edge), start the onboarding flow by going to `/wp-admin/admin.php?page=my-jetpack#/onboarding`
    - Make sure your site is completely Not connected (not site or user connected).
    - Also make sure your are Not logged into wordpress.com
- Enter a non-automattic account email address and click the "Start with email button".
- Check your email for the email it sends you.
- Click the link in the email to start the sign-in/authorization process.
- You should be on the wordpress.com authorization page (Asking you to "Approve" your user connection).
- In the url, replace `https://wordpress.com` with `http://calypso.localhost:3000` and reload the page.
- Click the "Approve" button.
- Confirm that you art redirected to the My Jetpack page on your site, and that there is also a url query param `from=jetpack-=onboarding` appended to the url.

**Unit tests:**
- Run `yarn test-client client/jetpack-connect/test/authorize.js` and confirm all test pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
