### PR TITLE
Fix sidebar flashing before Big Sky is loaded

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -137,7 +137,7 @@ const aiSiteBuilder: Flow = {
 						}
 
 						window.location.replace(
-							`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }`
+							`${ siteURL }/wp-admin/site-editor.php?p=%2Fpage%2F&canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }`
 						);
 					} else if ( providedDependencies.isLaunched ) {
 						const site = await resolveSelect( SITE_STORE ).getSite( providedDependencies.siteSlug );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

We are seeing a blip of flashing of the side bar on mobile when loading Big Sky.

## Proposed Changes

Upon checking, I find adding the p=%2Fpage%2F reduces one URL redirection and the sidebar is no longer showing. However, there is still a dark blank screen showing shortly before Big Sky is mounted. I'm unsure if we can fix that, Big Sky takes time to load.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make user experience better.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* use http://calypso.localhost:3000/setup/ai-site-builder to test the flow, better take screenrecord since it happens all fast. Make sure you don't see following frame: 
* 
<img width="864" alt="image" src="https://github.com/user-attachments/assets/2262e92e-43f8-4476-a375-48d1ebdff14f" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
