### PR TITLE
Logged-out nav: Add AI Website Builder item to the top and footer nav menu

### DIFF
--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -94,6 +94,14 @@ export const PureUniversalNavbarFooter = ( {
 								</li>
 								<li>
 									<a
+										href={ localizeUrl( 'https://wordpress.com/ai-website-builder/?ref=footer' ) }
+										target="_self"
+									>
+										{ __( 'AI Website Builder', __i18n_text_domain__ ) }
+									</a>
+								</li>
+								<li>
+									<a
 										href={ localizeUrl( 'https://wordpress.com/website-builder/' ) }
 										target="_self"
 									>

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/style.scss
@@ -142,7 +142,7 @@ $breakpoints: 320px, 360px, 480px, 660px, 782px, 960px, 1140px, 1366px, 1440px, 
 	a,
 	button {
 		text-align: left;
-		text-decoration: underline;
+		text-decoration: none;
 		display: block;
 		padding: 0;
 		color: #c3c4c7;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -97,6 +97,15 @@ const UniversalNavbarHeader = ( {
 														/>
 														<ClickableItem
 															titleValue=""
+															content={ __( 'AI Website Builder', __i18n_text_domain__ ) }
+															urlValue={ localizeUrl(
+																'//wordpress.com/ai-website-builder/?ref=header'
+															) }
+															type="dropdown"
+															target="_self"
+														/>
+														<ClickableItem
+															titleValue=""
 															content={ __( 'Website Builder', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/website-builder/' ) }
 															type="dropdown"
@@ -446,6 +455,12 @@ const UniversalNavbarHeader = ( {
 												titleValue=""
 												content={ __( 'Domain Names', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
+												type="menu"
+											/>
+											<ClickableItem
+												titleValue=""
+												content={ __( 'AI Website Builder', __i18n_text_domain__ ) }
+												urlValue={ localizeUrl( '//wordpress.com/ai-website-builder/?ref=header' ) }
 												type="menu"
 											/>
 											<ClickableItem

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -99,7 +99,7 @@ const UniversalNavbarHeader = ( {
 															titleValue=""
 															content={ __( 'AI Website Builder', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl(
-																'//wordpress.com/ai-website-builder/?ref=header'
+																'//wordpress.com/ai-website-builder/?ref=topnav'
 															) }
 															type="dropdown"
 															target="_self"
@@ -460,7 +460,7 @@ const UniversalNavbarHeader = ( {
 											<ClickableItem
 												titleValue=""
 												content={ __( 'AI Website Builder', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/ai-website-builder/?ref=header' ) }
+												urlValue={ localizeUrl( '//wordpress.com/ai-website-builder/?ref=topnav' ) }
 												type="menu"
 											/>
 											<ClickableItem

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -231,6 +231,11 @@ button.x-nav-link.x-link {
 	cursor: pointer;
 }
 
+.x-nav-item .x-link,
+.x-menu-list .x-link {
+	text-decoration: none;
+}
+
 .x-nav-link {
 	$offset-bottom: round(( $x-nav-item-height - $x-nav-item-line-height ) * 0.5);
 	$offset-top: $x-nav-padding-top + ( $x-nav-item-height - $x-nav-item-line-height - $offset-bottom );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pcNC1U-1yl-p2

## Proposed Changes

* adds `AI Website Builder` under Products in the footer, linking to https://wordpress.com/ai-website-builder/?ref=footer
* adds `AI Website Builder` under Products in the top nav, linking to https://wordpress.com/ai-website-builder/?ref=topnav

![a35912f5-244a-4b45-aa9b-809e62c18689](https://github.com/user-attachments/assets/f219373d-d3bb-46d4-a797-dcf6a9d6d1d4)
![fb5450c2-344f-43c6-b316-f3a38971aabc](https://github.com/user-attachments/assets/2ae4bc87-03b8-49d9-84f7-25d6872d947a)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to drive traffic to the new [/ai-website-builder](https://wordpress.com/ai-website-builder/) LP.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log out
* Go to a logged-out Calypso page:
  *. https://wordpress.com/plugins
  * https://wordpress.com/themes
  * https://wordpress.com/patterns
 * The `AI Website Builder` item should be visible in the top nav and footer

<img width="363" alt="Screenshot 2025-04-01 at 12 08 19" src="https://github.com/user-attachments/assets/e6e1ebef-61f5-4630-b7d5-cfaa97c15603" />
<img width="456" alt="Screenshot 2025-04-01 at 11 57 09" src="https://github.com/user-attachments/assets/ce4cd83a-cddf-4b3d-9adf-3b0c724fe7f4" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?