### PR TITLE
Rename post-checkout query param to redirect_to for consistency

### DIFF
--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -189,7 +189,7 @@ export const isInStepContainerV2FlowContext = ( pathname: string, query: string 
 		// flow it came from (if any) by inspecting the redirect_to query param (in the case
 		// of the onboarding flow).
 		const params = new URLSearchParams( query );
-		const redirectTo = params.get( 'redirect_to' ) ?? params.get( 'redirectTo' ) ?? '';
+		const redirectTo = params.get( 'redirect_to' ) ?? '';
 
 		return isRedirectingToStepContainerV2Flow( redirectTo );
 	}

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -67,8 +67,8 @@ interface CheckoutPendingProps {
  * when there is no `receiptId`, we cannot know what to do and the user will be
  * redirected to a generic thank-you page.
  *
- * The `redirectTo` prop comes from the query string parameter of the same
- * name. It may include a literal `/pending` as part of the URL; if that's the
+ * The `redirectTo` prop comes from the `redirect_to` query string parameter.
+ * It may include a literal `/pending` as part of the URL; if that's the
  * case, that string will be replaced by the receipt ID when the transaction
  * completes.
  *

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -274,7 +274,7 @@ export function checkoutPending( context, next ) {
 	/**
 	 * @type {string|undefined}
 	 */
-	const redirectTo = context.query.redirectTo;
+	const redirectTo = context.query.redirect_to;
 
 	const receiptId = Number.isInteger( Number( context.query.receiptId ) )
 		? Number( context.query.receiptId )

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -52,9 +52,9 @@ export interface RedirectForTransactionStatusArgs {
  * Redirect to a checkout pending page and from there to a (relative or absolute) url.
  *
  * The `url` parameter is the final destination. It will be appended to the
- * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `redirect_to` query param on a URL for the pending page. If `url` is
  * `/checkout/thank-you/:receiptId`, then this will look something like:
- * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ * `/checkout/thank-you/example.com/pending/1234?redirect_to=/checkout/thank-you/:receiptId`
  *
  * The pending page will redirect to the final destination when the order is complete.
  *
@@ -95,9 +95,9 @@ function isRelativeUrl( url: string ): boolean {
  * Redirect to a checkout pending page and from there to a relative url.
  *
  * The `url` parameter is the final destination. It will be appended to the
- * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `redirect_to` query param on a URL for the pending page. If `url` is
  * `/checkout/thank-you/:receiptId`, then this will look something like:
- * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ * `/checkout/thank-you/example.com/pending/1234?redirect_to=/checkout/thank-you/:receiptId`
  *
  * The pending page will redirect to the final destination when the order is complete.
  *
@@ -130,9 +130,9 @@ export function relativeRedirectThroughPending(
  * Redirect to a checkout pending page and from there to an absolute url.
  *
  * The `url` parameter is the final destination. It will be appended to the
- * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `redirect_to` query param on a URL for the pending page. If `url` is
  * `/checkout/thank-you/:receiptId`, then this will look something like:
- * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ * `/checkout/thank-you/example.com/pending/1234?redirect_to=/checkout/thank-you/:receiptId`
  *
  * The pending page will redirect to the final destination when the order is complete.
  *
@@ -160,9 +160,9 @@ export function absoluteRedirectThroughPending(
  * Add a relative or absolute url to the checkout pending page url.
  *
  * The `url` parameter is the final destination. It will be appended to the
- * `redirectTo` query param on a URL for the pending page. If `url` is
+ * `redirect_to` query param on a URL for the pending page. If `url` is
  * `/checkout/thank-you/:receiptId`, then this will look something like:
- * `/checkout/thank-you/example.com/pending/1234?redirectTo=/checkout/thank-you/:receiptId`
+ * `/checkout/thank-you/example.com/pending/1234?redirect_to=/checkout/thank-you/:receiptId`
  *
  * The pending page will redirect to the final destination when the order is complete.
  *
@@ -197,7 +197,7 @@ export function addUrlToPendingPageRedirect(
 		( orderId ? `${ orderId }` : ':orderId' );
 	const successUrlBase = `${ origin }${ successUrlPath }`;
 	const successUrlObject = new URL( successUrlBase );
-	successUrlObject.searchParams.set( 'redirectTo', url );
+	successUrlObject.searchParams.set( 'redirect_to', url );
 	successUrlObject.searchParams.set( 'receiptId', String( receiptId ) );
 	if ( fromSiteSlug ) {
 		successUrlObject.searchParams.set( 'from_site_slug', fromSiteSlug );
@@ -236,7 +236,7 @@ function interpolateReceiptId( url: string, receiptId: number ): string {
 /**
  * Return false for absolute URLs which are on unknown hosts.
  *
- * Because the `redirectTo` query param on the pending page is the target of
+ * Because the `redirect_to` query param on the pending page is the target of
  * that page's redirect, we want to make sure we do not create an open redirect
  * security hole that could go anywhere. This function will disallow a URL
  * which is absolute and on an unknown host.
@@ -299,7 +299,7 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 /**
  * Guard against redirecting to absolute URLs which are on unknown hosts.
  *
- * Because the `redirectTo` query param on the pending page is the target of
+ * Because the `redirect_to` query param on the pending page is the target of
  * that page's redirect, we want to make sure we do not create an open redirect
  * security hole that could go anywhere. This function will disallow a URL
  * which is absolute and on an unknown host, returning the `fallbackUrl` instead.
@@ -334,7 +334,7 @@ function getDefaultSuccessUrl(
  * is no receipt and no order (meaning we have to guess what to do).
  *
  * If a redirect is appropriate, the returned URL will usually be the
- * `redirectTo` option, but only if it is a relative URL or in a list of
+ * `redirect_to` option, but only if it is a relative URL or in a list of
  * allowed hosts to prevent having an open redirect. Otherwise it may be a
  * generic thank-you page.
  *

--- a/client/my-sites/checkout/src/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/src/test/generic-redirect-processor.ts
@@ -44,7 +44,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment_partner: 'IE',
 			postal_code: '10001',
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			zip: '10001',
 		},
 		tos: {
@@ -154,7 +154,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -190,7 +190,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=' +
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=' +
 					encodeURIComponent( thankYouUrl ) +
 					'&receiptId=%3AreceiptId',
 			},
@@ -228,7 +228,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=' +
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=' +
 					encodeURIComponent( thankYouUrl ) +
 					'&receiptId=%3AreceiptId',
 			},
@@ -275,7 +275,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -310,7 +310,7 @@ describe( 'genericRedirectProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+					'https://wordpress.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/src/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/test/paypal-express-processor.ts
@@ -49,7 +49,7 @@ describe( 'payPalExpressProcessor', () => {
 		domain_details: null,
 		postal_code: '',
 		success_url:
-			'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+			'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 		tos: {
 			locale: 'en',
 			path: '/',
@@ -113,7 +113,7 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			success_url:
-				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: 1234567,
@@ -150,7 +150,7 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			success_url:
-				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: 1234567,
@@ -179,7 +179,7 @@ describe( 'payPalExpressProcessor', () => {
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( {
 			...basicExpectedRequest,
 			success_url:
-				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: 1234567,
@@ -267,7 +267,7 @@ describe( 'payPalExpressProcessor', () => {
 			...basicExpectedRequest,
 			cancel_url: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: 0,
@@ -300,7 +300,7 @@ describe( 'payPalExpressProcessor', () => {
 			...basicExpectedRequest,
 			cancel_url: 'https://wordpress.com/checkout/no-site?signup=1&isDomainOnly=1',
 			success_url:
-				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
 				blog_id: 0,

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -37,7 +37,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 			urlType: 'relative',
 		} );
 		expect( actual ).toEqual(
-			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
@@ -53,7 +53,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 			urlType: 'absolute',
 		} );
 		expect( actual ).toEqual(
-			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
@@ -68,7 +68,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 			orderId,
 		} );
 		expect( actual ).toEqual(
-			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
@@ -81,7 +81,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 			orderId,
 		} );
 		expect( actual ).toEqual(
-			`${ currentWindowOrigin }/checkout/thank-you/no-site/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+			`${ currentWindowOrigin }/checkout/thank-you/no-site/pending/${ orderId }?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
@@ -96,7 +96,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 			fromSiteSlug,
 		} );
 		expect( actual ).toEqual(
-			`${ currentWindowOrigin }/checkout/thank-you/no-site/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+			`${ currentWindowOrigin }/checkout/thank-you/no-site/pending/${ orderId }?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }&from_site_slug=${ fromSiteSlug }`
 		);
@@ -109,7 +109,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 			siteSlug,
 		} );
 		expect( actual ).toEqual(
-			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/:orderId?redirectTo=${ encodeURIComponent(
+			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/:orderId?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
@@ -124,7 +124,7 @@ describe( 'addUrlToPendingPageRedirect', () => {
 			receiptId,
 		} );
 		expect( actual ).toEqual(
-			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/:orderId?redirectTo=${ encodeURIComponent(
+			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/:orderId?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ receiptId }`
 		);
@@ -143,7 +143,7 @@ describe( 'redirectThroughPending', () => {
 			orderId,
 		} );
 		expect( redirectSpy ).toHaveBeenCalledWith(
-			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+			`/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);
@@ -164,7 +164,7 @@ describe( 'redirectThroughPending', () => {
 			orderId,
 		} );
 		expect( global.window.location.href ).toEqual(
-			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirectTo=${ encodeURIComponent(
+			`${ currentWindowOrigin }/checkout/thank-you/${ siteSlug }/pending/${ orderId }?redirect_to=${ encodeURIComponent(
 				finalUrl
 			) }&receiptId=${ encodedReceiptPlaceholder }`
 		);

--- a/client/my-sites/checkout/src/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/src/test/we-chat-processor.ts
@@ -51,7 +51,7 @@ describe( 'weChatProcessor', () => {
 			payment_partner: 'IE',
 			postal_code: '10001',
 			success_url:
-				'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+				'https://example.com/checkout/thank-you/no-site/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			zip: '10001',
 		},
 		tos: {
@@ -202,7 +202,7 @@ describe( 'weChatProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -273,7 +273,7 @@ describe( 'weChatProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );
@@ -334,7 +334,7 @@ describe( 'weChatProcessor', () => {
 			payment: {
 				...basicExpectedStripeRequest.payment,
 				success_url:
-					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
+					'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirect_to=%2Fthank-you&receiptId=%3AreceiptId',
 			},
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The checkout page uses a `redirect_to` query param so flows navigating to the checkout can tell it where to go next.

Internally the checkout uses a similar system for transitioning from checkout, to checkout pending, to checkout success states. However it uses a `redirectTo` query param for some reason.

This PR makes the `redirect_to` spelling consistent.

Most of the changes are in `pending-page.ts` and `controller.jsx`. The other changes are updating tests

This PR was originally split out of https://github.com/Automattic/wp-calypso/pull/102189

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Code quality. Don't be afraid to work on "sand" pdL8AQ-1ae-p2#comment-1770

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through various onboarding and purchasing flows
* Try purchasing a plan
* Try purchasing a domain
* Purchase with credits
* Purchase with a credit card
* Purchase with a different method if you have access to it

There should be no changes from production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?