### PR TITLE
Use your domain: open inline help center

### DIFF
--- a/client/components/domains/use-your-domain-step/index.tsx
+++ b/client/components/domains/use-your-domain-step/index.tsx
@@ -1,13 +1,11 @@
 import { isPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Card, Button, Gridicon } from '@automattic/components';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import {
-	CALYPSO_HELP_WITH_HELP_CENTER,
-	INCOMING_DOMAIN_TRANSFER,
-	MAP_EXISTING_DOMAIN,
-} from '@automattic/urls';
+import { INCOMING_DOMAIN_TRANSFER, MAP_EXISTING_DOMAIN } from '@automattic/urls';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { formatCurrency, useTranslate } from 'i18n-calypso';
 import { stringify } from 'qs';
 import React, { useState } from 'react';
@@ -117,6 +115,7 @@ function UseYourDomainStep( { basePath, goBack, initialQuery }: UseYourDomainSte
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const [ searchQuery ] = useState( initialQuery || '' );
 
@@ -300,9 +299,7 @@ function UseYourDomainStep( { basePath, goBack, initialQuery }: UseYourDomainSte
 			<p className="use-your-domain-step__footer">
 				{ translate( "Not sure what works best for you? {{a}}We're happy to help!{{/a}}", {
 					components: {
-						a: (
-							<a href={ CALYPSO_HELP_WITH_HELP_CENTER } target="_blank" rel="noopener noreferrer" />
-						),
+						a: <button onClick={ () => setShowHelpCenter( true ) } />,
 					},
 				} ) }
 			</p>

--- a/client/components/domains/use-your-domain-step/style.scss
+++ b/client/components/domains/use-your-domain-step/style.scss
@@ -98,14 +98,32 @@
 	text-align: center;
 	color: var(--color-text);
 
+	button {
+		color: var(--color-link);
+		cursor: pointer;
+		font-size: inherit;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: var(--color-link-dark);
+		}
+
+		&:focus {
+			outline: thin dotted;
+		}
+	}
+
 	body.is-section-signup & {
 		color: var(--color-text-inverted);
 
-		a {
+		button {
 			color: var(--color-text-inverted);
 			text-decoration: underline;
 
-			&:hover {
+			&:hover,
+			&:focus,
+			&:active {
 				color: var(--color-neutral-0);
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #100243
Based on top of #101854

## Proposed Changes

Chance the "We're happy to help" text in the "Use your domain" screen, from opening a link to `/wordpress.com/help`, to opening the inline help center

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Keep the users on the current page instead of interrupting their flow

## Testing Instructions

In admin screens:
 - Visit `/domains/add/use-your-domain/{SITE_SLUG}`
 - Make sure that the "We're happy to help" text at the bottom looks as on `trunk`
 - Make sure that, when the text is clicked, the inline help center shows

https://github.com/user-attachments/assets/c9eab34a-fbfe-46c7-910d-37345e0e5de4

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
