### PR TITLE
Domains: Fix discrepancy between onboarding and domain-only search

### DIFF
--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -137,7 +137,7 @@
 	margin-bottom: 12px;
 }
 
-.register-domain-step__example-prompt {
+.domains__step-content.domains__step-content-domain-step .register-domain-step.register-domain-step__signup .register-domain-step__example-prompt {
 	font-size: 0.875rem;
 	line-height: 20px;
 	color: var(--studio-gray-40);
@@ -149,13 +149,9 @@
 		margin: 0 20px;
 	}
 
-	svg {
+	svg:first-child {
 		fill: #a7aaad;
 		margin-right: 13px;
-	}
-
-	@include break-xlarge {
-		margin: 0;
 	}
 }
 

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -374,8 +374,3 @@ body.is-section-signup {
 	border-right: none;
 	border-left: none;
 }
-
-body {
-	text-rendering: optimizelegibility;
-	-webkit-font-smoothing: antialiased;
-}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -374,3 +374,8 @@ body.is-section-signup {
 	border-right: none;
 	border-left: none;
 }
+
+body {
+	text-rendering: optimizelegibility;
+	-webkit-font-smoothing: antialiased;
+}

--- a/client/components/domains/side-explainer/style.scss
+++ b/client/components/domains/side-explainer/style.scss
@@ -10,6 +10,7 @@
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		line-height: 1.625rem;
 		color: var(--studio-gray-90);
+		text-wrap: balance;
 	}
 
 	.side-explainer__subtitle {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -11,7 +11,7 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { DESKTOP_BREAKPOINT, subscribeIsWithinBreakpoint } from '@automattic/viewport';
+import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -172,6 +172,7 @@ export class RenderDomainsStep extends Component {
 			checkDomainAvailabilityPromises: [],
 			removeDomainTimeout: 0,
 			addDomainTimeout: 0,
+			isDesktopViewport: false,
 		};
 	}
 
