### PR TITLE
Reader Editor: position relative and add `useInert` prop to FoldableCard 

### DIFF
--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -82,6 +82,7 @@ function FollowingStream( { ...props } ) {
 							className="following-stream__quick-post-card"
 							smooth
 							contentExpandedStyle={ { maxHeight: '800px' } }
+							useInert
 							onOpen={ () => {
 								focusEditor();
 							} }

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .is-section-reader .navigation-header.following-stream-header {
+
 	&.reader-dual-column {
 		max-width: 968px; // Max width of dual column reader stream.
 	}
@@ -10,7 +11,9 @@
 	margin-top: 0;
 
 	.section-nav-tabs__list {
+
 		.section-nav-tab__link {
+
 			&:hover {
 				background-color: transparent;
 			}
@@ -74,6 +77,7 @@
 }
 
 .following-stream__quick-post-card.card {
+	position: relative;
 
 	.accessible-focus & .foldable-card__action:focus {
 		outline: none;
@@ -83,6 +87,7 @@
 	}
 
 	&.is-expanded {
+
 		.foldable-card__content {
 			overflow: visible;
 		}

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -76,14 +76,18 @@
 	}
 }
 
+
 .following-stream__quick-post-card.card {
-	position: relative;
 
 	.accessible-focus & .foldable-card__action:focus {
 		outline: none;
 		border-color: var(--color-primary);
 		box-shadow: 0 0 0 2px var(--color-primary-light);
 		border-radius: 2px;
+	}
+
+	.foldable-card__content {
+		position: relative;
 	}
 
 	&.is-expanded {

--- a/packages/components/src/foldable-card/index.jsx
+++ b/packages/components/src/foldable-card/index.jsx
@@ -36,6 +36,7 @@ class FoldableCard extends Component {
 		smooth: PropTypes.bool,
 		contentExpandedStyle: PropTypes.object,
 		contentCollapsedStyle: PropTypes.object,
+		useInert: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -48,6 +49,7 @@ class FoldableCard extends Component {
 		expanded: false,
 		screenReaderText: false,
 		smooth: false,
+		useInert: true,
 	};
 
 	state = {
@@ -125,7 +127,7 @@ class FoldableCard extends Component {
 		const additionalStyle = this.state.expanded
 			? this.props.contentExpandedStyle
 			: this.props.contentCollapsedStyle;
-		const inertProps = this.state.expanded ? {} : { inert: '' };
+		const inertProps = this.state.expanded || ! this.props.useInert ? {} : { inert: '' };
 
 		return (
 			<div className="foldable-card__content" style={ additionalStyle } { ...inertProps }>

--- a/packages/components/src/foldable-card/index.jsx
+++ b/packages/components/src/foldable-card/index.jsx
@@ -125,8 +125,10 @@ class FoldableCard extends Component {
 		const additionalStyle = this.state.expanded
 			? this.props.contentExpandedStyle
 			: this.props.contentCollapsedStyle;
+		const inertProps = this.state.expanded ? {} : { inert: '' };
+
 		return (
-			<div className="foldable-card__content" style={ additionalStyle }>
+			<div className="foldable-card__content" style={ additionalStyle } { ...inertProps }>
 				{ this.props.children }
 			</div>
 		);

--- a/packages/components/src/foldable-card/index.jsx
+++ b/packages/components/src/foldable-card/index.jsx
@@ -49,7 +49,7 @@ class FoldableCard extends Component {
 		expanded: false,
 		screenReaderText: false,
 		smooth: false,
-		useInert: true,
+		useInert: false,
 	};
 
 	state = {

--- a/packages/components/src/foldable-card/style.scss
+++ b/packages/components/src/foldable-card/style.scss
@@ -4,7 +4,6 @@
 
 // Multisite
 .foldable-card.card {
-
 	@include a8c-clear-fix;
 	position: relative;
 	transition: margin 0.15s linear;
@@ -26,7 +25,6 @@
 	}
 
 	&.has-border {
-
 		.foldable-card__summary,
 		.foldable-card__summary-expanded {
 			margin-right: 48px;
@@ -130,7 +128,6 @@ button:not(:disabled).foldable-card__action {
 
 .foldable-card__content {
 	display: none;
-	position: relative;
 }
 
 .foldable-card.is-smooth .foldable-card__content {

--- a/packages/components/src/foldable-card/style.scss
+++ b/packages/components/src/foldable-card/style.scss
@@ -4,6 +4,7 @@
 
 // Multisite
 .foldable-card.card {
+
 	@include a8c-clear-fix;
 	position: relative;
 	transition: margin 0.15s linear;
@@ -25,6 +26,7 @@
 	}
 
 	&.has-border {
+
 		.foldable-card__summary,
 		.foldable-card__summary-expanded {
 			margin-right: 48px;
@@ -128,6 +130,7 @@ button:not(:disabled).foldable-card__action {
 
 .foldable-card__content {
 	display: none;
+	position: relative;
 }
 
 .foldable-card.is-smooth .foldable-card__content {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101242

## Proposed Changes

* This PR adds a `useInert` prop to the `FoldableCard`. When `useInert` is enabled it adds the `inert` HTML attribute to the fordable card element when it is collapsed. This cause the contents of the `FoldableCard` to be ignored by keyboard focus, meaning you can tab over the collapsed card instead of tabbing in it. When the `FoldableCard` is open the `intert` attribute is removed and you can tab in like you'd expect.
* This PR adds `position: relative;` specifically to the `FoldableCard` that contains the `QuickPost` component. This causes the absolute positioned elements inside the `QuickPost` component to be hidden when the `FoldableCard` is collapsed.

> [!NOTE]  
> Because the `FoldableCard` component is a widely used component (73 results in 48 files), this PR takes a backward compatible approach to making changes to it so as not to cause unexpected behavior elsewhere in the codebase. However a global approach to changing `FoldableCard` could be made like this: https://github.com/Automattic/wp-calypso/pull/102061/files

Inert Property (tabbing with keyboard):
Before | After
--|--
<video src="https://github.com/user-attachments/assets/3d1f4aa6-e89d-496e-9f86-41a5f20751f2" /> | <video src="https://github.com/user-attachments/assets/7a90a949-cefa-45bd-89fa-7cba952fbf9a" />


Position Relative (floating [+] button):
Before | After
--|--
<video src="https://github.com/user-attachments/assets/5165683e-1f35-4126-80a6-c484ae5d9e25" /> | <video src="https://github.com/user-attachments/assets/c8f07f76-1819-4a6e-9cbd-5633612a9a6c" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve UX of the Reader Editor and expand the capabilities of the `FoldableCard` component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Calypso Live go to /reader
* Expand and collapse the Reader Editor. There should be no weird floating buttons when the editor is collapsed. (See "Position Relative" videos above)
* With the editor closed used the tab key to navigate the page and see how it skips over the elements inside the collapsed foldable card.
* Open the foldable card using the keyboard navigation and see how you can now navigate the Reader Editor elements inside the expanded card.
* Review the code to confirm it is a backward compatible approach.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
