### PR TITLE
e2e tests: update Paid content test to match block api version 3

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -32,8 +32,10 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 * @param {EditorContext} context The current context for the editor at the point of test execution
 	 */
 	async configure( context: EditorContext ): Promise< void > {
-		// The Guest View will load by default. Wait for this view to fully render.
-		await context.addedBlockLocator.locator( '.wp-premium-content-logged-out-view' ).waitFor();
+		// The Guest View will load by default. Wait for this view to fully render and be visible.
+		await context.addedBlockLocator
+			.locator( '.wp-premium-content-logged-out-view:not([hidden])' )
+			.waitFor();
 
 		// Using the Block Toolbar, change to the Subscriber view.
 		// The exact steps differ between the viewports.
@@ -47,7 +49,9 @@ export class PaidContentBlockFlow implements BlockFlow {
 		}
 
 		// Verify the Subscriber version of the block is now loaded.
-		await context.addedBlockLocator.locator( '.wp-premium-content-subscriber-view' ).waitFor();
+		await context.addedBlockLocator
+			.locator( '.wp-premium-content-subscriber-view:not([hidden])' )
+			.waitFor();
 
 		// Fill the title and text for Subscriber view.
 		await context.addedBlockLocator

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -33,9 +33,7 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		// The Guest View will load by default. Wait for this view to fully render.
-		await context.addedBlockLocator
-			.getByRole( 'document', { name: 'Block: Guest View' } )
-			.waitFor();
+		await context.addedBlockLocator.locator( '.wp-block-premium-content-buttons' ).waitFor();
 
 		// Using the Block Toolbar, change to the Subscriber view.
 		// The exact steps differ between the viewports.

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -33,7 +33,7 @@ export class PaidContentBlockFlow implements BlockFlow {
 	 */
 	async configure( context: EditorContext ): Promise< void > {
 		// The Guest View will load by default. Wait for this view to fully render.
-		await context.addedBlockLocator.locator( '.wp-block-premium-content-buttons' ).waitFor();
+		await context.addedBlockLocator.locator( '.wp-premium-content-logged-out-view' ).waitFor();
 
 		// Using the Block Toolbar, change to the Subscriber view.
 		// The exact steps differ between the viewports.

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/paid-content.ts
@@ -47,9 +47,7 @@ export class PaidContentBlockFlow implements BlockFlow {
 		}
 
 		// Verify the Subscriber version of the block is now loaded.
-		await context.addedBlockLocator
-			.getByRole( 'document', { name: 'Block: Subscriber View' } )
-			.waitFor();
+		await context.addedBlockLocator.locator( '.wp-premium-content-subscriber-view' ).waitFor();
 
 		// Fill the title and text for Subscriber view.
 		await context.addedBlockLocator


### PR DESCRIPTION
## Proposed Changes

This PR updates the expected DOM structure in the post editor, for the Paid content block.

## Why are these changes being made?

This is necessary following the changes in https://github.com/Automattic/jetpack/pull/40685/

The markup in the editor is now a bit different.

See p1743782562169979-slack-C01U2KGS2PQ

## Testing Instructions

* I'm not quite sure how to best test this, short of running the tests with the updated changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