@@ -206,9 +207,12 @@ export class RenderDomainsStep extends Component {
 
 	subscribeToViewPortChanges() {
 		this.unsubscribeToViewPortChanges = subscribeIsWithinBreakpoint(
-			DESKTOP_BREAKPOINT,
+			'>=960px',
 			( isDesktopViewport ) => this.setState( { isDesktopViewport } )
 		);
+		if ( isWithinBreakpoint( '>=960px' ) ) {
+			this.setState( { isDesktopViewport: true } );
+		}
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -11,6 +11,7 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
+import { DESKTOP_BREAKPOINT, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -187,6 +188,7 @@ export class RenderDomainsStep extends Component {
 			// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 		}
+		this.subscribeToViewPortChanges();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -200,6 +202,17 @@ export class RenderDomainsStep extends Component {
 				this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 			}
 		}
+	}
+
+	subscribeToViewPortChanges() {
+		this.unsubscribeToViewPortChanges = subscribeIsWithinBreakpoint(
+			DESKTOP_BREAKPOINT,
+			( isDesktopViewport ) => this.setState( { isDesktopViewport } )
+		);
+	}
+
+	componentWillUnmount() {
+		this.unsubscribeToViewPortChanges?.();
 	}
 
 	getLocale() {
@@ -1444,6 +1457,7 @@ export class RenderDomainsStep extends Component {
 
 			return (
 				<Step.TwoColumnLayout
+					isLargeViewport={ this.state.isDesktopViewport }
 					firstColumnWidth={ 7 }
 					secondColumnWidth={ 3 }
 					topBar={ <Step.TopBar backButton={ ! hideBack && backButton } /> }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -346,6 +346,7 @@ body.is-section-signup {
 			border-color: #646970;
 			background: var(--color-surface);
 			box-shadow: none;
+			border-radius: 4px;
 
 			.search-component__input {
 				background: var(--color-surface);

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -73,10 +73,6 @@ body.is-section-stepper .domains__step-content,
 		border-radius: 0 2px 2px 0;
 	}
 
-	.search-filters__dropdown-filters.search-filters__dropdown-filters--is-open {
-		box-shadow: 0 0 0 3px var(--color-accent-light);
-	}
-
 	@include breakpoint-deprecated( "<660px" ) {
 		.register-domain-step__search-card,
 		.search-component.is-open.has-focus {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/colors.native";
 
 .domains__step-section-wrapper {
 	margin: 0 auto;
@@ -555,4 +556,84 @@ body.is-section-signup {
 	.domains__domain-side-content.fade-out {
 		display: none;
 	}
+}
+
+.step-container-v2__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
+	gap: 0!important;
+}
+
+@media (min-width: 1440px) {
+	.domains__domain-side-content {
+		margin: 0 0 0 60px !important;
+	}
+}
+
+.step-container-v2__content-wrapper.padding {
+	padding: 0 12px;
+}
+
+.step-container-v2__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
+	max-width: 1280px;
+}
+
+
+.domains__step-content-domain-step>div:nth-child(1) {
+	flex: 1!important;
+}
+
+.domains__step-content-domain-step>div:nth-child(2) {
+	display: flex;
+	flex-basis: auto!important;
+	flex-direction: column;
+	flex-grow: 0 !important;
+	flex-shrink: 1 !important;
+	flex-wrap: nowrap;
+}
+
+.step-route.onboarding.domains:has(.step-container-v2) .domains__domain-side-content {
+	margin-left: 40px;
+}
+
+.step-container-v2__top-bar {}
+
+.step-container-v2__content-wrapper.padding {
+	gap: 0;
+}
+
+.step-container-v2__content-wrapper>.step-container-v2__heading {
+	margin-top: calc( 48px + 48px - var(--step-container-v2-top-bar-height) );
+	margin-bottom: 36px;
+}
+
+.step-container-v2__heading {
+	margin-top: 0px;
+}
+
+@media (min-width: 600px) {
+	.register-domain-step__example-prompt {
+		margin: 0 20px!important;
+	}
+}
+
+.step-route.onboarding.domains h1.wp-brand-font {
+	//font-size: 36px !important;
+}
+
+@media (min-width: 661px) {
+	.register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
+		padding-top: 18px;
+	}
+}
+
+.register-domain-step__search.register-domain-step__search-domain-step {
+	padding-top: 18px!important;
+}
+
+h1.wp-brand-font {
+	letter-spacing: -0.4px !important;
+	line-height: 1.2em !important;
+}
+
+.step-route.onboarding.domains .step-container-v2__heading > p {
+	color: $gray-60;
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -620,7 +620,7 @@ body.is-section-signup {
 	}
 }
 
-.register-domain-step__search.register-domain-step__search-domain-step {
+body.is-section-stepper .register-domain-step__search.register-domain-step__search-domain-step {
 	padding-top: 18px!important;
 }
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -729,3 +729,12 @@ body.is-section-stepper .onboarding:not(.is-onboarding-2023-pricing-grid) .step-
 		margin: 0 !important;
 	}
 }
+
+.domain-product-price {
+	@include breakpoint-deprecated( "<660px" ) {
+
+		&.domain-product-price__domain-step-signup-flow {
+			flex-direction: column !important;
+		}
+	}
+}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -520,22 +520,59 @@ body.is-section-signup {
 .step-route.onboarding.domains:has(.step-container-v2) {
 	padding: 0;
 
-	.register-domain-step__search-card {
-		margin: 0;
+	.register-domain-step {
+		&__search-card {
+			@media (min-width: 600px) {
+				margin: 20px 20px 0;
+			}
+
+			@media (min-width: 960px) {
+				margin: 0;
+			}
+		}
+
+		&__domain-side-content-container-domain-explanation-image {
+			max-width: 100%;
+			margin-bottom: 0;
+		}
+
+		&__example-prompt {
+			margin: 0;
+
+			@media (min-width: 600px) {
+				margin: 0 20px;
+			}
+		}
 	}
 
 	.featured-domain-suggestions,
 	.domain-suggestion {
 		margin-inline: 0;
+
+		@media (min-width: 600px) {
+			margin-inline: 20px;
+
+			@media (min-width: 960px) {
+				margin: 0;
+			}
+		}
 	}
 
-	.register-domain-step__domain-side-content-container-domain-explanation-image {
-		max-width: 100%;
-		margin-bottom: 0;
-	}
+	.featured-domain-suggestions {
+		border-top: none;
 
-	.register-domain-step__example-prompt {
-		margin: 0;
+		@media (min-width: 600px) {
+			margin: 0 20px;
+
+			@media (min-width: 960px) {
+				margin: 0;
+			}
+		}
+
+		.featured-domain-suggestion {
+			margin: 0;
+			margin-bottom: 12px;
+		}
 	}
 
 	.domains__domain-side-content-container {
@@ -551,25 +588,48 @@ body.is-section-signup {
 		@include break-medium {
 			max-width: 290px;
 		}
+
+		@include break-large {
+			margin-left: 40px;
+		}
+
+		@include break-huge {
+			margin-left: 60px;
+		}
+
+		&.fade-out {
+			display: none;
+		}
 	}
 
-	.domains__domain-side-content.fade-out {
-		display: none;
+	.step-container-v2__heading {
+		h1:not(.small) {
+			letter-spacing: -0.4px;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1.2em;
+		}
+
+		> p {
+			color: $gray-60;
+			font-size: 1rem;
+		}
 	}
 }
 
-.step-container-v2__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
-	column-gap: 0;
-	max-width: 1280px;
-}
+.step-container-v2 {
+	&__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
+		column-gap: 0;
+		max-width: 1280px;
+	}
 
-.step-container-v2__content-wrapper.padding {
-	padding: 0 12px;
-	gap: 0;
-}
+	&__content-wrapper.padding {
+		padding: 0 12px;
+		gap: 0;
+	}
 
-.step-container-v2__heading {
-	margin-top: 0;
+	&__heading {
+		margin-top: 0;
+	}
 }
 
 .domains__step-content-domain-step > div {
@@ -587,133 +647,60 @@ body.is-section-signup {
 	}
 }
 
-.domains__domain-side-content {
-	@media (min-width: 1440px) {
-		margin: 0 0 0 60px;
-	}
-}
-
-.step-route.onboarding.domains:has(.step-container-v2) .domains__domain-side-content-container>.domains__domain-side-content {
-	@include break-large {
-		margin-left: 40px;
+.domain-product-price {
+	&.domain-product-single-price.domain-product-price__domain-step-signup-flow {
+		align-self: center;
 	}
 
-	@include break-huge {
-		margin-left: 60px;
+	@include breakpoint-deprecated( "<660px" ) {
+		&.domain-product-price__domain-step-signup-flow {
+			flex-direction: column;
+		}
 	}
-}
-
-.step-route.onboarding.domains:has(.step-container-v2) .step-container-v2__heading h1:not(.small) {
-	letter-spacing: -0.4px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.2em;
-}
-
-.step-route.onboarding.domains .step-container-v2__heading > p {
-	color: $gray-60;
-	font-size: 1rem;
-}
-
-body.is-section-stepper .featured-domain-suggestion.card .domain-product-price {
-	align-items: flex-start;
-	margin-top: 12px;
 }
 
 .domain-suggestion__content.domain-suggestion__content-domain {
 	align-items: unset;
 }
 
-.domain-product-price.domain-product-single-price.domain-product-price__domain-step-signup-flow {
-	align-self: center;
-}
-
-@media (min-width: 1080px) {
-	body.is-section-stepper .formatted-header .formatted-header__title {
-		font-size: 2.75rem !important;
-	}
-}
-
-body.is-section-stepper .onboarding:not(.is-onboarding-2023-pricing-grid) .step-container-v2__heading {
-	margin: calc(48px + 24px - var(--step-container-v2-top-bar-height)) 20px 24px 20px;
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	width: unset;
-	align-items: center;
-	flex-direction: column;
-
-	@media (min-width: 960px) {
-		margin-top: calc(48px + 48px - var(--step-container-v2-top-bar-height));
-		margin-bottom: 36px;
+body.is-section-stepper {
+	.featured-domain-suggestion.card .domain-product-price {
+		align-items: flex-start;
+		margin-top: 12px;
 	}
 
-	> h1 {
-		font-size: 2.25rem;
-
+	.formatted-header .formatted-header__title {
 		@media (min-width: 1080px) {
-			font-size: 2.75rem;
+			font-size: 2.75rem !important;
 		}
 	}
-}
 
-@media (min-width: 600px) {
-	.register-domain-step__example-prompt {
-		margin: 0 20px;
-	}
-
-	.step-route.onboarding.domains:has(.step-container-v2) .register-domain-step__search-card {
-		margin: 20px 20px 0;
-	}
-
-	body.is-section-stepper .step-route.onboarding.domains:has(.step-container-v2) {
-		.featured-domain-suggestions,
-		.domain-suggestion {
-			margin-inline: 20px;
-
-			@media (min-width: 960px) {
-				margin: 0;
-			}
-		}
-
-		.featured-domain-suggestions {
-			margin: 0 20px;
-			border-top: none;
-
-			.featured-domain-suggestion {
-				margin: 0;
-				margin-bottom: 12px;
-			}
-
-			@media (min-width: 960px) {
-				margin: 0;
-			}
+	.register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
+		@media (min-width: 661px) {
+			padding-top: 18px;
 		}
 	}
-}
 
-@media (min-width: 661px) {
-	body.is-section-stepper .register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
-		padding-top: 18px;
-	}
-}
+	.onboarding:not(.is-onboarding-2023-pricing-grid) .step-container-v2__heading {
+		margin: calc(48px + 24px - var(--step-container-v2-top-bar-height)) 20px 24px 20px;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		width: unset;
+		align-items: center;
+		flex-direction: column;
 
-@media (max-width: 600px) {
-	.is-section-stepper .step-route.onboarding.domains:has(.step-container-v2) .domains__step-content .register-domain-step__search-card {
+		@media (min-width: 960px) {
+			margin-top: calc(48px + 48px - var(--step-container-v2-top-bar-height));
+			margin-bottom: 36px;
+		}
 
-		margin: 20px 0 0;
-	}
-}
+		> h1 {
+			font-size: 2.25rem;
 
-@media (min-width: 960px) {
-	.is-section-stepper .step-route.onboarding.domains:has(.step-container-v2) .domains__step-content .register-domain-step__search-card {
-		margin: 0;
-	}
-}
-
-.domain-product-price {
-	@include breakpoint-deprecated( "<660px" ) {
-		&.domain-product-price__domain-step-signup-flow {
-			flex-direction: column;
+			@media (min-width: 1080px) {
+				font-size: 2.75rem;
+			}
 		}
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -688,21 +688,44 @@ body.is-section-stepper .onboarding:not(.is-onboarding-2023-pricing-grid) .step-
 	}
 }
 
-h1.wp-brand-font {
-	/* text-align: center; */
-}
-
 @media (min-width: 600px) {
-	body.is-section-stepper.is-group-stepper .domains__step-content .register-domain-step__search-card, body.is-section-signup .domains__step-content .register-domain-step__search-card {
+	.step-route.onboarding.domains:has(.step-container-v2) .register-domain-step__search-card {
 		margin: 20px 20px 0 !important;
 	}
 
-	body.is-section-stepper .featured-domain-suggestions {
-		margin: 0 20px !important;
-		border-top: none;
+	body.is-section-stepper {
+
+		.featured-domain-suggestions,
+		.domain-suggestion {
+			margin-inline: 20px!important;
+
+			& {
+				@media (min-width: 960px) {
+					margin: 0 !important;
+				}
+			}
+		}
+
+		.featured-domain-suggestions {
+			margin: 0 20px !important;
+			border-top: none;
+
+			.featured-domain-suggestion {
+				margin: 0!important;
+				margin-bottom: 12px !important;
+			}
+
+			& {
+				@media (min-width: 960px) {
+					margin: 0 !important;
+				}
+			}
+		}
 	}
 }
 
-.domain-suggestion.card.is-compact {
-	
+@media (min-width: 960px) {
+	.step-route.onboarding.domains:has(.step-container-v2) .register-domain-step__search-card {
+		margin: 0 !important;
+	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -637,3 +637,16 @@ h1.wp-brand-font {
 .step-route.onboarding.domains .step-container-v2__heading > p {
 	color: $gray-60;
 }
+
+body.is-section-stepper .featured-domain-suggestion.card .domain-product-price {
+	align-items: flex-start;
+	margin-top: 12px;
+}
+
+.domain-suggestion__content.domain-suggestion__content-domain {
+	align-items: unset !important;
+}
+
+.domain-product-price.domain-product-single-price.domain-product-price__domain-step-signup-flow {
+	align-self: center;
+}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -606,18 +606,22 @@ body.is-section-signup {
 	}
 }
 
-.step-route.onboarding.domains h1.wp-brand-font {
-	//font-size: 36px !important;
-}
-
 @media (min-width: 661px) {
-	.register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
+	body.is-section-stepper .register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
 		padding-top: 18px;
 	}
 }
 
-body.is-section-stepper .register-domain-step__search.register-domain-step__search-domain-step {
-	padding-top: 18px!important;
+@media (max-width: 600px) {
+	body.is-section-stepper .domains__step-content .register-domain-step__search-card {
+		margin: 20px 0 0!important;
+	}
+}
+
+@media (max-width: 661px) {
+	body.is-section-stepper .domains__step-content .register-domain-step__search-card {
+		margin: 20px 0 0;
+	}
 }
 
 h1.wp-brand-font {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -600,11 +600,6 @@ body.is-section-signup {
 	gap: 0;
 }
 
-.step-container-v2__content-wrapper>.step-container-v2__heading {
-	margin-top: calc( 48px + 48px - var(--step-container-v2-top-bar-height) );
-	margin-bottom: 36px;
-}
-
 .step-container-v2__heading {
 	margin-top: 0px;
 }
@@ -636,6 +631,7 @@ h1.wp-brand-font {
 
 .step-route.onboarding.domains .step-container-v2__heading > p {
 	color: $gray-60;
+	font-size: 1rem;
 }
 
 body.is-section-stepper .featured-domain-suggestion.card .domain-product-price {
@@ -649,4 +645,64 @@ body.is-section-stepper .featured-domain-suggestion.card .domain-product-price {
 
 .domain-product-price.domain-product-single-price.domain-product-price__domain-step-signup-flow {
 	align-self: center;
+}
+
+.domain-product-price.domain-product-single-price.domain-product-price__domain-step-signup-flow {
+	align-self: center;
+}
+
+.domain-suggestion.card.is-compact {}
+
+@media (min-width: 1080px) {
+	body.is-section-stepper .formatted-header .formatted-header__title {
+		font-size: 2.75rem !important;
+	}
+}
+
+.step-container-v2__heading{}
+
+p {}
+
+body.is-section-stepper .onboarding:not(.is-onboarding-2023-pricing-grid) .step-container-v2__heading {
+	margin: calc( 48px + 24px - var(--step-container-v2-top-bar-height) ) 20px 24px 20px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	width: unset !important;
+	align-items: center;
+	flex-direction: column;
+
+	@media (min-width: 960px) {
+		& {
+			margin-top: calc( 48px + 48px - var(--step-container-v2-top-bar-height) );
+			margin-bottom: 36px;
+		}
+	}
+
+	&>h1 {
+		font-size: 2.25rem;
+
+		@media (min-width: 1080px) {
+			font-size: 2.75rem;
+		}
+	}
+}
+
+h1.wp-brand-font {
+	/* text-align: center; */
+}
+
+@media (min-width: 600px) {
+	body.is-section-stepper.is-group-stepper .domains__step-content .register-domain-step__search-card, body.is-section-signup .domains__step-content .register-domain-step__search-card {
+		margin: 20px 20px 0 !important;
+	}
+
+	body.is-section-stepper .featured-domain-suggestions {
+		margin: 0 20px !important;
+		border-top: none;
+	}
+}
+
+.domain-suggestion.card.is-compact {
+	
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -559,7 +559,7 @@ body.is-section-signup {
 }
 
 .step-container-v2__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
-	gap: 0!important;
+	column-gap: 40px;
 }
 
 @media (min-width: 1440px) {
@@ -588,10 +588,6 @@ body.is-section-signup {
 	flex-grow: 0 !important;
 	flex-shrink: 1 !important;
 	flex-wrap: nowrap;
-}
-
-.step-route.onboarding.domains:has(.step-container-v2) .domains__domain-side-content {
-	margin-left: 40px;
 }
 
 .step-container-v2__top-bar {}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -559,74 +559,54 @@ body.is-section-signup {
 }
 
 .step-container-v2__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
-	column-gap: 0px !important;
-}
-
-@media (min-width: 1440px) {
-	.domains__domain-side-content {
-		margin: 0 0 0 60px !important;
-	}
+	column-gap: 0;
+	max-width: 1280px;
 }
 
 .step-container-v2__content-wrapper.padding {
 	padding: 0 12px;
-}
-
-.step-container-v2__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
-	max-width: 1280px;
-}
-
-
-.domains__step-content-domain-step>div:nth-child(1) {
-	flex: 1!important;
-}
-
-.domains__step-content-domain-step>div:nth-child(2) {
-	display: flex;
-	flex-basis: auto!important;
-	flex-direction: column;
-	flex-grow: 0 !important;
-	flex-shrink: 1 !important;
-	flex-wrap: nowrap;
-}
-
-.step-container-v2__top-bar {}
-
-.step-container-v2__content-wrapper.padding {
 	gap: 0;
 }
 
 .step-container-v2__heading {
-	margin-top: 0px;
+	margin-top: 0;
 }
 
-@media (min-width: 600px) {
-	.register-domain-step__example-prompt {
-		margin: 0 20px!important;
+.domains__step-content-domain-step > div {
+	&:nth-child(1) {
+		flex: 1 !important;
+	}
+
+	&:nth-child(2) {
+		display: flex;
+		flex-basis: auto !important;
+		flex-direction: column;
+		flex-grow: 0 !important;
+		flex-shrink: 1 !important;
+		flex-wrap: nowrap;
 	}
 }
 
-@media (min-width: 661px) {
-	body.is-section-stepper .register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
-		padding-top: 18px;
+.domains__domain-side-content {
+	@media (min-width: 1440px) {
+		margin: 0 0 0 60px;
 	}
 }
 
-@media (max-width: 600px) {
-	body.is-section-stepper .domains__step-content .register-domain-step__search-card {
-		margin: 20px 0 0!important;
+.step-route.onboarding.domains:has(.step-container-v2) .domains__domain-side-content-container>.domains__domain-side-content {
+	@include break-large {
+		margin-left: 40px;
+	}
+
+	@include break-huge {
+		margin-left: 60px;
 	}
 }
 
-@media (max-width: 661px) {
-	body.is-section-stepper .domains__step-content .register-domain-step__search-card {
-		margin: 20px 0 0;
-	}
-}
-
-h1.wp-brand-font {
-	letter-spacing: -0.4px !important;
-	line-height: 1.2em !important;
+.step-route.onboarding.domains:has(.step-container-v2) .step-container-v2__heading h1:not(.small) {
+	letter-spacing: -0.4px;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 1.2em;
 }
 
 .step-route.onboarding.domains .step-container-v2__heading > p {
@@ -640,18 +620,12 @@ body.is-section-stepper .featured-domain-suggestion.card .domain-product-price {
 }
 
 .domain-suggestion__content.domain-suggestion__content-domain {
-	align-items: unset !important;
+	align-items: unset;
 }
 
 .domain-product-price.domain-product-single-price.domain-product-price__domain-step-signup-flow {
 	align-self: center;
 }
-
-.domain-product-price.domain-product-single-price.domain-product-price__domain-step-signup-flow {
-	align-self: center;
-}
-
-.domain-suggestion.card.is-compact {}
 
 @media (min-width: 1080px) {
 	body.is-section-stepper .formatted-header .formatted-header__title {
@@ -659,27 +633,21 @@ body.is-section-stepper .featured-domain-suggestion.card .domain-product-price {
 	}
 }
 
-.step-container-v2__heading{}
-
-p {}
-
 body.is-section-stepper .onboarding:not(.is-onboarding-2023-pricing-grid) .step-container-v2__heading {
-	margin: calc( 48px + 24px - var(--step-container-v2-top-bar-height) ) 20px 24px 20px;
+	margin: calc(48px + 24px - var(--step-container-v2-top-bar-height)) 20px 24px 20px;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	width: unset !important;
+	width: unset;
 	align-items: center;
 	flex-direction: column;
 
 	@media (min-width: 960px) {
-		& {
-			margin-top: calc( 48px + 48px - var(--step-container-v2-top-bar-height) );
-			margin-bottom: 36px;
-		}
+		margin-top: calc(48px + 48px - var(--step-container-v2-top-bar-height));
+		margin-bottom: 36px;
 	}
 
-	&>h1 {
+	> h1 {
 		font-size: 2.25rem;
 
 		@media (min-width: 1080px) {
@@ -689,58 +657,63 @@ body.is-section-stepper .onboarding:not(.is-onboarding-2023-pricing-grid) .step-
 }
 
 @media (min-width: 600px) {
-	.step-route.onboarding.domains:has(.step-container-v2) .register-domain-step__search-card {
-		margin: 20px 20px 0 !important;
+	.register-domain-step__example-prompt {
+		margin: 0 20px;
 	}
 
-	body.is-section-stepper {
+	.step-route.onboarding.domains:has(.step-container-v2) .register-domain-step__search-card {
+		margin: 20px 20px 0;
+	}
 
+	body.is-section-stepper .step-route.onboarding.domains:has(.step-container-v2) {
 		.featured-domain-suggestions,
 		.domain-suggestion {
-			margin-inline: 20px!important;
+			margin-inline: 20px;
 
-			& {
-				@media (min-width: 960px) {
-					margin: 0 !important;
-				}
+			@media (min-width: 960px) {
+				margin: 0;
 			}
 		}
 
 		.featured-domain-suggestions {
-			margin: 0 20px !important;
+			margin: 0 20px;
 			border-top: none;
 
 			.featured-domain-suggestion {
-				margin: 0!important;
-				margin-bottom: 12px !important;
+				margin: 0;
+				margin-bottom: 12px;
 			}
 
-			& {
-				@media (min-width: 960px) {
-					margin: 0 !important;
-				}
+			@media (min-width: 960px) {
+				margin: 0;
 			}
 		}
 	}
 }
 
+@media (min-width: 661px) {
+	body.is-section-stepper .register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
+		padding-top: 18px;
+	}
+}
+
+@media (max-width: 600px) {
+	.is-section-stepper .step-route.onboarding.domains:has(.step-container-v2) .domains__step-content .register-domain-step__search-card {
+
+		margin: 20px 0 0;
+	}
+}
+
 @media (min-width: 960px) {
-	.step-route.onboarding.domains:has(.step-container-v2) .register-domain-step__search-card {
-		margin: 0 !important;
+	.is-section-stepper .step-route.onboarding.domains:has(.step-container-v2) .domains__step-content .register-domain-step__search-card {
+		margin: 0;
 	}
 }
 
 .domain-product-price {
 	@include breakpoint-deprecated( "<660px" ) {
-
 		&.domain-product-price__domain-step-signup-flow {
-			flex-direction: column !important;
+			flex-direction: column;
 		}
-	}
-}
-
-.step-route.onboarding.domains:has(.step-container-v2) .domains__domain-side-content {
-	@include breakpoint-deprecated( ">960px" ) {
-		margin-left: 40px;
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -531,11 +531,6 @@ body.is-section-signup {
 			}
 		}
 
-		&__domain-side-content-container-domain-explanation-image {
-			max-width: 100%;
-			margin-bottom: 0;
-		}
-
 		&__example-prompt {
 			margin: 0;
 
@@ -577,7 +572,15 @@ body.is-section-signup {
 
 	.domains__domain-side-content-container {
 		display: flex;
-		margin-top: 0;
+		justify-content: center;
+		width: 80%;
+		align-items: center;
+		margin: 20px auto 0;
+
+		@media (min-width: ($break-large)) {
+			width: unset;
+			margin-top: 0;
+		}
 	}
 
 	.domains__domain-side-content {
@@ -618,7 +621,7 @@ body.is-section-signup {
 
 .step-container-v2 {
 	&__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
-		column-gap: 0;
+		gap: 0;
 		max-width: 1280px;
 	}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -559,7 +559,7 @@ body.is-section-signup {
 }
 
 .step-container-v2__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
-	column-gap: 40px;
+	column-gap: 0px !important;
 }
 
 @media (min-width: 1440px) {
@@ -736,5 +736,11 @@ body.is-section-stepper .onboarding:not(.is-onboarding-2023-pricing-grid) .step-
 		&.domain-product-price__domain-step-signup-flow {
 			flex-direction: column !important;
 		}
+	}
+}
+
+.step-route.onboarding.domains:has(.step-container-v2) .domains__domain-side-content {
+	@include breakpoint-deprecated( ">960px" ) {
+		margin-left: 40px;
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -3,6 +3,12 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/colors.native";
 
+body {
+	.is-section-signup, .is-section-stepper {
+		text-rendering: optimizelegibility;
+		-webkit-font-smoothing: antialiased;
+	}
+}
 .domains__step-section-wrapper {
 	margin: 0 auto;
 	width: 100%;


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/NOMADO-28/fix-discrepancy-between-onboarding-and-domain-only-search.

## Proposed Changes
Fix the visual discrepancies between the domain-only flow and the onboarding domain flows. 
Also, there are some minor tweaks to the domain-only flow style (mainly anti-aliasing for the font family in the entire flow).

### Preview
#### Before
https://github.com/user-attachments/assets/61cfc728-97b8-4c7c-941d-ba520de7e1b4

#### After
https://github.com/user-attachments/assets/dc75dfef-3e1d-415e-b112-96fa16c18da6

<a id="minor-tweaks"></a>
#### Minor tweaks
|  Where | Before | After                                                                                     |
|----------------------|--------|-------------------------------------------------------------------------------------------|
| TLD filter           | ![image](https://github.com/user-attachments/assets/59eb8f73-d6d8-4a66-8a6c-6dc28416709f) | ![image](https://github.com/user-attachments/assets/20569ea1-ea63-4981-9a40-77f6acd87564) |
| Prompt tooltip       | ![image](https://github.com/user-attachments/assets/8ee53bba-68d4-4df9-8f2f-451498d86416) | ![image](https://github.com/user-attachments/assets/6994ed6d-b754-4aa7-9035-4aa5d5b3a959) |
| Focused search input | ![image](https://github.com/user-attachments/assets/2b1b5873-b41d-4e5d-8fee-8e3decb43515) | ![image](https://github.com/user-attachments/assets/72440005-c0db-4aa6-9eea-7f9c8d789dba) |

## Why are these changes being made?
So we can continue our work in the domain of UX with a synchronized state between both flows.

## Testing Instructions
The easiest way I could find to test this is to keep both onboarding and domain-only flow tabs open and switch between them while changing the browser's window width, ensuring both look identical.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2) (not quite, but still)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
