### PR TITLE
A4A: Revise the text for no Volume discount support.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/product-listing/index.tsx
@@ -269,7 +269,7 @@ export default function ProductListing( {
 					withCustomCard={ withCustomCard }
 					tooltip={
 						productDoNotHaveSupportedBundles
-							? translate( 'This product does not support the volume discount.' )
+							? translate( 'This product does not offer volume discounts.' )
 							: undefined
 					}
 					tooltipPosition="bottom"


### PR DESCRIPTION
A tiny improvement on the 'No volume discount' text we have.

| Before | After |
|--------|--------|
| <img width="430" alt="Screenshot 2025-04-03 at 3 13 37 PM" src="https://github.com/user-attachments/assets/9c0a3fd3-9579-4cde-b1d1-ad05a6432a61" /> | <img width="350" alt="Screenshot 2025-04-03 at 3 13 57 PM" src="https://github.com/user-attachments/assets/084acb6a-733a-4bb1-aa5e-31977a7df572" /> | 

Context pgjTho-oE-p2#comment-298

## Proposed Changes

* Update translation string.

## Why are these changes being made?

* Improves our text to be more clear.

## Testing Instructions

* Use the A4A live link and navigate to the `/marketplace/products` page.
* Switch a volume discount to 5 or more.
* Hover over products that do not support volume discounts.
* Confirm the tooltip shows the correct messaging.
## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?