### PR TITLE
Add Playground step tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
@@ -2,9 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import PlaygroundStep from '..';
 import { StepProps } from '../../../types';
 import { renderStep, mockStepProps, RenderStepOptions } from '../../test/helpers';
@@ -23,25 +22,22 @@ const renderPlaygroundStep = (
 	return renderStep( <PlaygroundStep { ...combinedProps } />, renderOptions );
 };
 
-const launchButton = () => screen.getByRole( 'button', { name: 'Launch on WordPress.com' } );
+const getLaunchButton = () => screen.getByRole( 'button', { name: 'Launch on WordPress.com' } );
 
 describe( 'Playground', () => {
 	describe( 'step', () => {
 		it( 'should render the iframe and the launch button', () => {
 			const { container } = renderPlaygroundStep();
 
-			expect( launchButton() ).toBeInTheDocument();
-			expect( container.querySelector( 'iframe' ) ).toBeInTheDocument();
+			expect( getLaunchButton() ).toBeVisible();
+			expect( container.querySelector( 'iframe' ) ).toBeVisible();
 		} );
 
 		it( 'should change page when the user clicks the launch button', async () => {
 			const submit = jest.fn();
 			renderPlaygroundStep( { navigation: { submit } } );
 
-			await waitFor( async () => {
-				await userEvent.click( launchButton() );
-			} );
-
+			await userEvent.click( getLaunchButton() );
 			expect( submit ).toHaveBeenCalled();
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
@@ -2,21 +2,47 @@
  * @jest-environment jsdom
  */
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import PlaygroundStep from '..';
 import { StepProps } from '../../../types';
 import { renderStep, mockStepProps, RenderStepOptions } from '../../test/helpers';
 
-const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions ) => {
+// Be sure to mock this hook to return true so that the step is rendered.
+jest.mock( 'calypso/landing/stepper/hooks/use-is-playground-eligible', () => ( {
+	useIsPlaygroundEligible: () => true,
+} ) );
+
+const renderPlaygroundStep = (
+	props?: Partial< StepProps >,
+	renderOptions?: RenderStepOptions
+) => {
 	const combinedProps = { ...mockStepProps( props ) };
 
 	return renderStep( <PlaygroundStep { ...combinedProps } />, renderOptions );
 };
 
-describe( 'Playground Step', () => {
-	it( 'should render the launch button', () => {
-		render();
-		expect( screen.getByRole( 'button', { name: 'Launch on WordPress.com' } ) ).toBeInTheDocument();
+const launchButton = () => screen.getByRole( 'button', { name: 'Launch on WordPress.com' } );
+
+describe( 'Playground', () => {
+	describe( 'step', () => {
+		it( 'should render the iframe and the launch button', () => {
+			const { container } = renderPlaygroundStep();
+
+			expect( launchButton() ).toBeInTheDocument();
+			expect( container.querySelector( 'iframe' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should change page when the user clicks the launch button', async () => {
+			const submit = jest.fn();
+			renderPlaygroundStep( { navigation: { submit } } );
+
+			await waitFor( async () => {
+				await userEvent.click( launchButton() );
+			} );
+
+			expect( submit ).toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import React from 'react';
+import PlaygroundStep from '..';
+import { StepProps } from '../../../types';
+import { renderStep, mockStepProps, RenderStepOptions } from '../../test/helpers';
+
+const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+
+	return renderStep( <PlaygroundStep { ...combinedProps } />, renderOptions );
+};
+
+describe( 'Playground Step', () => {
+	it( 'should render the launch button', () => {
+		render();
+		expect( screen.getByRole( 'button', { name: 'Launch on WordPress.com' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+
+const nodeCrypto = require( 'node:crypto' );
 const { ReadableStream, TransformStream } = require( 'node:stream/web' );
 const { TextEncoder, TextDecoder } = require( 'util' );
 const nock = require( 'nock' );
@@ -49,8 +51,12 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 } ) );
 
 // Mock crypto.randomUUID with its Node.js implementation
-global.crypto.randomUUID = () => require( 'crypto' ).randomUUID();
-global.crypto.subtle = require( 'node:crypto' ).subtle;
+global.crypto.randomUUID = () => nodeCrypto.randomUUID();
+
+// Mock crypto.subtle with its Node.js implementation, if needed.
+if ( ! global.crypto.subtle ) {
+	global.crypto.subtle = nodeCrypto.subtle;
+}
 
 // Add structuredClone if not available.
 if ( typeof global.structuredClone !== 'function' ) {

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+const { ReadableStream, TransformStream } = require( 'node:stream/web' );
 const { TextEncoder, TextDecoder } = require( 'util' );
 const nock = require( 'nock' );
 
@@ -21,6 +22,10 @@ afterAll( () => {
 // Define TextEncoder for ReactDOMServer
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// Define ReadableStream and TransformStream
+global.ReadableStream = ReadableStream;
+global.TransformStream = TransformStream;
 
 // This is used by @wordpress/components in https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/ui/utils/space.ts#L33
 // JSDOM or CSSDOM don't provide an implementation for it, so for now we have to mock it.
@@ -45,6 +50,12 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 
 // Mock crypto.randomUUID with its Node.js implementation
 global.crypto.randomUUID = () => require( 'crypto' ).randomUUID();
+global.crypto.subtle = require( 'node:crypto' ).subtle;
+
+// Add structuredClone if not available.
+if ( typeof global.structuredClone !== 'function' ) {
+	global.structuredClone = ( obj ) => JSON.parse( JSON.stringify( obj ) );
+}
 
 global.matchMedia = jest.fn( ( query ) => ( {
 	matches: false,

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -25,10 +25,6 @@ afterAll( () => {
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
-// Define ReadableStream and TransformStream
-global.ReadableStream = ReadableStream;
-global.TransformStream = TransformStream;
-
 // This is used by @wordpress/components in https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/ui/utils/space.ts#L33
 // JSDOM or CSSDOM don't provide an implementation for it, so for now we have to mock it.
 global.CSS = {
@@ -53,11 +49,6 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 // Mock crypto.randomUUID with its Node.js implementation
 global.crypto.randomUUID = () => nodeCrypto.randomUUID();
 
-// Mock crypto.subtle with its Node.js implementation, if needed.
-if ( ! global.crypto.subtle ) {
-	global.crypto.subtle = nodeCrypto.subtle;
-}
-
 // Add structuredClone if not available.
 if ( typeof global.structuredClone !== 'function' ) {
 	global.structuredClone = ( obj ) => JSON.parse( JSON.stringify( obj ) );
@@ -73,3 +64,14 @@ global.matchMedia = jest.fn( ( query ) => ( {
 	removeEventListener: jest.fn(),
 	dispatchEvent: jest.fn(),
 } ) );
+
+// This is used by @wp-playground/client
+global.ReadableStream = ReadableStream;
+global.TransformStream = TransformStream;
+global.Worker = require( 'worker_threads' ).Worker;
+
+// This is used by @wp-playground/client
+if ( ! global.crypto.subtle ) {
+	// Mock crypto.subtle with its Node.js implementation, if needed.
+	global.crypto.subtle = nodeCrypto.subtle;
+}

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -49,11 +49,6 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 // Mock crypto.randomUUID with its Node.js implementation
 global.crypto.randomUUID = () => nodeCrypto.randomUUID();
 
-// Add structuredClone if not available.
-if ( typeof global.structuredClone !== 'function' ) {
-	global.structuredClone = ( obj ) => JSON.parse( JSON.stringify( obj ) );
-}
-
 global.matchMedia = jest.fn( ( query ) => ( {
 	matches: false,
 	media: query,
@@ -69,6 +64,11 @@ global.matchMedia = jest.fn( ( query ) => ( {
 global.ReadableStream = ReadableStream;
 global.TransformStream = TransformStream;
 global.Worker = require( 'worker_threads' ).Worker;
+
+// This is used by @wp-playground/client
+if ( typeof global.structuredClone !== 'function' ) {
+	global.structuredClone = ( obj ) => JSON.parse( JSON.stringify( obj ) );
+}
 
 // This is used by @wp-playground/client
 if ( ! global.crypto.subtle ) {


### PR DESCRIPTION
This PR adds initial tests for the Playground onboarding flow.

## Proposed Changes

* Add tests for `Playground > step > *`
* Added missing global API to make Playground client work

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
The `@wp-playground/client` assumes some API are found by default on the global namespace. I've added them to the Jest file loaded in `setupFilesAfterEnv`. These are the missing APIs.

1. `ReadableStream` and `TransformStream`
2. `Worker`
3. `structuredClone` is added by using a simple mock
4. `crypto.subtle`. A check is needed to see if this exists because we are modifying an existing object. This way, it works in localhost and TeamCity

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Having working tests on TeamCity
* `yarn run test-client -- --testPathPattern client/landing/stepper/declarative-flow/internals/steps-repository/playground`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
