### PR TITLE
Fix package dependency issues

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/src/notice-banner/index.tsx
+++ b/packages/components/src/notice-banner/index.tsx
@@ -1,7 +1,7 @@
-import { alert } from '@automattic/components/src/icons';
 import { Icon, warning, info, check, closeSmall } from '@wordpress/icons';
 import clsx from 'clsx';
 import React from 'react';
+import { alert } from '../icons';
 import './style.scss';
 
 type NoticeBannerProps = {

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/plans-grid-next",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0",
 	"description": "WordPress.com plans UI grid components and helpers.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/plans-grid-next/src/hooks/use-grid-size.ts
+++ b/packages/plans-grid-next/src/hooks/use-grid-size.ts
@@ -1,5 +1,4 @@
 import { useLayoutEffect, useState } from '@wordpress/element';
-import ResizeObserver from 'resize-observer-polyfill';
 
 interface Props {
 	containerRef: React.MutableRefObject< HTMLDivElement | null >;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Changes the import in the notice banner component to use the relative path instead of the `src` directory. This change is necessary when using this package outside of Calypso. Also bumped the version number.
* Remove the 'resize-observer-polyfill' import which was not declared as a dependency in the package's package.json. Also bumped the version number.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes are necessary to use the `plans-grid-next` package outside Calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test the notice banner, run `yarn workspace @automattic/components run storybook` and check the story for the Notice Banner -> Error component. Confirm that the icon renders correctly.
<img width="658" alt="image" src="https://github.com/user-attachments/assets/33fed7d6-f478-4996-a598-a577f78bd109" />

* Go to `/setup/onboarding/plans` and resize the screen. Confirm that the plans layout changes correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
