### PR TITLE
E2E: Update selector when inserting media on Simple sites

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/image-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/image-block.ts
@@ -1,5 +1,5 @@
 import { Page, ElementHandle } from 'playwright';
-import { EditorComponent, envVariables } from '../..';
+import { EditorComponent } from '../..';
 
 type Sources = 'Media Library' | 'Google Photos' | 'Pexels';
 
@@ -91,11 +91,7 @@ export class ImageBlock {
 		const page = ( await this.block.ownerFrame() )?.page() as Page;
 		await page.locator( 'input[type="file"][multiple]' ).setInputFiles( path );
 
-		const confirmButtonSelector = envVariables.TEST_ON_ATOMIC
-			? 'button:text-is("Select")'
-			: 'button :text-is("Insert")'; // The whitespace is intentional as the text is nested in a span element.
-
-		await page.locator( confirmButtonSelector ).click();
+		await page.locator( 'button:text-is("Select")' ).click();
 
 		return await this.getImage();
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

p1743679659037599-slack-C01U2KGS2PQ

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/blocks/blocks__media.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?