### PR TITLE
Exclude destructive variants in button color customization

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -6,19 +6,19 @@
 }
 
 /* @wordpress/components Button overrides */
-.components-button.is-primary {
+.components-button.is-primary:not(.is-destructive) {
 	--wp-components-color-accent: var(--color-accent);
 	--wp-components-color-accent-inverted: var(--color-text-inverted);
 	--wp-components-color-accent-darker-10: var(--color-accent-60);
 	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }
 
-.components-button.is-secondary {
+.components-button.is-secondary:not(.is-destructive) {
 	--wp-components-color-accent: var(--color-accent);
 	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }
 
-.components-button.is-tertiary {
+.components-button.is-tertiary:not(.is-destructive) {
 	--wp-components-color-accent: var(--color-accent);
 	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }

--- a/client/devdocs/design/wordpress-components-gallery/button.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/button.tsx
@@ -50,6 +50,9 @@ const ButtonExample = () => {
 				<Button variant="primary" isBusy>
 					Busy
 				</Button>
+				<Button variant="primary" isDestructive>
+					Destructive
+				</Button>
 			</Flex>
 		</div>
 	);

--- a/client/devdocs/design/wordpress-components-gallery/button.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/button.tsx
@@ -22,6 +22,9 @@ const ButtonExample = () => {
 				<Button size="small" variant="tertiary">
 					Tertiary Button
 				</Button>
+				<Button size="small" variant="link">
+					Link Button
+				</Button>
 				<Button size="small" icon={ more } />
 				<Button size="small" variant="primary" icon={ more } />
 				<Button size="small" variant="secondary" icon={ more } />
@@ -43,6 +46,7 @@ const ButtonExample = () => {
 				<Button variant="primary">Primary Button</Button>
 				<Button variant="secondary">Secondary Button</Button>
 				<Button variant="tertiary">Tertiary Button</Button>
+				<Button variant="link">Link Button</Button>
 				<Button icon={ more } />
 				<Button variant="primary" icon={ more } />
 				<Button variant="secondary" icon={ more } />

--- a/client/devdocs/design/wordpress-components-gallery/button.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/button.tsx
@@ -32,6 +32,9 @@ const ButtonExample = () => {
 				<Button size="small" variant="primary" isBusy>
 					Busy
 				</Button>
+				<Button size="small" variant="primary" isDestructive>
+					Destructive
+				</Button>
 			</Flex>
 
 			<h2>Regular Buttons</h2>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101901#discussion_r2016353131, https://github.com/Automattic/wp-calypso/pull/101279

## Proposed Changes

- Limit the CSS custom properties override (`--wp-components-color-accent`, etc.) to `.components-button` variants that are not `.is-destructive`.
- This ensures that styles meant for primary/secondary/tertiary buttons do not unintentionally affect destructive buttons.
- Confirmed other variations like `.is-link` don’t need this restriction. 

<img width="1176" alt="Screenshot 2025-03-31 at 13 28 02" src="https://github.com/user-attachments/assets/baf7a85f-f186-42bf-ad8f-346a4bda4885" />


## Why are these changes being made?

Previously, our color overrides applied, including `.is-destructive` variants, due to their specificity. 
This caused the Gutenberg-intended destructive styling, such as red backgrounds, to be overwritten with the site's accent color.
https://github.com/Automattic/wp-calypso/pull/101901#discussion_r2016353131

## Testing Instructions

- Open Calypso Live
- Go to /devdocs/wordpress-components-gallery
- Confirm:
   - Destructive button has the intended red style
   - Non-destructive buttons do not have any regression

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label if any new strings were added?
- [x] For Jetpack: Have we added "[Status] Needs Privacy Updates" if needed?