### PR TITLE
Use ExternalLink for site link on /home

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -123,7 +123,6 @@ const SitePreview = ( {
 				<div className="home-site-preview__action-bar">
 					<div className="home-site-preview__site-info">
 						<h2 className="home-site-preview__info-title">{ selectedSiteName }</h2>
-
 						<ExternalLink
 							href={ selectedSiteURL }
 							className="home-site-preview__info-domain"

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, ExternalLink } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -123,13 +123,14 @@ const SitePreview = ( {
 				<div className="home-site-preview__action-bar">
 					<div className="home-site-preview__site-info">
 						<h2 className="home-site-preview__info-title">{ selectedSiteName }</h2>
-						<a
+
+						<ExternalLink
 							href={ selectedSiteURL }
-							title={ selectedSiteURL }
 							className="home-site-preview__info-domain"
+							localizeUrl={ false }
 						>
 							<Truncated>{ siteDomain }</Truncated>
-						</a>
+						</ExternalLink>
 					</div>
 					<SitePreviewEllipsisMenu />
 				</div>

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -87,13 +87,11 @@
 			}
 
 			.home-site-preview__info-domain {
-				text-overflow: ellipsis;
-				overflow: hidden;
-				font-size: rem(14px);
-				color: var(--studio-gray-60);
+				font-size: $font-body-small;
+				color: var(--color-text-subtle);
 
-				&:hover {
-					text-decoration: underline;
+				span {
+					display: block;
 				}
 			}
 		}


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTCOM-470/home-page-inconsistencies

## Proposed Changes

* Swaps out the external link element on /home

## Why are these changes being made?

* Replaces <a> usage with external link element and removes unneeded css

## Testing Instructions

* Check long site names still truncate properly.

![Screenshot 2025-04-01 at 20-00-30 My Home ‹ test — WordPress com](https://github.com/user-attachments/assets/036b4868-50f4-4c2d-b01a-e11210146747)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
