### PR TITLE
Add `root_vendor` property to `calypso_domain_search_results_suggestions_receive` Tracks event

### DIFF
--- a/client/components/domains/register-domain-step/analytics.js
+++ b/client/components/domains/register-domain-step/analytics.js
@@ -73,7 +73,8 @@ export const recordSearchResultsReceive = (
 	responseTimeInMs,
 	resultCount,
 	section,
-	flowName
+	flowName,
+	rootVendor = null
 ) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Receive Results', 'Response Time', responseTimeInMs ),
@@ -84,6 +85,7 @@ export const recordSearchResultsReceive = (
 			result_count: resultCount,
 			section,
 			flow_name: flowName,
+			root_vendor: rootVendor,
 		} )
 	);
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1280,6 +1280,7 @@ class RegisterDomainStep extends Component {
 				this.props.onDomainsAvailabilityChange( true );
 				const timeDiff = Date.now() - timestamp;
 				const analyticsResults = domainSuggestions.map( ( suggestion ) => suggestion.domain_name );
+				const rootVendor = domainSuggestions[ 0 ]?.vendor;
 
 				this.props.recordSearchResultsReceive(
 					domain,
@@ -1287,7 +1288,8 @@ class RegisterDomainStep extends Component {
 					timeDiff,
 					domainSuggestions.length,
 					this.props.analyticsSection,
-					this.props.flowName
+					this.props.flowName,
+					rootVendor
 				);
 
 				return domainSuggestions;
@@ -1418,7 +1420,8 @@ class RegisterDomainStep extends Component {
 			timeDiff,
 			subdomainSuggestions.length,
 			this.props.analyticsSection,
-			this.props.flowName
+			this.props.flowName,
+			vendor
 		);
 
 		// This part handles the other end of the condition handled by the line 282:


### PR DESCRIPTION
Related to #

## Proposed Changes

This PR adds a `root_vendor` property to the `calypso_domain_search_results_suggestions_receive` Tracks event.

## Why are these changes being made?

This ads more information to domain search events and helps us understand which domain suggestion provider was responsible for generating suggestions.

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Open your browser's network tab and filter for requests with `t.gif` (Tracks invisible pixel)
- Do a domain search and ensure the `calypso_domain_search_results_suggestions_receive` event has the `root_vendor` property

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
