### PR TITLE
Remove refs to importerList

### DIFF
--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -1,15 +1,11 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { BrowserRouter } from 'react-router-dom';
-import ImporterList from 'calypso/blocks/import/list';
-import { getFinalImporterUrl } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/helper';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import NewsletterImporter from 'calypso/my-sites/importer/newsletter/importer';
 import SectionImport from 'calypso/my-sites/importer/section-import';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import 'calypso/blocks/import/style/base.scss';
-
-const onboardingFlowRoute = '/setup/site-setup';
 
 export function importSite( context, next ) {
 	const state = context.store.getState();
@@ -38,31 +34,6 @@ export function importSite( context, next ) {
 
 	context.primary = (
 		<SectionImport engine={ engine } fromSite={ fromSite } afterStartImport={ afterStartImport } />
-	);
-	next();
-}
-
-export function importerList( context, next ) {
-	const state = context.store.getState();
-	const siteSlug = getSelectedSiteSlug( state );
-
-	context.primary = (
-		<BrowserRouter>
-			<div className="import__onboarding-page">
-				<ImporterList
-					siteSlug={ siteSlug }
-					getFinalImporterUrl={ getFinalImporterUrl }
-					submit={ ( { url } ) => {
-						url.startsWith( 'importer' )
-							? page( `${ onboardingFlowRoute }/${ url }&flow=onboarding` )
-							: page( url );
-					} }
-					onNavBack={ () => {
-						page( `/import/${ siteSlug }?flow=onboarding` );
-					} }
-				/>
-			</div>
-		</BrowserRouter>
 	);
 	next();
 }

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { get } from 'lodash';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
-import { importSite, importerList, importSubstackSite } from 'calypso/my-sites/importer/controller';
+import { importSite, importSubstackSite } from 'calypso/my-sites/importer/controller';
 import addTracker from './tracker';
 
 export default function () {
@@ -25,17 +25,6 @@ export default function () {
 		navigation,
 		redirectWithoutSite( '/import' ),
 		importSubstackSite,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/import/list/:site_id',
-		siteSelection,
-		navigation,
-		redirectWithoutSite( '/import' ),
-		importerList,
-		addTracker,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101605

## Proposed Changes

* Remove unused importerList references from the `/import` controller.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/pull/101605

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a free site, visiting `/import/list/{siteSlug}` should redirect you to `/import/{siteSlug}` rather than bringing up a list of importers.
* Visual inspection should be sufficient and tests should continue to pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
