### PR TITLE
Quick links: Remove links to the iframe editor

### DIFF
--- a/client/my-sites/advertising/useAdvertisingUrl.jsx
+++ b/client/my-sites/advertising/useAdvertisingUrl.jsx
@@ -1,18 +1,14 @@
 import { useSelector } from 'react-redux';
-import { getSiteAdminUrl, isAdminInterfaceWPAdmin } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const useAdvertisingUrl = () => {
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteAdminUrl = useSelector( ( state ) =>
 		getSiteAdminUrl( state, siteId, 'tools.php?page=advertising' )
 	);
-	const adminInterfaceIsWPAdmin = useSelector( ( state ) =>
-		isAdminInterfaceWPAdmin( state, siteId )
-	);
 
-	return adminInterfaceIsWPAdmin ? siteAdminUrl : `/advertising/${ selectedSiteSlug }`;
+	return siteAdminUrl;
 };
 
 export default useAdvertisingUrl;

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -133,9 +133,7 @@ export const QuickLinks = ( {
 			) }
 			{ ! isStaticHomePage && canModerateComments && (
 				<ActionBox
-					href={
-						usesWpAdminInterface ? `${ siteAdminUrl }edit-comments.php` : `/comments/${ siteSlug }`
-					}
+					href={ `${ siteAdminUrl }edit-comments.php` }
 					hideLinkIndicator
 					onClick={ trackManageCommentsAction }
 					label={ translate( 'Manage comments' ) }

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -116,7 +116,7 @@ export const QuickLinks = ( {
 				customizerLinks
 			) }
 			<ActionBox
-				href={ usesWpAdminInterface ? `${ siteAdminUrl }post-new.php` : `/post/${ siteSlug }` }
+				href={ `${ siteAdminUrl }post-new.php` }
 				hideLinkIndicator
 				onClick={ trackWritePostAction }
 				label={ translate( 'Write blog post' ) }
@@ -144,11 +144,7 @@ export const QuickLinks = ( {
 			) }
 			{ canEditPages && (
 				<ActionBox
-					href={
-						usesWpAdminInterface
-							? `${ siteAdminUrl }post-new.php?post_type=page`
-							: `/page/${ siteSlug }`
-					}
+					href={ `${ siteAdminUrl }post-new.php?post_type=page` }
 					hideLinkIndicator
 					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DOTCOM-1720/remove-editor-iframe-entrypoints

## Proposed Changes

* As part of the RDV effort, we now want to remove links to the iframed editor to avoid unnecessary redirections.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to your site's home
* On the `Quick links` on the right side, check that:
* `Write blog post` links to `https://{site}.wordpress.com/wp-admin/post-new.php)`
![image](https://github.com/user-attachments/assets/e6464a40-2110-4cfa-9cbf-16bb5c29f251)
* `Add a page` links to `https://{site}.wordpress.com/wp-admin/post-new.php?post_type=page`
![image](https://github.com/user-attachments/assets/ae9c8df8-9a04-4dd2-b1b2-0e0269c0d37d)
* `Manage comments` links to `https://{site}/wp-admin/edit-comments.php`
![image](https://github.com/user-attachments/assets/e648947d-bf52-4234-9c73-c3aa89009bf8)
* `Promote with Blaze` link to `https://{site}/wp-admin/tools.php?page=advertising`
![image](https://github.com/user-attachments/assets/d41e4c4d-6cd2-442c-9488-a926092ff3c9)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
