### PR TITLE
Fix Social E2E tests

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -56,24 +56,6 @@ const testCases: Array< {
 	},
 ];
 
-const getShareModal = async (
-	page: Page,
-	platform: ( typeof testCases )[ number ][ 'platform' ]
-) => {
-	let shareModal;
-	if ( 'Atomic' !== platform ) {
-		// Get the main editor iframe
-		const editorFrame = page.frameLocator( 'iframe' ).first();
-		shareModal = editorFrame.getByRole( 'dialog' );
-	} else {
-		shareModal = page.getByRole( 'dialog' );
-	}
-
-	await shareModal.waitFor( { state: 'visible' } );
-
-	return shareModal;
-};
-
 /**
  * Tests features offered by Jetpack Social on a Simple site with Free plan.
  *
@@ -158,7 +140,11 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				} );
 				await sharePostModalButton.click();
 
-				let shareModal = await getShareModal( page, platform );
+				const shareModal = ( await editorPage.getEditorParent() ).getByRole( 'dialog' ).filter( {
+					hasText: 'Social Preview',
+				} );
+
+				await shareModal.waitFor();
 				let reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
 
 				expect( await reshareButton.isVisible() ).toBe( false );
@@ -170,11 +156,8 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				await editorPage.enterTitle( 'Resharing: ' + DataHelper.getRandomPhrase() );
 				// Publish the post.
 				await editorPage.publish();
+				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
 				await editorPage.closeAllPanels();
-
-				if ( features.resharing ) {
-					connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
-				}
 
 				// Open the Jetpack sidebar.
 				await editorPage.openSettings( 'Jetpack' );
@@ -201,7 +184,10 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				if ( features.resharing ) {
 					await sharePostModalButton.click();
 
-					shareModal = await getShareModal( page, platform );
+					const shareModal = ( await editorPage.getEditorParent() ).getByRole( 'dialog' ).filter( {
+						hasText: 'Share Post',
+					} );
+					await shareModal.waitFor();
 
 					// Look for the Share button within the modal dialog
 					reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );


### PR DESCRIPTION
Social E2E tests have been failing - p1743683057785689-slack-C01U2KGS2PQ

The reason probably https://github.com/Automattic/wp-calypso/pull/101157#discussion_r2026986225

## Proposed Changes

* Fix Social E2E tests by using the editor component to get the editor parent instead of looking for iframe

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should be happy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?