### PR TITLE
Dont redirect to wordpress help when logged in during jetpack onboarding

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -167,6 +167,15 @@ export async function magicLogin( context, next ) {
 		query: { gravatar_flow, client_id, redirect_to, auto_trigger },
 	} = context;
 
+	// if (
+	// 	path.includes( 'jetpack-onboarding' ) &&
+	// 	config.isEnabled( 'jetpack/magic-link-signup' ) &&
+	// 	isUserLoggedIn( context.store.getState() )
+	// ) {
+	// 	// Log out the user and reload the page
+	// 	return context.store.dispatch( redirectToLogout( window.location.href ) );
+	// }
+
 	if ( isUserLoggedIn( context.store.getState() ) && auto_trigger === undefined ) {
 		return login( context, next );
 	}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -167,15 +167,6 @@ export async function magicLogin( context, next ) {
 		query: { gravatar_flow, client_id, redirect_to, auto_trigger },
 	} = context;
 
-	// if (
-	// 	path.includes( 'jetpack-onboarding' ) &&
-	// 	config.isEnabled( 'jetpack/magic-link-signup' ) &&
-	// 	isUserLoggedIn( context.store.getState() )
-	// ) {
-	// 	// Log out the user and reload the page
-	// 	return context.store.dispatch( redirectToLogout( window.location.href ) );
-	// }
-
 	if ( isUserLoggedIn( context.store.getState() ) && auto_trigger === undefined ) {
 		return login( context, next );
 	}

--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -11,9 +11,13 @@ import { withEnhancers } from 'calypso/state/utils';
 
 interface Props {
 	emailAddress: string;
+	shouldRedirect?: boolean;
 }
 
-const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( { emailAddress } ) => {
+const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
+	emailAddress,
+	shouldRedirect = true,
+} ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -24,11 +28,13 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( { emailAddress
 
 	return (
 		<div className="magic-login__successfully-jetpack">
-			<RedirectWhenLoggedIn
-				redirectTo="/help"
-				replaceCurrentLocation
-				waitForEmailAddress={ emailAddress }
-			/>
+			{ shouldRedirect && (
+				<RedirectWhenLoggedIn
+					redirectTo="/help"
+					replaceCurrentLocation
+					waitForEmailAddress={ emailAddress }
+				/>
+			) }
 
 			<h1 className="magic-login__form-header">{ translate( 'Check your email!' ) }</h1>
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1276,9 +1276,9 @@ class MagicLogin extends Component {
 			showCheckYourEmail: showEmailLinkVerification,
 			isWooJPC,
 			isSendingEmail,
+			isFromJetpackOnboarding,
 		} = this.props;
 		const { showSecondaryEmailOptions, showEmailCodeVerification, usernameOrEmail } = this.state;
-
 		if ( isWooJPC ) {
 			return (
 				<Main className="magic-login magic-login__request-link is-white-login">
@@ -1347,7 +1347,9 @@ class MagicLogin extends Component {
 		const isJetpackMagicLinkSignUpEnabled =
 			config.isEnabled( 'jetpack/magic-link-signup' ) && this.props.isJetpackLogin;
 		const shouldShowLoadingEllipsis =
-			isJetpackMagicLinkSignUpEnabled && ( isSendingEmail || this.isInitialMount );
+			isFromJetpackOnboarding &&
+			isJetpackMagicLinkSignUpEnabled &&
+			( isSendingEmail || this.isInitialMount );
 
 		// If this is part of the Jetpack login flow and the `jetpack/magic-link-signup` feature
 		// flag is enabled, some steps will display a different UI
@@ -1356,6 +1358,7 @@ class MagicLogin extends Component {
 			...( isJetpackMagicLinkSignUpEnabled ? { isJetpackMagicLinkSignUpEnabled: true } : {} ),
 			createAccountForNewUser: true,
 			shouldShowLoadingEllipsis,
+			isFromJetpackOnboarding,
 		};
 
 		return (
@@ -1403,6 +1406,9 @@ const mapState = ( state ) => ( {
 	isFromAutomatticForAgenciesPlugin:
 		'automattic-for-agencies-client' ===
 		new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ),
+	isFromJetpackOnboarding:
+		new URLSearchParams( getRedirectToOriginal( state )?.split( '?' )[ 1 ] ).get( 'from' ) ===
+		'jetpack-onboarding',
 	isWooJPC: isWooJPCFlow( state ),
 } );
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -176,6 +176,7 @@ class RequestLoginEmailForm extends Component {
 			isSubmitButtonDisabled,
 			isSubmitButtonBusy,
 			shouldShowLoadingEllipsis,
+			isFromJetpackOnboarding,
 		} = this.props;
 
 		if ( shouldShowLoadingEllipsis ) {
@@ -189,7 +190,10 @@ class RequestLoginEmailForm extends Component {
 			const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;
 
 			return isJetpackMagicLinkSignUpEnabled ? (
-				<EmailedLoginLinkSuccessfullyJetpackConnect emailAddress={ emailAddress } />
+				<EmailedLoginLinkSuccessfullyJetpackConnect
+					emailAddress={ emailAddress }
+					shouldRedirect={ ! isFromJetpackOnboarding }
+				/>
 			) : (
 				<EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />
 			);


### PR DESCRIPTION
RESOLVES MARTECH-63

## Proposed Changes

* Prevent redirect to `/help` during jetpack onboarding, even if the user is already logged in.

## Why are these changes being made?

* The `/help` page isn't particularly helpful in this case, and the email is sent regardless of being logged in or not anyway. This way they can see the message to go check their email and the magic link will handle letting the user know they are already logged in

## Testing Instructions

1. Create a Jurassic Ninja site with Jetpack Beta installed, and check out the bleeding edge branch
2. In an incognito browser, log into your non-a8c wordpress account
3. Go to `/wp-admin/admin.php?page=my-jetpack&step=onboarding` on the JN site (or just click on My Jetpack)
4. Fill out your email with the one you are logged in as

NOTE: For this next step you may have to throttle your network so you can grab the correct URL and replace the domain

5. Select `Start with email` and catch the URL that it redirects to. It should be something like `https://wordpress.com/log-in/jetpack/link?{a bunch of parameters}`
6. Replace `https://wordpress.com/` with either the domain of the Calypso Blue live link or your local host if you are testing locally
7. Make sure you are not redirected
![image](https://github.com/user-attachments/assets/0319661f-6390-4436-8be5-9573d92e7f10)

Bonus: If you wanted to see what the issue was before, just don't replace the domain and see that you are redirected to the `/help` page

![image](https://github.com/user-attachments/assets/0229e516-0c4e-4420-823c-d637427bfc55)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
