### PR TITLE
Plans Grid Next: add missing scss import

### DIFF
--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"description": "Calypso Data Stores.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/plans-grid-next",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "WordPress.com plans UI grid components and helpers.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -39,6 +39,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/onboarding": "workspace:^",
+		"@automattic/typography": "workspace:^",
 		"@emotion/react": "11.11.1",
 		"@emotion/styled": "^11.11.0",
 		"@wordpress/data": "^10.20.0",

--- a/packages/plans-grid-next/src/components/shared/header-price/style.scss
+++ b/packages/plans-grid-next/src/components/shared/header-price/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+
 .plans-grid-next-header-price {
 	padding: 0 20px;
 	margin: 0 0 4px 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,6 +1640,7 @@ __metadata:
     "@automattic/data-stores": "workspace:^"
     "@automattic/onboarding": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
+    "@automattic/typography": "workspace:^"
     "@emotion/react": "npm:11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@storybook/addon-actions": "npm:^7.6.20"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a missing SCSS import. It is necessary to use this package outside of Calypso.
* Bump the version for the `@automattic/data-stores` package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that the plans grid renders correctly on `/setup/onboarding/plans`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
