### PR TITLE
Stylelint: do not report needless disables for subfolder

### DIFF
--- a/packages/dataviews/.stylelintrc
+++ b/packages/dataviews/.stylelintrc
@@ -1,4 +1,4 @@
 {
-	"rules": {},
-	"ignoreFiles": ["**/*"],
+	"extends": [ "../../.stylelintrc" ],
+	"reportNeedlessDisables": false,
 }


### PR DESCRIPTION
## Proposed Changes

Enable stylelint report for `packages/dataviews`, but do not report needless disables in it.

## Why are these changes being made?

We want to run stylelint reports in the `packages/dataviews` folder, but we can't right now because gutenberg and wp-calypso codebases use different stylelint versions. The current issue is that the gutenberg version needs to disable an error when using the `container` property, but the wp-calypso doesn't. As a result, the `reportNeedlessDisables` config in wp-calypso will trigger an error due to an unnecessary disable.

Props to @jsnajdr for research.

## Testing Instructions

TeamCity tests should pass.