### PR TITLE
A4A > Sites Dashboard: UI enhancements to Performance feature

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -1029,9 +1029,17 @@
 		padding: 0;
 	}
 
+	.performance-profiler-insights-section .description-area, .core-web-vitals-display__description, .navigation-header__main {
+		a, .button.is-link {
+			color: var(--color-primary);
+		}
+	}
+
 	.site-performance-device-tab__controls:not(.disabled) .segmented-control__item.is-selected {
 		 .segmented-control__link {
 			color: var(--color-text-white);
+			background-color: var(--color-primary);
+			border-color: var(--color-primary);
 		}
 
 		+ .segmented-control__item .segmented-control__link {

--- a/client/hosting/performance/components/device-tab-control/style.scss
+++ b/client/hosting/performance/components/device-tab-control/style.scss
@@ -31,7 +31,6 @@
 				background-color: transparent;
 				color: var(--studio-gray-20);
 				border-color: var(--studio-gray-20);
-				border-right: unset;
 			}
 
 			&.is-selected + .segmented-control__item .segmented-control__link {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/101819#issuecomment-2774863216

## Proposed Changes

This PR makes some minor UI fixes to the CTA colors on the Performance tab on the Sites Dashboard

## Why are these changes being made?

* To fix some inconsistencies with CTA colors

## Testing Instructions

* Open A4A live link
* Go to Sites > Open any atomic site details > Click the Performance tab > Verify the button colors are matching the A4A primary colors:

<img width="1076" alt="Screenshot 2025-04-04 at 12 20 57 PM" src="https://github.com/user-attachments/assets/a9ffa607-f742-464d-b6c6-f738da846ed1" />

<img width="1076" alt="Screenshot 2025-04-04 at 12 21 21 PM" src="https://github.com/user-attachments/assets/a0c18dc5-7f4b-46f2-88b5-ff29d9317b99" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
