### PR TITLE
Signup: Fix 2FA accounts during signup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
@@ -3,8 +3,9 @@ import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 import type { AccountCreateReturn, SocialAuthParams } from 'calypso/lib/signup/api/type';
-
 type Props = {
 	error: ( Error & AccountCreateReturn ) | null;
 	recentSocialAuthAttemptParams?: SocialAuthParams;
@@ -12,6 +13,7 @@ type Props = {
 
 export function useErrorNotice( { error: errorResponse, recentSocialAuthAttemptParams }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const loginLink = login( {
 		signupUrl: window.location.pathname + window.location.search,
 		redirectTo: window.location.pathname + window.location.search,
@@ -57,24 +59,28 @@ export function useErrorNotice( { error: errorResponse, recentSocialAuthAttemptP
 					className="signup-form__notice signup-form__span-columns"
 					showDismiss={ false }
 					status="is-transparent-info"
-					text={ translate(
-						'This social account is linked to a WordPress.com account with two-factor authentication. ' +
-							'{{a}}Sign in to continue{{/a}}, or choose a different signup method.',
-						{
-							components: {
-								a: (
-									<a
-										href={ loginLink }
-										onClick={ ( event ) => {
-											event.preventDefault();
-											recordTracksEvent( 'calypso_signup_social_existing_user_login_link_click' );
-											window.location.href = loginLink;
-										} }
-									/>
-								),
-							},
-						}
-					) }
+					text={
+						<span>
+							<p>
+								{ errorResponse.message }
+								&nbsp;
+								{ translate( '{{a}}Log in now{{/a}} to finish signing up.', {
+									components: {
+										a: (
+											<a
+												href={ loginLink }
+												onClick={ () =>
+													dispatch(
+														recordTracksEventWithClientId( 'calypso_signup_login_midflow' )
+													)
+												}
+											/>
+										),
+									},
+								} ) }
+							</p>
+						</span>
+					}
 				/>
 			);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-error-notice.tsx
@@ -14,41 +14,70 @@ export function useErrorNotice( { error: errorResponse, recentSocialAuthAttemptP
 	const translate = useTranslate();
 	const loginLink = login( {
 		signupUrl: window.location.pathname + window.location.search,
+		redirectTo: window.location.pathname + window.location.search,
 	} );
-	if ( errorResponse && 'error' in errorResponse && errorResponse?.error === 'user_exists' ) {
-		return (
-			<Notice
-				className="signup-form__notice signup-form__span-columns"
-				showDismiss={ false }
-				status="is-transparent-info"
-				text={ translate(
-					'We found a WordPress.com account with the email "%(email)s". ' +
-						'{{a}}Log in to connect it{{/a}}, or use a different email to sign up.',
-					{
-						args: { email: errorResponse.data?.email },
-						components: {
-							a: (
-								<a
-									href={ loginLink }
-									onClick={ ( event ) => {
-										event.preventDefault();
-										recordTracksEvent( 'calypso_signup_social_existing_user_login_link_click' );
-										window.location.href = addQueryArgs(
-											{
-												service: recentSocialAuthAttemptParams?.service,
-												access_token: recentSocialAuthAttemptParams?.access_token,
-												id_token: recentSocialAuthAttemptParams?.id_token,
-											},
-											loginLink
-										);
-									} }
-								/>
-							),
-						},
-					}
-				) }
-			/>
-		);
+	if ( errorResponse && 'error' in errorResponse ) {
+		if ( errorResponse.error === 'user_exists' ) {
+			return (
+				<Notice
+					className="signup-form__notice signup-form__span-columns"
+					showDismiss={ false }
+					status="is-transparent-info"
+					text={ translate(
+						'We found a WordPress.com account with the email "%(email)s". ' +
+							'{{a}}Log in to connect it{{/a}}, or use a different email to sign up.',
+						{
+							args: { email: errorResponse.data?.email },
+							components: {
+								a: (
+									<a
+										href={ loginLink }
+										onClick={ ( event ) => {
+											event.preventDefault();
+											recordTracksEvent( 'calypso_signup_social_existing_user_login_link_click' );
+											window.location.href = addQueryArgs(
+												{
+													service: recentSocialAuthAttemptParams?.service,
+													access_token: recentSocialAuthAttemptParams?.access_token,
+													id_token: recentSocialAuthAttemptParams?.id_token,
+												},
+												loginLink
+											);
+										} }
+									/>
+								),
+							},
+						}
+					) }
+				/>
+			);
+		} else if ( errorResponse.error === '2FA_enabled' ) {
+			return (
+				<Notice
+					className="signup-form__notice signup-form__span-columns"
+					showDismiss={ false }
+					status="is-transparent-info"
+					text={ translate(
+						'This social account is linked to a WordPress.com account with two-factor authentication. ' +
+							'{{a}}Sign in to continue{{/a}}, or choose a different signup method.',
+						{
+							components: {
+								a: (
+									<a
+										href={ loginLink }
+										onClick={ ( event ) => {
+											event.preventDefault();
+											recordTracksEvent( 'calypso_signup_social_existing_user_login_link_click' );
+											window.location.href = loginLink;
+										} }
+									/>
+								),
+							},
+						}
+					) }
+				/>
+			);
+		}
 	}
 	return false;
 }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/101679

## Proposed Changes

Signup is blocked when you sign up with a social account that is tied a WP.com account with 2FA. 

This PR handles that case gracefully.

## Why are these changes being made?
Bug fix

## Testing Instructions

1. Login to WP.com using a Google account. 
2. Go to your account settings and activate 2FA
3. Checkout this PR locally. 
4. Run `yarn start-mock-wordpress-com` and follow the instructions in the CLI.
5. Go to /setup/onboarding.
6. Sign up via Google.
7. You should see an error message (`This account is associated with a WordPress.com account which has Two-Step Authentication enabled.`).
8. Click `Log in now`.
9. After login, you should be taken back to the flow (/setup/onboarding).