### PR TITLE
[POC]: Site Migration: Unify site-migration + hosted-site-migration (only code)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -28,7 +28,7 @@ const FLOW_NAME = 'site-migration';
 
 const siteMigration: Flow = {
 	name: FLOW_NAME,
-	isSignupFlow: true,
+	isSignupFlow: false,
 	__experimentalUseSessions: true,
 
 	useSideEffect() {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -1,22 +1,22 @@
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Onboard, type UserSelect } from '@automattic/data-stores';
-import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { getSiteAdminUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { HOW_TO_MIGRATE_OPTIONS } from '../../../constants';
 import { useIsSiteAdmin } from '../../../hooks/use-is-site-admin';
-import { useSiteData } from '../../../hooks/use-site-data';
 import { USER_STORE, ONBOARD_STORE } from '../../../stores';
 import { STEPS } from '../../internals/steps';
 import { type SiteMigrationIdentifyAction } from '../../internals/steps-repository/site-migration-identify';
@@ -28,7 +28,7 @@ const FLOW_NAME = 'site-migration';
 
 const siteMigration: Flow = {
 	name: FLOW_NAME,
-	isSignupFlow: false,
+	isSignupFlow: true,
 	__experimentalUseSessions: true,
 
 	useSideEffect() {
@@ -49,6 +49,9 @@ const siteMigration: Flow = {
 	useSteps() {
 		const baseSteps = [
 			STEPS.SITE_MIGRATION_IDENTIFY,
+			STEPS.PICK_SITE,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.PROCESSING,
 			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
 			STEPS.SITE_MIGRATION_HOW_TO_MIGRATE,
 			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
@@ -64,46 +67,31 @@ const siteMigration: Flow = {
 			STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
 		];
 
-		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? FLOW_NAME )
-			? [ STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ]
-			: [];
-
-		return stepsWithRequiredLogin( [ ...baseSteps, ...hostedVariantSteps ] );
+		return stepsWithRequiredLogin( baseSteps );
 	},
 
 	useAssertConditions(): AssertConditionResult {
-		const { siteSlug, siteId } = useSiteData();
 		const { isAdmin } = useIsSiteAdmin();
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const flowPath = this.variantSlug ?? FLOW_NAME;
 
 		useEffect( () => {
-			if ( isAdmin === false ) {
+			if ( isAdmin === false && userIsLoggedIn ) {
 				window.location.assign( '/start' );
 			}
-		}, [ isAdmin ] );
+		}, [ isAdmin, userIsLoggedIn ] );
 
-		if ( userIsLoggedIn && ! siteSlug && ! siteId && ! isHostedSiteMigrationFlow( flowPath ) ) {
-			window.location.assign( '/' );
-			return {
-				state: AssertConditionState.FAILURE,
-				message: 'site-migration does not have the site slug or site id.',
-			};
-		}
 		return { state: AssertConditionState.SUCCESS };
 	},
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
-		const { siteId, siteSlug } = useSiteData();
+		const { site, siteId, siteSlug } = useSiteData();
 		const variantSlug = this.variantSlug;
 		const flowPath = variantSlug ?? flowName;
-		const siteCount =
-			useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] )
-				?.site_count ?? 0;
+		const siteCount = useSelector( getCurrentUserSiteCount );
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
 		const actionQueryParam = urlQueryParams.get( 'action' );
@@ -111,7 +99,8 @@ const siteMigration: Flow = {
 
 		const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 		const siteWooCommerceUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) );
-		const hasSite = siteId && siteSlug;
+		const hasPreloadedSite = !! site?.ID;
+		const userHasWpComSites = siteCount && siteCount > 1;
 
 		const exitFlow = ( to: string ) => {
 			return window.location.assign( addQueryArgs( { sessionId }, to ) );
@@ -132,45 +121,21 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
-						if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) && ! hasSite ) {
-							return navigate(
-								addQueryArgs( { from, skipMigration: true }, STEPS.SITE_CREATION_STEP.slug )
-							);
-						}
-
-						return exitFlow(
-							addQueryArgs(
-								{
-									siteId,
-									siteSlug,
-									from,
-									origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
-									backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
-								},
-								'/setup/site-setup/importList'
-							)
+						return navigate(
+							addQueryArgs( { from, skipMigration: true }, STEPS.SITE_CREATION_STEP.slug )
 						);
 					}
 
