### PR TITLE
Site Setup: Use flow entry point to manage back button edgy cases

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -42,8 +42,8 @@ const siteMigration: Flow = {
 		const urlQueryParams = useQuery();
 		const ref = urlQueryParams.get( 'ref' );
 
-		if ( ref && ! get( 'migration' )?.entryPoint ) {
-			set( 'migration', { entryPoint: ref } );
+		if ( ref && ! get( 'flow' )?.entryPoint ) {
+			set( 'flow', { entryPoint: ref } );
 		}
 	},
 
@@ -536,12 +536,18 @@ const siteMigration: Flow = {
 		const goBack = () => {
 			const siteSlug = urlQueryParams.get( 'siteSlug' ) || '';
 			const siteId = urlQueryParams.get( 'siteId' ) || '';
-			const entryPoint = get( 'migration' )?.entryPoint;
+			const entryPoint = get( 'flow' )?.entryPoint;
 
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
 					if ( entryPoint === 'calypso-importer' ) {
 						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/import/${ siteSlug }` ) );
+					}
+
+					if ( entryPoint === 'wp-admin-importers-list' ) {
+						return exitFlow(
+							addQueryArgs( { siteSlug, siteId, ref: entryPoint }, '/setup/site-setup/importList' )
+						);
 					}
 
 					if ( entryPoint === 'wp-admin' ) {

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -425,7 +425,7 @@ const siteSetupFlow: Flow = {
 					if ( shouldRedirectToSiteMigration( currentStep, platform, origin, entryPoint ) ) {
 						return window.location.assign(
 							addQueryArgs(
-								{ siteSlug, siteId, from },
+								{ siteSlug, siteId, from, ref: entryPoint },
 								'/setup/site-migration/' + STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
 							)
 						);

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -12,6 +12,7 @@ import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getInitialQueryArguments } from 'calypso/state/selectors/get-initial-query-arguments';
 import { requestSite } from 'calypso/state/sites/actions';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../../../constants';
 import { useActivateDesign } from '../../../hooks/use-activate-design';
@@ -22,13 +23,14 @@ import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../stores';
 import { shouldRedirectToSiteMigration } from '../../helpers';
 import { useRedirectDesignSetupOldSlug } from '../../helpers/use-redirect-design-setup-old-slug';
 import { useLaunchpadDecider } from '../../internals/hooks/use-launchpad-decider';
+import { useFlowState } from '../../internals/state-manager/store';
 import { STEPS } from '../../internals/steps';
 import { redirect } from '../../internals/steps-repository/import/util';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import {
 	type AssertConditionResult,
 	AssertConditionState,
-	type FlowV1,
+	type Flow,
 	type ProvidedDependencies,
 } from '../../internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
@@ -47,9 +49,10 @@ function useGoalsAtFrontExperimentQueryParam() {
 	return Boolean( useSelector( getInitialQueryArguments )?.[ 'goals-at-front-experiment' ] );
 }
 
-const siteSetupFlow: FlowV1 = {
+const siteSetupFlow: Flow = {
 	name: 'site-setup',
 	isSignupFlow: false,
+	__experimentalUseSessions: true,
 
 	useSteps() {
 		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
@@ -272,6 +275,9 @@ const siteSetupFlow: FlowV1 = {
 		} );
 
 		useRedirectDesignSetupOldSlug( currentStep, navigate );
+		const { get } = useFlowState();
+		const entryPoint = get( 'flow' )?.entryPoint;
+		const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
@@ -530,7 +536,7 @@ const siteSetupFlow: FlowV1 = {
 					return navigate( 'goals' );
 				}
 
-				case 'importList':
+				case 'importList': {
 					if ( backToStep ) {
 						return navigate( `${ backToStep }?siteSlug=${ siteSlug }` );
 					}
@@ -539,7 +545,14 @@ const siteSetupFlow: FlowV1 = {
 						return goToFlow( backToFlow );
 					}
 
+					if ( entryPoint === 'wp-admin-importers-list' ) {
+						const adminUrl = `${ siteAdminUrl }import.php`;
+
+						return window.location.assign( adminUrl );
+					}
+
 					return navigate( `import?siteSlug=${ siteSlug }` );
+				}
 
 				case 'importerBlogger':
 				case 'importerMedium':

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -125,11 +125,8 @@ const siteSetupFlow: Flow = {
 		const backToFlow = urlQueryParams.get( 'backToFlow' );
 		const skippedCheckout = urlQueryParams.get( 'skippedCheckout' );
 
-		const adminUrl = useSelect(
-			( select ) =>
-				site && ( select( SITE_STORE ) as SiteSelect ).getSiteOption( site.ID, 'admin_url' ),
-			[ site ]
-		);
+		const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+
 		const isAtomic = useSelect(
 			( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
 			[ site ]
@@ -277,7 +274,6 @@ const siteSetupFlow: Flow = {
 		useRedirectDesignSetupOldSlug( currentStep, navigate );
 		const { get } = useFlowState();
 		const entryPoint = get( 'flow' )?.entryPoint;
-		const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
@@ -547,7 +543,7 @@ const siteSetupFlow: Flow = {
 					}
 
 					if ( entryPoint === 'wp-admin-importers-list' ) {
-						return window.location.assign( `${ siteAdminUrl }import.php` );
+						return window.location.assign( `${ adminUrl }import.php` );
 					}
 
 					return navigate( `import?siteSlug=${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -547,9 +547,7 @@ const siteSetupFlow: Flow = {
 					}
 
 					if ( entryPoint === 'wp-admin-importers-list' ) {
-						const adminUrl = `${ siteAdminUrl }import.php`;
-
-						return window.location.assign( adminUrl );
+						return window.location.assign( `${ siteAdminUrl }import.php` );
 					}
 
 					return navigate( `import?siteSlug=${ siteSlug }` );

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -2,6 +2,7 @@ import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
+import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ImporterMainPlatform } from 'calypso/lib/importer/types';
@@ -23,7 +24,6 @@ import { ONBOARD_STORE, SITE_STORE, USER_STORE } from '../../../stores';
 import { shouldRedirectToSiteMigration } from '../../helpers';
 import { useRedirectDesignSetupOldSlug } from '../../helpers/use-redirect-design-setup-old-slug';
 import { useLaunchpadDecider } from '../../internals/hooks/use-launchpad-decider';
-import { useFlowState } from '../../internals/state-manager/store';
 import { STEPS } from '../../internals/steps';
 import { redirect } from '../../internals/steps-repository/import/util';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
@@ -424,8 +424,9 @@ const siteSetupFlow: Flow = {
 				case 'importReady': {
 					const depUrl = ( providedDependencies?.url as string ) || '';
 					const { platform } = providedDependencies as { platform: ImporterMainPlatform };
+					const entryPoint = get( 'flow' )?.entryPoint;
 
-					if ( shouldRedirectToSiteMigration( currentStep, platform, origin ) ) {
+					if ( shouldRedirectToSiteMigration( currentStep, platform, origin, entryPoint ) ) {
 						return window.location.assign(
 							addQueryArgs(
 								{ siteSlug, siteId, from },

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -759,6 +759,14 @@ const siteSetupFlow: Flow = {
 			selectedGlobalStyles,
 			skippedCheckout,
 		] );
+
+		const { get, set } = useFlowState();
+		const urlQueryParams = useQuery();
+		const ref = urlQueryParams.get( 'ref' );
+
+		if ( ref && ! get( 'flow' )?.entryPoint ) {
+			set( 'flow', { entryPoint: ref } );
+		}
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/index.ts
@@ -3,11 +3,12 @@ import { STEPS } from '../internals/steps';
 export const shouldRedirectToSiteMigration = (
 	step: string,
 	platform: string,
-	origin?: string | null
+	origin?: string | null,
+	ref?: string | null
 ) => {
 	return (
 		step === STEPS.IMPORT_LIST.slug &&
 		platform === 'wordpress' &&
-		origin === STEPS.SITE_MIGRATION_IDENTIFY.slug
+		( origin === STEPS.SITE_MIGRATION_IDENTIFY.slug || ref === 'wp-admin-importers-list' )
 	);
 };

--- a/client/landing/stepper/declarative-flow/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/index.ts
@@ -4,11 +4,11 @@ export const shouldRedirectToSiteMigration = (
 	step: string,
 	platform: string,
 	origin?: string | null,
-	ref?: string | null
+	entryPoint?: string | null
 ) => {
 	return (
 		step === STEPS.IMPORT_LIST.slug &&
 		platform === 'wordpress' &&
-		( origin === STEPS.SITE_MIGRATION_IDENTIFY.slug || ref === 'wp-admin-importers-list' )
+		( origin === STEPS.SITE_MIGRATION_IDENTIFY.slug || entryPoint === 'wp-admin-importers-list' )
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
+++ b/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
@@ -9,7 +9,7 @@ type CreatedSite = Awaited< ReturnType< typeof createSite > >;
  */
 export type FlowStateManifest = Partial< {
 	domains: DomainStepResult;
-	migration: {
+	flow: {
 		entryPoint: string;
 	};
 	plans: PlansStepResult;


### PR DESCRIPTION
Related to:
* https://github.com/Automattic/wp-calypso/issues/100895
* https://github.com/Automattic/jetpack/pull/42718

> [!WARNING]
> This current solution doesn't ensure an alignment between our UI back button and the browser back button.  Make them aligned is part of a refactor initiated on https://github.com/Automattic/wp-calypso/pull/101550.  

## Proposed Changes
* Rename the flow state from `migration`>`entryPoint` to `flow`>`entryPoint` because now it will be used outside the migration flow context. 
* Update back logic make the user return from IMPORT_OR_MIGRATE to {SITE_}/import.php when the ref= 'wp-admin-importers-list' 


The overall idea is the [PR](https://github.com/Automattic/jetpack/pull/42718) will introduce a specialized `ref=wp-admin-importers-list`, which will be stored on the new `site-setup` flow state to be reused when the user advance in on `site-setup` steps and use the back button.

We must also repass this ref query param to the site migration flow to ensure the user can properly return to the /import.php page.


![image](https://github.com/user-attachments/assets/93402536-26a8-4f7c-a3f1-1991cbabd065)


## Why are these changes being made?
* As part of the Code Blue initiative, we are updating the /import page to suggest that users use our importing guided flows (PR here: https://github.com/Automattic/jetpack/pull/42693).
This PR ensures the user can return to the original page when they start the flow from there, regardless of whether they continue on the site setup or continue the site migration flow.


## Testing Instructions
* Create a free site
* Go to `/setup/site-setup/importList?siteSlug={YOUR_SITE_SLUG}&ref=wp-admin-importers-list`  
* Click "WordPress"
* Choose the Import option
* Click on the UI back button and check if you are on the import vs migrate again
* Click on the UI back button to check if you are on the importList again
* Click on the UI back button to check if you are on the /import.php page again. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
