### PR TITLE
[Odie] Bring back direct escalation when user downvotes or provided enough information

### DIFF
--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,7 +1,7 @@
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useOdieAssistantContext } from '../../context';
-import { zendeskMessageConverter } from '../../utils';
+import { userProvidedEnoughInformation, zendeskMessageConverter } from '../../utils';
 import ChatWithSupportLabel from '../chat-with-support';
 import DislikeFeedbackMessage from './dislike-feedback-message';
 import ErrorMessage from './error-message';
@@ -25,14 +25,14 @@ export const MessageContent = ( {
 	displayChatWithSupportLabel?: boolean;
 	displayChatWithSupportEndedLabel?: boolean;
 } ) => {
-	const { experimentVariationName } = useOdieAssistantContext();
+	const { __ } = useI18n();
+	const { chat } = useOdieAssistantContext();
 	const messageClasses = clsx(
 		'odie-chatbox-message',
 		`odie-chatbox-message-${ message.role }`,
 		`odie-chatbox-message-${ message.type ?? 'message' }`,
 		message?.context?.flags?.show_ai_avatar === false && 'odie-chatbox-message-no-avatar'
 	);
-	const { __ } = useI18n();
 	const isFeedbackMessage = message.type === 'conversation-feedback' && message?.meta?.feedbackUrl;
 
 	const containerClasses = clsx(
@@ -40,8 +40,8 @@ export const MessageContent = ( {
 		( isNextMessageFromSameSender || isFeedbackMessage ) && 'next-chat-message-same-sender'
 	);
 
-	const stopConflatingNegativeRatingWithContactSupport =
-		experimentVariationName === 'give_wapuu_a_chance';
+	const messages = chat?.messages;
+	const stopConflatingNegativeRatingWithContactSupport = userProvidedEnoughInformation( messages );
 
 	const isMessageWithOnlyText =
 		message.context?.flags?.hide_disclaimer_content ||

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,9 +1,7 @@
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { useOdieAssistantContext } from '../../context';
-import { userProvidedEnoughInformation, zendeskMessageConverter } from '../../utils';
+import { zendeskMessageConverter } from '../../utils';
 import ChatWithSupportLabel from '../chat-with-support';
-import DislikeFeedbackMessage from './dislike-feedback-message';
 import ErrorMessage from './error-message';
 import { FeedbackContent } from './feedback-content';
 import { IntroductionMessage } from './introduction-message';
@@ -26,7 +24,6 @@ export const MessageContent = ( {
 	displayChatWithSupportEndedLabel?: boolean;
 } ) => {
 	const { __ } = useI18n();
-	const { chat } = useOdieAssistantContext();
 	const messageClasses = clsx(
 		'odie-chatbox-message',
 		`odie-chatbox-message-${ message.role }`,
@@ -39,9 +36,6 @@ export const MessageContent = ( {
 		'odie-chatbox-message-sources-container',
 		( isNextMessageFromSameSender || isFeedbackMessage ) && 'next-chat-message-same-sender'
 	);
-
-	const messages = chat?.messages;
-	const stopConflatingNegativeRatingWithContactSupport = userProvidedEnoughInformation( messages );
 
 	const isMessageWithOnlyText =
 		message.context?.flags?.hide_disclaimer_content ||
@@ -85,9 +79,6 @@ export const MessageContent = ( {
 					{ isFeedbackMessage && (
 						<FeedbackContent content={ message.content } meta={ message?.meta } />
 					) }
-
-					{ ! stopConflatingNegativeRatingWithContactSupport &&
-						message.type === 'dislike-feedback' && <DislikeFeedbackMessage /> }
 				</div>
 			</div>
 

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -14,7 +14,7 @@ import {
 	useUpdateDocumentTitle,
 } from '../../hooks';
 import { useHelpCenterChatScroll } from '../../hooks/use-help-center-chat-scroll';
-import { getOdieInitialMessage, userProvidedEnoughInformation } from '../../utils';
+import { getOdieInitialMessage } from '../../utils';
 import { ViewMostRecentOpenConversationNotice } from '../odie-notice/view-most-recent-conversation-notice';
 import { DislikeFeedbackMessage } from './dislike-feedback-message';
 import { JumpToRecent } from './jump-to-recent';
@@ -146,11 +146,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		return currentMessage === nextMessage;
 	};
 
-	const removeDislikeStatus = ! userProvidedEnoughInformation( chat.messages );
-
-	const availableStatusWithFeedback = removeDislikeStatus
-		? [ 'sending', 'transfer' ]
-		: [ 'sending', 'dislike', 'transfer' ];
+	const availableStatusWithFeedback = [ 'sending', 'transfer' ];
 
 	return (
 		<>

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -6,7 +6,6 @@ import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from 'react';
 import { NavigationType, useNavigationType, useSearchParams } from 'react-router-dom';
-import { ThumbsDown } from '../../assets/thumbs-down';
 import { useOdieAssistantContext } from '../../context';
 import {
 	useAutoScroll,
@@ -15,21 +14,13 @@ import {
 	useUpdateDocumentTitle,
 } from '../../hooks';
 import { useHelpCenterChatScroll } from '../../hooks/use-help-center-chat-scroll';
-import { getOdieInitialMessage } from '../../utils';
+import { getOdieInitialMessage, userProvidedEnoughInformation } from '../../utils';
 import { ViewMostRecentOpenConversationNotice } from '../odie-notice/view-most-recent-conversation-notice';
 import { DislikeFeedbackMessage } from './dislike-feedback-message';
 import { JumpToRecent } from './jump-to-recent';
 import { ThinkingPlaceholder } from './thinking-placeholder';
 import ChatMessage from '.';
 import type { Chat, CurrentUser } from '../../types';
-
-const DislikeThumb = () => {
-	return (
-		<div className="chatbox-message__dislike-thumb">
-			<ThumbsDown />
-		</div>
-	);
-};
 
 const LoadingChatSpinner = () => {
 	return (
@@ -52,7 +43,7 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, botNameSlug, experimentVariationName, isChatLoaded, isUserEligibleForPaidSupport } =
+	const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport } =
 		useOdieAssistantContext();
 	const createZendeskConversation = useCreateZendeskConversation();
 	const resetSupportInteraction = useResetSupportInteraction();
@@ -155,7 +146,7 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 		return currentMessage === nextMessage;
 	};
 
-	const removeDislikeStatus = experimentVariationName === 'give_wapuu_a_chance';
+	const removeDislikeStatus = ! userProvidedEnoughInformation( chat.messages );
 
 	const availableStatusWithFeedback = removeDislikeStatus
 		? [ 'sending', 'transfer' ]
@@ -205,7 +196,6 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 						{ chat.provider === 'odie' && (
 							<>
 								<ViewMostRecentOpenConversationNotice />
-								{ chat.status === 'dislike' && ! removeDislikeStatus && <DislikeThumb /> }
 								{ availableStatusWithFeedback.includes( chat.status ) && (
 									<div className="odie-chatbox__action-message">
 										{ chat.status === 'sending' && <ThinkingPlaceholder /> }

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -795,3 +795,9 @@ $custom-border-corner-size: 16px;
 .odie-send-message-input-spinner {
 	color: $blueberry-color !important;
 }
+
+.odie__transfer-chat {
+	width: calc(100% - 80px)!important;
+	margin-top: 16px;
+    margin-left: 46px;
+}

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import Markdown from 'react-markdown';
 import { ODIE_FORWARD_TO_FORUMS_MESSAGE, ODIE_FORWARD_TO_ZENDESK_MESSAGE } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
+import { userProvidedEnoughInformation } from '../../utils';
 import CustomALink from './custom-a-link';
 import { DirectEscalationLink } from './direct-escalation-link';
 import { GetSupport } from './get-support';
@@ -22,13 +23,7 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithoutEscalationOption?: boolean;
 } ) => {
-	const {
-		isUserEligibleForPaidSupport,
-		hasUserEverEscalatedToHumanSupport,
-		trackEvent,
-		chat,
-		experimentVariationName,
-	} = useOdieAssistantContext();
+	const { isUserEligibleForPaidSupport, trackEvent, chat } = useOdieAssistantContext();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
@@ -38,18 +33,10 @@ export const UserMessage = ( {
 	const isPositiveFeedback =
 		hasFeedback && message && message.rating_value && +message.rating_value === 1;
 
-	const isExperimentGiveWapuuAChance = experimentVariationName === 'give_wapuu_a_chance';
+	const showExtraContactOptions =
+		( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
 
-	let showExtraContactOptions = false;
-	if ( isExperimentGiveWapuuAChance ) {
-		showExtraContactOptions = isRequestingHumanSupport;
-	} else {
-		showExtraContactOptions = ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
-	}
-
-	const showDirectEscalationLink = isExperimentGiveWapuuAChance
-		? hasUserEverEscalatedToHumanSupport
-		: ! ( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
+	const showDirectEscalationLink = userProvidedEnoughInformation( chat?.messages );
 
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE

--- a/packages/odie-client/src/hooks/use-auto-scroll.ts
+++ b/packages/odie-client/src/hooks/use-auto-scroll.ts
@@ -5,7 +5,7 @@ export const useAutoScroll = (
 	messagesContainerRef: RefObject< HTMLDivElement >,
 	isEnabled: boolean
 ) => {
-	const { chat, experimentVariationName } = useOdieAssistantContext();
+	const { chat } = useOdieAssistantContext();
 	const debounceTimeoutRef = useRef< number >( 500 );
 	const debounceTimeoutIdRef = useRef< number | null >( null );
 	const lastChatStatus = useRef< string | null >( null );
@@ -20,7 +20,7 @@ export const useAutoScroll = (
 			return;
 		}
 
-		if ( experimentVariationName === 'give_wapuu_a_chance' && chat.status === 'dislike' ) {
+		if ( chat.status === 'dislike' ) {
 			return;
 		}
 

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -121,6 +121,7 @@ export type Context = {
 		inquiry_type?: InquiryType;
 		language?: string;
 		product?: string;
+		category?: string;
 	};
 	flags?: {
 		forward_to_human_support?: boolean;

--- a/packages/odie-client/src/utils/index.ts
+++ b/packages/odie-client/src/utils/index.ts
@@ -7,3 +7,4 @@ export {
 	getHelpCenterZendeskConversationStartedElapsedTime,
 } from './storage-utils';
 export { getOdieInitialMessage } from './get-odie-initial-message';
+export { userProvidedEnoughInformation } from './user-provided-enough-information';

--- a/packages/odie-client/src/utils/user-provided-enough-information.ts
+++ b/packages/odie-client/src/utils/user-provided-enough-information.ts
@@ -14,7 +14,7 @@ export const userProvidedEnoughInformation = ( messages: Message[] ): boolean =>
 		].map( ( tag ) => tag.toLowerCase() )
 	);
 
-	// Extract inquiry_type from each message's context.question_tags and normalize to lowercase
+	// Extract category from each message's context.question_tags and normalize to lowercase
 	return messages.some( ( message ) => {
 		const category = message.context?.question_tags?.category?.toLowerCase();
 		return category && ! insufficientEnums.has( category );

--- a/packages/odie-client/src/utils/user-provided-enough-information.ts
+++ b/packages/odie-client/src/utils/user-provided-enough-information.ts
@@ -1,0 +1,22 @@
+import type { Message } from '../types';
+
+/**
+ * Check if the user provided enough information to proceed with the conversation with Happiness Engineers.
+ * @param messages - List of Message objects
+ * @returns boolean
+ */
+export const userProvidedEnoughInformation = ( messages: Message[] ): boolean => {
+	const insufficientEnums = new Set(
+		[
+			'Other (everything else)',
+			'User just said hi, hello or similar',
+			'User wanted to speak with an agent/human',
+		].map( ( tag ) => tag.toLowerCase() )
+	);
+
+	// Extract inquiry_type from each message's context.question_tags and normalize to lowercase
+	return messages.some( ( message ) => {
+		const category = message.context?.question_tags?.category?.toLowerCase();
+		return category && ! insufficientEnums.has( category );
+	} );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1742588507341749-slack-C07D72S1135

## Proposed Changes

We are bringing back direct escalation link and direct escalation when negatively rated, only in the case of user provided enough information. Remove the lingering code from the AB experiment.

## Why are these changes being made?
There might be users that don't know they can ask to connect with human support

## Testing Instructions

- Start a new conversation, ask for connect to a human.
- Check that Assistant replies asking you to provide more information.
- Check that there is no thumbs down or up.
- Provide enough information about your issue.
- Check that there is a link for direct escalation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?