### PR TITLE
Fixed plan selector alignment and plan blocks size on tablet screen sizes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -27,14 +27,22 @@
 	}
 }
 
-.step-container-v2--plans {
-	.plans-wrapper {
-		margin: 0;
-		padding: 0;
+.step-container-v2 {
+	.step-container-v2--plans {
+		.plans-wrapper {
+			margin: 0;
+			padding: 0;
+		}
 	}
 
 	// This is temporary until we make the plans step more consistent according to the designs.
 	@media(max-width: calc($break-small - 1px)) {
+		.plans-features-main .plans-features-main__subheader {
+			text-align: left;
+		}
+	}
+	
+	@media(max-width: calc($break-medium - 1px)) {
 		.plan-type-selector {
 			width: 100%;
 		}

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -150,7 +150,7 @@ const PlansPageSubheader = ( {
 	return (
 		<>
 			{ createWithBigSky && (
-				<Subheader>
+				<Subheader className="plans-features-main__subheader">
 					{ translate(
 						'Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.',
 						{
@@ -162,7 +162,7 @@ const PlansPageSubheader = ( {
 				</Subheader>
 			) }
 			{ ! createWithBigSky && deemphasizeFreePlan && offeringFreePlan ? (
-				<Subheader>
+				<Subheader className="plans-features-main__subheader">
 					{ translate(
 						'Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.',
 						{

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -404,7 +404,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		}
 
 		// we want to fit 3 plans per row in this breakpoint
-		const mediumBreakpoint = isInSiteDashboard ? 667 : 741;
+		const mediumBreakpoint = 669;
 
 		return new Map< GridSize, number >( [
 			[ 'small', 0 ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101964
Slack thread: p1743085286744789-slack-C04H4NY6STW

## Proposed Changes

* Set plan duration selector full width for mobile and tablet resolutions
* Increase one plan block for tablet resolutions
* Left align subtitle on StepContainerV2 mobile resolution

| Before | Header |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5b8b2889-5f33-422e-84ec-b763c009664e) | ![image](https://github.com/user-attachments/assets/28246d96-63aa-4c69-a563-c0167b36c391) | 
| ![image](https://github.com/user-attachments/assets/6535c83a-ed93-42c3-a379-a27e23d606c6) | ![image](https://github.com/user-attachments/assets/c4ff74ee-9fbc-4bf0-b673-7cb88d12a4a1) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding) (locally or use the feature flag `?flags=onboarding/step-container-v2` on staging)
* Add a paid domain to your cart and advance to the plans page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?