### PR TITLE
Site Migration: Transfer with software API, update hooks

### DIFF
--- a/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
@@ -67,9 +67,6 @@ describe( 'useRequestTransferWithSoftware', () => {
 				atomic_transfer_id: 456,
 				blog_id: SITE_ID,
 				atomic_transfer_status: 'pending',
-				plugins: { 'plugin-1': 'install' },
-				themes: { 'theme-1': 'activate' },
-				transfer_with_software_status: 'pending',
 			} );
 
 		const { result } = render();
@@ -83,9 +80,6 @@ describe( 'useRequestTransferWithSoftware', () => {
 					atomic_transfer_id: 456,
 					blog_id: SITE_ID,
 					atomic_transfer_status: 'pending',
-					plugins: { 'plugin-1': 'install' },
-					themes: { 'theme-1': 'activate' },
-					transfer_with_software_status: 'pending',
 				} );
 			},
 			{ timeout: 3000 }

--- a/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
@@ -16,10 +16,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 const mockSuccessResponse = {
 	blog_id: 123,
 	atomic_transfer_id: 456,
-	transfer_with_software_status: 'pending',
-	atomic_transfer_status: 'success',
-	plugins: { 'wpcom-migration': true },
-	themes: { 'twenty-twenty-four': false },
+	atomic_transfer_status: 'completed',
 };
 
 describe( 'useTransferWithSoftwareStatus', () => {
@@ -44,8 +41,7 @@ describe( 'useTransferWithSoftwareStatus', () => {
 		await waitFor( () => {
 			expect( result.current.isSuccess ).toBe( true );
 			expect( result.current.data ).toEqual( {
-				transfer_with_software_status: 'pending',
-				atomic_transfer_status: 'success',
+				atomic_transfer_status: 'completed',
 			} );
 		} );
 	} );
@@ -70,23 +66,5 @@ describe( 'useTransferWithSoftwareStatus', () => {
 
 		expect( result.current.isFetching ).toBe( false );
 		expect( nock.isDone() ).toBe( true ); // No pending nock requests
-	} );
-
-	it( 'should ignore extra fields in the response', async () => {
-		const queryClient = new QueryClient();
-		const wrapper = ( { children }: { children: React.ReactNode } ) => (
-			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
-		);
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/sites/123/atomic/transfer-with-software/456' )
-			.query( { http_envelope: 1 } )
-			.reply( 200, mockSuccessResponse );
-
-		const { result } = renderHook( () => useTransferWithSoftwareStatus( 123, 456 ), { wrapper } );
-
-		await waitFor( () => {
-			expect( result.current.isSuccess ).toBe( true );
-			expect( result.current.data ).not.toContain( { extra_field: 'extra_value' } );
-		} );
 	} );
 } );

