### PR TITLE
Revert "Self Service Downgrade: Disable downgrade buttons on plans grid"

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -461,7 +461,7 @@ describe( 'useGenerateActionHook', () => {
 
 		const action = result.current( { planSlug: PLAN_PERSONAL, availableForPurchase: false } );
 
-		expect( action.primary.text ).toBe( 'Requires downgrade' );
-		expect( action.primary.status ).toBe( 'disabled' );
+		expect( action.primary.text ).toBe( 'Downgrade' );
+		expect( action.primary.variant ).toBe( 'secondary' );
 	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	type PlanSlug,
 	isFreePlan,
@@ -424,15 +423,6 @@ function getLoggedInPlansAction( {
 
 	// Downgrade action if the plan is not available for purchase
 	if ( ! availableForPurchase ) {
-		if ( isEnabled( 'plans/self-service-downgrade' ) ) {
-			return {
-				primary: {
-					callback: () => {},
-					text: translate( 'Requires downgrade' ),
-					status: 'disabled',
-				},
-			};
-		}
 		return createLoggedInPlansAction( translate( 'Downgrade', { context: 'verb' } ), 'secondary' );
 	}
 

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -241,10 +241,8 @@
 	&.is-top-buttons {
 		padding: 0 20px;
 		@include plans-grid-medium-large {
-			button {
-				margin-top: 16px;
-				margin-bottom: 16px;
-			}
+			padding-top: 16px;
+			padding-bottom: 16px;
 		}
 	}
 

--- a/packages/plans-grid-next/src/components/plan-button/style.scss
+++ b/packages/plans-grid-next/src/components/plan-button/style.scss
@@ -21,7 +21,7 @@
 			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-wordpress-blue-50);
 		}
 
-		&:hover:not([disabled]) {
+		&:hover {
 			background-color: var(--studio-wordpress-blue-60);
 		}
 
@@ -34,7 +34,7 @@
 			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-wordpress-blue-60);
 		}
 
-		&:hover:not([disabled]) {
+		&:hover {
 			background-color: var(--studio-wordpress-blue-70);
 		}
 	}
@@ -46,7 +46,7 @@
 			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-wordpress-blue-70);
 		}
 
-		&:hover:not([disabled]) {
+		&:hover {
 			background-color: var(--studio-wordpress-blue-80);
 		}
 	}
@@ -58,7 +58,7 @@
 			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-woocommerce-purple-60);
 		}
 
-		&:hover:not([disabled]) {
+		&:hover {
 			background-color: var(--studio-woocommerce-purple-70);
 		}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101888

Breaks hover in the highlighted plan