### PR TITLE
Use loading spinner instead of ellipses for magic link page

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1346,7 +1346,7 @@ class MagicLogin extends Component {
 
 		const isJetpackMagicLinkSignUpEnabled =
 			config.isEnabled( 'jetpack/magic-link-signup' ) && this.props.isJetpackLogin;
-		const shouldShowLoadingEllipsis =
+		const shouldShowLoadingIndicator =
 			isFromJetpackOnboarding &&
 			isJetpackMagicLinkSignUpEnabled &&
 			( isSendingEmail || this.isInitialMount );
@@ -1357,7 +1357,7 @@ class MagicLogin extends Component {
 			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
 			...( isJetpackMagicLinkSignUpEnabled ? { isJetpackMagicLinkSignUpEnabled: true } : {} ),
 			createAccountForNewUser: true,
-			shouldShowLoadingEllipsis,
+			shouldShowLoadingIndicator,
 			isFromJetpackOnboarding,
 		};
 
@@ -1377,7 +1377,7 @@ class MagicLogin extends Component {
 
 				<RequestLoginEmailForm { ...requestLoginEmailFormProps } />
 
-				{ ! shouldShowLoadingEllipsis && this.renderLinks() }
+				{ ! shouldShowLoadingIndicator && this.renderLinks() }
 			</Main>
 		);
 	}

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -183,8 +183,8 @@ class RequestLoginEmailForm extends Component {
 			return (
 				<Spinner
 					style={ {
-						height: 'calc(4px * 20)',
-						width: 'calc(4px * 20)',
+						height: 'calc(4px * 12)',
+						width: 'calc(4px * 12)',
 					} }
 					className="magic-login__loading-spinner--jetpack"
 				/>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,4 +1,5 @@
 import { FormLabel } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -6,7 +7,6 @@ import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
@@ -57,7 +57,7 @@ class RequestLoginEmailForm extends Component {
 		onSubmitEmail: PropTypes.func,
 		onSendEmailLogin: PropTypes.func,
 		createAccountForNewUser: PropTypes.bool,
-		shouldShowLoadingEllipsis: PropTypes.bool,
+		shouldShowLoadingIndicator: PropTypes.bool,
 		blogId: PropTypes.string,
 		errorMessage: PropTypes.string,
 		onErrorDismiss: PropTypes.func,
@@ -175,12 +175,20 @@ class RequestLoginEmailForm extends Component {
 			isEmailInputError,
 			isSubmitButtonDisabled,
 			isSubmitButtonBusy,
-			shouldShowLoadingEllipsis,
+			shouldShowLoadingIndicator,
 			isFromJetpackOnboarding,
 		} = this.props;
 
-		if ( shouldShowLoadingEllipsis ) {
-			return <LoadingEllipsis className="magic-login__loading-ellipsis--jetpack" />;
+		if ( shouldShowLoadingIndicator ) {
+			return (
+				<Spinner
+					style={ {
+						height: 'calc(4px * 20)',
+						width: 'calc(4px * 20)',
+					} }
+					className="magic-login__loading-spinner--jetpack"
+				/>
+			);
 		}
 
 		const usernameOrEmail = this.getUsernameOrEmailFromState();

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -24,13 +24,11 @@
 
 .layout.is-jetpack-login {
 	.magic-login {
-		&__loading-ellipsis--jetpack {
+		&__loading-spinner--jetpack {
+			color: var(--studio-jetpack-green-40, #069e08 );
+			top: 25px;
 			left: 50%;
 			transform: translateX(-50%);
-
-			div {
-				background: var(--studio-jetpack-green-40, #069e08 );
-			}
 		}
 	}	
 }


### PR DESCRIPTION
## Proposed Changes

* Update loading indicator to Spinner for Jetpack magic link login flow

## Why are these changes being made?

* Spinner is more standard to use than the Ellipsis

## Testing Instructions

1. Start a Jurassic Ninja site with Bleeding edge checked out
2. Start up your local Calypso environment (or use the live link) and replace the domain in the URL. Reload the page and you should see a loading indicator until the email was sent
3. Go to `/wp-admin/admin.php?page=my-jetpack#/onboarding` on the site
4. Fill out your email and submit the form
5. Make sure you see the loading indicator

![image](https://github.com/user-attachments/assets/13f1fdf4-9ea9-4d32-a531-62d2070b2ec3)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
