### PR TITLE
Fix flickering back button between signup and domains step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -47,6 +47,9 @@ export const useStepNavigationWithTracking = ( {
 	/**
 	 * If the previous step is defined in the store, and the current step is not the first step, we can go back.
 	 * We need to make sure we're not at the first step because `previousStep` is persisted and can be a step from another flow or another run of the current flow.
+	 * We include a check for whether the previous step is the same sort of step as the current step. This can happen briefly while transitioning from one step to
+	 * the next where the onboard store data has updated, but `currentStepRoute` hasn't yet because the step hasn't been rendered yet. This would cause the back button
+	 * to flash briefly while navigating.
 	 */
 	const canUserGoBack =
 		stepData?.previousStep &&

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-step-navigation-with-tracking/index.ts
@@ -49,7 +49,10 @@ export const useStepNavigationWithTracking = ( {
 	 * We need to make sure we're not at the first step because `previousStep` is persisted and can be a step from another flow or another run of the current flow.
 	 */
 	const canUserGoBack =
-		stepData?.previousStep && currentStepRoute !== stepSlugs[ 0 ] && history.length > 1;
+		stepData?.previousStep &&
+		currentStepRoute !== stepSlugs[ 0 ] &&
+		history.length > 1 &&
+		stepData.previousStep !== currentStepRoute;
 
 	const tracksEventPropsFromFlow = flow.useTracksEventProps?.();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->





## Proposed Changes

* Update the `canUserGoBack` logic so it is `false` when the current step is the last step on the history queue.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Every so quickly, as a logged out user transitions from the signup step to the domains step, the back button flashes in the top-left corner.

Around 4 seconds on this video.

https://github.com/user-attachments/assets/b59b9ca2-1f54-4637-a6e2-70679161d81d

There's a brief moment where the `user` component is still being rendered and the `canUserGoBack` boolean changes to `true`. Which causes the back component to be rendered on the `user` step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The flicker seems a more obvious when the `onboarding/step-container-v2` flag is enabled. So probably easier to test on `calypso.localhost`

* Test incognito
* `/setup`
* Signup
* Closely observe the top bar and that no flickers appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
