### PR TITLE
Update VSCode Settings Sample with Stylelint Extends

### DIFF
--- a/.vscode/settings-sample.jsonc
+++ b/.vscode/settings-sample.jsonc
@@ -44,6 +44,9 @@
 	"css.validate": false,
 	"scss.validate": false,
 	"stylelint.validate": [ "css", "scss", "postcss" ],
+	"stylelint.config": {
+		"extends": [ "@wordpress/stylelint-config/scss-stylistic" ]
+	},
 	// Use the installed version of TypeScript, not the ones bundled with VS Code
 	"typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add stylelint `extends` settings to to the example settings file to make auto linting on save work.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While setting up my new computer, I couldn't get VSCode (Cursor, in truth) auto linting of *.scss files to work with Stylelint without this setting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Remove all your personal preferences in VS Code and make a copy of it.
    * Open `settings.json` (`Cmd + Shift + P` > `Preferences: Open Settings (JSON)`)
    * Copy the contents to a file on your computer
    * Remove all the contents of `settings.json`
    * Don't forget to restore its contents after completing your testing of this PR.
* Check out this PR and ensure to run `yarn install`
* Reopen VS Code or reload it (`Cmd + Shift + P` > `Developer: Reload Window`)
* Open a `.scss` file e.g. `client/components/async-load/style.scss`
* Mess up the formatting e.g. add spaces inside parentheses or use spaces instead of tabs for indentation.
* Save the file
* Confirm that the lints are auto-fixed. It should follow the rules found here: p4TIVU-af2-p2 Note these rules are different than Prettier's default rules, so confirm it's Stylelint doing the linting.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?