### PR TITLE
Apply container v2 to Application pass auth step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -105,8 +105,8 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 
 	const sourceDomain = new URL( source || '' ).host;
 
-	// translators: %(sourceDomain)s is the source domain that is being migrated.
 	const title = translate( 'Get ready for blazing fast speeds' );
+	// translators: %(sourceDomain)s is the source domain that is being migrated.
 	const subHeaderText = translate(
 		"We're ready to migrate {{strong}}%(sourceDomain)s{{/strong}} to WordPress.com. To ensure a smooth process, we need you to authorize us in your WordPress.com admin.",
 		{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -6,6 +6,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteIdParam } from 'calypso/landing/stepper/hooks/use-site-id-param';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
@@ -14,15 +15,15 @@ import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
 import Authorization from './components/authorization';
 import useStoreApplicationPassword from './hooks/use-store-application-password';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import './style.scss';
 
-const SiteMigrationApplicationPasswordsAuthorization: Step< {
+const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 	submits: {
 		action: 'migration-started' | 'fallback-credentials' | 'authorization' | 'contact-me';
 		authorizationUrl?: string;
 	};
-} > = function ( { navigation } ) {
+} > = function ( { navigation, flow } ) {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlugParam();
 	const siteId = parseInt( useSiteIdParam() ?? '' );
@@ -45,6 +46,8 @@ const SiteMigrationApplicationPasswordsAuthorization: Step< {
 	const isLoading =
 		isAuthorizationSuccessful &&
 		( ! hasStoreApplicationPasswordResponse || isStoreApplicationPasswordPending );
+
+	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	useEffect( () => {
 		if ( ! isAuthorizationSuccessful || ! siteSlug ) {
@@ -103,6 +106,19 @@ const SiteMigrationApplicationPasswordsAuthorization: Step< {
 	const sourceDomain = new URL( source || '' ).host;
 
 	// translators: %(sourceDomain)s is the source domain that is being migrated.
+	const title = translate( 'Get ready for blazing fast speeds' );
+	const subTitle = translate(
+		"We're ready to migrate {{strong}}%(sourceDomain)s{{/strong}} to WordPress.com. To ensure a smooth process, we need you to authorize us in your WordPress.com admin.",
+		{
+			args: {
+				sourceDomain,
+			},
+			components: {
+				strong: <strong />,
+			},
+			textOnly: true,
+		}
+	);
 	const subHeaderText = translate(
 		"We're ready to migrate {{strong}}%(sourceDomain)s{{/strong}} to WordPress.com. To ensure a smooth process, we need you to authorize us in your WordPress.com admin.",
 		{
@@ -124,9 +140,38 @@ const SiteMigrationApplicationPasswordsAuthorization: Step< {
 		/>
 	) : undefined;
 
+	const stepContent = ! isLoading ? (
+		<Authorization
+			onAuthorizationClick={ startAuthorization }
+			onShareCredentialsClick={ navigateToFallbackCredentials }
+		/>
+	) : (
+		<div data-testid="loading-ellipsis">
+			<LoadingEllipsis />
+		</div>
+	);
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ title } />
+				<Step.CenteredColumnLayout
+					columnWidth={ 5 }
+					topBar={
+						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
+					}
+					heading={ <Step.Heading text={ title } subText={ subTitle } /> }
+					className="site-migration-application-password-authorization-v2"
+				>
+					{ stepContent }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
+
 	return (
 		<>
-			<DocumentHead title={ translate( 'Get ready for blazing fast speeds' ) } />
+			<DocumentHead title={ title } />
 			<StepContainer
 				stepName="site-migration-application-password-authorization"
 				flowName="site-migration"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -107,18 +107,6 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 
 	// translators: %(sourceDomain)s is the source domain that is being migrated.
 	const title = translate( 'Get ready for blazing fast speeds' );
-	const subTitle = translate(
-		"We're ready to migrate {{strong}}%(sourceDomain)s{{/strong}} to WordPress.com. To ensure a smooth process, we need you to authorize us in your WordPress.com admin.",
-		{
-			args: {
-				sourceDomain,
-			},
-			components: {
-				strong: <strong />,
-			},
-			textOnly: true,
-		}
-	);
 	const subHeaderText = translate(
 		"We're ready to migrate {{strong}}%(sourceDomain)s{{/strong}} to WordPress.com. To ensure a smooth process, we need you to authorize us in your WordPress.com admin.",
 		{
@@ -160,7 +148,7 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 					topBar={
 						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
 					}
-					heading={ <Step.Heading text={ title } subText={ subTitle } /> }
+					heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
 					className="site-migration-application-password-authorization-v2"
 				>
 					{ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
@@ -36,7 +36,7 @@
 }
 
 .step-container.site-migration-application-password-authorization, 
-.step-container-v2__content.site-migration-application-password-authorization-v2 {
+.step-container-v2__content-row.site-migration-application-password-authorization-v2 {
 	.site-migration-application-password-authorization__authorization {
 		display: flex;
 		flex-direction: column;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/style.scss
@@ -33,7 +33,10 @@
 			}
 		}
 	}
+}
 
+.step-container.site-migration-application-password-authorization, 
+.step-container-v2__content.site-migration-application-password-authorization-v2 {
 	.site-migration-application-password-authorization__authorization {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-70

## Proposed Changes

Apply Container V2 to application password authorization step.
| Before | After |
|--------|--------|
| <img width="1424" alt="image" src="https://github.com/user-attachments/assets/6c57f795-dc73-4eed-9f72-085c303a98e2" /> | <img width="1422" alt="image" src="https://github.com/user-attachments/assets/9e59e802-964a-4dae-b1d8-f48aa6f31884" />
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To migrate to the new and improved stepper containers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [the /setup/onboarding flow](http://calypso.localhost:3000/start) locally or use the feature flag ?flags=onboarding/step-container-v2-migration-flow in testing servers.
* Advance until you're at the Goals screen
* Select Import or migrate an existing site
* Pick Migrate
* Enter a site (JN is fine)
* Select Migrate a Site
* Click Get Started
* Buy a plan
* Verify you see the step using the new Container v2
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/9b97a7d4-cd64-46dc-b2e1-f7faa31d7304" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
