### PR TITLE
Transfer with Software: Update prop names to reflect back-end change

### DIFF
--- a/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
@@ -53,7 +53,7 @@ describe( 'useRequestTransferWithSoftware', () => {
 
 	beforeEach( () => nock.cleanAll() );
 
-	it( 'should successfully request transfer with software and return the atomic_transfer_id', async () => {
+	it( 'should successfully request transfer with software and return the transfer_id', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/sites/' + SITE_ID + '/atomic/transfer-with-software', {
 				plugins: [ 'plugin-1', 'install' ],
@@ -64,9 +64,9 @@ describe( 'useRequestTransferWithSoftware', () => {
 				http_envelope: 1,
 			} )
 			.reply( 200, {
-				atomic_transfer_id: 456,
+				transfer_id: 456,
 				blog_id: SITE_ID,
-				atomic_transfer_status: 'pending',
+				transfer_status: 'pending',
 			} );
 
 		const { result } = render();
@@ -77,9 +77,9 @@ describe( 'useRequestTransferWithSoftware', () => {
 			() => {
 				expect( result.current.isSuccess ).toBe( true );
 				expect( result.current.data ).toEqual( {
-					atomic_transfer_id: 456,
+					transfer_id: 456,
 					blog_id: SITE_ID,
-					atomic_transfer_status: 'pending',
+					transfer_status: 'pending',
 				} );
 			},
 			{ timeout: 3000 }

--- a/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-status-query.tsx
@@ -15,8 +15,8 @@ jest.mock( '@automattic/calypso-config', () => ( {
 
 const mockSuccessResponse = {
 	blog_id: 123,
-	atomic_transfer_id: 456,
-	atomic_transfer_status: 'completed',
+	transfer_id: 456,
+	transfer_status: 'completed',
 };
 
 describe( 'useTransferWithSoftwareStatus', () => {
@@ -41,7 +41,7 @@ describe( 'useTransferWithSoftwareStatus', () => {
 		await waitFor( () => {
 			expect( result.current.isSuccess ).toBe( true );
 			expect( result.current.data ).toEqual( {
-				atomic_transfer_status: 'completed',
+				transfer_status: 'completed',
 			} );
 		} );
 	} );
@@ -57,7 +57,7 @@ describe( 'useTransferWithSoftwareStatus', () => {
 		expect( nock.isDone() ).toBe( true ); // No pending nock requests
 	} );
 
-	it( 'should not fetch when atomicTransferId is missing', () => {
+	it( 'should not fetch when transferId is missing', () => {
 		const queryClient = new QueryClient();
 		const wrapper = ( { children }: { children: React.ReactNode } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>

--- a/client/sites/hooks/use-transfer-with-software-start-mutation.ts
+++ b/client/sites/hooks/use-transfer-with-software-start-mutation.ts
@@ -3,8 +3,8 @@ import wpcom from 'calypso/lib/wp';
 
 type TransferWithSoftwareResponse = {
 	blog_id: number;
-	atomic_transfer_id: number;
-	atomic_transfer_status: string;
+	transfer_id: number;
+	transfer_status: string;
 };
 
 type SoftwareSlug = string;

--- a/client/sites/hooks/use-transfer-with-software-status-query.ts
+++ b/client/sites/hooks/use-transfer-with-software-status-query.ts
@@ -3,8 +3,8 @@ import wpcom from 'calypso/lib/wp';
 
 type TransferWithSoftwareStatusResponse = {
 	blog_id: number;
-	atomic_transfer_id: number;
-	atomic_transfer_status: string;
+	transfer_id: number;
+	transfer_status: string;
 };
 
 const getTransferWithSoftwareStatus: (
@@ -14,8 +14,8 @@ const getTransferWithSoftwareStatus: (
 	if ( ! siteId || ! atomicTransferId ) {
 		return {
 			blog_id: 0,
-			atomic_transfer_id: 0,
-			atomic_transfer_status: 'pending',
+			transfer_id: 0,
+			transfer_status: 'pending',
 		};
 	}
 	return wpcom.req.get(
@@ -37,12 +37,12 @@ export const useTransferWithSoftwareStatus = (
 		queryKey: [ 'software-transfer-status', siteId, atomicTransferId ],
 		queryFn: () => getTransferWithSoftwareStatus( siteId, atomicTransferId ),
 		select: ( data: TransferWithSoftwareStatusResponse ) => ( {
-			atomic_transfer_status: data.atomic_transfer_status,
+			transfer_status: data.transfer_status,
 		} ),
 		refetchOnWindowFocus: false,
 		refetchOnReconnect: false,
 		refetchInterval: ( { state } ) => {
-			if ( state.data?.atomic_transfer_status === 'completed' ) {
+			if ( state.data?.transfer_status === 'completed' ) {
 				return false;
 			}
 			return 5000;

--- a/client/sites/hooks/use-transfer-with-software-status-query.ts
+++ b/client/sites/hooks/use-transfer-with-software-status-query.ts
@@ -9,9 +9,9 @@ type TransferWithSoftwareStatusResponse = {
 
 const getTransferWithSoftwareStatus: (
 	siteId?: number,
-	atomicTransferId?: number
-) => Promise< TransferWithSoftwareStatusResponse > = async ( siteId, atomicTransferId ) => {
-	if ( ! siteId || ! atomicTransferId ) {
+	transferId?: number
+) => Promise< TransferWithSoftwareStatusResponse > = async ( siteId, transferId ) => {
+	if ( ! siteId || ! transferId ) {
 		return {
 			blog_id: 0,
 			transfer_id: 0,
@@ -19,7 +19,7 @@ const getTransferWithSoftwareStatus: (
 		};
 	}
 	return wpcom.req.get(
-		`/sites/${ siteId }/atomic/transfer-with-software/${ atomicTransferId }?http_envelope=1`,
+		`/sites/${ siteId }/atomic/transfer-with-software/${ transferId }?http_envelope=1`,
 		{
 			apiNamespace: 'wpcom/v2',
 		}
@@ -28,14 +28,14 @@ const getTransferWithSoftwareStatus: (
 
 export const useTransferWithSoftwareStatus = (
 	siteId?: number,
-	atomicTransferId?: number,
+	transferId?: number,
 	options?: {
 		retry?: UseQueryOptions[ 'retry' ];
 	}
 ) => {
 	return useQuery( {
-		queryKey: [ 'software-transfer-status', siteId, atomicTransferId ],
-		queryFn: () => getTransferWithSoftwareStatus( siteId, atomicTransferId ),
+		queryKey: [ 'software-transfer-status', siteId, transferId ],
+		queryFn: () => getTransferWithSoftwareStatus( siteId, transferId ),
 		select: ( data: TransferWithSoftwareStatusResponse ) => ( {
 			transfer_status: data.transfer_status,
 		} ),
@@ -48,6 +48,6 @@ export const useTransferWithSoftwareStatus = (
 			return 5000;
 		},
 		retry: options?.retry ?? false,
-		enabled: !! siteId && !! atomicTransferId, // Only run when both values exist.
+		enabled: !! siteId && !! transferId, // Only run when both values exist.
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 178867-ghe-Automattic/wpcom#discussion_r170519

## Proposed Changes

* Update the naming of the props to not mention Atomic.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Please see 178867-ghe-Automattic/wpcom#discussion_r170519 for more context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?