### PR TITLE
Update StepContainerV2 on import from another platform

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -1,18 +1,19 @@
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { ReactElement, useEffect } from 'react';
 import CaptureStep from 'calypso/blocks/import/capture';
 import DocumentHead from 'calypso/components/data/document-head';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { generateStepPath } from './helper';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import './style.scss';
 
-export const ImportWrapper: Step< {
+export const ImportWrapper: StepType< {
 	submits: {
 		platform: ImporterPlatform;
 		url: string;
@@ -29,6 +30,34 @@ export const ImportWrapper: Step< {
 		// (see useMigrationConfirmation's implementation)
 		[ setMigrationConfirmed ]
 	);
+
+	const isUsingStepContainerV2 = shouldUseStepContainerV2( props.flow );
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ __( 'Import your site content' ) } />
+				<Step.CenteredColumnLayout
+					className="step-container-v2--import__onboarding-page"
+					columnWidth={ 6 }
+					topBar={
+						<Step.TopBar
+							backButton={ <Step.BackButton onClick={ navigation.goBack } /> }
+							skipButton={
+								<Step.SkipButton
+									onClick={ navigation.goNext }
+									label={ __( 'Skip to dashboard' ) }
+								/>
+							}
+						/>
+					}
+					heading={ <Step.Heading text={ props.title } subText={ props.subTitle } /> }
+				>
+					{ children }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
 
 	return (
 		<>
@@ -51,7 +80,7 @@ export const ImportWrapper: Step< {
 	);
 };
 
-const ImportStep: Step< {
+const ImportStep: StepType< {
 	submits: {
 		platform: ImporterPlatform;
 		url: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -54,9 +54,15 @@ interface Props {
 	onSkip: () => void;
 	hideImporterListLink: boolean;
 	flowName: string;
+	setIsFetching: ( isFetching: boolean ) => void;
 }
 
-export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLink = false } ) => {
+export const Analyzer: FC< Props > = ( {
+	onComplete,
+	onSkip,
+	hideImporterListLink = false,
+	setIsFetching,
+} ) => {
 	const translate = useTranslate();
 	const [ siteURL, setSiteURL ] = useState< string >( '' );
 	const {
@@ -71,6 +77,10 @@ export const Analyzer: FC< Props > = ( { onComplete, onSkip, hideImporterListLin
 			onComplete( siteInfo );
 		}
 	}, [ onComplete, siteInfo ] );
+
+	useEffect( () => {
+		setIsFetching( isFetching );
+	}, [ isFetching, setIsFetching ] );
 
 	if ( isFetching || ( isFetched && ! hasError ) ) {
 		return <ScanningStep />;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101912

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
