### PR TITLE
Newsletter Flow: Display Jetpack-powered on first step only

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-goals/index.tsx
@@ -75,7 +75,6 @@ const NewsletterGoals: Step = ( { navigation } ) => {
 				</VStack>
 			}
 			recordTracksEvent={ recordTracksEvent }
-			showJetpackPowered
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -208,7 +208,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	};
 
 	const flowName = props.flow || '';
-	const isJetpackPowered = isNewsletterFlow( flowName );
 
 	// Return tailored processing screens for flows that need them
 	if ( isNewsletterFlow( flowName ) || isUpdateDesignFlow( flowName ) ) {
@@ -242,7 +241,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 					<Loading title={ getCurrentMessage() } subtitle={ getSubtitle() } progress={ progress } />
 				}
 				recordTracksEvent={ recordTracksEvent }
-				showJetpackPowered={ isJetpackPowered }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
@@ -2,7 +2,6 @@ import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
-import JetpackLogo from 'calypso/components/jetpack-logo';
 import Loading from 'calypso/components/loading';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import './style.scss';
@@ -78,16 +77,7 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 		isComplete ? null : duration
 	);
 
-	return (
-		<>
-			<Loading title={ steps.current[ currentStep ]?.title } progress={ progress } />
-			{ flowName === NEWSLETTER_FLOW && (
-				<div className="processing-step__jetpack-powered">
-					<JetpackLogo monochrome size={ 18 } /> <span>Jetpack powered</span>
-				</div>
-			) }
-		</>
-	);
+	return <Loading title={ steps.current[ currentStep ]?.title } progress={ progress } />;
 }
 
 TailoredFlowPreCheckoutScreen.propTypes = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -41,19 +41,6 @@
 				width: 540px;
 			}
 		}
-
-		.processing-step__jetpack-powered {
-			display: flex;
-			justify-content: center;
-			font-family: "SF Pro Text", $sans;
-			font-size: $font-body-extra-small;
-			font-weight: 400;
-			line-height: 20px;
-
-			svg.jetpack-logo {
-				margin-right: 6px;
-			}
-		}
 	}
 
 	.newsletter {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -47,7 +47,6 @@ const Subscribers: Step = function ( { navigation } ) {
 			stepName="subscribers"
 			flowName="newsletter"
 			isHorizontalLayout={ false }
-			showJetpackPowered
 			stepContent={
 				<div className="subscribers">
 					{ site?.ID && (


### PR DESCRIPTION
## Proposed Changes

Display the "Powered by Jetpack" colophon only on the first step of the Newsletter flow.

Fixes #101825. Closes DOTCOM-718.

## Why are these changes being made?

See #101825.

## Testing Instructions

* Go to `/setup/newsletter`
* Go through the entire flow and verify the "Powered by Jetpack" colophon appears only on the first step. 

## Screenshot
![Screenshot 2025-04-01 at 10 55 48](https://github.com/user-attachments/assets/224504cc-2bc2-4cf4-be60-629496614bfb)
