### PR TITLE
A4A > Feedback: Implement updated Contextual Feedback Mechanism

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
@@ -140,7 +140,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 					{
 						displayOnNextPage: true,
 						id: 'submit-product-feedback-success',
-						duration: 2000,
+						duration: 10000,
 					}
 				)
 			);

--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
@@ -57,6 +57,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 
 	// Additional args, like email for invite flow
 	const { value: args } = useUrlQueryParam( 'args' );
+	const { value: redirectUrlFromQueryParam } = useUrlQueryParam( 'redirectUrl' );
 
 	// We are storing the timestamp when last feedback for given preference was submitted or skipped
 	const feedbackTimestamp = useSelector( ( state ) => getPreference( state, FEEDBACK_PREFERENCE ) );
@@ -82,13 +83,14 @@ const useShowFeedback = ( type: FeedbackType ) => {
 			if ( ! data || ! agencyId ) {
 				return;
 			}
-			const { experience, comments } = data;
+			const { experience, comments, suggestions } = data;
 			const params: FeedbackSurveyResponsesPayload = {
 				site_id: agencyId,
 				survey_id: type,
 				survey_responses: {
 					rating: experience,
 					comment: comments,
+					suggestions: suggestions?.join( ', ' ) || '',
 				},
 			};
 
@@ -97,6 +99,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 					agency_id: agencyId,
 					survey_id: params.survey_id,
 					rating: params.survey_responses.rating,
+					suggestions: params.survey_responses.suggestions,
 				} )
 			);
 			saveFeedback( { params } );
@@ -147,7 +150,9 @@ const useShowFeedback = ( type: FeedbackType ) => {
 		if ( feedbackFormHash && ! showFeedback && ! isPending ) {
 			// If the feedback form hash is present but we don't want to show the feedback form, redirect to the default URL
 			// If feedback was interacted, redirect to the URL passed in the feedbackProps
-			redirectToDefaultUrl( feedbackInteracted ? feedbackProps.redirectUrl : undefined );
+			redirectToDefaultUrl(
+				redirectUrlFromQueryParam || ( feedbackInteracted ? feedbackProps.redirectUrl : undefined )
+			);
 		}
 	}, [
 		apiResponseData,
@@ -156,6 +161,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 		feedbackInteracted,
 		feedbackProps,
 		isPending,
+		redirectUrlFromQueryParam,
 		showFeedback,
 		translate,
 	] );

--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
@@ -87,8 +87,8 @@ const useShowFeedback = ( type: FeedbackType ) => {
 				survey_id: type,
 				survey_responses: {
 					rating: experience,
-					comment: comments,
-					suggestions: suggestions?.join( ', ' ) || '',
+					comment: { text: comments },
+					suggestions: { text: suggestions?.join( ', ' ) || '' },
 				},
 			};
 
@@ -97,7 +97,8 @@ const useShowFeedback = ( type: FeedbackType ) => {
 					agency_id: agencyId,
 					survey_id: params.survey_id,
 					rating: params.survey_responses.rating,
-					suggestions: params.survey_responses.suggestions,
+					suggestions: params.survey_responses.suggestions?.text,
+					comment: params.survey_responses.comment.text,
 				} )
 			);
 			saveFeedback( { params } );

