### PR TITLE
Move Playground first step to Step Container v2

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -104,7 +104,7 @@ button {
 .hundred-year-domain,
 .entrepreneur,
 .generate-content,
-.playground,
+.playground:not(:has(.step-container-v2)),
 .processing:not(:has(.step-container-v2)),
 .create-site:not(:has(.step-container-v2)) {
 	box-sizing: border-box;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -1,3 +1,4 @@
+import { Step } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { PlaygroundClient } from '@wp-playground/client';
@@ -5,11 +6,12 @@ import { useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useIsPlaygroundEligible } from '../../../../hooks/use-is-playground-eligible';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { PlaygroundIframe } from './components/playground-iframe';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import './style.scss';
 
-export const PlaygroundStep: Step = ( { navigation } ) => {
+export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 	const { submit } = navigation;
 	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const playgroundClientRef = useRef< PlaygroundClient | null >( null );
@@ -31,6 +33,33 @@ export const PlaygroundStep: Step = ( { navigation } ) => {
 		}
 		submit();
 	};
+
+	if ( shouldUseStepContainerV2( flow ) ) {
+		return (
+			<>
+				<DocumentHead title={ __( 'Playground' ) } />
+				<Step.FullWidthLayout
+					className="playground-v2"
+					hasContentPadding={ false }
+					topBar={
+						<Step.TopBar
+							rightElement={
+								<Step.PrimaryButton onClick={ launchSite }>
+									{ __( 'Launch on WordPress.com' ) }
+								</Step.PrimaryButton>
+							}
+						/>
+					}
+				>
+					<PlaygroundIframe
+						className="playground__onboarding-iframe"
+						playgroundClient={ playgroundClientRef.current }
+						setPlaygroundClient={ setPlaygroundClient }
+					/>
+				</Step.FullWidthLayout>
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
@@ -1,18 +1,3 @@
-@import "calypso/signup/style";
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-@import "@automattic/onboarding/styles/mixins";
-
-$header-height: 78px;
-
-.step-route.playground {
-    overflow-y: hidden;
-	padding-top: $header-height;
-	.step-wrapper__header {
-		display: none;
-	}
-}
-
 .playground__onboarding-iframe {
 	width: 100%;
 	height: 100vh;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #102188

## Proposed Changes

* Move first Playground step to Step Container v2

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The http://calypso.localhost:3000/setup/onboarding/playground flow switch step container version after the first step. This creates a visual glitch in dev and wp-calypso environments where `onboarding/step-container-v2` is enabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open http://calypso.localhost:3000/setup/onboarding/playground and be sure the topbar is the v2
* Click "Launch on WordPress.com" and check if you are redirected to the domain
* Be sure the flow continues as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
