### PR TITLE
Show specific message if the domain state is restricted

### DIFF
--- a/client/lib/emails/email-provider-constants.js
+++ b/client/lib/emails/email-provider-constants.js
@@ -12,3 +12,4 @@ export const EMAIL_WARNING_CODE_OTHER_USER_OWNS_DOMAIN_SUBSCRIPTION =
 	'other-user-owns-subscription';
 export const EMAIL_WARNING_CODE_OTHER_USER_OWNS_EMAIL = 'other-user-owns-email';
 export const EMAIL_WARNING_CODE_GRAVATAR_DOMAIN = 'domain-gravatar-domain';
+export const EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED = 'domain-state-restricted';

--- a/client/my-sites/email/email-domain-state-restricted-message/index.tsx
+++ b/client/my-sites/email/email-domain-state-restricted-message/index.tsx
@@ -32,7 +32,7 @@ export const EmailDomainStateRestrictedMessage = (
 
 	return (
 		<PromoCard className="email-domain-state-restricted-message__promo-card">
-			<p className="email-domain-state-restricted-message__text">{ reasonText }</p>
+			<p>{ reasonText }</p>
 		</PromoCard>
 	);
 };

--- a/client/my-sites/email/email-domain-state-restricted-message/index.tsx
+++ b/client/my-sites/email/email-domain-state-restricted-message/index.tsx
@@ -1,0 +1,38 @@
+import { CALYPSO_CONTACT } from '@automattic/urls';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import PromoCard from 'calypso/components/promo-section/promo-card';
+
+import './style.scss';
+
+type EmailDomainStateRestrictedMessageProps = {
+	domainName: string;
+};
+
+export const EmailDomainStateRestrictedMessage = (
+	props: EmailDomainStateRestrictedMessageProps
+) => {
+	const { domainName } = props;
+
+	const translate = useTranslate();
+
+	const translateOptions = {
+		components: {
+			contactSupportLink: <a href={ CALYPSO_CONTACT } rel="noopener noreferrer" target="_blank" />,
+			strong: <strong />,
+		},
+		args: {
+			domainName,
+		},
+	};
+
+	const reasonText: TranslateResult = translate(
+		'You are not currently allowed to buy email services for {{strong}}%(domainName)s{{/strong}}. Please {{contactSupportLink}}contact support{{/contactSupportLink}} for more details.',
+		translateOptions
+	);
+
+	return (
+		<PromoCard className="email-domain-state-restricted-message__promo-card">
+			<p className="email-domain-state-restricted-message__text">{ reasonText }</p>
+		</PromoCard>
+	);
+};

--- a/client/my-sites/email/email-domain-state-restricted-message/style.scss
+++ b/client/my-sites/email/email-domain-state-restricted-message/style.scss
@@ -1,0 +1,9 @@
+.email-domain-state-restricted-message__promo-card {
+	margin-top: 16px;
+	padding-bottom: 0;
+}
+
+.email-domain-state-restricted-message__text {
+	margin-top: 16px;
+	margin-bottom: 0;
+}

--- a/client/my-sites/email/email-domain-state-restricted-message/style.scss
+++ b/client/my-sites/email/email-domain-state-restricted-message/style.scss
@@ -2,8 +2,3 @@
 	margin-top: 16px;
 	padding-bottom: 0;
 }
-
-.email-domain-state-restricted-message__text {
-	margin-top: 16px;
-	margin-bottom: 0;
-}

--- a/client/my-sites/email/email-forwards-add/index.tsx
+++ b/client/my-sites/email/email-forwards-add/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Button, Card } from '@automattic/components';
+import { CALYPSO_CONTACT } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -10,7 +11,10 @@ import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import { getCurrentUserCannotAddEmailReason, getSelectedDomain } from 'calypso/lib/domains';
-import { EMAIL_WARNING_CODE_GRAVATAR_DOMAIN } from 'calypso/lib/emails/email-provider-constants';
+import {
+	EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED,
+	EMAIL_WARNING_CODE_GRAVATAR_DOMAIN,
+} from 'calypso/lib/emails/email-provider-constants';
 import EmailForwardingAddNewCompactList from 'calypso/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import {
