### PR TITLE
A4A: Update migration incentive verbiage

### DIFF
--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
@@ -79,7 +79,7 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 									}
 								),
 								translate(
-									"{{b}}WP Engine customers:{{/b}} You will receive %(commission)s per successful site migration up to %(maxCommission)s. If you have an existing contract, we'll host your site(s) for free until your existing WP Engine contract ends.",
+									"{{b}}WP Engine/Flywheel, Kinsta, Pantheon, Nexcess, or Pagely customers:{{/b}} You will receive $100 per successful site migration up to $10,000. If you have an existing contract, we'll host your site(s) for free until your existing WP Engine/Flywheel, Kinsta, Pantheon, Nexcess, or Pagely contract ends.",
 									{
 										components: {
 											b: <b />,

--- a/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-migration-offer-v3/index.tsx
@@ -79,7 +79,7 @@ const MigrationOfferV3 = ( { isExpanded, onToggleView }: Props ) => {
 									}
 								),
 								translate(
-									"{{b}}WP Engine/Flywheel, Kinsta, Pantheon, Nexcess, or Pagely customers:{{/b}} You will receive $100 per successful site migration up to $10,000. If you have an existing contract, we'll host your site(s) for free until your existing WP Engine/Flywheel, Kinsta, Pantheon, Nexcess, or Pagely contract ends.",
+									"{{b}}WP Engine/Flywheel, Kinsta, Pantheon, Nexcess, or Pagely customers:{{/b}} You will receive %(commission)s per successful site migration up to %(maxCommission)s. If you have an existing contract, we'll host your site(s) for free until your existing WP Engine/Flywheel, Kinsta, Pantheon, Nexcess, or Pagely contract ends.",
 									{
 										components: {
 											b: <b />,


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/2022
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/2023
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/2024

## Proposed Changes

This PR updates the Migration banner copy as we now need to mention that it’s WPE/Flywheel, Kinsta, Pantheon, Nexcess, or Pagely. 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Update the verbiage. See pfunGA-5vP-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the A4A live link
- Visit the following pages:
  - `/overview`
  - `/migrations/overview`
  - `/marketplace/hosting/wpcom`
 - Verify the banner verbiage looks like the one below

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/81cbbc62-6205-4b85-a031-da4cc4131107" />
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?