### PR TITLE
Stats: Remove feature flag stats/empty-module-traffic

### DIFF
--- a/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
+++ b/client/my-sites/stats/features/modules/stats-authors/stats-authors.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { blockPostAuthor } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -93,7 +92,7 @@ const StatAuthors: React.FC< StatsDefaultModuleProps > = ( {
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ translate( 'Authors' ) }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { customLink } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -98,7 +97,7 @@ const StatsClicks: React.FC< StatsDefaultModuleProps > = ( {
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ translate( 'Clicks' ) }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
+++ b/client/my-sites/stats/features/modules/stats-clicks/stats-clicks.tsx
@@ -98,7 +98,7 @@ const StatsClicks: React.FC< StatsDefaultModuleProps > = ( {
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) } // when removing stats/empty-module-traffic add this to the root of the card
+					className={ clsx( 'stats-card--empty-variant', className ) }
 					title={ translate( 'Clicks' ) }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
+++ b/client/my-sites/stats/features/modules/stats-comments/stats-comments.tsx
@@ -163,7 +163,7 @@ const StatsComments: React.FC< StatsDefaultModuleProps > = ( { className } ) => 
 			{ ! isRequestingData && ! hasPosts && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ moduleTitle }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices-wrapper.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices-wrapper.tsx
@@ -1,11 +1,8 @@
-import config from '@automattic/calypso-config';
-import { StatsCard } from '@automattic/components';
 import clsx from 'clsx';
 import { STATS_TYPE_DEVICE_STATS } from 'calypso/my-sites/stats/constants';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { default as usePlanUsageQuery } from '../../../hooks/use-plan-usage-query';
 import useStatsPurchases from '../../../hooks/use-stats-purchases';
-import StatsModulePlaceholder from '../../../stats-module/placeholder';
 import statsStrings from '../../../stats-strings';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsModuleDevices from './stats-module-devices';
@@ -21,7 +18,6 @@ const StatsModuleDevicesWrapper: React.FC< StatsAdvancedModuleWrapperProps > = (
 	query,
 	className,
 } ) => {
-	const isNewEmptyStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 	const { devices: devicesStrings } = statsStrings();
 	const shouldGateStats = useShouldGateStats( STATS_TYPE_DEVICE_STATS );
 
@@ -41,22 +37,13 @@ const StatsModuleDevicesWrapper: React.FC< StatsAdvancedModuleWrapperProps > = (
 
 	return (
 		<>
-			{ isFetching && isNewEmptyStateEnabled && (
+			{ isFetching && (
 				<StatsCardSkeleton
 					isLoading={ isFetching }
 					className={ className }
 					title={ devicesStrings?.title }
 					type={ 1 }
 				/>
-			) }
-			{ isFetching && ! isNewEmptyStateEnabled && (
-				<StatsCard
-					title={ devicesStrings.title }
-					className={ clsx( className, DEVICES_CLASS_NAME, 'stats-module__card', 'devices' ) }
-					isNew
-				>
-					<StatsModulePlaceholder isLoading />
-				</StatsCard>
 			) }
 			{ ! isFetching && ! isAdvancedFeatureEnabled && (
 				<StatsModuleUpgradeOverlay className={ className } siteId={ siteId } />

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-devices.tsx
@@ -103,7 +103,6 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isNewEmptyStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 
 	const optionLabels = {
 		[ OPTION_KEYS.SIZE ]: {
@@ -179,45 +178,40 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 
 	return (
 		<>
-			{ isNewEmptyStateEnabled && (
-				<>
-					{ showLoader && (
-						<StatsCardSkeleton
-							isLoading={ isFetching }
-							className={ className }
-							title={ devicesStrings.title }
-							type={ 3 }
-						/>
-					) }
-					{ ! showLoader &&
-						! data?.length && ( // no data and new empty state enabled
-							<StatsCard
-								className={ className }
-								title={ devicesStrings.title }
-								titleNodes={ <StatsInfoArea isNew /> }
-								isEmpty
-								emptyMessage={
-									<EmptyModuleCard
-										icon={ mobile }
-										description={ translate(
-											'The {{link}}devices and browsers{{/link}} your visitors use to access your site will display here.',
-											{
-												comment: '{{link}} links to support documentation.',
-												components: {
-													link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
-												},
-												context: 'Stats: Info box label when the Devices module is empty',
-											}
-										) }
-									/>
-								}
-							/>
-						) }
-				</>
+			{ showLoader && (
+				<StatsCardSkeleton
+					isLoading={ isFetching }
+					className={ className }
+					title={ devicesStrings.title }
+					type={ 3 }
+				/>
 			) }
+			{ ! showLoader &&
+				! data?.length && ( // no data and new empty state enabled
+					<StatsCard
+						className={ className }
+						title={ devicesStrings.title }
+						titleNodes={ <StatsInfoArea isNew /> }
+						isEmpty
+						emptyMessage={
+							<EmptyModuleCard
+								icon={ mobile }
+								description={ translate(
+									'The {{link}}devices and browsers{{/link}} your visitors use to access your site will display here.',
+									{
+										comment: '{{link}} links to support documentation.',
+										components: {
+											link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
+										},
+										context: 'Stats: Info box label when the Devices module is empty',
+									}
+								) }
+							/>
+						}
+					/>
+				) }
 
-			{ ( ! isNewEmptyStateEnabled ||
-				( isNewEmptyStateEnabled && ! showLoader && !! data?.length ) ) && (
+			{ ! showLoader && !! data?.length && (
 				<>
 					{
 						// Use dedicated StatsCard for the screen size chart section.
@@ -234,35 +228,24 @@ const StatsModuleDevices: React.FC< StatsModuleDevicesProps > = ( {
 								isEmpty={ ! showLoader && ( ! chartData || ! chartData.length ) }
 								emptyMessage={ devicesStrings.empty }
 							>
-								{ /* Remove StatsModulePlaceholder component and showLoader check when clearing `stats/empty-module-traffic` feature flag */ }
-								{ showLoader ? (
-									<StatsModulePlaceholder isLoading={ showLoader } />
-								) : (
-									<div className="stats-card--body__chart">
-										<PieChart
-											data={ chartData }
-											startAngle={ 0 }
-											svgSize={ 224 }
-											donut
-											hasTooltip
-										/>
-										<PieChartLegend
-											data={ chartData }
-											onlyPercent
-											svgElement={
-												<svg
-													width="15"
-													height="14"
-													viewBox="0 0 15 14"
-													fill="none"
-													xmlns="http://www.w3.org/2000/svg"
-												>
-													<rect x="0.5" width="14" height="14" rx="3" />
-												</svg>
-											}
-										/>
-									</div>
-								) }
+								<div className="stats-card--body__chart">
+									<PieChart data={ chartData } startAngle={ 0 } svgSize={ 224 } donut hasTooltip />
+									<PieChartLegend
+										data={ chartData }
+										onlyPercent
+										svgElement={
+											<svg
+												width="15"
+												height="14"
+												viewBox="0 0 15 14"
+												fill="none"
+												xmlns="http://www.w3.org/2000/svg"
+											>
+												<rect x="0.5" width="14" height="14" rx="3" />
+											</svg>
+										}
+									/>
+								</div>
 							</StatsCard>
 						) : (
 							// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.

--- a/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
+++ b/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
@@ -95,7 +95,7 @@ const StatsDownloads: React.FC< StatsDefaultModuleProps > = ( {
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) } // when removing stats/empty-module-traffic add this to the root of the card
+					className={ clsx( 'stats-card--empty-variant', className ) }
 					title={ moduleStrings.title }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
+++ b/client/my-sites/stats/features/modules/stats-downloads/stats-downloads.tsx
@@ -1,7 +1,6 @@
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { download } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -95,7 +94,7 @@ const StatsDownloads: React.FC< StatsDefaultModuleProps > = ( {
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ moduleStrings.title }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { mail } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
-import clsx from 'clsx';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -139,7 +138,7 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 			) }
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ translate( 'Emails' ) }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { megaphone } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -113,7 +112,7 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 			{ presentEmptyUI && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ moduleStrings.title }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
+++ b/client/my-sites/stats/features/modules/stats-referrers/stats-referrers.tsx
@@ -113,7 +113,7 @@ const StatsReferrers: React.FC< StatsDefaultModuleProps > = ( {
 			{ presentEmptyUI && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) } // when removing stats/empty-module-traffic add this to the root of the card
+					className={ clsx( 'stats-card--empty-variant', className ) }
 					title={ moduleStrings.title }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
+++ b/client/my-sites/stats/features/modules/stats-search/stats-search.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { search } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -89,7 +88,7 @@ const StatSearch: React.FC< StatsDefaultModuleProps > = ( {
 			) }
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ translate( 'Search' ) }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-shares/stats-shares.tsx
+++ b/client/my-sites/stats/features/modules/stats-shares/stats-shares.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { share } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -138,7 +137,7 @@ const StatShares: React.FC< StatSharesProps > = ( { siteId, className } ) => {
 			{ isEmptyStateV2 && ! isLoading && ! data?.length && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ title }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -108,7 +108,7 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 			{ presentEmptyUI && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) } // when removing stats/empty-module-traffic add this to the root of the card
+					className={ clsx( 'stats-card--empty-variant', className ) }
 					title={ moduleStrings.title }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
+++ b/client/my-sites/stats/features/modules/stats-top-posts/stats-top-posts.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { postList } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -108,7 +107,7 @@ const StatsTopPosts: React.FC< StatsDefaultModuleProps > = ( {
 			{ presentEmptyUI && (
 				// show empty state
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ moduleStrings.title }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-wrapper.tsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm-wrapper.tsx
@@ -1,12 +1,9 @@
-import config from '@automattic/calypso-config';
-import { StatsCard, StatsCardTitleExtras } from '@automattic/components';
 import clsx from 'clsx';
 import React from 'react';
 import { STATS_FEATURE_UTM_STATS } from 'calypso/my-sites/stats/constants';
 import { useShouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-stats';
 import { default as usePlanUsageQuery } from '../../../hooks/use-plan-usage-query';
 import useStatsPurchases from '../../../hooks/use-stats-purchases';
-import StatsModulePlaceholder from '../../../stats-module/placeholder';
 import statsStrings from '../../../stats-strings';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
 import StatsModuleUTM from './stats-module-utm';
@@ -22,7 +19,6 @@ const StatsModuleUTMWrapper: React.FC< StatsAdvancedModuleWrapperProps > = ( {
 	className,
 	summaryUrl,
 } ) => {
-	const isNewEmptyStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 	const moduleStrings = statsStrings();
 	const shouldGateStats = useShouldGateStats( STATS_FEATURE_UTM_STATS );
 
@@ -44,22 +40,13 @@ const StatsModuleUTMWrapper: React.FC< StatsAdvancedModuleWrapperProps > = ( {
 
 	return (
 		<>
-			{ isFetching && isNewEmptyStateEnabled && (
+			{ isFetching && (
 				<StatsCardSkeleton
 					isLoading={ isFetching }
 					className={ className }
 					title={ moduleStrings?.utm?.title }
 					type={ 3 }
 				/>
-			) }
-			{ isFetching && ! isNewEmptyStateEnabled && (
-				<StatsCard
-					title="UTM"
-					className={ clsx( className, 'stats-module-utm', 'stats-module__card', 'utm' ) }
-					titleNodes={ <StatsCardTitleExtras isNew /> }
-				>
-					<StatsModulePlaceholder isLoading />
-				</StatsCard>
 			) }
 			{ ! isFetching && ! isAdvancedFeatureEnabled && (
 				<StatsModuleUTMOverlay className={ className } siteId={ siteId } />
@@ -72,7 +59,6 @@ const StatsModuleUTMWrapper: React.FC< StatsAdvancedModuleWrapperProps > = ( {
 					moduleStrings={ moduleStrings.utm }
 					period={ period }
 					query={ query }
-					isLoading={ isFetching ?? true } // remove this line when cleaning 'stats/empty-module-traffic' - isFetching will never be true here and loaders are handled inside
 					hideSummaryLink={ hideSummaryLink }
 					postId={ postId }
 					summary={ summary }

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -136,7 +136,7 @@ const StatsModuleUTM = ( {
 			{ ! showLoader &&
 				! data?.length && ( // no data and new empty state enabled
 					<StatsCard
-						className={ clsx( 'stats-card--empty-variant', className ) }
+						className={ className }
 						title={ moduleStrings.title }
 						titleNodes={ <StatsInfoArea isNew /> }
 						isEmpty

--- a/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
+++ b/client/my-sites/stats/features/modules/stats-utm/stats-module-utm.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { trendingUp } from '@wordpress/icons';
@@ -14,7 +13,6 @@ import { JETPACK_SUPPORT_URL_TRAFFIC, UTM_SUPPORT_URL } from '../../../const';
 import useUTMMetricsQuery from '../../../hooks/use-utm-metrics-query';
 import ErrorPanel from '../../../stats-error';
 import StatsListCard from '../../../stats-list/stats-list-card';
-import StatsModulePlaceholder from '../../../stats-module/placeholder';
 import UTMBuilder from '../../../stats-module-utm-builder/';
 import { StatsEmptyActionUTMBuilder } from '../shared';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
@@ -46,7 +44,6 @@ const StatsModuleUTM = ( {
 	postId,
 	summaryUrl,
 } ) => {
-	const isNewEmptyStateEnabled = config.isEnabled( 'stats/empty-module-traffic' );
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const translate = useTranslate();
@@ -128,104 +125,56 @@ const StatsModuleUTM = ( {
 
 	return (
 		<>
-			{ isNewEmptyStateEnabled && (
-				<>
-					{ showLoader && (
-						<StatsCardSkeleton
-							isLoading={ isFetchingUTM }
-							className={ className }
-							title={ moduleStrings.title }
-							type={ 3 }
-						/>
-					) }
-					{ ! showLoader &&
-						! data?.length && ( // no data and new empty state enabled
-							<StatsCard
-								className={ clsx( 'stats-card--empty-variant', className ) }
-								title={ moduleStrings.title }
-								titleNodes={ <StatsInfoArea isNew /> }
-								isEmpty
-								emptyMessage={
-									<EmptyModuleCard
-										icon={ trendingUp }
-										description={ translate(
-											'Your {{link}}campaign UTM performance data{{/link}} will display here once readers click on your URLs with UTM codes. Get started!',
-											{
-												comment: '{{link}} links to support documentation.',
-												components: {
-													link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
-												},
-												context: 'Stats: Info box label when the UTM module is empty',
-											}
-										) }
-										cards={ <UTMBuilder trigger={ <StatsEmptyActionUTMBuilder /> } /> }
-									/>
-								}
-								footerAction={
-									summaryUrl
-										? {
-												url: summaryUrl,
-												label: translate( 'View more' ),
-										  }
-										: undefined
-								}
-							/>
-						) }
-					{ ! showLoader &&
-						!! data?.length && ( // show when new empty state is disabled or data is available
-							<StatsListCard
-								className={ clsx( className, 'stats-module__card', path ) }
-								moduleType={ path }
-								data={ data }
-								useShortLabel={ useShortLabel }
-								title={ moduleStrings?.title }
-								titleNodes={ titleNodes }
-								emptyMessage={ <div>{ moduleStrings.empty }</div> }
-								metricLabel={ metricLabel }
-								downloadCsv={ <UTMExportButton data={ data } path={ path } period={ period } /> }
-								showMore={
-									displaySummaryLink && ! summary
-										? {
-												url: getHref(),
-												label:
-													data.length >= 10
-														? translate( 'View all', {
-																context:
-																	'Stats: Button link to show more detailed stats information',
-														  } )
-														: translate( 'View details', {
-																context:
-																	'Stats: Button label to see the detailed content of a panel',
-														  } ),
-										  }
-										: undefined
-								}
-								error={ hasError && <ErrorPanel /> }
-								splitHeader
-								mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
-								toggleControl={
-									<div className="stats-module__extended-toggle">
-										<UTMBuilder />
-										<UTMDropdown
-											buttonLabel={ optionLabels[ selectedOption ].selectLabel }
-											onSelect={ setSelectedOption }
-											selectOptions={ optionLabels }
-											selected={ selectedOption }
-										/>
-									</div>
-								}
-							/>
-						) }
-				</>
+			{ showLoader && (
+				<StatsCardSkeleton
+					isLoading={ isFetchingUTM }
+					className={ className }
+					title={ moduleStrings.title }
+					type={ 3 }
+				/>
 			) }
-			{ ! isNewEmptyStateEnabled && (
-				<>
+			{ ! showLoader &&
+				! data?.length && ( // no data and new empty state enabled
+					<StatsCard
+						className={ clsx( 'stats-card--empty-variant', className ) }
+						title={ moduleStrings.title }
+						titleNodes={ <StatsInfoArea isNew /> }
+						isEmpty
+						emptyMessage={
+							<EmptyModuleCard
+								icon={ trendingUp }
+								description={ translate(
+									'Your {{link}}campaign UTM performance data{{/link}} will display here once readers click on your URLs with UTM codes. Get started!',
+									{
+										comment: '{{link}} links to support documentation.',
+										components: {
+											link: <a target="_blank" rel="noreferrer" href={ supportUrl } />,
+										},
+										context: 'Stats: Info box label when the UTM module is empty',
+									}
+								) }
+								cards={ <UTMBuilder trigger={ <StatsEmptyActionUTMBuilder /> } /> }
+							/>
+						}
+						footerAction={
+							summaryUrl
+								? {
+										url: summaryUrl,
+										label: translate( 'View more' ),
+								  }
+								: undefined
+						}
+					/>
+				) }
+			{ ! showLoader &&
+				!! data?.length && ( // show when new empty state is disabled or data is available
 					<StatsListCard
 						className={ clsx( className, 'stats-module__card', path ) }
 						moduleType={ path }
 						data={ data }
 						useShortLabel={ useShortLabel }
 						title={ moduleStrings?.title }
+						titleNodes={ titleNodes }
 						emptyMessage={ <div>{ moduleStrings.empty }</div> }
 						metricLabel={ metricLabel }
 						downloadCsv={ <UTMExportButton data={ data } path={ path } period={ period } /> }
@@ -245,7 +194,6 @@ const StatsModuleUTM = ( {
 								: undefined
 						}
 						error={ hasError && <ErrorPanel /> }
-						loader={ showLoader && <StatsModulePlaceholder isLoading={ showLoader } /> }
 						splitHeader
 						mainItemLabel={ optionLabels[ selectedOption ]?.headerLabel }
 						toggleControl={
@@ -260,8 +208,7 @@ const StatsModuleUTM = ( {
 							</div>
 						}
 					/>
-				</>
-			) }
+				) }
 		</>
 	);
 };

--- a/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
+++ b/client/my-sites/stats/features/modules/stats-videos/stats-videos.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { video } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -85,7 +84,7 @@ const StatsVideos: React.FC< StatsDefaultModuleProps > = ( {
 			) }
 			{ ! isRequestingData && ! data?.length && ! shouldGateStatsModule && (
 				<StatsCard
-					className={ clsx( 'stats-card--empty-variant', className ) }
+					className={ className }
 					title={ translate( 'Videos' ) }
 					isEmpty
 					emptyMessage={

--- a/client/my-sites/stats/sections/all-time-views-section/all-time-views-section.tsx
+++ b/client/my-sites/stats/sections/all-time-views-section/all-time-views-section.tsx
@@ -93,7 +93,6 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 				) }
 				{ isEmptyStateV2 && ! isRequestingData && ! hasData && ! shouldGateStats && (
 					<StatsCard
-						className={ clsx( 'stats-card--empty-variant' ) }
 						title={ translate( 'Total views' ) }
 						isEmpty
 						emptyMessage={

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -182,29 +182,6 @@
 	}
 }
 
-// TODO: update when cleaning stats/empty-module-traffic feature flag
-// (stats-card--empty-variant should be added to the root of the card when isEmpty is passed = className shouldn't
-// continue to set it - it's not compatible with footer actions)
-.stats-card--empty-variant {
-	.stats-card--header-and-body {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		flex-grow: 1;
-	}
-
-	.stats-card--footer {
-		margin-top: 2px;
-	}
-
-	.stats-card--body-empty {
-		display: flex;
-		flex: 1 0 auto;
-		align-items: center;
-		justify-content: center;
-	}
-}
-
 .stats-card-avatar {
 	display: flex;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101517

## Proposed Changes

* Remove feature flag `stats/empty-module-traffic`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Maintenance

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure all empty states still work well
* Ensure code changes look okay

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
