### PR TITLE
Checkout: Update failed purchase message to remove mention of credits

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
@@ -50,7 +50,7 @@ export default function FailedPurchaseDetails( {
 			{ failedPurchasesForDisplay }
 			<p>
 				{ translate(
-					'We added credits to your account, so you can try adding these items again. ' +
+					'We refunded the failed purchases so you can try adding these items again. ' +
 						"If the problem persists, please don't hesitate to {{a}}contact support{{/a}}.",
 					{
 						components: {


### PR DESCRIPTION
## Proposed Changes

This PR modifies the failed purchase page added in https://github.com/Automattic/wp-calypso/pull/85060 so that instead of reading "We added credits to your account, so you can try adding these items again.", it now will read "We refunded the failed purchases so you can try adding these items again.". This is because we've changed how failed purchases are treated in 173321-ghe-Automattic/wpcom so that they will now be refunded. 

Fixes https://github.com/Automattic/payments-shilling/issues/3560

## Testing Instructions

A visual check should be sufficient.