### PR TITLE
Help Center - DIFM: Fix flow value in old step container

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -114,7 +114,7 @@ const DIFMStartingPoint: StepType< {
 				customizedActionButtons={
 					shouldRenderHelpCenter ? (
 						<HelpCenterStepButton
-							flowName={ flow }
+							flowName={ DIFM_FLOW }
 							enabledGeos={ [ 'US' ] }
 							helpCenterButtonCopy={ translate( 'Questions?' ) }
 							helpCenterButtonLink={ translate( 'Contact our site building team' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://wp.me/pdh1Xd-31k#comment-3106

## Proposed Changes

Some recent work has been done on steps and I needed a change in part of the code in the DIFM starting point step.
But this change was only applied to ´if shouldUseStepContainerV2´, which for now is only on local.

The bug, not receiving the right chat, happens only on production indeed, and this is why.
