### PR TITLE
Components: Reset styles on ResponsiveToolbarGroup

### DIFF
--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -80,6 +80,8 @@
 }
 
 body.is-section-plugins #primary .main.is-logged-out {
+	// Need to specifically set this, to override the classic blue.
+	--wp-admin-theme-color: var(--studio-blue-50);
 	padding-top: 0;
 
 	.responsive-toolbar-group__swipe-list {
@@ -93,9 +95,14 @@ body.is-section-plugins #primary .main.is-logged-out {
 
 		.responsive-toolbar-group__button-item {
 			padding: 4px 12px;
-		}
-		.responsive-toolbar-group__button-item:not([class*="is-pressed"]):hover::before {
-			background: rgba(6, 117, 196, 0.1);
+
+			&::before {
+				background-color: transparent;
+			}
+
+			&:not([class*="is-pressed"]):hover::before {
+				background-color: color-mix(in srgb, var(--studio-blue) 10%, transparent);
+			}
 		}
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -218,6 +218,10 @@
 		&:not(.is-pressed) {
 			color: var(--studio-blue-90);
 
+			&::before {
+				background-color: transparent;
+			}
+
 			&:hover::before {
 				background-color: color-mix(in srgb, var(--studio-blue) 10%, transparent);
 			}

--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -29,7 +29,6 @@
 		border: 0;
 
 		.components-button {
-			color: var(--color-neutral-60);
 			line-height: 24px;
 			padding: 4px 12px;
 
@@ -42,22 +41,6 @@
 				border-radius: 4px;
 				left: 0;
 				right: 0;
-			}
-
-			&:focus-visible::before {
-				box-shadow: inset 0 0 0 2px var(--color-primary-light);
-			}
-
-			&:not(.is-pressed):not(.is-selected):hover::before {
-				background-color: var(--studio-gray-0);
-			}
-
-			&.is-pressed {
-				color: var(--color-text-inverted);
-
-				&::before {
-					background-color: var(--color-neutral-80);
-				}
 			}
 		}
 	}
@@ -73,11 +56,6 @@
 
 		.responsive-toolbar-group__menu-item {
 			border-radius: 4px;
-
-			&.is-selected {
-				color: var(--color-text-inverted);
-				background-color: var(--color-neutral-80);
-			}
 		}
 	}
 }

--- a/packages/components/src/responsive-toolbar-group/style.scss
+++ b/packages/components/src/responsive-toolbar-group/style.scss
@@ -1,3 +1,25 @@
+.responsive-toolbar-group__dropdown .responsive-toolbar-group__button-item,
+.responsive-toolbar-group__dropdown .responsive-toolbar-group__menu-item,
+.responsive-toolbar-group__swipe .responsive-toolbar-group__swipe-item {
+	height: 36px;
+	padding: 8px 12px;
+	border-radius: 4px;
+	line-height: 20px;
+
+	&::before {
+		left: 4px;
+		right: 4px;
+		height: 36px;
+		border-radius: 4px;
+		background-color: var(--studio-white);
+	}
+}
+
+.responsive-toolbar-group__grouped-list,
+.responsive-toolbar-group__swipe-list {
+	align-items: center;
+}
+
 .responsive-toolbar-group__dropdown {
 	position: relative;
 	padding-bottom: 24px;
@@ -10,14 +32,25 @@
 		display: flex;
 		opacity: 0;
 
+		.responsive-toolbar-group__menu-item {
+			font-size: rem(13px);
 
-		.responsive-toolbar-group__menu-item.is-selected {
-			background-color: #1e1e1e;
-			color: var(--color-text-inverted);
-		}
-		.responsive-toolbar-group__menu-item:not(.is-selected):not(.responsive-toolbar-group__more-item) {
-			&:hover {
-				background: var(--studio-gray-0);
+			&.is-selected {
+				color: var(--color-text-inverted);
+
+				&::before {
+					background-color: #1e1e1e;
+				}
+			}
+
+			&:not(.is-selected):not(.responsive-toolbar-group__more-item) {
+				&:hover::before {
+					background: var(--studio-gray-0);
+				}
+			}
+
+			&:not(:first-child) {
+				margin-top: 8px;
 			}
 		}
 
@@ -44,12 +77,6 @@
 		opacity: 1;
 	}
 
-	.is-multi {
-		.responsive-toolbar-group__menu-item:not(:first-child) {
-			margin-top: 8px;
-		}
-	}
-
 	.responsive-toolbar-group__full-list {
 		overflow: hidden;
 		position: absolute;
@@ -65,11 +92,6 @@
 		white-space: nowrap;
 
 		font-size: 0.875rem;
-	}
-
-	// Remove on-focus, on-click border
-	.components-toolbar .components-button::before {
-		box-shadow: none;
 	}
 }
 
@@ -99,11 +121,5 @@
 		>div {
 			flex-shrink: 0;
 		}
-	}
-
-	// Remove on-focus, on-click border
-	.components-toolbar .components-button::before,
-	.components-toolbar .components-button:focus {
-		box-shadow: none;
 	}
 }

