### PR TITLE
Fix for locale suggestions links losing query string

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -86,7 +86,7 @@ const UserStepComponent: StepType = function UserStep( {
 
 	const localeSuggestions = shouldRenderLocaleSuggestions && (
 		<LocaleSuggestions
-			path={ window.location.pathname + ( window.location.search || '' ) }
+			path={ window.location.pathname + window.location.search ) }
 			locale={ locale }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -86,7 +86,7 @@ const UserStepComponent: StepType = function UserStep( {
 
 	const localeSuggestions = shouldRenderLocaleSuggestions && (
 		<LocaleSuggestions
-			path={ window.location.pathname + window.location.search ) }
+			path={ window.location.pathname + window.location.search }
 			locale={ locale }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -85,7 +85,10 @@ const UserStepComponent: StepType = function UserStep( {
 	};
 
 	const localeSuggestions = shouldRenderLocaleSuggestions && (
-		<LocaleSuggestions path={ window.location.pathname } locale={ locale } />
+		<LocaleSuggestions
+			path={ window.location.pathname + ( window.location.search || '' ) }
+			locale={ locale }
+		/>
 	);
 
 	const isStepContainerV2 = shouldUseStepContainerV2( flow );


### PR DESCRIPTION
Fix for BSKY-202

When we have a localized flow, we are losing query string when switching to a different locale like suggested here. We are relying on this query string to pass along the prompt information.:

![Zrzut ekranu 2025-03-28 o 17 59 52](https://github.com/user-attachments/assets/d47ba003-cfc0-4912-82b2-e1c77a91ba7e)



## Testing instructions

1. Set your browser locale to NOT english
2. Open incognito
3.  Go to http://calypso.localhost:3000/setup/ai-site-builder/user/?prompt=mariachi+restaurant
4. Clcik the notice "change language to xyz"
5. Observe query string being preserved
6. Continue signup

