### PR TITLE
calypso-e2e: Fix the Confirm button selector in the Media Library

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -1,5 +1,5 @@
 import { Page, ElementHandle } from 'playwright';
-import { EditorComponent, envVariables } from '../..';
+import { EditorComponent } from '../..';
 
 type Sources = 'Media Library' | 'Google Photos' | 'Pexels';
 
@@ -91,9 +91,7 @@ export class ImageBlock {
 		const page = ( await this.block.ownerFrame() )?.page() as Page;
 		await page.locator( 'input[type="file"][multiple]' ).setInputFiles( path );
 
-		const confirmButtonSelector = envVariables.TEST_ON_ATOMIC
-			? 'button:text-is("Select")'
-			: 'button :text-is("Insert")'; // The whitespace is intentional as the text is nested in a span element.
+		const confirmButtonSelector = 'button:text-is("Select")';
 
 		await page.locator( confirmButtonSelector ).click();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix the Confirm button selector in the Media Library modal for the image for the Image Block E2E helper class.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There seems to be no difference between the Confirm button label on Simple and Atomic sites anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm E2E tests in TeamCity pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
