### PR TITLE
E2E: Add tests for the login page when the user is already logged in

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -192,9 +192,9 @@ export class LoginPage {
 	 */
 	async validateContinueAsYourself( username: string, email: string ) {
 		await this.page.waitForSelector( selectors.continue );
-		await this.page.locator( `text='${ username }'` ).waitFor();
-		await this.page.locator( `text='${ email }'` ).waitFor();
-		await this.page.locator( selectors.loginWithAnotherAccount ).waitFor();
+		await this.page.waitForSelector( `text='${ username }'` );
+		await this.page.waitForSelector( `text='${ email }'` );
+		await this.page.waitForSelector( selectors.loginWithAnotherAccount );
 
 		return true;
 	}

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -1,6 +1,11 @@
 import { Locator, Page, Response } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
+const selectors = {
+	continue: 'button:text("Continue")',
+	loginWithAnotherAccount: 'button:text="Log in with another account"',
+};
+
 /**
  * Represents the WPCOM login page.
  */
@@ -176,5 +181,21 @@ export class LoginPage {
 		await locator.click();
 
 		return locator;
+	}
+
+	/**
+	 * Validates the "Continue as yourself" UI when visiting the login page as a logged in user.
+	 *
+	 * @param username - The username of the account to continue as.
+	 * @param email - The email of the account to continue as.
+	 * @returns True if the message is valid, false otherwise.
+	 */
+	async validateContinueAsYourself( username: string, email: string ) {
+		await this.page.waitForSelector( selectors.continue );
+		await this.page.locator( `text='${ username }'` ).waitFor();
+		await this.page.locator( `text='${ email }'` ).waitFor();
+		await this.page.locator( selectors.loginWithAnotherAccount ).waitFor();
+
+		return true;
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -3,7 +3,7 @@ import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
 	continue: 'button:text("Continue")',
-	loginWithAnotherAccount: 'button:text="Log in with another account"',
+	loginWithAnotherAccount: ':text("Log in with another account")',
 };
 
 /**

--- a/test/e2e/specs/onboarding/onboarding__double-login.ts
+++ b/test/e2e/specs/onboarding/onboarding__double-login.ts
@@ -15,43 +15,40 @@ import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Login: Visit login while logged in' ), function () {
+describe( DataHelper.createSuiteTitle( 'Login: Visit login page while logged in' ), function () {
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'signupfree',
 	} );
 
 	let newUserDetails: NewUserResponse;
 	let page: Page;
+	let loginPage: LoginPage;
 
 	beforeAll( async function () {
 		page = await browser.newPage();
 	} );
 
-	describe( 'Register as new user', function () {
-		let loginPage: LoginPage;
+	it( 'Navigate to the Login page', async function () {
+		loginPage = new LoginPage( page );
+		await loginPage.visit();
+	} );
 
-		it( 'Navigate to the Login page', async function () {
-			loginPage = new LoginPage( page );
-			await loginPage.visit();
-		} );
+	it( 'Click on button to create a new account', async function () {
+		await loginPage.clickCreateNewAccount();
+	} );
 
-		it( 'Click on button to create a new account', async function () {
-			await loginPage.clickCreateNewAccount();
-		} );
+	it( 'Sign up as a new user', async function () {
+		const userSignupPage = new UserSignupPage( page );
+		newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+	} );
 
-		it( 'Sign up as a new user', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
-		} );
+	it( 'Go to login page', async function () {
+		loginPage = new LoginPage( page );
+		await loginPage.visit();
+	} );
 
-		it( 'Go to login page', async function () {
-			loginPage = new LoginPage( page );
-			await loginPage.visit();
-		} );
-
-		it( 'Make sure the "Continue" and "Login with another account" buttons are visible', async function () {
-			await loginPage.validateContinueAsYourself( testUser.username, testUser.email );
-		} );
+	it( 'Make sure the "Continue" and "Login with another account" buttons are visible', async function () {
+		await loginPage.validateContinueAsYourself( testUser.username, testUser.email );
 	} );
 
 	afterAll( async function () {

--- a/test/e2e/specs/onboarding/onboarding__double-login.ts
+++ b/test/e2e/specs/onboarding/onboarding__double-login.ts
@@ -1,5 +1,6 @@
 /**
  * @group calypso-release
+ * @group calypso-pr
  */
 
 import {

--- a/test/e2e/specs/onboarding/onboarding__double-login.ts
+++ b/test/e2e/specs/onboarding/onboarding__double-login.ts
@@ -1,0 +1,72 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	RestAPIClient,
+	NewUserResponse,
+	LoginPage,
+	UserSignupPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Login: Visit login while logged in' ), function () {
+	const testUser = DataHelper.getNewTestUser( {
+		usernamePrefix: 'signupfree',
+	} );
+
+	let newUserDetails: NewUserResponse;
+	let page: Page;
+
+	beforeAll( async function () {
+		page = await browser.newPage();
+	} );
+
+	describe( 'Register as new user', function () {
+		let loginPage: LoginPage;
+
+		it( 'Navigate to the Login page', async function () {
+			loginPage = new LoginPage( page );
+			await loginPage.visit();
+		} );
+
+		it( 'Click on button to create a new account', async function () {
+			await loginPage.clickCreateNewAccount();
+		} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		} );
+
+		it( 'Go to login page', async function () {
+			loginPage = new LoginPage( page );
+			await loginPage.visit();
+		} );
+
+		it( 'Make sure the "Continue" or login with another account button is visible', async function () {
+			await loginPage.validateContinueAsYourself( testUser.username, testUser.email );
+		} );
+	} );
+
+	afterAll( async function () {
+		if ( ! newUserDetails ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient(
+			{ username: testUser.username, password: testUser.password },
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
+		} );
+	} );
+} );

--- a/test/e2e/specs/onboarding/onboarding__double-login.ts
+++ b/test/e2e/specs/onboarding/onboarding__double-login.ts
@@ -48,7 +48,7 @@ describe( DataHelper.createSuiteTitle( 'Login: Visit login while logged in' ), f
 			await loginPage.visit();
 		} );
 
-		it( 'Make sure the "Continue" or login with another account button is visible', async function () {
+		it( 'Make sure the "Continue" and "Login with another account" buttons are visible', async function () {
 			await loginPage.validateContinueAsYourself( testUser.username, testUser.email );
 		} );
 	} );


### PR DESCRIPTION
This adds a test for when you visit the login page as an already logged in user. It checks that the "Continue" and "Login as another user" buttons are present.

Motivation is here: p1742968249042509-slack-C02FMH4G8