### PR TITLE
TimeSince: Localize the Date Time Format

### DIFF
--- a/packages/components/src/time-since/index.tsx
+++ b/packages/components/src/time-since/index.tsx
@@ -5,6 +5,7 @@ interface TimeSinceProps {
 	date: string;
 	dateFormat?: string;
 	className?: string;
+	locale?: string;
 }
 
 /**
@@ -63,14 +64,14 @@ function useRelativeTime( date: string, dateFormat = 'll' ) {
 		}
 
 		// For older dates, use the date format
-		return formatDate( dateObj, dateFormat );
+		return formatDate( dateObj, dateFormat, translate.localeSlug );
 	}, [ now, date, dateFormat, translate ] );
 }
 
 /**
  * Format a date using Intl.DateTimeFormat
  */
-function formatDate( date: Date, format: string ): string {
+function formatDate( date: Date, format: string, locale?: string ): string {
 	if ( ! date || isNaN( date.getTime() ) ) {
 		return '';
 	}
@@ -93,12 +94,13 @@ function formatDate( date: Date, format: string ): string {
 		formatOptions.timeStyle = 'medium';
 	}
 
-	return new Intl.DateTimeFormat( undefined, formatOptions ).format( date );
+	return new Intl.DateTimeFormat( locale, formatOptions ).format( date );
 }
 
 function TimeSince( { className, date, dateFormat = 'll' }: TimeSinceProps ) {
+	const translate = useTranslate();
 	const humanDate = useRelativeTime( date, dateFormat );
-	const fullDate = formatDate( new Date( date ), 'llll' );
+	const fullDate = formatDate( new Date( date ), 'llll', translate.localeSlug );
 
 	return (
 		<time className={ className } dateTime={ date } title={ fullDate }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 971-gh-Automattic/i18n-issues

## Proposed Changes

* Update the `<TimeSince  />` component to read the locale from `i18n-calypso` and pass it to the `Intl.DateTimeFormat` constructor.

| Before | After |
| - | - |
| ![OkXxxgOAxkwJx4gM](https://github.com/user-attachments/assets/d6fa0a0f-0379-4fe0-b79c-73011e41ce3c) | ![S2u4XANaCP3uYrb9](https://github.com/user-attachments/assets/8a691c57-5d98-40a5-9d0e-bb79245148b0) |



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The dates should be localized in the current user locale for consistency with the rest of the UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change Calypso UI to a Mag-16 language, for example German.
* Navigate to `/sites`.
* Confirm the dates in the Sites grid are formatted accordingly with the selected language.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
