### PR TITLE
Help Center: Add message when creating conversation

### DIFF
--- a/packages/odie-client/src/data/use-get-zendesk-conversation.ts
+++ b/packages/odie-client/src/data/use-get-zendesk-conversation.ts
@@ -7,12 +7,14 @@ import type { ZendeskMessage } from '../types';
 const parseResponse = ( conversation: Conversation ) => {
 	let clientId;
 
-	const messages = conversation?.messages.map( ( message: ZendeskMessage ) => {
-		if ( message.source?.id ) {
-			clientId = message.source?.id;
-		}
-		return zendeskMessageConverter( message );
-	} );
+	const messages = conversation?.messages
+		.filter( ( message: ZendeskMessage ) => ! message?.metadata?.isHidden )
+		.map( ( message: ZendeskMessage ) => {
+			if ( message.source?.id ) {
+				clientId = message.source?.id;
+			}
+			return zendeskMessageConverter( message );
+		} );
 
 	return { ...conversation, clientId, messages };
 };

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -79,6 +79,16 @@ export const useCreateZendeskConversation = (): ( ( {
 				supportInteractionId: currentInteractionID,
 				...( chatId ? { odieChatId: chatId } : {} ),
 			},
+			messages: [
+				{
+					text: userFieldMessage || 'User is contacting support',
+					type: 'text',
+					// @ts-expect-error valid argument but not present in the type
+					metadata: {
+						isHidden: true,
+					},
+				},
+			],
 		} );
 		setHelpCenterZendeskConversationStarted();
 

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -204,6 +204,7 @@ type MessageAction = {
 };
 
 export type ZendeskMessage = {
+	metadata?: Record< string, unknown >;
 	avatarUrl?: string;
 	displayName: string;
 	id: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
p1738706977834409-slack-C07D72S1135

We received reports that zendesk can auto-assign multiple HEs to one chat, one when a conversation is created and when the first message is sent by the user.
This PRs tries to mitigate this issue, by sending a message when conversation is created.
The message value would be the initial message or other default.
And this message would be hidden from the user, but not the HE.

Related to #

## Proposed Changes

* Post message when creating conversation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To mitigate zendesk issues when conversation is created and when the first message is sent

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Create a conversation
* Check the first message in the ticket created.
* Ensure that this message is not visible to the user.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?