### PR TITLE
Post-checkout: Show StepContainerV2's Loading when purchasing partner themes

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -83,6 +83,11 @@ body.command-palette-modal-open {
 		margin: 0;
 	}
 
+	.is-section-marketplace.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+
 	.is-section-themes.has-no-sidebar.is-logged-in &,
 	.theme-default .is-section-themes.has-no-sidebar.is-logged-in & {
 		padding: 79px 32px 32px;

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,6 +1,7 @@
 import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { DEFAULT_FLOW, getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 let lastScrollPosition = 0; // Used for calculating scroll direction.
 let sidebarTop = 0; // Current sidebar top position.
 let pinnedSidebarTop = true; // We pin sidebar to the top by default.
@@ -185,6 +186,10 @@ export const isInStepContainerV2FlowContext = ( pathname: string, query: string 
 	}
 
 	if ( pathname.startsWith( '/checkout' ) ) {
+		if ( shouldUseStepContainerV2( getSignupCompleteFlowName() ) ) {
+			return true;
+		}
+
 		// The checkout isn't technically part of a stepper flow, but we can infer what stepper
 		// flow it came from (if any) by inspecting the redirect_to query param (in the case
 		// of the onboarding flow).
@@ -199,6 +204,10 @@ export const isInStepContainerV2FlowContext = ( pathname: string, query: string 
 		if ( isRedirectingToStepContainerV2Flow( cancelTo ) ) {
 			return true;
 		}
+	}
+
+	if ( pathname.startsWith( '/marketplace' ) ) {
+		return shouldUseStepContainerV2( getSignupCompleteFlowName() );
 	}
 
 	return false;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -3,5 +3,5 @@
 
 .marketplace-thank-you__container {
 	max-width: 750px;
-	padding: 0 24px 0;
+	padding: 16px 24px 0;
 }

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -9,12 +9,13 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
 import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
-import { isRedirectingToStepContainerV2Flow } from 'calypso/layout/utils';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { getRedirectFromPendingPage } from 'calypso/my-sites/checkout/src/lib/pending-page';
 import { sendMessageToOpener } from 'calypso/my-sites/checkout/src/lib/popup';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
@@ -93,7 +94,7 @@ function CheckoutPending( {
 		fromSiteSlug,
 	} );
 
-	const content = isRedirectingToStepContainerV2Flow( redirectTo ?? '' ) ? (
+	const content = shouldUseStepContainerV2( getSignupCompleteFlowName() ) ? (
 		<Step.Loading title={ headingText } />
 	) : (
 		<Main className="checkout-thank-you__pending">

--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -1,6 +1,9 @@
+import { Step } from '@automattic/onboarding';
 import { TranslateResult } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import Loading from 'calypso/components/loading';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import './style.scss';
 
 const ACCELERATED_REFRESH_INTERVAL = 750;
@@ -81,6 +84,10 @@ export default function MarketplaceProgressBar( {
 			}
 		};
 	}, [ additionalSteps, currentStep ] );
+
+	if ( shouldUseStepContainerV2( getSignupCompleteFlowName() ) ) {
+		return <Step.Loading title={ stepValue } progress={ simulatedProgressPercentage } />;
+	}
 
 	return (
 		<Loading

--- a/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
@@ -28,11 +28,6 @@ body.is-section-marketplace {
 		align-items: center;
 		width: 100%;
 		height: 100vh;
-
-		> div {
-			width: 90%;
-			max-width: 509px;
-		}
 	}
 }
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1046,7 +1046,7 @@ $font-size: rem(14px);
 @media screen and (max-width: 781px) {
 	// client/layout/sidebar/style.scss
 	.theme-default {
-		.focus-content .layout__content {
+		&:has(.sidebar) .focus-content .layout__content {
 			padding: 70px 24px 24px;
 			transition: padding 0.15s ease-in-out;
 		}


### PR DESCRIPTION
## Proposed Changes

Title. We were showing the old masterbar and loading screen.

| Before | After |
| ------- | ----- |
| <video src="https://github.com/user-attachments/assets/31008e1a-2ad0-4238-9a22-4516ba5e92f8" /> | <video src="https://github.com/user-attachments/assets/e1db4637-30ce-440e-b1e7-b028b7a623c9" /> |

Note: in the Quicktime recording for some reason the progress bar becomes gray, but that doesn't happen in the browser. 🤔 

## Testing Instructions

Go through the same progression as the one from the video:

1. Enter `/setup/onboarding` and purchase the Personal plan;
2. Pick a Premium plan in the Design Picker and pay for the upgrade;
3. Grab the site URL and enter `/setup/site-setup?siteSlug=%s`;
4. Pick a partner theme this time and pay for it.

You should see StepContainerV2's loading (and top bar) between all pages, including the post-checkout for the partner theme purchase.