### PR TITLE
DIFM Site Migration: Reset site state when exiting to the overview screen

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -417,7 +417,6 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip' ) {
-						//something here
 						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 					}
 

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -417,6 +417,7 @@ const siteMigration: Flow = {
 					};
 
 					if ( action === 'skip' ) {
+						//something here
 						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
 					}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -105,22 +105,29 @@ const SiteMigrationCredentials: Step< {
 		} );
 	};
 
-	const handleSkip = () => {
+	const handleSkip = async () => {
 		recordTracksEvent( 'wpcom_support_free_migration_request_click', {
 			path: window.location.pathname,
 			automated_migration: true,
 		} );
-		sendTicket( {
-			locale,
-			from_url: fromUrl,
-			blog_url: siteSlug,
-		} );
-		// Reset the site in the state to ensure the correct overview screen is shown.
-		siteId && dispatch( resetSite( siteId ) );
 
-		return navigation.submit?.( {
-			action: 'skip',
-		} );
+		try {
+			await sendTicket( {
+				locale,
+				from_url: fromUrl,
+				blog_url: siteSlug,
+			} );
+
+			// Reset the site in the state to ensure the correct overview screen is shown.
+			siteId && dispatch( resetSite( siteId ) );
+
+			return navigation.submit?.( {
+				action: 'skip',
+			} );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'There was an error submitting the ticket', error );
+		}
 	};
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -115,6 +115,8 @@ const SiteMigrationCredentials: Step< {
 			from_url: fromUrl,
 			blog_url: siteSlug,
 		} );
+		// Reset the site in the state to ensure the correct overview screen is shown.
+		siteId && dispatch( resetSite( siteId ) );
 
 		return navigation.submit?.( {
 			action: 'skip',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -70,7 +70,7 @@ const SiteMigrationCredentials: Step< {
 	const siteSlugParam = useSiteSlugParam();
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const siteSlug = siteSlugParam ?? '';
-	const { sendTicket } = useSubmitMigrationTicket( {
+	const { sendTicketAsync } = useSubmitMigrationTicket( {
 		onSuccess: () => {
 			recordTracksEvent( 'calypso_migration_credentials_ticket_submit_success', {
 				blog_url: siteSlug,
@@ -112,7 +112,7 @@ const SiteMigrationCredentials: Step< {
 		} );
 
 		try {
-			await sendTicket( {
+			await sendTicketAsync( {
 				locale,
 				from_url: fromUrl,
 				blog_url: siteSlug,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/102241

## Proposed Changes

* Ensures the user sees the correct (helpful) migration information after clicking "Let us help you" in the DIFM migration flow.

Note: It feels messy to have to do this one-off cache clear any time we exit the flow, which speaks to the need for a helper function of some kind. Perhaps we should lift it up and clear the cache every time we exitFlow.

**Before**

note the brief flash of site overview content before the migration-related content shows up.

https://github.com/user-attachments/assets/61871335-72d6-4b2e-a5ff-0e1c0f8ce7c8

**After**

https://github.com/user-attachments/assets/b2d9326e-c877-46d3-8fec-2db747ebff23

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fixes a bug where the user would see unhelpful site overview screen for a few seconds/until site cache caught up with the migration status.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To see the original behavior, follow the testing instructions in the original issue: https://github.com/Automattic/wp-calypso/issues/102241
* Switch to this PR
* Create a new site with the migration intent and input your WordPress-based test site
* Choose DIFM (Let us help you)
* Pay for the migration
* On the credentials step, click "Let us help you"
* You should be redirected to the site overview at `/overview/{siteSlug}` with the migration pending screen:
<img width="1511" alt="Screenshot 2025-03-31 at 12 49 01 PM" src="https://github.com/user-attachments/assets/b8484d5d-b509-4891-b72d-98fa54e5668e" />
* You shouldn't see the typical site overview content at that point.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
