### PR TITLE
Stylelint config: use new name for disabled partial-extension rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -14,7 +14,7 @@
 		"value-keyword-case": null,
 		"scss/operator-no-unspaced": null,
 		"scss/selector-no-redundant-nesting-selector": null,
-		"scss/at-import-partial-extension": null,
+		"scss/load-partial-extension": null,
 		"scss/no-global-function-names": null,
 		"scss/comment-no-empty": null,
 		"scss/at-extend-no-missing-placeholder": null,


### PR DESCRIPTION
Stylelint recommended config has a rule that enforces _not_ using a file extension when importing a stylesheet:
```
'scss/load-partial-extension': 'never'
```
It will report an error like this if you mention `.scss` in your import:
```
✖  Unexpected extension ".scss" in @import  scss/load-partial-extension
```

However, Calypso config disables it. But it turns out it doesn't really disable it, because the rule was recently renamed from `scss/at-import-partial-extension` to `scss/load-partial-extension`. And we're disabling the old name. This PR fixes the disable statement.

Gutenberg still uses the older version of `stylelint-scss`, so the same config works there. But not in Calypso.

## Testing instructions:
Try to add `.scss` extension to an `@import 'something'` statement in a SCSS file. Run `yarn lint:css`. Before this patch, it will report an error. After this patch, the error is no longer reported: you have the freedom to use the extension or not.