--- a/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
@@ -16,7 +16,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 const mockSuccessResponse = {
 	blog_id: 123,
 	atomic_transfer_id: 456,
-	atomic_transfer_status: 'completed',
+	atomic_transfer_status: 'success',
 };
 
 describe( 'useTransferWithSoftwareStatus', () => {
@@ -41,7 +41,7 @@ describe( 'useTransferWithSoftwareStatus', () => {
 		await waitFor( () => {
 			expect( result.current.isSuccess ).toBe( true );
 			expect( result.current.data ).toEqual( {
-				atomic_transfer_status: 'completed',
+				atomic_transfer_status: 'success',
 			} );
 		} );
 	} );

--- a/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
@@ -16,7 +16,7 @@ jest.mock( '@automattic/calypso-config', () => ( {
 const mockSuccessResponse = {
 	blog_id: 123,
 	atomic_transfer_id: 456,
-	atomic_transfer_status: 'success',
+	atomic_transfer_status: 'completed',
 };
 
 describe( 'useTransferWithSoftwareStatus', () => {
@@ -41,7 +41,7 @@ describe( 'useTransferWithSoftwareStatus', () => {
 		await waitFor( () => {
 			expect( result.current.isSuccess ).toBe( true );
 			expect( result.current.data ).toEqual( {
-				atomic_transfer_status: 'success',
+				atomic_transfer_status: 'completed',
 			} );
 		} );
 	} );

--- a/client/sites/hooks/use-transfer-with-software-start-mutation.ts
+++ b/client/sites/hooks/use-transfer-with-software-start-mutation.ts
@@ -5,9 +5,6 @@ type TransferWithSoftwareResponse = {
 	blog_id: number;
 	atomic_transfer_id: number;
 	atomic_transfer_status: string;
-	plugins: Record< string, string >;
-	themes: Record< string, string >;
-	transfer_with_software_status: string;
 };
 
 type SoftwareSlug = string;

--- a/client/sites/hooks/use-transfer-with-software-status-query.ts
+++ b/client/sites/hooks/use-transfer-with-software-status-query.ts
@@ -20,8 +20,8 @@ const getTransferWithSoftwareStatus = async (
 };
 
 export const useTransferWithSoftwareStatus = (
-	siteId: number,
-	atomicTransferId: number,
+	siteId?: number,
+	atomicTransferId?: number,
 	options?: {
 		retry?: UseQueryOptions[ 'retry' ];
 	}
@@ -35,7 +35,7 @@ export const useTransferWithSoftwareStatus = (
 		refetchOnWindowFocus: false,
 		refetchOnReconnect: false,
 		refetchInterval: ( { state } ) => {
-			if ( state.data?.atomic_transfer_status === 'success' ) {
+			if ( state.data?.atomic_transfer_status === 'completed' ) {
 				return false;
 			}
 			return 5000;

--- a/client/sites/hooks/use-transfer-with-software-status-query.ts
+++ b/client/sites/hooks/use-transfer-with-software-status-query.ts
@@ -4,9 +4,6 @@ import wpcom from 'calypso/lib/wp';
 type TransferWithSoftwareStatusResponse = {
 	blog_id: number;
 	atomic_transfer_id: number;
-	plugins: { [ key: string ]: boolean };
-	themes: { [ key: string ]: boolean };
-	transfer_with_software_status: string;
 	atomic_transfer_status: string;
 };
 
@@ -33,7 +30,6 @@ export const useTransferWithSoftwareStatus = (
 		queryKey: [ 'software-transfer-status', siteId, atomicTransferId ],
 		queryFn: () => getTransferWithSoftwareStatus( siteId, atomicTransferId ),
 		select: ( data: TransferWithSoftwareStatusResponse ) => ( {
-			transfer_with_software_status: data.transfer_with_software_status,
 			atomic_transfer_status: data.atomic_transfer_status,
 		} ),
 		refetchOnWindowFocus: false,

--- a/client/sites/hooks/use-transfer-with-software-status-query.ts
+++ b/client/sites/hooks/use-transfer-with-software-status-query.ts
@@ -7,10 +7,17 @@ type TransferWithSoftwareStatusResponse = {
 	atomic_transfer_status: string;
 };
 
-const getTransferWithSoftwareStatus = async (
-	siteId: number,
-	atomicTransferId: number
-): Promise< TransferWithSoftwareStatusResponse > => {
+const getTransferWithSoftwareStatus: (
+	siteId?: number,
+	atomicTransferId?: number
+) => Promise< TransferWithSoftwareStatusResponse > = async ( siteId, atomicTransferId ) => {
+	if ( ! siteId || ! atomicTransferId ) {
+		return {
+			blog_id: 0,
+			atomic_transfer_id: 0,
+			atomic_transfer_status: 'pending',
+		};
+	}
 	return wpcom.req.get(
 		`/sites/${ siteId }/atomic/transfer-with-software/${ atomicTransferId }?http_envelope=1`,
 		{

--- a/client/sites/hooks/use-transfer-with-software-status-query.ts
+++ b/client/sites/hooks/use-transfer-with-software-status-query.ts
@@ -35,7 +35,7 @@ export const useTransferWithSoftwareStatus = (
 		refetchOnWindowFocus: false,
 		refetchOnReconnect: false,
 		refetchInterval: ( { state } ) => {
-			if ( state.data?.atomic_transfer_status === 'completed' ) {
+			if ( state.data?.atomic_transfer_status === 'success' ) {
 				return false;
 			}
 			return 5000;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 178867-ghe-Automattic/wpcom

## Proposed Changes

* We recently made changes to the backend API, this updates the hooks' expected response types to match.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 178867-ghe-Automattic/wpcom 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass and visual inspection should be sufficient.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?