### PR TITLE
StepContainerV2 Loading: Center progress bar when rendering the heading

### DIFF
--- a/packages/onboarding/src/step-container-v2/components/Heading/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/Heading/style.scss
@@ -16,10 +16,6 @@
 		line-height: 1.25;
 		text-wrap: balance;
 
-		// This ensures that the heading is always at least as tall as the line height.
-		// Useful in case of empty loading titles so we don't see the progress bar jump around.
-		min-height: 1lh;
-
 		&:not( .small ) {
 			@include break-large {
 				font-size: 2.75rem;

--- a/packages/onboarding/src/step-container-v2/wireframes/Loading/Loading.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/Loading/Loading.tsx
@@ -11,7 +11,13 @@ export const Loading = ( { title, progress }: { title?: ReactNode; progress?: nu
 		<StepContainerV2>
 			<TopBar />
 			<div className="step-container-v2--loading">
-				<Heading text={ title } size="small" align="center" />
+				{ title && (
+					<div className="step-container-v2--loading__heading-wrapper">
+						<div className="step-container-v2--loading__heading">
+							<Heading text={ title } size="small" align="center" />
+						</div>
+					</div>
+				) }
 				<ProgressBar className="step-container-v2--loading__progress-bar" value={ progress } />
 			</div>
 		</StepContainerV2>

--- a/packages/onboarding/src/step-container-v2/wireframes/Loading/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/Loading/style.scss
@@ -3,9 +3,18 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 3rem;
 	position: absolute;
 	inset: 0;
+
+	&__heading-wrapper {
+		position: absolute;
+		height: 0;
+	}
+
+	&__heading {
+		transform: translateY( -100% );
+		padding-bottom: 3rem;
+	}
 
 	&__progress-bar {
 		--wp-components-color-foreground: var( --color-accent, #3858e9 );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102189#discussion_r2022008904.

## Proposed Changes

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/10d30ad3-8bfc-49a9-a6d8-d0af2ebb13e0) | ![image](https://github.com/user-attachments/assets/6ef16fd6-33b3-495a-9a15-fedf50332843) |

## Testing Instructions

Check that the progress bar remains centered regardless of the presence or absence of the heading.
