### PR TITLE
Reader Editor: Remove the Cancel button

### DIFF
--- a/client/reader/components/quick-post/index.tsx
+++ b/client/reader/components/quick-post/index.tsx
@@ -143,10 +143,6 @@ function QuickPost( {
 			} );
 	};
 
-	const handleCancel = () => {
-		clearEditor();
-	};
-
 	const handleSiteSelect = ( siteId: number ) => {
 		dispatch( setSelectedSiteId( siteId ) );
 	};
@@ -230,13 +226,6 @@ function QuickPost( {
 				</div>
 			</div>
 			<div className="quick-post-input__actions">
-				<Button
-					onClick={ handleCancel }
-					disabled={ isDisabled }
-					className="quick-post-input__cancel"
-				>
-					{ translate( 'Cancel' ) }
-				</Button>
 				<Button
 					variant="primary"
 					onClick={ handleSubmit }

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -38,10 +38,6 @@
 		gap: 8px;
 	}
 
-	&__cancel {
-		color: var( --color-text-subtle );
-	}
-
 	&__success-message {
 		padding-left: 5px;
 		color: rgb( 0, 128, 0 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1743105394127549-slack-C083J8DHLLD

## Proposed Changes

* Removes the "Cancel" button from the Reader Editor.

Before | After
--|--
 <img width="1143" alt="Screenshot 2025-03-27 at 5 47 31 PM" src="https://github.com/user-attachments/assets/8e3dbf2b-615b-473c-ba4c-0f5e7e20d850" /> | <img width="1145" alt="Screenshot 2025-03-27 at 5 46 57 PM" src="https://github.com/user-attachments/assets/3dc72f39-265d-4f20-8821-b511c46dd58d" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The "Cancel" button clears the editor in one click with no confirmation or undo. We could change its behavior, but have opted to simply remove it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Calypso Live
* Go to /reader
* Confirm that the "Cancel" button is gone.
* Make sure you can still post from the Reader Editor.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?