### PR TITLE
composite-checkout: Prevent jumping forward to a step without completing intervening steps

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -291,7 +291,7 @@ A React Hook that will return the `onClick` function passed to each [payment met
 
 ### useMakeStepActive
 
-A React Hook that will return a function to set a step to be the active step. Only works within a step. The returned function looks like `( stepId: string ) => Promise< boolean >;`. Calling this function is similar to pressing the "Edit" button on the specified step. Note that this is risky! It will make the previous active step inactive, but **will not complete** that step, so if the previous step has any `isCompleteCallback` behavior, that behavior will not be triggered. It will also ignore the `canEditStep` prop of `CheckoutStep`.
+A React Hook that will return a function to set a step to be the active step. Only works within a step. The returned function looks like `( stepId: string ) => Promise< boolean >;`. Calling this function is similar to pressing the "Edit" button on the specified step. This will attempt to complete each step between the active step and the new step, if jumping forward, stopping on any step that is not complete.
 
 ### useSetStepComplete
 

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -195,7 +195,8 @@ function createCheckoutStepGroupActions(
 		// If we are going forward in steps, we must try to complete each step
 		// starting at the active one and ending before the new one, stopping at
 		// any step that is not complete.
-		for ( let step = state.activeStepNumber; step < stepNumber; step++ ) {
+		const activeStep = state.activeStepNumber > 0 ? state.activeStepNumber : 1;
+		for ( let step = activeStep; step < stepNumber; step++ ) {
 			const didStepComplete = await getStepCompleteCallback( step )();
 			debug(
 				`attempting to set step complete: '${ stepId }'; step ${ step } result was ${ didStepComplete }`

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -177,16 +177,38 @@ function createCheckoutStepGroupActions(
 		);
 	};
 
+	// A programmatic way to press the "Edit" button on a step.
 	const makeStepActive = async ( stepId: string ) => {
 		debug( `attempting to set step active: '${ stepId }'` );
 		const stepNumber = getStepNumberFromId( stepId );
 		if ( ! stepNumber ) {
 			throw new Error( `Cannot find step with id '${ stepId }' when trying to set step active.` );
 		}
+
+		// If we are going backwards in steps, just do it. The user will end up on
+		// this step again later anyway.
+		if ( stepNumber < state.activeStepNumber ) {
+			setActiveStepNumber( stepNumber );
+			return true;
+		}
+
+		// If we are going forward in steps, we must try to complete each step
+		// starting at the active one and ending before the new one, stopping at
+		// any step that is not complete.
+		for ( let step = state.activeStepNumber; step < stepNumber; step++ ) {
+			const didStepComplete = await getStepCompleteCallback( step )();
+			debug(
+				`attempting to set step complete: '${ stepId }'; step ${ step } result was ${ didStepComplete }`
+			);
+			if ( ! didStepComplete ) {
+				return false;
+			}
+		}
 		setActiveStepNumber( stepNumber );
 		return true;
 	};
 
+	// A programmatic way to press the "Continue to next step" button on a step.
 	const setStepComplete = async ( stepId: string ) => {
 		debug( `attempting to set step complete: '${ stepId }'` );
 		const stepNumber = getStepNumberFromId( stepId );
@@ -459,9 +481,11 @@ export const CheckoutStep = ( {
 	);
 	const { onPageLoadError } = useContext( CheckoutContext );
 	const { formStatus, setFormValidating, setFormReady } = useFormStatus();
+	const makeStepActive = useMakeStepActive();
 	const setThisStepCompleteStatus = ( newStatus: boolean ) =>
 		setStepCompleteStatus( { [ stepNumber ]: newStatus } );
-	const goToThisStep = () => setActiveStepNumber( stepNumber );
+
+	const goToThisStep = () => makeStepActive( stepId );
 
 	// This is the callback called when you press "Continue" on a step.
 	const goToNextStep = async () => {

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -423,7 +423,7 @@ describe( 'Checkout', () => {
 			} );
 		} );
 
-		it( 'does change steps if useMakeStepActive is used', async () => {
+		it( 'changes steps if useMakeStepActive is used', async () => {
 			function ManualStepChangeButton( { stepId } ) {
 				const setActiveStep = useMakeStepActive();
 				return <button onClick={ () => setActiveStep( stepId ) }>Change step</button>;
@@ -456,6 +456,40 @@ describe( 'Checkout', () => {
 				expect( firstStepContent ).toHaveStyle( 'display: none' );
 			} );
 			expect( secondStepContent ).toHaveStyle( 'display: block' );
+		} );
+
+		it( 'changes steps to the first incomplete step if useMakeStepActive is used', async () => {
+			function ManualStepChangeButton( { stepId } ) {
+				const setActiveStep = useMakeStepActive();
+				return <button onClick={ () => setActiveStep( stepId ) }>Change step</button>;
+			}
+			const stepOne = {
+				...steps[ 1 ],
+				id: 'step-will-fail',
+				className: 'step-will-fail',
+				isCompleteCallback: () => Promise.resolve( false ),
+			};
+			const stepTwo = {
+				...steps[ 1 ],
+				activeStepContent: (
+					<div>
+						<span>Custom Step - Summary Active</span>
+						<ManualStepChangeButton stepId={ steps[ 1 ].id } />
+					</div>
+				),
+			};
+			const { container, getAllByText } = render( <MyCheckout steps={ [ stepOne, stepTwo ] } /> );
+			const manualContinue = getAllByText( 'Change step' )[ 0 ];
+			const firstStep = container.querySelector( '.' + stepOne.className );
+			const secondStep = container.querySelector( '.' + stepTwo.className );
+			const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
+			const secondStepContent = secondStep.querySelector( '.checkout-steps__step-content' );
+			expect( firstStepContent ).toHaveStyle( 'display: block' );
+			expect( secondStepContent ).toHaveStyle( 'display: none' );
+			const user = userEvent.setup();
+			await user.click( manualContinue );
+			expect( firstStepContent ).toHaveStyle( 'display: block' );
+			expect( secondStepContent ).toHaveStyle( 'display: none' );
 		} );
 
 		it( 'does change steps if useSetStepComplete is used and the step becomes complete after a Promise resolves', async () => {


### PR DESCRIPTION
## Proposed Changes

This PR modifies the "Edit" button and the `useMakeStepActive` hook so that they use a similar system to `useSetStepComplete`: both will call the `isCompleteCallback` for each step between the active step and the new target step, stopping if they find a step that is not complete.

Fixes https://github.com/Automattic/payments-shilling/issues/3559

## Why are these changes being made?

There are four ways to change steps in a `CheckoutStepGroup`:

1. Click the "Continue" button on the active step. This calls the `isCompleteCallback` on that step which allows for validation and updating state (eg: validating and updating tax fields).
2. Click the "Edit" button on an inactive step. This performs no validation, [risking bugs](https://github.com/Automattic/payments-shilling/issues/3559).
3. Use the `useSetStepComplete` hook callback to set a step to complete. This calls the `isCompleteCallback` for the target step as well as any previous steps.
4. Use the `useMakeStepActive` hook callback to set a step to active. This performs no validation, [risking bugs](https://github.com/Automattic/payments-shilling/issues/3559).

## Testing Instructions

Automated tests are included.

To manually test:

1. Use an account with at least one saved payment method.
2. Visit checkout with a product in your cart.
3. Edit (if necessary) the contact/billing details step.
4. Change the contact info in such a way that the taxes should change (eg: US postal code `10001` charges taxes but `90210` does not), but **DO NOT CLICK** "Continue to Payment".
5. Click "Edit" on the payment method step.
6. Verify that the active step changes and that the taxes are changed based on the new tax info.
