### PR TITLE
Move payment method state to PaymentMethodProvider

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -714,7 +714,7 @@ export default function CheckoutMain( {
 			paymentMethodId,
 		}: {
 			transactionError: string | null;
-			paymentMethodId: string | null;
+			paymentMethodId: string | null | undefined;
 		} ) => {
 			const errorNoticeText = transactionError ? (
 				<div dangerouslySetInnerHTML={ { __html: DOMPurify.sanitize( transactionError ) } } /> // eslint-disable-line react/no-danger -- The API response can contain anchor elements that we need to parse so they are rendered properly

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -5,6 +5,7 @@ import debugFactory from 'debug';
 import { useCallback, useContext } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import joinClasses from '../lib/join-classes';
+import { PaymentMethodProviderContext } from '../lib/payment-method-provider-context';
 import { useAvailablePaymentMethodIds } from '../lib/payment-methods';
 import {
 	useAllPaymentMethods,
@@ -39,7 +40,8 @@ export default function CheckoutPaymentMethods( {
 	className?: string;
 } ) {
 	const { __ } = useI18n();
-	const { onPageLoadError, onPaymentMethodChanged } = useContext( CheckoutContext );
+	const { onPageLoadError } = useContext( CheckoutContext );
+	const { onPaymentMethodChanged } = useContext( PaymentMethodProviderContext );
 	const onError = useCallback(
 		( error: Error ) => onPageLoadError?.( 'payment_method_load', error ),
 		[ onPageLoadError ]

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -1,14 +1,15 @@
 import { ThemeProvider } from '@emotion/react';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import CheckoutContext from '../lib/checkout-context';
 import defaultTheme from '../lib/theme';
 import { validateArg, validatePaymentMethods } from '../lib/validation';
 import { CheckoutProviderProps } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { FormAndTransactionProvider } from './form-and-transaction-provider';
-import type { CheckoutContextInterface, PaymentMethod } from '../types';
+import { PaymentMethodProvider } from './payment-method-provider';
+import type { CheckoutContextInterface } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
@@ -17,7 +18,6 @@ export function CheckoutProvider( {
 	onPaymentRedirect,
 	onPaymentError,
 	onPageLoadError,
-	onPaymentMethodChanged,
 	redirectToUrl,
 	theme,
 	paymentMethods,
@@ -39,57 +39,13 @@ export function CheckoutProvider( {
 		initiallySelectedPaymentMethodId,
 	};
 
-	// Keep track of enabled/disabled payment methods.
-	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >(
-		paymentMethods.filter( ( method ) => method.isInitiallyDisabled ).map( ( method ) => method.id )
-	);
-	const availablePaymentMethodIds = paymentMethods
-		.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
-		.map( ( method ) => method.id );
-
-	// Automatically select first payment method unless explicitly set or disabled.
-	if (
-		selectFirstAvailablePaymentMethod &&
-		! initiallySelectedPaymentMethodId &&
-		availablePaymentMethodIds.length > 0
-	) {
-		initiallySelectedPaymentMethodId = availablePaymentMethodIds[ 0 ];
-	}
-
-	// Keep track of selected payment method.
-	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null >(
-		initiallySelectedPaymentMethodId
-	);
-
-	useDisablePaymentMethodsWhenListChanges( paymentMethods, setDisabledPaymentMethodIds );
-
-	// Reset the selected payment method if the list of payment methods changes.
-	useResetSelectedPaymentMethodWhenListChanges(
-		availablePaymentMethodIds,
-		initiallySelectedPaymentMethodId,
-		setPaymentMethodId
-	);
-
 	// Create a big blob of state to store in React Context for use by all this Provider's children.
 	const value: CheckoutContextInterface = useMemo(
 		() => ( {
-			allPaymentMethods: paymentMethods,
-			disabledPaymentMethodIds,
-			setDisabledPaymentMethodIds,
-			paymentMethodId,
-			setPaymentMethodId,
 			paymentProcessors,
 			onPageLoadError,
-			onPaymentMethodChanged,
 		} ),
-		[
-			paymentMethodId,
-			paymentMethods,
-			disabledPaymentMethodIds,
-			paymentProcessors,
-			onPageLoadError,
-			onPaymentMethodChanged,
-		]
+		[ paymentProcessors, onPageLoadError ]
 	);
 
 	const { __ } = useI18n();
@@ -103,18 +59,24 @@ export function CheckoutProvider( {
 	return (
 		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onLoadError }>
 			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
-			<ThemeProvider theme={ theme || defaultTheme }>
-				<FormAndTransactionProvider
-					onPaymentComplete={ onPaymentComplete }
-					onPaymentRedirect={ onPaymentRedirect }
-					onPaymentError={ onPaymentError }
-					isLoading={ isLoading }
-					isValidating={ isValidating }
-					redirectToUrl={ redirectToUrl }
-				>
-					<CheckoutContext.Provider value={ value }>{ children }</CheckoutContext.Provider>
-				</FormAndTransactionProvider>
-			</ThemeProvider>
+			<PaymentMethodProvider
+				paymentMethods={ paymentMethods }
+				selectFirstAvailablePaymentMethod={ selectFirstAvailablePaymentMethod }
+				initiallySelectedPaymentMethodId={ initiallySelectedPaymentMethodId }
+			>
+				<ThemeProvider theme={ theme || defaultTheme }>
+					<FormAndTransactionProvider
+						onPaymentComplete={ onPaymentComplete }
+						onPaymentRedirect={ onPaymentRedirect }
+						onPaymentError={ onPaymentError }
+						isLoading={ isLoading }
+						isValidating={ isValidating }
+						redirectToUrl={ redirectToUrl }
+					>
+						<CheckoutContext.Provider value={ value }>{ children }</CheckoutContext.Provider>
+					</FormAndTransactionProvider>
+				</ThemeProvider>
+			</PaymentMethodProvider>
 		</CheckoutErrorBoundary>
 	);
 }
@@ -138,62 +100,4 @@ function CheckoutProviderPropValidator( {
 		validatePaymentMethods( paymentMethods );
 	}, [ paymentMethods, paymentProcessors, propsToValidate ] );
 	return null;
-}
-
-function useDisablePaymentMethodsWhenListChanges(
-	paymentMethods: PaymentMethod[],
-	setDisabledPaymentMethodIds: ( setter: ( ids: string[] ) => string[] ) => void
-) {
-	const previousPaymentMethodIds = useRef< string[] >( [] );
-
-	const initiallyDisabledPaymentMethodIds = paymentMethods
-		.filter( ( method ) => method.isInitiallyDisabled )
-		.map( ( method ) => method.id );
-
-	const newInitiallyDisabledPaymentMethodIds = initiallyDisabledPaymentMethodIds.filter(
-		( id ) => ! previousPaymentMethodIds.current.includes( id )
-	);
-
-	const paymentMethodIdsHash = paymentMethods.map( ( method ) => method.id ).join( '-_-' );
-	const previousPaymentMethodIdsHash = useRef< string >();
-
-	useEffect( () => {
-		if ( previousPaymentMethodIdsHash.current !== paymentMethodIdsHash ) {
-			debug( 'paymentMethods changed; disabling any new isInitiallyDisabled payment methods' );
-
-			setDisabledPaymentMethodIds( ( currentlyDisabledIds: string[] ) => [
-				...currentlyDisabledIds,
-				...newInitiallyDisabledPaymentMethodIds,
-			] );
-			previousPaymentMethodIdsHash.current = paymentMethodIdsHash;
-			previousPaymentMethodIds.current = paymentMethods.map( ( method ) => method.id );
-		}
-	}, [
-		paymentMethodIdsHash,
-		setDisabledPaymentMethodIds,
-		paymentMethods,
-		newInitiallyDisabledPaymentMethodIds,
-	] );
-}
-
-// Reset the selected payment method if the list of payment methods changes.
-function useResetSelectedPaymentMethodWhenListChanges(
-	availablePaymentMethodIds: string[],
-	initiallySelectedPaymentMethodId: string | null,
-	setPaymentMethodId: ( id: string | null ) => void
-) {
-	const hashKey = availablePaymentMethodIds.join( '-_-' );
-	const previousKey = useRef< string >();
-
-	useEffect( () => {
-		if ( previousKey.current !== hashKey ) {
-			debug(
-				'paymentMethods changed; setting payment method to initial selection ',
-				initiallySelectedPaymentMethodId
-			);
-
-			previousKey.current = hashKey;
-			setPaymentMethodId( initiallySelectedPaymentMethodId );
-		}
-	}, [ hashKey, setPaymentMethodId, initiallySelectedPaymentMethodId ] );
 }

--- a/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
+++ b/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
@@ -119,7 +119,7 @@ function useCallStatusChangeCallbacks( {
 	onPaymentError?: PaymentErrorCallback;
 	transactionError: string | null;
 	transactionStatus: TransactionStatus;
-	paymentMethodId: string | null;
+	paymentMethodId: string | null | undefined;
 	transactionLastResponse: PaymentProcessorResponseData;
 } ): void {
 	// Store the callbacks as refs so we do not call them more than once if they

--- a/packages/composite-checkout/src/components/payment-method-provider.tsx
+++ b/packages/composite-checkout/src/components/payment-method-provider.tsx
@@ -1,0 +1,131 @@
+import debugFactory from 'debug';
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { PaymentMethodProviderContext } from '../lib/payment-method-provider-context';
+import type {
+	PaymentMethod,
+	PaymentMethodChangedCallback,
+	PaymentMethodProviderContextInterface,
+} from '../types';
+
+const debug = debugFactory( 'composite-checkout:payment-method-provider' );
+
+export function PaymentMethodProvider( {
+	paymentMethods,
+	selectFirstAvailablePaymentMethod,
+	initiallySelectedPaymentMethodId,
+	onPaymentMethodChanged,
+	children,
+}: {
+	paymentMethods: PaymentMethod[];
+	selectFirstAvailablePaymentMethod?: boolean;
+	initiallySelectedPaymentMethodId?: string | null;
+	onPaymentMethodChanged?: PaymentMethodChangedCallback;
+	children: React.ReactNode;
+} ) {
+	// Keep track of enabled/disabled payment methods.
+	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >(
+		paymentMethods.filter( ( method ) => method.isInitiallyDisabled ).map( ( method ) => method.id )
+	);
+	const availablePaymentMethodIds = paymentMethods
+		.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
+		.map( ( method ) => method.id );
+
+	// Automatically select first payment method unless explicitly set or disabled.
+	if (
+		selectFirstAvailablePaymentMethod &&
+		! initiallySelectedPaymentMethodId &&
+		availablePaymentMethodIds.length > 0
+	) {
+		initiallySelectedPaymentMethodId = availablePaymentMethodIds[ 0 ];
+	}
+
+	// Keep track of selected payment method.
+	const [ paymentMethodId, setPaymentMethodId ] = useState< string | null | undefined >(
+		initiallySelectedPaymentMethodId
+	);
+
+	useDisablePaymentMethodsWhenListChanges( paymentMethods, setDisabledPaymentMethodIds );
+
+	// Reset the selected payment method if the list of payment methods changes.
+	useResetSelectedPaymentMethodWhenListChanges(
+		availablePaymentMethodIds,
+		initiallySelectedPaymentMethodId,
+		setPaymentMethodId
+	);
+
+	const value: PaymentMethodProviderContextInterface = useMemo(
+		() => ( {
+			allPaymentMethods: paymentMethods,
+			disabledPaymentMethodIds,
+			setDisabledPaymentMethodIds,
+			paymentMethodId,
+			setPaymentMethodId,
+			onPaymentMethodChanged,
+		} ),
+		[ paymentMethodId, paymentMethods, disabledPaymentMethodIds, onPaymentMethodChanged ]
+	);
+
+	return (
+		<PaymentMethodProviderContext.Provider value={ value }>
+			{ children }
+		</PaymentMethodProviderContext.Provider>
+	);
+}
+
+function useDisablePaymentMethodsWhenListChanges(
+	paymentMethods: PaymentMethod[],
+	setDisabledPaymentMethodIds: ( setter: ( ids: string[] ) => string[] ) => void
+) {
+	const previousPaymentMethodIds = useRef< string[] >( [] );
+
+	const initiallyDisabledPaymentMethodIds = paymentMethods
+		.filter( ( method ) => method.isInitiallyDisabled )
+		.map( ( method ) => method.id );
+
+	const newInitiallyDisabledPaymentMethodIds = initiallyDisabledPaymentMethodIds.filter(
+		( id ) => ! previousPaymentMethodIds.current.includes( id )
+	);
+
+	const paymentMethodIdsHash = paymentMethods.map( ( method ) => method.id ).join( '-_-' );
+	const previousPaymentMethodIdsHash = useRef< string >();
+
+	useEffect( () => {
+		if ( previousPaymentMethodIdsHash.current !== paymentMethodIdsHash ) {
+			debug( 'paymentMethods changed; disabling any new isInitiallyDisabled payment methods' );
+
+			setDisabledPaymentMethodIds( ( currentlyDisabledIds: string[] ) => [
+				...currentlyDisabledIds,
+				...newInitiallyDisabledPaymentMethodIds,
+			] );
+			previousPaymentMethodIdsHash.current = paymentMethodIdsHash;
+			previousPaymentMethodIds.current = paymentMethods.map( ( method ) => method.id );
+		}
+	}, [
+		paymentMethodIdsHash,
+		setDisabledPaymentMethodIds,
+		paymentMethods,
+		newInitiallyDisabledPaymentMethodIds,
+	] );
+}
+
+// Reset the selected payment method if the list of payment methods changes.
+function useResetSelectedPaymentMethodWhenListChanges(
+	availablePaymentMethodIds: string[],
+	initiallySelectedPaymentMethodId: string | null | undefined,
+	setPaymentMethodId: ( id: string | null | undefined ) => void
+) {
+	const hashKey = availablePaymentMethodIds.join( '-_-' );
+	const previousKey = useRef< string >();
+
+	useEffect( () => {
+		if ( previousKey.current !== hashKey ) {
+			debug(
+				'paymentMethods changed; setting payment method to initial selection ',
+				initiallySelectedPaymentMethodId
+			);
+
+			previousKey.current = hashKey;
+			setPaymentMethodId( initiallySelectedPaymentMethodId );
+		}
+	}, [ hashKey, setPaymentMethodId, initiallySelectedPaymentMethodId ] );
+}

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -2,16 +2,8 @@ import { createContext } from 'react';
 import { CheckoutContextInterface } from '../types';
 
 const defaultCheckoutContext: CheckoutContextInterface = {
-	allPaymentMethods: [],
-	disabledPaymentMethodIds: [],
-	setDisabledPaymentMethodIds: noop,
-	paymentMethodId: null,
-	setPaymentMethodId: noop,
 	paymentProcessors: {},
 };
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-function noop(): void {}
 
 const CheckoutContext = createContext( defaultCheckoutContext );
 

--- a/packages/composite-checkout/src/lib/payment-method-provider-context.ts
+++ b/packages/composite-checkout/src/lib/payment-method-provider-context.ts
@@ -1,0 +1,15 @@
+import { createContext } from 'react';
+import { PaymentMethodProviderContextInterface } from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop(): void {}
+
+const defaultContext: PaymentMethodProviderContextInterface = {
+	allPaymentMethods: [],
+	disabledPaymentMethodIds: [],
+	setDisabledPaymentMethodIds: noop,
+	paymentMethodId: null,
+	setPaymentMethodId: noop,
+};
+
+export const PaymentMethodProviderContext = createContext( defaultContext );

--- a/packages/composite-checkout/src/lib/payment-methods/index.ts
+++ b/packages/composite-checkout/src/lib/payment-methods/index.ts
@@ -1,12 +1,12 @@
 import debugFactory from 'debug';
 import { useContext, useMemo } from 'react';
-import CheckoutContext from '../checkout-context';
+import { PaymentMethodProviderContext } from '../payment-method-provider-context';
 import type { PaymentMethod, TogglePaymentMethod } from '../../types';
 
 const debug = debugFactory( 'composite-checkout:payment-methods' );
 
-export function usePaymentMethodId(): [ string | null, ( id: string ) => void ] {
-	const { paymentMethodId, setPaymentMethodId } = useContext( CheckoutContext );
+export function usePaymentMethodId(): [ string | null | undefined, ( id: string ) => void ] {
+	const { paymentMethodId, setPaymentMethodId } = useContext( PaymentMethodProviderContext );
 	if ( ! setPaymentMethodId ) {
 		throw new Error( 'usePaymentMethodId can only be used inside a CheckoutProvider' );
 	}
@@ -14,7 +14,7 @@ export function usePaymentMethodId(): [ string | null, ( id: string ) => void ] 
 }
 
 export function usePaymentMethod(): PaymentMethod | null {
-	const { paymentMethodId, setPaymentMethodId } = useContext( CheckoutContext );
+	const { paymentMethodId, setPaymentMethodId } = useContext( PaymentMethodProviderContext );
 	const allPaymentMethods = useAllPaymentMethods();
 	if ( ! setPaymentMethodId ) {
 		throw new Error( 'usePaymentMethod can only be used inside a CheckoutProvider' );
@@ -31,7 +31,7 @@ export function usePaymentMethod(): PaymentMethod | null {
 }
 
 export function useAllPaymentMethods() {
-	const { allPaymentMethods } = useContext( CheckoutContext );
+	const { allPaymentMethods } = useContext( PaymentMethodProviderContext );
 	if ( ! allPaymentMethods ) {
 		throw new Error( 'useAllPaymentMethods cannot be used outside of CheckoutProvider' );
 	}
@@ -39,7 +39,9 @@ export function useAllPaymentMethods() {
 }
 
 export function useAvailablePaymentMethodIds(): string[] {
-	const { allPaymentMethods, disabledPaymentMethodIds } = useContext( CheckoutContext );
+	const { allPaymentMethods, disabledPaymentMethodIds } = useContext(
+		PaymentMethodProviderContext
+	);
 	if ( ! allPaymentMethods ) {
 		throw new Error( 'useAvailablePaymentMethodIds cannot be used outside of CheckoutProvider' );
 	}
@@ -53,8 +55,9 @@ export function useAvailablePaymentMethodIds(): string[] {
 }
 
 export function useTogglePaymentMethod(): TogglePaymentMethod {
-	const { allPaymentMethods, disabledPaymentMethodIds, setDisabledPaymentMethodIds } =
-		useContext( CheckoutContext );
+	const { allPaymentMethods, disabledPaymentMethodIds, setDisabledPaymentMethodIds } = useContext(
+		PaymentMethodProviderContext
+	);
 	if ( ! allPaymentMethods ) {
 		throw new Error( 'useTogglePaymentMethod cannot be used outside of CheckoutProvider' );
 	}

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -85,15 +85,18 @@ export type FormStatusManager = {
 	setFormStatus: FormStatusSetter;
 };
 
-export interface CheckoutContextInterface {
+export interface PaymentMethodProviderContextInterface {
 	allPaymentMethods: PaymentMethod[];
 	disabledPaymentMethodIds: string[];
 	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
-	paymentMethodId: string | null;
+	paymentMethodId: string | null | undefined;
 	setPaymentMethodId: ( id: string ) => void;
+	onPaymentMethodChanged?: PaymentMethodChangedCallback;
+}
+
+export interface CheckoutContextInterface {
 	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
-	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 }
 
 export type ReactStandardAction< T = string, P = unknown > = P extends void
@@ -132,7 +135,7 @@ export type StepChangedCallback = ( args: StepChangedEventArguments ) => void;
 export type PaymentMethodChangedCallback = ( method: string ) => void;
 export type PaymentEventCallback = ( args: PaymentEventCallbackArguments ) => void;
 export type PaymentErrorCallback = ( args: {
-	paymentMethodId: string | null;
+	paymentMethodId: string | null | undefined;
 	transactionError: string | null;
 } ) => void;
 export type CheckoutPageErrorCallback = (


### PR DESCRIPTION
## Proposed Changes

`CheckoutProvider` does too much. Previous efforts have been made (https://github.com/Automattic/wp-calypso/pull/81796, https://github.com/Automattic/wp-calypso/pull/81793, https://github.com/Automattic/wp-calypso/pull/80529) to move toward making it just a wrapper for a series of other providers (perhaps eventually replacing it entirely?), but there's still state that it maintains.

This PR moves all the state having to do with the list of payment methods to a new provider, `PaymentMethodProvider`. 

## Testing Instructions

Automated tests should handle most things.