### PR TITLE
Domains - SSL Card: show certificate issues only when there are.

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-security-details/index.tsx
@@ -89,25 +89,34 @@ const DomainSecurityDetails = ( { domain, isDisabled }: SecurityCardProps ) => {
 			);
 		}
 
-		if ( sslDetails?.failure_reasons ) {
+		if ( sslDetails.failure_reasons ) {
+			if ( sslDetails.failure_reasons.length > 0 ) {
+				return (
+					<>
+						<p className="domain-security-details__description-message">
+							{ translate(
+								'There are one or more problems with your DNS configuration that prevent an SSL certificate from being issued:'
+							) }
+						</p>
+						<ul>
+							{ sslDetails.failure_reasons?.map( ( failureReason ) => {
+								return <li key={ failureReason.error_type }>{ failureReason.message }</li>;
+							} ) }
+						</ul>
+						<p className="domain-security-details__description-message">
+							{ translate(
+								'Once you have fixed all the issues, you can request a new certificate by clicking the button below.'
+							) }
+						</p>
+					</>
+				);
+			}
 			return (
-				<>
-					<p className="domain-security-details__description-message">
-						{ translate(
-							'There are one or more problems with your DNS configuration that prevent an SSL certificate from being issued:'
-						) }
-					</p>
-					<ul>
-						{ sslDetails.failure_reasons?.map( ( failureReason ) => {
-							return <li key={ failureReason.error_type }>{ failureReason.message }</li>;
-						} ) }
-					</ul>
-					<p className="domain-security-details__description-message">
-						{ translate(
-							'Once you have fixed all the issues, you can request a new certificate by clicking the button below.'
-						) }
-					</p>
-				</>
+				<p className="domain-security-details__description-message">
+					{ translate(
+						'There was a problem issuing your SSL certificate. You can request a new certificate by clicking the button below.'
+					) }
+				</p>
 			);
 		}
 		return (


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/NOMADO-22/fix-ssl-certificate-section-displayed-as-an-error-state-when-there-are

## Proposed Changes
If a domain SSL certificate is pending but there are no issue that prevent it from being issued, we want to show a different message in the domain ssl card.

## Why are these changes being made?
Currently, if the certificate is not provisioned, we show this message even if the `failure_reasons` array is empty.

```There are one or more problems with your DNS configuration that prevent an SSL certificate from being issued:```

However, we don't provide any additional information or next steps, which can be confusing for users. To improve clarity and usability, we now show a new message that encourage users to manually trigger a new certificate provisioning attempt.

## Testing Instructions
I think the easiest way to test the PR is hack a little bit Calypso code to simulate a pending SSL certificate.

Replace line 67 with
`if ( isLoadingSSLDetails || ! sslDetails) {`

and add this line before line 93:
`sslDetails.failure_reasons = [];`

Verify that the ssl card show this message:

![Screenshot 2025-03-28 alle 14 52 57](https://github.com/user-attachments/assets/abce5e9d-8de0-4e5b-b7d8-a341b3b69d94)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
