### PR TITLE
Stepper: Fix user step gap in signup via email page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/style.scss
@@ -8,6 +8,10 @@ $gray-50: #646970;
 $breakpoint-mobile: 660px;
 
 .step-route.user {
+	.form-fieldset {
+		margin-bottom: 8px;
+	}
+
 	.locale-suggestions {
 		margin: 0 auto;
 	}


### PR DESCRIPTION
The default 20px margin is not suitable for the user step in Stepper. This fixes it to the specified 8px.

Fixes: https://github.com/Automattic/wp-calypso/issues/101947