### PR TITLE
StepContainerV2 Design Picker: Remove unwanted scrolling in Design Picker preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -661,17 +661,19 @@ $container-padding-large: 48px;
 	}
 }
 
-// TODO: Remove most of these customizations once we introduce the FixedColumnOnTheLeftLayout wireframe.
 .step-container-v2:has(.step-container-v2--design-picker-preview) {
+	// TODO: Remove this customization once we introduce the FixedColumnOnTheLeftLayout wireframe.
 	.step-container-v2__content-wrapper {
 		@include break-large {
-			padding-top: 0 !important;
+			padding-block: 0 !important;
+			max-height: calc(100vh - var(--step-container-v2-top-bar-height));
 		}
 	}
 
 	.step-container-v2--design-picker-preview {
 		display: flex;
 		flex: 1;
+		min-height: 0;
 
 		&__header-design-title {
 			.design-picker-design-title__container {
@@ -708,8 +710,8 @@ $container-padding-large: 48px;
 
 				.design-preview__site-preview {
 					transform: translateY(calc(var(--step-container-v2-top-bar-height) * -1));
-					height: calc(100% + var(--step-container-v2-top-bar-height)) !important;
-					margin-bottom: 0 !important;
+					// TODO: Remove this 32px subtraction once we introduce the FixedColumnOnTheLeftLayout wireframe.
+					height: calc(100% - 32px + var(--step-container-v2-top-bar-height)) !important;
 
 					.device-switcher__toolbar {
 						margin-block: 0;

--- a/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
+++ b/packages/onboarding/src/navigator/navigator-screens/hooks/use-navigator-screens.tsx
@@ -23,7 +23,11 @@ const useNavigatorScreens = ( screens: NavigatorScreenObject[] ) => {
 			onSubmit,
 			onBack,
 		} ) => (
-			<NavigatorScreen key={ path } path={ path } style={ { animationDuration: '0s' } }>
+			<NavigatorScreen
+				key={ path }
+				path={ path }
+				style={ { animationDuration: '0s', transitionDuration: '0s' } }
+			>
 				<>
 					<NavigatorHeader
 						title={ <>{ title ?? label }</> }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/102303.

## Proposed Changes

The page shouldn't scroll when browsing the theme preview step, only the sidebar and site preview.

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/a3836c68-1542-4eaa-9f88-1ec0f66d4df3" /> | <video src="https://github.com/user-attachments/assets/9f6f056a-1ced-4d17-ac9e-7fc35d5c0615" /> |

## Testing Instructions

Verify the before (`trunk`) and after (this PR) match the intended behavior. It only affects `onboarding/step-container-v2`.
