### PR TITLE
Playground onboarding flow: update url via react router so next step can pick up playground GET param correctly

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { usePhpVersions } from 'calypso/data/php-versions/use-php-versions';
 import { initializeWordPressPlayground } from '../../lib/initialize-playground';
 import type { PlaygroundClient } from '@wp-playground/client';
+
 export function PlaygroundIframe( {
 	className,
 	playgroundClient,
@@ -13,6 +15,7 @@ export function PlaygroundIframe( {
 } ) {
 	const iframeRef = useRef< HTMLIFrameElement >( null );
 	const recommendedPHPVersion = usePhpVersions().recommendedValue;
+	const [ , setSearchParams ] = useSearchParams();
 
 	useEffect( () => {
 		if ( ! iframeRef.current ) {
@@ -23,7 +26,7 @@ export function PlaygroundIframe( {
 			return;
 		}
 
-		initializeWordPressPlayground( iframeRef.current, recommendedPHPVersion ).then(
+		initializeWordPressPlayground( iframeRef.current, recommendedPHPVersion, setSearchParams ).then(
 			( playgroundClient ) => {
 				setPlaygroundClient( playgroundClient );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -11,7 +11,8 @@ const OPFS_PATH_PREFIX = '/wpcom-onboarding';
 
 export async function initializeWordPressPlayground(
 	iframe: HTMLIFrameElement,
-	recommendedPhpVersion: string
+	recommendedPhpVersion: string,
+	setSearchParams: ( callback: ( prev: URLSearchParams ) => URLSearchParams ) => void
 ): Promise< PlaygroundClient > {
 	let isWordPressInstalled = false;
 
@@ -19,8 +20,14 @@ export async function initializeWordPressPlayground(
 	let playgroundId = url.searchParams.get( 'playground' );
 	if ( ! playgroundId ) {
 		playgroundId = crypto.randomUUID();
+		// update url in browser history
 		url.searchParams.set( 'playground', playgroundId );
 		window.history.replaceState( {}, '', url.toString() );
+		// update search params through react router
+		setSearchParams( ( prev ) => {
+			prev.set( 'playground', playgroundId as string );
+			return prev;
+		} );
 	} else {
 		// TODO: check if WordPress is installed using playgroundAvailableInOpfs from @wp-playground/website
 		isWordPressInstalled = true;
@@ -43,8 +50,6 @@ export async function initializeWordPressPlayground(
 			shouldInstallWordPress: ! isWordPressInstalled,
 			mounts: [ mountDescriptor ],
 		} );
-
-		window.history.replaceState( {}, '', window.location.pathname + window.location.search );
 
 		await client.isReady();
 		return client;


### PR DESCRIPTION
Related to #101948 

## Proposed Changes

* update search params through react router for next step to pick GET param accurately

## Testing Instructions

- As a logged out user, head over to http://calypso.localhost:3000/setup/onboarding/playground & you will notice ?playground gets added to the URL
- Click "Launch on WordPress.com"
- You will get to the user screen `http://calypso.localhost:3000/setup/onboarding/user?playground=xxx`

Ensure playground GET param is not missing from url
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
