### PR TITLE
Help Center - DIFM: Update font size on prod

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/style.scss
@@ -1,6 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.difm-starting-point {
+	.help-center-step-button__button {
+		font-size: 0.875rem;
+		font-weight: 500;
+	}
+}
+
 .step-container-v2:has(.step-container-v2--difm-starting-point) {
 	.help-center-step-button {
 		font-size: 0.875rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://wp.me/pdh1Xd-31k#comment-3112

## Proposed Changes

On production, the old step container needs to have an updated font size and weight for the link on top right. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check /setup/site-setup/difmStartingPoint?siteSlug=fsdfdsfsdfsdf6.wordpress.com&flags=signup/help-center-link on prod