### PR TITLE
Revert "Add: Back button to the goals capture screen."

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -514,8 +514,6 @@ const siteSetupFlow: Flow = {
 
 		const goBack = () => {
 			switch ( currentStep ) {
-				case 'goals':
-					return history.back();
 				case 'bloggerStartingPoint':
 					return navigate( 'options' );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -16,7 +16,7 @@ import {
 	isHostedSiteMigrationFlow,
 	Step,
 } from '@automattic/onboarding';
-import { useDispatch, useSelect, resolveSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -34,7 +34,6 @@ import {
 import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
-import { SITE_STORE } from '../../../../stores';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -145,9 +144,9 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const shouldGoToCheckout = Boolean( planCartItem );
 
 	async function createSite() {
-		const slug = getSignupCompleteSlug();
-		const siteObj = await resolveSelect( SITE_STORE ).getSite?.( slug );
-		if ( isManageSiteFlow || ( slug && siteObj?.plan?.is_free ) ) {
+		if ( isManageSiteFlow ) {
+			const slug = getSignupCompleteSlug();
+
 			if ( planCartItem && slug ) {
 				await addPlanToCart( slug, flow, true, theme, planCartItem );
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals-capture-container.tsx
@@ -9,8 +9,6 @@ type GoalsCaptureContainerProps = {
 	stepName: string;
 	onSkip(): void;
 	goNext: NavigationControls[ 'goNext' ];
-	goBack: NavigationControls[ 'goBack' ];
-	hideBack?: boolean;
 	nextLabelText: string;
 	skipLabelText: string;
 	stepContent: React.ReactElement;
@@ -28,6 +26,7 @@ export const GoalsCaptureContainer: React.FC< GoalsCaptureContainerProps > = ( {
 		<StepContainer
 			{ ...otherProps }
 			isHorizontalLayout={ false }
+			hideBack
 			hideSkip={ false }
 			hideNext={ isMediumOrBiggerScreen }
 			formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/index.tsx
@@ -10,7 +10,6 @@ import { isGoalsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getQueryArgs } from 'calypso/lib/query-args';
-import { useSiteData } from '../../../../hooks/use-site-data';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { useCreateCourseGoalFeature } from '../../hooks/use-create-course-goal-feature';
 import DashboardIcon from './dashboard-icon';
@@ -189,7 +188,6 @@ const GoalsStep: StepType< {
 	);
 
 	const isMediumOrBiggerScreen = useViewportMatch( 'small', '>=' );
-	const { site } = useSiteData();
 
 	const getStep = () => {
 		if ( shouldUseStepContainerV2( flow ) ) {
@@ -199,14 +197,7 @@ const GoalsStep: StepType< {
 				<Step.CenteredColumnLayout
 					columnWidth={ 6 }
 					className="step-container-v2--goals"
-					topBar={
-						<Step.TopBar
-							rightElement={ <Step.SkipButton onClick={ handleSkip } /> }
-							leftElement={
-								site?.plan?.is_free ? <Step.BackButton onClick={ navigation.goBack } /> : undefined
-							}
-						/>
-					}
+					topBar={ <Step.TopBar rightElement={ <Step.SkipButton onClick={ handleSkip } /> } /> }
 					heading={ <Step.Heading text={ whatAreYourGoalsText } subText={ subHeaderText } /> }
 					stickyBottomBar={ <Step.StickyBottomBar rightElement={ nextButton } /> }
 				>
@@ -225,8 +216,6 @@ const GoalsStep: StepType< {
 				nextLabelText={ translate( 'Next' ) }
 				skipLabelText={ translate( 'Skip' ) }
 				recordTracksEvent={ recordTracksEvent }
-				goBack={ navigation.goBack }
-				hideBack={ ! site?.plan?.is_free }
 				stepContent={ getStepContent(
 					isMediumOrBiggerScreen && (
 						<Button


### PR DESCRIPTION
Reverts Automattic/wp-calypso#101322. Closes https://github.com/Automattic/wp-calypso/issues/102314.

It seems the back button may not be behaving as expected on some flows.
Reverting so we can debug this with more time.