### PR TITLE
Update plans step to use WideLayout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -494,7 +494,7 @@ function UnifiedPlansStep( {
 		return (
 			<>
 				<MarketingMessage path="signup/plans" />
-				<Step.FullWidthLayout
+				<Step.WideLayout
 					className="step-container-v2--plans"
 					topBar={
 						<Step.TopBar
@@ -506,7 +506,7 @@ function UnifiedPlansStep( {
 					heading={ <Step.Heading text={ getHeaderText() } subText={ fallbackSubHeaderText } /> }
 				>
 					{ stepContent }
-				</Step.FullWidthLayout>
+				</Step.WideLayout>
 			</>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related #101204

## Proposed Changes

* Use `WideLayout` for the plans step (when step container v2 is enabled)

**Before**
![CleanShot 2025-03-27 at 19 07 08@2x](https://github.com/user-attachments/assets/e39592e0-f852-4184-8a72-f136516cb58e)


**After**
![CleanShot 2025-03-27 at 19 06 30@2x](https://github.com/user-attachments/assets/33052735-9d89-4951-87e9-d9eb4b495b02)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `FullWidthLayout` is much wider than any other step. I raised it here: p1743044978661229-slack-C08HKNPL2BG. Until there's some other step that takes up the full screen (e.g. design picker) then this plan step feels out of place being so wide.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the plans step on `calypso.localhost` and try the plans step at various screen widths

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?