### PR TITLE
Support Content Footer: Use a different copy if on /support

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -11,6 +11,8 @@ if ( ! isset( $args ) ) {
 	$args = array();
 }
 
+$site_type = isset( $args['site_type'] ) ? $args['site_type'] : '';
+
 //phpcs:ignore WPCOM.I18nRules.LocalizedUrl.LocalizedUrlAssignedToVariable
 $subscribe_block = '[wpcom_guides_learn_button is_unsubscribed_caption="' . __( 'Subscribe now!', 'happy-blocks' ) . '" is_subscribed_caption="' . __( 'Unsubscribe', 'happy-blocks' ) . '" busy_caption="' . __( 'Just a moment...', 'happy-blocks' ) . '"]';
 $signup_url      = localized_wpcom_url( 'https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2Flearn%23support-content-subscribe' );
@@ -44,19 +46,35 @@ $signup_url      = localized_wpcom_url( 'https://wordpress.com/log-in?redirect_t
 				</a>
 			</div>
 		</div>
-		<div class="support-content-resource">
-			<h4 class="support-content-resource__title">
-				<?php esc_html_e( 'Check our guides', 'happy-blocks' ); ?>
-			</h4>
-			<p>
-				<?php esc_html_e( 'Find and follow step-by-step guides for every WordPress.com question.', 'happy-blocks' ); ?>
-			</p>
-			<div class="resource-link">
-				<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>">
-					<?php esc_html_e( 'Visit support guides', 'happy-blocks' ); ?>
-				</a>
+		<?php if ( $site_type === 'support' ) : ?>
+			<div class="support-content-resource">
+				<h4 class="support-content-resource__title">
+					<?php esc_html_e( 'Check our guides', 'happy-blocks' ); ?>
+				</h4>
+				<p>
+					<?php esc_html_e( 'Find and follow step-by-step guides for every WordPress.com question.', 'happy-blocks' ); ?>
+				</p>
+				<div class="resource-link">
+					<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>">
+						<?php esc_html_e( 'Visit support guides', 'happy-blocks' ); ?>
+					</a>
+				</div>
 			</div>
-		</div>
+		<?php else : ?>
+			<div class="support-content-resource">
+				<h4 class="support-content-resource__title">
+					<?php esc_html_e( 'Watch a course', 'happy-blocks' ); ?>
+				</h4>
+				<p>
+					<?php esc_html_e( 'Learn how to create a website with our step-by-step video course.', 'happy-blocks' ); ?>
+				</p>
+				<div class="resource-link">
+					<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/courses/create-your-website/' ) ); ?>">
+						<?php esc_html_e( 'Create your website', 'happy-blocks' ); ?>
+					</a>
+				</div>
+			</div>
+		<?php endif; ?>
 	</div>
 	<div class="support-content-links-subscribe">
 		<?php


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 156174-ghe-Automattic/wpcom-a8c-themes

## Proposed Changes

### Before

![image](https://github.com/user-attachments/assets/c0aa0da2-435c-4f1e-934c-84f91ebd1da2)

### After

![image](https://github.com/user-attachments/assets/0ff1ad19-cd1c-4f4c-834f-2ceb7cce45a5)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use 156174-ghe-Automattic/wpcom-a8c-themes
* Sandbox Support
* Go on /support and check the change