### PR TITLE
Click "View all" if its available

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -48,6 +48,17 @@ export class PeoplePage {
 	}
 
 	/**
+	 * Click view all link if its available.
+	 */
+	async clickViewAllIfAvailable(): Promise< void > {
+		const viewAllLink = await this.page.getByRole( 'link', { name: 'View all' } );
+
+		if ( ( await viewAllLink.count() ) > 0 ) {
+			await viewAllLink.click();
+		}
+	}
+
+	/**
 	 * Clicks on the navigation tab (desktop) or dropdown (mobile).
 	 *
 	 * @param {string} name Name of the tab to click.

--- a/test/e2e/specs/users/invite__revoke.ts
+++ b/test/e2e/specs/users/invite__revoke.ts
@@ -77,6 +77,7 @@ describe( DataHelper.createSuiteTitle( 'Invite: Revoke' ), function () {
 
 			if ( userManagementRevampFeature ) {
 				await peoplePage.clickTab( 'Users' );
+				await peoplePage.clickViewAllIfAvailable();
 			} else {
 				await peoplePage.clickTab( 'Invites' );
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
Users page is only showing the last invite.
To ensure that all current invites are listed and avoid race conditions, this PR clicks the `View All` link if it's available.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
