### PR TITLE
Subscribers: Fix email subscription missing translations

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -286,7 +286,7 @@ const SubscriberDataViews = ( {
 				),
 				elements: [
 					{
-						label: SubscribersStatus.Subscribed,
+						label: SubscribersStatus[ 'Subscribed' ],
 						value: SubscribersFilterBy.EmailSubscriber,
 					},
 					{

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -285,13 +285,22 @@ const SubscriberDataViews = ( {
 					</div>
 				),
 				elements: [
-					{ label: SubscribersStatus.Subscribed, value: SubscribersFilterBy.EmailSubscriber },
-					{ label: SubscribersStatus.NotSubscribed, value: SubscribersFilterBy.ReaderSubscriber },
 					{
-						label: SubscribersStatus.NotConfirmed,
+						label: SubscribersStatus.Subscribed,
+						value: SubscribersFilterBy.EmailSubscriber,
+					},
+					{
+						label: SubscribersStatus[ 'Not subscribed' ],
+						value: SubscribersFilterBy.ReaderSubscriber,
+					},
+					{
+						label: SubscribersStatus[ 'Not confirmed' ],
 						value: SubscribersFilterBy.UnconfirmedSubscriber,
 					},
-					{ label: SubscribersStatus.NotSending, value: SubscribersFilterBy.BlockedSubscriber },
+					{
+						label: SubscribersStatus[ 'Not sending' ],
+						value: SubscribersFilterBy.BlockedSubscriber,
+					},
 				],
 				filterBy: {
 					operators: [ 'is' as Operator ],

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -20,7 +20,7 @@ export enum SubscribersFilterBy {
 }
 
 export const SubscribersStatus = {
-	Subscribed: translate( 'Subscribed' ),
+	[ 'Subscribed' ]: translate( 'Subscribed' ),
 	[ 'Not confirmed' ]: translate( 'Not confirmed' ),
 	[ 'Not subscribed' ]: translate( 'Not subscribed' ),
 	[ 'Not sending' ]: translate( 'Not sending' ),

--- a/client/my-sites/subscribers/constants.ts
+++ b/client/my-sites/subscribers/constants.ts
@@ -21,9 +21,9 @@ export enum SubscribersFilterBy {
 
 export const SubscribersStatus = {
 	Subscribed: translate( 'Subscribed' ),
-	NotConfirmed: translate( 'Not confirmed' ),
-	NotSubscribed: translate( 'Not subscribed' ),
-	NotSending: translate( 'Not sending' ),
+	[ 'Not confirmed' ]: translate( 'Not confirmed' ),
+	[ 'Not subscribed' ]: translate( 'Not subscribed' ),
+	[ 'Not sending' ]: translate( 'Not sending' ),
 } as const;
 
 export const DEFAULT_PER_PAGE = 10;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Make sure the statuses correspond to the right translations.

Before | After
---- | ----
<img width="254" alt="Screenshot 2025-03-27 at 4 22 58 PM" src="https://github.com/user-attachments/assets/ebb5d6ba-e834-4386-a23e-8a46afae38f3" /> | <img width="257" alt="Screenshot 2025-03-27 at 4 22 52 PM" src="https://github.com/user-attachments/assets/a1a187a9-2a17-43f9-8e00-4a56233ce8b6" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* I noticed missing translations.

<img width="1606" alt="Screenshot 2025-03-27 at 4 29 51 PM" src="https://github.com/user-attachments/assets/4012a443-dca5-4ff5-9092-c705c737bf31" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change to a non-EN locale in /me/account
* Go to /subscribers/{site URL}
* Check that the Email Subscription column is translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