@@ -59,6 +63,8 @@ const EmailForwardsAdd = ( {
 	const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( selectedDomain );
 	const isGravatarRestrictedDomain =
 		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_GRAVATAR_DOMAIN;
+	const isDomainStateRestricted =
+		cannotAddEmailWarningReason?.code === EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED;
 
 	const goToEmail = useCallback( (): void => {
 		if ( ! selectedSite ) {
@@ -81,31 +87,60 @@ const EmailForwardsAdd = ( {
 		page( getEmailManagementPath( selectedSite.slug, selectedDomainName, currentRoute ) );
 	}, [ currentRoute, selectedDomainName, selectedSite ] );
 
-	const content = isGravatarRestrictedDomain ? (
-		<Notice showDismiss={ false } className="email-forwards-add__notice">
-			{ translate(
-				'This domain is associated with a Gravatar profile and cannot be used for email services at this time.'
-			) }
-		</Notice>
-	) : (
-		<Card>
-			{ areDomainsLoading && (
-				<div className="email-forwards-add__placeholder">
-					<p />
-					<p />
-					<Button disabled />
-				</div>
-			) }
+	const renderRestrictedDomainStatus = () => {
+		if ( isGravatarRestrictedDomain ) {
+			return (
+				<Notice showDismiss={ false } className="email-forwards-add__notice">
+					{ translate(
+						'This domain is associated with a Gravatar profile and cannot be used for email services at this time.'
+					) }
+				</Notice>
+			);
+		}
+		if ( isDomainStateRestricted ) {
+			return (
+				<Notice showDismiss={ false } className="email-forwards-add__notice">
+					{ translate(
+						'You are not currently allowed to buy email services for {{strong}}%(domainName)s{{/strong}}. Please {{contactSupportLink}}contact support{{/contactSupportLink}} for more details.',
+						{
+							components: {
+								strong: <strong />,
+								contactSupportLink: (
+									<a href={ CALYPSO_CONTACT } rel="noopener noreferrer" target="_blank" />
+								),
+							},
+							args: {
+								domainName: selectedDomainName,
+							},
+						}
+					) }
+				</Notice>
+			);
+		}
+	};
 
-			{ ! areDomainsLoading && (
-				<EmailForwardingAddNewCompactList
-					onAddedEmailForwards={ onAddedEmailForwards }
-					selectedDomainName={ selectedDomainName }
-					showFormHeader={ showFormHeader }
-				/>
-			) }
-		</Card>
-	);
+	const content =
+		isGravatarRestrictedDomain || isDomainStateRestricted ? (
+			renderRestrictedDomainStatus()
+		) : (
+			<Card>
+				{ areDomainsLoading && (
+					<div className="email-forwards-add__placeholder">
+						<p />
+						<p />
+						<Button disabled />
+					</div>
+				) }
+
+				{ ! areDomainsLoading && (
+					<EmailForwardingAddNewCompactList
+						onAddedEmailForwards={ onAddedEmailForwards }
+						selectedDomainName={ selectedDomainName }
+						showFormHeader={ showFormHeader }
+					/>
+				) }
+			</Card>
+		);
 
 	return (
 		<>

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -244,12 +244,6 @@ const EmailProvidersStackedComparison = ( {
 
 		switch ( cannotAddEmailWarningCode ) {
 			case EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED:
-				// return (
-				// 	<EmailNonDomainOwnerMessage
-				// 		domain={ domain }
-				// 		selectedSite={ selectedSite }
-				// 		source="email-comparison"
-				// 	/>);
 				return <EmailDomainStateRestrictedMessage domainName={ selectedDomainName } />;
 			default:
 				return (

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -244,6 +244,12 @@ const EmailProvidersStackedComparison = ( {
 
 		switch ( cannotAddEmailWarningCode ) {
 			case EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED:
+				// return (
+				// 	<EmailNonDomainOwnerMessage
+				// 		domain={ domain }
+				// 		selectedSite={ selectedSite }
+				// 		source="email-comparison"
+				// 	/>);
 				return <EmailDomainStateRestrictedMessage domainName={ selectedDomainName } />;
 			default:
 				return (
@@ -318,7 +324,9 @@ const EmailProvidersStackedComparison = ( {
 				{ shouldPromoteGoogleWorkspace ? [ ...emailProviderCards ].reverse() : emailProviderCards }
 			</>
 
-			{ ! isDomainInCart && <EmailForwardingLink selectedDomainName={ selectedDomainName } /> }
+			{ ! isDomainInCart && ! showEmailPurchaseDisabledMessage && (
+				<EmailForwardingLink selectedDomainName={ selectedDomainName } />
+			) }
 
 			<TrackComponentView
 				eventName="calypso_email_providers_comparison_page_view"

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -15,14 +15,20 @@ import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { hasDiscount } from 'calypso/components/gsuite/gsuite-price';
 import Main from 'calypso/components/main';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { getSelectedDomain, canCurrentUserAddEmail } from 'calypso/lib/domains';
+import {
+	getSelectedDomain,
+	canCurrentUserAddEmail,
+	getCurrentUserCannotAddEmailReason,
+} from 'calypso/lib/domains';
 import {
 	hasEmailForwards,
 	getDomainsWithEmailForwards,
 } from 'calypso/lib/domains/email-forwarding';
+import { EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED } from 'calypso/lib/emails/email-provider-constants';
 import { hasGSuiteSupportedDomain } from 'calypso/lib/gsuite';
 import { GOOGLE_WORKSPACE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
+import { EmailDomainStateRestrictedMessage } from 'calypso/my-sites/email/email-domain-state-restricted-message';
 import EmailExistingForwardsNotice from 'calypso/my-sites/email/email-existing-forwards-notice';
 import EmailExistingPaidServiceNotice from 'calypso/my-sites/email/email-existing-paid-service-notice';
 import { EmailNonDomainOwnerMessage } from 'calypso/my-sites/email/email-non-domain-owner-message';
@@ -92,7 +98,7 @@ const EmailProvidersStackedComparison = ( {
 	);
 
 	const currentUserCanAddEmail = canCurrentUserAddEmail( domain );
-	const showNonOwnerMessage = ! currentUserCanAddEmail && ! isDomainInCart;
+	const showEmailPurchaseDisabledMessage = ! currentUserCanAddEmail && ! isDomainInCart;
 
 	const isGSuiteSupported =
 		domain && canPurchaseGSuite && ( isDomainInCart || hasGSuiteSupportedDomain( [ domain ] ) );
@@ -100,7 +106,7 @@ const EmailProvidersStackedComparison = ( {
 	const shouldPromoteGoogleWorkspace = isGSuiteSupported && hasDiscount( gSuiteProduct );
 
 	const initialExpandedCards = () => {
-		if ( showNonOwnerMessage ) {
+		if ( showEmailPurchaseDisabledMessage ) {
 			return {
 				google: false,
 				titan: false,
@@ -131,7 +137,7 @@ const EmailProvidersStackedComparison = ( {
 
 	useEffect( () => {
 		setDetailsExpanded( initialExpandedCards() );
-	}, [ showNonOwnerMessage ] );
+	}, [ showEmailPurchaseDisabledMessage ] );
 
 	const changeExpandedState = ( providerKey: string, isCurrentlyExpanded: boolean ) => {
 		const expandedEntries = Object.entries( detailsExpanded ).map( ( entry ) => {
@@ -201,7 +207,7 @@ const EmailProvidersStackedComparison = ( {
 			intervalLength={ selectedIntervalLength }
 			isDomainInCart={ isDomainInCart }
 			key="ProfessionalEmailCard"
-			onExpandedChange={ ! showNonOwnerMessage ? changeExpandedState : undefined }
+			onExpandedChange={ ! showEmailPurchaseDisabledMessage ? changeExpandedState : undefined }
 			selectedDomainName={ selectedDomainName }
 			source={ source }
 		/>,
@@ -211,7 +217,7 @@ const EmailProvidersStackedComparison = ( {
 			intervalLength={ selectedIntervalLength }
 			isDomainInCart={ isDomainInCart }
 			key="GoogleWorkspaceCard"
-			onExpandedChange={ ! showNonOwnerMessage ? changeExpandedState : undefined }
+			onExpandedChange={ ! showEmailPurchaseDisabledMessage ? changeExpandedState : undefined }
 			selectedDomainName={ selectedDomainName }
 			source={ source }
 		/>,
@@ -230,6 +236,24 @@ const EmailProvidersStackedComparison = ( {
 				onClick={ handleCompareClick }
 			/>
 		),
+	};
+
+	const renderEmailPurchaseDisabledMessage = () => {
+		const cannotAddEmailWarningReason = getCurrentUserCannotAddEmailReason( domain );
+		const cannotAddEmailWarningCode = cannotAddEmailWarningReason?.code ?? null;
+
+		switch ( cannotAddEmailWarningCode ) {
+			case EMAIL_WARNING_CODE_DOMAIN_STATE_RESTRICTED:
+				return <EmailDomainStateRestrictedMessage domainName={ selectedDomainName } />;
+			default:
+				return (
+					<EmailNonDomainOwnerMessage
+						domain={ domain }
+						selectedSite={ selectedSite }
+						source="email-comparison"
+					/>
+				);
+		}
 	};
 
 	return (
@@ -273,7 +297,7 @@ const EmailProvidersStackedComparison = ( {
 				</div>
 			) }
 
-			{ ! showNonOwnerMessage && (
+			{ ! showEmailPurchaseDisabledMessage && (
 				<BillingIntervalToggle
 					intervalLength={ selectedIntervalLength }
 					onIntervalChange={ changeIntervalLength }
@@ -290,13 +314,7 @@ const EmailProvidersStackedComparison = ( {
 			{ ! isDomainInCart && domain && <EmailExistingPaidServiceNotice domain={ domain } /> }
 
 			<>
-				{ showNonOwnerMessage && (
-					<EmailNonDomainOwnerMessage
-						domain={ domain }
-						selectedSite={ selectedSite }
-						source="email-comparison"
-					/>
-				) }
+				{ showEmailPurchaseDisabledMessage && renderEmailPurchaseDisabledMessage() }
 				{ shouldPromoteGoogleWorkspace ? [ ...emailProviderCards ].reverse() : emailProviderCards }
 			</>
 


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/NOMADO-15/prevent-email-changes-for-domains-with-a-dispute-flag

## Proposed Changes
This PR improve prevent email forwarding service activation for domain that have an active dispute status. It also updates the message showed in the email management page.

## Why are these changes being made?
We shouldn't allow dns updates for domains with an active dispute status. Email Forwarding changes MX records configuration, so it should be prevented.

![email-before](https://github.com/user-attachments/assets/5a135232-775f-489a-961d-7a6da2670735)

![email-after](https://github.com/user-attachments/assets/215df832-bfa2-451f-b9e1-652357374ffc)

![email-f-before](https://github.com/user-attachments/assets/b325021f-c77b-4d0a-ae8f-6bf34cfbde47)

![email-f-after](https://github.com/user-attachments/assets/3c42c5f2-0e86-4bcd-9491-3664915e1119)

## Testing Instructions
Apply this PR locally or use the Calypso link below. You'd need a domain with a dispute flag enabled.

Open the email setting page (`/email/[domain]/purchase/[site]`)and verify that the message is the same as in the screenshot below. In addition, verify that the Email Forwardind cta has been removed.

Now check the Email Forwarding activation page (`/email/[domain]/forwarding/add/[site]?source=purchase`) and check that it shows the same message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
