### PR TITLE
composite-checkout: Move payment processor function list to PaymentProcessorProvider

### DIFF
--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -9,6 +9,7 @@ import { CheckoutProviderProps } from '../types';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { FormAndTransactionProvider } from './form-and-transaction-provider';
 import { PaymentMethodProvider } from './payment-method-provider';
+import { PaymentProcessorProvider } from './payment-processor-provider';
 import type { CheckoutContextInterface } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
@@ -42,10 +43,9 @@ export function CheckoutProvider( {
 	// Create a big blob of state to store in React Context for use by all this Provider's children.
 	const value: CheckoutContextInterface = useMemo(
 		() => ( {
-			paymentProcessors,
 			onPageLoadError,
 		} ),
-		[ paymentProcessors, onPageLoadError ]
+		[ onPageLoadError ]
 	);
 
 	const { __ } = useI18n();
@@ -73,7 +73,9 @@ export function CheckoutProvider( {
 						isValidating={ isValidating }
 						redirectToUrl={ redirectToUrl }
 					>
-						<CheckoutContext.Provider value={ value }>{ children }</CheckoutContext.Provider>
+						<PaymentProcessorProvider paymentProcessors={ paymentProcessors }>
+							<CheckoutContext.Provider value={ value }>{ children }</CheckoutContext.Provider>
+						</PaymentProcessorProvider>
 					</FormAndTransactionProvider>
 				</ThemeProvider>
 			</PaymentMethodProvider>

--- a/packages/composite-checkout/src/components/payment-processor-provider.tsx
+++ b/packages/composite-checkout/src/components/payment-processor-provider.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { PaymentProcessorProviderContext } from '../lib/payment-processor-provider-context';
+import type { PaymentProcessorProp, PaymentProcessorProviderContextInterface } from '../types';
+
+export function PaymentProcessorProvider( {
+	paymentProcessors,
+	children,
+}: {
+	paymentProcessors: PaymentProcessorProp;
+	children: React.ReactNode;
+} ) {
+	const value: PaymentProcessorProviderContextInterface = useMemo(
+		() => ( {
+			paymentProcessors,
+		} ),
+		[ paymentProcessors ]
+	);
+
+	return (
+		<PaymentProcessorProviderContext.Provider value={ value }>
+			{ children }
+		</PaymentProcessorProviderContext.Provider>
+	);
+}

--- a/packages/composite-checkout/src/lib/payment-processor-provider-context.ts
+++ b/packages/composite-checkout/src/lib/payment-processor-provider-context.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+import { PaymentProcessorProviderContextInterface } from '../types';
+
+const defaultContext: PaymentProcessorProviderContextInterface = {
+	paymentProcessors: {},
+};
+
+export const PaymentProcessorProviderContext = createContext( defaultContext );

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -1,5 +1,4 @@
 import { useContext } from 'react';
-import CheckoutContext from '../lib/checkout-context';
 import {
 	PaymentProcessorFunction,
 	PaymentProcessorResponseData,
@@ -8,9 +7,10 @@ import {
 	PaymentProcessorError,
 	PaymentProcessorResponseType,
 } from '../types';
+import { PaymentProcessorProviderContext } from './payment-processor-provider-context';
 
 export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
-	const { paymentProcessors } = useContext( CheckoutContext );
+	const { paymentProcessors } = useContext( PaymentProcessorProviderContext );
 	if ( ! paymentProcessors[ key ] ) {
 		throw new Error( `No payment processor found with key: ${ key }` );
 	}
@@ -18,7 +18,7 @@ export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
 }
 
 export function usePaymentProcessors(): Record< string, PaymentProcessorFunction > {
-	const { paymentProcessors } = useContext( CheckoutContext );
+	const { paymentProcessors } = useContext( PaymentProcessorProviderContext );
 	return paymentProcessors;
 }
 

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -94,8 +94,11 @@ export interface PaymentMethodProviderContextInterface {
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
 }
 
-export interface CheckoutContextInterface {
+export interface PaymentProcessorProviderContextInterface {
 	paymentProcessors: PaymentProcessorProp;
+}
+
+export interface CheckoutContextInterface {
 	onPageLoadError?: CheckoutPageErrorCallback;
 }
 


### PR DESCRIPTION
## Proposed Changes

`CheckoutProvider` does too much. Previous efforts have been made (https://github.com/Automattic/wp-calypso/pull/81796, https://github.com/Automattic/wp-calypso/pull/81793, https://github.com/Automattic/wp-calypso/pull/80529, https://github.com/Automattic/wp-calypso/pull/101974) to move toward making it just a wrapper for a series of other providers (perhaps eventually replacing it entirely?), but there's still state that it maintains.

This PR moves all the state having to do with the list of payment processor functions to a new provider, `PaymentProcessorProvider`. 

## Testing Instructions

Automated tests should handle most things.