### PR TITLE
Site Visibility: Disable the search engines indexing setting for sites with wpcomstaging.com domain

### DIFF
--- a/client/sites/settings/site/privacy/form.tsx
+++ b/client/sites/settings/site/privacy/form.tsx
@@ -2,6 +2,7 @@ import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products'
 import { FormLabel } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -10,6 +11,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import SitePreviewLinks from 'calypso/components/site-preview-links';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import {
@@ -17,7 +19,10 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import SiteSettingPrivacyNotice from './notice';
+import {
+	SiteSettingPrivacyPremiumStylesNotice,
+	SiteSettingsPrivacyDiscourageSearchEnginesNotice,
+} from './notice';
 import type { Fields } from './index';
 
 interface SiteSettingPrivacyFormProps {
@@ -55,6 +60,9 @@ const SiteSettingPrivacyForm = ( {
 	const hasSitePreviewLink = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS )
 	);
+
+	const primaryDomain = useSelector( ( state ) => getPrimaryDomainBySiteId( state, siteId ) );
+
 	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
 	const blogPublic = Number( fields.blog_public );
@@ -77,7 +85,8 @@ const SiteSettingPrivacyForm = ( {
 
 	const discourageSearchChecked =
 		( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
-		( 0 === blogPublic && ! wpcomPublicComingSoon );
+		( 0 === blogPublic && ! wpcomPublicComingSoon ) ||
+		primaryDomain?.isWpcomStagingDomain;
 
 	const recordEvent = ( message: string ) => {
 		dispatch( recordGoogleEvent( 'Site Settings', message ) );
@@ -103,13 +112,17 @@ const SiteSettingPrivacyForm = ( {
 
 	return (
 		<form>
+			{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 			<FormFieldset>
 				{ ! isNonAtomicJetpackSite &&
 					! isWPForTeamsSite &&
 					! isAtomicAndEditingToolkitDeactivated && (
 						<>
 							{ shouldShowPremiumStylesNotice && (
-								<SiteSettingPrivacyNotice selectedSite={ selectedSite } siteSlug={ siteSlug } />
+								<SiteSettingPrivacyPremiumStylesNotice
+									selectedSite={ selectedSite }
+									siteSlug={ siteSlug }
+								/>
 							) }
 							<FormLabel
 								className={ clsx( 'site-settings__visibility-label is-coming-soon', {
@@ -202,7 +215,8 @@ const SiteSettingPrivacyForm = ( {
 										wpcom_data_sharing_opt_out: true,
 									} )
 								}
-								disabled={ isRequestingSettings }
+								// See https://github.com/Automattic/wp-calypso/issues/101828.
+								disabled={ isRequestingSettings || primaryDomain?.isWpcomStagingDomain }
 								onClick={ () => {
 									recordEvent( 'Clicked Site Visibility Radio Button' );
 								} }
@@ -213,6 +227,12 @@ const SiteSettingPrivacyForm = ( {
 									'This option does not block access to your site — it is up to search engines to honor your request.'
 								) }
 							</FormSettingExplanation>
+							{ primaryDomain?.isWpcomStagingDomain && (
+								<SiteSettingsPrivacyDiscourageSearchEnginesNotice
+									selectedSite={ selectedSite }
+									siteSlug={ siteSlug }
+								/>
+							) }
 						</FormLabel>
 						{ ! isNonAtomicJetpackSite && (
 							<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">

--- a/client/sites/settings/site/privacy/notice.tsx
+++ b/client/sites/settings/site/privacy/notice.tsx
@@ -6,16 +6,44 @@ import {
 	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { SOURCE_SETTINGS_ADMINISTRATION } from 'calypso/my-sites/site-settings/site-tools/utils';
+import { useSelector } from 'calypso/state';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { ReactNode } from 'react';
 
-interface SiteSettingPrivacyNoticeProps {
+interface SiteSettingsAdvancedCustomizationNoticeProps {
+	notice: ReactNode;
+	actions: ReactNode;
+}
+
+const SiteSettingsAdvancedCustomizationNotice = ( {
+	notice,
+	actions,
+}: SiteSettingsAdvancedCustomizationNoticeProps ) => {
+	return (
+		<div className="site-settings__advanced-customization-notice">
+			<div className="site-settings__advanced-customization-notice-cta">
+				<Gridicon icon="info-outline" />
+				{ notice }
+			</div>
+			<div className="site-settings__advanced-customization-notice-buttons">{ actions }</div>
+		</div>
+	);
+};
+
+interface SiteSettingPrivacyPremiumStylesNoticeProps {
 	selectedSite: SiteDetails | null | undefined;
 	siteSlug: string | null;
 }
 
-const SiteSettingPrivacyNotice = ( { selectedSite, siteSlug }: SiteSettingPrivacyNoticeProps ) => {
+export const SiteSettingPrivacyPremiumStylesNotice = ( {
+	selectedSite,
+	siteSlug,
+}: SiteSettingPrivacyPremiumStylesNoticeProps ) => {
 	const translate = useTranslate();
 	// @TODO Cleanup once the test phase is over.
 	const upgradeToPlan = useSiteGlobalStylesOnPersonal( selectedSite?.ID )
@@ -24,22 +52,21 @@ const SiteSettingPrivacyNotice = ( { selectedSite, siteSlug }: SiteSettingPrivac
 	const upgradeUrl = `/plans/${ siteSlug }?plan=${ upgradeToPlan }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
 
 	return (
-		<>
-			<div className="site-settings__advanced-customization-notice">
-				<div className="site-settings__advanced-customization-notice-cta">
-					<Gridicon icon="info-outline" />
-					<span>
-						{ translate(
-							'Your site contains premium styles that will only be visible once you upgrade to a %(planName)s plan.',
-							{
-								args: {
-									planName: getPlan( upgradeToPlan )?.getTitle() ?? '',
-								},
-							}
-						) }
-					</span>
-				</div>
-				<div className="site-settings__advanced-customization-notice-buttons">
+		<SiteSettingsAdvancedCustomizationNotice
+			notice={
+				<span>
+					{ translate(
+						'Your site contains premium styles that will only be visible once you upgrade to a %(planName)s plan.',
+						{
+							args: {
+								planName: getPlan( upgradeToPlan )?.getTitle() ?? '',
+							},
+						}
+					) }
+				</span>
+			}
+			actions={
+				<>
 					{ selectedSite && (
 						<Button href={ selectedSite.URL } target="_blank">
 							{ translate( 'View site' ) }
@@ -56,10 +83,70 @@ const SiteSettingPrivacyNotice = ( { selectedSite, siteSlug }: SiteSettingPrivac
 					>
 						{ translate( 'Upgrade' ) }
 					</Button>
-				</div>
-			</div>
-		</>
+				</>
+			}
+		/>
 	);
 };
 
-export default SiteSettingPrivacyNotice;
+interface SiteSettingsPrivacyDiscourageSearchEnginesNoticeProps {
+	selectedSite: SiteDetails | null | undefined;
+	siteSlug: string;
+}
+
+export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {
+	selectedSite,
+	siteSlug,
+}: SiteSettingsPrivacyDiscourageSearchEnginesNoticeProps ) => {
+	const translate = useTranslate();
+	const hasNonWpcomDomains =
+		useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) || [] ).filter(
+			( domain ) => ! domain.isWPCOMDomain
+		).length > 0;
+
+	return (
+		<SiteSettingsAdvancedCustomizationNotice
+			notice={
+				<span>
+					{ translate(
+						'Your site is using {{strong}}wpcomstaging.com{{/strong}} as the primary domain, which is prevented from being indexed by search engines. To change this, set a custom domain as the primary domain.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</span>
+			}
+			actions={
+				hasNonWpcomDomains ? (
+					<Button
+						className="is-primary"
+						href={ addQueryArgs( `/domains/manage/${ siteSlug }`, {
+							source: SOURCE_SETTINGS_ADMINISTRATION,
+						} ) }
+						onClick={ () =>
+							recordTracksEvent( 'calypso_settings_site_privacy_manage_domains_button_click' )
+						}
+					>
+						{ translate( 'Manage domains' ) }
+					</Button>
+				) : (
+					<Button
+						className="is-primary"
+						href={ addQueryArgs( `/domains/add/${ siteSlug }`, {
+							redirect_to: window.location.pathname,
+						} ) }
+						onClick={ () =>
+							recordTracksEvent( 'calypso_settings_site_privacy_add_domain_button_click' )
+						}
+					>
+						{ translate( 'Add new domain' ) }
+					</Button>
+				)
+			}
+		/>
+	);
+};
+
+// When an AT site is still using the .wpcomstaging.com address, it has a special robots.txt file on it.  Note that wpcomstaging.com domains are prevented from search engine indexing by default.

--- a/client/sites/settings/site/privacy/notice.tsx
+++ b/client/sites/settings/site/privacy/notice.tsx
@@ -91,7 +91,7 @@ export const SiteSettingPrivacyPremiumStylesNotice = ( {
 
 interface SiteSettingsPrivacyDiscourageSearchEnginesNoticeProps {
 	selectedSite: SiteDetails | null | undefined;
-	siteSlug: string;
+	siteSlug: string | null;
 }
 
 export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {

--- a/client/sites/settings/site/privacy/notice.tsx
+++ b/client/sites/settings/site/privacy/notice.tsx
@@ -101,7 +101,7 @@ export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {
 }: SiteSettingsPrivacyDiscourageSearchEnginesNoticeProps ) => {
 	const translate = useTranslate();
 	const primaryDomain = useSelector( ( state ) =>
-		getPrimaryDomainBySiteId( state, selectedSite?.ID )
+		getPrimaryDomainBySiteId( state, selectedSite?.ID ?? 0 )
 	);
 	const hasNonWpcomDomains =
 		useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) || [] ).filter(
@@ -116,7 +116,7 @@ export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {
 						"Your site's current primary domain is {{strong}}%(domain)s{{/strong}}. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please register or connect a custom primary domain.",
 						{
 							args: {
-								domain: primaryDomain?.domain,
+								domain: primaryDomain?.domain ?? '',
 							},
 							components: {
 								strong: <strong style={ { overflowWrap: 'anywhere' } } />,

--- a/client/sites/settings/site/privacy/notice.tsx
+++ b/client/sites/settings/site/privacy/notice.tsx
@@ -155,5 +155,3 @@ export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {
 		/>
 	);
 };
-
-// When an AT site is still using the .wpcomstaging.com address, it has a special robots.txt file on it.  Note that wpcomstaging.com domains are prevented from search engine indexing by default.

--- a/client/sites/settings/site/privacy/notice.tsx
+++ b/client/sites/settings/site/privacy/notice.tsx
@@ -10,6 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { SOURCE_SETTINGS_ADMINISTRATION } from 'calypso/my-sites/site-settings/site-tools/utils';
 import { useSelector } from 'calypso/state';
+import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { useSiteGlobalStylesOnPersonal } from 'calypso/state/sites/hooks/use-site-global-styles-on-personal';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -99,6 +100,9 @@ export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {
 	siteSlug,
 }: SiteSettingsPrivacyDiscourageSearchEnginesNoticeProps ) => {
 	const translate = useTranslate();
+	const primaryDomain = useSelector( ( state ) =>
+		getPrimaryDomainBySiteId( state, selectedSite?.ID )
+	);
 	const hasNonWpcomDomains =
 		useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) || [] ).filter(
 			( domain ) => ! domain.isWPCOMDomain
@@ -109,8 +113,11 @@ export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {
 			notice={
 				<span>
 					{ translate(
-						'Your site is using {{strong}}wpcomstaging.com{{/strong}} as the primary domain, which is prevented from being indexed by search engines. To change this, set a custom domain as the primary domain.',
+						"Your site's current primary domain is {{strong}}%(domain)s{{/strong}}. This domain is intended for temporary use and will not be indexed by search engines. To ensure your site can be indexed, please register or connect a custom primary domain.",
 						{
+							args: {
+								domain: primaryDomain?.domain,
+							},
 							components: {
 								strong: <strong />,
 							},

--- a/client/sites/settings/site/privacy/notice.tsx
+++ b/client/sites/settings/site/privacy/notice.tsx
@@ -119,7 +119,7 @@ export const SiteSettingsPrivacyDiscourageSearchEnginesNotice = ( {
 								domain: primaryDomain?.domain,
 							},
 							components: {
-								strong: <strong />,
+								strong: <strong style={ { overflowWrap: 'anywhere' } } />,
 							},
 						}
 					) }

--- a/client/sites/settings/site/privacy/style.scss
+++ b/client/sites/settings/site/privacy/style.scss
@@ -21,10 +21,19 @@
 	background-color: var(--color-neutral-0);
 	align-items: center;
 	justify-content: space-between;
+	font-weight: normal;
+
+	&:last-child {
+		margin-top: 15px;
+	}
 
 	.site-settings__advanced-customization-notice-cta {
 		display: flex;
 		align-items: center;
+
+		svg {
+			flex-shrink: 0;
+		}
 	}
 
 	svg.gridicon.gridicons-info-outline {
@@ -34,12 +43,9 @@
 
 	.site-settings__advanced-customization-notice-buttons {
 		display: flex;
+		gap: 5px;
+		flex-shrink: 0;
 		padding-top: 10px;
-		min-width: 185px;
-
-		.button.is-primary {
-			margin-left: 5px;
-		}
 	}
 
 	@include break-xlarge {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101828

## Proposed Changes

* Disable the search engines indexing setting for sites with wpcomstaging.com domain
* Display the notice to explain the reason and allow users to manage their domains

![image](https://github.com/user-attachments/assets/9108c177-cfe2-42fc-b041-99746b657567)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The `wpcomstaging.com` domains are prevented from search engine indexing by default.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Hosting Overview on your site with the `wpcomstaging.com` domain
* Ensure the “Discourage search engines from indexing this site” setting is disabled
* Ensure you can see the notice
  ![image](https://github.com/user-attachments/assets/629785d7-4ade-45aa-b67f-6fd15bad34e5)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
