### PR TITLE
Jetpack Cloud: Keep section when switching sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -52,6 +52,7 @@ export class SiteSelector extends Component {
 		hideSelected: PropTypes.bool,
 		filter: PropTypes.func,
 		groups: PropTypes.bool,
+		keepCurrentSection: PropTypes.bool,
 		onSiteSelect: PropTypes.func,
 		searchPlaceholder: PropTypes.string,
 		selectedSite: PropTypes.object,
@@ -79,6 +80,7 @@ export class SiteSelector extends Component {
 		onClose: noop,
 		onSiteSelect: noop,
 		groups: false,
+		keepCurrentSection: false,
 		autoFocus: false,
 		showListBottomAdornment: true,
 	};
@@ -519,10 +521,19 @@ export class SiteSelector extends Component {
 }
 
 const navigateToSite =
-	( siteId, { allSitesPath, allSitesSingleUser, siteBasePath, wpcomSiteBasePath } ) =>
+	(
+		siteId,
+		{ allSitesPath, allSitesSingleUser, keepCurrentSection, siteBasePath, wpcomSiteBasePath }
+	) =>
 	( dispatch, getState ) => {
 		const state = getState();
 		const site = getSite( state, siteId );
+
+		const currentSection = state.route?.path?.current?.split( '/' )?.[ 1 ];
+		if ( keepCurrentSection && currentSection && siteId !== ALL_SITES ) {
+			page( `/${ currentSection }/${ site.slug }` );
+			return;
+		}
 
 		// We will need to open a new tab if we have wpcomSiteBasePath prop and current site is an Atomic site.
 		if ( site?.is_wpcom_atomic && wpcomSiteBasePath ) {

--- a/client/jetpack-cloud/components/sidebar/site-selector.tsx
+++ b/client/jetpack-cloud/components/sidebar/site-selector.tsx
@@ -54,6 +54,7 @@ const SiteSelector = () => {
 			/* eslint-disable-next-line jsx-a11y/no-autofocus */
 			autoFocus={ isVisible }
 			isJetpackAgencyDashboard={ canAccessJetpackManage }
+			keepCurrentSection
 			allSitesPath="/dashboard"
 			siteBasePath="/landing"
 		/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

https://github.com/Automattic/wp-calypso/pull/101676 had to be reverted because it caused switching the primary site to render a blank page. See p1742983213319599-slack-C02FMH4G8. This new PR makes sure that the change only affects the site selector on the jetpack cloud sidebar.

## Proposed Changes

* On Jetpack Cloud, switching sites when you are on a section different from `VaultPressBackup` (e.g. `Subscribers`) takes you to the `VaultPressBackup` section on that new site. This PR changes that so that you navigate to the same section on the desired site.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Jetpack Cloud live preview
* Click on the `Subscribers` section
* Switch sites
* Check that you stay on the `Subscribers` section, but for the desired site

|Before|After|
|---|---|
|![chrome-capture-2025-3-20](https://github.com/user-attachments/assets/4986f3ec-c8c4-4e5c-8b36-d9f9e35817ca)|![chrome-capture-2025-3-20 (1)](https://github.com/user-attachments/assets/84ebabd8-a76b-4a78-b0c0-fb4c09c8edf3)|

* Open the calypso live preview
* Go to `/me/account`
* Switch your primary site
* Check that no redirection happens

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?