### PR TITLE
Storybook: Expand controls by default

### DIFF
--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -2,6 +2,7 @@ import './style.scss';
 
 const parameters = {
 	controls: {
+		expanded: true,
 		sort: 'requiredFirst',
 	},
 	docs: {

--- a/packages/components/src/calendar/stories/date.stories.tsx
+++ b/packages/components/src/calendar/stories/date.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta< typeof Calendar > = {
 		onChange: { action: 'onChange', control: false },
 	},
 	parameters: {
-		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
 };

--- a/packages/components/src/logos/jetpack-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/jetpack-logo/stories/index.stories.tsx
@@ -4,9 +4,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta< typeof JetpackLogo > = {
 	title: 'packages/components/Logos/JetpackLogo',
 	component: JetpackLogo,
-	parameters: {
-		controls: { expanded: true },
-	},
 };
 export default meta;
 

--- a/packages/components/src/logos/wordpress-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/wordpress-logo/stories/index.stories.tsx
@@ -13,9 +13,6 @@ const meta: Meta< typeof WordPressLogo > = {
 			</div>
 		),
 	],
-	parameters: {
-		controls: { expanded: true },
-	},
 };
 export default meta;
 

--- a/packages/components/src/searchable-dropdown/index.stories.tsx
+++ b/packages/components/src/searchable-dropdown/index.stories.tsx
@@ -5,9 +5,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta< typeof SearchableDropdown > = {
 	title: 'packages/components/SearchableDropdown',
 	component: SearchableDropdown,
-	parameters: {
-		controls: { expanded: true },
-	},
 };
 
 export default meta;


### PR DESCRIPTION
Closes ARC-37

## Proposed Changes

Expands the Storybook controls by default so the prop descriptions can always be read.

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/4b6b0615-c433-4587-9c7c-9c086955475e" alt="Story controls, before" width="927">|<img src="https://github.com/user-attachments/assets/c99b4b2d-e768-43da-8eab-e81515e7b79d" alt="Story controls, after" width="927">|


## Why are these changes being made?

This will be increasingly useful as we improve are props documentation.

## Testing Instructions

`yarn components:storybook:start` and see the individual story pages (not Docs) for the `Calendar` component.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
