### PR TITLE
Onboarding consistency: Fix checkout blinks

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -7,11 +7,9 @@ import { getToken } from '@automattic/oauth-token';
 import { JETPACK_PRICING_PAGE } from '@automattic/urls';
 import debugFactory from 'debug';
 import defaultCalypsoI18n from 'i18n-calypso';
-import ReactDom from 'react-dom';
 import Modal from 'react-modal';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
-import { ProviderWrappedLayout } from 'calypso/controller';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
@@ -314,13 +312,6 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	}
 };
 
-function renderLayout( reduxStore, reactQueryClient ) {
-	ReactDom.render(
-		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />,
-		document.getElementById( 'wpcom' )
-	);
-}
-
 const boot = async ( currentUser, registerRoutes ) => {
 	saveOauthFlags();
 	utils();
@@ -341,12 +332,6 @@ const boot = async ( currentUser, registerRoutes ) => {
 	detectHistoryNavigation.start();
 	if ( registerRoutes ) {
 		registerRoutes();
-	}
-
-	// Render initial `<Layout>` for non-isomorphic sections.
-	// Isomorphic sections will take care of rendering their `<Layout>` themselves.
-	if ( ! document.getElementById( 'primary' ) ) {
-		renderLayout( reduxStore, queryClient );
 	}
 
 	page.start();

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -146,7 +146,7 @@ $font-size: rem(14px);
 /* stylelint-disable-next-line no-duplicate-selectors */
 .theme-default {
 	// client/layout/style.scss
-	.layout__content {
+	&:has(.sidebar) .layout__content {
 		min-height: 101vh; // Hack to give JS the chance to trigger the scroll event when the content is short. JS code: client/layout/utils.ts:36.
 	}
 


### PR DESCRIPTION
## Proposed Changes

From the video, I don't like these blinking loading messages. Should we also address them? Remember that the post-checkout process can take a while. Let's address this as part of a follow-up.

## Why are these changes being made?

Style consistency in the onboarding flow.

| Before | After |
| ------- | ----- |
| <video src="https://github.com/user-attachments/assets/4ddad975-af31-4d1c-a06b-f1912bcb0a74" /> | <video src="https://github.com/user-attachments/assets/1560fec2-a6c7-4f6d-b45b-a75d9735032a" /> |

## Testing Instructions

Go through `/setup/onboarding` with the `onboarding/step-container-v2` feature flag turned on and verify you don't see any blinks or gray backgrounds.

Turning the feature flag off and going through the same process also shouldn't break the app. And there should be no visual changes throughout Calypso as well when booting the app (refreshing the page, navigating through pages and refreshing the page.)