### PR TITLE
Improve Plugins upgrade and activate help flow

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -46,6 +46,7 @@ interface ExternalProps {
 	siteId?: number | null;
 	isEligible?: boolean;
 	backUrl?: string;
+	onClose: () => void;
 	onProceed: ( options: { geo_affinity?: string } ) => void;
 	standaloneProceed: boolean;
 	className?: string;
@@ -69,6 +70,7 @@ export const EligibilityWarnings = ( {
 	isEligible,
 	isMarketplace,
 	isPlaceholder,
+	onClose,
 	onProceed,
 	standaloneProceed,
 	recordUpgradeClick,
@@ -251,7 +253,10 @@ export const EligibilityWarnings = ( {
 
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
-					<SupportBlock useDialog={ context === 'plugin-details' } />
+					<SupportBlock
+						useHelpCenter={ context === 'plugin-details' }
+						onCloseEligibilityDialog={ onClose }
+					/>
 					<Button
 						primary
 						disabled={

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -33,7 +33,7 @@ import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
 import { launchSite } from 'calypso/state/sites/launch/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import HoldList, { hasBlockingHold, HardBlockingNotice, getBlockingMessages } from './hold-list';
-import SupportBlock from './support-block';
+import SupportLink from './support-link';
 import { isAtomicSiteWithoutBusinessPlan } from './utils';
 import WarningList from './warning-list';
 import type { EligibilityData } from 'calypso/state/automated-transfer/selectors';
@@ -253,7 +253,7 @@ export const EligibilityWarnings = ( {
 
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
-					<SupportBlock
+					<SupportLink
 						useHelpCenter={ context === 'plugin-details' }
 						onCloseEligibilityDialog={ onClose }
 					/>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -46,7 +46,7 @@ interface ExternalProps {
 	siteId?: number | null;
 	isEligible?: boolean;
 	backUrl?: string;
-	onClose?: () => void;
+	onDismiss?: () => void;
 	onProceed: ( options: { geo_affinity?: string } ) => void;
 	standaloneProceed: boolean;
 	className?: string;
@@ -70,7 +70,7 @@ export const EligibilityWarnings = ( {
 	isEligible,
 	isMarketplace,
 	isPlaceholder,
-	onClose,
+	onDismiss,
 	onProceed,
 	standaloneProceed,
 	recordUpgradeClick,
@@ -255,7 +255,7 @@ export const EligibilityWarnings = ( {
 				<div className="eligibility-warnings__confirm-buttons">
 					<SupportLink
 						shouldUseHelpAssistant={ context === 'plugin-details' }
-						onShowHelpAssistant={ onClose }
+						onShowHelpAssistant={ onDismiss }
 					/>
 					<Button
 						primary

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -17,7 +17,6 @@ import { includes } from 'lodash';
 import { useState } from 'react';
 import { connect } from 'react-redux';
 import DataCenterPicker from 'calypso/blocks/data-center-picker';
-import ActionPanelLink from 'calypso/components/action-panel/link';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useSelector } from 'calypso/state';
@@ -34,6 +33,7 @@ import { isSavingSiteSettings } from 'calypso/state/site-settings/selectors';
 import { launchSite } from 'calypso/state/sites/launch/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import HoldList, { hasBlockingHold, HardBlockingNotice, getBlockingMessages } from './hold-list';
+import SupportBlock from './support-block';
 import { isAtomicSiteWithoutBusinessPlan } from './utils';
 import WarningList from './warning-list';
 import type { EligibilityData } from 'calypso/state/automated-transfer/selectors';
@@ -251,14 +251,7 @@ export const EligibilityWarnings = ( {
 
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
-					<div className="support-block">
-						<span>{ translate( 'Need help?' ) }</span>
-						{ translate( '{{a}}Contact support{{/a}}', {
-							components: {
-								a: <ActionPanelLink href="/help/contact" />,
-							},
-						} ) }
-					</div>
+					<SupportBlock useDialog={ context === 'plugin-details' } />
 					<Button
 						primary
 						disabled={

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -254,8 +254,8 @@ export const EligibilityWarnings = ( {
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
 					<SupportLink
-						useHelpCenter={ context === 'plugin-details' }
-						onCloseEligibilityDialog={ onClose }
+						shouldUseHelpAssistant={ context === 'plugin-details' }
+						onShowHelpAssistant={ onClose }
 					/>
 					<Button
 						primary

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -46,7 +46,7 @@ interface ExternalProps {
 	siteId?: number | null;
 	isEligible?: boolean;
 	backUrl?: string;
-	onClose: () => void;
+	onClose?: () => void;
 	onProceed: ( options: { geo_affinity?: string } ) => void;
 	standaloneProceed: boolean;
 	className?: string;

--- a/client/blocks/eligibility-warnings/support-block.tsx
+++ b/client/blocks/eligibility-warnings/support-block.tsx
@@ -11,10 +11,12 @@ import type { HelpCenterSelect } from '@automattic/data-stores';
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const SupportBlock = ( {
-	useDialog = false,
+	onCloseEligibilityDialog,
 	translate,
+	useHelpCenter = false,
 }: {
-	useDialog?: boolean;
+	onCloseEligibilityDialog: () => void;
+	useHelpCenter?: boolean;
 } & LocalizeProps ) => {
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
@@ -26,21 +28,25 @@ const SupportBlock = ( {
 
 	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	const handleToggleHelpCenter = () => {
+	const handleOpenHelpCenter = () => {
+		onCloseEligibilityDialog();
+
+		if ( ! show ) {
+			setShowHelpCenter( true );
+		}
+
 		if ( isMinimized ) {
 			setIsMinimized( false );
-		} else {
-			setShowHelpCenter( ! show );
 		}
 	};
 
 	return (
 		<div className="support-block">
-			{ useDialog ? (
+			{ useHelpCenter ? (
 				<>
 					{ translate( '{{button}}Need help?{{/button}}', {
 						components: {
-							button: <Button variant="link" onClick={ handleToggleHelpCenter } />,
+							button: <Button variant="link" onClick={ handleOpenHelpCenter } />,
 						},
 					} ) }
 				</>

--- a/client/blocks/eligibility-warnings/support-block.tsx
+++ b/client/blocks/eligibility-warnings/support-block.tsx
@@ -1,0 +1,61 @@
+import { HelpCenter } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
+import {
+	useDispatch as useDataStoreDispatch,
+	useSelect as useDateStoreSelect,
+} from '@wordpress/data';
+import { localize, LocalizeProps } from 'i18n-calypso';
+import ActionPanelLink from 'calypso/components/action-panel/link';
+import type { HelpCenterSelect } from '@automattic/data-stores';
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+const SupportBlock = ( {
+	useDialog = false,
+	translate,
+}: {
+	useDialog?: boolean;
+} & LocalizeProps ) => {
+	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			show: store.isHelpCenterShown(),
+			isMinimized: store.getIsMinimized(),
+		};
+	}, [] );
+
+	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const handleToggleHelpCenter = () => {
+		if ( isMinimized ) {
+			setIsMinimized( false );
+		} else {
+			setShowHelpCenter( ! show );
+		}
+	};
+
+	return (
+		<div className="support-block">
+			{ useDialog ? (
+				<>
+					{ translate( '{{button}}Need help?{{/button}}', {
+						components: {
+							button: <Button variant="link" onClick={ handleToggleHelpCenter } />,
+						},
+					} ) }
+				</>
+			) : (
+				<>
+					<span>{ translate( 'Need help?' ) }</span>
+					{ translate( '{{a}}Contact support{{/a}}', {
+						components: {
+							a: <ActionPanelLink href="/help/contact" />,
+						},
+					} ) }
+				</>
+			) }
+		</div>
+	);
+};
+
+export default localize( SupportBlock );

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -10,7 +10,7 @@ import type { HelpCenterSelect } from '@automattic/data-stores';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const SupportBlock = ( {
+const SupportLink = ( {
 	onCloseEligibilityDialog,
 	translate,
 	useHelpCenter = false,
@@ -64,4 +64,4 @@ const SupportBlock = ( {
 	);
 };
 
-export default localize( SupportBlock );
+export default localize( SupportLink );

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import {
@@ -5,7 +6,9 @@ import {
 	useSelect as useDateStoreSelect,
 } from '@wordpress/data';
 import { localize, LocalizeProps } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import ActionPanelLink from 'calypso/components/action-panel/link';
+import { getSectionName } from 'calypso/state/ui/selectors';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
 const HELP_CENTER_STORE = HelpCenter.register();
@@ -18,6 +21,7 @@ const SupportLink = ( {
 	onCloseEligibilityDialog: () => void;
 	useHelpCenter?: boolean;
 } & LocalizeProps ) => {
+	const sectionName = useSelector( getSectionName );
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -25,7 +29,6 @@ const SupportLink = ( {
 			isMinimized: store.getIsMinimized(),
 		};
 	}, [] );
-
 	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleOpenHelpCenter = () => {
@@ -33,6 +36,11 @@ const SupportLink = ( {
 
 		if ( ! show ) {
 			setShowHelpCenter( true );
+			recordTracksEvent( 'calypso_inlinehelp_show', {
+				force_site_id: true,
+				location: 'help-center',
+				section: sectionName,
+			} );
 		}
 
 		if ( isMinimized ) {

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -1,5 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
+import { useResetSupportInteraction } from '@automattic/help-center/src/hooks/use-reset-support-interaction';
+import { clearHelpCenterZendeskConversationStarted } from '@automattic/odie-client/src/utils/storage-utils';
 import { Button } from '@wordpress/components';
 import {
 	useDispatch as useDataStoreDispatch,
@@ -31,13 +33,19 @@ const SupportLink = ( {
 	}, [] );
 	const { setShowHelpCenter, setIsMinimized, setNavigateToRoute } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
+	const resetSupportInteraction = useResetSupportInteraction();
 
-	const handleShowHelpAssistant = () => {
+	const handleShowHelpAssistant = async () => {
 		onShowHelpAssistant();
 
+		setNavigateToRoute( '/odie' );
+		await resetSupportInteraction();
+		clearHelpCenterZendeskConversationStarted();
+		recordTracksEvent( 'calypso_inlinehelp_clear_conversation' );
+
 		if ( ! show ) {
-			setNavigateToRoute( '/odie' );
 			setShowHelpCenter( true );
+
 			recordTracksEvent( 'calypso_inlinehelp_show', {
 				force_site_id: true,
 				location: 'help-center',

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -29,12 +29,14 @@ const SupportLink = ( {
 			isMinimized: store.getIsMinimized(),
 		};
 	}, [] );
-	const { setShowHelpCenter, setIsMinimized } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setIsMinimized, setNavigateToRoute } =
+		useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleOpenHelpCenter = () => {
 		onCloseEligibilityDialog();
 
 		if ( ! show ) {
+			setNavigateToRoute( '/odie' );
 			setShowHelpCenter( true );
 			recordTracksEvent( 'calypso_inlinehelp_show', {
 				force_site_id: true,

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -8,6 +8,7 @@ import {
 	useSelect as useDateStoreSelect,
 } from '@wordpress/data';
 import { localize, LocalizeProps } from 'i18n-calypso';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -35,13 +36,17 @@ const SupportLink = ( {
 		useDataStoreDispatch( HELP_CENTER_STORE );
 	const resetSupportInteraction = useResetSupportInteraction();
 
-	const handleShowHelpAssistant = async () => {
-		onShowHelpAssistant();
-
-		setNavigateToRoute( '/odie' );
+	const clearChat = useCallback( async () => {
 		await resetSupportInteraction();
 		clearHelpCenterZendeskConversationStarted();
 		recordTracksEvent( 'calypso_inlinehelp_clear_conversation' );
+	}, [ resetSupportInteraction ] );
+
+	const handleShowHelpAssistant = useCallback( async () => {
+		onShowHelpAssistant();
+
+		setNavigateToRoute( '/odie' );
+		await clearChat();
 
 		if ( ! show ) {
 			setShowHelpCenter( true );
@@ -56,18 +61,25 @@ const SupportLink = ( {
 		if ( isMinimized ) {
 			setIsMinimized( false );
 		}
-	};
+	}, [
+		onShowHelpAssistant,
+		setNavigateToRoute,
+		clearChat,
+		show,
+		setShowHelpCenter,
+		sectionName,
+		isMinimized,
+		setIsMinimized,
+	] );
 
 	return (
 		<div className="support-block">
 			{ shouldUseHelpAssistant ? (
-				<>
-					{ translate( '{{button}}Need help?{{/button}}', {
-						components: {
-							button: <Button variant="link" onClick={ handleShowHelpAssistant } />,
-						},
-					} ) }
-				</>
+				translate( '{{button}}Need help?{{/button}}', {
+					components: {
+						button: <Button variant="link" onClick={ handleShowHelpAssistant } />,
+					},
+				} )
 			) : (
 				<>
 					<span>{ translate( 'Need help?' ) }</span>

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -14,7 +14,7 @@ import type { HelpCenterSelect } from '@automattic/data-stores';
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const SupportLink = ( {
-	onShowHelpAssistant,
+	onShowHelpAssistant = () => {},
 	translate,
 	shouldUseHelpAssistant = false,
 }: {
@@ -33,9 +33,7 @@ const SupportLink = ( {
 		useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleShowHelpAssistant = () => {
-		if ( onShowHelpAssistant ) {
-			onShowHelpAssistant();
-		}
+		onShowHelpAssistant();
 
 		if ( ! show ) {
 			setNavigateToRoute( '/odie' );

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -14,12 +14,12 @@ import type { HelpCenterSelect } from '@automattic/data-stores';
 const HELP_CENTER_STORE = HelpCenter.register();
 
 const SupportLink = ( {
-	onCloseEligibilityDialog,
+	onShowHelpAssistant,
 	translate,
-	useHelpCenter = false,
+	shouldUseHelpAssistant = false,
 }: {
-	onCloseEligibilityDialog?: () => void;
-	useHelpCenter?: boolean;
+	onShowHelpAssistant?: () => void;
+	shouldUseHelpAssistant?: boolean;
 } & LocalizeProps ) => {
 	const sectionName = useSelector( getSectionName );
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
@@ -32,9 +32,9 @@ const SupportLink = ( {
 	const { setShowHelpCenter, setIsMinimized, setNavigateToRoute } =
 		useDataStoreDispatch( HELP_CENTER_STORE );
 
-	const handleOpenHelpCenter = () => {
-		if ( onCloseEligibilityDialog ) {
-			onCloseEligibilityDialog();
+	const handleShowHelpAssistant = () => {
+		if ( onShowHelpAssistant ) {
+			onShowHelpAssistant();
 		}
 
 		if ( ! show ) {
@@ -54,11 +54,11 @@ const SupportLink = ( {
 
 	return (
 		<div className="support-block">
-			{ useHelpCenter ? (
+			{ shouldUseHelpAssistant ? (
 				<>
 					{ translate( '{{button}}Need help?{{/button}}', {
 						components: {
-							button: <Button variant="link" onClick={ handleOpenHelpCenter } />,
+							button: <Button variant="link" onClick={ handleShowHelpAssistant } />,
 						},
 					} ) }
 				</>

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -18,7 +18,7 @@ const SupportLink = ( {
 	translate,
 	useHelpCenter = false,
 }: {
-	onCloseEligibilityDialog: () => void;
+	onCloseEligibilityDialog?: () => void;
 	useHelpCenter?: boolean;
 } & LocalizeProps ) => {
 	const sectionName = useSelector( getSectionName );
@@ -33,7 +33,9 @@ const SupportLink = ( {
 		useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleOpenHelpCenter = () => {
-		onCloseEligibilityDialog();
+		if ( onCloseEligibilityDialog ) {
+			onCloseEligibilityDialog();
+		}
 
 		if ( ! show ) {
 			setNavigateToRoute( '/odie' );

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -14,6 +14,25 @@ jest.mock( '@automattic/calypso-router', () => ( {
 	redirect: jest.fn(),
 } ) );
 
+jest.mock( '@automattic/help-center/src/hooks/use-reset-support-interaction', () => ( {
+	useResetSupportInteraction: () => jest.fn().mockResolvedValue( undefined ),
+} ) );
+
+jest.mock( '@automattic/odie-client/src/data', () => ( {
+	useManageSupportInteraction: () => ( {
+		startNewInteraction: jest.fn().mockResolvedValue( undefined ),
+		resolveInteraction: jest.fn().mockResolvedValue( undefined ),
+		addEventToInteraction: jest.fn().mockResolvedValue( undefined ),
+	} ),
+	useGetZendeskConversation: jest.fn(),
+	useOdieChat: jest.fn(),
+	broadcastOdieMessage: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/odie-client/src/utils/storage-utils', () => ( {
+	clearHelpCenterZendeskConversationStarted: jest.fn(),
+} ) );
+
 function renderWithStore( element: ReactElement, initialState: Record< string, unknown > ) {
 	const store = createStore( ( state ) => state, initialState );
 	return {
@@ -53,6 +72,10 @@ function createState( {
 describe( '<EligibilityWarnings>', () => {
 	beforeEach( () => {
 		page.redirect.mockReset();
+	} );
+
+	afterAll( () => {
+		jest.restoreAllMocks();
 	} );
 
 	it( 'renders error notice when AT has been blocked by a sticker', () => {

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -188,4 +188,32 @@ describe( '<EligibilityWarnings>', () => {
 		await userEvent.click( continueButton );
 		expect( handleProceed ).not.toHaveBeenCalled();
 	} );
+
+	it( 'renders a help center button if the context is plugin-details', async () => {
+		const state = createState( {} );
+
+		const { getByText, queryByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } currentContext="plugin-details" />,
+			state
+		);
+
+		expect( queryByText( 'Contact support' ) ).toBeNull();
+		const helpCenterButton = getByText( 'Need help?' );
+		expect( helpCenterButton ).toBeVisible();
+		expect( helpCenterButton ).toBeInstanceOf( HTMLButtonElement );
+	} );
+
+	it( 'renders a contact support link if the context is not plugin-details', async () => {
+		const state = createState( {} );
+
+		const { getByText } = renderWithStore(
+			<EligibilityWarnings backUrl="" onProceed={ noop } currentContext="foo" />,
+			state
+		);
+
+		expect( getByText( 'Need help?' ) ).toBeVisible();
+		const contactSupportLink = getByText( 'Contact support' );
+		expect( contactSupportLink ).toBeVisible();
+		expect( contactSupportLink ).toBeInstanceOf( HTMLAnchorElement );
+	} );
 } );

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -161,7 +161,10 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 					currentContext="plugin-details"
 					isMarketplace={ isMarketplaceProduct }
 					standaloneProceed
-					onDismiss={ () => setShowEligibility( false ) }
+					onDismiss={ () => {
+						setShowEligibility( false );
+						setShowAddCustomDomain( false );
+					} }
 					onProceed={ () =>
 						onClickInstallPlugin( {
 							dispatch,

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -319,6 +319,6 @@ function onClickInstallPlugin( {
 		);
 	}
 
-	// No need to go through chekout, go to install page directly.
+	// No need to go through checkout, go to install page directly.
 	return page( installPluginURL );
 }

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -161,6 +161,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 					currentContext="plugin-details"
 					isMarketplace={ isMarketplaceProduct }
 					standaloneProceed
+					onClose={ () => setShowEligibility( false ) }
 					onProceed={ () =>
 						onClickInstallPlugin( {
 							dispatch,

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -161,7 +161,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 					currentContext="plugin-details"
 					isMarketplace={ isMarketplaceProduct }
 					standaloneProceed
-					onClose={ () => setShowEligibility( false ) }
+					onDismiss={ () => setShowEligibility( false ) }
 					onProceed={ () =>
 						onClickInstallPlugin( {
 							dispatch,

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -7,7 +7,7 @@ import page from '@automattic/calypso-router';
 import { Button, Dialog } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import { marketplacePlanToAdd, getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
@@ -124,6 +124,11 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 		buttonText = translate( 'Included with your plan' );
 	}
 
+	const handleDismissEligibilityWarnings = useCallback( () => {
+		setShowEligibility( false );
+		setShowAddCustomDomain( false );
+	}, [ setShowEligibility, setShowAddCustomDomain ] );
+
 	return (
 		<>
 			<PluginCustomDomainDialog
@@ -161,10 +166,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 					currentContext="plugin-details"
 					isMarketplace={ isMarketplaceProduct }
 					standaloneProceed
-					onDismiss={ () => {
-						setShowEligibility( false );
-						setShowAddCustomDomain( false );
-					} }
+					onDismiss={ handleDismissEligibilityWarnings }
 					onProceed={ () =>
 						onClickInstallPlugin( {
 							dispatch,

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -6,6 +6,17 @@ import { setStore } from 'calypso/state/redux-store';
 import { receiveTheme, themeRequestFailure } from 'calypso/state/themes/actions';
 import ThemeSheetComponent from '../main';
 
+jest.mock( '@automattic/odie-client/src/data', () => ( {
+	useManageSupportInteraction: jest.fn().mockReturnValue( {
+		startNewInteraction: jest.fn(),
+		resolveInteraction: jest.fn(),
+		addEventToInteraction: jest.fn(),
+	} ),
+	useGetZendeskConversation: jest.fn(),
+	useOdieChat: jest.fn(),
+	broadcastOdieMessage: jest.fn(),
+} ) );
+
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'calypso/my-sites/themes/theme-preview', () =>
 	require( 'calypso/components/empty-component' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #100457 

## Proposed Changes

Replaces the 'Contact support' link in the plugins 'Upgrade and activate' modal with a 'Need help?' button, which activates Odie in the help center instead of navigating to the support page.

This modal is used in many other contexts, and for now it has only been changed for the 'plugin-details' context, but we could choose to change this behaviour more widely.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

From the issue: 'These are high intent users, that could convert to paid customers. We should put them in contact with Humans if possible or connect them with the AI assistant at the very least.'

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

https://github.com/user-attachments/assets/95412750-e07f-4f31-a895-a14b588fe5eb

* Navigate to a plugin details page, eg. http://calypso.localhost:3000/plugins/elementor/{your-domain}.wordpress.com
* Click the 'Upgrade and activate' button and observe the eligibility modal opening
* In the bottom left, instead of the linked text 'Need help? Contact support', observe that there is a button with only 'Need help?'

![wordpress com_plugins_wordpress-seo-premium_pixelantics6 wordpress com(Desktop)](https://github.com/user-attachments/assets/ee8bf631-82c3-4f2c-98e6-df4ae5f55ae6)

* Click the button
* Observe that the modal closes, and the Help Center is opened with Odie assistant loaded
* Try closing the chat and repeating the process
* Try minimizing the chat and repeating the process
* Navigate to a different context, eg. http://calypso.localhost:3000/plugins/upload/{your-domain}.wordpress.com and observe that the standard support contact link is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
