### PR TITLE
Add Prettier config override for DataViews

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@typescript-eslint/parser": "^6.21.0",
 		"@wordpress/eslint-plugin": "^22.6.0",
+		"@wordpress/prettier-config": "^4.20.0",
 		"@wordpress/stylelint-config": "^23.12.0",
 		"babel-loader": "^8.2.3",
 		"bunyan": "^1.8.15",

--- a/packages/dataviews/.eslintrc.js
+++ b/packages/dataviews/.eslintrc.js
@@ -1,4 +1,10 @@
 module.exports = {
 	root: true,
-	ignorePatterns: [ '**/*.ts', '**/*.tsx', '**/*.js', '**/*.json', '**/*.md' ],
+	ignorePatterns: [
+		'**/*.ts',
+		'**/*.tsx',
+		'**/*.js',
+		'**/*.json',
+		'**/*.md',
+	],
 };

--- a/packages/dataviews/.prettierrc.js
+++ b/packages/dataviews/.prettierrc.js
@@ -1,0 +1,2 @@
+// Use the WordPress/Gutenberg Prettier config: it has different `printWidth` and `tabWidth`.
+module.exports = require( '@wordpress/prettier-config' );

--- a/yarn.lock
+++ b/yarn.lock
@@ -35685,6 +35685,7 @@ __metadata:
     "@wordpress/icons": "npm:^10.20.0"
     "@wordpress/is-shallow-equal": "npm:^5.20.0"
     "@wordpress/keycodes": "npm:^4.20.0"
+    "@wordpress/prettier-config": "npm:^4.20.0"
     "@wordpress/primitives": "npm:^4.20.0"
     "@wordpress/rich-text": "npm:^7.20.0"
     "@wordpress/stylelint-config": "npm:^23.12.0"


### PR DESCRIPTION
Add a custom config to the `packages/dataviews` directory so that it keeps being formatted in Gutenberg style. `printWidth=80`, `tabWidth=4`.

We simply use the `@wordpress/prettier-config` package. Nothing is inherited from the root Calypso config.

## Testing instructions:
- run `yarn reformat-files` and verify that no files are reformatted. Before this patch you'd get a lot of changes in `packages/dataviews`
- test formatting in your editor (VSCode etc.). Does it pick up the custom config?