### PR TITLE
Use variant slug for login URLs when it exists

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -148,10 +148,11 @@ export const FlowRenderer: React.FC< { flow: Flow; steps: readonly StepperStep[]
 		// and are redirected to the user step.
 		const postAuthStepSlug = stepData?.nextStep ?? '';
 		if ( step.slug === PRIVATE_STEPS.USER.slug && postAuthStepSlug ) {
+			const flowSlug = flow.variantSlug ?? flow.name;
 			const previousAuthStepSlug = stepData?.previousStep;
 			const postAuthStepPath = createPath( {
 				pathname: generatePath( '/setup/:flow/:step/:lang?', {
-					flow: flow.name,
+					flow: flowSlug,
 					step: postAuthStepSlug,
 					lang: lang === 'en' || isLoggedIn ? null : lang,
 				} ),
@@ -160,7 +161,7 @@ export const FlowRenderer: React.FC< { flow: Flow; steps: readonly StepperStep[]
 			} );
 
 			const signupUrl = generatePath( '/setup/:flow/:step/:lang?', {
-				flow: flow.name,
+				flow: flowSlug,
 				step: 'user',
 				lang: lang === 'en' || isLoggedIn ? null : lang,
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
 * https://github.com/Automattic/wp-calypso/pull/101950

## Proposed Changes

* This PR ensures that the built-in Stepper user step uses `flow.variantSlug` in computing URLs, but falls back on `flow.name` when `flow.variantSlug` is not defined.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We shipped https://github.com/Automattic/wp-calypso/pull/101950 last week, which switched the `site-migration` and `hosted-site-migration` flows over to the built-in Stepper authentication logic.
* When testing the `hosted-site-migration` flow, I discovered that the "Log in" link that we were computing was sending redirecting users to the base `site-migration` flow after logging in, which then sent them to My Home because a `siteSlug` wasn't present on the URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via calypso.live
* In incognito window with no user logged in, navigate to `/setup/hosted-site-migration`
* Verify that you're taken to the user login step at `/setup/hosted-site-migration/user`
* Hover over the "Log in" link in the top right corner, and verify that the `redirect_to` URL parameter is pointing at the `/setup/hosted-site-migration` flow -- the URL-encoded value visible in the URL should start with `%2Fsetup%2Fhosted-site-migration%2Fsite-migration-identify`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [N/A] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
