### PR TITLE
Onboarding: Use LinkButton in places where we're not supposed to fire the skip Tracks event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -133,7 +133,7 @@ const UserStepComponent: StepType = function UserStep( {
 				backButton={
 					navigation.goBack ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
 				}
-				skipButton={ <Step.SkipButton href={ loginLink } label={ translate( 'Log in' ) } /> }
+				skipButton={ <Step.LinkButton href={ loginLink } label={ translate( 'Log in' ) } /> }
 			/>
 		);
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -838,7 +838,7 @@ export default function CheckoutMainContent( {
 						skipButton={
 							<span className="checkout-skip-button">
 								<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) } </label>
-								<Step.SkipButton
+								<Step.LinkButton
 									onClick={ toggleHelpCenter }
 									label={ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }
 								/>

--- a/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/LinkButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/LinkButton.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { normalizeButtonProps } from '../../../helpers/normalizeButtonProps';
+import { ButtonProps } from '../../../types';
+
+import './style.scss';
+
+export const LinkButton = ( originalProps: ButtonProps ) => {
+	const { __ } = useI18n();
+
+	const linkButtonProps = normalizeButtonProps( originalProps, {
+		label: __( 'Link', __i18n_text_domain__ ),
+		className: 'step-container-v2__link-button',
+	} );
+
+	return <Button variant="link" { ...linkButtonProps } />;
+};

--- a/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/style.scss
@@ -1,4 +1,4 @@
-.step-container-v2__skip-button {
+.step-container-v2__link-button {
 	font-size: inherit;
 	line-height: inherit;
 	font-weight: 500;

--- a/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
@@ -5,6 +5,12 @@ import { normalizeButtonProps } from '../../../helpers/normalizeButtonProps';
 import { ButtonProps } from '../../../types';
 import { LinkButton } from '../LinkButton/LinkButton';
 
+/**
+ * Do NOT use this button if you don't intend to skip the step.
+ *
+ * This button is visually identical to {@link LinkButton}.
+ * The difference between them is that this one fires a Tracks event when clicked.
+ */
 export const SkipButton = ( originalProps: ButtonProps ) => {
 	const { __ } = useI18n();
 	const stepContext = useStepContainerV2Context();

--- a/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/SkipButton/SkipButton.tsx
@@ -1,11 +1,9 @@
-import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useStepContainerV2Context } from '../../../contexts/StepContainerV2Context';
 import { decorateButtonWithTracksEventRecording } from '../../../helpers/decorateButtonWithTracksEventRecording';
 import { normalizeButtonProps } from '../../../helpers/normalizeButtonProps';
 import { ButtonProps } from '../../../types';
-
-import './style.scss';
+import { LinkButton } from '../LinkButton/LinkButton';
 
 export const SkipButton = ( originalProps: ButtonProps ) => {
 	const { __ } = useI18n();
@@ -13,12 +11,10 @@ export const SkipButton = ( originalProps: ButtonProps ) => {
 
 	const skipButtonProps = normalizeButtonProps( originalProps, {
 		label: __( 'Skip', __i18n_text_domain__ ),
-		className: 'step-container-v2__skip-button',
 	} );
 
 	return (
-		<Button
-			variant="link"
+		<LinkButton
 			{ ...decorateButtonWithTracksEventRecording( skipButtonProps, {
 				tracksEventName: 'calypso_signup_skip_step',
 				stepContext,

--- a/packages/onboarding/src/step-container-v2/index.tsx
+++ b/packages/onboarding/src/step-container-v2/index.tsx
@@ -9,6 +9,7 @@ export { StepContainerV2Provider } from './contexts/StepContainerV2Context';
 export { BackButton } from './components/buttons/BackButton/BackButton';
 export { NextButton } from './components/buttons/NextButton/NextButton';
 export { SkipButton } from './components/buttons/SkipButton/SkipButton';
+export { LinkButton } from './components/buttons/LinkButton/LinkButton';
 export { Heading } from './components/Heading/Heading';
 export { TopBar } from './components/TopBar/TopBar';
 export { StickyBottomBar } from './components/StickyBottomBar/StickyBottomBar';


### PR DESCRIPTION
## Proposed Changes

From the title, we were using the `SkipButton` in some places where it wasn't really a skip action, like clicking "Log in" or the "Visit help center" button.

## Testing Instructions

Enter the affected screens and verify you don't see the `calypso_signup_skip_step` event being fired anymore. Other screens, such as goals and DIFM, should still fire it.

