### PR TITLE
Design Picker: Fix bottom bar when browsing theme variations

### DIFF
--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -124,7 +124,7 @@ $design-preview-sidebar-width: 311px;
 	/**
 	 * Gutenberg Components
 	 */
-	.components-navigator-provider,
+	.components-navigator,
 	.components-navigator-screen {
 		display: flex;
 		flex-direction: column;
@@ -136,7 +136,7 @@ $design-preview-sidebar-width: 311px;
 		transform: none !important;
 	}
 
-	.components-navigator-provider {
+	.components-navigator {
 		contain: none;
 	}
 


### PR DESCRIPTION
## Proposed Changes

Override the correct class name to change Core's Navigator component behavior.

| Before | After |
| ------ | ------ | 
| ![image](https://github.com/user-attachments/assets/5233e2f0-910f-4c53-87bf-82bd765ca92b) | ![image](https://github.com/user-attachments/assets/de1f16e6-a506-44ae-98e6-02f5280b64ff) |

## Why

Significant changes were made to how `@wordpress/navigator` exposes its HTML elements in https://github.com/WordPress/gutenberg/pull/64613.

That PR was released as part of `@wordpress/components@28.9.0` in [Oct 3, 2024](https://github.com/WordPress/gutenberg/blob/v19.4.0/packages/components/CHANGELOG.md#2890-2024-10-03). It entered Calypso in [Nov 15, 2024](https://github.com/Automattic/wp-calypso/pull/96128), so chances are this was in this broken state since then.

It changed the main navigator element class name to `.components-navigator` instead of `.components-navigator-provider`, and our codebase failed to follow-up. 

Because that class name changed, the overrides that we added were not being applied correct, causing the regression in behavior.

## Testing Instructions

**On mobile**

1. Enter `/setup/site-setup/design-setup?siteSlug=%s`;
2. Pick a theme with color or font variations, such as Dropp;
3. Click Color or Fonts.

Verify the bottom bar is sticky at the bottom instead of overlaying the top bar.