### PR TITLE
Transfer domain: update paid plan modal copy

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -35,16 +35,16 @@ export function PaidPlanPaidDomainDialog( {
 		onFreePlanSelected();
 	}
 
-	const upsellDescription = translate(
-		"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-	);
-
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
-				{ translate( 'A paid plan is required for your domain.' ) }
+				{ translate( 'Paid plan required' ) }
 			</Heading>
-			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
+			<SubHeading id="plan-upsell-modal-description">
+				{ translate(
+					'To transfer your domain, you’ll need a paid plan. Choose annual billing and get the domain free for a year.'
+				) }
+			</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
 					<PaidDomainSuggestedPlanSection


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100248

## Proposed Changes

Update the "paid plan required" modal copy, shown when a user picks the free plan after picking a custom domain during onboarding flows

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Improve clarity of the message (see https://github.com/Automattic/wp-calypso/issues/100248)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/onboarding`
* In the domains step, select "Use a domain I own"
* Enter a valid domain
* Select the "Transfer your domain" option
* In the plans step, select the free plan
* Make sure that the modal shown includes the updated copy, as per [the specs](https://github.com/Automattic/wp-calypso/issues/100248#issuecomment-2743144706)


| Before | After |
|---|---|
| ![Screenshot 2025-03-26 at 17 46 17](https://github.com/user-attachments/assets/87ec28df-034e-4ead-a5d0-c0e137c5d0ef) | ![Screenshot 2025-03-26 at 17 45 26](https://github.com/user-attachments/assets/a0bb45bf-4b3d-47f4-8408-5cf5383a4e13) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
