### PR TITLE
Render Step.Loading while fetching sections

### DIFF
--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { Step } from '@automattic/onboarding';
 import * as LoadingError from 'calypso/layout/error';
+import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import { performanceTrackerStart } from 'calypso/lib/performance-tracking';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { setSectionLoading } from 'calypso/state/ui/actions';
@@ -86,6 +88,17 @@ function loadSectionHandler( sectionDefinition ) {
 	};
 }
 
+function emptyPageLoading( context, next ) {
+	if ( ! isInStepContainerV2FlowContext( context.pathname, context.querystring ) ) {
+		return next();
+	}
+
+	context.layout = <Step.Loading />;
+	controller.render( context );
+
+	next();
+}
+
 function createPageDefinition( path, sectionDefinition ) {
 	// skip this section if it's not enabled in current environment
 	const { envId } = sectionDefinition;
@@ -104,6 +117,10 @@ function createPageDefinition( path, sectionDefinition ) {
 	// if the section doesn't support logged-out views, redirect to login if user is not logged in
 	if ( ! sectionDefinition.enableLoggedOut ) {
 		handler = composeHandlers( controller.redirectLoggedOut, handler );
+	}
+
+	if ( path === '/checkout' ) {
+		handler = composeHandlers( emptyPageLoading, handler );
 	}
 
 	page( pathRegex, handler );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