-					if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) ) {
-						if ( ! hasSite ) {
-							if ( siteCount > 0 ) {
-								return navigate( `sitePicker?from=${ encodeURIComponent( from ) }` );
-							}
+					if ( ! hasPreloadedSite && userHasWpComSites ) {
+						return navigate( addQueryArgs( { from }, STEPS.PICK_SITE.slug ) );
+					}
 
-							if ( from ) {
-								return navigate( addQueryArgs( { from }, STEPS.SITE_CREATION_STEP.slug ) );
-							}
-
-							return navigate( 'error' );
-						}
+					if ( ! hasPreloadedSite ) {
+						return navigate( addQueryArgs( { from }, STEPS.SITE_CREATION_STEP.slug ) );
 					}
 
 					return navigate(
-						addQueryArgs(
-							{ from: from, siteSlug, siteId },
-							STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
-						)
+						addQueryArgs( { from, siteId, siteSlug }, STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug )
 					);
 				}
 
@@ -192,7 +157,6 @@ const siteMigration: Flow = {
 							const { ID: newSiteId, slug: newSiteSlug } =
 								providedDependencies.site as SiteExcerptData;
 
-							// If the action is migrate, navigate to the DIY/DIFM selector screen.
 							if ( 'migrate' === actionQueryParam ) {
 								return navigate(
 									addQueryArgs(
@@ -221,7 +185,7 @@ const siteMigration: Flow = {
 						skipMigration: 'import' === actionQueryParam ? true : undefined,
 					};
 
-					return navigate( addQueryArgs( queryArgs, STEPS.PROCESSING.slug ) );
+					return navigate( addQueryArgs( queryArgs, STEPS.PROCESSING.slug ), undefined, true );
 				}
 
 				case STEPS.PROCESSING.slug: {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -2,7 +2,7 @@ import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Onboard, type UserSelect } from '@automattic/data-stores';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -15,7 +15,11 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import { getSiteAdminUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
-import { HOW_TO_MIGRATE_OPTIONS } from '../../../constants';
+import {
+	HOW_TO_MIGRATE_OPTIONS,
+	STEPPER_TRACKS_EVENT_SIGNUP_START,
+	STEPPER_TRACKS_EVENT_SIGNUP_STEP_START,
+} from '../../../constants';
 import { useIsSiteAdmin } from '../../../hooks/use-is-site-admin';
 import { USER_STORE, ONBOARD_STORE } from '../../../stores';
 import { STEPS } from '../../internals/steps';
@@ -28,7 +32,7 @@ const FLOW_NAME = 'site-migration';
 
 const siteMigration: Flow = {
 	name: FLOW_NAME,
-	isSignupFlow: false,
+	isSignupFlow: true,
 	__experimentalUseSessions: true,
 
 	useSideEffect() {
@@ -40,12 +44,19 @@ const siteMigration: Flow = {
 		const { set, get } = useFlowState();
 		const urlQueryParams = useQuery();
 		const ref = urlQueryParams.get( 'ref' );
+		const hasPreloadedSite =
+			!! urlQueryParams.get( 'siteId' ) || !! urlQueryParams.get( 'siteSlug' );
 
 		if ( ref && ! get( 'migration' )?.entryPoint ) {
 			set( 'migration', { entryPoint: ref } );
 		}
-	},
 
+		if ( get( 'migration' )?.requiresSiteCreation === undefined ) {
+			set( 'migration', {
+				requiresSiteCreation: ! hasPreloadedSite,
+			} );
+		}
+	},
 	useSteps() {
 		const baseSteps = [
 			STEPS.SITE_MIGRATION_IDENTIFY,
@@ -84,6 +95,24 @@ const siteMigration: Flow = {
 		}, [ isAdmin, userIsLoggedIn ] );
 
 		return { state: AssertConditionState.SUCCESS };
+	},
+	useTracksEventProps() {
+		const { get } = useFlowState();
+		const requiresSiteCreation = get( 'migration' )?.requiresSiteCreation ?? false;
+
+		return useMemo(
+			() => ( {
+				eventsProperties: {
+					[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
+						requires_site_creation: requiresSiteCreation.toString(),
+					},
+					[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
+						requires_site_creation: requiresSiteCreation.toString(),
+					},
+				},
+			} ),
+			[ requiresSiteCreation ]
+		);
 	},
 
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -1,5 +1,5 @@
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
-import { Onboard, type SiteSelect, type UserSelect } from '@automattic/data-stores';
+import { Onboard, type UserSelect } from '@automattic/data-stores';
 import { isHostedSiteMigrationFlow } from '@automattic/onboarding';
 import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
@@ -16,11 +17,8 @@ import { getSiteAdminUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/sele
 import { HOW_TO_MIGRATE_OPTIONS } from '../../../constants';
 import { useIsSiteAdmin } from '../../../hooks/use-is-site-admin';
 import { useSiteData } from '../../../hooks/use-site-data';
-import { useSiteSlugParam } from '../../../hooks/use-site-slug-param';
-import { USER_STORE, SITE_STORE, ONBOARD_STORE } from '../../../stores';
-import { goToCheckout } from '../../../utils/checkout';
+import { USER_STORE, ONBOARD_STORE } from '../../../stores';
 import { STEPS } from '../../internals/steps';
-import { getSiteIdParam } from '../../internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from '../../internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from '../../internals/types';
 import { goToImporter } from '../../migration/helpers';
@@ -95,28 +93,25 @@ const siteMigration: Flow = {
 				message: 'site-migration does not have the site slug or site id.',
 			};
 		}
-
 		return { state: AssertConditionState.SUCCESS };
 	},
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
-		const { siteId } = useSiteData();
+		const { siteId, siteSlug } = useSiteData();
 		const variantSlug = this.variantSlug;
 		const flowPath = variantSlug ?? flowName;
 		const siteCount =
 			useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] )
 				?.site_count ?? 0;
-		const siteSlugParam = useSiteSlugParam();
 		const urlQueryParams = useQuery();
 		const fromQueryParam = urlQueryParams.get( 'from' );
 		const actionQueryParam = urlQueryParams.get( 'action' );
-		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
-
 		const { get, sessionId } = useFlowState();
 
 		const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 		const siteWooCommerceUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId ) );
