### PR TITLE
Self Service Downgrade: Remove email mention from lossless revert radio copy

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/atomic-revert-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/atomic-revert-step.tsx
@@ -190,7 +190,7 @@ export function AtomicRevertStep( props: Props ) {
 						}
 						label={ translate( 'Restore my posts, pages, and media.' ) }
 						help={ translate(
-							'Your posts, pages, and media added after upgrading will be automatically imported to your downgraded site. This process may take up to 24 hours. You will receive an email when complete.'
+							'Your posts, pages, and media added after upgrading will be automatically imported to your downgraded site. This process may take up to 24 hours.'
 						) }
 						checked={ enableLosslessRevert }
 						onChange={ setEnableLosslessRevert! }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 178675-ghe-Automattic/wpcom

## Proposed Changes

Removes email mention in lossless revert text.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Copy for lossless reverts need to match reality.

<img width="703" alt="Screenshot 2025-03-28 at 10 57 50" src="https://github.com/user-attachments/assets/a7cc0760-3f72-4834-8ecb-28243242c6f5" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to purchases for an Atomic site
* Go to Downgrade
* The `Restore my posts, pages, and media` description shouldn't mention about recieving an email.
<img width="699" alt="Screenshot 2025-03-28 at 10 56 46" src="https://github.com/user-attachments/assets/2e12b480-9afb-4207-ac21-2487e6c185c7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?