### PR TITLE
Jetpack Onboarding: various auth improvements

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -818,7 +818,9 @@ export function redirectJetpackDirectAuthError( context, next, newQuery = {} ) {
 
 	try {
 		const redirectTo = new URL(
-			queryParams.get( 'redirect_to' ) || window.sessionStorage.getItem( 'login_redirect_to' )
+			queryParams.get( 'redirect_to' ) ||
+				window.sessionStorage.getItem( 'login_redirect_to' ) ||
+				`${ window.location.origin }${ fallbackUrl }`
 		);
 		window.sessionStorage.setItem( 'login_redirect_to', redirectTo.toString() );
 		context.store.dispatch(

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -813,14 +813,14 @@ export function redirectJetpackDirectAuthError( context, next, newQuery = {} ) {
 
 	queryParams.set( 'allow_site_connection', '1' );
 
-	const redirectUrl = `/log-in/jetpack/?${ queryParams.toString() }`;
-	window.history.replaceState( null, '', redirectUrl );
+	const fallbackUrl = `/log-in/jetpack/?${ queryParams.toString() }`;
+	window.history.replaceState( null, '', fallbackUrl );
 
 	try {
 		const redirectTo = new URL(
-			queryParams.get( 'redirect_to' ) || `${ window.location.origin }${ redirectUrl }`
+			queryParams.get( 'redirect_to' ) || window.sessionStorage.getItem( 'login_redirect_to' )
 		);
-		window.sessionStorage?.setItem( 'login_redirect_to', redirectTo.toString() );
+		window.sessionStorage.setItem( 'login_redirect_to', redirectTo.toString() );
 		context.store.dispatch(
 			setRoute( redirectTo.pathname, Object.fromEntries( redirectTo.searchParams.entries() ) )
 		);

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -544,11 +544,6 @@ export async function jetpackGitHubAuth( context, next ) {
 		return next();
 	}
 
-	if ( isUserLoggedIn( context.store.getState() ) ) {
-		// Log out the user and reload the page
-		return context.store.dispatch( redirectToLogout( window.location.href ) );
-	}
-
 	const redirectUri = `${ window.location.origin }/log-in/jetpack/github/callback`;
 	try {
 		// Store redirect_to in sessionStorage for use on callback


### PR DESCRIPTION
Resolves MARTECH-54 and MARTECH-55

## Proposed Changes

- **Do not log out GitHub auth endpoint - not necessary and causes error sometimes**
- **Fix setting redirect_to in state**

When the situation gets complicated - the existing account is detected, any issue with the onboarding flow occurs - the current flow reads data mostly from state and sessionStorage. This PR fixes saving the route in the state, as we want to save the `redirect_to` value rather than fallback url.

Separately, GitHub auth endpoint doesn't need logging out of the account - in the contrary to Google/Apple, and it actually causes sporadically errors when the logic is present (triggers nonce errors). We get rid of that code.

## Testing Instructions

* Spin out the JN with this branch, and log in to the site in incognito mode to make things more fun
* Go through the GitHub flow, and confirm it works well
* The rest of things cannot be really tested on staging, we will test it thoroughly in production.
