### PR TITLE
Help Center: Load in LoggedOut layout

### DIFF
--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -1,0 +1,59 @@
+import { HelpCenter } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
+import { useBreakpoint } from '@automattic/viewport-react';
+import { useDispatch } from '@wordpress/data';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { onboardingUrl } from 'calypso/lib/paths';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
+import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import { getSiteBySlug } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+type Props = {
+	sectionName: string;
+	loadHelpCenter: boolean;
+	currentRoute: string;
+};
+
+export default function HelpCenterLoader( { sectionName, loadHelpCenter, currentRoute }: Props ) {
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	const isDesktop = useBreakpoint( '>782px' );
+	const handleClose = useCallback( () => {
+		setShowHelpCenter( false );
+	}, [ setShowHelpCenter ] );
+
+	const locale = useLocale();
+	const hasPurchases = useSelector( hasCancelableUserPurchases );
+	const user = useSelector( getCurrentUser );
+	const selectedSite = useSelector( getSelectedSite );
+	const primarySiteSlug = useSelector( getPrimarySiteSlug );
+	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
+
+	if ( ! loadHelpCenter ) {
+		return null;
+	}
+
+	return (
+		<AsyncLoad
+			require="@automattic/help-center"
+			placeholder={ null }
+			handleClose={ handleClose }
+			currentRoute={ currentRoute }
+			locale={ locale }
+			sectionName={ sectionName }
+			site={ selectedSite || primarySite }
+			currentUser={ user }
+			hasPurchases={ hasPurchases }
+			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
+			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
+			onboardingUrl={ onboardingUrl() }
+			googleMailServiceFamily={ getGoogleMailServiceFamily() }
+		/>
+	);
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -1,10 +1,7 @@
 import config from '@automattic/calypso-config';
-import { HelpCenter } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useShouldShowCriticalAnnouncementsQuery } from '@automattic/whats-new';
-import { useDispatch } from '@wordpress/data';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Component, useCallback, useEffect, useState } from 'react';
@@ -28,17 +25,14 @@ import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
 import OfflineStatus from 'calypso/layout/offline-status';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
