### PR TITLE
Account Settings: Fix input placeholder on the language search input

### DIFF
--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -54,8 +54,13 @@
 		flex: 1 1 auto;
 		margin-bottom: 12px;
 
+		.search-component__input-fade {
+			min-width: 0;
+		}
+
 		.search-component__input[type="search"] {
 			font-size: 0.875rem;
+			max-width: 100%;
 
 			@include break-small() {
 				padding-left: 12px;

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -89,6 +89,10 @@
 			@include break-small() {
 				display: none;
 			}
+
+			.search-component__icon-navigation {
+				background-color: transparent;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/102300

## Proposed Changes

* Adjust search language input glitches

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/me/account`
* Click on `Interface language`
* Check that the placeholder is not overflowing the search input:

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/65faaa00-c30f-43a2-90d2-fc3718e005bd)|![image](https://github.com/user-attachments/assets/e54ac3e7-3a26-42b7-b10c-2fab2df726d5)|

* Enable responsive design
* Select a smartphone (e.g. Samsung Galaxy S20 Ultra)
* Check that the lens on the search input is not overflowing

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/2c82da80-8772-4d0e-9c34-be5b67745279)|![image](https://github.com/user-attachments/assets/274a8dc6-c470-4637-91d4-336ce4f21538)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
