### PR TITLE
FoldableCard: Add inert and position relative to foldable card

### DIFF
--- a/packages/components/src/foldable-card/index.jsx
+++ b/packages/components/src/foldable-card/index.jsx
@@ -125,8 +125,10 @@ class FoldableCard extends Component {
 		const additionalStyle = this.state.expanded
 			? this.props.contentExpandedStyle
 			: this.props.contentCollapsedStyle;
+		const inertProps = this.state.expanded ? {} : { inert: '' };
+
 		return (
-			<div className="foldable-card__content" style={ additionalStyle }>
+			<div className="foldable-card__content" style={ additionalStyle } { ...inertProps }>
 				{ this.props.children }
 			</div>
 		);

--- a/packages/components/src/foldable-card/style.scss
+++ b/packages/components/src/foldable-card/style.scss
@@ -4,6 +4,7 @@
 
 // Multisite
 .foldable-card.card {
+
 	@include a8c-clear-fix;
 	position: relative;
 	transition: margin 0.15s linear;
@@ -25,6 +26,7 @@
 	}
 
 	&.has-border {
+
 		.foldable-card__summary,
 		.foldable-card__summary-expanded {
 			margin-right: 48px;
@@ -128,6 +130,7 @@ button:not(:disabled).foldable-card__action {
 
 .foldable-card__content {
 	display: none;
+	position: relative;
 }
 
 .foldable-card.is-smooth .foldable-card__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101242

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
