### PR TITLE
Reader: Update image border implementation

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -1,6 +1,3 @@
-@import '@wordpress/base-styles/variables';
-@import "@automattic/color-studio/dist/color-variables";
-
 /* stylelint-disable-next-line scss/load-no-partial-leading-underscore */
 @import "calypso/assets/stylesheets/shared/_rendered-blocks";
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -81,27 +81,15 @@
 	.image-wrapper {
 		position: relative;
 
-		.image-border {
-			content: "";
-			position: absolute;
-			pointer-events: none;
-			top: 0;
-			left: 0;
-			bottom: 0;
-			right: 0;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-			border-radius: 6px; /* stylelint-disable-line scales/radii */
-			margin: auto;
-			max-width: 100%;
-		}
-
 		figcaption {
 			border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */
 			border-bottom-right-radius: 6px; /* stylelint-disable-line scales/radii */
 		}
 	}
 	.image-wrapper img {
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
 		display: inherit;
+		border: 1px solid #E5E5E5;
 	}
 }
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -1,4 +1,5 @@
 @import '@wordpress/base-styles/variables';
+@import "@automattic/color-studio/dist/color-variables";
 
 /* stylelint-disable-next-line scss/load-no-partial-leading-underscore */
 @import "calypso/assets/stylesheets/shared/_rendered-blocks";
@@ -91,7 +92,7 @@
 	.image-wrapper img {
 		border-radius: $radius-large;
 		display: inherit;
-		border: 1px solid #E5E5E5;
+		border: 1px solid $studio-gray-5;
 	}
 }
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/variables';
+
 /* stylelint-disable-next-line scss/load-no-partial-leading-underscore */
 @import "calypso/assets/stylesheets/shared/_rendered-blocks";
 
@@ -73,7 +75,7 @@
 	.wp-block-jetpack-slideshow_slide img,
 	.wp-block-media-text__media img,
 	.wp-block-image img {
-		border-radius: 6px; /* stylelint-disable-line scales/radii */
+		border-radius: $radius-large;
 		display: inherit;
 	}
 
@@ -82,12 +84,12 @@
 		position: relative;
 
 		figcaption {
-			border-bottom-left-radius: 6px; /* stylelint-disable-line scales/radii */
-			border-bottom-right-radius: 6px; /* stylelint-disable-line scales/radii */
+			border-bottom-left-radius: $radius-large;
+			border-bottom-right-radius: $radius-large;
 		}
 	}
 	.image-wrapper img {
-		border-radius: 6px; /* stylelint-disable-line scales/radii */
+		border-radius: $radius-large;
 		display: inherit;
 		border: 1px solid #E5E5E5;
 	}

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -1,4 +1,5 @@
-@import '@wordpress/base-styles/variables';
+/* stylelint-disable-next-line scss/load-no-partial-leading-underscore */
+@import "@wordpress/base-styles/_variables";
 @import "@automattic/color-studio/dist/color-variables";
 
 /* stylelint-disable-next-line scss/load-no-partial-leading-underscore */

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/variables';
+@import "@automattic/color-studio/dist/color-variables";
+
 /* stylelint-disable-next-line scss/load-no-partial-leading-underscore */
 @import "calypso/assets/stylesheets/shared/_rendered-blocks";
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/variables';
+@import "@automattic/color-studio/dist/color-variables";
+
 // Styles targeted at story content
 @import './content';
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,6 +1,3 @@
-@import '@wordpress/base-styles/variables';
-@import "@automattic/color-studio/dist/color-variables";
-
 // Styles targeted at story content
 @import './content';
 

--- a/client/lib/post-normalizer/rule-add-image-wrapper-element.js
+++ b/client/lib/post-normalizer/rule-add-image-wrapper-element.js
@@ -50,29 +50,6 @@ const getImageAspectRatioClass = ( image ) => {
 	return '';
 };
 
-/**
- * Gets the current image width (rather than original width)
- * Checks the image width attribute
- * Checks if width set in img src URL query params, i.e. {image-url}?w={width}
- * Returns 0 if no current width found
- * @param image
- * @returns {number}
- */
-const getCurrentImageWidth = ( image ) => {
-	let width = image.width || 0;
-
-	if ( width === 0 && image.src !== undefined ) {
-		// Parse width from src
-		const params = image.src.split( '?' )[ 1 ];
-		if ( params !== undefined ) {
-			const searchParams = new URLSearchParams( params );
-			width = searchParams.get( 'w' ) || '0';
-		}
-	}
-
-	return parseInt( width );
-};
-
 export default function addImageWrapperElement( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
@@ -94,17 +71,6 @@ export default function addImageWrapperElement( post, dom ) {
 		parent.replaceChild( imageWrapper, image );
 		// set element as child of wrapper
 		imageWrapper.appendChild( image );
-
-		// Add div to allow image border with an inset box-shadow
-		const imageWidth = getCurrentImageWidth( image );
-		if ( imageWidth > 0 ) {
-			const imageBorder = document.createElement( 'div' );
-			const borderStyle = document.createAttribute( 'style' );
-			imageBorder.className = 'image-border';
-			borderStyle.value = 'width: ' + imageWidth + 'px';
-			imageBorder.setAttributeNode( borderStyle );
-			imageWrapper.appendChild( imageBorder );
-		}
 	} );
 
 	return post;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100488#top

## Proposed Changes

- Addresses image border inconsistencies by removing extra div and calculations
- Adds a border radius to images so that they're consistent in posts that were published using both the classic and Gutenberg editors

### Before

<img width="845" alt="Screenshot 2025-03-26 at 17 00 01" src="https://github.com/user-attachments/assets/e1d76e2f-7045-42ae-813c-8ae50e08b0c6" />

### After

<img width="641" alt="Screenshot 2025-03-26 at 16 57 07" src="https://github.com/user-attachments/assets/5fe4b3df-fc62-4f0a-9fdb-d3d4e72d0a69" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Various scenarios with different image positioning were causing the border to be misplaced and inconsistent ([examples](https://github.com/Automattic/wp-calypso/issues/100488#issuecomment-2751559796))

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the following URLs and ensure the borders appear as expected: 
  - `/reader/feeds/376341/posts/5576676564`
  - `/reader/feeds/133226297/posts/5608707143`
  - `/reader/feeds/133226297/posts/5608694237`
  - `/reader/feeds/133226297/posts/5608683349`
  - `/reader/feeds/133226297/posts/5608676689`
  - `/reader/feeds/133226297/posts/5608668454`
  - `/reader/feeds/133226297/posts/5608662523`
- Check images in other posts and make sure there are no regressions
- Try publishing some posts with different image alignments, using various image features, and ensure there are no regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
