### PR TITLE
E2E Tests: Fix onboarding coming soon check

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -178,7 +178,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			await tmpPage.goto( newSiteDetails.blog_details.url as string );
 
 			// View site.
-			const comingSoonPage = new ComingSoonPage( page );
+			const comingSoonPage = new ComingSoonPage( tmpPage );
 			await comingSoonPage.validateComingSoonState();
 
 			// Dispose the test page and context.


### PR DESCRIPTION
## Proposed Changes

In #100764 we removed a badge from the sidebar of WP-Admin. This meant that an e2e test checking the "coming soon" text started failing because that was rendered in a badge in the sidebar before. 

That said, the test was not meant to be testing that particular text, it was meant to check that the frontend of the site was showing "coming soon". (As otherwise the frontend page was being loaded for no reason)

This PR fixes the e2e test in question.