### PR TITLE
Reader: Fix search header styles on scroll

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -165,12 +165,12 @@ class SearchStream extends React.Component {
 		return (
 			<div>
 				<DocumentHead title={ documentTitle } />
+				<ReaderBackButton />
+				<NavigationHeader
+					title={ translate( 'Search' ) }
+					subtitle={ translate( 'Search for specific topics, authors, or blogs.' ) }
+				/>
 				<div className="search-stream__fixed-area" ref={ this.handleFixedAreaMounted }>
-					<ReaderBackButton />
-					<NavigationHeader
-						title={ translate( 'Search' ) }
-						subtitle={ translate( 'Search for specific topics, authors, or blogs.' ) }
-					/>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput
 							onSearch={ this.updateQuery }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -3,21 +3,27 @@
 @import "@wordpress/base-styles/variables";
 
 // .has-header-section only applies for logged out views
-.layout.has-header-section.is-section-reader .search-stream__fixed-area .navigation-header h1 {
-	@extend .wp-brand-font;
-	font-weight: 600;
-	font-size: 2.25rem;
-	line-height: 48px;
-	margin-bottom: 4px;
-}
+.layout.has-header-section {
+	.search-stream__fixed-area {
+		position: static;
+		padding-top: 0;
+		margin-top: 0;
+	}
 
-.layout.has-header-section.is-section-reader {
+	.is-section-reader {
+		.search-stream__fixed-area .navigation-header h1 {
+			@extend .wp-brand-font;
+			font-weight: 600;
+			font-size: 2.25rem;
+			line-height: 48px;
+			margin-bottom: 4px;
+		}
 
-	.layout__content {
-		background: var(--studio-white);
+		.layout__content {
+			background: var(--studio-white);
+		}
 	}
 }
-
 
 .is-reader-page .main.search-stream {
 	max-width: 905px;
@@ -63,17 +69,12 @@
 	top: 0;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
-	padding: 0 1px;
-    margin: 0 -1px;
-	@media only screen and (min-width: 601px) and (max-width: 660px) {
-		width: calc(100% - 96px);
-	}
-}
+	padding: 24px 0 0;
+	margin: 0 -1px;
 
-.layout.has-header-section .search-stream__fixed-area {
-	position: static;
-	padding-top: 0;
-	margin-top: 0;
+	.search__input-fade::before {
+		border-radius: 4px;
+	}
 }
 
 .search-stream__fixed-area .section-nav-tabs.is-dropdown {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -64,6 +64,15 @@ body.is-section-reader {
 			}
 		}
 
+		// For reader/search
+		main.search-stream {
+			.navigation-header {
+				&::after {
+					margin: 24px 0 0;
+				}
+			}
+		}
+
 		// For reader/a8c
 		.section-header {
 			@media (max-width: 1300px) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100357

## Proposed Changes

- Fix spacing of search header.
- Moved search header out of sticky content which is consistent with all other headers and also give us more spacing.

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/6979d459-387f-456d-bfed-9933096d4b53) | ![image](https://github.com/user-attachments/assets/b7dfebd0-6721-4e1b-b35c-54d433d3fa1a) |
| ![image](https://github.com/user-attachments/assets/18a74ba4-f59e-4a86-9a32-a5a5d567253d) | ![image](https://github.com/user-attachments/assets/fee32097-9b0a-4c84-9896-a9338b559058) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

While working on https://github.com/Automattic/wp-calypso/issues/100357 I noticed some broken styling on search header and decided to fix it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /reader/search. Verify the spacing with and without scroll.
* Test on different screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
