### PR TITLE
composite-checkout: Move paymentProcessors to PaymentMethodProvider

### DIFF
--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -42,10 +42,9 @@ export function CheckoutProvider( {
 	// Create a big blob of state to store in React Context for use by all this Provider's children.
 	const value: CheckoutContextInterface = useMemo(
 		() => ( {
-			paymentProcessors,
 			onPageLoadError,
 		} ),
-		[ paymentProcessors, onPageLoadError ]
+		[ onPageLoadError ]
 	);
 
 	const { __ } = useI18n();
@@ -61,6 +60,7 @@ export function CheckoutProvider( {
 			<CheckoutProviderPropValidator propsToValidate={ propsToValidate } />
 			<PaymentMethodProvider
 				paymentMethods={ paymentMethods }
+				paymentProcessors={ paymentProcessors }
 				selectFirstAvailablePaymentMethod={ selectFirstAvailablePaymentMethod }
 				initiallySelectedPaymentMethodId={ initiallySelectedPaymentMethodId }
 			>

--- a/packages/composite-checkout/src/components/payment-method-provider.tsx
+++ b/packages/composite-checkout/src/components/payment-method-provider.tsx
@@ -5,18 +5,21 @@ import type {
 	PaymentMethod,
 	PaymentMethodChangedCallback,
 	PaymentMethodProviderContextInterface,
+	PaymentProcessorProp,
 } from '../types';
 
 const debug = debugFactory( 'composite-checkout:payment-method-provider' );
 
 export function PaymentMethodProvider( {
 	paymentMethods,
+	paymentProcessors,
 	selectFirstAvailablePaymentMethod,
 	initiallySelectedPaymentMethodId,
 	onPaymentMethodChanged,
 	children,
 }: {
 	paymentMethods: PaymentMethod[];
+	paymentProcessors: PaymentProcessorProp;
 	selectFirstAvailablePaymentMethod?: boolean;
 	initiallySelectedPaymentMethodId?: string | null;
 	onPaymentMethodChanged?: PaymentMethodChangedCallback;
@@ -56,13 +59,20 @@ export function PaymentMethodProvider( {
 	const value: PaymentMethodProviderContextInterface = useMemo(
 		() => ( {
 			allPaymentMethods: paymentMethods,
+			paymentProcessors,
 			disabledPaymentMethodIds,
 			setDisabledPaymentMethodIds,
 			paymentMethodId,
 			setPaymentMethodId,
 			onPaymentMethodChanged,
 		} ),
-		[ paymentMethodId, paymentMethods, disabledPaymentMethodIds, onPaymentMethodChanged ]
+		[
+			paymentMethodId,
+			paymentMethods,
+			disabledPaymentMethodIds,
+			onPaymentMethodChanged,
+			paymentProcessors,
+		]
 	);
 
 	return (

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -1,9 +1,7 @@
 import { createContext } from 'react';
 import { CheckoutContextInterface } from '../types';
 
-const defaultCheckoutContext: CheckoutContextInterface = {
-	paymentProcessors: {},
-};
+const defaultCheckoutContext: CheckoutContextInterface = {};
 
 const CheckoutContext = createContext( defaultCheckoutContext );
 

--- a/packages/composite-checkout/src/lib/payment-method-provider-context.ts
+++ b/packages/composite-checkout/src/lib/payment-method-provider-context.ts
@@ -6,6 +6,7 @@ function noop(): void {}
 
 const defaultContext: PaymentMethodProviderContextInterface = {
 	allPaymentMethods: [],
+	paymentProcessors: {},
 	disabledPaymentMethodIds: [],
 	setDisabledPaymentMethodIds: noop,
 	paymentMethodId: null,

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -1,5 +1,4 @@
 import { useContext } from 'react';
-import CheckoutContext from '../lib/checkout-context';
 import {
 	PaymentProcessorFunction,
 	PaymentProcessorResponseData,
@@ -8,9 +7,10 @@ import {
 	PaymentProcessorError,
 	PaymentProcessorResponseType,
 } from '../types';
+import { PaymentMethodProviderContext } from './payment-method-provider-context';
 
 export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
-	const { paymentProcessors } = useContext( CheckoutContext );
+	const { paymentProcessors } = useContext( PaymentMethodProviderContext );
 	if ( ! paymentProcessors[ key ] ) {
 		throw new Error( `No payment processor found with key: ${ key }` );
 	}
@@ -18,7 +18,7 @@ export function usePaymentProcessor( key: string ): PaymentProcessorFunction {
 }
 
 export function usePaymentProcessors(): Record< string, PaymentProcessorFunction > {
-	const { paymentProcessors } = useContext( CheckoutContext );
+	const { paymentProcessors } = useContext( PaymentMethodProviderContext );
 	return paymentProcessors;
 }
 

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -87,6 +87,7 @@ export type FormStatusManager = {
 
 export interface PaymentMethodProviderContextInterface {
 	allPaymentMethods: PaymentMethod[];
+	paymentProcessors: PaymentProcessorProp;
 	disabledPaymentMethodIds: string[];
 	setDisabledPaymentMethodIds: ( methods: string[] ) => void;
 	paymentMethodId: string | null | undefined;
@@ -95,7 +96,6 @@ export interface PaymentMethodProviderContextInterface {
 }
 
 export interface CheckoutContextInterface {
-	paymentProcessors: PaymentProcessorProp;
 	onPageLoadError?: CheckoutPageErrorCallback;
 }
 


### PR DESCRIPTION
## Proposed Changes

`CheckoutProvider` does too much. Previous efforts have been made (https://github.com/Automattic/wp-calypso/pull/81796, https://github.com/Automattic/wp-calypso/pull/81793, https://github.com/Automattic/wp-calypso/pull/80529, https://github.com/Automattic/wp-calypso/pull/101974) to move toward making it just a wrapper for a series of other providers (perhaps eventually replacing it entirely?), but there's still state that it maintains.

This PR moves all the state having to do with the list of payment processor functions to the `PaymentMethodProvider`, since payment processor functions are closely tied to payment method objects.

## Testing Instructions

Automated tests should handle most things.