### PR TITLE
PTO Square: Do not show Best for devs badge in pricing for PTO

### DIFF
--- a/packages/calypso-products/src/is-partner-bundle-onboarding.ts
+++ b/packages/calypso-products/src/is-partner-bundle-onboarding.ts
@@ -1,0 +1,7 @@
+export function isPartnerBundleOnboarding(): boolean {
+	if ( new URLSearchParams( location.search ).has( 'partnerBundle' ) ) {
+		return true;
+	}
+
+	return false;
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -150,3 +150,4 @@ export * from './translations';
 export { findProductKeys } from './find-product-keys';
 export { isRenewable } from './is-renewable';
 export { isSenseiProduct } from './is-sensei-product';
+export { isPartnerBundleOnboarding } from './is-partner-bundle-onboarding';

--- a/packages/plans-grid-next/src/components/plan-logo.tsx
+++ b/packages/plans-grid-next/src/components/plan-logo.tsx
@@ -8,6 +8,7 @@ import {
 	isPremiumPlan,
 	isFreePlan,
 	PlanSlug,
+	isPartnerBundleOnboarding,
 } from '@automattic/calypso-products';
 import { CloudLogo, VIPLogo, WooLogo } from '@automattic/components';
 import clsx from 'clsx';
@@ -30,6 +31,7 @@ const PlanLogo: React.FunctionComponent< {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const translate = useTranslate();
 	const shouldShowWooLogo = isEcommercePlan( planSlug ) && ! isWooExpressPlan( planSlug );
+	const shouldShowPopularBadge = ! isPartnerBundleOnboarding();
 	const { gridPlansIndex } = usePlansGridContext();
 	const { current } = gridPlansIndex[ planSlug ];
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
@@ -65,11 +67,13 @@ const PlanLogo: React.FunctionComponent< {
 			className={ tableItemClasses }
 			isTableCell={ isTableCell }
 		>
-			<PopularBadge
-				isInSignup={ isInSignup }
-				planSlug={ planSlug }
-				additionalClassName={ popularBadgeClasses }
-			/>
+			{ shouldShowPopularBadge && (
+				<PopularBadge
+					isInSignup={ isInSignup }
+					planSlug={ planSlug }
+					additionalClassName={ popularBadgeClasses }
+				/>
+			) }
 			<header className={ headerClasses }>
 				{ isBusinessPlan( planSlug ) && (
 					<Plans2023Tooltip


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://linear.app/a8c/issue/DOTOBRD-57/pto-square-the-best-for-devs-badge-in-the-business-plan-is-not 

## Proposed Changes

* Add a utility that returns if the onboarding flow contains the `partnerBundle` query param
* Use that utility to hide the `Best for devs` badge from the pricing grid 

|Hosting flow | PTO flow|
|-------|------|
| ![CleanShot 2025-04-01 at 14 02 18@2x](https://github.com/user-attachments/assets/a4c8ce38-c473-40fe-a31b-016b5d930480)| ![CleanShot 2025-04-01 at 14 02 08@2x](https://github.com/user-attachments/assets/c83d5500-9b5b-49c8-bafa-c291847707a3)|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* In PTO flows, the `Best for devs` badge does not apply. It could be confusing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this changes
* Navigate to the PTO flow, i.e. `/setup/new-hosted-site/plans?partnerBundle=square`
* Check that the `Best for devs` badge is not displayed in the Pricing grid
* Navigate to another flow, e.g. `/setup/new-hosted-site`
* Check that the `Best for devs` badge is displayed in the Pricing grid

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
