### PR TITLE
Site Migration: Redirect user back to import list based on the ref

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -628,6 +628,10 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
+					if ( entryPoint === 'wp-admin-importers-list' ) {
+						return window.location.assign( `${ siteAdminUrl }import.php` );
+					}
+
 					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
 				}
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -313,6 +313,27 @@ describe( 'Site Migration Flow', () => {
 						},
 					} );
 				} );
+
+				it( 'redirects back to the importer list when the entry point is wp-admin-importers-list', () => {
+					jest.mocked( useFlowState ).mockReturnValue( {
+						get: jest.fn().mockReturnValue( { entryPoint: 'wp-admin-importers-list' } ),
+						set: jest.fn(),
+						sessionId: '123',
+					} );
+
+					runNavigationBack( {
+						from: STEPS.SITE_MIGRATION_IDENTIFY,
+						dependencies: {},
+						query: {
+							siteSlug: 'example.wordpress.com',
+							siteId: 123,
+						},
+					} );
+
+					expect( window.location.assign ).toMatchURL( {
+						path: 'https://example.wpcomstaging.com/wp-admin/import.php',
+					} );
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
Related to:
* https://github.com/Automattic/jetpack/pull/42693
* https://github.com/Automattic/jetpack/pull/42718

## Proposed Changes
*  Redirect users back to the import list when they come from there. 

## Why are these changes being made?
* Users coming from https://github.com/Automattic/jetpack/pull/42718 should be able to go back to the original place. 



## Testing Instructions
* Go to `/setup/site-migration?siteId={WPCOM_SITE_ID}&ref=wp-admin-importers-list
* Go to next step
* Click the UI back button 2 times
* Check if you are on the importer list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
