### PR TITLE
Site Migration: Remove application-password feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/access-method-picker.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -8,10 +7,6 @@ import { CredentialsFormFieldProps } from '../types';
 
 export const AccessMethodPicker: FC< CredentialsFormFieldProps > = ( { control } ) => {
 	const translate = useTranslate();
-	const applicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
-	const credentialsLabel = applicationPasswordEnabled
-		? translate( 'WordPress site credentials' )
-		: translate( 'WordPress credentials' );
 
 	return (
 		<div>
@@ -25,7 +20,7 @@ export const AccessMethodPicker: FC< CredentialsFormFieldProps > = ( { control }
 						<FormRadio
 							id="site-migration-credentials__radio-credentials"
 							htmlFor="site-migration-credentials__radio-credentials"
-							label={ credentialsLabel }
+							label={ translate( 'WordPress site credentials' ) }
 							checked={ value === 'credentials' }
 							{ ...props }
 							value="credentials"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/credentials-form.tsx
@@ -1,5 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
@@ -11,10 +9,8 @@ import { ApplicationPasswordsInfo } from '../types';
 import { AccessMethodPicker } from './access-method-picker';
 import { BackupFileField } from './backup-file-field';
 import { ErrorMessage } from './error-message';
-import { PasswordField } from './password-field';
 import { SiteAddressField } from './site-address-field';
 import { SpecialInstructions } from './special-instructions';
-import { UsernameField } from './username-field';
 
 interface CredentialsFormProps {
 	onSubmit: (
@@ -25,7 +21,6 @@ interface CredentialsFormProps {
 
 export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 	const translate = useTranslate();
-	const hasEnTranslation = useHasEnTranslation();
 
 	const {
 		control,
@@ -39,8 +34,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 
 	const queryError = useQuery().get( 'error' ) || null;
 
-	const applicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
-
 	let errorMessage;
 	if ( errors.root && errors.root.type !== 'manual' && errors.root.message ) {
 		errorMessage = errors.root.message;
@@ -52,11 +45,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 
 	const getContinueButtonText = () => {
 		if ( isBusy ) {
-			const hasScanningTranslation = hasEnTranslation( 'Scanning site' );
-			if ( applicationPasswordEnabled && hasScanningTranslation ) {
-				return translate( 'Scanning site' );
-			}
-			return translate( 'Verifying credentials' );
+			return translate( 'Scanning site' );
 		}
 		if ( canBypassVerification ) {
 			return translate( 'Continue anyways' );
@@ -71,7 +60,7 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 		submitHandler();
 	};
 
-	const showSpecialInstructions = ! applicationPasswordEnabled || accessMethod === 'backup';
+	const showSpecialInstructions = accessMethod === 'backup';
 
 	return (
 		<form className="site-migration-credentials__form" onSubmit={ onSubmitLocal }>
@@ -92,12 +81,6 @@ export const CredentialsForm: FC< CredentialsFormProps > = ( { onSubmit } ) => {
 				{ accessMethod === 'credentials' && (
 					<div className="site-migration-credentials">
 						<SiteAddressField control={ control } errors={ errors } />
-						{ ! applicationPasswordEnabled && (
-							<>
-								<UsernameField control={ control } errors={ errors } />
-								<PasswordField control={ control } errors={ errors } />
-							</>
-						) }
 					</div>
 				) }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/components/site-address-field.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { FormLabel } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -24,13 +23,9 @@ export const SiteAddressField: React.FC< CredentialsFormFieldProps > = ( { contr
 		? translate( 'Enter your WordPress site address' )
 		: translate( 'Enter your WordPress site address.' );
 
-	const labelText = isEnabled( 'automated-migration/application-password' )
-		? translate( 'Current WordPress site address' )
-		: translate( 'Current site address' );
-
 	return (
 		<div className="site-migration-credentials__form-field">
-			<FormLabel htmlFor="from_url">{ labelText }</FormLabel>
+			<FormLabel htmlFor="from_url">{ translate( 'Current WordPress site address' ) }</FormLabel>
 			<Controller
 				control={ control }
 				name="from_url"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -72,7 +71,6 @@ const removeEndingSlash = ( url: string ) => {
 export const useCredentialsForm = (
 	onSubmit: ( siteInfo?: UrlData, applicationPasswordsInfo?: ApplicationPasswordsInfo ) => void
 ) => {
-	const isApplicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
 	const siteSlug = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const [ siteInfo, setSiteInfo ] = useState< UrlData | undefined >( undefined );
@@ -180,7 +178,7 @@ export const useCredentialsForm = (
 		const siteInfoResult = shouldAnalyzeUrl ? await analyzeUrl( data.from_url ) : siteInfo;
 		setSiteInfo( siteInfoResult );
 
-		if ( isApplicationPasswordEnabled && accessMethod === 'credentials' && siteInfoResult ) {
+		if ( accessMethod === 'credentials' && siteInfoResult ) {
 			await submitWithApplicationPassword( siteId, data.from_url, siteInfoResult );
 		} else {
 			await requestAutomatedMigrationAndSubmit( data, siteInfoResult );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -84,11 +83,9 @@ const SiteMigrationCredentials: Step< {
 		}
 	}, [ siteId, updateMigrationStatus ] );
 
-	const subHeaderText = isEnabled( 'automated-migration/application-password' )
-		? translate( 'Help us get started by providing some basic details about your current website.' )
-		: translate(
-				'Please share the following details to access your site and start your migration to WordPress.com.'
-		  );
+	const subHeaderText = translate(
+		'Help us get started by providing some basic details about your current website.'
+	);
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -56,21 +56,17 @@ const fillAddressField = async () => {
 };
 
 const baseSiteInfo = {
-	url: 'https://site-url.wordpress.com',
+	url: 'https://external-site-url.com',
 	platform: 'wordpress',
 	platform_data: {
 		is_wpcom: false,
 	},
 };
 
-const siteInfoUsingWordPress = {
-	...baseSiteInfo,
-	platform: 'wordpress',
-};
-
 const siteInfoUsingTumblr = {
 	...baseSiteInfo,
 	platform: 'tumblr',
+	url: 'https://site-url.tumblr.com',
 };
 
 const siteInfoUsingWPCOM = {
@@ -84,11 +80,27 @@ describe( 'SiteMigrationCredentials', () => {
 	beforeAll( () => nock.disableNetConnect() );
 	beforeEach( () => {
 		jest.clearAllMocks();
-		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingWordPress );
+		( wp.req.get as jest.Mock ).mockResolvedValue( baseSiteInfo );
 	} );
-	afterEach( () => {
-		jest.clearAllMocks();
-		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingWordPress );
+
+	it( 'starts the authorization flow when using application password', async () => {
+		jest.mocked( wp.req.post ).mockResolvedValue( {
+			application_passwords_enabled: true,
+			authorization_url: 'https://external-site-url.com/wp-admin/authorize-application.php',
+		} );
+
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		await fillAddressField();
+		await userEvent.click( continueButton() );
+
+		expect( submit ).toHaveBeenCalledWith( {
+			action: 'application-passwords-approval',
+			platform: 'wordpress',
+			authorizationUrl: 'https://external-site-url.com/wp-admin/authorize-application.php',
+			from: 'https://external-site-url.com',
+		} );
 	} );
 
 	it( 'creates a credentials using backup file', async () => {
@@ -167,6 +179,7 @@ describe( 'SiteMigrationCredentials', () => {
 
 	it( 'shows error when user set invalid site address', async () => {
 		render();
+
 		await userEvent.type( siteAddressInput(), 'invalid-site-address' );
 		await userEvent.click( continueButton() );
 
@@ -177,7 +190,6 @@ describe( 'SiteMigrationCredentials', () => {
 
 	it( 'shows error message when there is an error on the with the backup file', async () => {
 		const submit = jest.fn();
-		render( { navigation: { submit } } );
 
 		( wpcomRequest as jest.Mock ).mockRejectedValue( {
 			code: 'rest_invalid_param',
@@ -188,6 +200,7 @@ describe( 'SiteMigrationCredentials', () => {
 			},
 		} );
 
+		render( { navigation: { submit } } );
 		await userEvent.click( backupOption() );
 		await userEvent.type( backupFileInput(), 'backup-file.zip' );
 		await userEvent.click( continueButton() );
@@ -215,11 +228,10 @@ describe( 'SiteMigrationCredentials', () => {
 
 	it( 'shows "Scanning site" on the Continue button during submission with application password', async () => {
 		const submit = jest.fn();
-		render( { navigation: { submit } } );
 		const pendingPromise = new Promise( () => {} );
-
 		( wpcomRequest as jest.Mock ).mockImplementation( () => pendingPromise );
 
+		render( { navigation: { submit } } );
 		await fillAddressField();
 		userEvent.click( continueButton() );
 
@@ -230,7 +242,7 @@ describe( 'SiteMigrationCredentials', () => {
 
 	it( 'shows "Scanning site" on the Continue button during submission when fetching site info with application password', async () => {
 		const submit = jest.fn();
-		render( { navigation: { submit } } );
+
 		const pendingPromise = new Promise( () => {} );
 
 		( wpcomRequest as jest.Mock ).mockResolvedValue( {
@@ -240,6 +252,7 @@ describe( 'SiteMigrationCredentials', () => {
 
 		( wp.req.get as jest.Mock ).mockImplementation( () => pendingPromise );
 
+		render( { navigation: { submit } } );
 		await fillAddressField();
 		await userEvent.click( continueButton() );
 
@@ -248,51 +261,33 @@ describe( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'submits credentials-required action when using password application and application_passwords_enabled is disabled', async () => {
+	it( 'submits credentials-required action when there is an error on to get the authorization path', async () => {
 		const submit = jest.fn();
-		render( { navigation: { submit } } );
-		await fillAddressField();
-		( wp.req.get as jest.Mock ).mockResolvedValueOnce( baseSiteInfo );
-		( wp.req.post as jest.Mock ).mockRejectedValueOnce( {
+		( wp.req.post as jest.Mock ).mockRejectedValue( {
 			code: 'failed_to_get_authorization_path',
 		} );
+
+		render( { navigation: { submit } } );
+		await fillAddressField();
 		await userEvent.click( continueButton() );
 
 		expect( submit ).toHaveBeenCalledWith( {
 			action: 'credentials-required',
-			from: 'https://site-url.wordpress.com',
+			from: 'https://external-site-url.com',
 			platform: 'wordpress',
-		} );
-	} );
-
-	it( 'submits application-passwords-approval action when using password application and application_passwords_enabled is enabled', async () => {
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-		await fillAddressField();
-		( wp.req.get as jest.Mock ).mockResolvedValueOnce( baseSiteInfo );
-		( wp.req.post as jest.Mock ).mockResolvedValueOnce( {
-			application_passwords_enabled: true,
-			authorization_url: 'https://site-url.wordpress.com/wp-admin/authorize-application.php',
-		} );
-		await userEvent.click( continueButton() );
-
-		expect( submit ).toHaveBeenCalledWith( {
-			action: 'application-passwords-approval',
-			from: 'https://site-url.wordpress.com',
-			platform: 'wordpress',
-			authorizationUrl: 'https://site-url.wordpress.com/wp-admin/authorize-application.php',
 		} );
 	} );
 
 	it( 'submits already-wpcom action when site is already WPCOM', async () => {
 		const submit = jest.fn();
-		render( { navigation: { submit } } );
-		await fillAddressField();
 		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingWPCOM );
 		( wpcomRequest as jest.Mock ).mockResolvedValue( {
 			status: 200,
 			body: {},
 		} );
+
+		render( { navigation: { submit } } );
+		await fillAddressField();
 		await userEvent.click( continueButton() );
 
 		expect( wpcomRequest ).toHaveBeenCalledWith( {
@@ -314,14 +309,15 @@ describe( 'SiteMigrationCredentials', () => {
 
 	it( 'submits site-is-not-using-wordpress action when platform is not wordpress', async () => {
 		const submit = jest.fn();
+		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingTumblr );
+
 		render( { navigation: { submit } } );
 		await fillAddressField();
-		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingTumblr );
 		await userEvent.click( continueButton() );
 
 		expect( submit ).toHaveBeenCalledWith( {
 			action: 'site-is-not-using-wordpress',
-			from: 'https://site-url.wordpress.com',
+			from: 'https://site-url.tumblr.com',
 			platform: 'tumblr',
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/test/index.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import config, { isEnabled } from '@automattic/calypso-config';
 import { waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -42,55 +41,18 @@ const messages = {
 const { getByRole, getByLabelText, getByTestId, getByText, findByText } = screen;
 
 const continueButton = ( name = /Continue/ ) => getByRole( 'button', { name } );
-const siteAddressInput = () =>
-	getByLabelText(
-		isEnabled( 'automated-migration/application-password' )
-			? 'Current WordPress site address'
-			: 'Current site address'
-	);
-const usernameInput = () => getByLabelText( 'WordPress admin username' );
-const passwordInput = () => getByLabelText( 'Password' );
+const siteAddressInput = () => getByLabelText( 'Current WordPress site address' );
 const backupOption = () => getByRole( 'radio', { name: 'Backup file' } );
-const credentialsOption = () =>
-	isEnabled( 'automated-migration/application-password' )
-		? getByRole( 'radio', { name: 'WordPress site credentials' } )
-		: getByRole( 'radio', { name: 'WordPress credentials' } );
+const credentialsOption = () => getByRole( 'radio', { name: 'WordPress site credentials' } );
 const backupFileInput = () => getByLabelText( 'Backup file location' );
 //TODO: it requires a testid because there is no accessible name, it is an issue with the component
 const specialInstructionsInput = () => getByTestId( 'special-instructions-textarea' );
 const specialInstructionsButton = () => getByRole( 'button', { name: 'Special instructions' } );
 const skipButton = () => getByRole( 'button', { name: /Let us guide you/ } );
 
-const fillAllFields = async () => {
-	await userEvent.click( credentialsOption() );
-	await userEvent.type( siteAddressInput(), 'site-url.com' );
-	await userEvent.type( usernameInput(), 'username' );
-	await userEvent.type( passwordInput(), 'password' );
-};
-
 const fillAddressField = async () => {
 	await userEvent.click( credentialsOption() );
 	await userEvent.type( siteAddressInput(), 'site-url.com' );
-};
-
-const fillNoteField = async () => {
-	await userEvent.click( specialInstructionsButton() );
-	await userEvent.type( specialInstructionsInput(), 'notes' );
-};
-
-const requestPayload = {
-	path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
-	apiNamespace: 'wpcom/v2',
-	method: 'POST',
-	body: {
-		migration_type: 'credentials',
-		blog_url: 'site-url.wordpress.com',
-		bypass_verification: true,
-		notes: 'notes',
-		from_url: 'site-url.com',
-		username: 'username',
-		password: 'password',
-	},
 };
 
 const baseSiteInfo = {
@@ -118,19 +80,7 @@ const siteInfoUsingWPCOM = {
 		is_wpcom: true,
 	},
 };
-
-const isApplicationPasswordEnabled = isEnabled( 'automated-migration/application-password' );
-const restaureIsApplicationPasswordEnabled = () => {
-	if ( isApplicationPasswordEnabled ) {
-		config.enable( 'automated-migration/application-password' );
-	} else {
-		config.disable( 'automated-migration/application-password' );
-	}
-};
-
-//TODO: Temporary skip for the test to remove the feature flag cases, they are causing a long running test.
-/* eslint-disable jest/no-disabled-tests */
-describe.skip( 'SiteMigrationCredentials', () => {
+describe( 'SiteMigrationCredentials', () => {
 	beforeAll( () => nock.disableNetConnect() );
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -138,89 +88,7 @@ describe.skip( 'SiteMigrationCredentials', () => {
 	} );
 	afterEach( () => {
 		jest.clearAllMocks();
-		restaureIsApplicationPasswordEnabled();
 		( wp.req.get as jest.Mock ).mockResolvedValue( siteInfoUsingWordPress );
-	} );
-
-	it( 'creates an automated migration ticket', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-
-		await userEvent.click( credentialsOption() );
-		await userEvent.type( siteAddressInput(), 'site-url.com' );
-		await userEvent.type( usernameInput(), 'username' );
-		await userEvent.type( passwordInput(), 'password' );
-
-		await userEvent.click( specialInstructionsButton() );
-		await userEvent.type( specialInstructionsInput(), 'notes' );
-		await userEvent.click( continueButton() );
-
-		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			body: {
-				migration_type: 'credentials',
-				blog_url: 'site-url.wordpress.com',
-				bypass_verification: false,
-				notes: 'notes',
-				from_url: 'site-url.com',
-				username: 'username',
-				password: 'password',
-			},
-		} );
-
-		await waitFor( () => {
-			expect( submit ).toHaveBeenCalledWith( {
-				action: 'submit',
-				from: 'https://site-url.wordpress.com',
-				platform: 'wordpress',
-			} );
-		} );
-	} );
-
-	it( 'creates a credentials ticket when site info fetching throws error', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-
-		await userEvent.click( credentialsOption() );
-		await userEvent.type( siteAddressInput(), 'site-url.com' );
-		await userEvent.type( usernameInput(), 'username' );
-		await userEvent.type( passwordInput(), 'password' );
-
-		await userEvent.click( specialInstructionsButton() );
-		await userEvent.type( specialInstructionsInput(), 'notes' );
-
-		( wp.req.get as jest.Mock ).mockRejectedValue( {
-			code: 'rest_other_error',
-			message: 'Error message from backend',
-		} );
-
-		await userEvent.click( continueButton() );
-
-		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			path: '/sites/site-url.wordpress.com/automated-migration?_locale=en',
-			apiNamespace: 'wpcom/v2',
-			method: 'POST',
-			body: {
-				migration_type: 'credentials',
-				blog_url: 'site-url.wordpress.com',
-				bypass_verification: false,
-				notes: 'notes',
-				from_url: 'site-url.com',
-				username: 'username',
-				password: 'password',
-			},
-		} );
-
-		await waitFor( () => {
-			expect( submit ).toHaveBeenCalledWith( {
-				action: 'submit',
-				platform: undefined,
-			} );
-		} );
 	} );
 
 	it( 'creates a credentials using backup file', async () => {
@@ -286,20 +154,6 @@ describe.skip( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'shows errors on the required fields when the user does not fill the fields when user select credentials option and application-password is disabled', async () => {
-		config.disable( 'automated-migration/application-password' );
-		render();
-
-		await userEvent.click( continueButton() );
-		await userEvent.click( credentialsOption() );
-
-		await waitFor( () => {
-			expect( getByText( messages.urlError ) ).toBeVisible();
-			expect( getByText( messages.usernameError ) ).toBeVisible();
-			expect( getByText( messages.passwordError ) ).toBeVisible();
-		} );
-	} );
-
 	it( 'shows errors on the required fields when the user does not fill the fields when user select backup option', async () => {
 		render();
 
@@ -318,33 +172,6 @@ describe.skip( 'SiteMigrationCredentials', () => {
 
 		await waitFor( () => {
 			expect( getByText( messages.noTLDError ) ).toBeVisible();
-		} );
-	} );
-
-	it( 'shows error messages by each field when the server returns "invalid param" by each field', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-
-		( wpcomRequest as jest.Mock ).mockRejectedValue( {
-			code: 'rest_invalid_param',
-			data: {
-				params: {
-					from_url: 'Invalid Param',
-					username: 'Invalid Param',
-					password: 'Invalid Param',
-					notes: 'Invalid Param',
-				},
-			},
-		} );
-
-		await fillAllFields();
-		await userEvent.click( continueButton() );
-		await waitFor( () => {
-			expect( getByText( /Enter a valid URL/ ) ).toBeVisible();
-			expect( getByText( /Enter a valid username/ ) ).toBeVisible();
-			expect( getByText( /Enter a valid password/ ) ).toBeVisible();
-			expect( submit ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -371,44 +198,6 @@ describe.skip( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'shows an error message when the server returns a generic error', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-
-		( wpcomRequest as jest.Mock ).mockRejectedValue( {
-			code: 'rest_other_error',
-			message: 'Error message from backend',
-		} );
-
-		await fillAllFields();
-		await userEvent.click( continueButton() );
-
-		await waitFor( () => {
-			expect( getByText( /Error message from backend/ ) ).toBeVisible();
-		} );
-		expect( submit ).not.toHaveBeenCalled();
-	} );
-
-	it( 'shows an generic error when server doesn`t return error and shows normal Continue button', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-
-		( wpcomRequest as jest.Mock ).mockRejectedValue( {} );
-
-		await fillAllFields();
-		await userEvent.click( continueButton() );
-
-		await waitFor( () => {
-			expect( getByText( /An error occurred while saving credentials./ ) ).toBeVisible();
-		} );
-
-		await waitFor( () => {
-			expect( continueButton() ).toBeVisible();
-		} );
-	} );
-
 	it( 'shows a notice when URL contains error=ticket-creation', async () => {
 		const submit = jest.fn();
 		const initialEntry = '/site-migration-credentials?error=ticket-creation';
@@ -424,22 +213,6 @@ describe.skip( 'SiteMigrationCredentials', () => {
 		} );
 	} );
 
-	it( 'shows "Verifying credentials" on the Continue button during submission', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-		const pendingPromise = new Promise( () => {} );
-
-		( wpcomRequest as jest.Mock ).mockImplementation( () => pendingPromise );
-
-		await fillAllFields();
-		userEvent.click( continueButton() );
-
-		await waitFor( () => {
-			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
-		} );
-	} );
-
 	it( 'shows "Scanning site" on the Continue button during submission with application password', async () => {
 		const submit = jest.fn();
 		render( { navigation: { submit } } );
@@ -452,121 +225,6 @@ describe.skip( 'SiteMigrationCredentials', () => {
 
 		await waitFor( () => {
 			expect( continueButton( /Scanning site/ ) ).toBeVisible();
-		} );
-	} );
-
-	it( 'shows error message when inputed credentials fail to log in', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-
-		( wpcomRequest as jest.Mock ).mockRejectedValue( {
-			code: 'automated_migration_tools_login_and_get_cookies_test_failed',
-			data: {
-				response_code: 404,
-			},
-		} );
-
-		await fillAllFields();
-		await userEvent.click( continueButton() );
-
-		await waitFor( () => {
-			expect( getByText( 'Check your site address.' ) ).toBeVisible();
-		} );
-	} );
-
-	it.each( [
-		{
-			response_code: 404,
-			errorMessage: 'Check your site address.',
-		},
-		{
-			response_code: 401,
-			errorMessage: 'Check your username.',
-		},
-		{
-			response_code: 401,
-			errorMessage: 'Check your password.',
-		},
-	] )(
-		'shows error message for %p verification error',
-		async ( { response_code, errorMessage } ) => {
-			config.disable( 'automated-migration/application-password' );
-			const submit = jest.fn();
-			render( { navigation: { submit } } );
-
-			( wpcomRequest as jest.Mock ).mockRejectedValue( {
-				code: 'automated_migration_tools_login_and_get_cookies_test_failed',
-				data: {
-					response_code,
-				},
-			} );
-
-			await fillAllFields();
-			await userEvent.click( continueButton() );
-
-			await waitFor( () => {
-				expect( continueButton( /Continue anyways/ ) ).toBeVisible();
-				expect(
-					getByText(
-						'We could not verify your credentials. Can you double check your account information and try again?'
-					)
-				).toBeVisible();
-				expect( getByText( errorMessage ) ).toBeVisible();
-			} );
-		}
-	);
-
-	it( 'creates a credentials ticket even when the siteinfo request faces an error', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-		await fillAllFields();
-		await fillNoteField();
-
-		( wp.req.get as jest.Mock ).mockRejectedValue( {
-			code: 'rest_other_error',
-			message: 'Error message from backend',
-		} );
-
-		( wpcomRequest as jest.Mock ).mockResolvedValue( {
-			status: 200,
-			body: {},
-		} );
-
-		await userEvent.click( continueButton() );
-
-		expect( wpcomRequest ).toHaveBeenCalledWith( {
-			...requestPayload,
-			body: {
-				...requestPayload.body,
-				bypass_verification: false,
-			},
-		} );
-
-		await waitFor( () => {
-			expect( submit ).toHaveBeenCalledWith( { action: 'submit' } );
-		} );
-	} );
-
-	it( 'shows "Verifying credentials" on the Continue button during submission when fetching site info', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-		const pendingPromise = new Promise( () => {} );
-
-		( wpcomRequest as jest.Mock ).mockResolvedValue( {
-			status: 200,
-			body: {},
-		} );
-
-		( wp.req.get as jest.Mock ).mockImplementation( () => pendingPromise );
-
-		await fillAllFields();
-		await userEvent.click( continueButton() );
-
-		await waitFor( () => {
-			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
 		} );
 	} );
 
@@ -587,23 +245,6 @@ describe.skip( 'SiteMigrationCredentials', () => {
 
 		await waitFor( () => {
 			expect( continueButton( /Scanning site/ ) ).toBeVisible();
-		} );
-	} );
-
-	it( 'shows "Verifying credentials" on the Continue button during site info verification', async () => {
-		config.disable( 'automated-migration/application-password' );
-		const submit = jest.fn();
-		render( { navigation: { submit } } );
-		const pendingPromise = new Promise( () => {} );
-
-		await fillAllFields();
-
-		( wpcomRequest as jest.Mock ).mockImplementation( () => pendingPromise );
-
-		await userEvent.click( continueButton() );
-
-		await waitFor( () => {
-			expect( continueButton( /Verifying credentials/ ) ).toBeVisible();
 		} );
 	} );
 

--- a/config/development.json
+++ b/config/development.json
@@ -35,7 +35,6 @@
 		"a4a-dev-sites": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,6 @@
 		"100-year-plan/vip": true,
 		"a4a-dev-sites": true,
 		"ad-tracking": false,
-		"automated-migration/application-password": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,

--- a/config/production.json
+++ b/config/production.json
@@ -24,7 +24,6 @@
 		"a4a-dev-sites": true,
 		"ad-tracking": true,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": true,
 		"bilmur-script": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,7 +23,6 @@
 		"a4a-dev-sites": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,

--- a/config/test.json
+++ b/config/test.json
@@ -26,7 +26,6 @@
 		"a4a-dev-sites": true,
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": true,
 		"calypso/all-domain-management": true,
 		"calypso/domains-dataviews": true,
 		"cancellation-offers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,7 +22,6 @@
 		"ad-tracking": false,
 		"a4a-dev-sites": true,
 		"akismet/checkout-quantity-dropdown": true,
-		"automated-migration/application-password": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/all-domain-management": true,


### PR DESCRIPTION
## Proposed Changes
* Remove all code and references to the `automated-migration/application-password` feature flag

## Why are these changes being made?
The feature was enabled 3 months ago with no issue.

## Testing Instructions
* Visual inspection should be enough 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
