### PR TITLE
i18n: Translate the Title of the Devices Stats Upgrade Module

### DIFF
--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-upgrade-overlay.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-upgrade-overlay.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import StatsCardUpsell from 'calypso/my-sites/stats/stats-card-upsell';
 import { STATS_TYPE_DEVICE_STATS } from '../../../constants';
@@ -17,6 +18,7 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 	className,
 	overlay,
 } ) => {
+	const translate = useTranslate();
 	const fakeData = [
 		{
 			label: 'Windows',
@@ -51,7 +53,7 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 	return (
 		// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.
 		<StatsListCard
-			title="Devices"
+			title={ translate( 'Devices' ) }
 			className={ clsx(
 				className,
 				'stats-module-upgrade-overlay',

--- a/client/my-sites/stats/features/modules/stats-devices/stats-module-upgrade-overlay.tsx
+++ b/client/my-sites/stats/features/modules/stats-devices/stats-module-upgrade-overlay.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import StatsCardUpsell from 'calypso/my-sites/stats/stats-card-upsell';
 import { STATS_TYPE_DEVICE_STATS } from '../../../constants';
 import StatsListCard from '../../../stats-list/stats-list-card';
+import statsStrings from '../../../stats-strings';
 
 import './stats-module-devices.scss';
 
@@ -19,6 +20,8 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 	overlay,
 } ) => {
 	const translate = useTranslate();
+	const { devices } = statsStrings();
+
 	const fakeData = [
 		{
 			label: 'Windows',
@@ -53,7 +56,7 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 	return (
 		// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.
 		<StatsListCard
-			title={ translate( 'Devices' ) }
+			title={ devices.title }
 			className={ clsx(
 				className,
 				'stats-module-upgrade-overlay',
@@ -62,7 +65,7 @@ const StatsModuleUpgradeOverlay: React.FC< StatsModuleUpgradeOverlayProps > = ( 
 			) }
 			moduleType="devices"
 			data={ fakeData }
-			mainItemLabel="Visitors"
+			mainItemLabel={ translate( 'Visitors' ) }
 			splitHeader
 			overlay={
 				overlay ?? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 963-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap the "Devices" title of the `<StatsModuleUpgradeOverlay />` in a translate function call.

| Before | After|
| - | - |
| ![UyEbwZgOXDZLKiaO](https://github.com/user-attachments/assets/b1254d6a-176b-424b-9cd4-2354aae9d685) | ![1QOhcJ7PF1Lq64jc](https://github.com/user-attachments/assets/fac74e60-8bb8-47e0-ac1d-90f2c903555f) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The title should be localized.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI to a Mag-16 language.
* Navigate to `/stats/day/{Free Site}`.
* Confirm the title of the Devices Stats module is now translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
