### PR TITLE
Prevent tracks for firing on launchpad step under certain conditions

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -4,6 +4,8 @@ import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import {
@@ -12,6 +14,7 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useExitFlow } from '../../../hooks/use-exit-flow';
 import { useSiteIdParam } from '../../../hooks/use-site-id-param';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
@@ -36,6 +39,22 @@ const newsletter: Flow = {
 			STEPS.SITE_CREATION_STEP,
 			STEPS.LAUNCHPAD,
 		] );
+	},
+	useTracksEventProps() {
+		const site = useSite();
+		const step = getStepFromURL();
+		if ( site && shouldShowLaunchpadFirst( site ) && step === 'launchpad' ) {
+			//prevent track events from firing until we're sure we won't redirect away from Launchpad
+			return {
+				isLoading: true,
+				eventsProperties: {},
+			};
+		}
+
+		return {
+			isLoading: false,
+			eventsProperties: {},
+		};
 	},
 	useSideEffect() {
 		const { setHidePlansFeatureComparison, setIntent } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/flows/start-writing/start-writing.ts
@@ -11,10 +11,13 @@ import {
 	type Flow,
 	type ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useExitFlow } from '../../../hooks/use-exit-flow';
 import { useSiteData } from '../../../hooks/use-site-data';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
@@ -41,6 +44,22 @@ const startWriting: Flow = {
 			STEPS.SITE_LAUNCH,
 			STEPS.CELEBRATION,
 		] );
+	},
+	useTracksEventProps() {
+		const site = useSite();
+		const step = getStepFromURL();
+		if ( site && shouldShowLaunchpadFirst( site ) && step === 'launchpad' ) {
+			//prevent track events from firing until we're sure we won't redirect away from Launchpad
+			return {
+				isLoading: true,
+				eventsProperties: {},
+			};
+		}
+
+		return {
+			isLoading: false,
+			eventsProperties: {},
+		};
 	},
 
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/flows/update-design/update-design.ts
+++ b/client/landing/stepper/declarative-flow/flows/update-design/update-design.ts
@@ -3,11 +3,14 @@ import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useQuery } from '../../../hooks/use-query';
 import { useSiteIdParam } from '../../../hooks/use-site-id-param';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
@@ -34,6 +37,23 @@ const updateDesign: Flow = {
 			setIntent( Onboard.SiteIntent.UpdateDesign );
 		}, [] );
 	},
+	useTracksEventProps() {
+		const site = useSite();
+		const step = getStepFromURL();
+		if ( site && shouldShowLaunchpadFirst( site ) && step === 'launchpad' ) {
+			//prevent track events from firing until we're sure we won't redirect away from Launchpad
+			return {
+				isLoading: true,
+				eventsProperties: {},
+			};
+		}
+
+		return {
+			isLoading: false,
+			eventsProperties: {},
+		};
+	},
+
 	useStepNavigation( currentStep, navigate ) {
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();

--- a/client/landing/stepper/declarative-flow/flows/write/write.ts
+++ b/client/landing/stepper/declarative-flow/flows/write/write.ts
@@ -4,8 +4,11 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
+import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { useSiteIdParam } from '../../../hooks/use-site-id-param';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
 import { USER_STORE } from '../../../stores';
@@ -30,7 +33,22 @@ const write: Flow = {
 	useSteps() {
 		return WRITE_FLOW_STEPS;
 	},
+	useTracksEventProps() {
+		const site = useSite();
+		const step = getStepFromURL();
+		if ( site && shouldShowLaunchpadFirst( site ) && step === 'launchpad' ) {
+			//prevent track events from firing until we're sure we won't redirect away from Launchpad
+			return {
+				isLoading: true,
+				eventsProperties: {},
+			};
+		}
 
+		return {
+			isLoading: false,
+			eventsProperties: {},
+		};
+	},
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
 		const siteId = useSiteIdParam();


### PR DESCRIPTION
!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/101706

## Proposed Changes
This PR fixes the issue where events are being recorded for `fullscreen launchpad` even though we are not showing that launchpad. This happens because we fist navigate to the `Launchpad` step before deciding if we should navigate to `/home` to show the focused launchpad.  We have to update multiple flows as launchpad is not apart of the onboarding flow however the onboarding flow hand off to other flows after site setup is completed. 


* use  `useTracksEventProps` to prevent events from firing when `shouldShowLaunchpadFirst` and we are on the launchpad step. This works as we are immediately redirected to home and so events are not registered. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To prevent tracks from being recorded incorrectly. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/onboarding` and go through the flow
* In network tab chose `img` and filter by `calypso_signup_step_start`
* After going through the flow the focused launchpad should be shown in my home and event `calypso_signup_step_start` with `step=launchpad` should not be fired.

**Non onboarding test**
* Go to `/start/free` and go through the flow
* In network tab chose `img` and filter by `calypso_signup_step_start`
* Verify you see the fullscreen launchpad
* Verify `calypso_signup_step_start` with `step=launchpad`  is fired

**Network tab**
![image](https://github.com/user-attachments/assets/aaa73f2f-44d7-4afb-9343-6b834a8bcd7d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?