### PR TITLE
Site Migration: Improve site-migration flow definition

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -8,7 +8,7 @@ import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-tri
 import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
-//TODO: Move to the a shared place
+//TODO: Move to a shared place
 import { getSiteIdParam } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import { type SiteMigrationIdentifyAction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify';
 import { AssertConditionState } from 'calypso/landing/stepper/declarative-flow/internals/types';

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -21,7 +21,7 @@ import { USER_STORE, SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/s
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
-//TODO: Move to the a shared place
+//TODO: Move to a shared place
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -5,28 +5,56 @@ import { SiteExcerptData } from '@automattic/sites';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
+import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
+import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
+//TODO: Move to the a shared place
+import { getSiteIdParam } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
+import { type SiteMigrationIdentifyAction } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify';
+import { AssertConditionState } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { goToImporter } from 'calypso/landing/stepper/declarative-flow/migration/helpers';
+import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { USER_STORE, SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
+//TODO: Move to the a shared place
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
-import { HOW_TO_MIGRATE_OPTIONS } from '../../../constants';
-import { useIsSiteAdmin } from '../../../hooks/use-is-site-admin';
-import { useSiteData } from '../../../hooks/use-site-data';
-import { useSiteSlugParam } from '../../../hooks/use-site-slug-param';
-import { USER_STORE, SITE_STORE, ONBOARD_STORE } from '../../../stores';
-import { goToCheckout } from '../../../utils/checkout';
-import { STEPS } from '../../internals/steps';
-import { getSiteIdParam } from '../../internals/steps-repository/import/util';
-import { type SiteMigrationIdentifyAction } from '../../internals/steps-repository/site-migration-identify';
-import { AssertConditionState } from '../../internals/types';
-import { goToImporter } from '../../migration/helpers';
-import type { AssertConditionResult, Flow, ProvidedDependencies } from '../../internals/types';
+import type {
+	AssertConditionResult,
+	FlowV2,
+	ProvidedDependencies,
+} from 'calypso/landing/stepper/declarative-flow/internals/types';
 
-const siteMigration: Flow = {
+const BASE_STEPS = [
+	STEPS.SITE_MIGRATION_IDENTIFY,
+	STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
+	STEPS.SITE_MIGRATION_HOW_TO_MIGRATE,
+	STEPS.SITE_MIGRATION_UPGRADE_PLAN,
+	STEPS.SITE_MIGRATION_INSTRUCTIONS,
+	STEPS.ERROR,
+	STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS,
+	STEPS.SITE_MIGRATION_CREDENTIALS,
+	STEPS.SITE_MIGRATION_ALREADY_WPCOM,
+	STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT,
+	STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION,
+	STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
+];
+
+const HOSTED_VARIANT_STEPS = [
+	...BASE_STEPS,
+	STEPS.PICK_SITE,
+	STEPS.SITE_CREATION_STEP,
+	STEPS.PROCESSING,
+];
+
+const siteMigration: FlowV2 = {
 	name: SITE_MIGRATION_FLOW,
 	isSignupFlow: false,
 	__experimentalUseSessions: true,
@@ -47,27 +75,12 @@ const siteMigration: Flow = {
 		}
 	},
 
-	useSteps() {
-		const baseSteps = [
-			STEPS.SITE_MIGRATION_IDENTIFY,
-			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
-			STEPS.SITE_MIGRATION_HOW_TO_MIGRATE,
-			STEPS.SITE_MIGRATION_UPGRADE_PLAN,
-			STEPS.SITE_MIGRATION_INSTRUCTIONS,
-			STEPS.ERROR,
-			STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS,
-			STEPS.SITE_MIGRATION_CREDENTIALS,
-			STEPS.SITE_MIGRATION_ALREADY_WPCOM,
-			STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT,
-			STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION,
-			STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS,
-		];
+	initialize() {
+		if ( isHostedSiteMigrationFlow( this.variantSlug ?? SITE_MIGRATION_FLOW ) ) {
+			return stepsWithRequiredLogin( HOSTED_VARIANT_STEPS );
+		}
 
-		const hostedVariantSteps = isHostedSiteMigrationFlow( this.variantSlug ?? SITE_MIGRATION_FLOW )
-			? [ STEPS.PICK_SITE, STEPS.SITE_CREATION_STEP, STEPS.PROCESSING ]
-			: [];
-
-		return stepsWithRequiredLogin( [ ...baseSteps, ...hostedVariantSteps ] );
+		return stepsWithRequiredLogin( BASE_STEPS );
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -6,18 +6,22 @@ import { isCurrentUserLoggedIn } from '@automattic/data-stores/src/user/selector
 import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { HOSTING_INTENT_MIGRATE } from 'calypso/data/hosting/use-add-hosting-trial-mutation';
+import { HOW_TO_MIGRATE_OPTIONS } from 'calypso/landing/stepper/constants';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
+import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
+import {
+	getAssertionConditionResult,
+	renderFlow,
+	runFlowNavigation,
+} from 'calypso/landing/stepper/declarative-flow/test/helpers';
 import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
+import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
-import { HOW_TO_MIGRATE_OPTIONS } from '../../constants';
-import { goToCheckout } from '../../utils/checkout';
-import siteMigrationFlow from '../flows/site-migration-flow/site-migration-flow';
-import { STEPS } from '../internals/steps';
-import { getAssertionConditionResult, renderFlow, runFlowNavigation } from './helpers';
+import siteMigrationFlow from '../site-migration-flow';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
 
-jest.mock( '../../utils/checkout' );
+jest.mock( 'calypso/landing/stepper/utils/checkout' );
 jest.mock( '@automattic/data-stores/src/user/selectors' );
 jest.mock( 'calypso/landing/stepper/hooks/use-is-site-admin' );
 jest.mock( 'calypso/lib/guides/trigger-guides-for-step', () => ( {


### PR DESCRIPTION
Related to DOTOBRD-79

## Proposed Changes
* Replace useSteps by initialize method
* Update all imports to use package-based (absolute) path instead of file file-based
* Move the steps definition to a const to avoid redefinition. 
* Move the test file to the same migration flow folder. 

> [!WARNING]
> There are more changes, but I would like to have it small to avoid major conflicts


## Why are these changes being made?
* It makes the code easy to support further evolutions.

## Testing Instructions
* Go to /setup/hosted-site-migration
* Randomly advance over the flow; the step should continue loading properly.

No visual change or behavior change is expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
