### PR TITLE
Self Service Downgrades: Use cancellation related features to highlight downgrade

### DIFF
--- a/client/me/purchases/downgrade/index.tsx
+++ b/client/me/purchases/downgrade/index.tsx
@@ -123,7 +123,7 @@ export const Downgrade: React.FC< DowngradeProps > = ( props ) => {
 	const featureSlugs = getFeatureDifference(
 		downgradePath[ purchase?.productSlug ?? '' ],
 		purchase?.productSlug ?? '',
-		'getCheckoutFeatures'
+		'getCancellationFeatures'
 	);
 	const features = featureSlugs.map( ( slug ) => getFeatureByKey( slug ) );
 	const isAtomicSiteDowngrade =

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -952,12 +952,12 @@ export function getFeatureByKey( feature: string ) {
 export function getFeatureDifference(
 	smallerPlan: string,
 	biggerPlan: string,
-	featureBundleSelector: keyof Plan
+	featureBundleSelector: keyof WPComPlan
 ) {
-	let biggerPlanObject = ( getPlan( biggerPlan ) as Plan )?.[ featureBundleSelector ] as
+	let biggerPlanObject = ( getPlan( biggerPlan ) as WPComPlan )?.[ featureBundleSelector ] as
 		| Array< string >
 		| ( () => Array< string > );
-	let smallerPlanObject = ( getPlan( smallerPlan ) as Plan )?.[ featureBundleSelector ] as
+	let smallerPlanObject = ( getPlan( smallerPlan ) as WPComPlan )?.[ featureBundleSelector ] as
 		| Array< string >
 		| ( () => Array< string > );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-3vt-p2#comment-6737

## Proposed Changes

### Ecommerce Downgrade
<img width="900" alt="image" src="https://github.com/user-attachments/assets/d60e0546-0e4c-4879-8264-2fe4ed5ddb3a" />


### Business Downgrade
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/409a2547-4953-4121-a5af-18a06979765c" />


### Premium Downgrade
<img width="900" alt="image" src="https://github.com/user-attachments/assets/cce4fa18-dd03-441c-b4d4-73a3e8616902" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Parts of the CtT feeback of the Self-Service Downgrade feature

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Got to purchases -> Downgrade for a paid plan
* Ensure the feature lists matches the Cancel flow equivalent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?