### PR TITLE
Hosted site flow: Hide back button for valid partner bundle flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -4,7 +4,6 @@ import {
 	isStartWritingFlow,
 	StepContainer,
 } from '@automattic/onboarding';
-import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
 import PlansWrapper from './plans-wrapper';
@@ -24,7 +23,6 @@ const plans: Step< {
 	const query = useQuery();
 	const queryParams = Object.fromEntries( query );
 	const plan = queryParams.plan;
-	const isValidWooPartner = useIsValidWooPartner();
 
 	const handleSubmit = ( plan: MinimalRequestCartProduct | null ) => {
 		const providedDependencies = {
@@ -41,8 +39,7 @@ const plans: Step< {
 		return null;
 	}
 
-	const isAllowedToGoBack =
-		isDomainUpsellFlow( flow ) || ( isNewHostedSiteCreationFlow( flow ) && ! isValidWooPartner );
+	const isAllowedToGoBack = isDomainUpsellFlow( flow );
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -4,6 +4,7 @@ import {
 	isStartWritingFlow,
 	StepContainer,
 } from '@automattic/onboarding';
+import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
 import PlansWrapper from './plans-wrapper';
@@ -23,6 +24,7 @@ const plans: Step< {
 	const query = useQuery();
 	const queryParams = Object.fromEntries( query );
 	const plan = queryParams.plan;
+	const isValidWooPartner = useIsValidWooPartner();
 
 	const handleSubmit = ( plan: MinimalRequestCartProduct | null ) => {
 		const providedDependencies = {
@@ -39,7 +41,8 @@ const plans: Step< {
 		return null;
 	}
 
-	const isAllowedToGoBack = isDomainUpsellFlow( flow ) || isNewHostedSiteCreationFlow( flow );
+	const isAllowedToGoBack =
+		isDomainUpsellFlow( flow ) || ( isNewHostedSiteCreationFlow( flow ) && ! isValidWooPartner );
 
 	return (
 		<StepContainer


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTOBRD-56

## Proposed Changes

* Hide back button for PTO flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently back button points to /sites which is incorrect when user is coming from landing page. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply changes from the branch to your local. 
* Visit `/setup/new-hosted-site/plans` and see the back button is hidden. 
* Visit `/setup/new-hosted-site/plans?partnerBundle=square` and see back button is hidden. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
