### PR TITLE
Stylelint: remove constraints on font-size units

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -25,7 +25,6 @@
 		"no-invalid-position-at-import-rule": null,
 		"declaration-property-unit-allowed-list": [
 			{
-				"/^font-size$|^font$/": [ "rem" ],
 				"line-height": [ "px" ],
 				"/radius$/": [ "px", "%" ]
 			},

--- a/apps/blaze-dashboard/src/styles/wp-admin.scss
+++ b/apps/blaze-dashboard/src/styles/wp-admin.scss
@@ -43,7 +43,7 @@
 	width: auto;
 	background: var(--studio-white);
 	color: var(--color-text);
-	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 13px;
 	margin-left: 20px;
 	margin-bottom: 2px;
 
@@ -60,13 +60,13 @@
 	h2,
 	h3 {
 		color: var(--studio-gray-90);
-		font-size: 1.3em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 1.3em;
 		margin: 1em 0;
 		font-weight: 600;
 	}
 
 	p {
-		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 13px;
 		line-height: 1.5;
 		margin: 0.5em 0;
 		padding: 2px;

--- a/apps/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/actions.scss
@@ -21,7 +21,6 @@
 			padding-right: 52px;
 			min-height: 37px;
 			width: 100%;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 14px;
 			font-family: inherit;
 			transition: border 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
@@ -41,7 +40,6 @@
 			right: 25px;
 			text-transform: uppercase;
 			font-weight: 600;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 12px;
 		}
 		button.active {
@@ -68,7 +66,6 @@
 	box-sizing: border-box;
 	cursor: pointer;
 	display: inline-block;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	max-width: 25%;
 	padding: 0 18px;
@@ -128,7 +125,6 @@
 	}
 
 	.wpnc__gridicon {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 24px;
 	}
 

--- a/apps/notifications/src/panel/boot/stylesheets/block-user.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/block-user.scss
@@ -12,7 +12,6 @@ div.wpnc__user {
 	}
 
 	p {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 0.85em;
 		margin: 0;
 	}

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -261,7 +261,7 @@ $with-sidebar-min-page-width: 1114px;
 		background: var(--color-surface);
 		border: 1px solid var(--color-neutral-light);
 		border-right: none;
-		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 13px;
 		height: 26px;
 		cursor: pointer;
 		user-select: none; // Makes text unselectable
@@ -378,12 +378,12 @@ $with-sidebar-min-page-width: 1114px;
 		transform: translateY(-50%);
 
 		h2 {
-			font: 400 21px/24px $sans; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font: 400 21px/24px $sans;
 			margin-bottom: 4px;
 		}
 
 		p {
-			font: 400 16px/24px $sans; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font: 400 16px/24px $sans;
 		}
 	}
 
@@ -681,7 +681,7 @@ $with-sidebar-min-page-width: 1114px;
 		.wpnc__comment .wpnc__user p.wpnc__excerpt {
 			color: var(--color-secondary);
 			max-height: 1.5em;
-			font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 14px;
 		}
 
 		.wpnc__reply {
@@ -714,7 +714,7 @@ $with-sidebar-min-page-width: 1114px;
 		}
 
 		.wpnc__note-icon .wpnc__gridicon {
-			font-size: 2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 2em;
 			background-color: var(--color-neutral-10);
 			border-color: var(--color-neutral-10);
 		}
