### PR TITLE
Revert "Jetpack Cloud: Keep section when switching sites"

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -524,13 +524,9 @@ const navigateToSite =
 		const state = getState();
 		const site = getSite( state, siteId );
 
-		const currentSection = state.route?.path?.current?.split( '/' )?.[ 1 ];
-
 		// We will need to open a new tab if we have wpcomSiteBasePath prop and current site is an Atomic site.
 		if ( site?.is_wpcom_atomic && wpcomSiteBasePath ) {
 			window.open( getCompleteSiteURL( wpcomSiteBasePath ) );
-		} else if ( currentSection && siteId !== ALL_SITES ) {
-			page( `/${ currentSection }/${ site.slug }` );
 		} else {
 			const pathname = getPathnameForSite();
 			if ( pathname ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/101881

Reverts Automattic/wp-calypso#101676

It's causing a blank page redirect when switching primary site: p1742983213319599-slack-C02FMH4G8