### PR TITLE
Self Service Downgrades : Show correct atomic transfer date in atomic warning screen

### DIFF
--- a/client/me/purchases/downgrade/atomic-warning.tsx
+++ b/client/me/purchases/downgrade/atomic-warning.tsx
@@ -41,11 +41,11 @@ export function AtomicWarning( {
 
 	useEffect( () => {
 		if ( purchase?.siteId ) {
-			dispatch( fetchAtomicTransfer( purchase.siteId ) );
+			dispatch( fetchAtomicTransfer( purchase.siteId as any ) );
 		}
 	}, [ dispatch, purchase?.siteId ] );
 
-	const atomicTransfer = useSelector( ( state ) => getAtomicTransfer( state, purchase.siteId ) );
+	const atomicTransfer = useSelector( ( state ) => getAtomicTransfer( state, purchase?.siteId ) );
 
 	const translate = useTranslate();
 	return (

--- a/client/me/purchases/downgrade/atomic-warning.tsx
+++ b/client/me/purchases/downgrade/atomic-warning.tsx
@@ -1,11 +1,12 @@
 import { WPCOM_FEATURES_BACKUPS, WPComPlan } from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import { AtomicRevertStep } from 'calypso/components/marketing-survey/cancel-purchase-form/step-components/atomic-revert-step';
 import { Purchase } from 'calypso/lib/purchases/types';
-import { useSelector } from 'calypso/state';
+import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 
@@ -36,7 +37,16 @@ export function AtomicWarning( {
 	const hasBackupsFeature = useSelector( ( state ) =>
 		siteHasFeature( state, site.ID, WPCOM_FEATURES_BACKUPS )
 	);
-	const atomicTransfer = useSelector( ( state ) => getAtomicTransfer( state, site.siteId ) );
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( purchase?.siteId ) {
+			dispatch( fetchAtomicTransfer( purchase.siteId ) );
+		}
+	}, [ dispatch, purchase?.siteId ] );
+
+	const atomicTransfer = useSelector( ( state ) => getAtomicTransfer( state, purchase.siteId ) );
+
 	const translate = useTranslate();
 	return (
 		<div className="atomic-warning__wrapper">

--- a/client/me/purchases/downgrade/atomic-warning.tsx
+++ b/client/me/purchases/downgrade/atomic-warning.tsx
@@ -9,6 +9,7 @@ import { Purchase } from 'calypso/lib/purchases/types';
 import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import type { CalypsoDispatch } from 'calypso/state/types';
 
 interface AtomicWarningProps {
 	purchaseRoot: string;
@@ -37,11 +38,11 @@ export function AtomicWarning( {
 	const hasBackupsFeature = useSelector( ( state ) =>
 		siteHasFeature( state, site.ID, WPCOM_FEATURES_BACKUPS )
 	);
-	const dispatch = useDispatch();
+	const dispatch = useDispatch< CalypsoDispatch >();
 
 	useEffect( () => {
 		if ( purchase?.siteId ) {
-			dispatch( fetchAtomicTransfer( purchase.siteId as any ) );
+			dispatch( fetchAtomicTransfer( purchase.siteId ) );
 		}
 	}, [ dispatch, purchase?.siteId ] );
 

--- a/client/me/purchases/downgrade/atomic-warning.tsx
+++ b/client/me/purchases/downgrade/atomic-warning.tsx
@@ -33,7 +33,7 @@ export function AtomicWarning( {
 }: AtomicWarningProps ) {
 	const [ atomicRevertCheckOne, setAtomicRevertCheckOne ] = useState( false );
 	const [ atomicRevertCheckTwo, setAtomicRevertCheckTwo ] = useState( false );
-	const [ enableLosslessRevert, setEnableLosslessRevert ] = useState( false );
+	const [ enableLosslessRevert, setEnableLosslessRevert ] = useState( true );
 	const hasBackupsFeature = useSelector( ( state ) =>
 		siteHasFeature( state, site.ID, WPCOM_FEATURES_BACKUPS )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-3vt-p2#comment-6726

## Proposed Changes

* Shows the correct atomic transfer date on the warning screen
* Default the lossless revert radio to true

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We need to show the correct atomic transfer date for the Self Service Downgrade.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the purchases screen on an Atomic plan
* Proceed to Downgrade the plan
* The date indicated on the top should match the moment the site became atomic
* The Recover posts, pages, media radio should be enabled by default
<img width="865" alt="Screenshot 2025-03-27 at 16 50 10" src="https://github.com/user-attachments/assets/334b2690-df73-4012-89c3-1996a4c187fa" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?