--- a/packages/design-picker/src/components/design-picker-category-filter/style.scss
+++ b/packages/design-picker/src/components/design-picker-category-filter/style.scss
@@ -25,19 +25,15 @@
 		font-size: rem(13px);
 
 		&::before {
-			left: 4px;
-			right: 4px;
-			height: 36px;
-			border-radius: 4px;
-			background-color: #EDEDEF; /* 50% of gray-5 */
+			background-color: rgba(var(--studio-gray-5-rgb), 0.5);
 		}
 
 		&:not([class*="is-pressed"]):hover {
 			color: var(--studio-gray-100);
-		}
 
-		&:not([class*="is-pressed"]):hover::before{
-			background-color: var(--studio-gray-5);
+			&::before{
+				background-color: var(--studio-gray-5);
+			}
 		}
 
 		&.is-pressed {
@@ -52,31 +48,13 @@
 	}
 
 	button.components-button.responsive-toolbar-group__menu-item {
-		height: 40px;
-		padding: 8px 12px;
-		border-radius: 4px;
-		line-height: 20px;
-		background-color: #EDEDEF; /* 50% of gray-5 */
-		font-size: rem(13px);
-
-		&:not(.responsive-toolbar-group__more-item):not([class*="is-selected"]):hover {
-			color: var(--studio-gray-100);
-			background-color: var(--studio-gray-5);
-		}
-
-		&:not(:first-child) {
-			margin-top: 8px;
-		}
-
 		&.is-selected {
-			background-color: var(--studio-wordpress-blue);
-
-			&:hover {
-				opacity: 0.95;
+			&::before {
+				background-color: var(--studio-wordpress-blue);
 			}
 
-			&:active {
-				opacity: 0.9;
+			&:hover::before {
+				background-color: var(--studio-wordpress-blue-60);
 			}
 		}
 	}

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -447,14 +447,6 @@
 		cursor: pointer;
 	}
 
-	.components-button:focus::before {
-		box-shadow: none;
-	}
-
-	.components-button:focus-visible::before {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-	}
-
 	.unified-design-picker__designs {
 		min-height: 100vh;
 	}


### PR DESCRIPTION
Broadly related to #100450, this removes and consolidates styles on the `ResponsiveToolbarGroup` component.

## Proposed Changes

* Move shared styles to the component, removing sometimes unnecessary overrides at the page level.
* By sharing styles, this ensures the wp component's focus style is not disabled and items always have focus styles.
* Improved the style for focus and hover on selected and default options.

## Why are these changes being made?

* For consistency, to simplify page-level styles, and ensure accessibility of the component is not removed.

## Screenshots

Every screenshot has one item selected, one hovered, and one focused. In about half of the before states, there is no focus style.


<table role="table">
<thead>
	<tr>
		<th>Before</th>
		<th>After</th>
	</tr>
</thead>
<tbody>
	<tr>
		<td colspan="2">Onboarding: Focus state wraps entire item now, dropdown items don't use background color.</td>
	</tr>
	<tr>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/81a90c68-95d2-4b56-b078-1800bc86ec1b"><img src="https://github.com/user-attachments/assets/81a90c68-95d2-4b56-b078-1800bc86ec1b" alt="rtb-design-picker-before" style="max-width: 100%;"></a></td>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/e463c18e-8968-4140-bf6b-d7f1b7cc9cde"><img src="https://github.com/user-attachments/assets/e463c18e-8968-4140-bf6b-d7f1b7cc9cde" alt="rtb-design-picker-after" style="max-width: 100%;"></a></td>
	</tr>
	<tr>
		<td colspan="2">Domains picker: Has focus state now. Highlight color is from the admin color scheme for the current site.</td>
	</tr>
	<tr>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/9630897e-7631-45f5-8ecd-540cd9515049"><img src="https://github.com/user-attachments/assets/9630897e-7631-45f5-8ecd-540cd9515049" alt="rtb-domains-before" style="max-width: 100%;"></a></td>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/9e647283-f25d-443e-9346-f470b45aec7a"><img src="https://github.com/user-attachments/assets/9e647283-f25d-443e-9346-f470b45aec7a" alt="rtb-domains-after" style="max-width: 100%;"></a></td>
	</tr>
	<tr>
		<td colspan="2">Marketing tools: Has focus state now. Highlight color is from the admin color scheme for the current site.</td>
	</tr>
	<tr>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/f02760ff-4790-4dba-b1b8-d21d3d51a275"><img src="https://github.com/user-attachments/assets/f02760ff-4790-4dba-b1b8-d21d3d51a275" alt="rtb-marketing-tools-before" style="max-width: 100%;"></a></td>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/9988ce5a-9974-4412-bfce-58b90a331ac2"><img src="https://github.com/user-attachments/assets/9988ce5a-9974-4412-bfce-58b90a331ac2" alt="rtb-marketing-tools-after" style="max-width: 100%;"></a></td>
	</tr>
	<tr>
		<td colspan="2">Themes (bar): Hover text is updated to use accent color like core menus. On all-sites theme page (`/themes`), this is blueberry and uses "global" styles. On a single site (`/themes/:site`), this uses the admin color scheme color.</td>
	</tr>
	<tr>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/86077568-4550-42d9-80fc-30e775c9a437"><img src="https://github.com/user-attachments/assets/86077568-4550-42d9-80fc-30e775c9a437" alt="rtb-theme-bar-before" style="max-width: 100%;"></a></td>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/b975ed25-2224-4a9b-8fb2-283746cd89cb"><img src="https://github.com/user-attachments/assets/b975ed25-2224-4a9b-8fb2-283746cd89cb" alt="rtb-theme-bar-after" style="max-width: 100%;"></a></td>
	</tr>
	<tr>
		<td colspan="2">Themes (dropdown): focus state wraps entire item; dropdown items are shorter to match core dropdown, and show more without scroll.</td>
	</tr>
	<tr>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/a5ada106-f51c-445b-8cd1-73ca2524722c"><img src="https://github.com/user-attachments/assets/a5ada106-f51c-445b-8cd1-73ca2524722c" alt="rtb-theme-dropdown-before" style="max-width: 100%;"></a></td>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/0eb375c2-a3e0-4707-8913-96ad2fb22539"><img src="https://github.com/user-attachments/assets/0eb375c2-a3e0-4707-8913-96ad2fb22539" alt="rtb-theme-dropdown-after" style="max-width: 100%;"></a></td>
	</tr>
	<tr>
		<td colspan="2">Logged out themes: Focus state updated to use blueberry blue</td>
	</tr>
	<tr>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/fefb20b7-d407-4e9e-9489-b043e6695297"><img src="https://github.com/user-attachments/assets/fefb20b7-d407-4e9e-9489-b043e6695297" alt="rtb-lo-themes-before" style="max-width: 100%;"></a></td>
		<td><img src="https://github.com/user-attachments/assets/fc048c75-d05f-4268-806e-cafd93cc0323" alt="" /></td>
	</tr>
	<tr>
		<td colspan="2">Logged out plugins: Focus state added, now uses blueberry blue</td>
	</tr>
	<tr>
		<td><a target="_blank" rel="noopener noreferrer" href="https://github.com/user-attachments/assets/18f20bb4-63e7-4447-9aa0-1c6e88fc2cf1"><img src="https://github.com/user-attachments/assets/18f20bb4-63e7-4447-9aa0-1c6e88fc2cf1" alt="rtb-lo-plugins-before" style="max-width: 100%;"></a></td>
		<td><img src="https://github.com/user-attachments/assets/c3ac0b0b-b8d9-475a-8ef7-eeb4f44a1db5" alt="" /></td>
	</tr>
	<tr>
		<td colspan="2">The focus state size issue is clear on the selected items, so now it correctly outlines the full item rather than an awkward inner outline. The color change here is to use the admin scheme's highlight color, like buttons etc do.</td>
	</tr>
	<tr>
		<td><img src="https://github.com/user-attachments/assets/1feeea62-b09e-40c7-be2d-fa173063dc3a" alt="" /></td>
		<td><img src="https://github.com/user-attachments/assets/f22a5ecf-ecd4-48a0-a574-6921df7112cc" alt="" /></td>
	</tr>
</tbody>
</table>

## Testing Instructions

View the places the `ResponsiveToolbarGroup` component is used:

- Themes, logged in & logged out: https://wordpress.com/themes
- Plugins, logged out only: https://wordpress.com/plugins
- Domain picker, not sure how to get here via UI but you can build a URL: https://wordpress.com/domains/add/[SITE]?domainAndPlanPackage=true
- Onboarding, the design step (will need to go through new site creation to get here, but then you can reload it): https://wordpress.com/setup/site-setup/design-setup?siteSlug=[SITE]
- Marketing Tools, also not sure how to get here via UI: https://wordpress.com/marketing/tools/[SITE]

Replace wordpress.com with calypso.localhost or the test container linked below.

The options should have interactive states (hover & focus) and indicate which item is currently selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
