### PR TITLE
Domains: Fix discrepancy between onboarding and domain-only search - take 2

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -638,6 +638,16 @@ body.is-section-signup {
 	}
 }
 
+// more classes are used here in order
+// to override parent styles - either that
+// or !important statements.
+.onboarding.domains .step-container-v2 {
+	&__content-wrapper.padding {
+		padding: 0 12px;
+		max-width: unset;
+	}
+}
+
 .domains__step-content-domain-step > div {
 	&:nth-child(1) {
 		flex: 1 !important;


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/NOMADO-28/fix-discrepancy-between-onboarding-and-domain-only-search.

## Proposed Changes
A simple fix to unify the styles between onboarding and domain-only search flows - follow-up PR after deployment of #102021.

## Why are these changes being made?
This PR is only needed because of the changes added in #102100, which makes the styles of these two flows differ. 

## Testing Instructions
Same as its parent PR #102021.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
