### PR TITLE
Color Scheme: Use the global color scheme on the domain-plan-package flow

### DIFF
--- a/client/layout/color-scheme/index.jsx
+++ b/client/layout/color-scheme/index.jsx
@@ -2,13 +2,15 @@ import config from '@automattic/calypso-config';
 import { getAdminColor } from 'calypso/state/admin-color/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function getColorScheme( { state, isGlobalSidebarVisible, sectionName } ) {
-	if ( isGlobalSidebarVisible ) {
-		return 'global';
-	}
+export function getColorScheme( { state, isGlobalSidebarVisible, sidebarIsHidden, sectionName } ) {
 	if ( sectionName === 'checkout' ) {
 		return null;
 	}
+
+	if ( isGlobalSidebarVisible || sidebarIsHidden ) {
+		return 'global';
+	}
+
 	const siteId = getSelectedSiteId( state );
 	const siteColorScheme = getAdminColor( state, siteId );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -451,6 +451,7 @@ export default withCurrentRoute(
 			: getColorScheme( {
 					state,
 					isGlobalSidebarVisible,
+					sidebarIsHidden,
 					sectionName,
 			  } );
 

--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/style.scss
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/style.scss
@@ -26,7 +26,7 @@
 			top: 2px !important;
 		}
 
-		button {
+		button.is-borderless {
 			margin: 0;
 			padding: 0;
 			color: #101517;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101291

## Proposed Changes

* Use the global color scheme on the domain-plan-package flow
* Fix the color of the back button

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/95ac34b5-dbeb-4ce9-94c2-02943cd0775c) | ![image](https://github.com/user-attachments/assets/751099d2-af92-4e3d-af3b-4d4fc67287c7) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to My Home on your site with the free domain upsell
  ![image](https://github.com/user-attachments/assets/6e0ee01e-b97a-43c1-b8d2-85bf772b9a26)
* Click the “Upgrade” button
* Ensure the color scheme on the domain-plan-package flow is `global`
* Ensure the color of the back button is correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
