### PR TITLE
Server Settings: Update the SSH url to use ssh.wp.com

### DIFF
--- a/client/sites/settings/sftp-ssh/sftp-form.tsx
+++ b/client/sites/settings/sftp-ssh/sftp-form.tsx
@@ -138,7 +138,7 @@ export const SftpForm = ( { disabled }: SftpFormProps ) => {
 	const siteIntent = useSiteOption( 'site_intent' );
 	const completeTasks = useCompleteLaunchpadTasksWithNotice();
 
-	const sshConnectString = `ssh ${ username }@sftp.wp.com`;
+	const sshConnectString = `ssh ${ username }@ssh.wp.com`;
 
 	const handleResetPassword = () => {
 		setPasswordLoading( true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Update the ssh domain we display in Server settings to `ssh.wp.com` since it looks nicer!

After approval and before merging the PR, I'll also update the [support docs](https://developer.wordpress.com/docs/developer-tools/ssh/) with the new SSH domain.

Related to: linear DOTCOM-1840
## Proposed Changes

* Update the SSH domain with the vanity one: ssh.wp.com

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Instead of displaying the sftp.wp.com, we can use ssh.wp.com which looks nicer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to https://wordpress.com/sites/settings/sftp-ssh/your-atomic-site
* Enable "SSH access" if neccessary
* Notice that the ssh command now uses a different domain: ssh.wp.com instead of sftp.wp.com. 
* The command should look like this: `ssh your-site.wordpress.com@ssh.wp.com`
* Try to ssh into the site using the command

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
