### PR TITLE
Use cancel_to URL parameter to hide masterBar if needed

### DIFF
--- a/client/layout/test/utils.test.ts
+++ b/client/layout/test/utils.test.ts
@@ -2,20 +2,8 @@ import configApi from '@automattic/calypso-config';
 import { SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { isInStepContainerV2FlowContext } from '../utils';
 
-jest.mock( 'calypso/signup/utils', () => ( {
-	getFlowFromURL: jest.fn(),
-	DEFAULT_FLOW: 'main',
-	isRedirectingToStepContainerV2Flow: jest.fn(),
-} ) );
-
 jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn(),
-} ) );
-
-jest.mock( '@automattic/onboarding', () => ( {
-	SITE_SETUP_FLOW: 'site-setup',
-	ONBOARDING_FLOW: 'onboarding',
-	SITE_MIGRATION_FLOW: 'site-migration',
 } ) );
 
 describe( 'layout/utils', () => {

--- a/client/layout/test/utils.test.ts
+++ b/client/layout/test/utils.test.ts
@@ -1,0 +1,108 @@
+import configApi from '@automattic/calypso-config';
+import { SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { isInStepContainerV2FlowContext } from '../utils';
+
+jest.mock( 'calypso/signup/utils', () => ( {
+	getFlowFromURL: jest.fn(),
+	DEFAULT_FLOW: 'main',
+	isRedirectingToStepContainerV2Flow: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	SITE_SETUP_FLOW: 'site-setup',
+	ONBOARDING_FLOW: 'onboarding',
+	SITE_MIGRATION_FLOW: 'site-migration',
+} ) );
+
+describe( 'layout/utils', () => {
+	describe( 'isInStepContainerV2FlowContext', () => {
+		beforeEach( () => {
+			// Reset all mocks before each test
+			jest.clearAllMocks();
+
+			// Default mock for configApi.isEnabled to return true for step-container-v2
+			( configApi.isEnabled as jest.Mock ).mockImplementation( ( feature ) => {
+				if ( feature === 'onboarding/step-container-v2' ) {
+					return true;
+				}
+				return false;
+			} );
+		} );
+
+		describe( 'setup path', () => {
+			it( 'should return false when path starts with /setup and flow is a not supported flow', () => {
+				const pathname = '/setup/random-flow';
+				const query = 'step=step1';
+				const result = isInStepContainerV2FlowContext( pathname, query );
+
+				expect( result ).toBe( false );
+			} );
+
+			it( 'should return true when path starts with /setup and flow is a supported flow', () => {
+				const supportedFlows = [ SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW ];
+
+				supportedFlows.forEach( ( flow ) => {
+					const pathname = '/setup/' + flow;
+					const query = 'step=step1';
+					const result = isInStepContainerV2FlowContext( pathname, query );
+					expect( result ).toBe( true );
+				} );
+			} );
+
+			it( 'should return false when configApi.isEnabled returns false', () => {
+				const pathname = '/setup/' + SITE_SETUP_FLOW;
+				const query = 'step=step1';
+				( configApi.isEnabled as jest.Mock ).mockReturnValue( false );
+
+				const result = isInStepContainerV2FlowContext( pathname, query );
+
+				expect( configApi.isEnabled ).toHaveBeenCalledWith( 'onboarding/step-container-v2' );
+				expect( result ).toBe( false );
+			} );
+		} );
+
+		describe( 'checkout path', () => {
+			it( 'should return true when path starts with /checkout and redirect_to is to a StepContainerV2 flow', () => {
+				const pathname = '/checkout/site.com';
+				const query = 'redirect_to=%2Fsetup%2Fsite-setup';
+
+				const result = isInStepContainerV2FlowContext( pathname, query );
+
+				expect( result ).toBe( true );
+			} );
+
+			it( 'should return true when path starts with /checkout and cancel_to is to a StepContainerV2 flow', () => {
+				const pathname = '/checkout/site.com';
+				const query = 'cancel_to=%2Fsetup%2Fsite-setup';
+
+				const result = isInStepContainerV2FlowContext( pathname, query );
+
+				expect( result ).toBe( true );
+			} );
+
+			it( 'should return false when path starts with /checkout but neither redirect_to nor cancel_to is to a StepContainerV2 flow', () => {
+				const pathname = '/checkout/site.com';
+				const query = 'redirect_to=%2Fsome-path&cancel_to=%2Fother-path';
+
+				const result = isInStepContainerV2FlowContext( pathname, query );
+
+				expect( result ).toBe( false );
+			} );
+		} );
+
+		describe( 'other paths', () => {
+			it( 'should return false for paths that do not start with /setup or /checkout', () => {
+				const pathname = '/some-other-path';
+				const query = '';
+
+				const result = isInStepContainerV2FlowContext( pathname, query );
+
+				expect( result ).toBe( false );
+			} );
+		} );
+	} );
+} );

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -190,8 +190,15 @@ export const isInStepContainerV2FlowContext = ( pathname: string, query: string 
 		// of the onboarding flow).
 		const params = new URLSearchParams( query );
 		const redirectTo = params.get( 'redirect_to' ) ?? '';
+		const cancelTo = params.get( 'cancel_to' ) ?? '';
 
-		return isRedirectingToStepContainerV2Flow( redirectTo );
+		if ( isRedirectingToStepContainerV2Flow( redirectTo ) ) {
+			return true;
+		}
+
+		if ( isRedirectingToStepContainerV2Flow( cancelTo ) ) {
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/102368

## Proposed Changes

* We're also checking the `cancel_to` parameter to know if a user is in a StepContainerV2 flow
* Added unit tests for `isInStepContainerV2FlowContext`

| Before | After |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/662d2c4f-1214-4527-93c9-41b28fd5c0b9) | ![Image](https://github.com/user-attachments/assets/dc668816-1560-44f4-85f6-1e1404fdfc00) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Scenario 1

- Go to /setup/onboarding
- Free plan
- Skipped goals
- Filter design picker by Store and choose “Chrono”
- Agree to upgrade
- Land on checkout
- Ensure the bug is fixed

### Scenario 2

- Go to /setup/onboarding
- Paid plan
- Ensure checkout is still working as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
