### PR TITLE
Replace --color-text-subtle gray-50 with gray-60

### DIFF
--- a/client/blocks/data-center-picker/index.tsx
+++ b/client/blocks/data-center-picker/index.tsx
@@ -70,7 +70,7 @@ const SupportLink = styled.a`
 const StyledLabel = styled.div`
 	text-transform: none;
 	font-size: 0.875rem;
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 	text-wrap: wrap;
 `;
 

--- a/client/components/thank-you/index.tsx
+++ b/client/components/thank-you/index.tsx
@@ -56,7 +56,7 @@ const ThankYouNextSteps = styled.div`
 	}
 
 	p {
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		padding-right: 20px;
 	}
 	> div {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/goals-first-design-choice.scss
@@ -56,7 +56,7 @@
 	}
 
 	.goals-first-design-choice__description {
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		font-size: $font-body-small;
 		font-weight: 400;
 		line-height: 20px;

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -103,7 +103,7 @@ export const Discount = styled.span`
 export const DoNotPayThis = styled.del`
 	text-decoration: line-through;
 	margin-right: 8px;
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 
 	.rtl & {
 		margin-right: 0;
@@ -118,7 +118,7 @@ export const DoNotPayThis = styled.del`
 export const Price = styled.span`
 	display: inline-flex;
 	justify-content: right;
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 	.item-variant-option--selected & {
 		color: var( --studio-white );
 	}

--- a/client/my-sites/importer/newsletter/importer.scss
+++ b/client/my-sites/importer/newsletter/importer.scss
@@ -94,9 +94,9 @@ $newsletter_importer_line-height: 20px;
 
 	.summary__content-indent {
 		margin-left: 28px;
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		svg {
-			fill: var( --studio-gray-50 );
+			fill: var( --color-text-subtle );
 		}
 		.summary__content-stats-count {
 			font-weight: 400;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-item.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-item.tsx
@@ -28,7 +28,7 @@ const PlanPrice = styled.span`
 	font-size: 14px;
 	line-height: 20px;
 	letter-spacing: -0.15px;
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 `;
 
 export const PlanName = styled.span`
@@ -45,7 +45,7 @@ export const PlanDescription = styled.div`
 	font-size: 14px;
 	line-height: 20px;
 	letter-spacing: -0.15px;
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 `;
 
 const PlanInfo = ( { planSlug, description, isBusy, onPlanSelected }: Props ) => {

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -35,7 +35,7 @@ const StyledLi = styled.li`
 	margin: 5px 0;
 
 	.title {
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		font-size: 14px;
 		font-weight: 500;
 		margin-top: 10px;

--- a/client/performance-profiler/components/screenshot-thumbnail.tsx
+++ b/client/performance-profiler/components/screenshot-thumbnail.tsx
@@ -15,8 +15,8 @@ const Container = styled.div< { activeTab: TabType } >`
 `;
 
 const UnavailableScreenshot = styled.div`
-	color: var( --studio-gray-50 );
-	background-color: var( --studio-gray-0 );
+	color: var( --color-text-subtle );
+	background-color: var( --color-surface-backdrop );
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/client/performance-profiler/pages/loading-screen/progress.tsx
+++ b/client/performance-profiler/pages/loading-screen/progress.tsx
@@ -90,9 +90,9 @@ const LoadingProgressContainer = styled.div`
 		}
 
 		&.incomplete {
-			color: var( --studio-gray-50 );
+			color: var( --color-text-subtle );
 			::before {
-				border: 1px dashed var( --studio-gray-5 );
+				border: 1px dashed var( --color-border-subtle );
 			}
 		}
 	}

--- a/client/signup/accordion-form/accordion-form-section.tsx
+++ b/client/signup/accordion-form/accordion-form-section.tsx
@@ -70,14 +70,14 @@ const SkipLink = styled.a< { disabled?: boolean } >`
 `;
 
 const RequiredLabel = styled.span`
-	background: var( --studio-gray-0 );
+	background: var( --color-surface-backdrop );
 	border-radius: 4px;
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 	font-weight: 500;
 	font-size: 11px;
 	line-height: 13px;
 	letter-spacing: 0.38px;
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 	padding: 2px 8px;
 	text-transform: uppercase;
 `;

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -14,7 +14,7 @@ import { tip } from 'calypso/signup/icons';
 
 // TODO: This probably should be moved out to a more suitable folder name like difm-components
 export const Label = styled.label`
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 	font-weight: 400;
 	font-size: 0.875rem;
 	cursor: inherit;

--- a/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
@@ -48,7 +48,7 @@ const Cart = styled.div`
 		border-top: 1px solid var( --studio-gray-5 );
 	}
 	.page-picker__disclaimer {
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		font-size: 12px;
 
 		@media ( max-width: 600px ) {
@@ -78,7 +78,7 @@ const DummyLineItemContainer = styled.div`
 		font-weight: 500;
 	}
 	.page-picker__sub-label {
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		font-size: 12px;
 		width: 100%;
 		display: flex;

--- a/client/signup/steps/website-content/dialogs.tsx
+++ b/client/signup/steps/website-content/dialogs.tsx
@@ -7,7 +7,7 @@ const DialogContent = styled.div`
 	padding: 16px;
 	p {
 		font-size: 1rem;
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 	}
 	ul {
 		margin-inline-start: 1rem;

--- a/client/site-profiler/components/footnote/index.tsx
+++ b/client/site-profiler/components/footnote/index.tsx
@@ -23,7 +23,7 @@ const Description = styled.ul`
 	margin: 0;
 	max-width: 760px;
 	li {
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		font-size: 11px;
 		line-height: 18px;
 		margin-bottom: 18px;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -193,8 +193,8 @@
 
 	--color-text: var(--studio-gray-80);
 	--color-text-rgb: var(--studio-gray-80-rgb);
-	--color-text-subtle: var(--studio-gray-50);
-	--color-text-subtle-rgb: var(--studio-gray-50-rgb);
+	--color-text-subtle: var(--studio-gray-60);
+	--color-text-subtle-rgb: var(--studio-gray-60-rgb);
 	--color-text-inverted: var(--studio-white);
 	--color-text-inverted-rgb: var(--studio-white-rgb);
 

--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -28,7 +28,7 @@ const GPTResponsePlaceholder = styled( LoadingPlaceholder )< { width?: string } 
 `;
 
 const GPTResponseDisclaimer = styled.div`
-	color: var( --studio-gray-50 );
+	color: var( --color-text-subtle );
 	font-size: 11px;
 	text-align: right;
 

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -15,7 +15,7 @@
 
 			.odie__transfer-chat--wait-time {
 				font-size: 0.75rem;
-				color: var( --studio-gray-50 );
+				color: var( --color-text-subtle );
 				align-content: center;
 			}
 		}

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -13,7 +13,7 @@ const SubdomainSuggestion = styled.div`
 	.is-domain-name {
 		position: absolute;
 		top: -15px;
-		color: var( --studio-gray-50 );
+		color: var( --color-text-subtle );
 		text-decoration: line-through;
 		max-width: 80%;
 		text-overflow: ellipsis;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-1764/replace-studio-gray-50-with-60

## Proposed Changes

* Replace --color-text-subtle gray-50 with gray-60
* Replace hardcoded color: gray-50's with text-subtle (and the new gray-60 value)

## Why are these changes being made?

* Gray-50 isn't giving quite enough contrast on various screens

## Testing Instructions

* Smoke test

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
