### PR TITLE
Remove lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,0 @@
-{
-	"packages": [ "client", "packages/*", "apps/*" ],
-	"version": "independent",
-	"npmClient": "yarn",
-	"useWorkspaces": true,
-	"ignoreChanges": [ "**/*.md", "**/.eslintrc.{js,json,yaml,yml}" ]
-}


### PR DESCRIPTION
## What

Remove the `lerna.json` file.

## Why 

We've [dropped lerna a few years ago](https://github.com/Automattic/wp-calypso/pull/56129/), and we don't use it anywhere (searched for docs and flows). 
