### PR TITLE
Stop using external types for `react-router` and `history` packages

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,14 +5,7 @@
 		"noEmit": true,
 		"types": [ "node", "@types/gtag.js", "@emotion/react/types/css-prop" ],
 		"paths": {
-			"calypso/*": [ "./*" ],
-
-			// Workaround for https://github.com/Automattic/wp-calypso/pull/57487#issuecomment-957104486
-			// TLDR: We have `node_modules/history` and `node_modules/@types/history`, which have incompatible types.
-			// `tsc` will always pick the former by default, even if the project depends on the latter. Hardcoding the
-			// path here works around that limitation.
-			// To be removed when we don't have `@types/history` (brought in by `history@^4`) in our dependency tree.
-			"history": [ "../node_modules/@types/history" ]
+			"calypso/*": [ "./*" ]
 		}
 	},
 	"references": [ { "path": "../packages" }, { "path": "../build-tools" } ],

--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
 		"@types/qs": "^6.9.7",
 		"@types/react": "^18.3.18",
 		"@types/react-modal": "^3.13.1",
-		"@types/react-router-dom": "^5.3.3",
 		"@types/react-transition-group": "^4.4.4",
 		"@types/store": "^2.0.5",
 		"@types/validator": "^13.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8193,13 +8193,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/history@npm:*, @types/history@npm:^4.7.11":
-  version: 4.7.11
-  resolution: "@types/history@npm:4.7.11"
-  checksum: 3facf37c2493d1f92b2e93a22cac7ea70b06351c2ab9aaceaa3c56aa6099fb63516f6c4ec1616deb5c56b4093c026a043ea2d3373e6c0644d55710364d02c934
-  languageName: node
-  linkType: hard
-
 "@types/html-minifier-terser@npm:^6.0.0":
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
@@ -8584,27 +8577,6 @@ __metadata:
   dependencies:
     "@types/react": "npm:*"
   checksum: 58b39870509d65ecd5998365bf2e59062da29db6c525135db50e8eab4e7ecf8d81ee331e34d16a889a47b49a8e2888252b66f2365817ae613ccc32f2ddea983a
-  languageName: node
-  linkType: hard
-
-"@types/react-router-dom@npm:^5.3.3":
-  version: 5.3.3
-  resolution: "@types/react-router-dom@npm:5.3.3"
-  dependencies:
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-    "@types/react-router": "npm:*"
-  checksum: a9231a16afb9ed5142678147eafec9d48582809295754fb60946e29fcd3757a4c7a3180fa94b45763e4c7f6e3f02379e2fcb8dd986db479dcab40eff5fc62a91
-  languageName: node
-  linkType: hard
-
-"@types/react-router@npm:*":
-  version: 5.1.13
-  resolution: "@types/react-router@npm:5.1.13"
-  dependencies:
-    "@types/history": "npm:*"
-    "@types/react": "npm:*"
-  checksum: d75eb06708cf43aea97e91e62b0b7ea8b4393350f00df2443a8527a3a69ef145c2d31ff2d0e30817b13ea13ae5c2e8291f410d63efd7afc466ff981750e3ef19
   languageName: node
   linkType: hard
 
@@ -35661,7 +35633,6 @@ __metadata:
     "@types/qs": "npm:^6.9.7"
     "@types/react": "npm:^18.3.18"
     "@types/react-modal": "npm:^3.13.1"
-    "@types/react-router-dom": "npm:^5.3.3"
     "@types/react-transition-group": "npm:^4.4.4"
     "@types/store": "npm:^2.0.5"
     "@types/superagent": "npm:^4.1.24"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

As flagged in https://github.com/Automattic/wp-calypso/pull/102067#issuecomment-2766068555, the `history` package now comes with first-party types.

Looking into the hack introduced in https://github.com/Automattic/wp-calypso/pull/57487#issuecomment-957104486 (which was hardcoding types for `history` to an older version), I realized that the version of `react-router` that we consume should also come with its own types — which means that we don't have to consume `@types/react-router-dom`, which indirectly also removed `@types/history` too.

And we can clean up the paths hack, too!

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Cleaning up unnecessary types hack and removing dependencies.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure that the project builds
- Make sure that usages of `react-router`, `react-router-dom` and `history` across the repo load types correctly, and don't generate any type errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
