### PR TITLE
[Site Admin]: remove `as` prop from SidebarNavigationItem component

### DIFF
--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -26,6 +26,7 @@ Initial release of the site-admin package providing a framework for building mod
 ## Next
 
 - Add `history` package dependency
+- Set `SiteNavigationItem`’s `as` prop automatically based on to or onClick.
 
 ### Components
 - `SiteHub`: Site navigation and context switcher

--- a/packages/site-admin/src/components/sidebar-navigation-item/index.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/index.tsx
@@ -52,7 +52,8 @@ export function SidebarNavigationItem( {
 			navigate( 'forward', `[id="${ uid }"]` );
 		}
 	}
-	const linkProps = useLink( to );
+
+	const { href } = useLink( to );
 
 	return (
 		<Item
@@ -62,10 +63,10 @@ export function SidebarNavigationItem( {
 				className
 			) }
 			id={ uid }
-			onClick={ handleClick }
-			href={ to ? linkProps.href : undefined }
 			as={ onClick ? 'button' : 'a' }
 			{ ...props }
+			onClick={ handleClick }
+			href={ to ? href : undefined }
 		>
 			<HStack justify="flex-start">
 				{ icon && <Icon icon={ icon } size={ 24 } /> }

--- a/packages/site-admin/src/components/sidebar-navigation-item/index.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/index.tsx
@@ -10,6 +10,7 @@ import { useContext } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 import { chevronRightSmall, chevronLeftSmall, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
+import { ComponentProps } from 'react';
 /**
  * Internal dependencies
  */
@@ -19,21 +20,18 @@ import { useHistory, useLink } from '../../router';
 import './style.scss';
 
 type SidebarNavigationItemProps = {
-	className?: string;
 	suffix?: 'CHEVRON' | React.ReactNode;
 	uid: string;
 	to?: string;
-	onClick?: ( e: React.MouseEvent ) => void;
-	children: React.ReactNode;
 	icon?: React.ReactElement;
-};
+} & ComponentProps< typeof Item >;
 
 export function SidebarNavigationItem( {
-	className,
-	icon,
 	suffix,
 	uid,
 	to = '',
+	icon,
+	className,
 	onClick,
 	children,
 	...props
@@ -42,7 +40,7 @@ export function SidebarNavigationItem( {
 	const { navigate } = useContext( SidebarNavigationContext );
 
 	// If there is no custom click handler, create one that navigates to `params`.
-	function handleClick( e: React.MouseEvent ) {
+	function handleClick( e: React.MouseEvent< HTMLDivElement > ) {
 		if ( onClick ) {
 			onClick( e );
 			navigate( 'forward' );

--- a/packages/site-admin/src/components/sidebar-navigation-item/index.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/index.tsx
@@ -23,7 +23,6 @@ type SidebarNavigationItemProps = {
 	suffix?: 'CHEVRON' | React.ReactNode;
 	uid: string;
 	to?: string;
-	as?: 'button' | 'a';
 	onClick?: ( e: React.MouseEvent ) => void;
 	children: React.ReactNode;
 	icon?: React.ReactElement;
@@ -35,7 +34,6 @@ export function SidebarNavigationItem( {
 	suffix,
 	uid,
 	to = '',
-	as = 'button',
 	onClick,
 	children,
 	...props
@@ -66,7 +64,7 @@ export function SidebarNavigationItem( {
 			id={ uid }
 			onClick={ handleClick }
 			href={ to ? linkProps.href : undefined }
-			as={ as }
+			as={ onClick ? 'button' : 'a' }
 			{ ...props }
 		>
 			<HStack justify="flex-start">

--- a/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
@@ -35,6 +35,17 @@ const meta: Meta< typeof SidebarNavigationItem > = {
 			options: [ 'small', 'medium', 'large' ],
 		},
 	},
+	decorators: [
+		( Story ) => {
+			const [ navState ] = useState( createNavState() );
+
+			return (
+				<SidebarNavigationContext.Provider value={ navState }>
+					<Story />
+				</SidebarNavigationContext.Provider>
+			);
+		},
+	],
 };
 
 export default meta;
@@ -53,13 +64,10 @@ export const Default: Story = {
 		const iconKey = iconName as unknown as IconName;
 		const icon = allIcons?.[ iconKey ] || allIcons.capturePhoto;
 
-		const [ navState ] = useState( createNavState() );
 		return (
-			<SidebarNavigationContext.Provider value={ navState }>
-				<SidebarNavigationItem { ...validArgs } icon={ icon }>
-					{ __( 'Site Photos Gallery', 'a8c-site-admin' ) }
-				</SidebarNavigationItem>
-			</SidebarNavigationContext.Provider>
+			<SidebarNavigationItem { ...validArgs } icon={ icon }>
+				{ __( 'Site Photos Gallery', 'a8c-site-admin' ) }
+			</SidebarNavigationItem>
 		);
 	},
 };

--- a/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
@@ -30,9 +30,9 @@ const meta: Meta< typeof SidebarNavigationItem > = {
 			control: 'select',
 			options: [ ...iconNames, 'none' ],
 		},
-		as: {
+		size: {
 			control: 'select',
-			options: [ 'button', 'a' ],
+			options: [ 'small', 'medium', 'large' ],
 		},
 	},
 };
@@ -42,6 +42,10 @@ export default meta;
 type Story = StoryObj< typeof SidebarNavigationItem >;
 
 export const Default: Story = {
+	name: 'Default',
+	args: {
+		onClick: fn(),
+	},
 	render: function Template( args ) {
 		const { icon: iconName, children, ...validArgs } = args;
 
@@ -53,17 +57,11 @@ export const Default: Story = {
 		return (
 			<SidebarNavigationContext.Provider value={ navState }>
 				<SidebarNavigationItem { ...validArgs } icon={ icon }>
-					{ children }
+					{ __( 'Site Photos Gallery', 'a8c-site-admin' ) }
 				</SidebarNavigationItem>
 			</SidebarNavigationContext.Provider>
 		);
 	},
-};
-
-Default.storyName = 'SidebarNavigationItem';
-Default.args = {
-	children: __( 'Site Photos Gallery', 'a8c-site-admin' ),
-	onClick: fn(),
 };
 
 // Add a story for the suffix prop.

--- a/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta< typeof SidebarNavigationItem > = {
 		},
 	},
 	decorators: [
-		( Story ) => {
+		function WithNavigationContext( Story ) {
 			const [ navState ] = useState( createNavState() );
 
 			return (

--- a/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
@@ -25,6 +25,7 @@ const iconNames = Object.keys( allIcons ) as IconName[];
 const meta: Meta< typeof SidebarNavigationItem > = {
 	title: 'Components/SidebarNavigationItem',
 	component: SidebarNavigationItem,
+	tags: [ 'autodocs' ],
 	argTypes: {
 		icon: {
 			control: 'select',
@@ -52,8 +53,11 @@ export default meta;
 
 type Story = StoryObj< typeof SidebarNavigationItem >;
 
-export const Default: Story = {
-	name: 'Default',
+/**
+ * This story demonstrates how the component renders a `<button>` element
+ * when the `onClick` prop is provided.
+ */
+export const WithOnClickHandler: Story = {
 	args: {
 		onClick: fn(),
 	},
@@ -72,7 +76,17 @@ export const Default: Story = {
 	},
 };
 
-// Add a story for the suffix prop.
+/**
+ * This story demonstrates how the component renders a `<a>` element
+ * when the `to` prop is provided
+ */
+export const WithToProp: Story = {
+	args: {
+		to: '/',
+		children: __( 'Site Photos Gallery', 'a8c-site-admin' ),
+	},
+};
+
 export const WithChevronSuffix: Story = {
 	args: {
 		children: __( 'More options', 'a8c-site-admin' ),

--- a/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/sidebar-navigation-item/stories/index.stories.tsx
@@ -14,10 +14,7 @@ import { SidebarNavigationItem, SidebarNavigationContext, createNavState } from 
  */
 import type { Meta, StoryObj } from '@storybook/react';
 
-type IconName = keyof typeof allIcons;
-
 const { Icon, ...allIcons } = allIconComponents;
-const iconNames = Object.keys( allIcons ) as IconName[];
 
 /**
  * Storybook metadata
@@ -28,8 +25,23 @@ const meta: Meta< typeof SidebarNavigationItem > = {
 	tags: [ 'autodocs' ],
 	argTypes: {
 		icon: {
-			control: 'select',
-			options: [ ...iconNames, 'none' ],
+			control: {
+				type: 'select',
+				labels: {
+					'': 'No icon',
+				},
+			},
+			options: [ '', ...Object.keys( allIcons ) ],
+			mapping: {
+				'': undefined,
+				...Object.entries( allIcons ).reduce(
+					( acc, [ name, icon ] ) => ( {
+						...acc,
+						[ name ]: icon,
+					} ),
+					{}
+				),
+			},
 		},
 		size: {
 			control: 'select',
@@ -60,19 +72,8 @@ type Story = StoryObj< typeof SidebarNavigationItem >;
 export const WithOnClickHandler: Story = {
 	args: {
 		onClick: fn(),
-	},
-	render: function Template( args ) {
-		const { icon: iconName, children, ...validArgs } = args;
-
-		// Pick the icon component based on the icon name.
-		const iconKey = iconName as unknown as IconName;
-		const icon = allIcons?.[ iconKey ] || allIcons.capturePhoto;
-
-		return (
-			<SidebarNavigationItem { ...validArgs } icon={ icon }>
-				{ __( 'Site Photos Gallery', 'a8c-site-admin' ) }
-			</SidebarNavigationItem>
-		);
+		children: __( 'Site Photos Gallery', 'a8c-site-admin' ),
+		icon: allIcons.capturePhoto,
 	},
 };
 
@@ -82,8 +83,9 @@ export const WithOnClickHandler: Story = {
  */
 export const WithToProp: Story = {
 	args: {
-		to: '/',
-		children: __( 'Site Photos Gallery', 'a8c-site-admin' ),
+		to: '/home',
+		children: __( 'Home', 'a8c-site-admin' ),
+		icon: allIcons.home,
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR simplifies the SidebarNavigationItem component by:

- Remove redundant `as` prop since element type is determined by `href` presence
- Update type definitions to extend from `Item` props
- Clean up story controls and examples
- Update documentation to reflect changes
- Fix prop spreading order for proper overrides

This change makes the component more intuitive to use while maintaining all functionality.

Closes ARC-28

Related to #

## Proposed Changes

* [Site Admin]: remove `as` prop from SidebarNavigationItem component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1) Run Storybook application 
```sh
yarn workspace @automattic/site-admin run storybook:start
```
2) Use the `SiteNavigationItem` to confimrm
  * renders a `<button />` when the component instance defines the onClick callback
  * renders an `a` anchor element when it defines the `to` property

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/c0a10161-e79e-4ee1-be0b-bb39aed1110a" />

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/5b2d2165-11f9-41b2-bf34-6659ef13d109" />


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
