### PR TITLE
Design Picker: Do not add plan to cart if site already has it

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -354,7 +354,8 @@ const UnifiedDesignPickerStep: StepType< {
 		isExternallyManagedThemeAvailable,
 	} = useMarketplaceThemeProducts();
 
-	const requiredPlanSlug = getRequiredPlan( selectedDesign, site?.plan?.product_slug || '' );
+	const sitePlanSlug = site?.plan?.product_slug;
+	const requiredPlanSlug = getRequiredPlan( selectedDesign, sitePlanSlug || '' );
 
 	const didPurchaseSelectedTheme = useSelector( ( state ) =>
 		site && selectedDesignThemeId
@@ -442,7 +443,7 @@ const UnifiedDesignPickerStep: StepType< {
 			stepName,
 			siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
 			destination,
-			plan: requiredPlanSlug,
+			plan: requiredPlanSlug === sitePlanSlug ? undefined : requiredPlanSlug,
 			extraProducts: selectedMarketplaceProductCartItems,
 		} );
 	}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/102372.

## Proposed Changes

Do not pass the plan to the checkout URL if it matches the existing site's plan.

## Why are these changes being made?

Because it's broken in production. If the site has the same plan, it still adds it to the cart, which generates an error at checkout.

## Testing Instructions

- `/setup/onboarding`
- Pick a Business plan
- Pay for it at checkout
- Skip goals
- Filter design picker by Store and choose “Chrono”
- Agree to upgrade and transfer to atomic

Land on checkout and notice only the theme is added to the cart.

Repeat the process but with a site on Personal or Premium. Verify you see the Business plan in the cart this time.