### PR TITLE
Components: Fix the text and logo alignment in JetpackColophon

### DIFF
--- a/client/components/jetpack-colophon/style.scss
+++ b/client/components/jetpack-colophon/style.scss
@@ -6,7 +6,7 @@
 		display: inline-block;
 		fill: currentColor;
 	}
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font-size: $font-body-small;
 		margin-bottom: 24px;
 	}
@@ -17,14 +17,13 @@
 	vertical-align: top;
 
 	.jetpack-logo {
-		vertical-align: inherit;
-		margin-top: -5px;
-		margin-left: 4px;
+		vertical-align: middle;
+		margin-inline: 0.25em;
 	}
 }
 
 .jetpack-colophon__grayscale {
-	color: var(--color-neutral-40);
+	color: var( --color-neutral-40 );
 	.jetpack-logo__icon-circle {
 		fill: currentColor;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 963-gh-Automattic/i18n-issues

## Proposed Changes

* Fix the alignment of the text and the logo within the `<JetpackColophon  />` component. 

| Before | After |
| - | - |
| ![Cwh9srj5Hc0p2VYn](https://github.com/user-attachments/assets/11d8994e-0e19-4d70-bbdf-5061e743819c) | ![NiMx9rGD7YlccFrz](https://github.com/user-attachments/assets/849213d9-a0fa-4824-9808-e1d708b91c0f) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The logo and the text were misaligned.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to Simplified or Traditional Chinese.
* Navigate to `/stats/day` and scroll to the very bottom of the screen to find the Jetpack Colophon component.
* Confirm the text and the Jetpack logo are well aligned.
* Check other locales.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
