### PR TITLE
Reader: Update Quick Edit mobile styles

### DIFF
--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -17,18 +17,22 @@
 		justify-content: space-between;
 		align-items: end;
 
-		.sites-dropdown__wrapper {
-			border-color: var( --color-border-subtle );
-			border-radius: 6px;
+		.sites-dropdown {
+			min-width: 200px;
+
+			&__wrapper {
+				border-color: var( --color-border-subtle );
+				border-radius: 6px;
+			}
+
+			&.is-open .sites-dropdown__wrapper {
+				border-radius: 6px 6px 0 0;
+			}
 		}
 
 		.site-selector {
 			border-color: var( --color-border-subtle );
 			border-radius: 0 0 6px 6px;
-		}
-
-		.sites-dropdown.is-open .sites-dropdown__wrapper {
-			border-radius: 6px 6px 0 0;
 		}
 	}
 

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -16,9 +16,10 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: end;
+		gap: 10px;
 
 		.sites-dropdown {
-			min-width: 200px;
+			flex: 0 1 300px;
 
 			&__wrapper {
 				border-color: var( --color-border-subtle );

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -21,12 +21,8 @@
 		.sites-dropdown {
 			flex: 0 1 300px;
 
-			&__wrapper {
+			.sites-dropdown__wrapper {
 				border-color: var( --color-border-subtle );
-				border-radius: 6px;
-			}
-
-			&.is-open .sites-dropdown__wrapper {
 				border-radius: 6px 6px 0 0;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pe7F0s-2C4-p2

## Proposed Changes

Updates responsive styles

### Before

![Screenshot 2025-03-31 at 17 01 48](https://github.com/user-attachments/assets/e86f7344-d873-4dc7-b11a-b05751d427ce)

### After

<img width="477" alt="Screenshot 2025-03-31 at 18 00 56" src="https://github.com/user-attachments/assets/160d9c84-30b0-4ed4-8e1e-6237bf672639" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Improve broken UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/reader/`
- Open the Quick Edit dropdown
- Test at various sizes to ensure it looks correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