@@ -812,7 +812,7 @@ $with-sidebar-min-page-width: 1114px;
 
 			code {
 				font-family: $code;
-				font-size: 90%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 90%;
 				color: var(--color-neutral-50);
 				background: var(--color-neutral-0);
 				border: 1px solid var(--color-neutral-10);

--- a/apps/notifications/src/panel/boot/stylesheets/note-common.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/note-common.scss
@@ -35,7 +35,6 @@ div.wpnc__note-actions {
 		clip: auto !important;
 		color: #21759b;
 		display: block;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 14px;
 		font-weight: bold;
 		height: auto;

--- a/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -21,7 +21,6 @@
 		text-decoration: none;
 		vertical-align: top;
 		box-sizing: border-box;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 14px;
 		line-height: 21px;
 		border-radius: 4px;
@@ -57,7 +56,6 @@
 		&.is-compact {
 			padding: 7px;
 			color: var(--color-neutral-40);
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 11px;
 			line-height: 1;
 			text-transform: uppercase;

--- a/apps/notifications/src/panel/boot/stylesheets/shared/forms.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/forms.scss
@@ -3,7 +3,6 @@
 	padding: 7px 14px;
 	width: 100%;
 	color: var(--color-neutral-70);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 16px;
 	line-height: 1.5;
 	border: 1px solid var(--color-neutral-10);

--- a/apps/notifications/src/panel/boot/stylesheets/shared/reset.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/reset.scss
@@ -57,7 +57,6 @@
 		border: 0;
 		margin: 0;
 		font-family: inherit;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 100%;
 		font-style: inherit;
 		font-weight: inherit;

--- a/apps/notifications/src/panel/suggestions/styles.scss
+++ b/apps/notifications/src/panel/suggestions/styles.scss
@@ -38,7 +38,6 @@ $box-shadow: 0 5px 6px color-mix(in srgb, var(--color-neutral-10) 50%, transpare
 			border-bottom: 1px solid $light-border-color;
 			cursor: pointer;
 			line-height: $img-size;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 14px;
 			height: $img-size;
 			overflow: hidden;
@@ -67,7 +66,6 @@ $box-shadow: 0 5px 6px color-mix(in srgb, var(--color-neutral-10) 50%, transpare
 	}
 
 	small {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 11px;
 		font-weight: 400;
 		float: right;

--- a/apps/o2-blocks/src/github-issue-template/style.scss
+++ b/apps/o2-blocks/src/github-issue-template/style.scss
@@ -21,7 +21,6 @@
 		.wp-block-a8c-github-template__icon {
 			background: none;
 			color: var(--color-text-inverted);
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 26px;
 			top: calc(50% - 23px);
 

--- a/apps/o2-blocks/src/p2-autocomplete/editor.scss
+++ b/apps/o2-blocks/src/p2-autocomplete/editor.scss
@@ -25,7 +25,6 @@
 	text-overflow: ellipsis;
 	text-align: right;
 	padding-right: 8px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.8em;
 	flex-grow: 1;
 }

--- a/apps/o2-blocks/src/project-status/editor.scss
+++ b/apps/o2-blocks/src/project-status/editor.scss
@@ -22,7 +22,6 @@
 	margin-bottom: 10px;
 
 	.wp-block-project-status__title {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 13px;
 		font-weight: bold;
 		font-family:
@@ -39,7 +38,6 @@
 }
 
 .wp-block-project-status__counts {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 13px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
@@ -54,7 +52,6 @@
 	border-radius: 4px;
 	padding: 0 20px;
 	text-align: right;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 13px;
 	margin: 16px 0;
 	margin-left: auto;
@@ -66,7 +63,6 @@
 	border: 1px solid #222;
 	border-radius: 4px;
 	padding: 0 20px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 13px;
 	margin: 16px 0;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/apps/o2-blocks/src/task/editor.scss
+++ b/apps/o2-blocks/src/task/editor.scss
@@ -23,7 +23,6 @@
 	color: var(--color-text-inverted);
 	background: #7a6ff0;
 	border-radius: 2px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	height: 24px;
 	line-height: 24px;
@@ -49,7 +48,6 @@
 	display: inline-block;
 	font-weight: bold;
 	color: 111;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	height: 20px;
 	line-height: 20px;
@@ -73,7 +71,6 @@
 }
 
 .wp-block-todo__assigned {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 13px;
 	font-weight: 600;
 	display: flex;
@@ -88,7 +85,6 @@
 	height: 24px;
 	margin-left: 10px;
 	color: rgba(255, 255, 255, 0.6);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	text-transform: uppercase;
 	text-align: center;

--- a/apps/o2-blocks/src/todo/editor.scss
+++ b/apps/o2-blocks/src/todo/editor.scss
@@ -91,7 +91,6 @@ $color-add-button-icon: #7e8993; // dark-gray-200
 		display: none;
 
 		.components-button {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 13px !important; // yep, I'm a monster.
 			color: $color-add-button-text;
 			border: 1px solid $color-add-button-border;

--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -115,7 +115,7 @@
 	}
 
 	.inner-notice-container .banner__action a.button.is-compact {
-		font-size: 12px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-size: 12px;
 		line-height: 1;
 		padding: 7px;
 	}

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -21,7 +21,7 @@
 	width: auto;
 	background: var(--studio-white);
 	color: var(--color-text);
-	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 13px;
 	margin-bottom: 2px;
 
 	// Avoid overriding hidden notices.
@@ -33,13 +33,13 @@
 	h2,
 	h3 {
 		color: var(--studio-gray-90);
-		font-size: 1.3em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 1.3em;
 		margin: 1em 0;
 		font-weight: 600;
 	}
 
 	p {
-		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 13px;
 		line-height: 1.5;
 		margin: 0.5em 0;
 		padding: 2px;

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -219,7 +219,6 @@ code,
 kbd,
 tt,
 var {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font: 15px $code;
 }
 abbr,
@@ -235,11 +234,9 @@ ins {
 	text-decoration: none;
 }
 small {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 75%;
 }
 big {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 125%;
 }
 figure {

--- a/client/assets/stylesheets/directly.scss
+++ b/client/assets/stylesheets/directly.scss
@@ -57,7 +57,6 @@ textarea {
 	color: var(--color-text-inverted);
 	border-width: 1px 1px 2px;
 	cursor: pointer;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	font-weight: 500;
 	vertical-align: top;
@@ -128,7 +127,6 @@ textarea {
 
 	.header-title {
 		text-transform: uppercase;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 11px;
 		font-weight: 700;
 		color: var(--color-neutral-light);
@@ -185,7 +183,6 @@ textarea {
 	padding: 18px 10px 18px 24px;
 	.chat-list-item-title {
 		margin-bottom: 2px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 16px;
 	}
 	.chat-list-item-meta {
@@ -216,7 +213,6 @@ textarea {
 		margin-top: 0;
 		label {
 			text-transform: none;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 14px;
 			font-weight: 600;
 			margin-bottom: 5px;
@@ -248,7 +244,6 @@ textarea {
 
 // Message bubbles
 .message-container {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
 
@@ -304,7 +299,6 @@ textarea {
 // Avatar + name + reputation, used inside .message-container.is-expert
 .author {
 	.name-wrapper {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 12px;
 		font-weight: 500;
 	}
@@ -319,7 +313,6 @@ textarea {
 .system-message {
 	border: 1px solid var(--color-neutral-5);
 	background: var(--color-neutral-0);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	margin-right: 0;
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
@@ -424,7 +417,6 @@ textarea {
 	}
 	.notification {
 		background: var(--color-primary);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 12px;
 		font-weight: 500;
 		min-width: 24px;

--- a/client/assets/stylesheets/shared/_extends.scss
+++ b/client/assets/stylesheets/shared/_extends.scss
@@ -40,7 +40,6 @@
 %generic-reset {
 	border: 0;
 	font-family: inherit;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 100%;
 	font-style: inherit;
 	font-weight: inherit;

--- a/client/assets/stylesheets/shared/_reset.scss
+++ b/client/assets/stylesheets/shared/_reset.scss
@@ -55,7 +55,6 @@ th,
 td {
 	border: 0;
 	font-family: inherit;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 100%;
 	font-style: inherit;
 	font-weight: inherit;

--- a/client/blocks/import-light/capture/style.scss
+++ b/client/blocks/import-light/capture/style.scss
@@ -1,6 +1,6 @@
 .import-light__capture {
 	.form-label {
-		font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 1em;
 		font-weight: 500;
 		color: var(--studio-gray-60);
 

--- a/client/blocks/import-light/summary/style.scss
+++ b/client/blocks/import-light/summary/style.scss
@@ -1,10 +1,10 @@
 .import-light__summary {
 	.onboarding-title {
-		font-size: 3em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 3em;
 	}
 
 	.onboarding-subtitle {
-		font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 1.125em;
 		margin-bottom: 1.5em;
 	}
 }

--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -53,7 +53,7 @@ html[dir="rtl"] {
 		padding-bottom: 2rem;
 
 		h3 {
-			font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 1.125em;
 			color: var(--studio-gray-90);
 			margin-bottom: 1em;
 		}

--- a/client/blocks/import/ready/style.scss
+++ b/client/blocks/import/ready/style.scss
@@ -129,7 +129,7 @@
 
 	.import__details-learn-more {
 		display: inline-block;
-		font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 1.125em;
 		font-weight: 500;
 		text-decoration: underline;
 		color: var(--studio-gray-100);
@@ -142,7 +142,7 @@
 
 	.import__details-features {
 		p {
-			font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 1em;
 		}
 
 		strong {
@@ -153,7 +153,7 @@
 
 	.import__details-footer {
 		font-weight: 300; /* stylelint-disable-line scales/font-weights */
-		font-size: 0.875em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 0.875em;
 		color: var(--studio-gray-80);
 	}
 }

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -119,7 +119,7 @@
 		.import__heading {
 			.onboarding-title {
 				font-family: var(--font-base, var(--font-base-default));
-				font-size: 1.75em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 1.75em;
 				margin-bottom: 0.5em;
 			}
 

--- a/client/blocks/import/style/components.scss
+++ b/client/blocks/import/style/components.scss
@@ -25,7 +25,7 @@
 
 	.action-card__main p {
 		color: var(--studio-gray-40);
-		font-size: 0.875em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 0.875em;
 		margin-bottom: 0;
 	}
 

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -34,7 +34,6 @@
 }
 
 .post-edit-button__label {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 13px;
 	margin-left: 4px;
 

--- a/client/blocks/reader-excerpt/style.scss
+++ b/client/blocks/reader-excerpt/style.scss
@@ -16,7 +16,6 @@
 	sub {
 		vertical-align: baseline;
 		position: relative;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 0.83em;
 	}
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -514,7 +514,6 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 
 .reader-full-post .reader-post-card__tag-link {
 	color: var( --color-neutral-80 );
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	margin-top: 2px;
 	white-space: nowrap;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -385,7 +385,6 @@
 .reader__content .reader-post-card__byline-secondary-item,
 .reader__content .reader-post-card__tag-link {
 	color: var(--color-neutral-40);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	margin-top: 2px;
 	cursor: pointer;
@@ -505,7 +504,6 @@
 	.site-icon {
 		width: 40px !important;
 		height: 40px !important;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 40px !important;
 		line-height: 40px !important;
 	}
@@ -522,7 +520,6 @@
 .reader-post-card__link {
 	color: var(--color-neutral-100);
 	cursor: pointer;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 15px;
 
 	&:hover {

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -144,7 +144,6 @@
 
 	&.has-thumbnail {
 		.reader-related-card__title {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 17px;
 		}
 
@@ -250,7 +249,6 @@
 
 .reader-related-card__byline-author {
 	cursor: pointer;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	margin-top: 2px;
 	white-space: nowrap;
@@ -322,7 +320,6 @@
 }
 
 .reader-related-card__title {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 17px;
 	font-weight: 700;
 	line-height: 25px;

--- a/client/components/app-promo-card/style.scss
+++ b/client/components/app-promo-card/style.scss
@@ -74,7 +74,7 @@
 	font-family: $brand-serif;
 	font-style: normal;
 	font-weight: 400;
-	font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-size: 32px;
 	line-height: 40px;
 	letter-spacing: -0.32px;
 
@@ -86,7 +86,7 @@
 	margin: 0;
 	font-style: normal;
 	font-weight: 400;
-	font-size: 17px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-size: 17px;
 	line-height: 25px;
 
 	color: var(--studio-gray-50);

--- a/client/components/date-control/style.scss
+++ b/client/components/date-control/style.scss
@@ -14,7 +14,7 @@
 		color: var(--studio-black);
 		display: flex;
 		font-family: $font-sf-pro-display;
-		font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-size: 14px;
 		font-style: normal;
 		font-weight: 500;
 		gap: 8px;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -309,19 +309,19 @@ body.is-section-signup .featured-domain-suggestions {
 @include breakpoint-deprecated( ">660px" ) {
 	.domain-registration-suggestion__title {
 		.featured-domain-suggestions--title-in-18em & {
-			font-size: 1.8em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 1.8em;
 		}
 		.featured-domain-suggestions--title-in-16em & {
-			font-size: 1.6em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 1.6em;
 		}
 		.featured-domain-suggestions--title-in-14em & {
 			font-size: $font-title-small;
 		}
 		.featured-domain-suggestions--title-in-12em & {
-			font-size: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 1.2em;
 		}
 		.featured-domain-suggestions--title-in-10em & {
-			font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 1em;
 		}
 	}
 

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -38,7 +38,6 @@
 }
 
 .map-domain-step__domain-heading {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 1em;
 	font-weight: 600;
 
@@ -60,7 +59,6 @@
 }
 
 .map-domain-step__domain-text {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.9em;
 	margin-top: 20px;
 }

--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -30,7 +30,7 @@
 	}
 
 	.form-label .form-label__optional {
-		font-size: 100%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 100%;
 		margin-left: 5px;
 	}
 

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -24,7 +24,6 @@
 		&.is-free-with-plan,
 		&.is-sale-price {
 			font-weight: 400;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 90%;
 		}
 
@@ -36,7 +35,6 @@
 	.transfer-domain-step__free-with-plan {
 		color: var(--color-neutral-50);
 		font-weight: 400;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 0.9em;
 		line-height: 25px;
 	}
@@ -90,7 +88,6 @@
 }
 
 .transfer-domain-step__domain-text {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.9em;
 	margin-top: 20px;
 }
@@ -107,7 +104,6 @@
 }
 
 .transfer-domain-step__domain-heading {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 1em;
 	font-weight: 600;
 	margin: auto 0;

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -26,7 +26,6 @@
 
 .empty-content__title {
 	color: var(--color-neutral-70);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 34px;
 
 	@include breakpoint-deprecated( "<660px" ) {

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -43,7 +43,6 @@
 	.environment {
 		position: relative;
 		display: none;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 9px;
 		font-weight: 600;
 		line-height: 1;

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -50,7 +50,6 @@
 			text-align: start;
 
 			.formatted-header__title {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				font-size: 17px;
 				font-weight: 600;
 				padding: 0 24px;
@@ -95,7 +94,6 @@
 		margin: 0;
 
 		.formatted-header__title {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 18px;
 			font-weight: 600;
 			margin-bottom: 0;

--- a/client/components/gsuite/gsuite-features/style.scss
+++ b/client/components/gsuite/gsuite-features/style.scss
@@ -48,7 +48,6 @@
 }
 .gsuite-features__feature {
 	.gsuite-features__feature-header {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 17px;
 		font-weight: 600;
 	}

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -251,8 +251,6 @@
 	sup {
 		position: relative;
 		top: -0.5em;
-
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 0.75em;
 	}
 }

--- a/client/components/jetpack/licensing-activation/style.scss
+++ b/client/components/jetpack/licensing-activation/style.scss
@@ -109,7 +109,6 @@
 .licensing-activation__title {
 	font-style: normal;
 	font-weight: bold;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 44px;
 	line-height: 52px;
 

--- a/client/components/jetpack/upsell-product-card/style.scss
+++ b/client/components/jetpack/upsell-product-card/style.scss
@@ -43,7 +43,6 @@
 		sup {
 			position: relative;
 			top: -0.5em;
-			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			font-size: 0.75em;
 		}
 	}

--- a/client/components/jetpack/upsell-product-wpcom-plan-card/style.scss
+++ b/client/components/jetpack/upsell-product-wpcom-plan-card/style.scss
@@ -54,7 +54,6 @@
 		sup {
 			position: relative;
 			top: -0.5em;
-			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 			font-size: 0.75em;
 		}
 	}

--- a/client/components/jetpack/wpcom-upsell-placeholder/style.scss
+++ b/client/components/jetpack/wpcom-upsell-placeholder/style.scss
@@ -70,7 +70,6 @@
 		.wpcom-upsell-placeholder__action-button {
 			display: inline-block;
 			margin: 0 1em 4px 0;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 14px;
 			line-height: 22px;
 			border-radius: 2px;

--- a/client/components/readme-viewer/style.scss
+++ b/client/components/readme-viewer/style.scss
@@ -23,13 +23,11 @@
 
 		th {
 			color: var(--color-primary-dark);
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 0.75em;
 			padding: 0.25em 3em 0.25em 0;
 		}
 
 		td {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 0.83em;
 			padding: 1.17em 3em 1.17em 0;
 		}
@@ -47,32 +45,26 @@
 	}
 
 	h1 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 1.33em;
 	}
 
 	h2 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 1.17em;
 	}
 
 	h3 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 1em;
 	}
 
 	h4 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 0.83em;
 	}
 
 	h5 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 0.67em;
 	}
 
 	h6 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 0.5em;
 	}
 }

--- a/client/components/stats-interval-dropdown/style.scss
+++ b/client/components/stats-interval-dropdown/style.scss
@@ -10,7 +10,7 @@
 	background: #fff;
 	color: var(--studio-black);
 	font-family: $font-sf-pro-text;
-	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 13px;
 	font-weight: 400;
 
 	>.components-button[aria-expanded="true"],
@@ -68,7 +68,7 @@
 // Mimic the style of Button component.
 .stats-interval-display {
 	font-family: $font-sf-pro-text;
-	font-size: 13px; // stylelint-disable-line declaration-property-unit-allowed-list
+	font-size: 13px;
 	font-weight: 400;
 	line-height: 36px;
 }

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -162,7 +162,7 @@
 					content: counter(li);
 					counter-increment: li;
 					display: flex;
-					font-size: 10.909px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+					font-size: 10.909px;
 					font-weight: 400;
 					height: 20px;
 					justify-content: center;

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -3,7 +3,6 @@
 	bottom: 50px;
 	right: 83px;
 	z-index: z-index("root", ".webpack-build-monitor");
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 9px;
 	padding: 4px 6px;
 	background: var(--color-success);

--- a/client/jetpack-cloud/sections/golden-token/golden-token-dialog/style.scss
+++ b/client/jetpack-cloud/sections/golden-token/golden-token-dialog/style.scss
@@ -362,13 +362,11 @@ $tablet-width: 760px;
 	}
 
 	h3 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 24px;
 		margin: 0;
 	}
 
 	p {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 14px;
 	}
 }

--- a/client/jetpack-cloud/sections/manage/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/manage/pricing/header/style.scss
@@ -12,7 +12,6 @@
 
 	.header__main-title {
 		h1 {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 2.5em;
 			font-weight: 600;
 

--- a/client/jetpack-cloud/sections/partner-portal/header/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/header/style.scss
@@ -4,7 +4,6 @@
 
 .header__main-title {
 	h1 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 2.5em;
 		font-weight: 600;
 

--- a/client/jetpack-cloud/sections/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/pricing/header/style.scss
@@ -7,7 +7,6 @@
 
 .header__main-title {
 	h1 {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 2.5em;
 		font-weight: 600;
 

--- a/client/landing/browsehappy/style.scss
+++ b/client/landing/browsehappy/style.scss
@@ -6,7 +6,6 @@ nav.browsehappy__nav {
 	height: 48px;
 	padding: 0 18px 0 24px;
 	margin-top: 9px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 16px;
 	font-weight: 600;
 
@@ -31,7 +30,6 @@ main.browsehappy__main {
 
 	h1 {
 		@extend .wp-brand-font;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 34px;
 	}
 }
@@ -39,7 +37,6 @@ main.browsehappy__main {
 a.browsehappy__anyway {
 	color: inherit;
 	text-decoration: underline;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 13px;
 	padding-top: 1em;
 }

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -4,7 +4,6 @@
 
 	.content-card__title {
 		color: var(--color-neutral-70);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 34px;
 		margin-bottom: 1em;
 

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -52,7 +52,6 @@
 	border-radius: 2px;
 	background: var(--color-neutral-5);
 	color: var(--color-neutral-20);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.6em;
 	text-transform: uppercase;
 	white-space: nowrap;

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -53,7 +53,6 @@
 	}
 
 	.tours__title {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 140%;
 		display: flex;
 		align-items: center;
@@ -189,7 +188,6 @@ a.config-elements__text-link,
 	position: relative;
 	top: 3px;
 	font-style: normal;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 190%;
 	line-height: 0;
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -505,7 +505,7 @@ body.is-mobile-app-view {
 		.dashicons-plus {
 			padding-top: 0;
 			&::before {
-				font-size: 40px !important; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 40px !important;
 				vertical-align: middle;
 				top: 2px !important;
 			}
@@ -517,7 +517,7 @@ body.is-mobile-app-view {
 				width: 52px;
 				display: inline-block;
 				position: relative;
-				font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 32px;
 				text-align: center;
 				top: 7px;
 				height: unset;
@@ -530,7 +530,7 @@ body.is-mobile-app-view {
 
 		.dashicons-update {
 			&::before {
-				font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 40px;
 				top: 3px;
 			}
 		}
@@ -540,7 +540,7 @@ body.is-mobile-app-view {
 			position: relative;
 			float: left;
 			&::before {
-				font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 40px;
 				top: -1px;
 				vertical-align: middle;
 			}
@@ -824,7 +824,7 @@ body.is-mobile-app-view {
 				line-height: 18px;
 
 				.username {
-					font-size: 11px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+					font-size: 11px;
 					line-height: 14px;
 					margin-bottom: 4px;
 				}
@@ -1124,7 +1124,6 @@ a.masterbar__quick-language-switcher {
 		}
 
 		@include breakpoint-deprecated( ">480px" ) {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 100%;
 		}
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -13,11 +13,9 @@
 			max-height: 180px;
 		}
 		.empty-content__title {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 90%;
 		}
 		.empty-content__line {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 60%;
 			margin-bottom: 20px;
 		}
@@ -321,7 +319,7 @@
 	}
 }
 
-/* stylelint-disable declaration-property-unit-allowed-list, scales/font-weights */
+/* stylelint-disable scales/font-weights */
 .grav-powered-magic-login {
 	max-width: 480px;
 	font-size: 14px;
@@ -753,4 +751,4 @@
 	display: block;
 	margin: 0 auto;
 }
-/* stylelint-enable declaration-property-unit-allowed-list, scales/font-weights */
+/* stylelint-enable scales/font-weights */

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -580,7 +580,7 @@ $image-height: 47px;
 	}
 }
 
-/* stylelint-disable declaration-property-unit-allowed-list, scales/font-weights, scales/radii */
+/* stylelint-disable scales/font-weights, scales/radii */
 .layout.is-section-login.is-grav-powered-client {
 	background-color: #fff;
 
@@ -908,7 +908,7 @@ $image-height: 47px;
 		}
 	}
 }
-/* stylelint-enable declaration-property-unit-allowed-list, scales/font-weights, scales/radii */
+/* stylelint-enable scales/font-weights, scales/radii */
 
 .wp-login__p2-logo {
 	position: absolute;

--- a/client/me/application-password-item/style.scss
+++ b/client/me/application-password-item/style.scss
@@ -8,7 +8,6 @@
 
 .application-password-item__generated {
 	color: var(--color-neutral-40);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.9em;
 }
 

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -21,7 +21,6 @@
 .application-passwords__new-password-display {
 	background: var(--color-neutral-0);
 	border: 1px solid var(--color-border-subtle);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 200%;
 	font-weight: 600;
 	width: 70%;
@@ -34,7 +33,6 @@
 
 .application-passwords__new-password-message {
 	color: var(--color-neutral-40);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.9em;
 }
 

--- a/client/me/purchases/purchases-site/header.scss
+++ b/client/me/purchases/purchases-site/header.scss
@@ -15,7 +15,6 @@
 		height: 32px;
 		width: 32px;
 		line-height: 32px;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 32px;
 	}
 

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -7,7 +7,6 @@
 	width: 100%;
 	color: var(--color-link);
 	text-align: left;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 100%;
 
 	&:active,

--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -105,7 +105,6 @@ button.security-2fa-backups-codes-list__generate-button {
 }
 
 .security-2fa-backup-codes-list__warning {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 75%;
 
 	.gridicon {

--- a/client/me/security-2fa-key/style.scss
+++ b/client/me/security-2fa-key/style.scss
@@ -41,7 +41,6 @@
 
 .security-2fa-key__item-subtitle {
 	color: var(--muriel-gray-400);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.9em;
 	margin-bottom: 0;
 }

--- a/client/my-sites/activity/activity-log-tasklist/style.scss
+++ b/client/my-sites/activity/activity-log-tasklist/style.scss
@@ -57,7 +57,6 @@
 }
 
 .activity-log-tasklist__update-bullet {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 7px;
 	margin: 0 7px;
 	vertical-align: middle;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/style.scss
@@ -19,7 +19,7 @@
 			width: 100%;
 			justify-content: start;
 			cursor: pointer;
-			font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+			font-size: 14px;
 			font-weight: 500;
 
 			&:hover {

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -844,7 +844,7 @@ main.akismet-checkout-thank-you {
 	}
 
 	.akismet-checkout-thank-you__emoji {
-		font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 40px;
 	}
 
 	.akismet-checkout-thank-you__card {

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -138,7 +138,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 		gap: 4px;
 
 		font-weight: 500;
-		/* stylelint-disable-next-line */
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.154px;

--- a/client/my-sites/domains/components/domain-warnings/style.scss
+++ b/client/my-sites/domains/components/domain-warnings/style.scss
@@ -1,5 +1,4 @@
 .domain-warnings__password {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 110%;
 	padding: 5px;
 }

--- a/client/my-sites/domains/domain-management/dataviews/style.scss
+++ b/client/my-sites/domains/domain-management/dataviews/style.scss
@@ -66,7 +66,6 @@ body.is-section-domains.is-bulk-all-domains-page {
 			}
 
 			.domains-dataviews__domain-name {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				font-size: 14px;
 				font-weight: 500;
 

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/style.scss
@@ -16,7 +16,7 @@
 	&__sidebar {
 		padding: 24px;
 		background-color: var(--studio-gray-0);
-		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 14px;
 		line-height: 20px;
 		&-content {
 			p {

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -212,7 +212,7 @@
 			}
 
 			.components-input-control__input {
-				font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 13px;
 				height: 32px;
 				padding-left: 8px;
 				padding-right: 8px;

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -69,6 +69,6 @@
 	word-wrap: break-word;
 
 	@include breakpoint-deprecated( ">660px" ) {
-		font-size: 17px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 17px;
 	}
 }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -18,7 +18,7 @@
 
 	h2.formatted-header__title {
 		margin: 0 0 12px;
-		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 18px;
 		font-family: "SF Pro Display", $sans;
 	}
 	.highlight-cards-heading {
@@ -193,7 +193,7 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 
 h3.highlight-cards-heading,
 h3.ads__table-header-title {
-	font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 18px;
 }
 body:not(.theme-jetpack-cloud) {
 	.earn__ads-header {

--- a/client/my-sites/people/invite-people/style.scss
+++ b/client/my-sites/people/invite-people/style.scss
@@ -17,14 +17,12 @@
 	}
 
 	.invite-people__link-instructions {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 14px;
 		margin-bottom: 28px;
 	}
 
 	.invite-people__link-selector {
 		display: flex;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 14px;
 
 		.invite-people__link-selector-role {
@@ -48,7 +46,6 @@
 
 	.invite-people__link-footer {
 		color: var(--color-text-subtle);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 12px;
 		font-style: italic;
 		margin-top: 8px;

--- a/client/my-sites/plans/jetpack-plans/plans-filter-bar/style.scss
+++ b/client/my-sites/plans/jetpack-plans/plans-filter-bar/style.scss
@@ -88,7 +88,6 @@
 	white-space: nowrap;
 	text-align: center;
 	font-weight: 700;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 16px;
 	padding-left: 10px;
 

--- a/client/my-sites/plans/jetpack-plans/upsell/style.scss
+++ b/client/my-sites/plans/jetpack-plans/upsell/style.scss
@@ -200,8 +200,6 @@
 .jetpack-upsell__price-plus {
 	margin-bottom: 0.5rem;
 	margin-inline-end: 0.5rem;
-
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 28px;
 	font-weight: 700;
 	line-height: 1;

--- a/client/my-sites/plugins/sidebar/style.scss
+++ b/client/my-sites/plugins/sidebar/style.scss
@@ -5,13 +5,13 @@
 			padding-inline: 0;
 		}
 		.sidebar__site-title {
-			font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 18px;
 			font-weight: 500;
 		}
 	}
 
 	.sidebar__sub-heading {
-		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 13px;
 		padding-inline: 20px;
 		margin-top: 4px;
 		margin-bottom: 13px;

--- a/client/my-sites/plugins/woocommerce-box.scss
+++ b/client/my-sites/plugins/woocommerce-box.scss
@@ -94,7 +94,7 @@ $c-gray-100: #101517 !default;
 	}
 
 	&.large {
-		font-size: 1.2em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 1.2em;
 		padding: 25px 20px;
 	}
 
@@ -160,7 +160,7 @@ $c-gray-100: #101517 !default;
 	}
 
 	&.coupon p {
-		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 18px;
 		margin: 10px 0 10px 70px;
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -820,7 +820,6 @@ $font-size: rem(14px);
 				content: "\f534";
 				/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
 				font-family: dashicons;
-				/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
 				font-size: 20px;
 				line-height: 20px;
 				background-color: #a7aaad;

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -19,7 +19,6 @@
 
 .disconnect-site__down-flow {
 	> p {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 14px;
 		padding: 0 20px;
 		text-align: center;

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-dropdown.scss
@@ -13,7 +13,7 @@ $stats-utm-border: 1px solid var(--gray-gray-5, #dcdcde);
 		color: var(--studio-black);
 		display: flex;
 		font-family: $font-sf-pro-display;
-		font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-size: 14px;
 		font-style: normal;
 		font-weight: 500;
 		gap: 8px;

--- a/client/my-sites/stats/pages/realtime/style.scss
+++ b/client/my-sites/stats/pages/realtime/style.scss
@@ -35,7 +35,6 @@
 
 .stats-realtime-header__title {
 	font-family: $brand-serif;
-	// stylelint-disable-next-line declaration-property-unit-allowed-list
 	font-size: 32px;
 	font-style: normal;
 	font-weight: 400;
@@ -44,7 +43,6 @@
 
 .stats-realtime-header__description {
 	font-family: inherit;
-	// stylelint-disable-next-line declaration-property-unit-allowed-list
 	font-size: 14px;
 	font-style: normal;
 	font-weight: 400;

--- a/client/my-sites/stats/sections/posting-activity-section/style.scss
+++ b/client/my-sites/stats/sections/posting-activity-section/style.scss
@@ -169,7 +169,7 @@ $lowestLevelColor: var(--color-neutral-5);
 	.post-date,
 	.post-count {
 		font-family: var(--p2-font-inter);
-		font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.24px;
 		color: var(--studio-white);

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -174,7 +174,6 @@ ul.module-tabs {
 		&.is-loading .no-link .value {
 			animation: loading-fade 1.6s ease-in-out infinite;
 			cursor: default;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 110%;
 			color: var(--color-neutral-light);
 		}

--- a/client/my-sites/stats/stats-email-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-email-chart-tabs/style.scss
@@ -172,7 +172,6 @@ ul.module-tabs {
 		&.is-loading .no-link .value {
 			animation: loading-fade 1.6s ease-in-out infinite;
 			cursor: default;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 110%;
 			color: var(--color-neutral-light);
 		}

--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -19,7 +19,6 @@ $break-large-stats-countries: 1280px;
 	}
 
 	> div > h1 {
-		// stylelint-disable-next-line
 		font-size: 32px;
 		font-weight: 400;
 		line-height: 40px;

--- a/client/my-sites/stats/stats-module-utm-builder/style.scss
+++ b/client/my-sites/stats/stats-module-utm-builder/style.scss
@@ -25,7 +25,7 @@ $modal-content-padding: 32px;
 	
 		// Overwrite the modal's class
 		h1.components-modal__header-heading {
-			font-size: 32px; // stylelint-disable-line declaration-property-unit-allowed-list
+			font-size: 32px;
 			line-height: 39px;
 			font-weight: 400;
 		}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -580,7 +580,7 @@ ul.module-header-actions {
 	}
 
 	.section-header__label-text {
-		font-size: 20px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 20px;
 		line-height: 26px;
 	}
 }
@@ -619,14 +619,14 @@ ul.module-header-actions {
 	}
 
 	.section-header__label-text {
-		font-size: 20px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 20px;
 		line-height: 26px;
 	}
 
 	.stats-list__module-content-list-item-value,
 	.stats-list__module-content-list-item-wrapper span,
 	.module-content-list-item-wrapper span {
-		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 14px;
 		line-height: 20px;
 		white-space: nowrap;
 	}
@@ -666,7 +666,7 @@ ul.module-header-actions {
 
 		a {
 			border: 0;
-			font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 14px;
 			font-weight: 600;
 			line-height: 20px;
 			color: var(--studio-gray-100);

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -388,7 +388,6 @@ $button-padding: 8px 32px;
 
 		.components-panel__body-title {
 			button {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				font-size: 20px;
 				font-weight: 500;
 			}

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -215,7 +215,6 @@ $stats-tab-outer-padding: 10px;
 		&.is-loading .no-link .value {
 			animation: loading-fade 1.6s ease-in-out infinite;
 			cursor: default;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 110%;
 			color: var(--color-neutral-light);
 		}

--- a/client/my-sites/stats/stats-upsell-modal/style.scss
+++ b/client/my-sites/stats/stats-upsell-modal/style.scss
@@ -57,7 +57,6 @@
 
 	.stats-upsell-modal__title {
 		@extend .wp-brand-font;
-		/* stylelint-disable declaration-property-unit-allowed-list -- typography-exception */
 		font-size: 28px;
 		line-height: 34px; /* 125% */
 		@include break-medium {

--- a/client/my-sites/stats/stats-upsell/style.scss
+++ b/client/my-sites/stats/stats-upsell/style.scss
@@ -78,7 +78,6 @@
 
 	.stats-upsell__title {
 		@extend .wp-brand-font;
-		/* stylelint-disable declaration-property-unit-allowed-list -- typography-exception */
 		font-size: 28px;
 		text-wrap: wrap;
 		line-height: 34px; /* 125% */

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -336,7 +336,7 @@ $button-border: 4px;
 
 .theme__sheet-action-bar-cost-upgrade {
 	text-transform: uppercase;
-	font-size: 90%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 90%;
 }
 
 .theme__sheet-web-preview {

--- a/client/performance-profiler/components/performance-score/style.scss
+++ b/client/performance-profiler/components/performance-score/style.scss
@@ -29,20 +29,20 @@
 
 		.current-score {
 			color: #000;
-			font-size: 96px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 96px;
 			line-height: 96px;
 			font-weight: 300; /* stylelint-disable-line scales/font-weights */
 		}
 
 		.max-score {
 			color: var(--studio-gray-60);
-			font-size: 26px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 26px;
 			line-height: 26px;
 		}
 
 		&.mobile {
 			.current-score {
-				font-size: 64px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 64px;
 				line-height: 64px;
 			}
 

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -61,7 +61,6 @@
 	}
 
 	&.is-too-large {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 2em;
 	}
 }

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -34,7 +34,6 @@
 	}
 
 	.reader-post-card__title-link {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 17px;
 		line-height: 1.5;
 	}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -915,7 +915,6 @@ body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .bac
 	}
 
 	.reader-post-card__tag-link {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 13px;
 		white-space: nowrap;
 		cursor: pointer;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -530,13 +530,13 @@ body.is-section-reader {
 	text-align: center;
 
 	h2 {
-		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 18px;
 		font-weight: 500;
 		margin-bottom: 10px;
 	}
 
 	h1 {
-		font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 40px;
 		font-weight: 500;
 	}
 }

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -16,7 +16,7 @@
 	}
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: 60px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 60px;
 		font-weight: 400;
 		margin-bottom: 4px;
 
@@ -179,12 +179,12 @@
 			padding-right: 2px;
 
 			@media (max-width: $break-medium) {
-				font-size: 28px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: 28px;
 				line-height: 32px;
 			}
 		}
 		.trending-tags__count {
-			font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 16px;
 			color: var(--studio-gray-50);
 		}
 	}
@@ -208,7 +208,7 @@
 	}
 
 	h2 {
-		font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 16px;
 		color: var(--studio-gray-50);
 		font-weight: 500;
 		width: 100%;
@@ -227,7 +227,7 @@
 			width: 50%;
 		}
 		button {
-			font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 16px;
 			color: var(--studio-gray-50);
 			text-decoration: none;
 			font-weight: 500;
@@ -284,7 +284,7 @@
 	padding-left: 35px;
 
 	.alphabetic-tags__letter-title {
-		font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 32px;
 		margin-bottom: 22px;
 		font-weight: 500;
 

--- a/client/signup/gravatar-step-wrapper/style.scss
+++ b/client/signup/gravatar-step-wrapper/style.scss
@@ -1,5 +1,3 @@
-/* stylelint-disable declaration-property-unit-allowed-list */
-
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -23,7 +23,7 @@ html[dir="rtl"] {
 .is-section-site-profiler .main {
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		/* stylelint-disable-next-line */
+		/* stylelint-disable-next-line scales/font-sizes */
 		font-size: 4.375rem;
 		line-height: 1;
 		margin-bottom: 1rem;
@@ -36,13 +36,12 @@ html[dir="rtl"] {
 
 	h2 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		/* stylelint-disable-next-line */
+		/* stylelint-disable-next-line scales/font-sizes */
 		font-size: 2.5rem;
 		line-height: 1.15;
 		margin-bottom: 1rem;
 
 		@media ( max-width: $break-small ) {
-			/* stylelint-disable-next-line */
 			font-size: 1.875em;
 		}
 	}

--- a/client/sites/deployments/deployments/styles.scss
+++ b/client/sites/deployments/deployments/styles.scss
@@ -176,7 +176,6 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	span {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 13px;
 		font-style: normal;
 		font-weight: 400;

--- a/client/sites/marketing/connections/account-dialog-account.scss
+++ b/client/sites/marketing/connections/account-dialog-account.scss
@@ -81,6 +81,5 @@
 }
 
 .account-dialog-account__description {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 0.9em;
 }

--- a/client/sites/marketing/style.scss
+++ b/client/sites/marketing/style.scss
@@ -915,7 +915,7 @@
 	display: inline-block;
 	margin: 8px 8px 0 0;
 	cursor: default;
-	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 13px;
 	font-weight: 500;
 	border-radius: 4px;
 	color: var(--color-neutral-80);

--- a/desktop/public_desktop/wordpress-desktop.css
+++ b/desktop/public_desktop/wordpress-desktop.css
@@ -95,7 +95,6 @@ html.is-desktop.detail-page-open {
 html.desktop-auth body {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	line-height: 1.5;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 15px;
 	height: 100%;
 	display: flex;
@@ -120,7 +119,6 @@ html.desktop-auth p {
 
 html.desktop-auth .welcome h2,
 html.desktop-auth .welcome h3 {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 28px;
 	font-weight: 700;
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
@@ -133,7 +131,6 @@ html.desktop-auth .welcome ol {
 }
 
 html.desktop-auth .welcome code {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 15px;
 	color: #646970;
 }
@@ -150,7 +147,6 @@ html.desktop-auth .large-icon svg {
 }
 
 html.desktop-auth .large-emoji {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 56px;
 	padding: 4px;
 	margin: auto;
@@ -184,7 +180,6 @@ html.desktop-auth .button-emphasis {
 	cursor: pointer;
 	font-weight: 600;
 	text-decoration: none;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	line-height: 21px;
 	border-radius: 4px;

--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -34,7 +34,6 @@
 		padding-right: 48px;
 		&:not(a) {
 			color: var(--color-primary);
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 100%;
 			line-height: 1.5;
 			text-align: left;

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -25,7 +25,6 @@
 
 	&-text {
 		font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 11.5px; // 11.5px mobile, 15px desktop (30% upscaling)
 		font-weight: 500;
 		letter-spacing: 0.05em;

--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -51,7 +51,6 @@
 
 	h1 {
 		color: var(--color-neutral-70);
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 1.375em;
 		font-weight: 600;
 		margin-bottom: 0.5em;

--- a/packages/components/src/ribbon/style.scss
+++ b/packages/components/src/ribbon/style.scss
@@ -12,7 +12,6 @@
 	text-align: right;
 }
 .ribbon .ribbon__title {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 10px;
 	font-weight: normal;
 	color: var(--color-text-inverted);

--- a/packages/components/src/screen-reader-text/style.scss
+++ b/packages/components/src/screen-reader-text/style.scss
@@ -17,7 +17,6 @@
 		clip: auto !important;
 		color: #21759b;
 		display: block;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 14px;
 		font-weight: bold;
 		height: auto;

--- a/packages/components/src/suggestions/style.scss
+++ b/packages/components/src/suggestions/style.scss
@@ -10,7 +10,6 @@
 	background: var(--color-surface);
 	border: 1px solid var(--color-border-subtle);
 	border-top: 0;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 15px;
 	white-space: pre-wrap;
 	cursor: pointer;
@@ -29,7 +28,6 @@
 }
 
 .suggestions__category-heading {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 10px;
 	font-weight: 600;
 	text-transform: uppercase;
@@ -40,7 +38,6 @@
 
 
 .suggestions__title {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 10px;
 	color: var(--studio-gray-40);
 	background-color: #fff;

--- a/packages/design-picker/src/components/style-variation-badges/style.scss
+++ b/packages/design-picker/src/components/style-variation-badges/style.scss
@@ -14,7 +14,7 @@
 		color: var(--studio-gray-80);
 		cursor: pointer;
 		display: inline-flex;
-		font-size: 11px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 11px;
 		font-weight: 500;
 		height: 100%;
 		justify-content: center;

--- a/packages/help-center/src/components/help-center-chat-history.scss
+++ b/packages/help-center/src/components/help-center-chat-history.scss
@@ -15,7 +15,6 @@
 
 			h4 {
 				font-weight: 400;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 				font-size: 20px;
 				line-height: 26px;
 				text-align: center;
@@ -30,7 +29,6 @@
 			gap: 24px;
 			color: var(--studio-gray-70, #3C434A);
 			text-align: center;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 14px;
 			font-style: normal;
 			line-height: 20px;

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -66,7 +66,7 @@
 			box-sizing: border-box;
 			min-width: 26px;
 			height: 20px;
-			font-size: 12px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: 12px;
 			background-color: $help-center-blue;
 			color: #FFF;
 		}

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -9,19 +9,19 @@
 
 @mixin onboarding-heading-text {
 	@include onboarding-font-recoleta;
-	font-size: 42px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 42px;
 	line-height: 57px;
 }
 
 @mixin onboarding-heading-text-tablet {
 	@include onboarding-font-recoleta;
-	font-size: 36px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 36px;
 	line-height: 40px;
 }
 
 @mixin onboarding-heading-text-mobile {
 	@include onboarding-font-recoleta;
-	font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 32px;
 	line-height: 40px;
 }
 
@@ -39,7 +39,7 @@
 }
 
 @mixin onboarding-large-text {
-	font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-size: 16px;
 	line-height: 24px;
 }
 

--- a/packages/social-previews/src/bluesky-preview/post/card/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/post/card/styles.scss
@@ -37,14 +37,12 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
     color: rgb(11, 15, 20);
-    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
     font-size: 16px;
     font-weight: 700;
     letter-spacing: 0.25px;
 }
 
 .bluesky-preview__card-site {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -61,7 +59,6 @@
     -webkit-line-clamp: 2;
 	color: rgb(11, 15, 20);
 	display: -webkit-box;
-    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
     font-size: 15px;
     font-weight: 400;
     letter-spacing: 0.25px;

--- a/packages/social-previews/src/bluesky-preview/post/header/styles.scss
+++ b/packages/social-previews/src/bluesky-preview/post/header/styles.scss
@@ -12,7 +12,6 @@
 	line-height: 1.47;
 
 	&--displayname {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 16px;
 		letter-spacing: 0.25px;
 		font-weight: 700;
@@ -23,7 +22,6 @@
 	&--username,
 	&--separator,
 	&--date {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 15px;
 		letter-spacing: 0.25px;
 		font-weight: 400;

--- a/packages/social-previews/src/google-search-preview/style.scss
+++ b/packages/social-previews/src/google-search-preview/style.scss
@@ -39,7 +39,6 @@
 
 .search-preview__site--title {
 	color: #202124; // matching Google results
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	line-height: 20px;
 }
@@ -51,7 +50,6 @@
 
 .search-preview__title {
 	color: #1a0dab; // matching Google results
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 20px;
 	line-height: 1.3;
 	max-width: 616px;
@@ -66,7 +64,6 @@
 
 .search-preview__url {
 	color: #4d5156; // matching Google results
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	line-height: 1.3;
 	max-width: 616px;
@@ -74,7 +71,6 @@
 
 .search-preview__description {
 	color: #4d5156; // matching Google results
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 1.5;// matching Google results

--- a/packages/social-previews/src/nextdoor-preview/style.scss
+++ b/packages/social-previews/src/nextdoor-preview/style.scss
@@ -69,7 +69,6 @@
 			gap: 0.25rem;
 			color: #666;
 			letter-spacing: -0.32px;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 14px;
 			line-height: 19px;
 			white-space: pre-wrap;
@@ -92,7 +91,6 @@
 			display: flex;
 			align-items: center;
 			gap: 0.25rem;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 13px;
 			font-weight: 600;
 			line-height: 16px;
@@ -160,13 +158,11 @@
 			white-space: nowrap;
 			text-overflow: ellipsis;
 			overflow: hidden;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 15px;
 			line-height: 20px;
 		}
 
 		&--url {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 13px;
 			color: #666;
 		}

--- a/packages/social-previews/src/threads-preview/style.scss
+++ b/packages/social-previews/src/threads-preview/style.scss
@@ -1,5 +1,4 @@
 /* stylelint-disable scales/radii */
-/* stylelint-disable declaration-property-unit-allowed-list */
 @import "./variables";
 
 .threads-preview {

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -72,7 +72,6 @@
 	.twitter-preview__header {
 		display: flex;
 		gap: 0.25rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 16px;
 		line-height: 18px;
 		margin-bottom: 2px;

--- a/packages/wpcom.js/examples/media-editor/app.css
+++ b/packages/wpcom.js/examples/media-editor/app.css
@@ -1,7 +1,6 @@
 body {
 	font-family: sans-serif;
 	color: #444;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 }
 
@@ -23,7 +22,6 @@ h3 {
 	height: 24px;
 	line-height: 24px;
 	color: var(--color-text-inverted);
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 10px;
 	text-transform: uppercase;
 }
@@ -37,7 +35,6 @@ h3 {
 	margin: 0 10px 10px;
 	border: 1px solid #bbb;
 	padding: 10px;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 12px;
 	background-color: var(--studio-white);
 }
@@ -83,12 +80,10 @@ h3 {
 
 .image-container .image-summary span {
 	display: block;
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 10px;
 }
 
 .image-container .image-summary span.image-revision-number {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font-size: 10px;
 	font-weight: bold;
 	position: absolute;

--- a/packages/wpcom.js/examples/server/public/main.css
+++ b/packages/wpcom.js/examples/server/public/main.css
@@ -1,5 +1,4 @@
 body {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	font: 14px "Helvetica Nueue", "Lucida Grande", Arial, sans-serif;
 	padding: 50px 80px;
 	margin: 0;


### PR DESCRIPTION
This PR makes Calypso Stylelint config more compatible with Gutenberg, and allows @oandregal to seamlessy merge a vendor copy of DataViews to the repo.

We have a stylelint rule that says that `font-size` must use the `rem` units and nothing else. I'm removing it completely because:
1. Gutenberg doesn't have this rule. It only limits `line-height` to use `px` and that's it.
2. The rule is massively ignored anyway, in this PR I'm removing 240 needless disables that come up after the rule is removed.

## Testing instructions:
Verify that I'm removing only comments that don't affect production behavior. Anything else would be an oversight.