### PR TITLE
Reader - fix domain free plan upsell banner.

### DIFF
--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -22,6 +22,7 @@ import Banner from 'calypso/components/banner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { addQueryArgs } from 'calypso/lib/url';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -29,7 +30,11 @@ import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isSiteOnECommerceTrial, isSiteOnWooExpress } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	getMostRecentlySelectedSiteId,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { IsEligibleForOneClickCheckoutReturnValue } from 'calypso/my-sites/checkout/purchase-modal/use-is-eligible-for-one-click-checkout';
 import type { IAppState } from 'calypso/state/types';
@@ -153,7 +158,7 @@ export const UpsellNudge = ( {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const shouldNotDisplay =
 		isVip ||
-		! canManageSite ||
+		// ! canManageSite ||
 		! site ||
 		typeof site !== 'object' ||
 		typeof site.jetpack !== 'boolean' ||
@@ -293,7 +298,10 @@ export const UpsellNudge = ( {
 };
 
 const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: OwnProps ) => {
-	const siteId = getSelectedSiteId( state );
+	const siteId =
+		getSelectedSiteId( state ) ||
+		getMostRecentlySelectedSiteId( state ) ||
+		getPrimarySiteId( state );
 	const siteFeatures = getFeaturesBySiteId( state, siteId || undefined );
 	const hasFeature =
 		siteFeatures === null ? null : siteHasFeature( state, siteId, ownProps.feature || '' );

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -158,7 +158,7 @@ export const UpsellNudge = ( {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const shouldNotDisplay =
 		isVip ||
-		// ! canManageSite ||
+		! canManageSite ||
 		! site ||
 		typeof site !== 'object' ||
 		typeof site.jetpack !== 'boolean' ||

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -29,12 +29,8 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isSiteOnECommerceTrial, isSiteOnWooExpress } from 'calypso/state/sites/plans/selectors';
-import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import {
-	getMostRecentlySelectedSiteId,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
+import { getSite, getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getMostRecentlySelectedSiteId, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { IsEligibleForOneClickCheckoutReturnValue } from 'calypso/my-sites/checkout/purchase-modal/use-is-eligible-for-one-click-checkout';
 import type { IAppState } from 'calypso/state/types';
@@ -316,8 +312,8 @@ const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: OwnProps ) =
 		isSiteWooExpressOrEcomFreeTrial: siteId
 			? isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId )
 			: false,
-		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
-		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ) || false,
+		siteSlug: ownProps.disableHref ? null : getSiteSlug( state, siteId ),
+		siteIsWPForTeams: isSiteWPForTeams( state, siteId ) || false,
 	};
 } )( UpsellNudge );
 

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -19,7 +19,7 @@ function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) 
 			forceHref
 			callToAction={ translate( 'Upgrade' ) }
 			compact
-			href={ '/plans/' + siteSlug }
+			href={ '/domains/add/' + siteSlug + '?domainAndPlanPackage=true' }
 			title={ translate( 'Free domain with an annual plan' ) }
 			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
 			tracksClickName="calypso_upgrade_nudge_cta_click"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/101295

## Proposed Changes

Fixes two issue with the banner:
1. The banner would disappear if there was no site currently selected in state. I updated the upsell nudge component to fall back to the most recently selected site Id and then primary site id if no site is currently selected.
    * Unlike most places upsells exist, the reader can be loaded in a state where no site is currently selected. However, it "feels like" a site is selected due to its appearance in the top admin bar. The top admin bar displays the site by the same fallback logic. Updating this component to fallback to these other site ID values allows it to work consistently in places like the reader, without changing its behavior in contexts were individual sites are always selected.
2. We update the banner to link to the specific flow build for this upsell, instead of the plans page for the site.

BEFORE
![reader-banner-disappear-before](https://github.com/user-attachments/assets/f816cf00-8c39-4829-b0ad-311d33743f21)
When clicked, the banner would land at:
<img width="1231" alt="Screenshot 2025-03-31 at 12 02 04 PM" src="https://github.com/user-attachments/assets/5bddda46-2e3f-47b9-b181-5306bad74cec" />

AFTER
![reader-upsell-disappear-after](https://github.com/user-attachments/assets/97b427bf-ee99-4977-908b-b458eb1af423)
When clicked, the banner will land at:
<img width="1379" alt="Screenshot 2025-03-31 at 12 01 04 PM" src="https://github.com/user-attachments/assets/cf91dd49-739c-453c-ab46-5684e9181128" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

1. We don't want the banner to disappear when it shouldn't. This limits opportunities for users to get the promotional upgrade, and our ability to upsell.
2. When it does work, we want it going to the newer flow that gives a better user experience for the upsell.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new account with 1 site on a free plan.
* Visit the reader, you should see the upsell banner.
* Click "W" in the masterbar to navigate to /sites.
* Without clicking anything else on /sites, click "Reader" in the masterbar.
* Verify the upsell is still present. This is where it would previously disappear.
* Click on the upsell and verify you are sent to the multi-step flow for this promotion. previously this was the plans page.

For testing the extra change/case around replacing the `getSelectedSiteSlug` selector with `getSiteSlug`, you can verify that these both provide the same return value when a site is selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
