### PR TITLE
Storybook docgen: Support `@wordpress/components` props

### DIFF
--- a/packages/calypso-storybook/src/index.js
+++ b/packages/calypso-storybook/src/index.js
@@ -50,6 +50,21 @@ module.exports = function storybookDefaultConfig( {
 		typescript: {
 			check: false,
 			reactDocgen: 'react-docgen-typescript',
+			reactDocgenTypescriptOptions: {
+				propFilter: ( prop ) => {
+					// Always show props declared in `@wordpress/components`
+					if ( prop.declarations.some( ( d ) => d.fileName.includes( '@wordpress/components' ) ) ) {
+						return true;
+					}
+
+					// Hide props declared in other `node_modules` (mostly built-in React props)
+					if ( prop.declarations.every( ( d ) => d.fileName.includes( 'node_modules' ) ) ) {
+						return false;
+					}
+
+					return true;
+				},
+			},
 		},
 		webpackFinal: async ( config ) => {
 			config.resolve.alias = {

--- a/packages/components/styles/storybook-utils/typed-wp-components.tsx
+++ b/packages/components/styles/storybook-utils/typed-wp-components.tsx
@@ -1,0 +1,8 @@
+/**
+ * These re-exports, in combination with the `reactDocgenTypescriptOptions.propFilter` in the
+ * Storybook config, allow the docgen to read and display type information for `@wordpress/components`.
+ */
+
+import { Button as _Button } from '@wordpress/components';
+
+export const Button = _Button;

--- a/packages/components/styles/wp-button-override.stories.tsx
+++ b/packages/components/styles/wp-button-override.stories.tsx
@@ -1,12 +1,9 @@
-import { Button } from '@wordpress/components';
 import React from 'react';
+import { Button } from './storybook-utils/typed-wp-components';
 import type { Meta, StoryObj } from '@storybook/react';
 
 // Not using a relative path here to ensure that the build is working.
 import '@automattic/components/styles/wp-button-override.scss';
-
-// TODO: Investigate why displayName becomes `UnforwardedButton` when imported.
-Button.displayName = 'Button';
 
 /**
  * This reference is for A8C-specific style overrides for the `Button` component from `@wordpress/components`.


### PR DESCRIPTION
Closes ARC-35

## Proposed Changes

In Storybook, adds a way to show props originating from the `@wordpress/components` package.

Previously, the docgen was unable to process types declared in `node_modules`.

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/4b72ef10-bf6e-4886-a8c9-afe2fb34b676" alt="Button props table, before" width="911">|<img src="https://github.com/user-attachments/assets/ac69503d-a315-47d3-8d4c-f948182cb170" alt="Button props table, after" width="911">|

## Why are these changes being made?

We are increasingly needing to document components that slightly override or compose from `@wordpress/components`. This will also be needed in #100771.

## Testing Instructions

`yarn components:storybook:start` and see the story for WP Overrides ▸ Button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
