### PR TITLE
Remove underlines from sidebar and masterbar submenu links

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -7,6 +7,10 @@ $devdocs-max-width: 720px;
 	padding: 24px;
 }
 
+a:has(.devdocs__title) {
+	text-decoration: none;
+}
+
 .sidebar__separator {
 	margin: 20px 0;
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -679,6 +679,12 @@ body.is-mobile-app-view {
 	}
 }
 
+.masterbar__item-subitems {
+	a {
+		text-decoration: none;
+	}
+}
+
 .masterbar__item-launch-site {
 	gap: 6px;
 	cursor: pointer;
@@ -795,9 +801,6 @@ body.is-mobile-app-view {
 		min-width: 264px !important;
 		padding-top: 12px;
 
-		a {
-			text-decoration: none;
-		}
 
 		@media only screen and (max-width: 781px) {
 			max-height: 100%;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -127,6 +127,7 @@
 	overflow: hidden;
 	display: flex;
 	align-items: center;
+	text-decoration: none;
 
 	&,
 	&:visited {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes a couple of unnecessarily underlined links that popped up as a result of #101358.

## Proposed Changes

* No links inside masterbar submenus should have underlines because in principle they'll always be menu items.
* No sidebar item links should have underlines based on the same principle.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that items inside dropdowns in masterbar don't have underlines, such as:

<img width="186" alt="Screenshot 2025-04-02 at 3 53 58 pm" src="https://github.com/user-attachments/assets/c869d25c-74bf-4259-a214-306e38088305" />

* Check that sidebar in /devdocs page has no underlines:

<img width="338" alt="Screenshot 2025-04-02 at 3 56 14 pm" src="https://github.com/user-attachments/assets/5a06f043-0d7f-4657-bad8-f5a49b66816d" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
