### PR TITLE
Remove the global-styles dependency from the data-stores package

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '@automattic/global-styles/src/constants';
 import { __ } from '@wordpress/i18n';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
+import { DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from './constants';
 import {
 	SiteLaunchError,
 	AtomicTransferError,

--- a/packages/data-stores/src/site/constants.ts
+++ b/packages/data-stores/src/site/constants.ts
@@ -1,2 +1,3 @@
 export const STORE_KEY = 'automattic/site';
 export const getPlaceholderSiteID = () => '226011606'; // assemblerdemo
+export const DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = 'default';

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -11,6 +11,7 @@
 		{ "path": "../calypso-analytics" },
 		{ "path": "../calypso-products" },
 		{ "path": "../calypso-config" },
+		{ "path": "../global-styles" },
 		{ "path": "../i18n-utils" },
 		{ "path": "../shopping-cart" },
 		{ "path": "../js-utils" }

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -11,7 +11,6 @@
 		{ "path": "../calypso-analytics" },
 		{ "path": "../calypso-products" },
 		{ "path": "../calypso-config" },
-		{ "path": "../global-styles" },
 		{ "path": "../i18n-utils" },
 		{ "path": "../shopping-cart" },
 		{ "path": "../js-utils" }


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Define `DEFAULT_GLOBAL_STYLES_VARIATION_SLUG` within `@automattic/data-stores` and remove it's dependence on `@automattic/global-styles`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Jetpack can't update to the latest version of `@automattic/data-stores` because the package has got a new undeclared dependency on `@automattic/global-styles`; which is a private package. Added in https://github.com/Automattic/wp-calypso/pull/95618.

Discussed here p1743531431572359-slack-C02DQP0FP

My ideal solution would have been to flip the dependency. As a private package, `global-styles` is in a much better position to depend on `data-stores` than the other way round. I could move the `DEFAULT_GLOBAL_STYLES_VARIATION_SLUG` constant (and related constants?) to `@automattic/data-stores`.

Unfortunately this involves quite a lot of unpicking. `global-styles` can't depend on `data-stores` because there's already something close to a circular dependency. See here: https://github.com/Automattic/wp-calypso/blob/cc549f77f7ea2432ad16e0b9167be179d3aca83a/packages/data-stores/src/site/actions.ts#L36

`data-stores` depends on `design-picker` depends on `global-styles`. At least when it comes to types. The build still works because at runtime the dependency isn't there, but the type declarations are circular. The design picker types should probably move to `data-stores`. The place that fetches and mutates the data can have the type definitions.

Unpicking this dependency is trickier than what's needed to unblock Jetpack from updating their `@automattic/data-stores` dependency. So I'm hardcoding the constant in `data-stores` too.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the onboarding flow and use the design picker to choose global styles, or stick with default styles
* There should be no change from production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?