### PR TITLE
Self service downgrade: Show refund text for eligible users

### DIFF
--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -227,7 +227,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 
 		return hasRefund
 			? translate(
-					'We will change the plan immediately and refund the remaining value of %(amount)s from %(currentPlan)s to %(targetPlan)s.',
+					"When you downgrade from %(currentPlan)s to %(targetPlan)s, we'll immediately process a refund of %(amount)s to your original payment method.",
 					{
 						args: {
 							...basePlanArgs,

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -141,15 +141,14 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 			currency: currencyCode,
 		} );
 		const precision = defaultFormatter.resolvedOptions().maximumFractionDigits;
-		const amount =
-			isRefundable( purchase ) &&
-			Array.isArray( refundOptions ) &&
-			refundOptions[ 0 ]?.refund_amount
-				? refundOptions[ 0 ].refund_amount
-				: 0;
+		const matchingRefundOption =
+			isRefundable( purchase ) && Array.isArray( refundOptions )
+				? refundOptions.find( ( option ) => option.to_product_id === targetPlan?.getProductId() )
+				: null;
+		const refundAmount = matchingRefundOption?.refund_amount ?? 0;
 
-		return parseFloat( amount ).toFixed( precision );
-	}, [ purchase ] );
+		return parseFloat( refundAmount ).toFixed( precision );
+	}, [ purchase, targetPlan ] );
 
 	if (
 		isDataLoading( { hasLoadedSites, hasLoadedUserPurchasesFromServer: loadedFromServer } ) ||

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -227,7 +227,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 
 		return hasRefund
 			? translate(
-					"When you downgrade from %(currentPlan)s to %(targetPlan)s, we'll immediately process a refund of %(amount)s to your original payment method.",
+					"When you downgrade from %(currentPlan)s to %(targetPlan)s, we'll process a refund of %(amount)s to your original payment method.",
 					{
 						args: {
 							...basePlanArgs,

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -29,6 +29,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import HeaderCake from 'calypso/components/header-cake';
+import { hasAmountAvailableToRefund } from 'calypso/lib/purchases';
 import { cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
 import { Purchase } from 'calypso/lib/purchases/types';
 import { managePurchase } from 'calypso/me/purchases/paths';
@@ -196,6 +197,21 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 		}
 	};
 
+	const getDowngradeMessage = () => {
+		const planArgs = {
+			currentPlan: currentPlan?.getTitle() ?? '',
+			targetPlan: targetPlan?.getTitle() ?? '',
+		};
+		return ! hasAmountAvailableToRefund( purchase ) || ! purchase?.mostRecentRenewDate
+			? translate( 'We will change the plan immediately from %(currentPlan)s to %(targetPlan)s.', {
+					args: planArgs,
+			  } )
+			: translate(
+					'We will change the plan immediately and refund the remaining value from %(currentPlan)s to %(targetPlan)s.',
+					{ args: planArgs }
+			  );
+	};
+
 	if ( isAtomicWarningVisible ) {
 		return (
 			<AtomicWarning
@@ -222,17 +238,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 				<div className="downgrade__inner-wrapper">
 					<div className="downgrade__content">
 						<div>
-							<strong>
-								{ translate(
-									'We will change the plan immediately from %(currentPlan)s to %(targetPlan)s.',
-									{
-										args: {
-											currentPlan: currentPlan?.getTitle() ?? '',
-											targetPlan: targetPlan?.getTitle() ?? '',
-										},
-									}
-								) }
-							</strong>
+							<strong>{ getDowngradeMessage() }</strong>
 						</div>
 
 						{ features.length > 0 && (

--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -25,11 +25,11 @@ import {
 import page from '@automattic/calypso-router';
 import { Card, Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import { useTranslate, formatCurrency } from 'i18n-calypso';
+import React, { useState, useMemo } from 'react';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import HeaderCake from 'calypso/components/header-cake';
-import { hasAmountAvailableToRefund } from 'calypso/lib/purchases';
+import { hasAmountAvailableToRefund, isRefundable } from 'calypso/lib/purchases';
 import { cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
 import { Purchase } from 'calypso/lib/purchases/types';
 import { managePurchase } from 'calypso/me/purchases/paths';
@@ -130,6 +130,27 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 	const isAtomicSiteDowngrade =
 		isAtomicSite && ! targetPlan?.getIncludedFeatures?.().includes( WPCOM_FEATURES_ATOMIC );
 
+	const refundAmount = useMemo( () => {
+		if ( ! purchase ) {
+			return '0';
+		}
+
+		const { refundOptions, currencyCode } = purchase;
+		const defaultFormatter = new Intl.NumberFormat( 'en-US', {
+			style: 'currency',
+			currency: currencyCode,
+		} );
+		const precision = defaultFormatter.resolvedOptions().maximumFractionDigits;
+		const amount =
+			isRefundable( purchase ) &&
+			Array.isArray( refundOptions ) &&
+			refundOptions[ 0 ]?.refund_amount
+				? refundOptions[ 0 ].refund_amount
+				: 0;
+
+		return parseFloat( amount ).toFixed( precision );
+	}, [ purchase ] );
+
 	if (
 		isDataLoading( { hasLoadedSites, hasLoadedUserPurchasesFromServer: loadedFromServer } ) ||
 		! purchase
@@ -198,18 +219,25 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 	};
 
 	const getDowngradeMessage = () => {
-		const planArgs = {
+		const hasRefund = hasAmountAvailableToRefund( purchase ) && purchase?.mostRecentRenewDate;
+		const basePlanArgs = {
 			currentPlan: currentPlan?.getTitle() ?? '',
 			targetPlan: targetPlan?.getTitle() ?? '',
 		};
-		return ! hasAmountAvailableToRefund( purchase ) || ! purchase?.mostRecentRenewDate
-			? translate( 'We will change the plan immediately from %(currentPlan)s to %(targetPlan)s.', {
-					args: planArgs,
-			  } )
-			: translate(
-					'We will change the plan immediately and refund the remaining value from %(currentPlan)s to %(targetPlan)s.',
-					{ args: planArgs }
-			  );
+
+		return hasRefund
+			? translate(
+					'We will change the plan immediately and refund the remaining value of %(amount)s from %(currentPlan)s to %(targetPlan)s.',
+					{
+						args: {
+							...basePlanArgs,
+							amount: formatCurrency( parseFloat( refundAmount ), purchase.currencyCode ),
+						},
+					}
+			  )
+			: translate( 'We will change the plan immediately from %(currentPlan)s to %(targetPlan)s.', {
+					args: basePlanArgs,
+			  } );
 	};
 
 	if ( isAtomicWarningVisible ) {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -979,6 +979,7 @@ class ManagePurchase extends Component<
 			<CompactCard href={ link }>
 				<Icon icon={ download } className="card__icon" />
 				{ translate( 'Downgrade plan' ) }
+				{ this.renderRefundText() }
 			</CompactCard>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/issues/100441
- Related to pau2Xa-6Mk-p2

## Proposed Changes

* Show refund text in the Downgrade screen: `When you downgrade from %(currentPlan)s to %(targetPlan)s, we'll immediately process a refund of %(amount)s to your original payment method`.
* Show the `Refund available` beneath the Downgrade button (similar to Cancel)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of an epic to support self service downgrades in wpcom

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the purchases screen for a plan subscription found within the refund window
* You should see the `Refund available` text in Downgrade button
<img width="480" alt="Screenshot 2025-03-26 at 13 00 50" src="https://github.com/user-attachments/assets/9f53d96d-5480-4df6-96ee-e8161bfa4d3b" />

* The Downgrade screen should show the refund text
<img width="1029" alt="Screenshot 2025-03-27 at 11 36 59" src="https://github.com/user-attachments/assets/65d29b73-b7db-4bcc-b23c-3e4dfd665b02" />


* Switch to a plan outside the refund window
* The `Refund available` should not be visible
* The Downgrade screen should show the default text
 
<img width="480" alt="Screenshot 2025-03-26 at 13 01 09" src="https://github.com/user-attachments/assets/d0b9ea6f-f73a-4312-862f-1b638dc40c74" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
