### PR TITLE
Add loading ellipses when magic link email is attempting to send

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -128,6 +128,8 @@ class MagicLogin extends Component {
 		hashedEmail: null,
 	};
 
+	isInitialMount = true;
+
 	componentDidMount() {
 		const { userEmail, oauth2Client, query } = this.props;
 
@@ -145,6 +147,8 @@ class MagicLogin extends Component {
 				is_initial_view: true,
 			} );
 		}
+
+		this.isInitialMount = false;
 
 		// If the auto_trigger query parameter is set to true, automatically trigger the email send.
 		if ( query?.auto_trigger !== undefined ) {
@@ -1271,6 +1275,7 @@ class MagicLogin extends Component {
 			translate,
 			showCheckYourEmail: showEmailLinkVerification,
 			isWooJPC,
+			isSendingEmail,
 		} = this.props;
 		const { showSecondaryEmailOptions, showEmailCodeVerification, usernameOrEmail } = this.state;
 
@@ -1339,14 +1344,18 @@ class MagicLogin extends Component {
 			);
 		}
 
+		const isJetpackMagicLinkSignUpEnabled =
+			config.isEnabled( 'jetpack/magic-link-signup' ) && this.props.isJetpackLogin;
+		const shouldShowLoadingEllipsis =
+			isJetpackMagicLinkSignUpEnabled && ( isSendingEmail || this.isInitialMount );
+
 		// If this is part of the Jetpack login flow and the `jetpack/magic-link-signup` feature
 		// flag is enabled, some steps will display a different UI
 		const requestLoginEmailFormProps = {
 			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
-			...( this.props.isJetpackLogin && config.isEnabled( 'jetpack/magic-link-signup' )
-				? { isJetpackMagicLinkSignUpEnabled: true }
-				: {} ),
+			...( isJetpackMagicLinkSignUpEnabled ? { isJetpackMagicLinkSignUpEnabled: true } : {} ),
 			createAccountForNewUser: true,
+			shouldShowLoadingEllipsis,
 		};
 
 		return (
@@ -1365,7 +1374,7 @@ class MagicLogin extends Component {
 
 				<RequestLoginEmailForm { ...requestLoginEmailFormProps } />
 
-				{ this.renderLinks() }
+				{ ! shouldShowLoadingEllipsis && this.renderLinks() }
 			</Main>
 		);
 	}

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
@@ -56,6 +57,7 @@ class RequestLoginEmailForm extends Component {
 		onSubmitEmail: PropTypes.func,
 		onSendEmailLogin: PropTypes.func,
 		createAccountForNewUser: PropTypes.bool,
+		shouldShowLoadingEllipsis: PropTypes.bool,
 		blogId: PropTypes.string,
 		errorMessage: PropTypes.string,
 		onErrorDismiss: PropTypes.func,
@@ -68,6 +70,7 @@ class RequestLoginEmailForm extends Component {
 	state = {
 		usernameOrEmail: this.props.userEmail || '',
 		site: {},
+		isLoadingSite: !! this.props.blogId,
 	};
 
 	usernameOrEmailRef = createRef();
@@ -77,7 +80,8 @@ class RequestLoginEmailForm extends Component {
 		if ( blogId ) {
 			wpcom.req
 				.get( `/sites/${ this.props.blogId }` )
-				.then( ( result ) => this.setState( { site: result } ) );
+				.then( ( result ) => this.setState( { site: result, isLoadingSite: false } ) )
+				.catch( () => this.setState( { isLoadingSite: false } ) );
 		}
 	}
 
@@ -173,7 +177,12 @@ class RequestLoginEmailForm extends Component {
 			isEmailInputError,
 			isSubmitButtonDisabled,
 			isSubmitButtonBusy,
+			shouldShowLoadingEllipsis,
 		} = this.props;
+
+		if ( shouldShowLoadingEllipsis ) {
+			return <LoadingEllipsis className="magic-login__loading-ellipsis--jetpack" />;
+		}
 
 		const usernameOrEmail = this.getUsernameOrEmailFromState();
 		const siteIcon = this.state.site?.icon?.img ?? this.state.site?.icon?.ico ?? null;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -24,6 +24,19 @@
 	}
 }
 
+.layout.is-jetpack-login {
+	.magic-login {
+		&__loading-ellipsis--jetpack {
+			left: 50%;
+			transform: translateX(-50%);
+
+			div {
+				background: var(--studio-jetpack-green-40, #069e08 );
+			}
+		}
+	}	
+}
+
 .layout.is-wpcom-magic-login {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Resolves MARTECH-56

## Proposed Changes

* Prevent any data from being loaded during the Jetpack Magic login flow until everything has had a chance to load initially

## Why are these changes being made?

* There were flashes on the screen from several components while the login flow was loading. This shows a loading ellipses until that has been done to avoid content flashing


## Testing Instructions

1. Start a Jurassic Ninja site with Bleeding edge checked out
2. Go to `/wp-admin/admin.php?page=my-jetpack#/onboarding` on the site
3. Fill out your email and submit the form
4. When you are sent to the loading page, you will see the flashes that were reported
5. Start up your local Calypso environment (or use the live link) and replace the domain in the URL. Reload the page and you should see a loading indicator until the email was sent

![image](https://github.com/user-attachments/assets/d477e1da-f979-4d88-a682-7f00a0b80147)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
