### PR TITLE
Update: Add object-cache-pro to incompatible plugins

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -64,6 +64,7 @@ const incompatiblePlugins = new Set( [
 	'comet-cache',
 	'hyper-cache',
 	'jch-optimize',
+	'object-cache-pro',
 	'performance-lab',
 	'powered-cache',
 	'quick-cache',


### PR DESCRIPTION
Adding object-cache-pro to the list of incompatible plugins as it relies on Redis and causes fatals.

Related to https://github.com/Automattic/jetpack/pull/42654

## Proposed Changes

* This PR adds `object-cache-pro` to the incompatible plugin list.

## Why are these changes being made?

* To prevent the installation of `object-cache-pro`. Although this paid plugin likely cannot be installed via marketplace, we'll want to make sure there is parity between `wpcomsh` and `calypso`.

## Testing Instructions

* Checkout branch
* It's a paid plugin, so a fake plugin called `object-cache-pro/object-cache-pro.php` can be created for testing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