+		const hasSite = siteId && siteSlug;
 
 		const exitFlow = ( to: string ) => {
 			return window.location.assign( addQueryArgs( { sessionId }, to ) );
@@ -127,11 +122,7 @@ const siteMigration: Flow = {
 			triggerGuidesForStep( flowName, currentStep, siteId );
 		}, [ flowName, currentStep, siteId ] );
 
-		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
-			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
-			const siteId = getSiteIdBySlug( siteSlug ) || getSiteIdParam( urlQueryParams );
-
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
 					const { from, platform, action } = providedDependencies as {
@@ -141,15 +132,12 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip_platform_identification' || platform !== 'wordpress' ) {
-						if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) ) {
-							// siteId/siteSlug wont be defined here if coming from a direct link/signup.
-							// We need to make sure there's a site to import into.
-							if ( ! siteSlugParam ) {
-								return navigate(
-									addQueryArgs( { from, skipMigration: true }, STEPS.SITE_CREATION_STEP.slug )
-								);
-							}
+						if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) && ! hasSite ) {
+							return navigate(
+								addQueryArgs( { from, skipMigration: true }, STEPS.SITE_CREATION_STEP.slug )
+							);
 						}
+
 						return exitFlow(
 							addQueryArgs(
 								{
@@ -165,7 +153,7 @@ const siteMigration: Flow = {
 					}
 
 					if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) ) {
-						if ( ! siteSlugParam ) {
+						if ( ! hasSite ) {
 							if ( siteCount > 0 ) {
 								return navigate( `sitePicker?from=${ encodeURIComponent( from ) }` );
 							}
@@ -237,6 +225,13 @@ const siteMigration: Flow = {
 				}
 
 				case STEPS.PROCESSING.slug: {
+					const { siteId, siteSlug } = providedDependencies as {
+						siteId: string;
+						siteSlug: string;
+						siteCreated: boolean;
+						skipMigration: boolean;
+					};
+
 					if ( providedDependencies?.siteCreated ) {
 						if ( ! fromQueryParam || providedDependencies?.skipMigration ) {
 							// If we get to this point without a fromQueryParam then we are coming from a direct

--- a/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
+++ b/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
@@ -11,6 +11,7 @@ export type FlowStateManifest = Partial< {
 	domains: DomainStepResult;
 	migration: {
 		entryPoint: string;
+		requiresSiteCreation: boolean;
 	};
 	plans: PlansStepResult;
 	newsletterSetup: {

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -3,7 +3,6 @@
  */
 import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selectors';
-import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -126,9 +126,6 @@ describe( 'Site Migration Flow', () => {
 			it( 'redirects to PROCESSING', () => {
 				const destination = runNavigation( {
 					from: STEPS.SITE_CREATION_STEP,
-					dependencies: {
-						siteCreated: true,
-					},
 				} );
 
 				expect( destination ).toMatchDestination( {
@@ -164,11 +161,11 @@ describe( 'Site Migration Flow', () => {
 					from: STEPS.PROCESSING,
 					dependencies: {
 						siteCreated: true,
+						siteId: 123,
+						siteSlug: 'example.wordpress.com',
 					},
 					query: {
 						from: 'https://site-to-be-migrated.com',
-						siteId: 123,
-						siteSlug: 'example.wordpress.com',
 					},
 				} );
 
@@ -187,11 +184,11 @@ describe( 'Site Migration Flow', () => {
 					from: STEPS.PROCESSING,
 					dependencies: {
 						siteCreated: true,
+						siteId: 123,
+						siteSlug: 'example.wordpress.com',
 					},
 					query: {
 						from: 'https://site-to-be-migrated.com',
-						siteId: 123,
-						siteSlug: 'example.wordpress.com',
 						action: 'migrate',
 					},
 				} );
@@ -209,8 +206,6 @@ describe( 'Site Migration Flow', () => {
 					from: STEPS.PROCESSING,
 					dependencies: {
 						siteCreated: true,
-					},
-					query: {
 						siteId: 123,
 						siteSlug: 'example.wordpress.com',
 					},
@@ -227,6 +222,7 @@ describe( 'Site Migration Flow', () => {
 				} );
 			} );
 		} );
+
 		describe( 'SITE_MIGRATION_IDENTIFY', () => {
 			beforeEach( () => jest.clearAllMocks() );
 
@@ -292,6 +288,46 @@ describe( 'Site Migration Flow', () => {
 							backToFlow: '/site-migration/site-migration-identify',
 						},
 					} );
+				} );
+			} );
+
+			it( 'redirects to IMPORT_OR_MIGRATE when the source site is WordPress and there is a site already created (siteId or siteSlug)', () => {
+				const destination = runNavigation( {
+					from: STEPS.SITE_MIGRATION_IDENTIFY,
+					dependencies: {
+						platform: 'wordpress',
+						from: 'https://site-to-be-migrated.com',
+					},
+					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
+				} );
+
+				expect( destination ).toMatchDestination( {
+					step: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
+					query: {
+						siteId: 123,
+						siteSlug: 'example.wordpress.com',
+						from: 'https://site-to-be-migrated.com',
+					},
+				} );
+			} );
+
+			it( 'redirects to IMPORT flow when the source site is not WordPress and there is a site already created (siteId or siteSlug)', () => {
+				runNavigation( {
+					from: STEPS.SITE_MIGRATION_IDENTIFY,
+					dependencies: {
+						platform: 'non-wordpress',
+						from: 'https://site-to-be-migrated.com',
+					},
+					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
+				} );
+
+				expect( window.location.assign ).toMatchURL( {
+					path: '/setup/site-setup/importList',
+					query: {
+						siteId: 123,
+						siteSlug: 'example.wordpress.com',
+						from: 'https://site-to-be-migrated.com',
+					},
 				} );
 			} );
 
@@ -597,18 +633,19 @@ describe( 'Site Migration Flow', () => {
 					},
 					query: {
 						siteSlug: 'example.wordpress.com',
+						siteId: 123,
 						from: 'https://site-to-be-migrated.com',
 					},
 				} );
 
 				expect( goToCheckout ).toHaveBeenCalledWith( {
-					destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
+					destination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_INSTRUCTIONS.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com&siteId=123`,
 					extraQueryParams: { hosting_intent: HOSTING_INTENT_MIGRATE },
 					flowName: 'site-migration',
 					from: 'https://site-to-be-migrated.com',
 					siteSlug: 'example.wordpress.com',
 					stepName: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
-					cancelDestination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&from=https%3A%2F%2Fsite-to-be-migrated.com`,
+					cancelDestination: `/setup/site-migration/${ STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug }?siteSlug=example.wordpress.com&siteId=123&from=https%3A%2F%2Fsite-to-be-migrated.com`,
 					plan: PLAN_MIGRATION_TRIAL_MONTHLY,
 				} );
 			} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -8,14 +8,31 @@ import nock from 'nock';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { HOW_TO_MIGRATE_OPTIONS } from '../../constants';
+import { useSiteData } from '../../hooks/use-site-data';
 import { goToCheckout } from '../../utils/checkout';
 import siteMigrationFlow from '../flows/site-migration-flow/site-migration-flow';
 import { STEPS } from '../internals/steps';
 import { getAssertionConditionResult, renderFlow, runFlowNavigation } from './helpers';
+import type { SiteDetails } from '@automattic/data-stores/src/site/types';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
+
+const mockSiteData = {
+	siteSlug: 'example.wordpress.com',
+	siteId: 123,
+	site: { ID: 123, canAutoupdateFiles: true } as unknown as SiteDetails,
+	siteSlugOrId: 'example.wordpress.com',
+} as unknown as ReturnType< typeof useSiteData >;
+
+const mockNoSiteData = {
+	siteSlug: '',
+	siteId: 0,
+	site: null,
+	siteSlugOrId: '',
+} as unknown as ReturnType< typeof useSiteData >;
 
 jest.mock( '../../utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
@@ -30,6 +47,14 @@ jest.mock( 'calypso/landing/stepper/declarative-flow/internals/state-manager/sto
 		set: jest.fn(),
 		sessionId: '123',
 	} ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site-data', () => ( {
+	useSiteData: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserSiteCount: jest.fn().mockReturnValue( 0 ),
 } ) );
 
 jest.mock( 'calypso/state/sites/selectors/get-site-option' );
@@ -64,25 +89,15 @@ describe( 'Site Migration Flow', () => {
 		nock( apiBaseUrl ).get( testSettingsEndpoint ).reply( 200, {} );
 		nock( apiBaseUrl ).post( testSettingsEndpoint ).reply( 200, {} );
 		nock( apiBaseUrl ).post( '/wpcom/v2/guides/trigger' ).reply( 200, {} );
+
+		jest.mocked( useSiteData ).mockReturnValue( mockSiteData );
 	} );
 
 	afterEach( () => {
-		// Restore the original implementation after each test
 		jest.restoreAllMocks();
 	} );
 
 	describe( 'useAssertConditions', () => {
-		it( 'redirects the user to home when there is no siteSlug and siteId', () => {
-			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
-
-			runUseAssertionCondition( {
-				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
-				currentURL: `/setup/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }?siteSlug=&siteId=`,
-			} );
-
-			expect( window.location.assign ).toHaveBeenCalledWith( '/' );
-		} );
-
 		it( 'redirects the user to the start page when the user is not a site admin', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );
 			( useIsSiteAdmin as jest.Mock ).mockReturnValue( { isAdmin: false } );
@@ -224,8 +239,6 @@ describe( 'Site Migration Flow', () => {
 		} );
 
 		describe( 'SITE_MIGRATION_IDENTIFY', () => {
-			beforeEach( () => jest.clearAllMocks() );
-
 			it( 'redirects to SITE_MIGRATION_IMPORT_OR_MIGRATE step when the platform is WordPress', async () => {
 				const destination = runNavigation( {
 					from: STEPS.SITE_MIGRATION_IDENTIFY,
@@ -244,50 +257,6 @@ describe( 'Site Migration Flow', () => {
 						siteSlug: 'example.wordpress.com',
 						from: 'https://site-to-be-migrated.com',
 					},
-				} );
-			} );
-
-			it( 'redirects to import flow when it is not possible to identify the platform', async () => {
-				runNavigation( {
-					from: STEPS.SITE_MIGRATION_IDENTIFY,
-					dependencies: {
-						action: 'continue',
-						platform: 'unknown',
-						from: 'https://example-to-be-migrated.com',
-					},
-					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
-				} );
-
-				await waitFor( () => {
-					expect( window.location.assign ).toMatchURL( {
-						path: '/setup/site-setup/importList',
-						query: {
-							siteId: 123,
-							siteSlug: 'example.wordpress.com',
-							from: 'https://example-to-be-migrated.com',
-						},
-					} );
-				} );
-			} );
-
-			it( 'redirects to the import content flow when the user skips platform identification', async () => {
-				runNavigation( {
-					from: STEPS.SITE_MIGRATION_IDENTIFY,
-					dependencies: {
-						action: 'skip_platform_identification',
-					},
-					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
-				} );
-
-				await waitFor( () => {
-					expect( window.location.assign ).toMatchURL( {
-						path: '/setup/site-setup/importList',
-						query: {
-							siteSlug: 'example.wordpress.com',
-							origin: 'site-migration-identify',
-							backToFlow: '/site-migration/site-migration-identify',
-						},
-					} );
 				} );
 			} );
 
@@ -311,29 +280,36 @@ describe( 'Site Migration Flow', () => {
 				} );
 			} );
 
-			it( 'redirects to IMPORT flow when the source site is not WordPress and there is a site already created (siteId or siteSlug)', () => {
-				runNavigation( {
+			it( 'redirects to SITE_CREATION_STEP when the flow has no site preloaded and the user has no wpcom sites', () => {
+				jest.mocked( useSiteData ).mockReturnValue( mockNoSiteData );
+				jest.mocked( getCurrentUserSiteCount ).mockReturnValue( 0 );
+
+				const destination = runNavigation( {
 					from: STEPS.SITE_MIGRATION_IDENTIFY,
-					dependencies: {
-						platform: 'non-wordpress',
-						from: 'https://site-to-be-migrated.com',
-					},
-					query: { siteId: 123, siteSlug: 'example.wordpress.com' },
 				} );
 
-				expect( window.location.assign ).toMatchURL( {
-					path: '/setup/site-setup/importList',
-					query: {
-						siteId: 123,
-						siteSlug: 'example.wordpress.com',
-						from: 'https://site-to-be-migrated.com',
+				expect( destination ).toMatchDestination( {
+					step: STEPS.SITE_CREATION_STEP,
+				} );
+			} );
+
+			it( 'redirects to PICK_SITE when the flow has no preloaded site and the platform is WordPress', () => {
+				jest.mocked( useSiteData ).mockReturnValue( mockNoSiteData );
+				jest.mocked( getCurrentUserSiteCount ).mockReturnValue( 2 );
+
+				const destination = runNavigation( {
+					from: STEPS.SITE_MIGRATION_IDENTIFY,
+					dependencies: {
+						platform: 'wordpress',
 					},
+				} );
+
+				expect( destination ).toMatchDestination( {
+					step: STEPS.PICK_SITE,
 				} );
 			} );
 
 			describe( 'back', () => {
-				beforeEach( () => jest.clearAllMocks() );
-
 				it( 'redirects back to SITE_MIGRATION_IDENTIFY step', () => {
 					runNavigationBack( {
 						from: STEPS.SITE_MIGRATION_IDENTIFY,
@@ -353,10 +329,6 @@ describe( 'Site Migration Flow', () => {
 		} );
 
 		describe( 'SITE_MIGRATION_IMPORT_OR_MIGRATE', () => {
-			beforeEach( () => {
-				jest.clearAllMocks();
-			} );
-
 			it( 'redirects to SITE_MIGRATION_HOW_TO_MIGRATE step', () => {
 				const destination = runNavigation( {
 					from: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
@@ -405,6 +377,13 @@ describe( 'Site Migration Flow', () => {
 					sessionId: '123',
 				} );
 
+				jest.mocked( useSiteData ).mockReturnValue( {
+					siteSlug: 'example.wordpress.com',
+					siteId: 0,
+					site: null,
+					siteSlugOrId: '',
+				} );
+
 				runNavigation( {
 					from: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
 					dependencies: {
@@ -412,12 +391,12 @@ describe( 'Site Migration Flow', () => {
 					},
 					query: {
 						ref: 'calypso-importer',
-						siteSlug: 'site-to-be-migrated.com',
+						siteSlug: 'example.wordpress.com',
 					},
 				} );
 
 				expect( window.location.assign ).toMatchURL( {
-					path: '/import/site-to-be-migrated.com',
+					path: '/import/example.wordpress.com',
 					query: {
 						engine: 'wordpress',
 						ref: 'site-migration',
@@ -539,6 +518,7 @@ describe( 'Site Migration Flow', () => {
 						siteSlug: 'example.wordpress.com',
 						siteId: 123,
 						from: 'https://site-to-be-migrated.com',
+						destination: 'upgrade',
 					},
 				} );
 			} );


### PR DESCRIPTION
This PR intent explores the unification of our site migration flows.  (site-migration and hosted-site-migration)
Related 
paYKcK-68f-p2

## Proposed Changes

* Unify the site-migration+ hosted-site-migration flows (only the code, not the URLs for now)


## Testing Instructions

Scenario: Brand new usage (Migrate)
* Go to `/setup/site-migration`
* Check if you can now select a site or create a new one
* Continue the flow

Scenario: Usage with an existent site (Migrate)
* Go to `/setup/site-migration?siteId={SOME_EXISTING_SITE_ID}`
* Check if the flow doesn't show any step related to select a site or create a new one


Scenario: Brand new import
* Go to `/setup/site-migration`
* Skip the identification or use a non-WordPress site
* Check a new site is automatically created 
* Check if you can see the importing options. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?