--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import { removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useUrlQueryParam from 'calypso/a8c-for-agencies/hooks/use-url-query-param';
@@ -9,9 +8,9 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from '../../../../state/preferences/selectors';
+import { A4A_OVERVIEW_LINK, A4A_FEEDBACK_LINK } from '../../sidebar-menu/lib/constants';
 import { getA4AfeedbackProps } from '../lib/get-a4a-feedback-props';
 import useSaveFeedbackMutation from './use-save-feedback-mutation';
-import type { Props as A4AFeedbackProps } from '../index';
 import type {
 	FeedbackQueryData,
 	FeedbackType,
@@ -19,7 +18,6 @@ import type {
 	FeedbackSurveyResponsesPayload,
 } from '../types';
 
-const FEEDBACK_URL_HASH_FRAGMENT = '#feedback';
 const FEEDBACK_PREFERENCE = 'a4a-feedback';
 
 const redirectToDefaultUrl = ( redirectUrl?: string ) => {
@@ -27,7 +25,7 @@ const redirectToDefaultUrl = ( redirectUrl?: string ) => {
 		page.redirect( redirectUrl );
 		return;
 	}
-	page.redirect( removeQueryArgs( window.location.pathname + window.location.search, 'args' ) );
+	page.redirect( A4A_OVERVIEW_LINK );
 };
 
 const getUpdatedPreference = (
@@ -52,8 +50,8 @@ const useShowFeedback = ( type: FeedbackType ) => {
 
 	const { mutate: saveFeedback, isPending, data: apiResponseData } = useSaveFeedbackMutation();
 
-	// Let's use hash #feedback if we want to show the feedback
-	const feedbackFormHash = window.location.hash === FEEDBACK_URL_HASH_FRAGMENT;
+	// Check if the current page is the feedback page
+	const isFeedbackPage = window.location.pathname === A4A_FEEDBACK_LINK;
 
 	// Additional args, like email for invite flow
 	const { value: args } = useUrlQueryParam( 'args' );
@@ -121,7 +119,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 	}, [ dispatch, feedbackTimestamp, type ] );
 
 	// Combine props passed to Feedback component
-	const updatedFeedbackProps: A4AFeedbackProps = useMemo(
+	const updatedFeedbackProps = useMemo(
 		() => ( {
 			...feedbackProps,
 			onSubmit: onSubmitFeedback,
@@ -147,7 +145,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 			);
 		}
 
-		if ( feedbackFormHash && ! showFeedback && ! isPending ) {
+		if ( isFeedbackPage && ! showFeedback && ! isPending ) {
 			// If the feedback form hash is present but we don't want to show the feedback form, redirect to the default URL
 			// If feedback was interacted, redirect to the URL passed in the feedbackProps
 			redirectToDefaultUrl(
@@ -157,7 +155,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 	}, [
 		apiResponseData,
 		dispatch,
-		feedbackFormHash,
+		isFeedbackPage,
 		feedbackInteracted,
 		feedbackProps,
 		isPending,
@@ -168,7 +166,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 
 	return {
 		isFeedbackShown: ! showFeedback,
-		showFeedback: feedbackFormHash && showFeedback,
+		showFeedback: isFeedbackPage && showFeedback,
 		feedbackProps: updatedFeedbackProps,
 		isSubmitting: isPending,
 	};

--- a/client/a8c-for-agencies/components/a4a-feedback/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/index.tsx
@@ -2,25 +2,28 @@ import { FormLabel } from '@automattic/components';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useState } from 'react';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import IconBad from 'calypso/assets/images/a8c-for-agencies/feedback/bad.svg';
 import IconGood from 'calypso/assets/images/a8c-for-agencies/feedback/good.svg';
 import IconNeutral from 'calypso/assets/images/a8c-for-agencies/feedback/neutral.svg';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import type { FeedbackQueryData, FeedbackProps, FeedbackSuggestion } from './types';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import useShowFeedback from './hooks/use-show-a4a-feedback';
+import type { FeedbackType, FeedbackSuggestion } from './types';
 
 import './style.scss';
 
-export interface Props extends FeedbackProps {
-	onSubmit: ( data: FeedbackQueryData ) => void;
-	onSkip: () => void;
-}
-
-export function A4AFeedback( { title, description, suggestion, onSubmit, onSkip }: Props ) {
+export function A4AFeedback( { type }: { type: FeedbackType } ) {
 	const translate = useTranslate();
 	const [ experience, setExperience ] = useState< string >( 'good' );
 	const [ comments, setComments ] = useState< string >( '' );
 	const [ suggestions, setSuggestions ] = useState< FeedbackSuggestion[] >( [] );
+
+	const {
+		feedbackProps: { title, description, suggestion, onSubmit, onSkip },
+		isSubmitting,
+	} = useShowFeedback( type );
 
 	const onSuggestionChange = ( option: FeedbackSuggestion ) => {
 		if ( suggestions.find( ( suggestion ) => suggestion.value === option.value ) ) {
@@ -33,92 +36,97 @@ export function A4AFeedback( { title, description, suggestion, onSubmit, onSkip 
 	};
 
 	return (
-		<div className="a4a-feedback__wrapper">
-			<div className="a4a-feedback__content">
-				<h1 className="a4a-feedback__title">{ title }</h1>
-				<div className="a4a-feedback__description">{ description }</div>
-				<div className="a4a-feedback__questions">
-					<div className="a4a-feedback__question-details">
-						{ translate( 'Share your feedback' ) }
-					</div>
-					<div className="a4a-feedback__experience-selector">
-						<div className="a4a-feedback__experience-selector-label">
-							{ translate( 'What was your experience like?' ) }
-						</div>
-						<div className="a4a-feedback__experience-selector-buttons">
-							<Button
-								variant={ experience === 'good' ? 'primary' : 'secondary' }
-								onClick={ () => setExperience( 'good' ) }
-							>
-								<img src={ IconGood } alt="Good" />
-							</Button>
-							<Button
-								variant={ experience === 'neutral' ? 'primary' : 'secondary' }
-								onClick={ () => setExperience( 'neutral' ) }
-							>
-								<img src={ IconNeutral } alt="Neutral" />
-							</Button>
-							<Button
-								variant={ experience === 'bad' ? 'primary' : 'secondary' }
-								onClick={ () => setExperience( 'bad' ) }
-							>
-								<img src={ IconBad } alt="Bad" />
-							</Button>
-						</div>
-					</div>
-					{ suggestion && (
-						<FormFieldset>
-							<FormLabel className="a4a-feedback__comments-label" htmlFor="suggestion">
-								{ suggestion.label }
-							</FormLabel>
-							<div className="a4a-feedback__suggestions">
-								{ suggestion.options.map( ( option ) => (
-									<CheckboxControl
-										key={ `suggestion-${ option.value }` }
-										label={ option.label }
-										checked={
-											!! suggestions.find( ( suggestion ) => suggestion.value === option.value )
-										}
-										onChange={ () => onSuggestionChange( option ) }
-									/>
-								) ) }
+		<Layout className="a4a-feedback" title={ title } wide>
+			<LayoutBody>
+				<div className="a4a-feedback__wrapper">
+					<div className="a4a-feedback__content">
+						<h1 className="a4a-feedback__title">{ title }</h1>
+						<div className="a4a-feedback__description">{ description }</div>
+						<div className="a4a-feedback__questions">
+							<div className="a4a-feedback__question-details">
+								{ translate( 'Share your feedback' ) }
 							</div>
-						</FormFieldset>
-					) }
-					<FormFieldset>
-						<FormLabel className="a4a-feedback__comments-label" htmlFor="comments">
-							{ translate( 'Share your suggestions' ) }
-						</FormLabel>
-						<FormTextarea
-							className="a4a-feedback__comments"
-							name="comments"
-							id="comments"
-							value={ comments }
-							onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
-								setComments( event.target.value )
-							}
-						/>
-					</FormFieldset>
-					<div className="a4a-feedback__cta">
-						<Button
-							variant="primary"
-							onClick={ () =>
-								onSubmit( {
-									experience,
-									comments,
-									suggestions: suggestions.map( ( suggestion ) => suggestion.value ),
-								} )
-							}
-							disabled={ ! experience }
-						>
-							{ translate( 'Send your feedback' ) }
-						</Button>
-						<Button className="a8c-blue-link" onClick={ onSkip }>
-							{ translate( 'Skip' ) }
-						</Button>
+							<div className="a4a-feedback__experience-selector">
+								<div className="a4a-feedback__experience-selector-label">
+									{ translate( 'What was your experience like?' ) }
+								</div>
+								<div className="a4a-feedback__experience-selector-buttons">
+									<Button
+										variant={ experience === 'good' ? 'primary' : 'secondary' }
+										onClick={ () => setExperience( 'good' ) }
+									>
+										<img src={ IconGood } alt="Good" />
+									</Button>
+									<Button
+										variant={ experience === 'neutral' ? 'primary' : 'secondary' }
+										onClick={ () => setExperience( 'neutral' ) }
+									>
+										<img src={ IconNeutral } alt="Neutral" />
+									</Button>
+									<Button
+										variant={ experience === 'bad' ? 'primary' : 'secondary' }
+										onClick={ () => setExperience( 'bad' ) }
+									>
+										<img src={ IconBad } alt="Bad" />
+									</Button>
+								</div>
+							</div>
+							{ suggestion && (
+								<FormFieldset>
+									<FormLabel className="a4a-feedback__comments-label" htmlFor="suggestion">
+										{ suggestion.label }
+									</FormLabel>
+									<div className="a4a-feedback__suggestions">
+										{ suggestion.options.map( ( option ) => (
+											<CheckboxControl
+												key={ `suggestion-${ option.value }` }
+												label={ option.label }
+												checked={
+													!! suggestions.find( ( suggestion ) => suggestion.value === option.value )
+												}
+												onChange={ () => onSuggestionChange( option ) }
+											/>
+										) ) }
+									</div>
+								</FormFieldset>
+							) }
+							<FormFieldset>
+								<FormLabel className="a4a-feedback__comments-label" htmlFor="comments">
+									{ translate( 'Share your suggestions' ) }
+								</FormLabel>
+								<FormTextarea
+									className="a4a-feedback__comments"
+									name="comments"
+									id="comments"
+									value={ comments }
+									onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+										setComments( event.target.value )
+									}
+								/>
+							</FormFieldset>
+							<div className="a4a-feedback__cta">
+								<Button
+									variant="primary"
+									onClick={ () =>
+										onSubmit( {
+											experience,
+											comments,
+											suggestions: suggestions.map( ( suggestion ) => suggestion.value ),
+										} )
+									}
+									disabled={ ! experience || isSubmitting }
+									isBusy={ isSubmitting }
+								>
+									{ translate( 'Send your feedback' ) }
+								</Button>
+								<Button className="a8c-blue-link" onClick={ onSkip } disabled={ isSubmitting }>
+									{ translate( 'Skip' ) }
+								</Button>
+							</div>
+						</div>
 					</div>
 				</div>
-			</div>
-		</div>
+			</LayoutBody>
+		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/components/a4a-feedback/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/index.tsx
@@ -106,7 +106,7 @@ export function A4AFeedback( { title, description, suggestion, onSubmit, onSkip 
 								onSubmit( {
 									experience,
 									comments,
-									suggestions: suggestions.map( ( suggestion ) => suggestion.text ),
+									suggestions: suggestions.map( ( suggestion ) => suggestion.value ),
 								} )
 							}
 							disabled={ ! experience }

--- a/client/a8c-for-agencies/components/a4a-feedback/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/index.tsx
@@ -1,5 +1,5 @@
 import { FormLabel } from '@automattic/components';
-import { Button } from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useState } from 'react';
 import IconBad from 'calypso/assets/images/a8c-for-agencies/feedback/bad.svg';
@@ -7,7 +7,7 @@ import IconGood from 'calypso/assets/images/a8c-for-agencies/feedback/good.svg';
 import IconNeutral from 'calypso/assets/images/a8c-for-agencies/feedback/neutral.svg';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import type { FeedbackQueryData, FeedbackProps } from './types';
+import type { FeedbackQueryData, FeedbackProps, FeedbackSuggestion } from './types';
 
 import './style.scss';
 
@@ -16,17 +16,21 @@ export interface Props extends FeedbackProps {
 	onSkip: () => void;
 }
 
-export function A4AFeedback( {
-	title,
-	description,
-	questionDetails,
-	ctaText,
-	onSubmit,
-	onSkip,
-}: Props ) {
+export function A4AFeedback( { title, description, suggestion, onSubmit, onSkip }: Props ) {
 	const translate = useTranslate();
 	const [ experience, setExperience ] = useState< string >( 'good' );
 	const [ comments, setComments ] = useState< string >( '' );
+	const [ suggestions, setSuggestions ] = useState< FeedbackSuggestion[] >( [] );
+
+	const onSuggestionChange = ( option: FeedbackSuggestion ) => {
+		if ( suggestions.find( ( suggestion ) => suggestion.value === option.value ) ) {
+			setSuggestions( ( prev ) =>
+				prev.filter( ( suggestion ) => suggestion.value !== option.value )
+			);
+		} else {
+			setSuggestions( ( prev ) => [ ...prev, option ] );
+		}
+	};
 
 	return (
 		<div className="a4a-feedback__wrapper">
@@ -34,10 +38,12 @@ export function A4AFeedback( {
 				<h1 className="a4a-feedback__title">{ title }</h1>
 				<div className="a4a-feedback__description">{ description }</div>
 				<div className="a4a-feedback__questions">
-					<div className="a4a-feedback__question-details">{ questionDetails }</div>
+					<div className="a4a-feedback__question-details">
+						{ translate( 'Share your feedback' ) }
+					</div>
 					<div className="a4a-feedback__experience-selector">
 						<div className="a4a-feedback__experience-selector-label">
-							{ translate( 'Overall' ) }
+							{ translate( 'What was your experience like?' ) }
 						</div>
 						<div className="a4a-feedback__experience-selector-buttons">
 							<Button
@@ -60,12 +66,28 @@ export function A4AFeedback( {
 							</Button>
 						</div>
 					</div>
+					{ suggestion && (
+						<FormFieldset>
+							<FormLabel className="a4a-feedback__comments-label" htmlFor="suggestion">
+								{ suggestion.label }
+							</FormLabel>
+							<div className="a4a-feedback__suggestions">
+								{ suggestion.options.map( ( option ) => (
+									<CheckboxControl
+										key={ `suggestion-${ option.value }` }
+										label={ option.label }
+										checked={
+											!! suggestions.find( ( suggestion ) => suggestion.value === option.value )
+										}
+										onChange={ () => onSuggestionChange( option ) }
+									/>
+								) ) }
+							</div>
+						</FormFieldset>
+					) }
 					<FormFieldset>
 						<FormLabel className="a4a-feedback__comments-label" htmlFor="comments">
-							{ translate(
-								'Additional feedback about this experience {{span}}(Optional){{/span}}',
-								{ components: { span: <span></span> } }
-							) }
+							{ translate( 'Share your suggestions' ) }
 						</FormLabel>
 						<FormTextarea
 							className="a4a-feedback__comments"
@@ -80,13 +102,19 @@ export function A4AFeedback( {
 					<div className="a4a-feedback__cta">
 						<Button
 							variant="primary"
-							onClick={ () => onSubmit( { experience, comments } ) }
+							onClick={ () =>
+								onSubmit( {
+									experience,
+									comments,
+									suggestions: suggestions.map( ( suggestion ) => suggestion.text ),
+								} )
+							}
 							disabled={ ! experience }
 						>
-							{ ctaText }
+							{ translate( 'Send your feedback' ) }
 						</Button>
 						<Button className="a8c-blue-link" onClick={ onSkip }>
-							{ translate( 'Skip feedback' ) }
+							{ translate( 'Skip' ) }
 						</Button>
 					</div>
 				</div>

--- a/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
@@ -21,27 +21,22 @@ export const getA4AfeedbackProps = (
 						{
 							label: translate( 'Learning about referrals' ),
 							value: 'learning-about-referrals',
-							text: 'Learning about referrals',
 						},
 						{
 							label: translate( 'Finding referral mode' ),
 							value: 'finding-referral-mode',
-							text: 'Finding referral mode',
 						},
 						{
 							label: translate( 'Adding products and hosting to the referral cart' ),
 							value: 'adding-products-and-hosting-to-the-referral-cart',
-							text: 'Adding products and hosting to the referral cart',
 						},
 						{
 							label: translate( 'Sending a referral to my client' ),
 							value: 'sending-a-referral-to-my-client',
-							text: 'Sending a referral to my client',
 						},
 						{
 							label: translate( 'Other' ),
 							value: 'other',
-							text: 'Other',
 						},
 					],
 				},
@@ -61,24 +56,20 @@ export const getA4AfeedbackProps = (
 						{
 							label: translate( 'Discovering the Partner Directories feature' ),
 							value: 'discovering-the-partner-directories-feature',
-							text: 'Discovering the Partner Directories feature',
 						},
 						{
 							label: translate( 'Understanding how Partner Directories can benefit my agency' ),
 							value: 'understanding-how-partner-directories-can-benefit-my-agency',
-							text: 'Understanding how Partner Directories can benefit my agency',
 						},
 						{
 							label: translate(
 								'Understanding the criteria my agency needs to meet in order to be included'
 							),
 							value: 'understanding-the-criteria-my-agency-needs-to-meet-in-order-to-be-included',
-							text: 'Understanding the criteria my agency needs to meet in order to be included',
 						},
 						{
 							label: translate( 'Other' ),
 							value: 'other',
-							text: 'Other',
 						},
 					],
 				},
@@ -97,22 +88,18 @@ export const getA4AfeedbackProps = (
 						{
 							label: translate( 'Finding where to invite my team members' ),
 							value: 'finding-where-to-invite-my-team-members',
-							text: 'Finding where to invite my team members',
 						},
 						{
 							label: translate( 'Sending an invitation to a team member' ),
 							value: 'sending-an-invitation-to-a-team-member',
-							text: 'Sending an invitation to a team member',
 						},
 						{
 							label: translate( 'Finding documentation on team member permissions' ),
 							value: 'finding-documentation-on-team-member-permissions',
-							text: 'Finding documentation on team member permissions',
 						},
 						{
 							label: translate( 'Other' ),
 							value: 'other',
-							text: 'Other',
 						},
 					],
 				},
@@ -129,22 +116,18 @@ export const getA4AfeedbackProps = (
 						{
 							label: translate( 'Finding the right products or hosting' ),
 							value: 'finding-the-right-products-or-hosting',
-							text: 'Finding the right products or hosting',
 						},
 						{
 							label: translate( 'Understanding the pricing structure' ),
 							value: 'understanding-the-pricing-structure',
-							text: 'Understanding the pricing structure',
 						},
 						{
 							label: translate( 'Setting up my product or hosting' ),
 							value: 'setting-up-my-product-or-hosting',
-							text: 'Setting up my product or hosting',
 						},
 						{
 							label: translate( 'Other' ),
 							value: 'other',
-							text: 'Other',
 						},
 					],
 				},

--- a/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
@@ -4,7 +4,7 @@ import {
 	A4A_PARTNER_DIRECTORY_LINK,
 	A4A_REFERRALS_DASHBOARD,
 } from '../../sidebar-menu/lib/constants';
-import type { FeedbackProps, FeedbackType } from '../types';
+import { FeedbackProps, FeedbackType } from '../types';
 
 export const getA4AfeedbackProps = (
 	type: FeedbackType,
@@ -12,7 +12,7 @@ export const getA4AfeedbackProps = (
 	args?: Record< string, unknown >
 ): FeedbackProps => {
 	switch ( type ) {
-		case 'referral-complete':
+		case FeedbackType.ReferralCompleted:
 			return {
 				title: translate( 'Well done! You sent your first referral!' ),
 				description: translate(
@@ -46,7 +46,7 @@ export const getA4AfeedbackProps = (
 					],
 				},
 			};
-		case 'agency-details-added':
+		case FeedbackType.PDDetailsAdded:
 			return {
 				title: translate( 'Details successfully added!' ),
 				description: translate(
@@ -79,7 +79,7 @@ export const getA4AfeedbackProps = (
 					],
 				},
 			};
-		case 'member-invite-sent':
+		case FeedbackType.MemberInviteSent:
 			return {
 				title: translate( 'Invite emailed!' ),
 				description: translate(
@@ -109,7 +109,7 @@ export const getA4AfeedbackProps = (
 					],
 				},
 			};
-		case 'purchase-complete':
+		case FeedbackType.PurchaseCompleted:
 			return {
 				title: translate( 'Purchase complete!' ),
 				description: translate(

--- a/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
@@ -10,41 +10,149 @@ export const getA4AfeedbackProps = (
 	switch ( type ) {
 		case 'referral-complete':
 			return {
-				title: translate( 'Your referral order is complete!' ),
+				title: translate( 'Well done! You sent your first referral!' ),
 				description: translate(
-					'Your referral order was emailed to %(email)s for payment. Once they pay, you can assign the products to a site.',
+					'We emailed your referral order to %(email)s. Assign products to a site after they pay',
 					{ args: { email: args?.email } }
 				) as string,
-				questionDetails: translate( 'How was your experience making a referral?' ),
-				ctaText: translate( 'Submit and continue to Dashboard' ),
+				suggestion: {
+					label: translate( 'What could have been better during the Referrals process?' ),
+					options: [
+						{
+							label: translate( 'Learning about referrals' ),
+							value: 'learning-about-referrals',
+							text: 'Learning about referrals',
+						},
+						{
+							label: translate( 'Finding referral mode' ),
+							value: 'finding-referral-mode',
+							text: 'Finding referral mode',
+						},
+						{
+							label: translate( 'Adding products and hosting to the referral cart' ),
+							value: 'adding-products-and-hosting-to-the-referral-cart',
+							text: 'Adding products and hosting to the referral cart',
+						},
+						{
+							label: translate( 'Sending a referral to my client' ),
+							value: 'sending-a-referral-to-my-client',
+							text: 'Sending a referral to my client',
+						},
+						{
+							label: translate( 'Other' ),
+							value: 'other',
+							text: 'Other',
+						},
+					],
+				},
 			};
 		case 'agency-details-added':
 			return {
-				title: translate( 'Agency details added!' ),
+				title: translate( 'Details successfully added!' ),
 				description: translate(
-					"Nice job! Your information has been added to your agency's public profile."
+					"Well done! We've updated your agency's public profile with your information."
 				),
-				questionDetails: translate( "How was your experience adding your agency's details?" ),
-				ctaText: translate( 'Submit and continue to Partner Directory' ),
 				redirectUrl: A4A_PARTNER_DIRECTORY_LINK,
+				suggestion: {
+					label: translate(
+						'What could have been better during the Partner Directory application process?'
+					),
+					options: [
+						{
+							label: translate( 'Discovering the Partner Directories feature' ),
+							value: 'discovering-the-partner-directories-feature',
+							text: 'Discovering the Partner Directories feature',
+						},
+						{
+							label: translate( 'Understanding how Partner Directories can benefit my agency' ),
+							value: 'understanding-how-partner-directories-can-benefit-my-agency',
+							text: 'Understanding how Partner Directories can benefit my agency',
+						},
+						{
+							label: translate(
+								'Understanding the criteria my agency needs to meet in order to be included'
+							),
+							value: 'understanding-the-criteria-my-agency-needs-to-meet-in-order-to-be-included',
+							text: 'Understanding the criteria my agency needs to meet in order to be included',
+						},
+						{
+							label: translate( 'Other' ),
+							value: 'other',
+							text: 'Other',
+						},
+					],
+				},
 			};
 		case 'member-invite-sent':
 			return {
-				title: translate( 'Invite sent!' ),
+				title: translate( 'Invite emailed!' ),
 				description: translate(
-					"Your team member invite was emailed to %(email)s. Once they accept, you'll see them as an active member in the Team section.",
+					"We sent %(email)s an invite. After accepting, they'll become an active member in your Team section.",
 					{ args: { email: args?.email } }
 				) as string,
-				questionDetails: translate( 'How was your experience inviting a team member?' ),
-				ctaText: translate( 'Submit and continue to Team' ),
 				redirectUrl: `${ A4A_TEAM_LINK }/${ TAB_INVITED_MEMBERS }`,
+				suggestion: {
+					label: translate( 'What could have been better during the team invitation process?' ),
+					options: [
+						{
+							label: translate( 'Finding where to invite my team members' ),
+							value: 'finding-where-to-invite-my-team-members',
+							text: 'Finding where to invite my team members',
+						},
+						{
+							label: translate( 'Sending an invitation to a team member' ),
+							value: 'sending-an-invitation-to-a-team-member',
+							text: 'Sending an invitation to a team member',
+						},
+						{
+							label: translate( 'Finding documentation on team member permissions' ),
+							value: 'finding-documentation-on-team-member-permissions',
+							text: 'Finding documentation on team member permissions',
+						},
+						{
+							label: translate( 'Other' ),
+							value: 'other',
+							text: 'Other',
+						},
+					],
+				},
+			};
+		case 'purchase-complete':
+			return {
+				title: translate( 'Purchase complete!' ),
+				description: translate(
+					"Well done! You've made your first purchase on Automattic for Agencies."
+				),
+				suggestion: {
+					label: translate( 'What could have been better during your purchase process?' ),
+					options: [
+						{
+							label: translate( 'Finding the right products or hosting' ),
+							value: 'finding-the-right-products-or-hosting',
+							text: 'Finding the right products or hosting',
+						},
+						{
+							label: translate( 'Understanding the pricing structure' ),
+							value: 'understanding-the-pricing-structure',
+							text: 'Understanding the pricing structure',
+						},
+						{
+							label: translate( 'Setting up my product or hosting' ),
+							value: 'setting-up-my-product-or-hosting',
+							text: 'Setting up my product or hosting',
+						},
+						{
+							label: translate( 'Other' ),
+							value: 'other',
+							text: 'Other',
+						},
+					],
+				},
 			};
 		default:
 			return {
 				title: translate( 'General feedback' ),
 				description: translate( 'Please share general feedback' ),
-				questionDetails: translate( 'How was your experience?' ),
-				ctaText: translate( 'Submit and continue' ),
 			};
 	}
 };

--- a/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/lib/get-a4a-feedback-props.ts
@@ -1,5 +1,9 @@
 import { TAB_INVITED_MEMBERS } from 'calypso/a8c-for-agencies/sections/team/constants';
-import { A4A_TEAM_LINK, A4A_PARTNER_DIRECTORY_LINK } from '../../sidebar-menu/lib/constants';
+import {
+	A4A_TEAM_LINK,
+	A4A_PARTNER_DIRECTORY_LINK,
+	A4A_REFERRALS_DASHBOARD,
+} from '../../sidebar-menu/lib/constants';
 import type { FeedbackProps, FeedbackType } from '../types';
 
 export const getA4AfeedbackProps = (
@@ -12,9 +16,10 @@ export const getA4AfeedbackProps = (
 			return {
 				title: translate( 'Well done! You sent your first referral!' ),
 				description: translate(
-					'We emailed your referral order to %(email)s. Assign products to a site after they pay',
+					'We emailed your referral order to %(email)s. You can assign your products to a site or set up hosting once they pay.',
 					{ args: { email: args?.email } }
 				) as string,
+				redirectUrl: A4A_REFERRALS_DASHBOARD,
 				suggestion: {
 					label: translate( 'What could have been better during the Referrals process?' ),
 					options: [

--- a/client/a8c-for-agencies/components/a4a-feedback/style.scss
+++ b/client/a8c-for-agencies/components/a4a-feedback/style.scss
@@ -8,17 +8,24 @@ $highlight-color: #3858E9;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+
+	.form-fieldset {
+		margin-block-end: 0;
+	}
 }
 
 .a4a-feedback__content {
-	padding-block-start: 32px;
+	margin-block-start: calc(48px + 8px);
 	display: flex;
 	align-items: flex-start;
 	flex-direction: row;
 	flex-wrap: wrap;
+	border: 1px solid var(--color-neutral-5);
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	padding: 16px 24px;
 
 	@include break-large {
-		width: 600px;
+		width: 470px;
 		max-width: 90%;
 	}
 }
@@ -28,37 +35,37 @@ $highlight-color: #3858E9;
 }
 
 .a4a-feedback__description {
-	@include body-large;
+	@include body-medium;
 	color: var(--color-neutral-60);
-	padding-block: 4px 32px;
+	padding-block: 8px 12px;
+	border-bottom: 1px solid var(--color-neutral-0);
+	flex: 1 1 auto;
 }
 
 .a4a-feedback__questions {
+	padding-block-start: 16px;
 	display: flex;
 	flex-direction: column;
 	gap: 24px;
-	border: 1px solid var(--color-neutral-5);
-	border-radius: 4px;
-	padding: 16px 24px;
 	flex: 1 1 auto;
 }
 
 .a4a-feedback__question-details {
 	@include heading-large;
+	padding-block-end: 8px;
 }
 
 .a4a-feedback__experience-selector-label {
 	@include heading-medium;
-	padding-block-end: 8px;
+	padding-block-end: 12px;
+	text-transform: uppercase;
 }
 
-.a4a-feedback__comments-label {
+.form-label.a4a-feedback__comments-label {
 	@include heading-medium;
-	padding-block-end: 8px;
-
-	span {
-		opacity: 0.8;
-	}
+	padding-block-end: 12px;
+	text-transform: uppercase;
+	margin-block-end: 0;
 }
 
 .a4a-feedback__comments {
@@ -128,3 +135,10 @@ $highlight-color: #3858E9;
 		}
 	}
 }
+
+.a4a-feedback__suggestions {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+

--- a/client/a8c-for-agencies/components/a4a-feedback/types.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/types.ts
@@ -13,7 +13,6 @@ export type FeedbackQueryData = {
 export type FeedbackSuggestion = {
 	label: string;
 	value: string;
-	text: string;
 };
 
 export type FeedbackProps = {

--- a/client/a8c-for-agencies/components/a4a-feedback/types.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/types.ts
@@ -1,8 +1,9 @@
-export type FeedbackType =
-	| 'referral-complete'
-	| 'agency-details-added'
-	| 'member-invite-sent'
-	| 'purchase-complete';
+export enum FeedbackType {
+	ReferralCompleted = 'referral-completed',
+	PDDetailsAdded = 'partner-directory-details-added',
+	MemberInviteSent = 'team-member-invite-sent',
+	PurchaseCompleted = 'purchase-completed',
+}
 
 export type FeedbackQueryData = {
 	experience: string;
@@ -27,8 +28,8 @@ export type FeedbackProps = {
 
 interface FeedbackSurveyResponses {
 	rating: string;
-	comment: string;
-	suggestions?: string;
+	comment: { text: string };
+	suggestions?: { text: string };
 }
 export interface FeedbackSurveyResponsesPayload {
 	site_id: number;

--- a/client/a8c-for-agencies/components/a4a-feedback/types.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/types.ts
@@ -1,25 +1,35 @@
-export type FeedbackType = 'referral-complete' | 'agency-details-added' | 'member-invite-sent';
-export type FeedbackData = {
-	title: string;
-	description: string;
-	questionDetails: string;
-};
+export type FeedbackType =
+	| 'referral-complete'
+	| 'agency-details-added'
+	| 'member-invite-sent'
+	| 'purchase-complete';
+
 export type FeedbackQueryData = {
 	experience: string;
 	comments: string;
+	suggestions?: string[];
+};
+
+export type FeedbackSuggestion = {
+	label: string;
+	value: string;
+	text: string;
 };
 
 export type FeedbackProps = {
 	title: string;
 	description: string;
-	questionDetails: string;
-	ctaText: string;
 	redirectUrl?: string;
+	suggestion?: {
+		label: string;
+		options: FeedbackSuggestion[];
+	};
 };
 
 interface FeedbackSurveyResponses {
 	rating: string;
 	comment: string;
+	suggestions?: string;
 }
 export interface FeedbackSurveyResponsesPayload {
 	site_id: number;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -2,6 +2,7 @@
 // the 'calypso/a8c-for-agencies/lib/permission.ts' file
 // to include the necessary permissions for the new routes.
 export const A4A_LANDING_LINK = '/landing';
+export const A4A_FEEDBACK_LINK = '/feedback';
 export const A4A_OVERVIEW_LINK = '/overview';
 export const A4A_SITES_LINK = '/sites';
 export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -113,7 +113,7 @@ const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {
 
 const DYNAMIC_PATH_PATTERNS: Record< string, RegExp > = {
 	'sites-overview': /^\/sites\/overview\/[^/]+(\/.*)?$/,
-	marketplace: /^\/marketplace\/[^/]+\/[^/]+(\/.*)?$/,
+	marketplace: /^\/marketplace\/[^/]+(\/[^/]+)?(\/.*)?(\?.*)?(#.*)?$/,
 	licenses: /^\/purchases\/licenses(\/.*)?$/,
 	team: /^\/team(\/.*)?$/,
 	plugins: /^\/plugins(\/.*)?$/,

--- a/client/a8c-for-agencies/lib/permission.ts
+++ b/client/a8c-for-agencies/lib/permission.ts
@@ -5,6 +5,7 @@ import {
 } from 'calypso/a8c-for-agencies/sections/partner-directory/constants';
 import {
 	A4A_LANDING_LINK,
+	A4A_FEEDBACK_LINK,
 	A4A_OVERVIEW_LINK,
 	A4A_SITES_LINK,
 	A4A_SITES_LINK_NEEDS_ATTENTION,
@@ -113,7 +114,7 @@ const MEMBER_ACCESSIBLE_DYNAMIC_PATHS: Record< string, string[] > = {
 
 const DYNAMIC_PATH_PATTERNS: Record< string, RegExp > = {
 	'sites-overview': /^\/sites\/overview\/[^/]+(\/.*)?$/,
-	marketplace: /^\/marketplace\/[^/]+(\/[^/]+)?(\/.*)?(\?.*)?(#.*)?$/,
+	marketplace: /^\/marketplace\/[^/]+\/[^/]+(\/.*)?$/,
 	licenses: /^\/purchases\/licenses(\/.*)?$/,
 	team: /^\/team(\/.*)?$/,
 	plugins: /^\/plugins(\/.*)?$/,
@@ -126,7 +127,7 @@ export const isPathAllowed = ( pathname: string, agency: Agency | null ) => {
 	}
 
 	// Everyone can access the landing page and the overview page
-	if ( [ A4A_LANDING_LINK, A4A_OVERVIEW_LINK ].includes( pathname ) ) {
+	if ( [ A4A_LANDING_LINK, A4A_OVERVIEW_LINK, A4A_FEEDBACK_LINK ].includes( pathname ) ) {
 		return true;
 	}
 

--- a/client/a8c-for-agencies/sections/feedback/controller.tsx
+++ b/client/a8c-for-agencies/sections/feedback/controller.tsx
@@ -1,0 +1,9 @@
+import { type Callback } from '@automattic/calypso-router';
+import { A4AFeedback } from 'calypso/a8c-for-agencies/components/a4a-feedback';
+import MainSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/main';
+
+export const feedbackContext: Callback = ( context, next ) => {
+	context.primary = <A4AFeedback type={ context.query.type } />;
+	context.secondary = <MainSidebar path={ context.path } />;
+	next();
+};

--- a/client/a8c-for-agencies/sections/feedback/index.tsx
+++ b/client/a8c-for-agencies/sections/feedback/index.tsx
@@ -1,0 +1,8 @@
+import page from '@automattic/calypso-router';
+import { A4A_FEEDBACK_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { feedbackContext } from './controller';
+
+export default function () {
+	page( A4A_FEEDBACK_LINK, feedbackContext, makeLayout, clientRender );
+}

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -49,7 +50,7 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted );
 
 	const [ selectedSite, setSelectedSite ] = useState( { ID: 0, domain: '' } );
 	const [ currentPage, setCurrentPage ] = useState< number >( initialPage );
@@ -184,7 +185,7 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 					addQueryArgs(
 						{
 							redirectUrl: redirectUrl,
-							type: 'purchase-complete',
+							type: FeedbackType.PurchaseCompleted,
 						},
 						A4A_FEEDBACK_LINK
 					)

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -4,6 +4,7 @@ import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
@@ -11,6 +12,7 @@ import {
 	A4A_MARKETPLACE_DOWNLOAD_PRODUCTS_LINK,
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
+	A4A_FEEDBACK_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import FormRadio from 'calypso/components/forms/form-radio';
 import Pagination from 'calypso/components/pagination';
@@ -46,6 +48,8 @@ type Props = {
 export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
 
 	const [ selectedSite, setSelectedSite ] = useState( { ID: 0, domain: '' } );
 	const [ currentPage, setCurrentPage ] = useState< number >( initialPage );
@@ -173,12 +177,19 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 		}
 
 		const fromDashboard = getQueryArg( window.location.href, 'source' ) === 'dashboard';
-		if ( fromDashboard ) {
-			return page.redirect( A4A_SITES_LINK );
-		}
-
-		return page.redirect( A4A_LICENSES_LINK );
-	}, [ assignLicensesToSite, dispatch, licenseKeysArray, selectedSite?.ID ] );
+		const redirectUrl = fromDashboard ? A4A_SITES_LINK : A4A_LICENSES_LINK;
+		return isFeedbackShown
+			? page.redirect( redirectUrl )
+			: page.redirect(
+					addQueryArgs(
+						{
+							redirectUrl: redirectUrl,
+							type: 'purchase-complete',
+						},
+						A4A_FEEDBACK_LINK
+					)
+			  );
+	}, [ assignLicensesToSite, dispatch, isFeedbackShown, licenseKeysArray, selectedSite?.ID ] );
 
 	return (
 		<Layout

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -5,6 +5,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useContext, useEffect, useRef, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
+import { A4AFeedback } from 'calypso/a8c-for-agencies/components/a4a-feedback';
+import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -62,6 +64,9 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 
 	const { selectedCartItems, onRemoveCartItem, onClearCart, setSelectedCartItems } =
 		useShoppingCart();
+
+	// Show feedback after purchase
+	const { showFeedback, feedbackProps } = useShowFeedback( 'purchase-complete' );
 
 	// Fetch selected products by slug for site checkout
 	const { selectedProductsBySlug } = useProductsBySlug();
@@ -252,58 +257,62 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 				</LayoutTop>
 			) }
 			<LayoutBody>
-				<div className="checkout__container">
-					<div className="checkout__main">
-						<h1 className="checkout__main-title">{ title }</h1>
+				{ showFeedback && ! isClient ? (
+					<A4AFeedback { ...feedbackProps } />
+				) : (
+					<div className="checkout__container">
+						<div className="checkout__main">
+							<h1 className="checkout__main-title">{ title }</h1>
 
-						{ isClient && !! checkoutItems?.length && isDoNotMatchReferralClientEmail && (
-							<LayoutBanner level="error" hideCloseButton>
-								{ translate(
-									'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
-									{
-										args: {
-											referralEmail: referral?.client?.email,
-										},
-										components: {
-											b: <b />,
-										},
-										comment: '%(referralEmail)s is the email of the referral client.',
-									}
-								) }
-							</LayoutBanner>
-						) }
-
-						<div className="checkout__main-list">
-							{ referralBlogId && isLoadingReferralDevSite ? (
-								<div className="product-info__placeholder"></div>
-							) : (
-								checkoutItems.map( ( items ) => (
-									<ProductInfo
-										key={ `product-info-${ items.product_id }-${ items.quantity }` }
-										product={ items }
-										isAutomatedReferrals={ isAutomatedReferrals }
-										vendor={ getVendorInfo( items.slug ) }
-									/>
-								) )
+							{ isClient && !! checkoutItems?.length && isDoNotMatchReferralClientEmail && (
+								<LayoutBanner level="error" hideCloseButton>
+									{ translate(
+										'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
+										{
+											args: {
+												referralEmail: referral?.client?.email,
+											},
+											components: {
+												b: <b />,
+											},
+											comment: '%(referralEmail)s is the email of the referral client.',
+										}
+									) }
+								</LayoutBanner>
 							) }
+
+							<div className="checkout__main-list">
+								{ referralBlogId && isLoadingReferralDevSite ? (
+									<div className="product-info__placeholder"></div>
+								) : (
+									checkoutItems.map( ( items ) => (
+										<ProductInfo
+											key={ `product-info-${ items.product_id }-${ items.quantity }` }
+											product={ items }
+											isAutomatedReferrals={ isAutomatedReferrals }
+											vendor={ getVendorInfo( items.slug ) }
+										/>
+									) )
+								) }
+							</div>
+						</div>
+						<div
+							className={ clsx( 'checkout__aside', {
+								'checkout__aside--referral': isAutomatedReferrals,
+								'checkout__aside--client': isClient,
+							} ) }
+						>
+							<PricingSummary
+								items={ checkoutItems }
+								onRemoveItem={ siteId || isClient ? undefined : onRemoveItem }
+								isAutomatedReferrals={ isAutomatedReferrals }
+								isClient={ isClient }
+							/>
+
+							{ actionContent }
 						</div>
 					</div>
-					<div
-						className={ clsx( 'checkout__aside', {
-							'checkout__aside--referral': isAutomatedReferrals,
-							'checkout__aside--client': isClient,
-						} ) }
-					>
-						<PricingSummary
-							items={ checkoutItems }
-							onRemoveItem={ siteId || isClient ? undefined : onRemoveItem }
-							isAutomatedReferrals={ isAutomatedReferrals }
-							isClient={ isClient }
-						/>
-
-						{ actionContent }
-					</div>
-				</div>
+				) }
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -230,9 +230,11 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 		);
 	}
 
+	const isFeedback = showFeedback && ! isClient;
+
 	return (
 		<Layout
-			className="checkout"
+			className={ clsx( 'checkout', { 'checkout--feedback': isFeedback } ) }
 			title={ title }
 			wide
 			withBorder={ ! isClient }
@@ -257,7 +259,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 				</LayoutTop>
 			) }
 			<LayoutBody>
-				{ showFeedback && ! isClient ? (
+				{ isFeedback ? (
 					<A4AFeedback { ...feedbackProps } />
 				) : (
 					<div className="checkout__container">

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -5,8 +5,6 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useContext, useEffect, useRef, useState } from 'react';
 import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-agency-approval-notice';
-import { A4AFeedback } from 'calypso/a8c-for-agencies/components/a4a-feedback';
-import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -64,9 +62,6 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 
 	const { selectedCartItems, onRemoveCartItem, onClearCart, setSelectedCartItems } =
 		useShoppingCart();
-
-	// Show feedback after purchase
-	const { showFeedback, feedbackProps } = useShowFeedback( 'purchase-complete' );
 
 	// Fetch selected products by slug for site checkout
 	const { selectedProductsBySlug } = useProductsBySlug();
@@ -230,11 +225,9 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 		);
 	}
 
-	const isFeedback = showFeedback && ! isClient;
-
 	return (
 		<Layout
-			className={ clsx( 'checkout', { 'checkout--feedback': isFeedback } ) }
+			className="checkout"
 			title={ title }
 			wide
 			withBorder={ ! isClient }
@@ -259,62 +252,58 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 				</LayoutTop>
 			) }
 			<LayoutBody>
-				{ isFeedback ? (
-					<A4AFeedback { ...feedbackProps } />
-				) : (
-					<div className="checkout__container">
-						<div className="checkout__main">
-							<h1 className="checkout__main-title">{ title }</h1>
+				<div className="checkout__container">
+					<div className="checkout__main">
+						<h1 className="checkout__main-title">{ title }</h1>
 
-							{ isClient && !! checkoutItems?.length && isDoNotMatchReferralClientEmail && (
-								<LayoutBanner level="error" hideCloseButton>
-									{ translate(
-										'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
-										{
-											args: {
-												referralEmail: referral?.client?.email,
-											},
-											components: {
-												b: <b />,
-											},
-											comment: '%(referralEmail)s is the email of the referral client.',
-										}
-									) }
-								</LayoutBanner>
-							) }
-
-							<div className="checkout__main-list">
-								{ referralBlogId && isLoadingReferralDevSite ? (
-									<div className="product-info__placeholder"></div>
-								) : (
-									checkoutItems.map( ( items ) => (
-										<ProductInfo
-											key={ `product-info-${ items.product_id }-${ items.quantity }` }
-											product={ items }
-											isAutomatedReferrals={ isAutomatedReferrals }
-											vendor={ getVendorInfo( items.slug ) }
-										/>
-									) )
+						{ isClient && !! checkoutItems?.length && isDoNotMatchReferralClientEmail && (
+							<LayoutBanner level="error" hideCloseButton>
+								{ translate(
+									'This referral is not intended for your account. Please make sure you sign in using {{b}}%(referralEmail)s{{/b}}.',
+									{
+										args: {
+											referralEmail: referral?.client?.email,
+										},
+										components: {
+											b: <b />,
+										},
+										comment: '%(referralEmail)s is the email of the referral client.',
+									}
 								) }
-							</div>
-						</div>
-						<div
-							className={ clsx( 'checkout__aside', {
-								'checkout__aside--referral': isAutomatedReferrals,
-								'checkout__aside--client': isClient,
-							} ) }
-						>
-							<PricingSummary
-								items={ checkoutItems }
-								onRemoveItem={ siteId || isClient ? undefined : onRemoveItem }
-								isAutomatedReferrals={ isAutomatedReferrals }
-								isClient={ isClient }
-							/>
+							</LayoutBanner>
+						) }
 
-							{ actionContent }
+						<div className="checkout__main-list">
+							{ referralBlogId && isLoadingReferralDevSite ? (
+								<div className="product-info__placeholder"></div>
+							) : (
+								checkoutItems.map( ( items ) => (
+									<ProductInfo
+										key={ `product-info-${ items.product_id }-${ items.quantity }` }
+										product={ items }
+										isAutomatedReferrals={ isAutomatedReferrals }
+										vendor={ getVendorInfo( items.slug ) }
+									/>
+								) )
+							) }
 						</div>
 					</div>
-				) }
+					<div
+						className={ clsx( 'checkout__aside', {
+							'checkout__aside--referral': isAutomatedReferrals,
+							'checkout__aside--client': isClient,
+						} ) }
+					>
+						<PricingSummary
+							items={ checkoutItems }
+							onRemoveItem={ siteId || isClient ? undefined : onRemoveItem }
+							isAutomatedReferrals={ isAutomatedReferrals }
+							isClient={ isClient }
+						/>
+
+						{ actionContent }
+					</div>
+				</div>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -7,7 +7,10 @@ import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
-import { A4A_REFERRALS_DASHBOARD } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_REFERRALS_DASHBOARD,
+	A4A_FEEDBACK_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { REFERRAL_EMAIL_QUERY_PARAM_KEY } from 'calypso/a8c-for-agencies/constants';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -139,11 +142,12 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		if ( isSuccess && !! email ) {
 			sessionStorage.setItem( MARKETPLACE_TYPE_SESSION_STORAGE_KEY, MARKETPLACE_TYPE_REGULAR );
 			page.redirect(
-				! isFeedbackShown
-					? addQueryArgs( A4A_REFERRALS_DASHBOARD, {
+				isFeedbackShown
+					? addQueryArgs( A4A_REFERRALS_DASHBOARD, { [ REFERRAL_EMAIL_QUERY_PARAM_KEY ]: email } )
+					: addQueryArgs( A4A_FEEDBACK_LINK, {
 							args: { email },
-					  } ) + '#feedback'
-					: addQueryArgs( A4A_REFERRALS_DASHBOARD, { [ REFERRAL_EMAIL_QUERY_PARAM_KEY ]: email } )
+							type: 'referral-complete',
+					  } )
 			);
 			setEmail( '' );
 			setMessage( '' );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -7,6 +7,7 @@ import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
 	A4A_REFERRALS_DASHBOARD,
 	A4A_FEEDBACK_LINK,
@@ -27,7 +28,6 @@ import useRequestClientPaymentMutation from '../hooks/use-request-client-payment
 import useShoppingCart from '../hooks/use-shopping-cart';
 import NoticeSummary from './notice-summary';
 import type { ShoppingCartItem } from '../types';
-
 interface Props {
 	checkoutItems: ShoppingCartItem[];
 }
@@ -136,7 +136,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 		translate,
 	] );
 
-	const { isFeedbackShown } = useShowFeedback( 'referral-complete' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.ReferralCompleted );
 
 	useEffect( () => {
 		if ( isSuccess && !! email ) {
@@ -146,7 +146,7 @@ function RequestClientPayment( { checkoutItems }: Props ) {
 					? addQueryArgs( A4A_REFERRALS_DASHBOARD, { [ REFERRAL_EMAIL_QUERY_PARAM_KEY ]: email } )
 					: addQueryArgs( A4A_FEEDBACK_LINK, {
 							args: { email },
-							type: 'referral-complete',
+							type: FeedbackType.ReferralCompleted,
 					  } )
 			);
 			setEmail( '' );

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -17,7 +17,7 @@
 	height: 100%;
 }
 
-.checkout:not( .checkout--feedback ) .hosting-dashboard-layout__body {
+.checkout .hosting-dashboard-layout__body {
 	padding: 0;
 	flex-grow: 1;
 

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style.scss
@@ -17,7 +17,7 @@
 	height: 100%;
 }
 
-.checkout .hosting-dashboard-layout__body {
+.checkout:not( .checkout--feedback ) .hosting-dashboard-layout__body {
 	padding: 0;
 	flex-grow: 1;
 

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
@@ -1,11 +1,13 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { getQueryArg } from '@wordpress/url';
+import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
+import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
+	A4A_FEEDBACK_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import {
@@ -22,6 +24,8 @@ export default function DownloadProductsForm() {
 	const translate = useTranslate();
 	const sites = useSelector( getSites );
 	const { data: allProducts } = useProductsQuery();
+
+	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
 
 	const attachedSiteId = getQueryArg( window.location.href, 'attachedSiteId' ) as string;
 	const licenseKeys = getQueryArg( window.location.href, 'products' ) as string;
@@ -61,10 +65,29 @@ export default function DownloadProductsForm() {
 				allProducts={ allProducts }
 			/>
 		) );
-
-	const onNavigate = useCallback( () => {
-		return page.redirect( 'dashboard' === source ? A4A_SITES_LINK : A4A_LICENSES_LINK );
-	}, [ source ] );
+	const onNavigate = useCallback(
+		( showFeedback = true ) => {
+			const redirectUrl = 'dashboard' === source ? A4A_SITES_LINK : A4A_LICENSES_LINK;
+			const wooProduct = wooKeys?.[ 0 ];
+			const productSlug = getProductSlugFromLicenseKey( wooProduct );
+			const product = allProducts?.find(
+				( product ) => productSlug && product.slug.startsWith( productSlug )
+			);
+			// We want to show feedback only if product is not free and the user has not already submitted feedback
+			const isFreeProduct = product?.price_per_unit === 0;
+			if ( ! isFeedbackShown && showFeedback && ! isFreeProduct ) {
+				page.redirect(
+					addQueryArgs( A4A_FEEDBACK_LINK, {
+						redirectUrl: redirectUrl,
+						type: 'purchase-complete',
+					} )
+				);
+				return;
+			}
+			page.redirect( redirectUrl );
+		},
+		[ allProducts, isFeedbackShown, source, wooKeys ]
+	);
 
 	// redirect if licenseKeys does not contain a valid product
 	useEffect( () => {
@@ -80,7 +103,8 @@ export default function DownloadProductsForm() {
 		} );
 
 		if ( invalidKeys.length ) {
-			onNavigate();
+			// If there are invalid keys, we don't want to show feedback
+			onNavigate( false );
 		}
 	}, [ licenseKeys, allProducts, site, onNavigate ] );
 
@@ -100,7 +124,13 @@ export default function DownloadProductsForm() {
 						) }
 				</p>
 				<div className="download-products-form__controls">
-					<Button primary className="download-products-form__navigate" onClick={ onNavigate }>
+					<Button
+						primary
+						className="download-products-form__navigate"
+						onClick={ () => {
+							onNavigate();
+						} }
+					>
 						{ translate( 'Done' ) }
 					</Button>
 				</div>

--- a/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/download-products-form/index.tsx
@@ -4,6 +4,7 @@ import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
@@ -25,7 +26,7 @@ export default function DownloadProductsForm() {
 	const sites = useSelector( getSites );
 	const { data: allProducts } = useProductsQuery();
 
-	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted );
 
 	const attachedSiteId = getQueryArg( window.location.href, 'attachedSiteId' ) as string;
 	const licenseKeys = getQueryArg( window.location.href, 'products' ) as string;
@@ -79,7 +80,7 @@ export default function DownloadProductsForm() {
 				page.redirect(
 					addQueryArgs( A4A_FEEDBACK_LINK, {
 						redirectUrl: redirectUrl,
-						type: 'purchase-complete',
+						type: FeedbackType.PurchaseCompleted,
 					} )
 				);
 				return;

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/index.tsx
@@ -136,7 +136,7 @@ function HostingOverviewV3( { section }: SectionProps ) {
 							items={ selectedCartItems }
 							onRemoveItem={ onRemoveCartItem }
 							onCheckout={ () => {
-								page( A4A_MARKETPLACE_CHECKOUT_LINK );
+								page.redirect( A4A_MARKETPLACE_CHECKOUT_LINK );
 							} }
 						/>
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
@@ -2,7 +2,8 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
+import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
@@ -92,10 +93,13 @@ function useIssueAndAssignLicenses(
 ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const [ redirectWithFeedbackUrl, setRedirectWithFeedbackUrl ] = useState< string | null >( null );
 
 	const agency = useSelector( getActiveAgency );
 
 	const products = useProductsQuery();
+
+	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
 
 	const {
 		isReady: isIssueReady,
@@ -114,6 +118,19 @@ function useIssueAndAssignLicenses(
 	} );
 
 	const getLicenseIssuedMessage = useGetLicenseIssuedMessage();
+
+	useEffect( () => {
+		if ( redirectWithFeedbackUrl ) {
+			window.history.replaceState(
+				null,
+				'',
+				addQueryArgs( window.location.href, {
+					redirectUrl: redirectWithFeedbackUrl,
+				} ) + '#feedback'
+			);
+			setRedirectWithFeedbackUrl( null );
+		}
+	}, [ redirectWithFeedbackUrl ] );
 
 	return useMemo( () => {
 		const isReady = isIssueReady && isAssignReady;
@@ -167,18 +184,22 @@ function useIssueAndAssignLicenses(
 				);
 				const hasPurchaseWPCOMPlan = !! wpcomPlan;
 
-				if ( ! hasPurchaseWPCOMPlan ) {
+				if ( ! hasPurchaseWPCOMPlan && isFeedbackShown ) {
 					const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
 					dispatch( successNotice( issuedMessage, { displayOnNextPage: true } ) );
 				}
 
-				page.redirect(
-					hasPurchaseWPCOMPlan
-						? addQueryArgs( A4A_SITES_LINK_NEEDS_SETUP, {
-								wpcom_creator_purchased: wpcomPlan.slug,
-						  } )
-						: A4A_LICENSES_LINK
-				);
+				const redirectUrl = hasPurchaseWPCOMPlan
+					? addQueryArgs( A4A_SITES_LINK_NEEDS_SETUP, {
+							wpcom_creator_purchased: wpcomPlan.slug,
+					  } )
+					: A4A_LICENSES_LINK;
+
+				if ( isFeedbackShown ) {
+					page.redirect( redirectUrl );
+				} else {
+					setRedirectWithFeedbackUrl( redirectUrl );
+				}
 				return;
 			}
 
@@ -195,24 +216,30 @@ function useIssueAndAssignLicenses(
 			if ( fromDashboard ) {
 				const licenseItem =
 					products?.data?.find?.( ( p ) => p.slug === issuedLicenses[ 0 ].slug )?.name ?? '';
-				const message =
-					selectedSite?.domain && licenseItem
-						? translate(
-								'{{strong}}%(licenseItem)s{{/strong}} was successfully assigned to ' +
-									'{{em}}%(selectedSite)s{{/em}}. Please allow a few minutes ' +
-									'for your features to activate.',
-								{
-									args: { selectedSite: selectedSite.domain, licenseItem },
-									components: {
-										strong: <strong />,
-										em: <em />,
-									},
-								}
-						  )
-						: translate( 'Your license has been successfully issued and assigned to your site.' );
-				dispatch( successNotice( message, { displayOnNextPage: true } ) );
+				if ( isFeedbackShown ) {
+					const message =
+						selectedSite?.domain && licenseItem
+							? translate(
+									'{{strong}}%(licenseItem)s{{/strong}} was successfully assigned to ' +
+										'{{em}}%(selectedSite)s{{/em}}. Please allow a few minutes ' +
+										'for your features to activate.',
+									{
+										args: { selectedSite: selectedSite.domain, licenseItem },
+										components: {
+											strong: <strong />,
+											em: <em />,
+										},
+									}
+							  )
+							: translate( 'Your license has been successfully issued and assigned to your site.' );
+					dispatch( successNotice( message, { displayOnNextPage: true } ) );
+				}
 
-				page.redirect( A4A_SITES_LINK );
+				if ( isFeedbackShown ) {
+					page.redirect( A4A_SITES_LINK );
+				} else {
+					setRedirectWithFeedbackUrl( A4A_SITES_LINK );
+				}
 				return;
 			}
 
@@ -235,7 +262,11 @@ function useIssueAndAssignLicenses(
 			}
 
 			// Otherwise, send them to the overview of all licenses
-			page.redirect( A4A_LICENSES_LINK );
+			if ( isFeedbackShown ) {
+				page.redirect( A4A_LICENSES_LINK );
+			} else {
+				setRedirectWithFeedbackUrl( A4A_LICENSES_LINK );
+			}
 		};
 
 		return { issueAndAssignLicenses, isReady, isLoading: isIssueLoading || isAssignLoading };
@@ -254,6 +285,7 @@ function useIssueAndAssignLicenses(
 		agency?.tier,
 		isIssueLoading,
 		isAssignLoading,
+		isFeedbackShown,
 	] );
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
@@ -8,6 +8,7 @@ import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
 	A4A_SITES_LINK_NEEDS_SETUP,
+	A4A_FEEDBACK_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { AGENCY_FIRST_PURCHASE_SESSION_STORAGE_KEY } from 'calypso/a8c-for-agencies/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
@@ -121,14 +122,12 @@ function useIssueAndAssignLicenses(
 
 	useEffect( () => {
 		if ( redirectWithFeedbackUrl ) {
-			window.history.replaceState(
-				null,
-				'',
-				addQueryArgs( window.location.href, {
+			page.redirect(
+				addQueryArgs( A4A_FEEDBACK_LINK, {
+					type: 'purchase-complete',
 					redirectUrl: redirectWithFeedbackUrl,
-				} ) + '#feedback'
+				} )
 			);
-			setRedirectWithFeedbackUrl( null );
 		}
 	}, [ redirectWithFeedbackUrl ] );
 
@@ -184,22 +183,18 @@ function useIssueAndAssignLicenses(
 				);
 				const hasPurchaseWPCOMPlan = !! wpcomPlan;
 
-				if ( ! hasPurchaseWPCOMPlan && isFeedbackShown ) {
+				if ( ! hasPurchaseWPCOMPlan ) {
 					const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
 					dispatch( successNotice( issuedMessage, { displayOnNextPage: true } ) );
 				}
 
-				const redirectUrl = hasPurchaseWPCOMPlan
-					? addQueryArgs( A4A_SITES_LINK_NEEDS_SETUP, {
-							wpcom_creator_purchased: wpcomPlan.slug,
-					  } )
-					: A4A_LICENSES_LINK;
-
-				if ( isFeedbackShown ) {
-					page.redirect( redirectUrl );
-				} else {
-					setRedirectWithFeedbackUrl( redirectUrl );
-				}
+				page.redirect(
+					hasPurchaseWPCOMPlan
+						? addQueryArgs( A4A_SITES_LINK_NEEDS_SETUP, {
+								wpcom_creator_purchased: wpcomPlan.slug,
+						  } )
+						: A4A_LICENSES_LINK
+				);
 				return;
 			}
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview-v2/hooks/use-issue-and-assign-licenses.tsx
@@ -4,6 +4,7 @@ import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
 	A4A_LICENSES_LINK,
 	A4A_SITES_LINK,
@@ -100,7 +101,7 @@ function useIssueAndAssignLicenses(
 
 	const products = useProductsQuery();
 
-	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted );
 
 	const {
 		isReady: isIssueReady,
@@ -124,7 +125,7 @@ function useIssueAndAssignLicenses(
 		if ( redirectWithFeedbackUrl ) {
 			page.redirect(
 				addQueryArgs( A4A_FEEDBACK_LINK, {
-					type: 'purchase-complete',
+					type: FeedbackType.PurchaseCompleted,
 					redirectUrl: redirectWithFeedbackUrl,
 				} )
 			);

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -5,6 +5,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import validateEmail from 'calypso/a8c-for-agencies/components/form/hoc/with-error-handling/validators/email';
@@ -47,7 +48,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 
 	const agency = useSelector( getActiveAgency );
 
-	const { isFeedbackShown } = useShowFeedback( 'agency-details-added' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.PDDetailsAdded );
 
 	const onSubmitSuccess = useCallback(
 		( response: Agency ) => {
@@ -63,7 +64,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 				? page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK )
 				: page(
 						addQueryArgs( A4A_FEEDBACK_LINK, {
-							type: 'agency-details-added',
+							type: FeedbackType.PDDetailsAdded,
 						} )
 				  );
 		},

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -1,9 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Button, SearchableDropdown } from '@automattic/components';
 import { TextareaControl, TextControl, ToggleControl } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { A4AFeedback } from 'calypso/a8c-for-agencies/components/a4a-feedback';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
@@ -11,7 +11,10 @@ import validateEmail from 'calypso/a8c-for-agencies/components/form/hoc/with-err
 import validateNonEmpty from 'calypso/a8c-for-agencies/components/form/hoc/with-error-handling/validators/non-empty';
 import validateUrl from 'calypso/a8c-for-agencies/components/form/hoc/with-error-handling/validators/url';
 import FormSection from 'calypso/a8c-for-agencies/components/form/section';
-import { A4A_PARTNER_DIRECTORY_DASHBOARD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
+	A4A_FEEDBACK_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import BudgetSelector from 'calypso/a8c-for-agencies/sections/partner-directory/components/budget-selector';
 import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
 import { reduxDispatch } from 'calypso/lib/redux-bridge';
@@ -44,8 +47,7 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 
 	const agency = useSelector( getActiveAgency );
 
-	const { showFeedback, isFeedbackShown, feedbackProps } =
-		useShowFeedback( 'agency-details-added' );
+	const { isFeedbackShown } = useShowFeedback( 'agency-details-added' );
 
 	const onSubmitSuccess = useCallback(
 		( response: Agency ) => {
@@ -57,13 +59,13 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 					duration: 6000,
 				} )
 			);
-			! isFeedbackShown
-				? window.history.replaceState(
-						null,
-						'',
-						window.location.pathname + window.location.search + '#feedback'
-				  )
-				: page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK );
+			isFeedbackShown
+				? page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK )
+				: page(
+						addQueryArgs( A4A_FEEDBACK_LINK, {
+							type: 'agency-details-added',
+						} )
+				  );
 		},
 		[ agency, isFeedbackShown, translate ]
 	);
@@ -115,10 +117,6 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 			};
 		} );
 	};
-
-	if ( showFeedback ) {
-		return <A4AFeedback { ...feedbackProps } />;
-	}
 
 	return (
 		<Form

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -6,8 +6,13 @@ import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext, useRef } from 'react';
+import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
-import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_SITES_LINK_NEEDS_SETUP,
+	A4A_FEEDBACK_LINK,
+	A4A_LICENSES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import {
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
@@ -68,6 +73,8 @@ export default function LicensePreview( {
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
@@ -282,6 +289,19 @@ export default function LicensePreview( {
 										target="_blank"
 										rel="norefferer noopener noreferrer"
 										href={ pressableManageUrl }
+										onClick={ () => {
+											if ( ! isFeedbackShown ) {
+												page.redirect(
+													addQueryArgs(
+														{
+															type: 'purchase-complete',
+															redirectUrl: A4A_LICENSES_LINK,
+														},
+														A4A_FEEDBACK_LINK
+													)
+												);
+											}
+										} }
 									>
 										{ translate( 'Manage in Pressable' ) }
 										<Icon className="gridicon" icon={ external } size={ 18 } />

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useContext, useRef } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import {
 	A4A_SITES_LINK_NEEDS_SETUP,
@@ -74,7 +75,7 @@ export default function LicensePreview( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted );
 
 	const site = useSelector( ( state ) => getSite( state, blogId as number ) );
 	const isPressableLicense = isPressableHostingProduct( licenseKey );
@@ -294,7 +295,7 @@ export default function LicensePreview( {
 												page.redirect(
 													addQueryArgs(
 														{
-															type: 'purchase-complete',
+															type: FeedbackType.PurchaseCompleted,
 															redirectUrl: A4A_LICENSES_LINK,
 														},
 														A4A_FEEDBACK_LINK

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -3,8 +3,6 @@ import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
-import { A4AFeedback } from 'calypso/a8c-for-agencies/components/a4a-feedback';
-import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import {
 	DATAVIEWS_TABLE,
 	initialDataViewsState,
@@ -60,8 +58,6 @@ export default function ReferralsOverview( {
 	const { value: referralEmail, setValue: setReferralEmail } = useUrlQueryParam(
 		REFERRAL_EMAIL_QUERY_PARAM_KEY
 	);
-
-	const { showFeedback, feedbackProps } = useShowFeedback( 'referral-complete' );
 
 	const isDesktop = useDesktopBreakpoint();
 
@@ -132,19 +128,15 @@ export default function ReferralsOverview( {
 				</LayoutTop>
 
 				<LayoutBody>
-					{ showFeedback ? (
-						<A4AFeedback { ...feedbackProps } />
-					) : (
-						<LayoutBodyContent
-							tipaltiData={ tipaltiData }
-							referrals={ referrals }
-							isLoading={ isLoading }
-							dataViewsState={ dataViewsState }
-							setDataViewsState={ setDataViewsState }
-							isArchiveView={ isArchiveView }
-							onReferralRefetch={ refetchReferrals }
-						/>
-					) }
+					<LayoutBodyContent
+						tipaltiData={ tipaltiData }
+						referrals={ referrals }
+						isLoading={ isLoading }
+						dataViewsState={ dataViewsState }
+						setDataViewsState={ setDataViewsState }
+						isArchiveView={ isArchiveView }
+						onReferralRefetch={ refetchReferrals }
+					/>
 				</LayoutBody>
 			</LayoutColumn>
 			{ dataViewsState.selectedItem && (

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -82,14 +82,6 @@ $data-view-border-color: #f1f1f1;
 		max-width: 700px;
 	}
 
-	.consolidated-view, .a4a-feedback__wrapper {
-		padding: 16px;
-
-		@include breakpoint-deprecated( ">660px" ) {
-			padding: 16px 64px 48px;
-		}
-	}
-
 	&.main.hosting-dashboard-layout {
 		@include break-large {
 			background: inherit;

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/style.scss
@@ -82,6 +82,14 @@ $data-view-border-color: #f1f1f1;
 		max-width: 700px;
 	}
 
+	.consolidated-view {
+		padding: 16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			padding: 16px 64px 48px;
+		}
+	}
+
 	&.main.hosting-dashboard-layout {
 		@include break-large {
 			background: inherit;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -1,8 +1,14 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { A4A_SITES_LINK_DEVELOPMENT } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import {
+	A4A_SITES_LINK_DEVELOPMENT,
+	A4A_FEEDBACK_LINK,
+	A4A_SITES_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useIsSiteReady from 'calypso/a8c-for-agencies/data/sites/use-is-site-ready';
 import useTrackProvisioningSites from 'calypso/a8c-for-agencies/hooks/use-track-provisioning-sites';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -29,6 +35,8 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 		},
 		'https://wordpress.com/setup/hosted-site-migration/site-migration-identify'
 	);
+
+	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
 
 	const readySiteMessage = development
 		? translate(
@@ -58,6 +66,22 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 		onDismiss?.();
 	};
 
+	const handleRedirectToFeedback = () => {
+		if ( isFeedbackShown ) {
+			return;
+		}
+		onClose();
+		page.redirect(
+			addQueryArgs(
+				{
+					type: 'purchase-complete',
+					redirectUrl: A4A_SITES_LINK,
+				},
+				A4A_FEEDBACK_LINK
+			)
+		);
+	};
+
 	return (
 		showBanner && (
 			<NoticeBanner
@@ -77,7 +101,13 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 										{ translate( 'Migrate to this site' ) }
 									</Button>
 								) : (
-									<Button href={ wpOverviewUrl } target="_blank" rel="noreferrer" primary>
+									<Button
+										onClick={ handleRedirectToFeedback }
+										href={ wpOverviewUrl }
+										target="_blank"
+										rel="noreferrer"
+										primary
+									>
 										{ translate( 'Set up your site' ) }
 									</Button>
 								),

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -4,6 +4,7 @@ import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
 	A4A_SITES_LINK_DEVELOPMENT,
 	A4A_FEEDBACK_LINK,
@@ -36,7 +37,7 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 		'https://wordpress.com/setup/hosted-site-migration/site-migration-identify'
 	);
 
-	const { isFeedbackShown } = useShowFeedback( 'purchase-complete' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted );
 
 	const readySiteMessage = development
 		? translate(
@@ -74,7 +75,7 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 		page.redirect(
 			addQueryArgs(
 				{
-					type: 'purchase-complete',
+					type: FeedbackType.PurchaseCompleted,
 					redirectUrl: A4A_SITES_LINK,
 				},
 				A4A_FEEDBACK_LINK

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -3,14 +3,16 @@ import { Button, TextControl, TextareaControl } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
-import { A4AFeedback } from 'calypso/a8c-for-agencies/components/a4a-feedback';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormSection from 'calypso/a8c-for-agencies/components/form/section';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
-import { A4A_TEAM_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import {
+	A4A_FEEDBACK_LINK,
+	A4A_TEAM_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useSendTeamMemberInvite from 'calypso/a8c-for-agencies/data/team/use-send-team-member-invite';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
@@ -34,7 +36,7 @@ export default function TeamInvite() {
 
 	const { mutate: sendInvite, isPending: isSending } = useSendTeamMemberInvite();
 
-	const { showFeedback, isFeedbackShown, feedbackProps } = useShowFeedback( 'member-invite-sent' );
+	const { isFeedbackShown } = useShowFeedback( 'member-invite-sent' );
 
 	const onSendInvite = useCallback( () => {
 		setError( '' );
@@ -67,15 +69,14 @@ export default function TeamInvite() {
 						} )
 					);
 					dispatch( recordTracksEvent( 'calypso_a4a_team_invite_success' ) );
-					! isFeedbackShown
-						? window.history.replaceState(
-								null,
-								'',
-								addQueryArgs( window.location.href, {
+					isFeedbackShown
+						? page.redirect( `${ A4A_TEAM_LINK }/${ TAB_INVITED_MEMBERS }` )
+						: page.redirect(
+								addQueryArgs( A4A_FEEDBACK_LINK, {
 									args: { email: username },
-								} ) + '#feedback'
-						  )
-						: page.redirect( `${ A4A_TEAM_LINK }/${ TAB_INVITED_MEMBERS }` );
+									type: 'member-invite-sent',
+								} )
+						  );
 				},
 
 				onError: ( error ) => {
@@ -108,64 +109,60 @@ export default function TeamInvite() {
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>
-				{ showFeedback ? (
-					<A4AFeedback { ...feedbackProps } />
-				) : (
-					<Form
-						className="team-invite-form"
-						title={ translate( 'Invite a team member.' ) }
-						autocomplete="off"
-						description={ translate( 'Invite team members to manage client sites and purchases.' ) }
-					>
-						<FormSection title={ translate( 'Team member information' ) }>
-							<FormField
-								label={ translate( 'Email or WordPress.com Username' ) }
-								error={ error }
-								isRequired
-							>
-								<TextControl
-									type="text"
-									placeholder={ translate( 'team-member@example.com' ) }
-									value={ username }
-									onChange={ onUsernameChange }
-									onClick={ () =>
-										dispatch( recordTracksEvent( 'calypso_a4a_team_invite_username_click' ) )
-									}
-								/>
-							</FormField>
+				<Form
+					className="team-invite-form"
+					title={ translate( 'Invite a team member.' ) }
+					autocomplete="off"
+					description={ translate( 'Invite team members to manage client sites and purchases.' ) }
+				>
+					<FormSection title={ translate( 'Team member information' ) }>
+						<FormField
+							label={ translate( 'Email or WordPress.com Username' ) }
+							error={ error }
+							isRequired
+						>
+							<TextControl
+								type="text"
+								placeholder={ translate( 'team-member@example.com' ) }
+								value={ username }
+								onChange={ onUsernameChange }
+								onClick={ () =>
+									dispatch( recordTracksEvent( 'calypso_a4a_team_invite_username_click' ) )
+								}
+							/>
+						</FormField>
 
-							<FormField
-								label={ translate( 'Message' ) }
-								description={ translate(
-									'Optional: Include a custom message to provide more context to your team member.'
-								) }
-							>
-								<TextareaControl
-									value={ message }
-									onChange={ setMessage }
-									onClick={ () =>
-										dispatch( recordTracksEvent( 'calypso_a4a_team_invite_message_click' ) )
-									}
-								/>
-							</FormField>
-						</FormSection>
+						<FormField
+							label={ translate( 'Message' ) }
+							description={ translate(
+								'Optional: Include a custom message to provide more context to your team member.'
+							) }
+						>
+							<TextareaControl
+								value={ message }
+								onChange={ setMessage }
+								onClick={ () =>
+									dispatch( recordTracksEvent( 'calypso_a4a_team_invite_message_click' ) )
+								}
+							/>
+						</FormField>
+					</FormSection>
 
-						<div className="team-invite-form__required-information">
-							{ translate( '* Indicates a required field' ) }
-						</div>
+					<div className="team-invite-form__required-information">
+						{ translate( '* Indicates a required field' ) }
+					</div>
 
-						<div className="team-invite-form__footer">
-							<Button
-								variant="primary"
-								onClick={ onSendInvite }
-								disabled={ isSending }
-								isBusy={ isSending }
-							>
-								{ translate( 'Send invite' ) }
-							</Button>
-						</div>
-					</Form>
-				) }
+					<div className="team-invite-form__footer">
+						<Button
+							variant="primary"
+							onClick={ onSendInvite }
+							disabled={ isSending }
+							isBusy={ isSending }
+						>
+							{ translate( 'Send invite' ) }
+						</Button>
+					</div>
+				</Form>
 			</LayoutBody>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-invite/index.tsx
@@ -4,6 +4,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
+import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormSection from 'calypso/a8c-for-agencies/components/form/section';
@@ -36,7 +37,7 @@ export default function TeamInvite() {
 
 	const { mutate: sendInvite, isPending: isSending } = useSendTeamMemberInvite();
 
-	const { isFeedbackShown } = useShowFeedback( 'member-invite-sent' );
+	const { isFeedbackShown } = useShowFeedback( FeedbackType.MemberInviteSent );
 
 	const onSendInvite = useCallback( () => {
 		setError( '' );
@@ -74,7 +75,7 @@ export default function TeamInvite() {
 						: page.redirect(
 								addQueryArgs( A4A_FEEDBACK_LINK, {
 									args: { email: username },
-									type: 'member-invite-sent',
+									type: FeedbackType.MemberInviteSent,
 								} )
 						  );
 				},

--- a/client/sections.js
+++ b/client/sections.js
@@ -765,6 +765,12 @@ const sections = [
 		group: 'a8c-for-agencies',
 	},
 	{
+		name: 'a8c-for-agencies-feedback',
+		paths: [ '/feedback' ],
+		module: 'calypso/a8c-for-agencies/sections/feedback',
+		group: 'a8c-for-agencies',
+	},
+	{
 		name: 'a8c-for-agencies-auth',
 		paths: [ '/connect', '/connect/oauth/token' ],
 		module: 'calypso/a8c-for-agencies/sections/auth',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -161,6 +161,7 @@
 		"a8c-for-agencies": false,
 		"a8c-for-agencies-auth": false,
 		"a8c-for-agencies-landing": false,
+		"a8c-for-agencies-feedback": false,
 		"a8c-for-agencies-overview": false,
 		"a8c-for-agencies-plugins": false,
 		"a8c-for-agencies-sites": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -51,6 +51,7 @@
 		"a8c-for-agencies": true,
 		"a8c-for-agencies-auth": true,
 		"a8c-for-agencies-landing": true,
+		"a8c-for-agencies-feedback": true,
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -44,6 +44,7 @@
 		"a8c-for-agencies": true,
 		"a8c-for-agencies-auth": true,
 		"a8c-for-agencies-landing": true,
+		"a8c-for-agencies-feedback": true,
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -44,6 +44,7 @@
 		"a8c-for-agencies": true,
 		"a8c-for-agencies-auth": true,
 		"a8c-for-agencies-landing": true,
+		"a8c-for-agencies-feedback": true,
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -46,6 +46,7 @@
 		"a8c-for-agencies": true,
 		"a8c-for-agencies-auth": true,
 		"a8c-for-agencies-landing": true,
+		"a8c-for-agencies-feedback": true,
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2006
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2007
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2008
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2009
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2010

## Proposed Changes

This PR:

- Updates the contextual feedback mechanism as the new requirements and design, including the adding referrals, inviting team member, updating agency details flows.
- Adds the feedback to the post-purchase flow

Note: Reset the preference (instructions below) before testing.

## Why are these changes being made?

* To help bolster our retention and get relevant, in-context feedback from agencies.

## Testing Instructions

* ~Patch 179607-ghe-Automattic/wpcom to your sandbox~
* Open the A4A live link
* Perform the below actions and verify the feedback is shown as displayed below. Fill out the form and submit it > Verify the form is submitted by checking the Slack message (channel name can be found here: https://github.com/Automattic/automattic-for-agencies-dev/issues/2006). 

1) Sending a referral (/marketplace/products > Toggle the refer mode on and send a referral)

<img width="1660" alt="Screenshot 2025-04-08 at 12 18 32 PM" src="https://github.com/user-attachments/assets/34acaca0-8d95-48c0-b7f0-57d199ed10b8" />

2) Adding a team member (/team/invite > Send invite)

<img width="1660" alt="Screenshot 2025-04-08 at 12 17 23 PM" src="https://github.com/user-attachments/assets/fab6d9bd-ba16-4600-84c4-e122d6f99cd2" />

3) Filling out partner directory information (/partner-directory/agency-details > Save public profile)

<img width="1666" alt="Screenshot 2025-04-04 at 10 54 36 AM" src="https://github.com/user-attachments/assets/b254b60f-2027-4ab4-9c57-de965dc16439" />

* Go to Marketplace > For the flows mentioned below: Verify the feedback form is shown > Submit the form > Verify you are redirected to the appropriate pages > Verify the form is submitted by checking the Slack message.

Note: Reset the preference (instructions below) after each flow.

1)  Go to Sites Dashboard > Click on Add + on backup or scan on any site > Purchase the product > Verify the feedback form is shown > Submit the form or skip it > Verify you are redirected to the sites dashboard
2) Go to Marketplace > Add a product (not free, non-WooCommerce) > Go to Checkout > Purchase the product > Verify you are redirected to the Licenses page > Click the `Assign` button > Assing the license to a site > Verify the feedback form is shown > Submit the form or skip it > Verify you are redirected to the Licenses page
3) Go to Marketplace > Add a product (not free, WooCommerce) > Go to Checkout > Purchase the product > Verify you are redirected to the Licenses page > Click the `Assign` button > Assing the license to a site > Verify that you are redirected to the Download Products page > Click the `Done` button > Verify the feedback form is shown > Submit the form or skip it > Verify you are redirected to the Licenses page
4) Go to Marketplace > Add a product (free, WooCommerce) > Go to Checkout > Purchase the product > Verify you are redirected to the Licenses page > Click the `Assign` button > Assing the license to a site > Verify that you are redirected to the Download Products page > Click the `Done` button > Verify the feedback form is not shown > Verify you are redirected to the Licenses page
3) Go to Markeplace > Add WP.com hosting > Go to Checkout > Purchase the hosting > Verify you are redirected to the Needs setup page > Create a site > Once you are in the Sites Dashboard > Click the `Set up your site` button on the banner > Verify you are redirected to the WP.com overview page > Go to A4A dashboard > Verify the feedback form is shown > Submit the form or skip it > Verify you are redirected to the Licenses page
4) Go to Markeplace > Add Pressable hosting > Go to Checkout > Purchase the hosting > Verify you are redirected to the Licenses page > Click the `Manage in Pressable` button > Verify you are redirected to Pressable > Go to A4A dashboard > Verify the feedback form is shown > Submit the form or skip it > Verify you are redirected to the Licenses page

<img width="1660" alt="Screenshot 2025-04-08 at 12 16 41 PM" src="https://github.com/user-attachments/assets/4193df0f-e847-4574-ad0b-547cd0e4ed1a" />

---
How the preferences are stored:

<img width="304" alt="Screenshot 2024-12-05 at 11 06 08 AM" src="https://github.com/user-attachments/assets/1ca12427-cee1-4f6c-9a3c-c40272e94c6a">

Preferences can be reset from staging
---
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?