### PR TITLE
Stats: "Revert Stats: Update UTM module to emphasize campaigns"

### DIFF
--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
@@ -29,7 +29,6 @@ $stats-utm-border: 1px solid var(--gray-gray-5, #dcdcde);
 
 .stats-utm-picker__popover-list {
 	padding: 8px 0;
-	border-left: $stats-utm-border;
 	box-sizing: border-box;
 	list-style: none;
 	margin: 0;

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
@@ -65,7 +65,9 @@ $stats-utm-border: 1px solid var(--gray-gray-5, #dcdcde);
 		flex: 1; // take full width
 	}
 
-	&.is-not-grouped + &.is-grouped {
+	&.is-grouped + &.is-not-grouped {
+		margin-top: 2px;
+
 		&::before {
 			content: "";
 			margin: 2px 0;

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
@@ -66,8 +66,6 @@ $stats-utm-border: 1px solid var(--gray-gray-5, #dcdcde);
 	}
 
 	&.is-grouped + &.is-not-grouped {
-		margin-top: 2px;
-
 		&::before {
 			content: "";
 			margin: 2px 0;

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -51,21 +51,9 @@ const StatsModuleUTM = ( {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const translate = useTranslate();
 
-	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.CAMPAIGN );
+	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
 
 	const optionLabels = {
-		[ OPTION_KEYS.CAMPAIGN ]: {
-			selectLabel: translate( 'Campaign' ),
-			headerLabel: translate( 'Posts by Campaign' ),
-		},
-		[ OPTION_KEYS.SOURCE ]: {
-			selectLabel: translate( 'Source' ),
-			headerLabel: translate( 'Posts by Source' ),
-		},
-		[ OPTION_KEYS.MEDIUM ]: {
-			selectLabel: translate( 'Medium' ),
-			headerLabel: translate( 'Posts by Medium' ),
-		},
 		[ OPTION_KEYS.SOURCE_MEDIUM ]: {
 			selectLabel: translate( 'Source / Medium' ),
 			headerLabel: translate( 'Posts by Source / Medium' ),
@@ -75,6 +63,18 @@ const StatsModuleUTM = ( {
 			selectLabel: translate( 'Campaign / Source / Medium' ),
 			headerLabel: translate( 'Posts by Campaign / Source / Medium' ),
 			isGrouped: true,
+		},
+		[ OPTION_KEYS.SOURCE ]: {
+			selectLabel: translate( 'Source' ),
+			headerLabel: translate( 'Posts by Source' ),
+		},
+		[ OPTION_KEYS.MEDIUM ]: {
+			selectLabel: translate( 'Medium' ),
+			headerLabel: translate( 'Posts by Medium' ),
+		},
+		[ OPTION_KEYS.CAMPAIGN ]: {
+			selectLabel: translate( 'Campaign' ),
+			headerLabel: translate( 'Posts by Campaign' ),
 		},
 	};
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101439
Related https://github.com/Automattic/red-team/issues/355

## Proposed Changes

* Revert setting default UTM option to medium as this hides the selection if there are no events with utm medium

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To not show the settings of the module if it is not activated

## Testing Instructions

1. View a page on a site with only utm_medium, for example, example.com?utm_medium=yolo
2. Go to view utm stats wordprss.com/stats/example.com
3. You should see the UTM events

Tested this fixes the issue on user's website in - 9574191-zd-a8c

![Arc -2025-03-27 at 12 13 43@2x](https://github.com/user-attachments/assets/37fdd9fd-b0b6-46ca-8b97-422af2dd6e3f)


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
