### PR TITLE
Show loading state while removing domain from minicart

### DIFF
--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -115,8 +115,7 @@ export class DomainsMiniCart extends Component {
 	domainCount = () => {
 		let result = this.props.domainsInCart.length + ( this.props.wpcomSubdomainSelected ? 1 : 0 );
 
-		// Only deduct a removal domain if it's on removal queue and is at the temporarycart
-		// This avoids the case where a domain is removed from the temporarycart but is still on the removal queue
+		// Deduct domains from the count that are on the removal queue
 		this.props.domainRemovalQueue?.forEach( ( item ) => {
 			if ( this.props.domainsInCart.some( ( domain ) => domain.meta === item.meta ) ) {
 				result--;

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -101,6 +101,9 @@ export class DomainsMiniCart extends Component {
 						borderless
 						className="domains__domain-cart-remove"
 						onClick={ this.props.removeDomainClickHandler( domain ) }
+						aria-label={ translate( 'Remove %(domain)s from cart', {
+							args: { domain: domain.meta },
+						} ) }
 					>
 						{ translate( 'Remove' ) }
 					</Button>
@@ -114,13 +117,11 @@ export class DomainsMiniCart extends Component {
 
 		// Only deduct a removal domain if it's on removal queue and is at the temporarycart
 		// This avoids the case where a domain is removed from the temporarycart but is still on the removal queue
-		if ( this.props.temporaryCart?.length > 0 && this.props.domainRemovalQueue?.length > 0 ) {
-			this.props.domainRemovalQueue.forEach( ( item ) => {
-				if ( this.props.temporaryCart.some( ( domain ) => domain.meta === item.meta ) ) {
-					result--;
-				}
-			} );
-		}
+		this.props.domainRemovalQueue?.forEach( ( item ) => {
+			if ( this.props.domainsInCart.some( ( domain ) => domain.meta === item.meta ) ) {
+				result--;
+			}
+		} );
 
 		return result;
 	};

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -149,8 +149,22 @@ export class DomainsMiniCart extends Component {
 		);
 	};
 
+	formatCartTotal = () => {
+		const isRemovingDomain = this.props.domainsInCart.some( ( domain ) =>
+			this.props.domainRemovalQueue.some( ( removalItem ) => removalItem.meta === domain.meta )
+		);
+
+		const hasTemporaryDomain = this.props.domainsInCart.some( ( domain ) => domain.temporary );
+
+		return isRemovingDomain || hasTemporaryDomain
+			? '...'
+			: formatCurrency(
+					this.props.domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
+					this.props.domainsInCart[ 0 ]?.currency ?? this.props.userCurrency ?? 'USD'
+			  );
+	};
+
 	mobile = () => {
-		const userCurrency = this.props.userCurrency ?? 'USD';
 		const MobileHeader = (
 			<div className="domains__domain-cart-title">
 				<div className="domains__domain-cart-total">
@@ -161,12 +175,7 @@ export class DomainsMiniCart extends Component {
 						} ) }
 					</div>
 					<div key="rowtotalprice" className="domains__domain-cart-total-price">
-						{ this.props.domainsInCart.some( ( domain ) => domain.temporary )
-							? '...'
-							: formatCurrency(
-									this.props.domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
-									this.props.domainsInCart?.[ 0 ]?.currency ?? userCurrency
-							  ) }
+						{ this.formatCartTotal() }
 					</div>
 				</div>
 				<Button
@@ -225,8 +234,6 @@ export class DomainsMiniCart extends Component {
 			return this.mobile();
 		}
 
-		const userCurrency = this.props.userCurrency ?? 'USD';
-
 		return (
 			<div className="domains__domain-side-content domains__domain-cart">
 				<div className="domains__domain-cart-title">{ translate( 'Your domains' ) }</div>
@@ -246,14 +253,7 @@ export class DomainsMiniCart extends Component {
 						} ) }
 					</div>
 					<div key="rowtotalprice" className="domains__domain-cart-total-price">
-						<strong>
-							{ this.props.domainsInCart.some( ( domain ) => domain.temporary )
-								? '...'
-								: formatCurrency(
-										this.props.domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
-										this.props.domainsInCart?.[ 0 ]?.currency ?? userCurrency
-								  ) }
-						</strong>
+						<strong>{ this.formatCartTotal() }</strong>
 					</div>
 				</div>
 				<Button

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -973,7 +973,6 @@ export class RenderDomainsStep extends Component {
 				{ domainsInCart.length > 0 || this.state.wpcomSubdomainSelected ? (
 					<DomainsMiniCart
 						domainsInCart={ domainsInCart }
-						temporaryCart={ this.state.temporaryCart }
 						domainRemovalQueue={ this.state.domainRemovalQueue }
 						cartIsLoading={ cartIsLoading }
 						flowName={ flowName }

--- a/client/signup/steps/domains/test/domains-mini-cart.test.js
+++ b/client/signup/steps/domains/test/domains-mini-cart.test.js
@@ -29,9 +29,12 @@ describe( 'DomainsMiniCart', () => {
 
 	it( 'calls removeDomainClickHandler when remove button is clicked', () => {
 		const removeDomainClickHandlerMock = jest.fn();
-		const domainsInCart = [ { meta: 'example.com', cost: 10, currency: 'USD' } ];
+		const domainsInCart = [
+			{ meta: 'example1.com', cost: 10, currency: 'USD' },
+			{ meta: 'example2.com', cost: 20, currency: 'USD' },
+		];
 
-		const { getByText } = render(
+		const { getByText, getByRole, rerender } = render(
 			<DomainsMiniCart
 				domainRemovalQueue={ [] }
 				domainsInCart={ domainsInCart }
@@ -40,12 +43,25 @@ describe( 'DomainsMiniCart', () => {
 			/>
 		);
 
-		fireEvent.click( getByText( 'Remove' ) );
+		expect( getByText( '2 domains' ) ).toBeInTheDocument();
+
+		fireEvent.click( getByRole( 'button', { name: 'Remove example1.com from cart' } ) );
 
 		expect( removeDomainClickHandlerMock ).toHaveBeenCalledWith( domainsInCart[ 0 ] );
+
+		rerender(
+			<DomainsMiniCart
+				domainRemovalQueue={ domainsInCart.slice( 0, 1 ) }
+				domainsInCart={ domainsInCart }
+				removeDomainClickHandler={ removeDomainClickHandlerMock }
+				flowName="onboarding"
+			/>
+		);
+
+		expect( getByText( '1 domain' ) ).toBeInTheDocument();
 	} );
 
-	it( 'calls choose my domain latter button and ensure it works as expected', () => {
+	it( 'calls choose my domain later button and ensure it works as expected', () => {
 		const handleSkipClickHandlerMock = jest.fn();
 		const domainsInCart = [ { meta: 'example.com', cost: 10, currency: 'USD' } ];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101880
Related to https://github.com/Automattic/wp-calypso/pull/101839

## Proposed Changes

* Do not show total price while a domain is being removed
  * You'd think we could show the real price while a domain is being removed because we'd just sum up the remaining domains. However it doesn't work like this because after round tripping to the server we may discover that some discount is now applied differently (e.g. if you removed the free-for-one-year domain)
* Show the correct total while domains are being removed
  * The old logic had something to do with `temporaryCart`, but it seems like the logic had gone stale.
* I removed the `temporaryCart` prop from the mini cart component since it's no longer used.
  * Claude said that `temporaryCart` is where pending domains are supposed to sit before while the API request is being made. Once the API request is successful it moves the domain from `temporaryCart` to `domainsInCart` array. However these two arrays are merged before being passed to the mini cart component. So I think this is not how the mini cart is supposed to work. https://github.com/Automattic/wp-calypso/blob/270eb3edaf8010e03790e970ec5c8184e9191cf9/client/signup/steps/domains/index.jsx#L939-L949

Pinging @paulopmt1 to see if he can remember what the deal is with the temporary array (found some of your previous work https://github.com/Automattic/wp-calypso/pull/84171)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before**


https://github.com/user-attachments/assets/ba42f1dd-369b-40bc-8779-3f0147ba9b45

**After**


https://github.com/user-attachments/assets/c76dbcc3-621f-4cc5-ba07-cb7ebe42982b



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