-import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { onboardingUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
-import { useSelector } from 'calypso/state';
 import { isOffline } from 'calypso/state/application/selectors';
-import { isUserLoggedIn, getCurrentUser } from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	getShouldShowCollapsedGlobalSidebar,
 	getShouldShowGlobalSidebar,
@@ -48,16 +42,13 @@ import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tour
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
-import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
-import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
-import { getSiteBySlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
-	getSelectedSite,
 	getSelectedSiteId,
 	getSidebarIsCollapsed,
 	masterbarIsVisible,
@@ -65,6 +56,7 @@ import {
 import BodySectionCssClass from './body-section-css-class';
 import { getColorScheme, getColorSchemeFromCurrentQuery, refreshColorScheme } from './color-scheme';
 import GlobalNotifications from './global-notifications';
+import HelpCenterLoader from './help-center-loader';
 import LayoutLoader from './loader';
 import { shouldLoadInlineHelp, handleScroll } from './utils';
 
@@ -79,8 +71,6 @@ import '@automattic/components/src/button/style.scss';
 import '@automattic/components/src/card/style.scss';
 
 import './style.scss';
-
-const HELP_CENTER_STORE = HelpCenter.register();
 
 function SidebarScrollSynchronizer() {
 	const isNarrow = useBreakpoint( '<660px' );
@@ -135,43 +125,6 @@ function WhatsNewLoader( { loadWhatsNew, siteId } ) {
 				siteId={ siteId }
 			/>
 		)
-	);
-}
-
-function HelpCenterLoader( { sectionName, loadHelpCenter, currentRoute } ) {
-	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
-	const isDesktop = useBreakpoint( '>782px' );
-	const handleClose = useCallback( () => {
-		setShowHelpCenter( false );
-	}, [ setShowHelpCenter ] );
-
-	const locale = useLocale();
-	const hasPurchases = useSelector( hasCancelableUserPurchases );
-	const user = useSelector( getCurrentUser );
-	const selectedSite = useSelector( getSelectedSite );
-	const primarySiteSlug = useSelector( getPrimarySiteSlug );
-	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
-
-	if ( ! loadHelpCenter ) {
-		return null;
-	}
-
-	return (
-		<AsyncLoad
-			require="@automattic/help-center"
-			placeholder={ null }
-			handleClose={ handleClose }
-			currentRoute={ currentRoute }
-			locale={ locale }
-			sectionName={ sectionName }
-			site={ selectedSite || primarySite }
-			currentUser={ user }
-			hasPurchases={ hasPurchases }
-			// hide Calypso's version of the help-center on Desktop, because the Editor has its own help-center
-			hidden={ sectionName === 'gutenberg-editor' && isDesktop }
-			onboardingUrl={ onboardingUrl() }
-			googleMailServiceFamily={ getGoogleMailServiceFamily() }
-		/>
 	);
 }
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -47,9 +47,12 @@ import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
+import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import { refreshColorScheme, getColorSchemeFromCurrentQuery } from './color-scheme';
+import HelpCenterLoader from './help-center-loader';
+import { shouldLoadInlineHelp } from './utils';
 
 import './style.scss';
 
@@ -81,6 +84,7 @@ const LayoutLoggedOut = ( {
 	twoFactorEnabled,
 	/* eslint-disable no-shadow */
 	clearLastActionRequiresLogin,
+	userAllowedToHelpCenter,
 	colorScheme,
 } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -122,6 +126,13 @@ const LayoutLoggedOut = ( {
 		! isJetpackCloudOAuth2Client( oauth2Client ) &&
 		! isA4AOAuth2Client( oauth2Client ) &&
 		! isWooOAuth2Client( oauth2Client );
+
+	const loadHelpCenter =
+		isLoggedIn &&
+		// we want to show only the Help center in my home and the help section (but not the FAB)
+		( [ 'home', 'help' ].includes( sectionName ) ||
+			shouldLoadInlineHelp( sectionName, currentRoute || '' ) ) &&
+		userAllowedToHelpCenter;
 
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
@@ -241,6 +252,13 @@ const LayoutLoggedOut = ( {
 
 	return (
 		<div className={ clsx( 'layout', classes ) }>
+			{ loadHelpCenter && (
+				<HelpCenterLoader
+					sectionName={ sectionName }
+					loadHelpCenter={ loadHelpCenter }
+					currentRoute={ currentRoute }
+				/>
+			) }
 			{ 'development' === process.env.NODE_ENV && <SympathyDevWarning /> }
 			<BodySectionCssClass group={ sectionGroup } section={ sectionName } bodyClass={ bodyClass } />
 			<div className="layout__header-section">
@@ -380,6 +398,7 @@ export default withCurrentRoute(
 				isWooJPC,
 				isWoo: getIsWoo( state ),
 				isBlazePro: getIsBlazePro( state ),
+				userAllowedToHelpCenter: ! getIsOnboardingAffiliateFlow( state ),
 				twoFactorEnabled,
 				colorScheme,
 			};

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -130,7 +130,7 @@ const LayoutLoggedOut = ( {
 		isLoggedIn &&
 		// we want to show only the Help center in my home and the help section (but not the FAB)
 		( [ 'home', 'help' ].includes( sectionName ) ||
-			currentRoute.startsWith( '/start/do-it-for-me/' ) ) &&
+			currentRoute?.startsWith( '/start/do-it-for-me/' ) ) &&
 		userAllowedToHelpCenter;
 
 	const classes = {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -52,7 +52,6 @@ import { masterbarIsVisible } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import { refreshColorScheme, getColorSchemeFromCurrentQuery } from './color-scheme';
 import HelpCenterLoader from './help-center-loader';
-import { shouldLoadInlineHelp } from './utils';
 
 import './style.scss';
 
@@ -131,7 +130,7 @@ const LayoutLoggedOut = ( {
 		isLoggedIn &&
 		// we want to show only the Help center in my home and the help section (but not the FAB)
 		( [ 'home', 'help' ].includes( sectionName ) ||
-			shouldLoadInlineHelp( sectionName, currentRoute || '' ) ) &&
+			currentRoute.startsWith( '/start/do-it-for-me/' ) ) &&
 		userAllowedToHelpCenter;
 
 	const classes = {

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -18,6 +18,12 @@ describe( 'index', () => {
 									items: {},
 									lastTimeShown: {},
 								},
+								purchases: {
+									hasLoadedUserPurchasesFromServer: false,
+								},
+								sites: {
+									items: {},
+								},
 							} ),
 							subscribe: () => {},
 						} }

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -11,7 +11,7 @@ export function shouldLoadInlineHelp( sectionName: string, currentRoute: string 
 	}
 
 	const exemptedSections = [ 'jetpack-connect', 'devdocs', 'help', 'home' ];
-	const exemptedRoutes = [ '/log-in/jetpack' ];
+	const exemptedRoutes = [ '/log-in/jetpack', '/log-in' ];
 	const exemptedRoutesStartingWith = [
 		'/start/p2',
 		'/start/setup-site',

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -11,7 +11,7 @@ export function shouldLoadInlineHelp( sectionName: string, currentRoute: string 
 	}
 
 	const exemptedSections = [ 'jetpack-connect', 'devdocs', 'help', 'home' ];
-	const exemptedRoutes = [ '/log-in/jetpack', '/log-in' ];
+	const exemptedRoutes = [ '/log-in/jetpack' ];
 	const exemptedRoutesStartingWith = [
 		'/start/p2',
 		'/start/setup-site',

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -16,7 +16,8 @@ import {
 	reject,
 	reduce,
 } from 'lodash';
-import { Store, Unsubscribe as ReduxUnsubscribe } from 'redux';
+import { Store, Unsubscribe as ReduxUnsubscribe, AnyAction } from 'redux';
+import { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
@@ -356,6 +357,11 @@ export default class SignupFlowController {
 
 		if ( dependencies.bearer_token && ! wpcom.isTokenLoaded() ) {
 			wpcom.loadToken( dependencies.bearer_token );
+			// Reload proxy to refresh auth status for parts that incorrectly use wpcom-proxy-request in Calypso.
+			reloadProxy();
+			requestAllBlogsAccess();
+			// Fetch current user to refresh auth status and re-render all dependent components.
+			this._reduxStore.dispatch( fetchCurrentUser() as unknown as AnyAction );
 		}
 
 		for ( const pendingStep of pendingSteps ) {

--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -24,6 +24,7 @@ import wpcom from 'calypso/lib/wp';
 import flows from 'calypso/signup/config/flows';
 import untypedSteps from 'calypso/signup/config/steps';
 import { getStepUrl } from 'calypso/signup/utils';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import {

--- a/client/state/selectors/get-sites-items.ts
+++ b/client/state/selectors/get-sites-items.ts
@@ -7,5 +7,5 @@ const EMPTY_SITES = Object.freeze( {} );
  * Returns site items object or empty object.
  */
 export default function getSitesItems( state: AppState ): Record< number | string, SiteDetails > {
-	return state.sites.items || EMPTY_SITES;
+	return state.sites?.items || EMPTY_SITES;
 }

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -39,6 +39,8 @@ global.fetch = jest.fn( () =>
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	canAccessWpcomApis: jest.fn(),
+	reloadProxy: jest.fn(),
+	requestAllBlogsAccess: jest.fn(),
 } ) );
 
 global.matchMedia = jest.fn( ( query ) => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Second take of https://github.com/Automattic/wp-calypso/pull/101843

## Proposed Changes

- This adds the Help Center to the `LayoutLoggedOut`
- To reloads the proxy on auth to hydrate tokens and what not
- It fetches the user to update the Redux store with the new auth data.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- DIFM flow needs the Help Center to be available for users right after log in.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make [this hook](https://github.com/Automattic/wp-calypso/blob/trunk/client/signup/help-center-step-button/use-should-render-help-center-button.ts) return true
- Go to /start/do-it-for-me/new-or-existing-site?flags=signup%2Fhelp-center-link, logged out
- Signup with email
- Try to click on "Questions? Contact our..."
- The Help Center should open and a chat should start successfully.
