### PR TITLE
Import flow: bugfix when clicking Try Again in Error Page

### DIFF
--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -65,7 +65,6 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 
 	function onTryAgainClick() {
 		job?.importerId && resetImport( siteId, job.importerId );
-		stepNavigator?.goToImportCapturePage?.();
 	}
 
 	function checkProgress() {

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -65,7 +65,6 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 
 	function onTryAgainClick() {
 		job?.importerId && resetImport( siteId, job.importerId );
-		stepNavigator?.goToImportCapturePage?.();
 	}
 
 	function checkProgress() {

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -65,7 +65,6 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 
 	function onTryAgainClick() {
 		job?.importerId && resetImport( siteId, job.importerId );
-		stepNavigator?.goToImportCapturePage?.();
 	}
 
 	function checkProgress() {

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -123,7 +123,6 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 
 	const onTryAgainClick = useCallback( () => {
 		dispatch( resetImport( siteItem?.ID, job?.importerId ) );
-		stepNavigator?.goToImportCapturePage?.();
 	}, [ siteItem, job ] );
 
 	const onBackToGoalsClick = useCallback( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTOBRD-59 (https://linear.app/a8c/issue/DOTOBRD-59/onboarding-style-consistency-take-your-site-to-the-next-level)

## Proposed Changes

There was a redirect happening when clicking try again after an unsuccessful import from:
* WordPress
* Blogger
* Medium
* Squarespace

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Clicking the Try Again button after an unsuccessful import took you to an incorrect upsell.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /start
* Pick a free site
* Select the import link in the Goals step
* Click pick your current platform from a list
* Foreach importer in WordPress, Blogger, Medium and Squarespace do the following:
  * Upload a wrong import file (a random zip file will do)
  * Verify you get to the error step
  * Verify that clicking `Try Again` actually takes you to the correct importer upload step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
