### PR TITLE
Help Center: Show odie chat on domain transfer screen

### DIFF
--- a/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
+++ b/client/components/domains/use-my-domain/transfer-or-connect/index.jsx
@@ -52,7 +52,7 @@ function DomainTransferOrConnect( {
 	);
 	const [ isFetching, setIsFetching ] = useState( false );
 
-	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
 
 	const handleConnect = () => {
 		recordMappingButtonClickInUseYourDomain( domain );
@@ -141,7 +141,10 @@ function DomainTransferOrConnect( {
 							__( "Not sure what's best for you? <a>We're happy to help!</a>" ),
 							{
 								a: createElement( 'button', {
-									onClick: () => setShowHelpCenter( true ),
+									onClick: () => {
+										setNavigateToRoute( '/odie' );
+										setShowHelpCenter( true );
+									},
 								} ),
 							}
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/102003

## Proposed Changes

* Open Odie instead of the Home Center homepage in the Use Your Domain screen (We're happy)

![image](https://github.com/user-attachments/assets/65ded6ef-eed4-46e2-b382-8ac7da3d783e)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Reach `/domains/add/use-my-domain/[SITE-SLUG]`
* Write a domain in the input field and click on Continue
* Click on  `We're happy to help!` and Odie should show
