### PR TITLE
StepContainerV2 DesignPicker: Fix top and bottom bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -694,6 +694,8 @@ $container-padding-large: 48px;
 		}
 
 		.design-preview {
+			padding: 0;
+
 			&.design-preview--is-fullscreen {
 				padding-bottom: var(--step-container-v2-sticky-bottom-bar-height);
 				z-index: 0;
@@ -701,6 +703,11 @@ $container-padding-large: 48px;
 
 			.navigator-screen__footer {
 				display: none;
+			}
+
+			.design-preview__screenshot-wrapper {
+				box-sizing: border-box;
+				margin: 0;
 			}
 
 			@include break-large {
@@ -714,6 +721,11 @@ $container-padding-large: 48px;
 
 				.design-preview__sidebar {
 					padding-top: 24px;
+				}
+
+				.design-preview__screenshot-wrapper {
+					// TODO: Remove this 32px subtraction once we introduce the FixedColumnOnTheLeftLayout wireframe.
+					height: calc(100% - 32px);
 				}
 
 				.design-preview__site-preview {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -693,13 +693,21 @@ $container-padding-large: 48px;
 			}
 		}
 
-		.design-preview.design-preview--is-fullscreen {
-			padding-bottom: var(--step-container-v2-sticky-bottom-bar-height);
-			z-index: 0;
-		}
+		.design-preview {
+			&.design-preview--is-fullscreen {
+				padding-bottom: var(--step-container-v2-sticky-bottom-bar-height);
+				z-index: 0;
+			}
 
-		@include break-large {
-			.design-preview {
+			.navigator-screen__footer {
+				display: none;
+			}
+
+			@include break-large {
+				.navigator-screen__footer {
+					display: flex;
+				}
+
 				flex: 1;
 				height: auto;
 				gap: 48px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -452,7 +452,7 @@ const UnifiedDesignPickerPreview = ( {
 				return unlockPremiumGlobalStyles;
 			}
 
-			return pickDesign;
+			return () => pickDesign();
 		}
 
 		const isPersonalDesign = selectedDesign?.design_tier === PERSONAL_THEME;
@@ -461,7 +461,7 @@ const UnifiedDesignPickerPreview = ( {
 			return isPersonalDesign && shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : upgradePlan;
 		}
 
-		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : pickDesign;
+		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();
 	}
 
 	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -681,7 +681,7 @@ const UnifiedDesignPickerPreview = ( {
 							leftElement={
 								( activeScreen || styleVariations.length > 0 ) && (
 									<Step.BackButton
-										recordTracksEvent={ ! activeScreen }
+										enableTracksEvent={ ! activeScreen }
 										onClick={ () => {
 											if ( activeScreen?.onBack ) {
 												navigatorRef.current?.goBack();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -93,12 +93,12 @@ interface UnifiedDesignPickerPreviewProps {
 	stepName: string;
 	handleSubmit: () => void;
 	numOfSelectedGlobalStyles: number;
-	previewDesignVariation: () => void;
+	previewDesignVariation: ( variation: StyleVariation ) => void;
 	setSelectedColorVariation: ( colorVariation: GlobalStyles | null ) => void;
 	setSelectedFontVariation: ( fontVariation: GlobalStyles | null ) => void;
 	setGlobalStyles: ( globalStyles?: GlobalStylesObject | null ) => void;
 	resetPreview: () => void;
-	selectedStyleVariation: StyleVariation;
+	selectedStyleVariation: StyleVariation | undefined;
 	selectedColorVariation: GlobalStyles | null;
 	selectedFontVariation: GlobalStyles | null;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -524,6 +524,12 @@ const UnifiedDesignPickerPreview = ( {
 		onScreenSubmit: recordDesignPreviewScreenSubmit,
 	} );
 
+	/**
+	 * This is temporary. It's a way of using the inner navigator from the Design Preview component.
+	 *
+	 * Since Design Preview is a monolith and it defines the navigator down the tree,
+	 * a bigger rewrite would be necessary to wrap Design Preview in a navigator instance.
+	 */
 	const navigatorRef = useRef< Navigator >( null );
 
 	const designTitle = selectedDesign.design_type !== 'vertical' ? selectedDesign.title : '';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -1,0 +1,736 @@
+import {
+	TERM_ANNUALLY,
+	TERM_MONTHLY,
+	getPlan,
+	isFreePlan,
+	findFirstSimilarPlanKey,
+} from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { Onboard, useStarterDesignBySlug } from '@automattic/data-stores';
+import {
+	getDesignPreviewUrl,
+	PERSONAL_THEME,
+	getThemeIdFromDesign,
+} from '@automattic/design-picker';
+import DesignPreview, { useScreens, type DesignPreviewProps } from '@automattic/design-preview';
+import { StepContainer, Step } from '@automattic/onboarding';
+import { Navigator } from '@wordpress/components/build-types/navigator/types';
+import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useRef } from 'react';
+import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
+import { useQueryTheme } from 'calypso/components/data/query-theme';
+import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
+import {
+	THEME_TIERS,
+	THEME_TIER_PREMIUM,
+	THEME_TIER_FREE,
+} from 'calypso/components/theme-tier/constants';
+import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToSlug } from 'calypso/lib/url';
+import { useSelector } from 'calypso/state';
+import { getEligibility } from 'calypso/state/automated-transfer/selectors';
+import { hasPurchasedDomain } from 'calypso/state/purchases/selectors/has-purchased-domain';
+import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
+import { getTheme, getThemeDemoUrl } from 'calypso/state/themes/selectors';
+import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
+import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
+import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
+import { useSiteData } from '../../../../hooks/use-site-data';
+import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
+import { goToCheckout } from '../../../../utils/checkout';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
+import { STEP_NAME } from './constants';
+import DesignPickerDesignTitle from './design-picker-design-title';
+import { EligibilityWarningsModal } from './eligibility-warnings-modal';
+import type { SiteSelect, GlobalStyles, OnboardSelect } from '@automattic/data-stores';
+import type { Design, StyleVariation } from '@automattic/design-picker';
+import type { GlobalStylesObject } from '@automattic/global-styles';
+
+const SiteIntent = Onboard.SiteIntent;
+
+function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: string ) {
+	if ( ! selectedDesign?.design_tier ) {
+		return;
+	}
+	// Different designs require different plans to unlock them, additionally the terms required can vary.
+	// A site with a plan of a given length cannot upgrade a plan of a shorter length. For example,
+	// if a site is on a 2 year starter plan and want to buy an explorer theme, they must buy a 2 year explorer plan
+	// not a 1 year explorer plan.
+	const tierMinimumUpsellPlan =
+		THEME_TIERS[ selectedDesign.design_tier as keyof typeof THEME_TIERS ]?.minimumUpsellPlan;
+
+	let requiredTerm;
+	if ( ! currentPlanSlug || isFreePlan( currentPlanSlug ) ) {
+		// Marketplace themes require upgrading to a monthly business plan or higher, everything else requires an annual plan.
+		requiredTerm = selectedDesign?.is_externally_managed ? TERM_MONTHLY : TERM_ANNUALLY;
+	} else {
+		requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
+	}
+
+	return findFirstSimilarPlanKey( tierMinimumUpsellPlan, { term: requiredTerm } );
+}
+
+interface UnifiedDesignPickerPreviewProps {
+	selectedDesign: Design;
+	pickDesign: () => void;
+	getEventPropsByDesign: (
+		design: Design,
+		options: {
+			styleVariation?: StyleVariation;
+			colorVariation?: GlobalStylesObject | null;
+			fontVariation?: GlobalStylesObject | null;
+		}
+	) => Record< string, unknown >;
+	flow: string;
+	isPremiumThemeAvailable: boolean;
+	stepName: string;
+	handleSubmit: () => void;
+	numOfSelectedGlobalStyles: number;
+	previewDesignVariation: () => void;
+	setSelectedColorVariation: ( colorVariation: GlobalStyles | null ) => void;
+	setSelectedFontVariation: ( fontVariation: GlobalStyles | null ) => void;
+	setGlobalStyles: ( globalStyles?: GlobalStylesObject | null ) => void;
+	resetPreview: () => void;
+	selectedStyleVariation: StyleVariation;
+	selectedColorVariation: GlobalStyles | null;
+	selectedFontVariation: GlobalStyles | null;
+}
+
+const UnifiedDesignPickerPreview = ( {
+	selectedDesign,
+	pickDesign,
+	getEventPropsByDesign,
+	flow,
+	isPremiumThemeAvailable,
+	stepName,
+	handleSubmit,
+	numOfSelectedGlobalStyles,
+	previewDesignVariation,
+	setSelectedColorVariation,
+	setSelectedFontVariation,
+	setGlobalStyles,
+	resetPreview,
+	selectedStyleVariation,
+	selectedColorVariation,
+	selectedFontVariation,
+}: UnifiedDesignPickerPreviewProps ) => {
+	const translate = useTranslate();
+	const { intent } = useSelect( ( select ) => {
+		const onboardStore = select( ONBOARD_STORE ) as OnboardSelect;
+		return {
+			intent: onboardStore.getIntent(),
+		};
+	}, [] );
+	const { site, siteSlug, siteId, siteSlugOrId } = useSiteData();
+	const siteTitle = site?.name;
+	const siteDescription = site?.description;
+	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
+
+	// @TODO Cleanup once the test phase is over.
+	const isGlobalStylesOnPersonal = useSiteGlobalStylesOnPersonal( site?.ID );
+
+	const wpcomSiteSlug = useSelector( ( state ) => getSiteSlug( state, site?.ID ) );
+	const didPurchaseDomain = useSelector(
+		( state ) => site?.ID && hasPurchasedDomain( state, site.ID )
+	);
+
+	const [ designPreviewPath, setDesignPreviewPath ] = useState< string | undefined >( '/' );
+
+	const [ showEligibility, setShowEligibility ] = useState( false );
+
+	const isJetpack = useSelect(
+		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isJetpackSite( site.ID ),
+		[ site ]
+	);
+	const isAtomic = useSelect(
+		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
+		[ site ]
+	);
+
+	const shouldUnlockGlobalStyles =
+		shouldLimitGlobalStyles && selectedDesign && numOfSelectedGlobalStyles && siteSlugOrId;
+
+	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '' );
+
+	const styleVariations = selectedDesignDetails?.style_variations ?? [];
+
+	function recordDesignPreviewScreenSelect( screenSlug: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_screen_select', {
+			screen_slug: screenSlug,
+			...getEventPropsByDesign( selectedDesign as Design, {
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+			} ),
+		} );
+	}
+
+	function recordDesignPreviewScreenBack( screenSlug: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_screen_back', {
+			screen_slug: screenSlug,
+			...getEventPropsByDesign( selectedDesign as Design, {
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+			} ),
+		} );
+	}
+
+	function recordDesignPreviewScreenSubmit( screenSlug: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_screen_submit', {
+			screen_slug: screenSlug,
+			...getEventPropsByDesign( selectedDesign as Design, {
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+			} ),
+		} );
+	}
+
+	function handleSelectColorVariation( colorVariation: GlobalStyles | null ) {
+		setSelectedColorVariation( colorVariation );
+		recordTracksEvent(
+			'calypso_signup_design_preview_color_variation_preview_click',
+			getEventPropsByDesign( selectedDesign as Design, { colorVariation } )
+		);
+	}
+
+	function handleSelectFontVariation( fontVariation: GlobalStyles | null ) {
+		setSelectedFontVariation( fontVariation );
+		recordTracksEvent(
+			'calypso_signup_design_preview_font_variation_preview_click',
+			getEventPropsByDesign( selectedDesign as Design, { fontVariation } )
+		);
+	}
+
+	// ********** Logic for unlocking a selected premium design
+
+	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
+	// This is needed while the screenshots property is not being indexed on ElasticSearch
+	// It should be removed when this property is ready on useQueryThemes
+	useQueryTheme( 'wpcom', selectedDesignThemeId );
+	const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedDesignThemeId ) );
+
+	const selectedDesignSlug = selectedDesign?.slug || '';
+
+	// Get theme URL for the design preview.
+	const themeDemoUrl = useSelector(
+		( state ) =>
+			getThemeDemoUrl( state, selectedDesignSlug, siteId + '' ) +
+			'?demo=true&iframe=true&theme_preview=true'
+	);
+	const screenshot = theme?.screenshots?.[ 0 ] ?? theme?.screenshot;
+	const fullLengthScreenshot = screenshot?.replace( /\?.*/, '' );
+
+	const {
+		selectedMarketplaceProduct,
+		selectedMarketplaceProductCartItems,
+		isMarketplaceThemeSubscriptionNeeded,
+		isMarketplaceThemeSubscribed,
+		isExternallyManagedThemeAvailable,
+	} = useMarketplaceThemeProducts();
+
+	const sitePlanSlug = site?.plan?.product_slug;
+	const requiredPlanSlug = getRequiredPlan( selectedDesign, sitePlanSlug || '' );
+
+	const didPurchaseSelectedTheme = useSelector( ( state ) =>
+		site && selectedDesignThemeId
+			? isThemePurchased( state, selectedDesignThemeId, site.ID )
+			: false
+	);
+
+	const canSiteActivateTheme = useIsThemeAllowedOnSite(
+		site?.ID ?? null,
+		selectedDesignThemeId ?? ''
+	);
+
+	const isPluginBundleEligible = useIsPluginBundleEligible();
+	const isBundled = selectedDesign?.software_sets && selectedDesign.software_sets.length > 0;
+
+	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
+
+	const isLockedTheme =
+		// The exp moves the Design Picker step in front of the plan selection so people can unlock theme later.
+		! isGoalsAtFrontExperiment &&
+		( ! canSiteActivateTheme ||
+			( selectedDesign?.design_tier === THEME_TIER_PREMIUM &&
+				! isPremiumThemeAvailable &&
+				! didPurchaseSelectedTheme ) ||
+			( selectedDesign?.is_externally_managed &&
+				( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||
+			( ! isPluginBundleEligible && isBundled ) );
+
+	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
+
+	const eligibility = useSelector( ( state ) => site && getEligibility( state, site.ID ) );
+
+	const hasEligibilityMessages =
+		! isAtomic &&
+		! isJetpack &&
+		( eligibility?.eligibilityHolds?.length || eligibility?.eligibilityWarnings?.length );
+
+	function upgradePlan() {
+		if ( selectedDesign ) {
+			recordTracksEvent(
+				'calypso_signup_design_preview_unlock_theme_click',
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
+			);
+		}
+
+		recordTracksEvent( 'calypso_signup_design_upgrade_modal_show', {
+			theme: selectedDesign?.slug,
+		} );
+		setShowUpgradeModal( true );
+	}
+
+	function closeUpgradeModal() {
+		recordTracksEvent( 'calypso_signup_design_upgrade_modal_close_button_click', {
+			theme: selectedDesign?.slug,
+		} );
+		setShowUpgradeModal( false );
+	}
+
+	function navigateToCheckout() {
+		// When the user is done with checkout, send them back to the current url
+		// If the theme is externally managed, send them to the marketplace thank you page
+		const destination = selectedDesign?.is_externally_managed
+			? addQueryArgs( `/marketplace/thank-you/${ wpcomSiteSlug ?? siteSlug }?onboarding`, {
+					themes: selectedDesign?.slug,
+			  } )
+			: addQueryArgs( window.location.href.replace( window.location.origin, '' ), {
+					continue: 1,
+			  } );
+
+		goToCheckout( {
+			flowName: flow,
+			stepName,
+			siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
+			destination,
+			plan: requiredPlanSlug === sitePlanSlug ? undefined : requiredPlanSlug,
+			extraProducts: selectedMarketplaceProductCartItems,
+		} );
+	}
+	function handleCheckout() {
+		recordTracksEvent( 'calypso_signup_design_upgrade_modal_checkout_button_click', {
+			theme: selectedDesign?.slug,
+			theme_tier: selectedDesign?.design_tier,
+			is_externally_managed: selectedDesign?.is_externally_managed,
+		} );
+
+		if ( siteSlugOrId ) {
+			// We want to display the Eligibility Modal only for externally managed themes
+			// and when no domain was purchased yet.
+			if (
+				selectedDesign?.is_externally_managed &&
+				hasEligibilityMessages &&
+				! didPurchaseDomain
+			) {
+				setShowEligibility( true );
+			} else {
+				navigateToCheckout();
+			}
+		}
+		setShowUpgradeModal( false );
+	}
+
+	const [ showPremiumGlobalStylesModal, setShowPremiumGlobalStylesModal ] = useState( false );
+
+	function unlockPremiumGlobalStyles() {
+		// These conditions should be true at this point, but just in case...
+		if ( shouldUnlockGlobalStyles ) {
+			recordTracksEvent(
+				'calypso_signup_design_global_styles_gating_modal_show',
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
+			);
+			setShowPremiumGlobalStylesModal( true );
+		}
+	}
+
+	function closePremiumGlobalStylesModal() {
+		// These conditions should be true at this point, but just in case...
+		if ( shouldUnlockGlobalStyles ) {
+			recordTracksEvent(
+				'calypso_signup_design_global_styles_gating_modal_close_button_click',
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
+			);
+			setShowPremiumGlobalStylesModal( false );
+		}
+	}
+
+	function handleCheckoutForPremiumGlobalStyles() {
+		// These conditions should be true at this point, but just in case...
+		if ( shouldUnlockGlobalStyles ) {
+			recordTracksEvent(
+				'calypso_signup_design_global_styles_gating_modal_checkout_button_click',
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
+			);
+
+			goToCheckout( {
+				flowName: flow,
+				stepName,
+				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
+				// When the user is done with checkout, send them back to the current url
+				destination: window.location.href.replace( window.location.origin, '' ),
+				plan: isGlobalStylesOnPersonal ? 'personal' : 'premium',
+			} );
+
+			setShowPremiumGlobalStylesModal( false );
+		}
+	}
+
+	function tryPremiumGlobalStyles() {
+		// These conditions should be true at this point, but just in case...
+		if ( shouldUnlockGlobalStyles ) {
+			recordTracksEvent(
+				'calypso_signup_design_global_styles_gating_modal_try_button_click',
+				getEventPropsByDesign( selectedDesign, {
+					styleVariation: selectedStyleVariation,
+					colorVariation: selectedColorVariation,
+					fontVariation: selectedFontVariation,
+				} )
+			);
+
+			pickDesign();
+		}
+	}
+
+	function handleBackClick() {
+		recordTracksEvent(
+			'calypso_signup_design_preview_exit',
+			getEventPropsByDesign( selectedDesign as Design, {
+				styleVariation: selectedStyleVariation,
+				colorVariation: selectedColorVariation,
+				fontVariation: selectedFontVariation,
+			} )
+		);
+
+		resetPreview();
+	}
+
+	function recordStepContainerTracksEvent( eventName: string ) {
+		recordTracksEvent( eventName, {
+			step: 'design-setup',
+			flow,
+			intent,
+		} );
+	}
+
+	function recordDeviceClick( device: string ) {
+		recordTracksEvent( 'calypso_signup_design_preview_device_click', { device } );
+	}
+
+	function getPrimaryActionButtonAction(): () => void {
+		if ( isGlobalStylesOnPersonal ) {
+			if ( isLockedTheme ) {
+				return upgradePlan;
+			}
+
+			if ( shouldUnlockGlobalStyles ) {
+				return unlockPremiumGlobalStyles;
+			}
+
+			return () => pickDesign();
+		}
+
+		const isPersonalDesign = selectedDesign?.design_tier === PERSONAL_THEME;
+		if ( isLockedTheme ) {
+			// For personal themes we favor the GS Upgrade Modal over the Plan Upgrade Modal.
+			return isPersonalDesign && shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : upgradePlan;
+		}
+
+		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();
+	}
+
+	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
+
+	const getPrimaryActionButtonProps = () => {
+		const action = getPrimaryActionButtonAction();
+		const text =
+			action === upgradePlan && ! isGoalsAtFrontExperiment
+				? translate( 'Unlock theme' )
+				: translate( 'Continue' );
+
+		return {
+			action,
+			text,
+		};
+	};
+
+	const { action: primaryActionButtonAction, text: primaryActionButtonText } =
+		getPrimaryActionButtonProps();
+
+	const primaryActionButton = isUsingStepContainerV2 ? (
+		<Step.PrimaryButton onClick={ primaryActionButtonAction }>
+			{ primaryActionButtonText }
+		</Step.PrimaryButton>
+	) : (
+		<Button
+			className="navigation-link"
+			primary
+			borderless={ false }
+			onClick={ primaryActionButtonAction }
+		>
+			{ primaryActionButtonText }
+		</Button>
+	);
+
+	const screens = useScreens( {
+		siteId,
+		stylesheet: selectedDesign?.recipe?.stylesheet ?? '',
+		isVirtual: selectedDesign?.is_virtual,
+		isExternallyManaged: selectedDesign?.is_externally_managed,
+		limitGlobalStyles: shouldLimitGlobalStyles,
+		variations: styleVariations,
+		splitDefaultVariation:
+			( isGlobalStylesOnPersonal &&
+				selectedDesign?.design_tier === THEME_TIER_FREE &&
+				shouldLimitGlobalStyles ) ||
+			( ! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
+				! isBundled &&
+				! isPremiumThemeAvailable &&
+				shouldLimitGlobalStyles ),
+		needsUpgrade: shouldLimitGlobalStyles || isLockedTheme,
+		selectedVariation: selectedStyleVariation,
+		selectedColorVariation: selectedColorVariation,
+		selectedFontVariation: selectedFontVariation,
+		onSelectVariation: previewDesignVariation,
+		onSelectColorVariation: handleSelectColorVariation,
+		onSelectFontVariation: handleSelectFontVariation,
+		onScreenSelect: recordDesignPreviewScreenSelect,
+		onScreenBack: recordDesignPreviewScreenBack,
+		onScreenSubmit: recordDesignPreviewScreenSubmit,
+	} );
+
+	const navigatorRef = useRef< Navigator >( null );
+
+	const designTitle = selectedDesign.design_type !== 'vertical' ? selectedDesign.title : '';
+	const headerDesignTitle = (
+		<DesignPickerDesignTitle
+			designTitle={ designTitle }
+			selectedDesign={ selectedDesign }
+			siteId={ siteId }
+			siteSlug={ siteSlug }
+		/>
+	);
+
+	// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview
+	const shouldCustomizeText = intent === SiteIntent.Write || intent === SiteIntent.Sell;
+	const previewUrl = getDesignPreviewUrl( selectedDesign, {
+		site_title: shouldCustomizeText ? siteTitle : undefined,
+		site_tagline: shouldCustomizeText ? siteDescription : undefined,
+	} );
+
+	const getActionButtons = () => {
+		if ( ! isUsingStepContainerV2 ) {
+			return (
+				<>
+					<div className="action-buttons__title">{ headerDesignTitle }</div>
+					<div>{ primaryActionButton }</div>
+				</>
+			);
+		}
+
+		return primaryActionButton;
+	};
+
+	const actionButtons = getActionButtons();
+
+	const designPreviewProps: DesignPreviewProps = {
+		navigatorRef,
+		previewUrl: themeDemoUrl || previewUrl,
+		siteInfo: {
+			title: shouldCustomizeText ? site?.name ?? '' : '',
+			tagline: shouldCustomizeText ? site?.description ?? '' : '',
+		},
+		splitDefaultVariation:
+			( isGlobalStylesOnPersonal &&
+				selectedDesign?.design_tier === THEME_TIER_FREE &&
+				shouldLimitGlobalStyles ) ||
+			( ! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
+				! isBundled &&
+				! isPremiumThemeAvailable &&
+				! didPurchaseSelectedTheme &&
+				! isPluginBundleEligible &&
+				! isGlobalStylesOnPersonal &&
+				shouldLimitGlobalStyles ),
+		needsUpgrade: shouldLimitGlobalStyles || isLockedTheme,
+		title: headerDesignTitle,
+		selectedDesignTitle: designTitle,
+		shortDescription: selectedDesign.description,
+		description: selectedDesignDetails?.description,
+		variations: styleVariations,
+		selectedVariation: selectedStyleVariation,
+		onSelectVariation: previewDesignVariation,
+		actionButtons,
+		recordDeviceClick,
+		siteId: site?.ID ?? 0,
+		stylesheet: selectedDesign.recipe?.stylesheet ?? '',
+		screenshot: fullLengthScreenshot,
+		isExternallyManaged: selectedDesign.is_externally_managed,
+		selectedColorVariation: selectedColorVariation,
+		selectedFontVariation: selectedFontVariation,
+		onGlobalStylesChange: setGlobalStyles,
+		onNavigatorPathChange: ( path?: string ) => setDesignPreviewPath( path ),
+		screens,
+	};
+
+	const stepContent = (
+		<>
+			{ requiredPlanSlug && ! isGoalsAtFrontExperiment && (
+				<UpgradeModal
+					slug={ selectedDesign.slug }
+					isOpen={ showUpgradeModal }
+					//TODO: Fix NEEED typo
+					isMarketplacePlanSubscriptionNeeeded={ ! isExternallyManagedThemeAvailable }
+					isMarketplaceThemeSubscriptionNeeded={ isMarketplaceThemeSubscriptionNeeded }
+					marketplaceProduct={ selectedMarketplaceProduct }
+					requiredPlan={ requiredPlanSlug }
+					closeModal={ closeUpgradeModal }
+					checkout={ handleCheckout }
+				/>
+			) }
+			<QueryEligibility siteId={ site?.ID } />
+			<EligibilityWarningsModal
+				site={ site ?? undefined }
+				isMarketplace={ selectedDesign?.is_externally_managed }
+				isOpen={ showEligibility }
+				handleClose={ () => {
+					recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
+						flow: 'onboarding',
+						theme: selectedDesign?.slug,
+					} );
+					setShowEligibility( false );
+				} }
+				handleContinue={ () => {
+					navigateToCheckout();
+					setShowEligibility( false );
+				} }
+			/>
+			<PremiumGlobalStylesUpgradeModal
+				checkout={ handleCheckoutForPremiumGlobalStyles }
+				closeModal={ closePremiumGlobalStylesModal }
+				isOpen={ showPremiumGlobalStylesModal }
+				numOfSelectedGlobalStyles={ numOfSelectedGlobalStyles }
+				{ ...( ! isLockedTheme && { tryStyle: tryPremiumGlobalStyles } ) }
+			/>
+			<DesignPreview { ...designPreviewProps } />
+		</>
+	);
+
+	const activeScreen = screens.find( ( screen ) => screen.path === designPreviewPath );
+
+	if ( isUsingStepContainerV2 ) {
+		// TODO: Create a new wireframe for the design preview. It should be named "FixedColumnOnTheLeftLayout"
+		return (
+			<Step.FullWidthLayout
+				className="step-container-v2--design-picker-preview"
+				topBar={ ( { isLargeViewport } ) => {
+					if ( ! isLargeViewport && activeScreen ) {
+						return null;
+					}
+
+					return (
+						<Step.TopBar
+							leftElement={ ! activeScreen && <Step.BackButton onClick={ handleBackClick } /> }
+							rightElement={
+								! isGoalsAtFrontExperiment ? undefined : (
+									<Step.SkipButton onClick={ () => handleSubmit() }>
+										{ translate( 'Skip setup' ) }
+									</Step.SkipButton>
+								)
+							}
+						/>
+					);
+				} }
+				stickyBottomBar={ ( { isLargeViewport } ) => {
+					if ( isLargeViewport ) {
+						return null;
+					}
+
+					return (
+						<Step.StickyBottomBar
+							leftElement={
+								( activeScreen || styleVariations.length > 0 ) && (
+									<Step.BackButton
+										recordTracksEvent={ ! activeScreen }
+										onClick={ () => {
+											if ( activeScreen?.onBack ) {
+												navigatorRef.current?.goBack();
+												return activeScreen.onBack( activeScreen.slug );
+											}
+
+											return handleBackClick();
+										} }
+									/>
+								)
+							}
+							centerElement={
+								activeScreen && (
+									<div className="step-container-v2--design-picker-preview__header-design-title">
+										{ headerDesignTitle }
+									</div>
+								)
+							}
+							rightElement={
+								<Step.PrimaryButton
+									onClick={ () => {
+										if ( activeScreen?.onSubmit ) {
+											navigatorRef.current?.goBack();
+											return activeScreen.onSubmit( activeScreen.slug );
+										}
+
+										return primaryActionButtonAction();
+									} }
+								>
+									{ activeScreen?.actionText ?? primaryActionButtonText }
+								</Step.PrimaryButton>
+							}
+						/>
+					);
+				} }
+			>
+				{ stepContent }
+			</Step.FullWidthLayout>
+		);
+	}
+
+	return (
+		<StepContainer
+			stepName={ STEP_NAME }
+			stepContent={ stepContent }
+			hideSkip={ ! isGoalsAtFrontExperiment }
+			skipLabelText={ translate( 'Skip setup' ) }
+			skipButtonAlign="top"
+			hideBack={ !! activeScreen }
+			className="design-setup__preview design-setup__preview__has-more-info"
+			goBack={ handleBackClick }
+			customizedActionButtons={ ! activeScreen ? actionButtons : undefined }
+			recordTracksEvent={ recordStepContainerTracksEvent }
+		/>
+	);
+};
+
+export default UnifiedDesignPickerPreview;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -452,7 +452,7 @@ const UnifiedDesignPickerPreview = ( {
 				return unlockPremiumGlobalStyles;
 			}
 
-			return () => pickDesign();
+			return pickDesign;
 		}
 
 		const isPersonalDesign = selectedDesign?.design_tier === PERSONAL_THEME;
@@ -461,7 +461,7 @@ const UnifiedDesignPickerPreview = ( {
 			return isPersonalDesign && shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : upgradePlan;
 		}
 
-		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();
+		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : pickDesign;
 	}
 
 	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
@@ -483,7 +483,7 @@ const UnifiedDesignPickerPreview = ( {
 		getPrimaryActionButtonProps();
 
 	const primaryActionButton = isUsingStepContainerV2 ? (
-		<Step.PrimaryButton onClick={ primaryActionButtonAction }>
+		<Step.PrimaryButton onClick={ () => primaryActionButtonAction() }>
 			{ primaryActionButtonText }
 		</Step.PrimaryButton>
 	) : (
@@ -491,7 +491,7 @@ const UnifiedDesignPickerPreview = ( {
 			className="navigation-link"
 			primary
 			borderless={ false }
-			onClick={ primaryActionButtonAction }
+			onClick={ () => primaryActionButtonAction() }
 		>
 			{ primaryActionButtonText }
 		</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -452,7 +452,7 @@ const UnifiedDesignPickerPreview = ( {
 				return unlockPremiumGlobalStyles;
 			}
 
-			return () => pickDesign();
+			return pickDesign;
 		}
 
 		const isPersonalDesign = selectedDesign?.design_tier === PERSONAL_THEME;
@@ -461,7 +461,7 @@ const UnifiedDesignPickerPreview = ( {
 			return isPersonalDesign && shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : upgradePlan;
 		}
 
-		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();
+		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : pickDesign;
 	}
 
 	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
@@ -469,7 +469,7 @@ const UnifiedDesignPickerPreview = ( {
 	const getPrimaryActionButtonProps = () => {
 		const action = getPrimaryActionButtonAction();
 		const text =
-			action === upgradePlan && ! isGoalsAtFrontExperiment
+			action !== pickDesign && ! isGoalsAtFrontExperiment
 				? translate( 'Unlock theme' )
 				: translate( 'Continue' );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -10,7 +10,6 @@ import { StepContainer, ONBOARDING_FLOW, isSiteSetupFlow, Step } from '@automatt
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
-import AsyncLoad from 'calypso/components/async-load';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Loading from 'calypso/components/loading';
@@ -36,6 +35,7 @@ import { STEP_NAME } from './constants';
 import useIsUpdatedBadgeDesign from './hooks/use-is-updated-badge-design';
 import useRecipe from './hooks/use-recipe';
 import useTrackFilters from './hooks/use-track-filters';
+import UnifiedDesignPickerPreview from './unified-design-picker-preview';
 import type { Step as StepType } from '../../types';
 import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
@@ -358,9 +358,7 @@ const UnifiedDesignPickerStep: StepType< {
 
 	if ( selectedDesign && isPreviewingDesign ) {
 		return (
-			<AsyncLoad
-				require="./unified-design-picker-preview"
-				placeholder={ null }
+			<UnifiedDesignPickerPreview
 				selectedDesign={ selectedDesign }
 				pickDesign={ pickDesign }
 				getEventPropsByDesign={ getEventPropsByDesign }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,69 +1,29 @@
-import {
-	TERM_ANNUALLY,
-	TERM_MONTHLY,
-	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
-	getPlan,
-	isFreePlan,
-	findFirstSimilarPlanKey,
-} from '@automattic/calypso-products';
-import { Button } from '@automattic/components';
-import {
-	Onboard,
-	updateLaunchpadSettings,
-	useStarterDesignBySlug,
-	useStarterDesignsQuery,
-} from '@automattic/data-stores';
+import { WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED } from '@automattic/calypso-products';
+import { Onboard, updateLaunchpadSettings, useStarterDesignsQuery } from '@automattic/data-stores';
 import {
 	UnifiedDesignPicker,
 	useCategorization,
 	useDesignPickerFilters,
-	getDesignPreviewUrl,
-	PERSONAL_THEME,
-	getThemeIdFromDesign,
 } from '@automattic/design-picker';
-import { useScreens, type DesignPreviewProps } from '@automattic/design-preview';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, ONBOARDING_FLOW, isSiteSetupFlow, Step } from '@automattic/onboarding';
-import { Navigator } from '@wordpress/components/build-types/navigator/types';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useEffect, useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
-import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
-import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Loading from 'calypso/components/loading';
-import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
-import {
-	THEME_TIERS,
-	THEME_TIER_PREMIUM,
-	THEME_TIER_FREE,
-} from 'calypso/components/theme-tier/constants';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
-import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
-import { urlToSlug } from 'calypso/lib/url';
-import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
-import { getEligibility } from 'calypso/state/automated-transfer/selectors';
-import { hasPurchasedDomain } from 'calypso/state/purchases/selectors/has-purchased-domain';
-import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
-import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
-import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
-import { getTheme, getThemeDemoUrl } from 'calypso/state/themes/selectors';
-import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { useActivateDesign } from '../../../../hooks/use-activate-design';
-import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
-import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
-import { goToCheckout } from '../../../../utils/checkout';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import {
@@ -73,13 +33,11 @@ import {
 } from '../../analytics/record-design';
 import { getCategorizationOptions } from './categories';
 import { STEP_NAME } from './constants';
-import DesignPickerDesignTitle from './design-picker-design-title';
-import { EligibilityWarningsModal } from './eligibility-warnings-modal';
 import useIsUpdatedBadgeDesign from './hooks/use-is-updated-badge-design';
 import useRecipe from './hooks/use-recipe';
 import useTrackFilters from './hooks/use-track-filters';
 import type { Step as StepType } from '../../types';
-import type { OnboardSelect, SiteSelect, GlobalStyles } from '@automattic/data-stores';
+import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import './style.scss';
@@ -132,30 +90,7 @@ const UnifiedDesignPickerStep: StepType< {
 	}, [] );
 
 	const { site, siteSlug, siteId, siteSlugOrId } = useSiteData();
-	const siteTitle = site?.name;
-	const siteDescription = site?.description;
-	const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 	const { data: siteActiveTheme } = useActiveThemeQuery( site?.ID ?? 0, !! site?.ID );
-	// @TODO Cleanup once the test phase is over.
-	const isGlobalStylesOnPersonal = useSiteGlobalStylesOnPersonal( site?.ID );
-
-	const wpcomSiteSlug = useSelector( ( state ) => getSiteSlug( state, site?.ID ) );
-	const didPurchaseDomain = useSelector(
-		( state ) => site?.ID && hasPurchasedDomain( state, site.ID )
-	);
-
-	const [ designPreviewPath, setDesignPreviewPath ] = useState< string | undefined >( '/' );
-
-	const [ showEligibility, setShowEligibility ] = useState( false );
-
-	const isJetpack = useSelect(
-		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isJetpackSite( site.ID ),
-		[ site ]
-	);
-	const isAtomic = useSelect(
-		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
-		[ site ]
-	);
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const isComingFromTheUpgradeScreen = queryParams.get( 'continue' ) === '1';
 	const isComingFromSuccessfulImport = queryParams.get( 'comingFromSuccessfulImport' ) === '1';
@@ -202,6 +137,48 @@ const UnifiedDesignPickerStep: StepType< {
 
 	const designPickerFilters = useDesignPickerFilters();
 
+	const getEventPropsByDesign = useCallback(
+		(
+			design: Design,
+			options: {
+				styleVariation?: StyleVariation;
+				colorVariation?: GlobalStylesObject | null;
+				fontVariation?: GlobalStylesObject | null;
+			} = {}
+		) => {
+			return {
+				...getDesignEventProps( {
+					...options,
+					flow,
+					intent,
+					design,
+				} ),
+				categories: categorization.selections?.join( ',' ),
+				...( design.recipe?.pattern_ids && {
+					pattern_ids: design.recipe.pattern_ids.join( ',' ),
+				} ),
+				...( design.recipe?.header_pattern_ids && {
+					header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
+				} ),
+				...( design.recipe?.footer_pattern_ids && {
+					footer_pattern_ids: design.recipe.footer_pattern_ids.join( ',' ),
+				} ),
+			};
+		},
+		[ flow, intent, categorization.selections ]
+	);
+
+	function recordPreviewDesign( design: Design, styleVariation?: StyleVariation ) {
+		recordPreviewedDesign( { flow, intent, design, styleVariation } );
+	}
+
+	function recordPreviewStyleVariation( design: Design, styleVariation?: StyleVariation ) {
+		recordTracksEvent(
+			'calypso_signup_design_preview_style_variation_preview_click',
+			getEventPropsByDesign( design, { styleVariation } )
+		);
+	}
+
 	// ********** Logic for selecting a design and style variation
 	const {
 		isPreviewingDesign,
@@ -220,55 +197,14 @@ const UnifiedDesignPickerStep: StepType< {
 		resetPreview,
 	} = useRecipe( allDesigns, pickUnlistedDesign, recordPreviewDesign, recordPreviewStyleVariation );
 
-	const shouldUnlockGlobalStyles =
-		shouldLimitGlobalStyles && selectedDesign && numOfSelectedGlobalStyles && siteSlugOrId;
+	useQueryThemes( 'wpcom', {
+		number: 1000,
+	} );
 
 	// Make sure people is at the top when entering/leaving preview mode.
 	useEffect( () => {
 		window.scrollTo( { top: 0 } );
 	}, [ isPreviewingDesign ] );
-
-	const selectedDesignHasStyleVariations = ( selectedDesign?.style_variations || [] ).length > 0;
-	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
-		enabled: isPreviewingDesign,
-	} );
-
-	function getEventPropsByDesign(
-		design: Design,
-		options: {
-			styleVariation?: StyleVariation;
-			colorVariation?: GlobalStylesObject | null;
-			fontVariation?: GlobalStylesObject | null;
-		} = {}
-	) {
-		return {
-			...getDesignEventProps( {
-				...options,
-				flow,
-				intent,
-				design,
-			} ),
-			categories: categorization.selections?.join( ',' ),
-			...( design.recipe?.pattern_ids && { pattern_ids: design.recipe.pattern_ids.join( ',' ) } ),
-			...( design.recipe?.header_pattern_ids && {
-				header_pattern_ids: design.recipe.header_pattern_ids.join( ',' ),
-			} ),
-			...( design.recipe?.footer_pattern_ids && {
-				footer_pattern_ids: design.recipe.footer_pattern_ids.join( ',' ),
-			} ),
-		};
-	}
-
-	function recordPreviewDesign( design: Design, styleVariation?: StyleVariation ) {
-		recordPreviewedDesign( { flow, intent, design, styleVariation } );
-	}
-
-	function recordPreviewStyleVariation( design: Design, styleVariation?: StyleVariation ) {
-		recordTracksEvent(
-			'calypso_signup_design_preview_style_variation_preview_click',
-			getEventPropsByDesign( design, { styleVariation } )
-		);
-	}
 
 	function trackAllDesignsView() {
 		recordTracksEvent( 'calypso_signup_design_scrolled_to_end', {
@@ -276,123 +212,6 @@ const UnifiedDesignPickerStep: StepType< {
 			categories: categorization?.selections?.join( ',' ),
 		} );
 	}
-
-	function recordDesignPreviewScreenSelect( screenSlug: string ) {
-		recordTracksEvent( 'calypso_signup_design_preview_screen_select', {
-			screen_slug: screenSlug,
-			...getEventPropsByDesign( selectedDesign as Design, {
-				styleVariation: selectedStyleVariation,
-				colorVariation: selectedColorVariation,
-				fontVariation: selectedFontVariation,
-			} ),
-		} );
-	}
-
-	function recordDesignPreviewScreenBack( screenSlug: string ) {
-		recordTracksEvent( 'calypso_signup_design_preview_screen_back', {
-			screen_slug: screenSlug,
-			...getEventPropsByDesign( selectedDesign as Design, {
-				styleVariation: selectedStyleVariation,
-				colorVariation: selectedColorVariation,
-				fontVariation: selectedFontVariation,
-			} ),
-		} );
-	}
-
-	function recordDesignPreviewScreenSubmit( screenSlug: string ) {
-		recordTracksEvent( 'calypso_signup_design_preview_screen_submit', {
-			screen_slug: screenSlug,
-			...getEventPropsByDesign( selectedDesign as Design, {
-				styleVariation: selectedStyleVariation,
-				colorVariation: selectedColorVariation,
-				fontVariation: selectedFontVariation,
-			} ),
-		} );
-	}
-
-	function handleSelectColorVariation( colorVariation: GlobalStyles | null ) {
-		setSelectedColorVariation( colorVariation );
-		recordTracksEvent(
-			'calypso_signup_design_preview_color_variation_preview_click',
-			getEventPropsByDesign( selectedDesign as Design, { colorVariation } )
-		);
-	}
-
-	function handleSelectFontVariation( fontVariation: GlobalStyles | null ) {
-		setSelectedFontVariation( fontVariation );
-		recordTracksEvent(
-			'calypso_signup_design_preview_font_variation_preview_click',
-			getEventPropsByDesign( selectedDesign as Design, { fontVariation } )
-		);
-	}
-
-	// ********** Logic for unlocking a selected premium design
-
-	useQueryThemes( 'wpcom', {
-		number: 1000,
-	} );
-
-	const selectedDesignThemeId = selectedDesign ? getThemeIdFromDesign( selectedDesign ) : null;
-	// This is needed while the screenshots property is not being indexed on ElasticSearch
-	// It should be removed when this property is ready on useQueryThemes
-	useQueryTheme( 'wpcom', selectedDesignThemeId );
-	const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedDesignThemeId ) );
-
-	const selectedDesignSlug = selectedDesign?.slug || '';
-
-	// Get theme URL for the design preview.
-	const themeDemoUrl = useSelector(
-		( state ) =>
-			getThemeDemoUrl( state, selectedDesignSlug, siteId + '' ) +
-			'?demo=true&iframe=true&theme_preview=true'
-	);
-	const screenshot = theme?.screenshots?.[ 0 ] ?? theme?.screenshot;
-	const fullLengthScreenshot = screenshot?.replace( /\?.*/, '' );
-
-	const {
-		selectedMarketplaceProduct,
-		selectedMarketplaceProductCartItems,
-		isMarketplaceThemeSubscriptionNeeded,
-		isMarketplaceThemeSubscribed,
-		isExternallyManagedThemeAvailable,
-	} = useMarketplaceThemeProducts();
-
-	const sitePlanSlug = site?.plan?.product_slug;
-	const requiredPlanSlug = getRequiredPlan( selectedDesign, sitePlanSlug || '' );
-
-	const didPurchaseSelectedTheme = useSelector( ( state ) =>
-		site && selectedDesignThemeId
-			? isThemePurchased( state, selectedDesignThemeId, site.ID )
-			: false
-	);
-
-	const canSiteActivateTheme = useIsThemeAllowedOnSite(
-		site?.ID ?? null,
-		selectedDesignThemeId ?? ''
-	);
-
-	const isPluginBundleEligible = useIsPluginBundleEligible();
-	const isBundled = selectedDesign?.software_sets && selectedDesign.software_sets.length > 0;
-
-	const isLockedTheme =
-		// The exp moves the Design Picker step in front of the plan selection so people can unlock theme later.
-		! isGoalsAtFrontExperiment &&
-		( ! canSiteActivateTheme ||
-			( selectedDesign?.design_tier === THEME_TIER_PREMIUM &&
-				! isPremiumThemeAvailable &&
-				! didPurchaseSelectedTheme ) ||
-			( selectedDesign?.is_externally_managed &&
-				( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||
-			( ! isPluginBundleEligible && isBundled ) );
-
-	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
-
-	const eligibility = useSelector( ( state ) => site && getEligibility( state, site.ID ) );
-
-	const hasEligibilityMessages =
-		! isAtomic &&
-		! isJetpack &&
-		( eligibility?.eligibilityHolds?.length || eligibility?.eligibilityWarnings?.length );
 
 	const getBadge = ( themeId: string, isLockedStyleVariation: boolean ) => (
 		<ThemeTierBadge
@@ -404,132 +223,6 @@ const UnifiedDesignPickerStep: StepType< {
 			themeId={ themeId }
 		/>
 	);
-
-	function upgradePlan() {
-		if ( selectedDesign ) {
-			recordTracksEvent(
-				'calypso_signup_design_preview_unlock_theme_click',
-				getEventPropsByDesign( selectedDesign, {
-					styleVariation: selectedStyleVariation,
-					colorVariation: selectedColorVariation,
-					fontVariation: selectedFontVariation,
-				} )
-			);
-		}
-
-		recordTracksEvent( 'calypso_signup_design_upgrade_modal_show', {
-			theme: selectedDesign?.slug,
-		} );
-		setShowUpgradeModal( true );
-	}
-
-	function closeUpgradeModal() {
-		recordTracksEvent( 'calypso_signup_design_upgrade_modal_close_button_click', {
-			theme: selectedDesign?.slug,
-		} );
-		setShowUpgradeModal( false );
-	}
-
-	function navigateToCheckout() {
-		// When the user is done with checkout, send them back to the current url
-		// If the theme is externally managed, send them to the marketplace thank you page
-		const destination = selectedDesign?.is_externally_managed
-			? addQueryArgs( `/marketplace/thank-you/${ wpcomSiteSlug ?? siteSlug }?onboarding`, {
-					themes: selectedDesign?.slug,
-			  } )
-			: addQueryArgs( window.location.href.replace( window.location.origin, '' ), {
-					continue: 1,
-			  } );
-
-		goToCheckout( {
-			flowName: flow,
-			stepName,
-			siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
-			destination,
-			plan: requiredPlanSlug === sitePlanSlug ? undefined : requiredPlanSlug,
-			extraProducts: selectedMarketplaceProductCartItems,
-		} );
-	}
-	function handleCheckout() {
-		recordTracksEvent( 'calypso_signup_design_upgrade_modal_checkout_button_click', {
-			theme: selectedDesign?.slug,
-			theme_tier: selectedDesign?.design_tier,
-			is_externally_managed: selectedDesign?.is_externally_managed,
-		} );
-
-		if ( siteSlugOrId ) {
-			// We want to display the Eligibility Modal only for externally managed themes
-			// and when no domain was purchased yet.
-			if (
-				selectedDesign?.is_externally_managed &&
-				hasEligibilityMessages &&
-				! didPurchaseDomain
-			) {
-				setShowEligibility( true );
-			} else {
-				navigateToCheckout();
-			}
-		}
-		setShowUpgradeModal( false );
-	}
-
-	// ********** Logic for Premium Global Styles
-	const [ showPremiumGlobalStylesModal, setShowPremiumGlobalStylesModal ] = useState( false );
-
-	function unlockPremiumGlobalStyles() {
-		// These conditions should be true at this point, but just in case...
-		if ( shouldUnlockGlobalStyles ) {
-			recordTracksEvent(
-				'calypso_signup_design_global_styles_gating_modal_show',
-				getEventPropsByDesign( selectedDesign, {
-					styleVariation: selectedStyleVariation,
-					colorVariation: selectedColorVariation,
-					fontVariation: selectedFontVariation,
-				} )
-			);
-			setShowPremiumGlobalStylesModal( true );
-		}
-	}
-
-	function closePremiumGlobalStylesModal() {
-		// These conditions should be true at this point, but just in case...
-		if ( shouldUnlockGlobalStyles ) {
-			recordTracksEvent(
-				'calypso_signup_design_global_styles_gating_modal_close_button_click',
-				getEventPropsByDesign( selectedDesign, {
-					styleVariation: selectedStyleVariation,
-					colorVariation: selectedColorVariation,
-					fontVariation: selectedFontVariation,
-				} )
-			);
-			setShowPremiumGlobalStylesModal( false );
-		}
-	}
-
-	function handleCheckoutForPremiumGlobalStyles() {
-		// These conditions should be true at this point, but just in case...
-		if ( shouldUnlockGlobalStyles ) {
-			recordTracksEvent(
-				'calypso_signup_design_global_styles_gating_modal_checkout_button_click',
-				getEventPropsByDesign( selectedDesign, {
-					styleVariation: selectedStyleVariation,
-					colorVariation: selectedColorVariation,
-					fontVariation: selectedFontVariation,
-				} )
-			);
-
-			goToCheckout( {
-				flowName: flow,
-				stepName,
-				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
-				// When the user is done with checkout, send them back to the current url
-				destination: window.location.href.replace( window.location.origin, '' ),
-				plan: isGlobalStylesOnPersonal ? 'personal' : 'premium',
-			} );
-
-			setShowPremiumGlobalStylesModal( false );
-		}
-	}
 
 	const handleSubmit = useCallback(
 		(
@@ -626,48 +319,14 @@ const UnifiedDesignPickerStep: StepType< {
 		]
 	);
 
-	function tryPremiumGlobalStyles() {
-		// These conditions should be true at this point, but just in case...
-		if ( shouldUnlockGlobalStyles ) {
-			recordTracksEvent(
-				'calypso_signup_design_global_styles_gating_modal_try_button_click',
-				getEventPropsByDesign( selectedDesign, {
-					styleVariation: selectedStyleVariation,
-					colorVariation: selectedColorVariation,
-					fontVariation: selectedFontVariation,
-				} )
-			);
-
-			pickDesign();
-		}
-	}
-
 	function pickUnlistedDesign( theme: string ) {
 		// TODO: move this logic from this step to the flow(s). See: https://wp.me/pdDR7T-KR
 		exitFlow?.( `/theme/${ theme }/${ siteSlug }` );
 	}
 
 	function handleBackClick() {
-		if ( isPreviewingDesign ) {
-			recordTracksEvent(
-				'calypso_signup_design_preview_exit',
-				getEventPropsByDesign( selectedDesign as Design, {
-					styleVariation: selectedStyleVariation,
-					colorVariation: selectedColorVariation,
-					fontVariation: selectedFontVariation,
-				} )
-			);
-
-			resetPreview();
-			return;
-		}
-
 		designPickerFilters.resetFilters();
 		goBack?.();
-	}
-
-	function recordDeviceClick( device: string ) {
-		recordTracksEvent( 'calypso_signup_design_preview_device_click', { device } );
 	}
 
 	function recordStepContainerTracksEvent( eventName: string ) {
@@ -677,95 +336,14 @@ const UnifiedDesignPickerStep: StepType< {
 			intent,
 		} );
 	}
-	function getPrimaryActionButtonAction(): () => void {
-		if ( isGlobalStylesOnPersonal ) {
-			if ( isLockedTheme ) {
-				return upgradePlan;
-			}
-
-			if ( shouldUnlockGlobalStyles ) {
-				return unlockPremiumGlobalStyles;
-			}
-
-			return () => pickDesign();
-		}
-
-		const isPersonalDesign = selectedDesign?.design_tier === PERSONAL_THEME;
-		if ( isLockedTheme ) {
-			// For personal themes we favor the GS Upgrade Modal over the Plan Upgrade Modal.
-			return isPersonalDesign && shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : upgradePlan;
-		}
-
-		return shouldUnlockGlobalStyles ? unlockPremiumGlobalStyles : () => pickDesign();
-	}
 
 	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
-
-	const getPrimaryActionButtonProps = () => {
-		const action = getPrimaryActionButtonAction();
-		const text =
-			action === upgradePlan && ! isGoalsAtFrontExperiment
-				? translate( 'Unlock theme' )
-				: translate( 'Continue' );
-
-		return {
-			action,
-			text,
-		};
-	};
-
-	const { action: primaryActionButtonAction, text: primaryActionButtonText } =
-		getPrimaryActionButtonProps();
-
-	const primaryActionButton = isUsingStepContainerV2 ? (
-		<Step.PrimaryButton onClick={ primaryActionButtonAction }>
-			{ primaryActionButtonText }
-		</Step.PrimaryButton>
-	) : (
-		<Button
-			className="navigation-link"
-			primary
-			borderless={ false }
-			onClick={ primaryActionButtonAction }
-		>
-			{ primaryActionButtonText }
-		</Button>
-	);
 
 	useEffect( () => {
 		if ( isComingFromTheUpgradeScreen ) {
 			pickDesign();
 		}
 	}, [ isComingFromTheUpgradeScreen, pickDesign ] );
-
-	const screens = useScreens( {
-		siteId,
-		stylesheet: selectedDesign?.recipe?.stylesheet ?? '',
-		isVirtual: selectedDesign?.is_virtual,
-		isExternallyManaged: selectedDesign?.is_externally_managed,
-		limitGlobalStyles: shouldLimitGlobalStyles,
-		variations: selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : [],
-		splitDefaultVariation:
-			( isGlobalStylesOnPersonal &&
-				selectedDesign?.design_tier === THEME_TIER_FREE &&
-				shouldLimitGlobalStyles ) ||
-			( ! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
-				! isBundled &&
-				! isPremiumThemeAvailable &&
-				shouldLimitGlobalStyles ),
-		needsUpgrade: shouldLimitGlobalStyles || isLockedTheme,
-		selectedVariation: selectedStyleVariation,
-		selectedColorVariation: selectedColorVariation,
-		selectedFontVariation: selectedFontVariation,
-		onSelectVariation: previewDesignVariation,
-		onSelectColorVariation: handleSelectColorVariation,
-		onSelectFontVariation: handleSelectFontVariation,
-		onScreenSelect: recordDesignPreviewScreenSelect,
-		onScreenBack: recordDesignPreviewScreenBack,
-		onScreenSubmit: recordDesignPreviewScreenSubmit,
-	} );
-
-	const navigatorRef = useRef< Navigator >( null );
 
 	// ********** Main render logic
 
@@ -779,213 +357,26 @@ const UnifiedDesignPickerStep: StepType< {
 	}
 
 	if ( selectedDesign && isPreviewingDesign ) {
-		const designTitle = selectedDesign.design_type !== 'vertical' ? selectedDesign.title : '';
-		const headerDesignTitle = (
-			<DesignPickerDesignTitle
-				designTitle={ designTitle }
-				selectedDesign={ selectedDesign }
-				siteId={ siteId }
-				siteSlug={ siteSlug }
-			/>
-		);
-
-		// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview
-		const shouldCustomizeText = intent === SiteIntent.Write || intent === SiteIntent.Sell;
-		const previewUrl = getDesignPreviewUrl( selectedDesign, {
-			site_title: shouldCustomizeText ? siteTitle : undefined,
-			site_tagline: shouldCustomizeText ? siteDescription : undefined,
-		} );
-
-		const getActionButtons = () => {
-			if ( ! isUsingStepContainerV2 ) {
-				return (
-					<>
-						<div className="action-buttons__title">{ headerDesignTitle }</div>
-						<div>{ primaryActionButton }</div>
-					</>
-				);
-			}
-
-			return primaryActionButton;
-		};
-
-		const actionButtons = getActionButtons();
-
-		const designPreviewProps: DesignPreviewProps = {
-			navigatorRef,
-			previewUrl: themeDemoUrl || previewUrl,
-			siteInfo: {
-				title: shouldCustomizeText ? site?.name ?? '' : '',
-				tagline: shouldCustomizeText ? site?.description ?? '' : '',
-			},
-			splitDefaultVariation:
-				( isGlobalStylesOnPersonal &&
-					selectedDesign?.design_tier === THEME_TIER_FREE &&
-					shouldLimitGlobalStyles ) ||
-				( ! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
-					! isBundled &&
-					! isPremiumThemeAvailable &&
-					! didPurchaseSelectedTheme &&
-					! isPluginBundleEligible &&
-					! isGlobalStylesOnPersonal &&
-					shouldLimitGlobalStyles ),
-			needsUpgrade: shouldLimitGlobalStyles || isLockedTheme,
-			title: headerDesignTitle,
-			selectedDesignTitle: designTitle,
-			shortDescription: selectedDesign.description,
-			description: selectedDesignDetails?.description,
-			variations: selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : [],
-			selectedVariation: selectedStyleVariation,
-			onSelectVariation: previewDesignVariation,
-			actionButtons,
-			recordDeviceClick,
-			siteId: site?.ID ?? 0,
-			stylesheet: selectedDesign.recipe?.stylesheet ?? '',
-			screenshot: fullLengthScreenshot,
-			isExternallyManaged: selectedDesign.is_externally_managed,
-			selectedColorVariation: selectedColorVariation,
-			selectedFontVariation: selectedFontVariation,
-			onGlobalStylesChange: setGlobalStyles,
-			onNavigatorPathChange: ( path?: string ) => setDesignPreviewPath( path ),
-			screens,
-		};
-
-		const stepContent = (
-			<>
-				{ requiredPlanSlug && ! isGoalsAtFrontExperiment && (
-					<UpgradeModal
-						slug={ selectedDesign.slug }
-						isOpen={ showUpgradeModal }
-						//TODO: Fix NEEED typo
-						isMarketplacePlanSubscriptionNeeeded={ ! isExternallyManagedThemeAvailable }
-						isMarketplaceThemeSubscriptionNeeded={ isMarketplaceThemeSubscriptionNeeded }
-						marketplaceProduct={ selectedMarketplaceProduct }
-						requiredPlan={ requiredPlanSlug }
-						closeModal={ closeUpgradeModal }
-						checkout={ handleCheckout }
-					/>
-				) }
-				<QueryEligibility siteId={ site?.ID } />
-				<EligibilityWarningsModal
-					site={ site ?? undefined }
-					isMarketplace={ selectedDesign?.is_externally_managed }
-					isOpen={ showEligibility }
-					handleClose={ () => {
-						recordTracksEvent( 'calypso_automated_transfer_eligibility_modal_dismiss', {
-							flow: 'onboarding',
-							theme: selectedDesign?.slug,
-						} );
-						setShowEligibility( false );
-					} }
-					handleContinue={ () => {
-						navigateToCheckout();
-						setShowEligibility( false );
-					} }
-				/>
-				<PremiumGlobalStylesUpgradeModal
-					checkout={ handleCheckoutForPremiumGlobalStyles }
-					closeModal={ closePremiumGlobalStylesModal }
-					isOpen={ showPremiumGlobalStylesModal }
-					numOfSelectedGlobalStyles={ numOfSelectedGlobalStyles }
-					{ ...( ! isLockedTheme && { tryStyle: tryPremiumGlobalStyles } ) }
-				/>
-				<AsyncLoad
-					require="@automattic/design-preview"
-					placeholder={ null }
-					{ ...designPreviewProps }
-				/>
-			</>
-		);
-
-		const activeScreen = screens.find( ( screen ) => screen.path === designPreviewPath );
-
-		if ( isUsingStepContainerV2 ) {
-			// TODO: Create a new wireframe for the design preview. It should be named "FixedColumnOnTheLeftLayout"
-			return (
-				<Step.FullWidthLayout
-					className="step-container-v2--design-picker-preview"
-					topBar={ ( { isLargeViewport } ) => {
-						if ( ! isLargeViewport && activeScreen ) {
-							return null;
-						}
-
-						return (
-							<Step.TopBar
-								leftElement={ ! activeScreen && <Step.BackButton onClick={ handleBackClick } /> }
-								rightElement={
-									! isGoalsAtFrontExperiment ? undefined : (
-										<Step.SkipButton onClick={ () => handleSubmit() }>
-											{ translate( 'Skip setup' ) }
-										</Step.SkipButton>
-									)
-								}
-							/>
-						);
-					} }
-					stickyBottomBar={ ( { isLargeViewport } ) => {
-						if ( isLargeViewport ) {
-							return null;
-						}
-
-						return (
-							<Step.StickyBottomBar
-								leftElement={
-									activeScreen && (
-										<Step.BackButton
-											recordTracksEvent={ ! activeScreen }
-											onClick={ () => {
-												if ( activeScreen?.onBack ) {
-													navigatorRef.current?.goBack();
-													return activeScreen.onBack( activeScreen.slug );
-												}
-
-												return handleBackClick();
-											} }
-										/>
-									)
-								}
-								centerElement={
-									activeScreen && (
-										<div className="step-container-v2--design-picker-preview__header-design-title">
-											{ headerDesignTitle }
-										</div>
-									)
-								}
-								rightElement={
-									<Step.PrimaryButton
-										onClick={ () => {
-											if ( activeScreen?.onSubmit ) {
-												navigatorRef.current?.goBack();
-												return activeScreen.onSubmit( activeScreen.slug );
-											}
-
-											return primaryActionButtonAction();
-										} }
-									>
-										{ activeScreen?.actionText ?? primaryActionButtonText }
-									</Step.PrimaryButton>
-								}
-							/>
-						);
-					} }
-				>
-					{ stepContent }
-				</Step.FullWidthLayout>
-			);
-		}
-
 		return (
-			<StepContainer
-				stepName={ STEP_NAME }
-				stepContent={ stepContent }
-				hideSkip={ ! isGoalsAtFrontExperiment }
-				skipLabelText={ translate( 'Skip setup' ) }
-				skipButtonAlign="top"
-				hideBack={ !! activeScreen }
-				className="design-setup__preview design-setup__preview__has-more-info"
-				goBack={ handleBackClick }
-				customizedActionButtons={ ! activeScreen ? actionButtons : undefined }
-				recordTracksEvent={ recordStepContainerTracksEvent }
+			<AsyncLoad
+				require="./unified-design-picker-preview"
+				placeholder={ null }
+				selectedDesign={ selectedDesign }
+				pickDesign={ pickDesign }
+				getEventPropsByDesign={ getEventPropsByDesign }
+				flow={ flow }
+				isPremiumThemeAvailable={ isPremiumThemeAvailable }
+				stepName={ stepName }
+				handleSubmit={ handleSubmit }
+				numOfSelectedGlobalStyles={ numOfSelectedGlobalStyles }
+				previewDesignVariation={ previewDesignVariation }
+				setSelectedColorVariation={ setSelectedColorVariation }
+				setSelectedFontVariation={ setSelectedFontVariation }
+				setGlobalStyles={ setGlobalStyles }
+				resetPreview={ resetPreview }
+				selectedStyleVariation={ selectedStyleVariation }
+				selectedColorVariation={ selectedColorVariation }
+				selectedFontVariation={ selectedFontVariation }
 			/>
 		);
 	}
@@ -1097,27 +488,5 @@ const UnifiedDesignPickerStep: StepType< {
 		/>
 	);
 };
-
-function getRequiredPlan( selectedDesign: Design | undefined, currentPlanSlug: string ) {
-	if ( ! selectedDesign?.design_tier ) {
-		return;
-	}
-	// Different designs require different plans to unlock them, additionally the terms required can vary.
-	// A site with a plan of a given length cannot upgrade a plan of a shorter length. For example,
-	// if a site is on a 2 year starter plan and want to buy an explorer theme, they must buy a 2 year explorer plan
-	// not a 1 year explorer plan.
-	const tierMinimumUpsellPlan =
-		THEME_TIERS[ selectedDesign.design_tier as keyof typeof THEME_TIERS ]?.minimumUpsellPlan;
-
-	let requiredTerm;
-	if ( ! currentPlanSlug || isFreePlan( currentPlanSlug ) ) {
-		// Marketplace themes require upgrading to a monthly business plan or higher, everything else requires an annual plan.
-		requiredTerm = selectedDesign?.is_externally_managed ? TERM_MONTHLY : TERM_ANNUALLY;
-	} else {
-		requiredTerm = getPlan( currentPlanSlug )?.term || TERM_ANNUALLY;
-	}
-
-	return findFirstSimilarPlanKey( tierMinimumUpsellPlan, { term: requiredTerm } );
-}
 
 export default UnifiedDesignPickerStep;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -142,7 +142,8 @@ const UnifiedDesignPickerStep: StepType< {
 		( state ) => site?.ID && hasPurchasedDomain( state, site.ID )
 	);
 
-	const [ shouldHideActionButtons, setShouldHideActionButtons ] = useState( false );
+	const [ designPreviewPath, setDesignPreviewPath ] = useState< string | undefined >( '/' );
+
 	const [ showEligibility, setShowEligibility ] = useState( false );
 
 	const isJetpack = useSelect(
@@ -848,7 +849,7 @@ const UnifiedDesignPickerStep: StepType< {
 					selectedFontVariation={ selectedFontVariation }
 					onSelectFontVariation={ handleSelectFontVariation }
 					onGlobalStylesChange={ setGlobalStyles }
-					onNavigatorPathChange={ ( path?: string ) => setShouldHideActionButtons( path !== '/' ) }
+					onNavigatorPathChange={ ( path?: string ) => setDesignPreviewPath( path ) }
 					onScreenSelect={ recordDesignPreviewScreenSelect }
 					onScreenBack={ recordDesignPreviewScreenBack }
 					onScreenSubmit={ recordDesignPreviewScreenSubmit }
@@ -856,22 +857,22 @@ const UnifiedDesignPickerStep: StepType< {
 			</>
 		);
 
+		const isAtDesignPreviewRoot = designPreviewPath === '/';
+
 		if ( isUsingStepContainerV2 ) {
 			// TODO: Create a new wireframe for the design preview. It should be named "FixedColumnOnTheLeftLayout"
 			return (
 				<Step.FullWidthLayout
 					className="step-container-v2--design-picker-preview"
 					topBar={ ( { isLargeViewport } ) => {
-						if ( ! isLargeViewport ) {
+						if ( ! isLargeViewport && ! isAtDesignPreviewRoot ) {
 							return null;
 						}
 
 						return (
 							<Step.TopBar
 								leftElement={
-									shouldHideActionButtons ? undefined : (
-										<Step.BackButton onClick={ handleBackClick } />
-									)
+									isAtDesignPreviewRoot && <Step.BackButton onClick={ handleBackClick } />
 								}
 								rightElement={
 									! isGoalsAtFrontExperiment ? undefined : (
@@ -892,9 +893,11 @@ const UnifiedDesignPickerStep: StepType< {
 							<Step.StickyBottomBar
 								leftElement={ <Step.BackButton onClick={ handleBackClick } /> }
 								centerElement={
-									<div className="step-container-v2--design-picker-preview__header-design-title">
-										{ headerDesignTitle }
-									</div>
+									! isAtDesignPreviewRoot && (
+										<div className="step-container-v2--design-picker-preview__header-design-title">
+											{ headerDesignTitle }
+										</div>
+									)
 								}
 								rightElement={ actionButtons }
 							/>
@@ -913,10 +916,10 @@ const UnifiedDesignPickerStep: StepType< {
 				hideSkip={ ! isGoalsAtFrontExperiment }
 				skipLabelText={ translate( 'Skip setup' ) }
 				skipButtonAlign="top"
-				hideBack={ shouldHideActionButtons }
+				hideBack={ ! isAtDesignPreviewRoot }
 				className="design-setup__preview design-setup__preview__has-more-info"
 				goBack={ handleBackClick }
-				customizedActionButtons={ ! shouldHideActionButtons ? actionButtons : undefined }
+				customizedActionButtons={ isAtDesignPreviewRoot ? actionButtons : undefined }
 				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -24,10 +24,11 @@ import {
 import { useScreens, type DesignPreviewProps } from '@automattic/design-preview';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, ONBOARDING_FLOW, isSiteSetupFlow, Step } from '@automattic/onboarding';
+import { Navigator } from '@wordpress/components/build-types/navigator/types';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
@@ -764,6 +765,8 @@ const UnifiedDesignPickerStep: StepType< {
 		onScreenSubmit: recordDesignPreviewScreenSubmit,
 	} );
 
+	const navigatorRef = useRef< Navigator >( null );
+
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
@@ -809,6 +812,7 @@ const UnifiedDesignPickerStep: StepType< {
 		const actionButtons = getActionButtons();
 
 		const designPreviewProps: DesignPreviewProps = {
+			navigatorRef,
 			previewUrl: themeDemoUrl || previewUrl,
 			siteInfo: {
 				title: shouldCustomizeText ? site?.name ?? '' : '',
@@ -930,6 +934,7 @@ const UnifiedDesignPickerStep: StepType< {
 										recordTracksEvent={ ! activeScreen }
 										onClick={ () => {
 											if ( activeScreen?.onBack ) {
+												navigatorRef.current?.goBack();
 												return activeScreen.onBack( activeScreen.slug );
 											}
 
@@ -948,6 +953,7 @@ const UnifiedDesignPickerStep: StepType< {
 									<Step.PrimaryButton
 										onClick={ () => {
 											if ( activeScreen?.onSubmit ) {
+												navigatorRef.current?.goBack();
 												return activeScreen.onSubmit( activeScreen.slug );
 											}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -202,16 +202,16 @@ const UnifiedDesignPickerStep: StepType< {
 		);
 	}
 
-	useQueryThemes( 'wpcom', {
-		number: 1000,
-	} );
-
 	function trackAllDesignsView() {
 		recordTracksEvent( 'calypso_signup_design_scrolled_to_end', {
 			intent,
 			categories: categorization?.selections?.join( ',' ),
 		} );
 	}
+
+	useQueryThemes( 'wpcom', {
+		number: 1000,
+	} );
 
 	const getBadge = ( themeId: string, isLockedStyleVariation: boolean ) => (
 		<ThemeTierBadge

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -137,6 +137,29 @@ const UnifiedDesignPickerStep: StepType< {
 
 	const designPickerFilters = useDesignPickerFilters();
 
+	// ********** Logic for selecting a design and style variation
+	const {
+		isPreviewingDesign,
+		selectedDesign,
+		selectedStyleVariation,
+		selectedColorVariation,
+		selectedFontVariation,
+		numOfSelectedGlobalStyles,
+		globalStyles,
+		setSelectedDesign,
+		previewDesign,
+		previewDesignVariation,
+		setSelectedColorVariation,
+		setSelectedFontVariation,
+		setGlobalStyles,
+		resetPreview,
+	} = useRecipe( allDesigns, pickUnlistedDesign, recordPreviewDesign, recordPreviewStyleVariation );
+
+	// Make sure people is at the top when entering/leaving preview mode.
+	useEffect( () => {
+		window.scrollTo( { top: 0 } );
+	}, [ isPreviewingDesign ] );
+
 	const getEventPropsByDesign = useCallback(
 		(
 			design: Design,
@@ -179,32 +202,9 @@ const UnifiedDesignPickerStep: StepType< {
 		);
 	}
 
-	// ********** Logic for selecting a design and style variation
-	const {
-		isPreviewingDesign,
-		selectedDesign,
-		selectedStyleVariation,
-		selectedColorVariation,
-		selectedFontVariation,
-		numOfSelectedGlobalStyles,
-		globalStyles,
-		setSelectedDesign,
-		previewDesign,
-		previewDesignVariation,
-		setSelectedColorVariation,
-		setSelectedFontVariation,
-		setGlobalStyles,
-		resetPreview,
-	} = useRecipe( allDesigns, pickUnlistedDesign, recordPreviewDesign, recordPreviewStyleVariation );
-
 	useQueryThemes( 'wpcom', {
 		number: 1000,
 	} );
-
-	// Make sure people is at the top when entering/leaving preview mode.
-	useEffect( () => {
-		window.scrollTo( { top: 0 } );
-	}, [ isPreviewingDesign ] );
 
 	function trackAllDesignsView() {
 		recordTracksEvent( 'calypso_signup_design_scrolled_to_end', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -930,17 +930,19 @@ const UnifiedDesignPickerStep: StepType< {
 						return (
 							<Step.StickyBottomBar
 								leftElement={
-									<Step.BackButton
-										recordTracksEvent={ ! activeScreen }
-										onClick={ () => {
-											if ( activeScreen?.onBack ) {
-												navigatorRef.current?.goBack();
-												return activeScreen.onBack( activeScreen.slug );
-											}
+									activeScreen && (
+										<Step.BackButton
+											recordTracksEvent={ ! activeScreen }
+											onClick={ () => {
+												if ( activeScreen?.onBack ) {
+													navigatorRef.current?.goBack();
+													return activeScreen.onBack( activeScreen.slug );
+												}
 
-											return handleBackClick();
-										} }
-									/>
+												return handleBackClick();
+											} }
+										/>
+									)
 								}
 								centerElement={
 									activeScreen && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -21,6 +21,7 @@ import {
 	PERSONAL_THEME,
 	getThemeIdFromDesign,
 } from '@automattic/design-picker';
+import { useScreens, type DesignPreviewProps } from '@automattic/design-preview';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
 import { StepContainer, ONBOARDING_FLOW, isSiteSetupFlow, Step } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -699,29 +700,69 @@ const UnifiedDesignPickerStep: StepType< {
 
 	const isUsingStepContainerV2 = shouldUseStepContainerV2( flow );
 
-	function getPrimaryActionButton() {
+	const getPrimaryActionButtonProps = () => {
 		const action = getPrimaryActionButtonAction();
 		const text =
 			action === upgradePlan && ! isGoalsAtFrontExperiment
 				? translate( 'Unlock theme' )
 				: translate( 'Continue' );
 
-		if ( ! isUsingStepContainerV2 ) {
-			return (
-				<Button className="navigation-link" primary borderless={ false } onClick={ action }>
-					{ text }
-				</Button>
-			);
-		}
+		return {
+			action,
+			text,
+		};
+	};
 
-		return <Step.PrimaryButton onClick={ action }>{ text }</Step.PrimaryButton>;
-	}
+	const { action: primaryActionButtonAction, text: primaryActionButtonText } =
+		getPrimaryActionButtonProps();
+
+	const primaryActionButton = isUsingStepContainerV2 ? (
+		<Step.PrimaryButton onClick={ primaryActionButtonAction }>
+			{ primaryActionButtonText }
+		</Step.PrimaryButton>
+	) : (
+		<Button
+			className="navigation-link"
+			primary
+			borderless={ false }
+			onClick={ primaryActionButtonAction }
+		>
+			{ primaryActionButtonText }
+		</Button>
+	);
 
 	useEffect( () => {
 		if ( isComingFromTheUpgradeScreen ) {
 			pickDesign();
 		}
 	}, [ isComingFromTheUpgradeScreen, pickDesign ] );
+
+	const screens = useScreens( {
+		siteId,
+		stylesheet: selectedDesign?.recipe?.stylesheet ?? '',
+		isVirtual: selectedDesign?.is_virtual,
+		isExternallyManaged: selectedDesign?.is_externally_managed,
+		limitGlobalStyles: shouldLimitGlobalStyles,
+		variations: selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : [],
+		splitDefaultVariation:
+			( isGlobalStylesOnPersonal &&
+				selectedDesign?.design_tier === THEME_TIER_FREE &&
+				shouldLimitGlobalStyles ) ||
+			( ! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
+				! isBundled &&
+				! isPremiumThemeAvailable &&
+				shouldLimitGlobalStyles ),
+		needsUpgrade: shouldLimitGlobalStyles || isLockedTheme,
+		selectedVariation: selectedStyleVariation,
+		selectedColorVariation: selectedColorVariation,
+		selectedFontVariation: selectedFontVariation,
+		onSelectVariation: previewDesignVariation,
+		onSelectColorVariation: handleSelectColorVariation,
+		onSelectFontVariation: handleSelectFontVariation,
+		onScreenSelect: recordDesignPreviewScreenSelect,
+		onScreenBack: recordDesignPreviewScreenBack,
+		onScreenSubmit: recordDesignPreviewScreenSubmit,
+	} );
 
 	// ********** Main render logic
 
@@ -757,15 +798,53 @@ const UnifiedDesignPickerStep: StepType< {
 				return (
 					<>
 						<div className="action-buttons__title">{ headerDesignTitle }</div>
-						<div>{ getPrimaryActionButton() }</div>
+						<div>{ primaryActionButton }</div>
 					</>
 				);
 			}
 
-			return getPrimaryActionButton();
+			return primaryActionButton;
 		};
 
 		const actionButtons = getActionButtons();
+
+		const designPreviewProps: DesignPreviewProps = {
+			previewUrl: themeDemoUrl || previewUrl,
+			siteInfo: {
+				title: shouldCustomizeText ? site?.name ?? '' : '',
+				tagline: shouldCustomizeText ? site?.description ?? '' : '',
+			},
+			splitDefaultVariation:
+				( isGlobalStylesOnPersonal &&
+					selectedDesign?.design_tier === THEME_TIER_FREE &&
+					shouldLimitGlobalStyles ) ||
+				( ! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
+					! isBundled &&
+					! isPremiumThemeAvailable &&
+					! didPurchaseSelectedTheme &&
+					! isPluginBundleEligible &&
+					! isGlobalStylesOnPersonal &&
+					shouldLimitGlobalStyles ),
+			needsUpgrade: shouldLimitGlobalStyles || isLockedTheme,
+			title: headerDesignTitle,
+			selectedDesignTitle: designTitle,
+			shortDescription: selectedDesign.description,
+			description: selectedDesignDetails?.description,
+			variations: selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : [],
+			selectedVariation: selectedStyleVariation,
+			onSelectVariation: previewDesignVariation,
+			actionButtons,
+			recordDeviceClick,
+			siteId: site?.ID ?? 0,
+			stylesheet: selectedDesign.recipe?.stylesheet ?? '',
+			screenshot: fullLengthScreenshot,
+			isExternallyManaged: selectedDesign.is_externally_managed,
+			selectedColorVariation: selectedColorVariation,
+			selectedFontVariation: selectedFontVariation,
+			onGlobalStylesChange: setGlobalStyles,
+			onNavigatorPathChange: ( path?: string ) => setDesignPreviewPath( path ),
+			screens,
+		};
 
 		const stepContent = (
 			<>
@@ -809,55 +888,12 @@ const UnifiedDesignPickerStep: StepType< {
 				<AsyncLoad
 					require="@automattic/design-preview"
 					placeholder={ null }
-					previewUrl={ themeDemoUrl || previewUrl }
-					siteInfo={ {
-						title: shouldCustomizeText ? site?.name : '',
-						tagline: shouldCustomizeText ? site?.description : '',
-					} }
-					splitDefaultVariation={
-						( isGlobalStylesOnPersonal &&
-							selectedDesign?.design_tier === THEME_TIER_FREE &&
-							shouldLimitGlobalStyles ) ||
-						( ! ( selectedDesign?.design_tier === THEME_TIER_PREMIUM ) &&
-							! isBundled &&
-							! isPremiumThemeAvailable &&
-							! didPurchaseSelectedTheme &&
-							! isPluginBundleEligible &&
-							! isGlobalStylesOnPersonal &&
-							shouldLimitGlobalStyles )
-					}
-					needsUpgrade={ shouldLimitGlobalStyles || isLockedTheme }
-					title={ headerDesignTitle }
-					selectedDesignTitle={ designTitle }
-					shortDescription={ selectedDesign.description }
-					description={ selectedDesignDetails?.description }
-					variations={
-						selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : []
-					}
-					selectedVariation={ selectedStyleVariation }
-					onSelectVariation={ previewDesignVariation }
-					actionButtons={ actionButtons }
-					recordDeviceClick={ recordDeviceClick }
-					limitGlobalStyles={ shouldLimitGlobalStyles }
-					siteId={ site?.ID }
-					stylesheet={ selectedDesign.recipe?.stylesheet }
-					screenshot={ fullLengthScreenshot }
-					isExternallyManaged={ selectedDesign.is_externally_managed }
-					isVirtual={ selectedDesign.is_virtual }
-					selectedColorVariation={ selectedColorVariation }
-					onSelectColorVariation={ handleSelectColorVariation }
-					selectedFontVariation={ selectedFontVariation }
-					onSelectFontVariation={ handleSelectFontVariation }
-					onGlobalStylesChange={ setGlobalStyles }
-					onNavigatorPathChange={ ( path?: string ) => setDesignPreviewPath( path ) }
-					onScreenSelect={ recordDesignPreviewScreenSelect }
-					onScreenBack={ recordDesignPreviewScreenBack }
-					onScreenSubmit={ recordDesignPreviewScreenSubmit }
+					{ ...designPreviewProps }
 				/>
 			</>
 		);
 
-		const isAtDesignPreviewRoot = designPreviewPath === '/';
+		const activeScreen = screens.find( ( screen ) => screen.path === designPreviewPath );
 
 		if ( isUsingStepContainerV2 ) {
 			// TODO: Create a new wireframe for the design preview. It should be named "FixedColumnOnTheLeftLayout"
@@ -865,15 +901,13 @@ const UnifiedDesignPickerStep: StepType< {
 				<Step.FullWidthLayout
 					className="step-container-v2--design-picker-preview"
 					topBar={ ( { isLargeViewport } ) => {
-						if ( ! isLargeViewport && ! isAtDesignPreviewRoot ) {
+						if ( ! isLargeViewport && activeScreen ) {
 							return null;
 						}
 
 						return (
 							<Step.TopBar
-								leftElement={
-									isAtDesignPreviewRoot && <Step.BackButton onClick={ handleBackClick } />
-								}
+								leftElement={ ! activeScreen && <Step.BackButton onClick={ handleBackClick } /> }
 								rightElement={
 									! isGoalsAtFrontExperiment ? undefined : (
 										<Step.SkipButton onClick={ () => handleSubmit() }>
@@ -891,15 +925,38 @@ const UnifiedDesignPickerStep: StepType< {
 
 						return (
 							<Step.StickyBottomBar
-								leftElement={ <Step.BackButton onClick={ handleBackClick } /> }
+								leftElement={
+									<Step.BackButton
+										recordTracksEvent={ ! activeScreen }
+										onClick={ () => {
+											if ( activeScreen?.onBack ) {
+												return activeScreen.onBack( activeScreen.slug );
+											}
+
+											return handleBackClick();
+										} }
+									/>
+								}
 								centerElement={
-									! isAtDesignPreviewRoot && (
+									activeScreen && (
 										<div className="step-container-v2--design-picker-preview__header-design-title">
 											{ headerDesignTitle }
 										</div>
 									)
 								}
-								rightElement={ actionButtons }
+								rightElement={
+									<Step.PrimaryButton
+										onClick={ () => {
+											if ( activeScreen?.onSubmit ) {
+												return activeScreen.onSubmit( activeScreen.slug );
+											}
+
+											return primaryActionButtonAction();
+										} }
+									>
+										{ activeScreen?.actionText ?? primaryActionButtonText }
+									</Step.PrimaryButton>
+								}
 							/>
 						);
 					} }
@@ -916,10 +973,10 @@ const UnifiedDesignPickerStep: StepType< {
 				hideSkip={ ! isGoalsAtFrontExperiment }
 				skipLabelText={ translate( 'Skip setup' ) }
 				skipButtonAlign="top"
-				hideBack={ ! isAtDesignPreviewRoot }
+				hideBack={ !! activeScreen }
 				className="design-setup__preview design-setup__preview__has-more-info"
 				goBack={ handleBackClick }
-				customizedActionButtons={ isAtDesignPreviewRoot ? actionButtons : undefined }
+				customizedActionButtons={ ! activeScreen ? actionButtons : undefined }
 				recordTracksEvent={ recordStepContainerTracksEvent }
 			/>
 		);

--- a/config/development.json
+++ b/config/development.json
@@ -138,7 +138,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
-		"onboarding/step-container-v2": false,
+		"onboarding/step-container-v2": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/trail-map-feature-grid": false,

--- a/config/development.json
+++ b/config/development.json
@@ -138,7 +138,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
-		"onboarding/step-container-v2": true,
+		"onboarding/step-container-v2": false,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/trail-map-feature-grid": false,

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -1,9 +1,10 @@
 import { GlobalStylesProvider, useSyncGlobalStylesUserConfig } from '@automattic/global-styles';
 import { NavigatorScreenObject } from '@automattic/onboarding';
+import { Navigator } from '@wordpress/components/build-types/navigator/types';
 import { useViewportMatch } from '@wordpress/compose';
 import { Element } from '@wordpress/element';
 import clsx from 'clsx';
-import { useMemo, useState } from 'react';
+import { MutableRefObject, useMemo, useState } from 'react';
 import { useInlineCss } from '../hooks';
 import Sidebar from './sidebar';
 import SitePreview from './site-preview';
@@ -41,6 +42,7 @@ export interface DesignPreviewProps {
 	selectedFontVariation: GlobalStylesObject | null;
 	onGlobalStylesChange: ( globalStyles?: GlobalStylesObject | null ) => void;
 	onNavigatorPathChange?: ( path?: string ) => void;
+	navigatorRef: MutableRefObject< Navigator | null >;
 }
 
 // @todo Get the style variations of theme, and then combine the selected one with colors & fonts for consistency
@@ -66,6 +68,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	onGlobalStylesChange,
 	selectedDesignTitle,
 	onNavigatorPathChange,
+	navigatorRef,
 } ) => {
 	const isDesktop = useViewportMatch( 'large' );
 	const [ isInitialScreen, setIsInitialScreen ] = useState( true );
@@ -94,6 +97,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 			} ) }
 		>
 			<Sidebar
+				navigatorRef={ navigatorRef }
 				title={ title }
 				author={ author }
 				categories={ categories }

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -1,21 +1,23 @@
 import { GlobalStylesProvider, useSyncGlobalStylesUserConfig } from '@automattic/global-styles';
+import { NavigatorScreenObject } from '@automattic/onboarding';
 import { useViewportMatch } from '@wordpress/compose';
+import { Element } from '@wordpress/element';
 import clsx from 'clsx';
 import { useMemo, useState } from 'react';
-import { useInlineCss, useScreens } from '../hooks';
+import { useInlineCss } from '../hooks';
 import Sidebar from './sidebar';
 import SitePreview from './site-preview';
 import type { Category, StyleVariation } from '@automattic/design-picker/src/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import './style.scss';
 
-interface DesignPreviewProps {
+export interface DesignPreviewProps {
 	previewUrl: string;
 	siteInfo?: {
 		title: string;
 		tagline: string;
 	};
-	title?: string;
+	title?: Element;
 	author?: string;
 	categories?: Category[];
 	description?: string;
@@ -23,6 +25,7 @@ interface DesignPreviewProps {
 	pricingBadge?: React.ReactNode;
 	variations?: StyleVariation[];
 	selectedVariation?: StyleVariation;
+	screens: NavigatorScreenObject[];
 	selectedDesignTitle: string;
 	onSelectVariation: ( variation: StyleVariation ) => void;
 	splitDefaultVariation: boolean;
@@ -32,19 +35,12 @@ interface DesignPreviewProps {
 	recordDeviceClick: ( device: string ) => void;
 	siteId: number;
 	stylesheet: string;
-	isVirtual?: boolean;
 	screenshot?: string;
 	isExternallyManaged?: boolean;
 	selectedColorVariation: GlobalStylesObject | null;
-	onSelectColorVariation: ( variation: GlobalStylesObject | null ) => void;
 	selectedFontVariation: GlobalStylesObject | null;
-	onSelectFontVariation: ( variation: GlobalStylesObject | null ) => void;
 	onGlobalStylesChange: ( globalStyles?: GlobalStylesObject | null ) => void;
-	limitGlobalStyles: boolean;
 	onNavigatorPathChange?: ( path?: string ) => void;
-	onScreenSelect?: ( screenSlug: string ) => void;
-	onScreenBack?: ( screenSlug: string ) => void;
-	onScreenSubmit?: ( screenSlug: string ) => void;
 }
 
 // @todo Get the style variations of theme, and then combine the selected one with colors & fonts for consistency
@@ -59,27 +55,16 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	pricingBadge,
 	variations,
 	selectedVariation,
-	onSelectVariation,
-	splitDefaultVariation,
-	needsUpgrade,
+	screens,
 	onClickCategory,
 	actionButtons,
 	recordDeviceClick,
-	siteId,
-	stylesheet,
 	screenshot,
-	isVirtual,
 	isExternallyManaged,
 	selectedColorVariation,
-	onSelectColorVariation,
 	selectedFontVariation,
-	onSelectFontVariation,
 	onGlobalStylesChange,
 	selectedDesignTitle,
-	limitGlobalStyles,
-	onScreenSelect,
-	onScreenBack,
-	onScreenSubmit,
 	onNavigatorPathChange,
 } ) => {
 	const isDesktop = useViewportMatch( 'large' );
@@ -91,26 +76,6 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	);
 
 	const inlineCss = useInlineCss( variations, selectedVariation );
-
-	const screens = useScreens( {
-		siteId,
-		stylesheet,
-		isVirtual,
-		isExternallyManaged,
-		limitGlobalStyles,
-		variations,
-		splitDefaultVariation,
-		needsUpgrade,
-		selectedVariation,
-		selectedColorVariation,
-		selectedFontVariation,
-		onSelectVariation,
-		onSelectColorVariation,
-		onSelectFontVariation,
-		onScreenSelect,
-		onScreenBack,
-		onScreenSubmit,
-	} );
 
 	const isFullscreen = ! isDesktop && ( screens.length === 1 || ! isInitialScreen );
 

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavigatorScreens, useNavigatorButtons } from '@automattic/onboarding';
-import { useMemo } from '@wordpress/element';
+import { Element, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useTranslate } from 'i18n-calypso';
 import type { Category } from '@automattic/design-picker/src/types';
@@ -26,7 +26,7 @@ const CategoryBadge: React.FC< CategoryBadgeProps > = ( { category, onClick } ) 
 };
 
 interface SidebarProps {
-	title?: string;
+	title?: Element;
 	author?: string;
 	categories?: Category[];
 	description?: string;

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -1,7 +1,9 @@
 import { NavigatorScreens, useNavigatorButtons } from '@automattic/onboarding';
+import { Navigator } from '@wordpress/components/build-types/navigator/types';
 import { Element, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useTranslate } from 'i18n-calypso';
+import { MutableRefObject } from 'react';
 import type { Category } from '@automattic/design-picker/src/types';
 import type { NavigatorScreenObject } from '@automattic/onboarding';
 
@@ -34,6 +36,7 @@ interface SidebarProps {
 	pricingBadge?: React.ReactNode;
 	screens: NavigatorScreenObject[];
 	actionButtons: React.ReactNode;
+	navigatorRef: MutableRefObject< Navigator | null >;
 	onClickCategory?: ( category: Category ) => void;
 	onNavigatorPathChange?: ( path?: string ) => void;
 }
@@ -47,6 +50,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	shortDescription,
 	screens,
 	actionButtons,
+	navigatorRef,
 	onClickCategory,
 	onNavigatorPathChange,
 } ) => {
@@ -65,7 +69,11 @@ const Sidebar: React.FC< SidebarProps > = ( {
 
 	return (
 		<div className="design-preview__sidebar">
-			<NavigatorScreens screens={ screens } onNavigatorPathChange={ onNavigatorPathChange }>
+			<NavigatorScreens
+				navigatorRef={ navigatorRef }
+				screens={ screens }
+				onNavigatorPathChange={ onNavigatorPathChange }
+			>
 				<>
 					<div className="design-preview__sidebar-header">
 						<div className="design-preview__sidebar-title">

--- a/packages/design-preview/src/index.ts
+++ b/packages/design-preview/src/index.ts
@@ -1,1 +1,2 @@
-export { default } from './components';
+export { default, type DesignPreviewProps } from './components';
+export { useScreens } from './hooks';

--- a/packages/onboarding/src/navigator/navigator-screens/navigator-screens.tsx
+++ b/packages/onboarding/src/navigator/navigator-screens/navigator-screens.tsx
@@ -1,16 +1,31 @@
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
+	useNavigator,
 } from '@wordpress/components';
+import { Navigator } from '@wordpress/components/build-types/navigator/types';
+import { MutableRefObject } from 'react';
 import NavigatorListener from '../navigator-listener';
 import { useNavigatorScreens } from './hooks';
 import type { NavigatorScreenObject } from './types';
 import './navigator-screens.scss';
 
+const NavigatorRefSetter = ( {
+	navigatorRef,
+}: {
+	navigatorRef: MutableRefObject< Navigator | null >;
+} ) => {
+	const navigator = useNavigator();
+	navigatorRef.current = navigator;
+
+	return null;
+};
+
 interface Props {
 	children: JSX.Element;
 	screens: NavigatorScreenObject[];
 	initialPath?: string;
+	navigatorRef: MutableRefObject< Navigator | null >;
 	onNavigatorPathChange?: ( path?: string ) => void;
 }
 
@@ -18,6 +33,7 @@ const NavigatorScreens = ( {
 	children,
 	screens,
 	initialPath = '/',
+	navigatorRef,
 	onNavigatorPathChange,
 }: Props ) => {
 	const navigatorScreens = useNavigatorScreens( screens );
@@ -31,6 +47,7 @@ const NavigatorScreens = ( {
 		<NavigatorProvider initialPath={ initialPath }>
 			<NavigatorScreen path={ initialPath }>{ children }</NavigatorScreen>
 			{ navigatorScreens }
+			<NavigatorRefSetter navigatorRef={ navigatorRef } />
 			{ onNavigatorPathChange && (
 				<NavigatorListener onNavigatorPathChange={ onNavigatorPathChange } />
 			) }

--- a/packages/onboarding/src/step-container-v2/components/buttons/BackButton/BackButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/BackButton/BackButton.tsx
@@ -9,9 +9,9 @@ import { ButtonProps } from '../../../types';
 import './style.scss';
 
 export const BackButton = ( {
-	recordTracksEvent,
+	enableTracksEvent = true,
 	...originalProps
-}: ButtonProps & { recordTracksEvent?: boolean } ) => {
+}: ButtonProps & { enableTracksEvent?: boolean } ) => {
 	const { __ } = useI18n();
 	const stepContext = useStepContainerV2Context();
 
@@ -21,7 +21,7 @@ export const BackButton = ( {
 		icon: chevronLeft,
 	} );
 
-	const buttonProps = recordTracksEvent
+	const buttonProps = enableTracksEvent
 		? decorateButtonWithTracksEventRecording( backButtonProps, {
 				tracksEventName: 'calypso_signup_previous_step_button_click',
 				stepContext,

--- a/packages/onboarding/src/step-container-v2/components/buttons/BackButton/BackButton.tsx
+++ b/packages/onboarding/src/step-container-v2/components/buttons/BackButton/BackButton.tsx
@@ -8,7 +8,10 @@ import { ButtonProps } from '../../../types';
 
 import './style.scss';
 
-export const BackButton = ( originalProps: ButtonProps ) => {
+export const BackButton = ( {
+	recordTracksEvent,
+	...originalProps
+}: ButtonProps & { recordTracksEvent?: boolean } ) => {
 	const { __ } = useI18n();
 	const stepContext = useStepContainerV2Context();
 
@@ -18,12 +21,12 @@ export const BackButton = ( originalProps: ButtonProps ) => {
 		icon: chevronLeft,
 	} );
 
-	return (
-		<Button
-			{ ...decorateButtonWithTracksEventRecording( backButtonProps, {
+	const buttonProps = recordTracksEvent
+		? decorateButtonWithTracksEventRecording( backButtonProps, {
 				tracksEventName: 'calypso_signup_previous_step_button_click',
 				stepContext,
-			} ) }
-		/>
-	);
+		  } )
+		: backButtonProps;
+
+	return <Button { ...buttonProps } />;
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/102301.

## Proposed Changes

* Splits the `UnifiedDesignPickerPreview` component out of the giant `UnifiedDesignPickerStep` component
* Removes `shouldHideActionButtons` from the unified design picker component
  * The action buttons in the floating toolbars should always be shown
* Ensures that the sticky bottom bar navigates using the design picker's internal navigation system

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Issue with mobile navigation through the design picker discovered during CfT
pdtkmj-3xe-p2#comment-6772

In the theme preview step on themes without global styles, there should be a navigation header at the top. This PR ensures there's the standard `<TopBar>` in that situation.

But more than that, the sticky bottom bar wasn't plugged in to the design picker's internal navigation system. Which navigates between pages of the design picker without adjusting the URL (so it's disconnected from the usual stepper related navigation).

This resulted in an unfortunately large refactor, and the design picker's navigation mechanism needing to be exposed through a ref https://github.com/Automattic/wp-calypso/pull/102310/files#diff-54190ddf0beadd08aacea4cacaab2a12b490a5e38df6fda709fc4d9fec213f67R13 so the sticky footer could access the navigation functions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


https://github.com/user-attachments/assets/84985150-c645-4916-8975-ba6c4e7d4825


https://github.com/user-attachments/assets/d86fc807-d674-43b8-9b11-8267ab42d412


* This can be tested on `calypso.live` ([see the link below](https://github.com/Automattic/wp-calypso/pull/102310#issuecomment-2770933343)) but because of the transition between the `onboarding` flow and `site-setup` flow you have to do a little fiddling to disable the `onboarding/step-container-v2` flag (which is what users currently see in production). 
* The StepContainerV2 changes are enabled by default on `calypso.live`.
* If you want to test _without_ StepContainerV2, then you can go through the onboarding flow as usual, then **when you land on the design picker step**, append `&flags=-onboarding/setup-container-v2` to the URL and reload the page.


There are a number of flows to check. These flows should be tested with:
- mobile layout and the `onboarding/step-container-v2` flag set (the default in local dev)
- desktop layout and `onboarding/step-container-v2` set
- mobile layout and `onboarding/step-container-v2` **unset**
- desktop layout and `onboarding/step-container-v2` **unset**

Navigation should work similarly in all these situations.

All flows to check start at `/setup/site-setup/design-setup?siteSlug=%s`. The flows to check are:

| On plans step | On design picker | In design preview | Mobile ✅ w/ flag | Desktop ✅ w/ flag | Mobile ✅ w/o flag | Desktop ✅ w/o flag |
| --- | --- | --- | --- | --- | --- | --- |
| Free | Free theme | Free style variation | ✅ | ✅ | ✅ | ✅ |
| Free | Twenty Twenty-Five | Premium style variation |  ✅ | ✅ |  | ✅ |
| Free | Memphoria | Any style variation | ✅ |  ✅ | ✅ | ✅ |
| Free | Dropp | Make no style changes | ✅ |  ✅ |  | ✅ |
| Free | Dropp | Change font or color, use the save button | ✅ | ✅  |  | ✅ |
| Free | Dropp | Change font or color, use the back button | ✅ |  N/A | ✅ | N/A |
| Free | Chrono (under store designs) | Unlock | ✅ | ✅  | ✅ | ✅ |
| Premium | Free theme | Free style variation | ✅ | ✅  |  | ✅ |
| Premium | Twenty Twenty-Five | Premium style variation | ✅ | ✅   |  | ✅ |
| Premium | Memphoria | Any style variation | ✅ |  ✅ | ✅ | ✅ |
| Premium | Dropp | Make no style changes | ✅ | ✅  |  | ✅ |
| Premium | Dropp | Change font or color, use the save button | ✅ | ✅  |  | ✅ |
| Premium | Dropp | Change font or color, use the back button | ✅ | N/A |  | N/A |
| Business | Chrono (under store designs) | Unlock |   ✅ | ✅  | ✅ | ✅ |



In all of these flows, try using Back to navigate around the design picker/previewer states

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?