### PR TITLE
Revert "Domains: Fix discrepancy between onboarding and domain-only search"

### DIFF
--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -137,7 +137,7 @@
 	margin-bottom: 12px;
 }
 
-.domains__step-content.domains__step-content-domain-step .register-domain-step.register-domain-step__signup .register-domain-step__example-prompt {
+.register-domain-step__example-prompt {
 	font-size: 0.875rem;
 	line-height: 20px;
 	color: var(--studio-gray-40);
@@ -149,9 +149,13 @@
 		margin: 0 20px;
 	}
 
-	svg:first-child {
+	svg {
 		fill: #a7aaad;
 		margin-right: 13px;
+	}
+
+	@include break-xlarge {
+		margin: 0;
 	}
 }
 

--- a/client/components/domains/side-explainer/style.scss
+++ b/client/components/domains/side-explainer/style.scss
@@ -30,7 +30,6 @@
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		line-height: 1.625rem;
 		color: var(--studio-gray-90);
-		text-wrap: balance;
 	}
 
 	.side-explainer__subtitle {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -11,7 +11,6 @@ import {
 	Step,
 } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
-import { subscribeIsWithinBreakpoint, isWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -172,7 +171,6 @@ export class RenderDomainsStep extends Component {
 			checkDomainAvailabilityPromises: [],
 			removeDomainTimeout: 0,
 			addDomainTimeout: 0,
-			isDesktopViewport: false,
 		};
 	}
 
@@ -189,7 +187,6 @@ export class RenderDomainsStep extends Component {
 			// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 		}
-		this.subscribeToViewPortChanges();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -203,20 +200,6 @@ export class RenderDomainsStep extends Component {
 				this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 			}
 		}
-	}
-
-	subscribeToViewPortChanges() {
-		this.unsubscribeToViewPortChanges = subscribeIsWithinBreakpoint(
-			'>=960px',
-			( isDesktopViewport ) => this.setState( { isDesktopViewport } )
-		);
-		if ( isWithinBreakpoint( '>=960px' ) ) {
-			this.setState( { isDesktopViewport: true } );
-		}
-	}
-
-	componentWillUnmount() {
-		this.unsubscribeToViewPortChanges?.();
 	}
 
 	getLocale() {
@@ -1455,7 +1438,6 @@ export class RenderDomainsStep extends Component {
 
 			return (
 				<Step.TwoColumnLayout
-					isLargeViewport={ this.state.isDesktopViewport }
 					firstColumnWidth={ 7 }
 					secondColumnWidth={ 3 }
 					topBar={ <Step.TopBar leftElement={ ! hideBack && backButton } /> }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,14 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/colors.native";
 
-body {
-	.is-section-signup, .is-section-stepper {
-		text-rendering: optimizelegibility;
-		-webkit-font-smoothing: antialiased;
-	}
-}
 .domains__step-section-wrapper {
 	margin: 0 auto;
 	width: 100%;
@@ -71,6 +64,10 @@ body.is-section-stepper .domains__step-content,
 
 	.search-filters__dropdown-filters {
 		border-radius: 0 2px 2px 0;
+	}
+
+	.search-filters__dropdown-filters.search-filters__dropdown-filters--is-open {
+		box-shadow: 0 0 0 3px var(--color-accent-light);
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {
@@ -342,7 +339,6 @@ body.is-section-signup {
 			border-color: #646970;
 			background: var(--color-surface);
 			box-shadow: none;
-			border-radius: 4px;
 
 			.search-component__input {
 				background: var(--color-surface);
@@ -523,67 +519,27 @@ body.is-section-signup {
 .step-route.onboarding.domains:has(.step-container-v2) {
 	padding: 0;
 
-	.register-domain-step {
-		&__search-card {
-			@media (min-width: 600px) {
-				margin: 20px 20px 0;
-			}
-
-			@media (min-width: 960px) {
-				margin: 0;
-			}
-		}
-
-		&__example-prompt {
-			margin: 0;
-
-			@media (min-width: 600px) {
-				margin: 0 20px;
-			}
-		}
+	.register-domain-step__search-card {
+		margin: 0;
 	}
 
 	.featured-domain-suggestions,
 	.domain-suggestion {
 		margin-inline: 0;
-
-		@media (min-width: 600px) {
-			margin-inline: 20px;
-
-			@media (min-width: 960px) {
-				margin: 0;
-			}
-		}
 	}
 
-	.featured-domain-suggestions {
-		border-top: none;
+	.register-domain-step__domain-side-content-container-domain-explanation-image {
+		max-width: 100%;
+		margin-bottom: 0;
+	}
 
-		@media (min-width: 600px) {
-			margin: 0 20px;
-
-			@media (min-width: 960px) {
-				margin: 0;
-			}
-		}
-
-		.featured-domain-suggestion {
-			margin: 0;
-			margin-bottom: 12px;
-		}
+	.register-domain-step__example-prompt {
+		margin: 0;
 	}
 
 	.domains__domain-side-content-container {
 		display: flex;
-		justify-content: center;
-		width: 80%;
-		align-items: center;
-		margin: 20px auto 0;
-
-		@media (min-width: ($break-large)) {
-			width: unset;
-			margin-top: 0;
-		}
+		margin-top: 0;
 	}
 
 	.domains__domain-side-content {
@@ -594,119 +550,9 @@ body.is-section-signup {
 		@include break-large {
 			max-width: 290px;
 		}
-
-		@include break-large {
-			margin-left: 40px;
-		}
-
-		@include break-huge {
-			margin-left: 60px;
-		}
-
-		&.fade-out {
-			display: none;
-		}
 	}
 
-	.step-container-v2__heading {
-		h1:not(.small) {
-			letter-spacing: -0.4px;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			line-height: 1.2em;
-		}
-
-		> p {
-			color: $gray-60;
-			font-size: 1rem;
-		}
-	}
-}
-
-.step-container-v2 {
-	&__content.step-container-v2__content--two-column-layout.domains__step-content.domains__step-content-domain-step {
-		gap: 0;
-		max-width: 1280px;
-	}
-
-	&__content-wrapper.padding {
-		padding: 0 12px;
-		gap: 0;
-	}
-
-	&__heading {
-		margin-top: 0;
-	}
-}
-
-.domains__step-content-domain-step > div {
-	&:nth-child(1) {
-		flex: 1 !important;
-	}
-
-	&:nth-child(2) {
-		display: flex;
-		flex-basis: auto !important;
-		flex-direction: column;
-		flex-grow: 0 !important;
-		flex-shrink: 1 !important;
-		flex-wrap: nowrap;
-	}
-}
-
-.domain-product-price {
-	&.domain-product-single-price.domain-product-price__domain-step-signup-flow {
-		align-self: center;
-	}
-
-	@include breakpoint-deprecated( "<660px" ) {
-		&.domain-product-price__domain-step-signup-flow {
-			flex-direction: column;
-		}
-	}
-}
-
-.domain-suggestion__content.domain-suggestion__content-domain {
-	align-items: unset;
-}
-
-body.is-section-stepper {
-	.featured-domain-suggestion.card .domain-product-price {
-		align-items: flex-start;
-		margin-top: 12px;
-	}
-
-	.formatted-header .formatted-header__title {
-		@media (min-width: 1080px) {
-			font-size: 2.75rem !important;
-		}
-	}
-
-	.register-domain-step__search.register-domain-step__search-domain-step:not(.is-sticky) {
-		@media (min-width: 661px) {
-			padding-top: 18px;
-		}
-	}
-
-	.onboarding:not(.is-onboarding-2023-pricing-grid) .step-container-v2__heading {
-		margin: calc(48px + 24px - var(--step-container-v2-top-bar-height)) 20px 24px 20px;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		width: unset;
-		align-items: center;
-		flex-direction: column;
-
-		@media (min-width: 960px) {
-			margin-top: calc(48px + 48px - var(--step-container-v2-top-bar-height));
-			margin-bottom: 36px;
-		}
-
-		> h1 {
-			font-size: 2.25rem;
-
-			@media (min-width: 1080px) {
-				font-size: 2.75rem;
-			}
-		}
+	.domains__domain-side-content.fade-out {
+		display: none;
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#102021.

The original PR modified the appearance of `StepContainerV2` in all steps, including domains, plans, and loading.

## Domains and plans

The distance between the top bar and the heading is different.

| Before | After |
| ------- | ---- |
| ![image](https://github.com/user-attachments/assets/9b53e661-ba3f-4fcc-80a8-ce28c55c9c56) | ![image](https://github.com/user-attachments/assets/464583f7-154f-481c-aca8-9a852e006f8d) |

## Domains

The elements are not stretched horizontally anymore.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/user-attachments/assets/b72bf0da-4dc7-4840-8be3-dba393eac597) | ![image](https://github.com/user-attachments/assets/d88dabc3-b079-4254-8a6b-ae6f284cf043) |

## Loading

The heading lost its padding compared to the progress bar and is also bigger.

| Before | After |
| ------- | ---- |
| ![image](https://github.com/user-attachments/assets/ccb121e9-5f2b-4ff5-a488-aab35fd56042) | ![image](https://github.com/user-attachments/assets/45365f10-d254-4410-94bc-ef8f7fffbd21) |

---

On top of that, it added [overrides to the components](https://github.com/Automattic/wp-calypso/pull/102341/files#diff-cb1ccc077529ffbb975378b235656e5efa8f6d3467b8f4609479c84d6fcb3503L690) of `StepContainerV2`, like `Heading` and [how the TwoColumnLayout works](https://github.com/Automattic/wp-calypso/pull/102341/files#diff-cb1ccc077529ffbb975378b235656e5efa8f6d3467b8f4609479c84d6fcb3503L641-L654).

`StepContainerV2` was created with consistency in mind, so applying overrides to it defeats its raison d'être. That's why we will move its implementation to CSS modules, so modifications like that aren't possible in the future. **We want the wireframes and components (heading, buttons, etc.) to look consistent across the designs** [as explained in the README](https://github.com/Automattic/wp-calypso/blob/trunk/packages/onboarding/src/step-container-v2/README.md#L17).

---

The root problem of the original PR was that it wasn't an apple-to-apple comparison. It meant to change `/setup/onboarding/domains` and make it consistent with the domains-only flow, but `/setup/onboarding` is already using `StepContainerV2` instead of the old `StepContainer`, which doesn't follow the same styling conventions.

And because `StepContainerV2` is enabled locally, it was mistakenly compared to the flow that doesn't use it (domains only), making the inconsistency more apparent (after all, they look different... but on purpose.)