### PR TITLE
Tests: Run for dataviews package

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,6 +308,7 @@
 		"readline-sync": "^1.4.10",
 		"recursive-copy": "^2.0.14",
 		"replace": "^1.1.5",
+		"resize-observer-polyfill": "^1.5.1",
 		"sass": "1.54.0",
 		"sass-loader": "^13.3.3",
 		"source-map": "^0.7.4",

--- a/packages/dataviews/jest.config.js
+++ b/packages/dataviews/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+};

--- a/test/packages/setup.js
+++ b/test/packages/setup.js
@@ -1,3 +1,16 @@
 import '@testing-library/jest-dom';
 
 global.crypto.randomUUID = () => 'fake-uuid';
+
+global.ResizeObserver = require( 'resize-observer-polyfill' );
+
+global.matchMedia = jest.fn( ( query ) => ( {
+	matches: false,
+	media: query,
+	onchange: null,
+	addListener: jest.fn(), // deprecated
+	removeListener: jest.fn(), // deprecated
+	addEventListener: jest.fn(),
+	removeEventListener: jest.fn(),
+	dispatchEvent: jest.fn(),
+} ) );

--- a/yarn.lock
+++ b/yarn.lock
@@ -35734,6 +35734,7 @@ __metadata:
     redux: "npm:^5.0.1"
     replace: "npm:^1.1.5"
     request: "npm:^2.88.2"
+    resize-observer-polyfill: "npm:^1.5.1"
     sass: "npm:1.54.0"
     sass-loader: "npm:^13.3.3"
     source-map: "npm:^0.7.4"


### PR DESCRIPTION
## Proposed Changes

Enables running the unit tests of the dataviews package.

Fixes [DOTCOM-1819](https://linear.app/a8c/issue/DOTCOM-1819/run-unit-tests-properly-in-the-fork) 

## Why are these changes being made?

Currently, tests for the dataviews package aren't run due to the fact that package tests automatically run only when the package has a jest config file.

## Testing Instructions

* Run `yarn run test-packages packages/dataviews` and verify dataviews tests pass.
* Verify the unit tests check is green.