### PR TITLE
Janitorial: Remove UUID in favor of crypto

### DIFF
--- a/client/components/date-range/inputs.tsx
+++ b/client/components/date-range/inputs.tsx
@@ -1,7 +1,6 @@
 import { FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useRef, useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -27,7 +26,7 @@ const DateRangeInputs: FunctionComponent< Props > = ( {
 	onInputChange = noop,
 	...props
 } ) => {
-	const uniqueIdRef = useRef( uuidv4() );
+	const uniqueIdRef = useRef( crypto.randomUUID() );
 	const uniqueId = uniqueIdRef.current;
 	const translate = useTranslate();
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -31,7 +31,6 @@ import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { v4 as uuid } from 'uuid';
 import Illustration from 'calypso/assets/images/domains/domain.svg';
 import DomainSearchResults from 'calypso/components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'calypso/components/domains/example-domain-suggestions';
@@ -423,7 +422,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	getNewRailcarId() {
-		return `${ uuid().replace( /-/g, '' ) }-domain-suggestion`;
+		return `${ crypto.randomUUID().replace( /-/g, '' ) }-domain-suggestion`;
 	}
 
 	focusSearchCard = () => {

--- a/client/components/forms/range/index.jsx
+++ b/client/components/forms/range/index.jsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import { omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { v4 as uuid } from 'uuid';
 import FormRange from 'calypso/components/forms/form-range';
 
 import './style.scss';
@@ -27,7 +26,7 @@ export default class extends Component {
 	};
 
 	state = {
-		id: 'range' + uuid(),
+		id: 'range' + crypto.randomUUID(),
 	};
 
 	getMinContentElement = () => {

--- a/client/components/reviews-rating-stars/star.tsx
+++ b/client/components/reviews-rating-stars/star.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import React, { forwardRef } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 const vars = {
 	gray5: 'var(--color-neutral-5)',
@@ -94,7 +93,7 @@ const Star = forwardRef< SVGSVGElement, StarProps >( ( props, ref ) => {
 
 	const onFill = isChecked ? vars.yellow50 : vars.yellow20;
 	const offFill = vars.gray5;
-	const gradientId = 'gradient_' + uuidv4();
+	const gradientId = 'gradient_' + crypto.randomUUID();
 	let gradientPercentage = 0;
 	let halfFill = false;
 	let fill = offFill;

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -6,7 +6,6 @@ import i18n from 'i18n-calypso';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { v4 as uuid } from 'uuid';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
@@ -99,7 +98,7 @@ class Search extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.instanceId = uuid();
+		this.instanceId = crypto.randomUUID();
 
 		this.state = {
 			keyword: props.initialValue || '',

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import debugModule from 'debug';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { v4 as uuid } from 'uuid';
 import SeoPreviewPane from 'calypso/components/seo-preview-pane';
 import SpinnerLine from 'calypso/components/spinner-line';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -19,7 +18,7 @@ const debug = debugModule( 'calypso:web-preview' );
 const noop = () => {};
 
 export default class WebPreviewContent extends Component {
-	previewId = uuid();
+	previewId = crypto.randomUUID();
 
 	loadingTimeoutTimer = null;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -10,7 +10,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg } from '@wordpress/url';
 import { formatCurrency } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
-import { v4 as uuid } from 'uuid';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import { domainTransfer } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
@@ -26,7 +25,7 @@ export interface Props {
 
 const defaultState: DomainTransferForm = {
 	domains: {
-		[ uuid() ]: {
+		[ crypto.randomUUID() ]: {
 			domain: '',
 			auth: '',
 			valid: false,
@@ -155,7 +154,7 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 			resulting_domain_count: domainCount + 1,
 		} );
 		const newDomainsState = { ...domainsState };
-		newDomainsState[ uuid() ] = {
+		newDomainsState[ crypto.randomUUID() ] = {
 			domain: '',
 			auth: '',
 			valid: false,
@@ -226,7 +225,7 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 				}
 			} );
 
-			newDomainsState[ uuid() ] = { ...domainTransferObj };
+			newDomainsState[ crypto.randomUUID() ] = { ...domainTransferObj };
 
 			// Only keep the latest entry - 100-year domain flows are only
 			// allowed to have one domain at a time, so always keep the latest

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Children, createRef, useMemo, useState, useRef, useLayoutEffect } from 'react';
-import { v4 as uuid } from 'uuid';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
 import HoverIntent from 'calypso/lib/hover-intent';
@@ -88,7 +87,7 @@ export const ExpandableSidebarMenu = ( {
 		setSubmenuHovered( false );
 	};
 
-	const menuId = useMemo( () => 'menu' + uuid(), [] );
+	const menuId = useMemo( () => 'menu' + crypto.randomUUID(), [] );
 
 	useLayoutEffect( () => {
 		if ( submenuHovered && offScreen( submenu.current ) ) {

--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -1,5 +1,4 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
-import { v4 as uuid } from 'uuid';
 import { costToUSD, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { debug, TRACKING_IDS, ICON_MEDIA_SIGNUP_PIXEL_URL } from './constants';
@@ -53,7 +52,7 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 	// Prepare a few more variables.
 
 	const currentUser = getCurrentUser();
-	const syntheticOrderId = 's_' + uuid().replace( /-/g, '' ); // 35-byte signup tracking ID.
+	const syntheticOrderId = 's_' + crypto.randomUUID().replace( /-/g, '' ); // 35-byte signup tracking ID.
 	const usdCost = costToUSD( syntheticCart.total_cost, syntheticCart.currency );
 
 	// Google Ads Gtag

--- a/client/lib/analytics/ad-tracking/floodlight.js
+++ b/client/lib/analytics/ad-tracking/floodlight.js
@@ -1,6 +1,5 @@
 import { getTracksAnonymousUserId, getCurrentUser } from '@automattic/calypso-analytics';
 import cookie from 'cookie';
-import { v4 as uuid } from 'uuid';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import {
 	debug,
@@ -68,7 +67,7 @@ function floodlightSessionId() {
 	}
 
 	// Generate a 32-byte random session id
-	const newSessionId = uuid().replace( new RegExp( '-', 'g' ), '' );
+	const newSessionId = crypto.randomUUID().replace( new RegExp( '-', 'g' ), '' );
 	debug( 'Floodlight: New session: ' + newSessionId );
 	return newSessionId;
 }

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -11,7 +11,6 @@ import {
 	property,
 	some,
 } from 'lodash';
-import { v4 as uuid } from 'uuid';
 
 function Controller( options ) {
 	if ( ! ( this instanceof Controller ) ) {
@@ -124,7 +123,7 @@ Controller.prototype.sanitize = function () {
 
 Controller.prototype.validate = function () {
 	const fieldValues = getAllFieldValues( this._currentState );
-	const id = uuid();
+	const id = crypto.randomUUID();
 
 	this._setState( setFieldsValidating( this._currentState ) );
 

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -42,6 +42,17 @@ const EXPECTED_FILE_OBJECT = {
 	external: true,
 };
 
+let originalRandomUUID;
+
+beforeAll( () => {
+	originalRandomUUID = global.crypto.randomUUID;
+	global.crypto.randomUUID = () => 'fake-uuid';
+} );
+
+afterAll( () => {
+	global.crypto.randomUUID = originalRandomUUID;
+} );
+
 describe( 'MediaUtils', () => {
 	describe( '#url()', () => {
 		let media;

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -6,11 +6,7 @@ import { map } from 'lodash';
 import { ValidationErrors as MediaValidationErrors } from '../constants';
 import * as MediaUtils from '../utils';
 
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'someid',
-} ) );
-
-const UNIQUEID = 'media-someid';
+const UNIQUEID = 'media-fake-uuid';
 const DUMMY_FILENAME = 'test.jpg';
 const DUMMY_FILE_BLOB = {
 	fileContents: {

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -6,8 +6,8 @@ import { map } from 'lodash';
 import { ValidationErrors as MediaValidationErrors } from '../constants';
 import * as MediaUtils from '../utils';
 
-jest.mock( 'uuid', () => ( {
-	v4: () => 'someid',
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'someid',
 } ) );
 
 const UNIQUEID = 'media-someid';

--- a/client/lib/media/utils/create-transient-media-id.js
+++ b/client/lib/media/utils/create-transient-media-id.js
@@ -1,10 +1,8 @@
-import { v4 as uuid } from 'uuid';
-
 /**
  * Returns an ID for transient media items. To be consistent in creating
  * transient media IDs they are all prefixed with 'media-'
  * @param {string} moreSpecificPrefix can be used to further specify the prefix
  */
 export function createTransientMediaId( moreSpecificPrefix = '' ) {
-	return `media-${ moreSpecificPrefix }${ uuid() }`;
+	return `media-${ moreSpecificPrefix }${ crypto.randomUUID() }`;
 }

--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -5,7 +5,6 @@ import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { v4 as uuid } from 'uuid';
 import QueryCountryStates from 'calypso/components/data/query-country-states';
 import FormSelect from 'calypso/components/forms/form-select';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
@@ -62,7 +61,7 @@ class StateSelect extends PureComponent {
 			selectText,
 		} = this.props;
 		const validationId = `validation-field-${ this.props.name }`;
-		const fieldId = uuid();
+		const fieldId = crypto.randomUUID();
 
 		return (
 			<>

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid_v4 } from 'uuid';
 import {
 	FIELD_DOMAIN,
 	FIELD_FIRSTNAME,
@@ -70,7 +69,7 @@ abstract class MailboxFormFieldBase< T > implements MailboxFormField< T > {
 
 class DataMailboxFormField extends MailboxFormFieldBase< string > {
 	isVisible = false;
-	value = uuid_v4();
+	value = crypto.randomUUID() as string;
 	readonly typeName = 'data';
 }
 

--- a/client/package.json
+++ b/client/package.json
@@ -213,7 +213,6 @@
 		"use-debounce": "^3.1.0",
 		"util": "^0.12.3",
 		"utility-types": "^3.10.0",
-		"uuid": "^9.0.1",
 		"valid-url": "^1.0.9",
 		"webpack": "^5.97.1",
 		"webpack-bundle-analyzer": "^4.10.2",

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -270,6 +270,11 @@ describe( 'EditorMediaModal', () => {
 
 		test( 'should copy external media after loading WordPress library if 1 or more media are selected and button is pressed', async () => {
 			const user = userEvent.setup();
+			const originalRandomUUID = global.crypto.randomUUID;
+			global.crypto.randomUUID = jest
+				.fn()
+				.mockImplementationOnce( () => '1' )
+				.mockImplementationOnce( () => '2' );
 
 			const addExternalMedia = jest.fn();
 
@@ -292,8 +297,8 @@ describe( 'EditorMediaModal', () => {
 			// EditorMediaModal will generate transient ID for the media selected
 			// by using uniqueId, which increments its value within the same session.
 			const transientItems = [
-				Object.assign( {}, DUMMY_MEDIA[ 0 ], { ID: 'media-fake-uuid', transient: true } ),
-				Object.assign( {}, DUMMY_MEDIA[ 1 ], { ID: 'media-fake-uuid', transient: true } ),
+				Object.assign( {}, DUMMY_MEDIA[ 0 ], { ID: 'media-1', transient: true } ),
+				Object.assign( {}, DUMMY_MEDIA[ 1 ], { ID: 'media-2', transient: true } ),
 			];
 
 			expect( addExternalMedia ).toHaveBeenCalledWith(
@@ -302,10 +307,14 @@ describe( 'EditorMediaModal', () => {
 				undefined,
 				'external'
 			);
+
+			global.crypto.randomUUID = originalRandomUUID;
 		} );
 
 		test( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', async () => {
 			const user = userEvent.setup();
+			const originalRandomUUID = global.crypto.randomUUID;
+			global.crypto.randomUUID = jest.fn().mockImplementationOnce( () => '3' );
 
 			const addExternalMedia = jest.fn();
 
@@ -328,7 +337,7 @@ describe( 'EditorMediaModal', () => {
 			// EditorMediaModal will generate transient ID for the media selected
 			// by using uniqueId, which increments its value within the same session.
 			const transientItems = [
-				Object.assign( {}, DUMMY_VIDEO_MEDIA[ 0 ], { ID: 'media-fake-uuid', transient: true } ),
+				Object.assign( {}, DUMMY_VIDEO_MEDIA[ 0 ], { ID: 'media-3', transient: true } ),
 			];
 
 			expect( addExternalMedia ).toHaveBeenCalledWith(
@@ -337,6 +346,7 @@ describe( 'EditorMediaModal', () => {
 				undefined,
 				'external'
 			);
+			global.crypto.randomUUID = originalRandomUUID;
 		} );
 	} );
 } );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -29,8 +29,8 @@ jest.mock( 'calypso/blocks/image-editor', () => () => <div data-testid="image-ed
 jest.mock( '../detail', () => () => <div data-testid="media-modal-detail-base" /> );
 
 const mockV4 = jest.fn();
-jest.mock( 'uuid', () => ( {
-	v4: () => mockV4(),
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => mockV4(),
 } ) );
 
 /**

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -27,12 +27,6 @@ jest.mock( 'calypso/my-sites/media-library', () => ( {
 } ) );
 jest.mock( 'calypso/blocks/image-editor', () => () => <div data-testid="image-editor" /> );
 jest.mock( '../detail', () => () => <div data-testid="media-modal-detail-base" /> );
-
-const mockV4 = jest.fn();
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => mockV4(),
-} ) );
-
 /**
  * Module variables
  */
@@ -276,8 +270,6 @@ describe( 'EditorMediaModal', () => {
 
 		test( 'should copy external media after loading WordPress library if 1 or more media are selected and button is pressed', async () => {
 			const user = userEvent.setup();
-			mockV4.mockImplementationOnce( () => '1' );
-			mockV4.mockImplementationOnce( () => '2' );
 
 			const addExternalMedia = jest.fn();
 
@@ -300,8 +292,8 @@ describe( 'EditorMediaModal', () => {
 			// EditorMediaModal will generate transient ID for the media selected
 			// by using uniqueId, which increments its value within the same session.
 			const transientItems = [
-				Object.assign( {}, DUMMY_MEDIA[ 0 ], { ID: 'media-1', transient: true } ),
-				Object.assign( {}, DUMMY_MEDIA[ 1 ], { ID: 'media-2', transient: true } ),
+				Object.assign( {}, DUMMY_MEDIA[ 0 ], { ID: 'media-fake-uuid', transient: true } ),
+				Object.assign( {}, DUMMY_MEDIA[ 1 ], { ID: 'media-fake-uuid', transient: true } ),
 			];
 
 			expect( addExternalMedia ).toHaveBeenCalledWith(
@@ -314,7 +306,6 @@ describe( 'EditorMediaModal', () => {
 
 		test( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', async () => {
 			const user = userEvent.setup();
-			mockV4.mockImplementationOnce( () => '3' );
 
 			const addExternalMedia = jest.fn();
 
@@ -337,7 +328,7 @@ describe( 'EditorMediaModal', () => {
 			// EditorMediaModal will generate transient ID for the media selected
 			// by using uniqueId, which increments its value within the same session.
 			const transientItems = [
-				Object.assign( {}, DUMMY_VIDEO_MEDIA[ 0 ], { ID: 'media-3', transient: true } ),
+				Object.assign( {}, DUMMY_VIDEO_MEDIA[ 0 ], { ID: 'media-fake-uuid', transient: true } ),
 			];
 
 			expect( addExternalMedia ).toHaveBeenCalledWith(

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -1,5 +1,5 @@
+import crypto from 'crypto';
 import superagent from 'superagent';
-import { v4 as uuid } from 'uuid';
 const URL = require( 'url' );
 
 function getUserFromRequest( request ) {
@@ -35,7 +35,7 @@ function getUserFromRequest( request ) {
 	// We didn't get a full identity, create an anon ID
 	return {
 		_ut: 'anon',
-		_ui: uuid(),
+		_ui: crypto.randomUUID(),
 	};
 }
 

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import config from '@automattic/calypso-config';
 import uaParser from 'ua-parser-js';
 import isStaticRequest from 'calypso/server/lib/is-static-request';

--- a/client/server/middleware/logger.js
+++ b/client/server/middleware/logger.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import uaParser from 'ua-parser-js';
-import { v4 as uuidv4 } from 'uuid';
 import isStaticRequest from 'calypso/server/lib/is-static-request';
 import { getLogger } from 'calypso/server/lib/logger';
 import { finalizePerfMarks } from 'calypso/server/lib/performance-mark';
@@ -62,7 +61,7 @@ export default () => {
 
 	return ( req, res, next ) => {
 		req.logger = logger.child( {
-			reqId: uuidv4(),
+			reqId: crypto.randomUUID(),
 			url: req.originalUrl,
 			appVersion: process.env.COMMIT_SHA,
 			env,

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -12,6 +12,9 @@ jest.mock( 'calypso/server/lib/logger', () => ( {
 	getLogger: () => mockRootLogger,
 } ) );
 jest.mock( '@automattic/calypso-config', () => jest.fn() );
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => '00000000-0000-0000-0000-000000000000',
+} ) );
 
 const fakeRequest = ( { method, url, ip, httpVersion, headers = {} } = {} ) => {
 	const req = new EventEmitter();

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -12,8 +12,8 @@ jest.mock( 'calypso/server/lib/logger', () => ( {
 	getLogger: () => mockRootLogger,
 } ) );
 jest.mock( '@automattic/calypso-config', () => jest.fn() );
-jest.mock( 'uuid', () => ( {
-	v4: jest.fn( () => '00000000-0000-0000-0000-000000000000' ),
+jest.mock( 'crypto', () => ( {
+	randomUUID: jest.fn( () => '00000000-0000-0000-0000-000000000000' ),
 } ) );
 
 const fakeRequest = ( { method, url, ip, httpVersion, headers = {} } = {} ) => {

--- a/client/server/middleware/test/logger.js
+++ b/client/server/middleware/test/logger.js
@@ -12,9 +12,6 @@ jest.mock( 'calypso/server/lib/logger', () => ( {
 	getLogger: () => mockRootLogger,
 } ) );
 jest.mock( '@automattic/calypso-config', () => jest.fn() );
-jest.mock( 'crypto', () => ( {
-	randomUUID: jest.fn( () => '00000000-0000-0000-0000-000000000000' ),
-} ) );
 
 const fakeRequest = ( { method, url, ip, httpVersion, headers = {} } = {} ) => {
 	const req = new EventEmitter();

--- a/client/state/data-layer/wpcom/concierge/initial/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/initial/test/index.js
@@ -9,6 +9,16 @@ import {
 } from '../';
 
 describe( 'wpcom-api', () => {
+	let originalRandomUUID;
+
+	beforeAll( () => {
+		originalRandomUUID = global.crypto.randomUUID;
+		global.crypto.randomUUID = () => 'fake-uuid';
+	} );
+
+	afterAll( () => {
+		global.crypto.randomUUID = originalRandomUUID;
+	} );
 	describe( 'concierge', () => {
 		test( 'fetchConciergeInitial()', () => {
 			const action = {

--- a/client/state/data-layer/wpcom/concierge/initial/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/initial/test/index.js
@@ -9,8 +9,8 @@ import {
 } from '../';
 
 // we are mocking uuid.v4 here, so that conciergeInitialFetchError() will contain the expected id in the tests
-jest.mock( 'uuid', () => ( {
-	v4: () => 'fake-uuid',
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'fake-uuid',
 } ) );
 
 describe( 'wpcom-api', () => {

--- a/client/state/data-layer/wpcom/concierge/initial/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/initial/test/index.js
@@ -8,11 +8,6 @@ import {
 	showConciergeInitialFetchError,
 } from '../';
 
-// we are mocking uuid.v4 here, so that conciergeInitialFetchError() will contain the expected id in the tests
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'fake-uuid',
-} ) );
-
 describe( 'wpcom-api', () => {
 	describe( 'concierge', () => {
 		test( 'fetchConciergeInitial()', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
@@ -12,6 +12,17 @@ import { bookConciergeAppointment, onSuccess, onError } from '../';
 import toApi from '../to-api';
 
 describe( 'wpcom-api', () => {
+	let originalRandomUUID;
+
+	beforeAll( () => {
+		originalRandomUUID = global.crypto.randomUUID;
+		global.crypto.randomUUID = () => 'fake-uuid';
+	} );
+
+	afterAll( () => {
+		global.crypto.randomUUID = originalRandomUUID;
+	} );
+
 	describe( 'concierge', () => {
 		test( 'bookConciergeAppointment()', () => {
 			const action = {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
@@ -11,11 +11,6 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { bookConciergeAppointment, onSuccess, onError } from '../';
 import toApi from '../to-api';
 
-// we are mocking uuid.v4 here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'fake-uuid',
-} ) );
-
 describe( 'wpcom-api', () => {
 	describe( 'concierge', () => {
 		test( 'bookConciergeAppointment()', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/test/index.js
@@ -12,8 +12,8 @@ import { bookConciergeAppointment, onSuccess, onError } from '../';
 import toApi from '../to-api';
 
 // we are mocking uuid.v4 here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'uuid', () => ( {
-	v4: () => 'fake-uuid',
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'fake-uuid',
 } ) );
 
 describe( 'wpcom-api', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
@@ -4,11 +4,6 @@ import { updateConciergeBookingStatus } from 'calypso/state/concierge/actions';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { cancelConciergeAppointment } from '../';
 
-// we are mocking uuid.v4 here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'fake-uuid',
-} ) );
-
 describe( 'wpcom-api', () => {
 	describe( 'concierge', () => {
 		test( 'cancelConciergeAppointment()', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/cancel/test/index.js
@@ -5,8 +5,8 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { cancelConciergeAppointment } from '../';
 
 // we are mocking uuid.v4 here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'uuid', () => ( {
-	v4: () => 'fake-uuid',
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'fake-uuid',
 } ) );
 
 describe( 'wpcom-api', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
@@ -6,6 +6,17 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchAppointmentDetails, onSuccess, onError } from '../';
 
 describe( 'wpcom-api', () => {
+	let originalRandomUUID;
+
+	beforeAll( () => {
+		originalRandomUUID = global.crypto.randomUUID;
+		global.crypto.randomUUID = () => 'fake-uuid';
+	} );
+
+	afterAll( () => {
+		global.crypto.randomUUID = originalRandomUUID;
+	} );
+
 	describe( 'concierge', () => {
 		test( 'fetchAppointmentDetails()', () => {
 			const action = {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
@@ -5,11 +5,6 @@ import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-f
 import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchAppointmentDetails, onSuccess, onError } from '../';
 
-// we are mocking uuid.v4 here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'fake-uuid',
-} ) );
-
 describe( 'wpcom-api', () => {
 	describe( 'concierge', () => {
 		test( 'fetchAppointmentDetails()', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/test/index.js
@@ -6,8 +6,8 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchAppointmentDetails, onSuccess, onError } from '../';
 
 // we are mocking uuid.v4 here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'uuid', () => ( {
-	v4: () => 'fake-uuid',
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'fake-uuid',
 } ) );
 
 describe( 'wpcom-api', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
@@ -5,11 +5,6 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { rescheduleConciergeAppointment } from '../';
 import toApi from '../to-api';
 
-// we are mocking crypto.randomUUID here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'fake-uuid',
-} ) );
-
 describe( 'wpcom-api', () => {
 	describe( 'concierge', () => {
 		test( 'rescheduleConciergeAppointment()', () => {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/reschedule/test/index.js
@@ -5,9 +5,9 @@ import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { rescheduleConciergeAppointment } from '../';
 import toApi from '../to-api';
 
-// we are mocking uuid.v4 here, so that conciergeShiftsFetchError() will contain the expected id in the tests
-jest.mock( 'uuid', () => ( {
-	v4: () => 'fake-uuid',
+// we are mocking crypto.randomUUID here, so that conciergeShiftsFetchError() will contain the expected id in the tests
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'fake-uuid',
 } ) );
 
 describe( 'wpcom-api', () => {

--- a/client/state/notices/actions.ts
+++ b/client/state/notices/actions.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from 'uuid';
 import { NOTICE_CREATE, NOTICE_REMOVE } from 'calypso/state/action-types';
 import type {
 	NoticeActionCreator,
@@ -23,7 +22,7 @@ export const createNotice: NoticeActionCreatorWithStatus = (
 	return {
 		type: NOTICE_CREATE,
 		notice: Object.assign( { showDismiss: true }, noticeOptions, {
-			noticeId: id || uuid(),
+			noticeId: id || crypto.randomUUID(),
 			status,
 			text,
 		} ),

--- a/client/state/notices/test/__snapshots__/actions.js.snap
+++ b/client/state/notices/test/__snapshots__/actions.js.snap
@@ -2,7 +2,7 @@
 
 exports[`actions createNotice() should use default options when none provided 1`] = `
 Object {
-  "noticeId": "someid",
+  "noticeId": "fake-uuid",
   "showDismiss": true,
   "status": "is-info",
   "text": "Notice text",
@@ -12,7 +12,7 @@ Object {
 exports[`actions status helpers errorNotice dispatches expected action 1`] = `
 Object {
   "notice": Object {
-    "noticeId": "someid",
+    "noticeId": "fake-uuid",
     "showDismiss": true,
     "status": "is-error",
     "text": "text",
@@ -24,7 +24,7 @@ Object {
 exports[`actions status helpers infoNotice dispatches expected action 1`] = `
 Object {
   "notice": Object {
-    "noticeId": "someid",
+    "noticeId": "fake-uuid",
     "showDismiss": true,
     "status": "is-info",
     "text": "text",
@@ -36,7 +36,7 @@ Object {
 exports[`actions status helpers plainNotice dispatches expected action 1`] = `
 Object {
   "notice": Object {
-    "noticeId": "someid",
+    "noticeId": "fake-uuid",
     "showDismiss": true,
     "status": "is-plain",
     "text": "text",
@@ -48,7 +48,7 @@ Object {
 exports[`actions status helpers successNotice dispatches expected action 1`] = `
 Object {
   "notice": Object {
-    "noticeId": "someid",
+    "noticeId": "fake-uuid",
     "showDismiss": true,
     "status": "is-success",
     "text": "text",
@@ -60,7 +60,7 @@ Object {
 exports[`actions status helpers warningNotice dispatches expected action 1`] = `
 Object {
   "notice": Object {
-    "noticeId": "someid",
+    "noticeId": "fake-uuid",
     "showDismiss": true,
     "status": "is-warning",
     "text": "text",

--- a/client/state/notices/test/actions.js
+++ b/client/state/notices/test/actions.js
@@ -9,6 +9,17 @@ import {
 	warningNotice,
 } from '../actions';
 
+let originalRandomUUID;
+
+beforeAll( () => {
+	originalRandomUUID = global.crypto.randomUUID;
+	global.crypto.randomUUID = () => 'fake-uuid';
+} );
+
+afterAll( () => {
+	global.crypto.randomUUID = originalRandomUUID;
+} );
+
 describe( 'actions', () => {
 	describe( 'removeNotice()', () => {
 		test( 'should return an action object', () => {

--- a/client/state/notices/test/actions.js
+++ b/client/state/notices/test/actions.js
@@ -9,8 +9,8 @@ import {
 	warningNotice,
 } from '../actions';
 
-jest.mock( 'uuid', () => ( {
-	v4: () => 'someid',
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'someid',
 } ) );
 
 describe( 'actions', () => {

--- a/client/state/notices/test/actions.js
+++ b/client/state/notices/test/actions.js
@@ -9,10 +9,6 @@ import {
 	warningNotice,
 } from '../actions';
 
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'someid',
-} ) );
-
 describe( 'actions', () => {
 	describe( 'removeNotice()', () => {
 		test( 'should return an action object', () => {

--- a/client/state/partner-portal/licenses/test/handlers.js
+++ b/client/state/partner-portal/licenses/test/handlers.js
@@ -16,6 +16,17 @@ import {
 import * as handlers from 'calypso/state/partner-portal/licenses/handlers';
 
 describe( 'handlers', () => {
+	let originalRandomUUID;
+
+	beforeAll( () => {
+		originalRandomUUID = global.crypto.randomUUID;
+		global.crypto.randomUUID = () => 'fake-uuid';
+	} );
+
+	afterAll( () => {
+		global.crypto.randomUUID = originalRandomUUID;
+	} );
+
 	describe( '#fetchLicensesHandler()', () => {
 		test( 'should return an http request action', () => {
 			const { fetchLicensesHandler } = handlers;

--- a/client/state/partner-portal/licenses/test/handlers.js
+++ b/client/state/partner-portal/licenses/test/handlers.js
@@ -15,8 +15,8 @@ import {
 } from 'calypso/state/action-types';
 import * as handlers from 'calypso/state/partner-portal/licenses/handlers';
 
-jest.mock( 'uuid', () => ( {
-	v4: () => 'noticeid',
+jest.mock( 'crypto', () => ( {
+	randomUUID: () => 'noticeid',
 } ) );
 
 describe( 'handlers', () => {

--- a/client/state/partner-portal/licenses/test/handlers.js
+++ b/client/state/partner-portal/licenses/test/handlers.js
@@ -15,10 +15,6 @@ import {
 } from 'calypso/state/action-types';
 import * as handlers from 'calypso/state/partner-portal/licenses/handlers';
 
-jest.mock( 'crypto', () => ( {
-	randomUUID: () => 'noticeid',
-} ) );
-
 describe( 'handlers', () => {
 	describe( '#fetchLicensesHandler()', () => {
 		test( 'should return an http request action', () => {
@@ -212,7 +208,7 @@ describe( 'handlers', () => {
 				type: 'NOTICE_CREATE',
 				notice: {
 					showDismiss: true,
-					noticeId: 'noticeid',
+					noticeId: 'fake-uuid',
 					status: 'is-error',
 					text: translate( 'Failed to retrieve your licenses. Please try again later.' ),
 				},

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,5 +1,4 @@
 import { filter, forEach, partition, get } from 'lodash';
-import { v4 as uuid } from 'uuid';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import wpcom from 'calypso/lib/wp';
 import readerContentWidth from 'calypso/reader/lib/content-width';
@@ -137,7 +136,7 @@ function receiveErrorForPostKey( error, postKey ) {
 				ID: postKey.postId,
 				site_ID: postKey.blogId,
 				is_external: ! postKey.blogId,
-				global_ID: uuid(),
+				global_ID: crypto.randomUUID(),
 				is_error: true,
 				error,
 			},

--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
 		"@types/react-router-dom": "^5.3.3",
 		"@types/react-transition-group": "^4.4.4",
 		"@types/store": "^2.0.5",
-		"@types/uuid": "^9.0.8",
 		"@types/validator": "^13.7.1",
 		"@types/webpack-env": "^1.18.8",
 		"@types/wordpress__block-editor": "^11.5.8",

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -34,8 +34,7 @@
 		"cookie": "^0.7.2",
 		"debug": "^4.4.0",
 		"hash.js": "^1.1.7",
-		"tslib": "^2.3.0",
-		"uuid": "^9.0.1"
+		"tslib": "^2.3.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/calypso-analytics/src/train-tracks.ts
+++ b/packages/calypso-analytics/src/train-tracks.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from 'uuid';
 import { recordTracksEvent } from './tracks';
 
 export type Railcar = {
@@ -70,5 +69,5 @@ export function recordTrainTracksInteract( { railcarId, action }: TrainTracksInt
 }
 
 export function getNewRailcarId( suffix = 'recommendation' ) {
-	return `${ uuid().replace( /-/g, '' ) }-${ suffix }`;
+	return `${ crypto.randomUUID().replace( /-/g, '' ) }-${ suffix }`;
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,8 +60,7 @@
 		"react-modal": "^3.16.1",
 		"react-router-dom": "^6.23.1",
 		"react-slider": "^2.0.5",
-		"utility-types": "^3.10.0",
-		"uuid": "^9.0.1"
+		"utility-types": "^3.10.0"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^10.20.0",

--- a/packages/components/src/select-dropdown/index.jsx
+++ b/packages/components/src/select-dropdown/index.jsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import { filter, find, get, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Children, cloneElement, Component, forwardRef } from 'react';
-import { v4 as uuid } from 'uuid';
 import Count from '../count';
 import Gridicon from '../gridicon';
 import DropdownItem from './item';
@@ -55,7 +54,7 @@ class SelectDropdown extends Component {
 		showSelectedOption: true,
 	};
 
-	instanceId = uuid();
+	instanceId = crypto.randomUUID();
 
 	state = {
 		isOpen: false,

--- a/packages/design-picker/src/components/theme-preview/index.tsx
+++ b/packages/design-picker/src/components/theme-preview/index.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { v4 as uuid } from 'uuid';
+
 import './style.scss';
 
 interface Viewport {
@@ -55,7 +55,7 @@ const ThemePreview: React.FC< ThemePreviewProps > = ( {
 	const [ frameLocation, setFrameLocation ] = useState( '' );
 	const [ viewport, setViewport ] = useState< Viewport >();
 	const [ containerResizeListener, { width: containerWidth } ] = useResizeObserver();
-	const calypso_token = useMemo( () => iframeToken || uuid(), [ iframeToken ] );
+	const calypso_token = useMemo( () => iframeToken || crypto.randomUUID(), [ iframeToken ] );
 	const scale = containerWidth && viewportWidth ? containerWidth / viewportWidth : iframeScaleRatio;
 	const { title, tagline } = siteInfo || {};
 

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -43,8 +43,7 @@
 		"clsx": "^2.1.1",
 		"lodash": "^4.17.21",
 		"tslib": "^2.3.0",
-		"use-debounce": "^3.1.0",
-		"uuid": "^9.0.1"
+		"use-debounce": "^3.1.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -10,7 +10,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import React from 'react';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
-import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal Dependencies
  */
@@ -90,7 +89,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 		) {
 			startNewInteraction( {
 				event_source: 'help-center',
-				event_external_id: uuidv4(),
+				event_external_id: crypto.randomUUID(),
 			} );
 		} else if ( openSupportInteraction && ! currentSupportInteraction ) {
 			setCurrentSupportInteraction( openSupportInteraction[ 0 ] );

--- a/packages/help-center/src/hooks/use-reset-support-interaction.ts
+++ b/packages/help-center/src/hooks/use-reset-support-interaction.ts
@@ -3,7 +3,6 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
-import { v4 as uuidv4 } from 'uuid';
 
 export const useResetSupportInteraction = () => {
 	const { currentSupportInteraction } = useSelect( ( select ) => {
@@ -25,7 +24,7 @@ export const useResetSupportInteraction = () => {
 
 			return await startNewInteraction( {
 				event_source: 'help-center',
-				event_external_id: uuidv4(),
+				event_external_id: crypto.randomUUID(),
 			} );
 		}
 	};

--- a/packages/help-center/src/hooks/use-start-support-interaction.ts
+++ b/packages/help-center/src/hooks/use-start-support-interaction.ts
@@ -2,7 +2,6 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useManageSupportInteraction } from '@automattic/odie-client/src/data';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
-import { v4 as uuidv4 } from 'uuid';
 
 export const useStartSupportInteraction = () => {
 	const { setCurrentSupportInteraction } = useDispatch( HELP_CENTER_STORE );
@@ -12,7 +11,7 @@ export const useStartSupportInteraction = () => {
 	const startInteraction = async () => {
 		const interaction = await startNewInteraction( {
 			event_source: 'help-center',
-			event_external_id: uuidv4(),
+			event_external_id: crypto.randomUUID(),
 		} );
 		await queryClient.invalidateQueries( {
 			queryKey: [ 'support-interactions', 'get-interactions', 'help-center' ],

--- a/packages/odie-client/src/components/closed-conversation-footer/index.tsx
+++ b/packages/odie-client/src/components/closed-conversation-footer/index.tsx
@@ -4,7 +4,6 @@ import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { comment, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { v4 as uuidv4 } from 'uuid';
 import { useOdieAssistantContext } from '../../context';
 import { useManageSupportInteraction } from '../../data';
 import './style.scss';
@@ -26,7 +25,7 @@ export const ClosedConversationFooter = () => {
 		trackEvent( 'chat_new_from_closed_conversation' );
 		await startNewInteraction( {
 			event_source: 'help-center',
-			event_external_id: uuidv4(),
+			event_external_id: crypto.randomUUID(),
 		} );
 	};
 

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -2,7 +2,6 @@ import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { v4 as uuidv4 } from 'uuid';
 import { ODIE_TRANSFER_MESSAGE } from '../constants';
 import { emptyChat, useOdieAssistantContext } from '../context';
 import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
@@ -93,7 +92,7 @@ export const useGetCombinedChat = ( canConnectToZendesk: boolean ) => {
 
 				startNewInteraction( {
 					event_source: 'help-center',
-					event_external_id: uuidv4(),
+					event_external_id: crypto.randomUUID(),
 				} );
 			}
 		}

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -40,7 +40,6 @@
 	},
 	"dependencies": {
 		"debug": "^4.4.0",
-		"uuid": "^9.0.1",
 		"wp-error": "^1.3.0"
 	},
 	"devDependencies": {

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -1,5 +1,4 @@
 import debugFactory from 'debug';
-import { v4 as uuidv4 } from 'uuid';
 import WPError from 'wp-error';
 
 /**
@@ -96,7 +95,7 @@ const makeRequest = ( originalParams, fn ) => {
 	}
 
 	// generate a uuid for this API request
-	const id = uuidv4();
+	const id = crypto.randomUUID();
 	params.callback = id;
 	params.supports_args = true; // supports receiving variable amount of arguments
 	params.supports_error_obj = true; // better Error object info

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -42,7 +42,7 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 } ) );
 
 // Mock crypto.randomUUID with its Node.js implementation
-global.crypto.randomUUID = () => 'fake-uuid';
+global.crypto.randomUUID = () => require( 'crypto' ).randomUUID();
 
 global.matchMedia = jest.fn( ( query ) => ( {
 	matches: false,

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -41,6 +41,9 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 	canAccessWpcomApis: jest.fn(),
 } ) );
 
+// Mock crypto.randomUUID with its Node.js implementation
+global.crypto.randomUUID = () => 'fake-uuid';
+
 global.matchMedia = jest.fn( ( query ) => ( {
 	matches: false,
 	media: query,

--- a/test/packages/setup.js
+++ b/test/packages/setup.js
@@ -1,1 +1,3 @@
 import '@testing-library/jest-dom';
+
+global.crypto.randomUUID = () => 'fake-uuid';

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,7 +224,6 @@ __metadata:
     hash.js: "npm:^1.1.7"
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.8.2"
-    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -718,7 +717,6 @@ __metadata:
     resize-observer-polyfill: "npm:^1.5.1"
     typescript: "npm:^5.8.2"
     utility-types: "npm:^3.10.0"
-    uuid: "npm:^9.0.1"
     webpack: "npm:^5.97.1"
   peerDependencies:
     "@wordpress/data": ^10.20.0
@@ -916,7 +914,6 @@ __metadata:
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.8.2"
     use-debounce: "npm:^3.1.0"
-    uuid: "npm:^9.0.1"
   peerDependencies:
     "@wordpress/data": ^10.20.0
     "@wordpress/element": ^6.20.0
@@ -9214,7 +9211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^9.0.1, @types/uuid@npm:^9.0.8":
+"@types/uuid@npm:^9.0.1":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
   checksum: b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
@@ -13882,7 +13879,6 @@ __metadata:
     use-debounce: "npm:^3.1.0"
     util: "npm:^0.12.3"
     utility-types: "npm:^3.10.0"
-    uuid: "npm:^9.0.1"
     valid-url: "npm:^1.0.9"
     webpack: "npm:^5.97.1"
     webpack-bundle-analyzer: "npm:^4.10.2"
@@ -35887,7 +35883,6 @@ __metadata:
     "@types/react-transition-group": "npm:^4.4.4"
     "@types/store": "npm:^2.0.5"
     "@types/superagent": "npm:^4.1.24"
-    "@types/uuid": "npm:^9.0.8"
     "@types/validator": "npm:^13.7.1"
     "@types/webpack-env": "npm:^1.18.8"
     "@types/wordpress__block-editor": "npm:^11.5.8"
@@ -36073,7 +36068,6 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     debug: "npm:^4.4.0"
     postcss: "npm:^8.5.3"
-    uuid: "npm:^9.0.1"
     webpack: "npm:^5.97.1"
     wp-error: "npm:^1.3.0"
   languageName: unknown


### PR DESCRIPTION
## Proposed Changes

This removes the external `uuid` library in favor of native `crypto`.

## Why are these changes being made?
Getting rid of an external library and get whatever benefits that come with that.

## Testing Instructions
I can't possibly write testing steps for everything that changed here. But

1. Make sure everything is green in this PR.
2. Make sure all changes of files under `server` also import Node.js's `crypto`.
3. Smoke test /setup/onboarding,  ($$) until checkout.
4. Smoke test My Home.
5. Smoke test DateRange component /devdocs/design/date-range.
6. Smoke test Range /devdocs/design/ranges
7. Go to /plugins/woocommerce-bookings, click 1-review, and make sure the review rating stars work.
8. Make sure the sidebar works in my Home.



