### PR TITLE
Stats: Fixes bar chart traffic stats displays overlapping and incorrect y-axis values

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -152,7 +152,7 @@ function Chart( {
 
 	const ChartYAxis = () => (
 		<div ref={ yAxisRef } className="chart__y-axis">
-			<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
+			<div className="chart__y-axis-width-spacer">{ numberFormat( 1e5 ) }</div>
 			<div className="chart__y-axis-label is-hundred">
 				{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, { decimals: 2 } ) }
 			</div>

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -78,7 +78,7 @@ $y-axis-padding: 0 20px;
 // For forcing the width of y-axis to the width of the label
 // Uses invisible text to establish consistent width while maintaining layout flow
 .chart__y-axis-width-spacer {
-	color: color-mix(in srgb,var(--color-surface) 0,#0000);
+	color: color-mix(in srgb, transparent 100%, var(--color-surface));
 }
 
 // X-axis
@@ -122,7 +122,7 @@ $y-axis-padding: 0 20px;
 // X-axis width spacer
 // Similar to y-axis, creates consistent width spacing using invisible text
 .chart__x-axis-width-spacer {
-	color: color-mix(in srgb,var(--color-surface) 0,#0000);
+	color: color-mix(in srgb, transparent 100%, var(--color-surface));
 	padding: $y-axis-padding;
 	right: 0;
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -77,6 +77,7 @@ $y-axis-padding: 0 20px;
 
 // For forcing the width of y-axis to the width of the label
 .chart__y-axis-width-fix {
+	color: transparent; // Fallback for browsers that don't support color-mix
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 }
 
@@ -119,6 +120,7 @@ $y-axis-padding: 0 20px;
 }
 
 .chart__x-axis-width-spacer {
+	color: transparent; // Fallback for browsers that don't support color-mix
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	padding: $y-axis-padding;
 	right: 0;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -76,6 +76,8 @@ $y-axis-padding: 0 20px;
 }
 
 // For forcing the width of y-axis to the width of the label
+// Uses invisible text to establish consistent width while maintaining layout flow
+// The color property has a fallback for browsers that don't support color-mix
 .chart__y-axis-width-fix {
 	color: transparent; // Fallback for browsers that don't support color-mix
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
@@ -119,6 +121,9 @@ $y-axis-padding: 0 20px;
 	background: var(--color-neutral-60);
 }
 
+// X-axis width spacer
+// Similar to y-axis, creates consistent width spacing using invisible text
+// Uses the same fallback pattern for browser compatibility
 .chart__x-axis-width-spacer {
 	color: transparent; // Fallback for browsers that don't support color-mix
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -77,9 +77,7 @@ $y-axis-padding: 0 20px;
 
 // For forcing the width of y-axis to the width of the label
 // Uses invisible text to establish consistent width while maintaining layout flow
-// The color property has a fallback for browsers that don't support color-mix
 .chart__y-axis-width-spacer {
-	color: transparent; // Fallback for browsers that don't support color-mix
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 }
 
@@ -123,9 +121,7 @@ $y-axis-padding: 0 20px;
 
 // X-axis width spacer
 // Similar to y-axis, creates consistent width spacing using invisible text
-// Uses the same fallback pattern for browser compatibility
 .chart__x-axis-width-spacer {
-	color: transparent; // Fallback for browsers that don't support color-mix
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	padding: $y-axis-padding;
 	right: 0;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -77,7 +77,7 @@ $y-axis-padding: 0 20px;
 
 // For forcing the width of y-axis to the width of the label
 // Uses invisible text to establish consistent width while maintaining layout flow
-.chart__y-axis-width-spacer {
+.chart .chart__y-axis .chart__y-axis-width-spacer {
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 }
 
@@ -121,7 +121,7 @@ $y-axis-padding: 0 20px;
 
 // X-axis width spacer
 // Similar to y-axis, creates consistent width spacing using invisible text
-.chart__x-axis-width-spacer {
+.chart .chart__x-axis .chart__x-axis-width-spacer {
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 	padding: $y-axis-padding;
 	right: 0;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -77,8 +77,8 @@ $y-axis-padding: 0 20px;
 
 // For forcing the width of y-axis to the width of the label
 // Uses invisible text to establish consistent width while maintaining layout flow
-.chart .chart__y-axis .chart__y-axis-width-spacer {
-	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
+.chart__y-axis-width-spacer {
+	color: color-mix(in srgb,var(--color-surface) 0,#0000);
 }
 
 // X-axis
@@ -121,8 +121,8 @@ $y-axis-padding: 0 20px;
 
 // X-axis width spacer
 // Similar to y-axis, creates consistent width spacing using invisible text
-.chart .chart__x-axis .chart__x-axis-width-spacer {
-	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
+.chart__x-axis-width-spacer {
+	color: color-mix(in srgb,var(--color-surface) 0,#0000);
 	padding: $y-axis-padding;
 	right: 0;
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -78,7 +78,7 @@ $y-axis-padding: 0 20px;
 // For forcing the width of y-axis to the width of the label
 // Uses invisible text to establish consistent width while maintaining layout flow
 // The color property has a fallback for browsers that don't support color-mix
-.chart__y-axis-width-fix {
+.chart__y-axis-width-spacer {
 	color: transparent; // Fallback for browsers that don't support color-mix
 	color: color-mix(in srgb, var(--color-surface) 0%, transparent);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR fixes the issue described in #102296 by  flipping the color order in `color-mix()` to `color-mix(in srgb, transparent 100%, var(--color-surface))` to  preserve invisibility and avoid minification issues.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The bar chart (legacy component on the traffic page) uses invisible text elements to set consistent y-axis widths. A recent colour system update in https://github.com/Automattic/wp-calypso/pull/101639 replaced `color: rgba(var(--color-surface-rgb), 0);` with a `color-mix()` version.

However, in production builds only, the minifier dropped the % from 0%, breaking the color-mix syntax and making the text visible. This didn’t affect development (due to minification and dev environment) or line charts (which use a newer component).

This PR fixes it by flipping the color order in `color-mix()` to `color-mix(in srgb, transparent 100%, var(--color-surface))`, which preserves invisibility and avoids minification issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live Link
* Go to Jetpack > Stats
* Ensure Traffic "tab" is selected
* Check that the y-axis no longer shows `100,000` overlapping values

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/8e3cd57d-904f-4363-9f54-87bc788bd65b) | ![image](https://github.com/user-attachments/assets/1dc5beca-09d4-4419-82fe-88b4a9ee899a)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
