### PR TITLE
E2E: Remove search tests that require indexing

### DIFF
--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -12,16 +12,14 @@ import {
 	JetpackInstantSearchModalComponent,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
-import { skipDescribeIf, skipItIf } from '../../jest-helpers';
+import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
 /* 
-	Unfortunately, we can't test Search as thoroughly on Atomic as we can on Simple sites.
-	Indexing of new posts on Simple site is REALLY fast, usually seconds.
-	On Atomic, it's more variable and usually on the scale of a few minutes.
-	This means we can't create reliable data conditions to validate the actual search result content.
-	So on atomic, we're limited to validating the integtity and interactability of the search modal.
+	Unfortunately, we can't test Search as thoroughly as we'd like, as the time to index new posts
+	is variable (up to several minutes). This means we're limited to validating the integrity and
+	interactability of the search modal.
 */
 
 skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
@@ -61,23 +59,6 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 
 			postWithSearchBlockUrl = response.URL;
 		} );
-
-		skipItIf( envVariables.TEST_ON_ATOMIC )(
-			'Create a new post to be searched using the REST API',
-			async function () {
-				await restAPIClient.createPost( siteId, {
-					title: searchString,
-					content: searchString,
-				} );
-			}
-		);
-
-		skipItIf( envVariables.TEST_ON_ATOMIC )(
-			'Wait for index to update using the REST API',
-			async function () {
-				await waitForIndexToUpdate( restAPIClient, siteId, searchString );
-			}
-		);
 
 		it( 'Navigate to post with search block', async function () {
 			// We can't wait for the "load" event because WordAds mess with it.
@@ -130,17 +111,6 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 			expect( termInModal ).toEqual( searchString );
 		} );
 
-		skipItIf( envVariables.TEST_ON_ATOMIC )( 'There are search results', async function () {
-			expect( await searchModalComponent.getNumberOfResults() ).toBeGreaterThanOrEqual( 1 );
-		} );
-
-		skipItIf( envVariables.TEST_ON_ATOMIC )(
-			'The search term is present in the results as a highlighted match',
-			async function () {
-				await searchModalComponent.validateHighlightedMatch( searchString );
-			}
-		);
-
 		it( 'Clear the search term', async function () {
 			await Promise.all( [
 				searchModalComponent.expectAndWaitForSearch( '' ),
@@ -150,53 +120,8 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 			expect( await searchModalComponent.getSearchTerm() ).toEqual( '' );
 		} );
 
-		skipItIf( envVariables.TEST_ON_ATOMIC )(
-			'There are still default popular results',
-			async function () {
-				expect( await searchModalComponent.getNumberOfResults() ).toBeGreaterThanOrEqual( 1 );
-			}
-		);
-
-		skipItIf( envVariables.TEST_ON_ATOMIC )(
-			'There are no highlighted matches in the results',
-			async function () {
-				expect( await searchModalComponent.getNumberOfHighlightedMatches() ).toBe( 0 );
-			}
-		);
-
 		it( 'Close the modal', async function () {
 			await searchModalComponent.closeModal();
 		} );
 	}
 );
-
-async function waitForIndexToUpdate(
-	restAPIClient: RestAPIClient,
-	siteId: number,
-	expectedSearch: string
-) {
-	const sleep = ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
-	const MAX_RETRIES = 15;
-	const RETRY_INTERVAL_MS = 3000;
-	for ( let i = 0; i < MAX_RETRIES; i++ ) {
-		// We start with the sleep because, c'mon, it's not going to re-index instantly!
-		// So puting the polling delay upfront makes the most sense. The test is still very fast!
-		await sleep( RETRY_INTERVAL_MS );
-		const response = await restAPIClient.jetpackSearch( siteId, {
-			query: expectedSearch,
-			// We are incrementing size here to bust the ElasticSearch cache.
-			// Otherwise, if it hasn't indexed the post by the first search request, the ES cache will
-			// continue to return no results, even after the post has been indexed!!!!
-			// We just need there to be any hit for the post name, so we can just keep bumping the size
-			// to do the cache busting.
-			size: i + 1,
-		} );
-		if ( response.results.length > 0 ) {
-			return;
-		}
-	}
-
-	throw new Error(
-		`Could not find any Jetpack Search results for query ${ expectedSearch } after 45 seconds. The index may not be updating.`
-	);
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Indexing takes a variable amount of time, which causes tests to fail from time to time. This removes tests that rely on indexing, and we now only test the general UI. Note that these were already skipped on Atomic for the same reason.

More info: pdWQjU-1d6-p2

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This should still work:
```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/search/search__jetpack-instant.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?