### PR TITLE
Fix cropped language search input in Firefox on Account Settings page

### DIFF
--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -55,6 +55,7 @@
 		margin-bottom: 12px;
 
 		.search-component__input[type="search"] {
+			width: 100%;
 			font-size: 0.875rem;
 
 			@include break-small() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101866, https://github.com/Automattic/wp-calypso/issues/102322

## Proposed Changes

This PR fixes the cropped language search input in Firefox on Account Settings page.

| before | after |
|--------|--------|
| <img width="512" alt="426760686-fc0389df-b77b-4ac1-abcf-5c3d60b9c7ef" src="https://github.com/user-attachments/assets/27bd96bf-0690-4e88-b52f-2ee98fd46b82" /> | <img width="518" alt="Screenshot 2025-04-02 at 16 37 32" src="https://github.com/user-attachments/assets/165085e7-4c6e-462e-b374-7cefd1c88285" /> | 

---
Created another existing issue: https://github.com/Automattic/wp-calypso/issues/102322

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The language search input in the Account Settings (/me/account) page is visually cropped in Firefox, making it hard for users to see what they’re typing. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1.	Open the Account Settings page on Firefox: https://wordpress.com/me/account
2.	Click the “Interface language” dropdown.
3.	Observe the search input box.
4. Check on Chrome and Safari

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
