### PR TITLE
Created the new Pre-Release E2E Tests ($targetDevice) config

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1058,21 +1058,13 @@ object PreReleaseE2ETests : BuildType({
 
 fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildType {
 	return E2EBuildType(
-
-		id("calypso_WebApp_Calypso_E2E_Pre_Release_$targetDevice")
-		uuid = buildUuid
-
-		name = "Pre-Release E2E Tests ($targetDevice)"
-		description = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production. Will run on $targetDevice size."
-
-		steps {
-			bashNodeScript {
-				name = "Prepare environment"
-				scriptContent = """
-					echo "@todo: will run scripts"
-				"""
-			}
-		}
+		buildId = "calypso_WebApp_Calypso_E2E_Pre_Release_$targetDevice",
+		buildUuid = buildUuid,
+		buildName = "Pre-Release E2E Tests ($targetDevice)",
+		buildDescription = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production. Will run on $targetDevice size.",
+		testGroup = "calypso-pr",
+		buildFeatures = {
+		},
 	)
 }
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -23,6 +23,8 @@ object WebApp : Project({
 	buildType(playwrightPrBuildType("desktop", "23cc069f-59e5-4a63-a131-539fb55264e7"))
 	buildType(playwrightPrBuildType("mobile", "90fbd6b7-fddb-4668-9ed0-b32598143616"))
 	buildType(PreReleaseE2ETests)
+	buildType(e2ePreReleaseBuildType("desktop", "532ee9d0-4671-4c53-a7aa-bb3c5de95c0a"))
+	buildType(e2ePreReleaseBuildType("mobile", "2d7f6910-92cf-44b4-a719-e4b2029ea36c"))
 	buildType(AuthenticationE2ETests)
 	buildType(QuarantinedE2ETests)
 })
@@ -1053,6 +1055,26 @@ object PreReleaseE2ETests : BuildType({
 		}
 	}
 })
+
+fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildType {
+	return E2EBuildType(
+
+		id("calypso_WebApp_Calypso_E2E_Pre_Release_$targetDevice")
+		uuid = buildUuid
+
+		name = "Pre-Release E2E Tests ($targetDevice)"
+		description = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production. Will run on $targetDevice size."
+
+		steps {
+			bashNodeScript {
+				name = "Prepare environment"
+				scriptContent = """
+					echo "@todo: will run scripts"
+				"""
+			}
+		}
+	)
+}
 
 object AuthenticationE2ETests : E2EBuildType(
 	buildId = "calypso_WebApp_Calypso_E2E_Authentication",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101799
Slack thread: p1743526169375589-slack-C04H4NY6STW

## Proposed Changes

* Adding the initial TeamCity's configuration for the new E2E pre-release tests

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to run Pre-release E2E mobile tests on Calypso
