### PR TITLE
Language Select: Fix search icon misaligned on mobile

### DIFF
--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -17,11 +17,6 @@
 
 	.language-picker-component__title {
 		font-size: 2rem;
-		padding: 0 10px 12px;
-
-		@include break-small() {
-			padding: initial;
-		}
 	}
 
 	.components-custom-select-control {

--- a/packages/language-picker/src/style.scss
+++ b/packages/language-picker/src/style.scss
@@ -89,6 +89,22 @@
 			.search-component__icon-navigation {
 				background-color: transparent;
 			}
+
+			.search-component:not(.is-open) {
+				width: 30px;
+				height: 30px;
+				top: 1px;
+				right: 26px;
+
+				.search-component__icon-navigation {
+					padding: 0;
+				}
+
+				.search-component__open-icon {
+					width: 30px;
+					height: 30px;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/102322

## Proposed Changes

* This PR fixes the search icon getting out of bounds and being misaligned on mobile.
* It also fixes a small padding issue related to the heading title. This makes it consistent with how things look on the other resolutions.

| before | after |
|--------|--------|
| <img width="572" alt="image" src="https://github.com/user-attachments/assets/0a7990eb-8164-4b71-9c4a-36e6e6620bfb" /> | <img width="570" alt="image" src="https://github.com/user-attachments/assets/d4b9ff36-4411-4a52-96cf-83d2a81c7a65" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The language search icon in the Account Settings (/me/account) page is misaligned on mobile. Making it look bad.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /me/account on a mobile device.
* Open the language dropdown.
* Observe the placement of the search icon inside the input field.
* Click on the search icon and make sure it looks good there as well.
* Make sure everything looks good on the desktop view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
