### PR TITLE
Social-first Sign Up: Avoid layout jump when switching method

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -131,6 +131,8 @@ const SignupFormSocialFirst = ( {
 		);
 	};
 
+	// This component uses a technique from this video https://www.youtube.com/watch?v=8327_1PINWI
+	// to handle the visibility of the steps while preserving their layout properties and avoiding shifts.
 	const getVisibilityClassName = ( step: Screen ) => {
 		return clsx( 'signup-form-social-first-screen', {
 			visible: currentStep === step,

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
 import { isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
@@ -13,7 +14,6 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import PasswordlessSignupForm from './passwordless';
 import SocialSignupForm from './social';
-import type { CSSProperties } from 'react';
 import './style.scss';
 
 interface QueryArgs {
@@ -131,13 +131,15 @@ const SignupFormSocialFirst = ( {
 		);
 	};
 
-	const getStepStyle = ( step: 'initial' | 'email' ): CSSProperties => ( {
-		visibility: step === currentStep ? 'visible' : 'hidden',
-	} );
+	const getVisibilityClassName = ( step: Screen ) => {
+		return clsx( 'signup-form-social-first-screen', {
+			visible: currentStep === step,
+		} );
+	};
 
 	return (
 		<div className="signup-form signup-form-social-first">
-			<div className="signup-form-social-first-initial" style={ getStepStyle( 'initial' ) }>
+			<div className={ getVisibilityClassName( 'initial' ) }>
 				{ notice }
 				<SocialSignupForm
 					handleResponse={ handleSocialResponse }
@@ -150,52 +152,54 @@ const SignupFormSocialFirst = ( {
 				/>
 				{ renderTermsOfService() }
 			</div>
-			<div className="signup-form-social-first-email" style={ getStepStyle( 'email' ) }>
-				<PasswordlessSignupForm
-					stepName={ stepName }
-					flowName={ flowName }
-					goToNextStep={ goToNextStep }
-					logInUrl={ logInUrl }
-					queryArgs={ queryArgs }
-					labelText={ emailLabelText ?? __( 'Your email' ) }
-					submitButtonLabel={ __( 'Continue' ) }
-					userEmail={ userEmail }
-					renderTerms={ renderEmailStepTermsOfService }
-					secondaryFooterButton={
-						backButtonInFooter ? undefined : (
-							<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
-								{ __( 'See all options' ) }
-							</Button>
-						)
-					}
-					passDataToNextStep={ passDataToNextStep }
-					onCreateAccountError={ ( error: { error: string }, email: string ) => {
-						if ( isExistingAccountError( error.error ) ) {
-							window.location.assign(
-								addQueryArgs(
-									{
-										email_address: email,
-										is_signup_existing_account: true,
-										redirect_to: queryArgs?.redirect_to,
-									},
-									logInUrl
-								)
-							);
+			<div className={ getVisibilityClassName( 'email' ) }>
+				<div className="signup-form-social-first-email">
+					<PasswordlessSignupForm
+						stepName={ stepName }
+						flowName={ flowName }
+						goToNextStep={ goToNextStep }
+						logInUrl={ logInUrl }
+						queryArgs={ queryArgs }
+						labelText={ emailLabelText ?? __( 'Your email' ) }
+						submitButtonLabel={ __( 'Continue' ) }
+						userEmail={ userEmail }
+						renderTerms={ renderEmailStepTermsOfService }
+						secondaryFooterButton={
+							backButtonInFooter ? undefined : (
+								<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
+									{ __( 'See all options' ) }
+								</Button>
+							)
 						}
-					} }
-					onCreateAccountSuccess={ onCreateAccountSuccess }
-					inputPlaceholder={ isGravatar ? __( 'Enter your email address' ) : undefined }
-					submitButtonLoadingLabel={ isGravatar ? __( 'Continue' ) : undefined }
-				/>
-				{ backButtonInFooter ? (
-					<Button
-						onClick={ () => setCurrentStep( 'initial' ) }
-						className="back-button"
-						variant="link"
-					>
-						<span>{ __( 'Back' ) }</span>
-					</Button>
-				) : null }
+						passDataToNextStep={ passDataToNextStep }
+						onCreateAccountError={ ( error: { error: string }, email: string ) => {
+							if ( isExistingAccountError( error.error ) ) {
+								window.location.assign(
+									addQueryArgs(
+										{
+											email_address: email,
+											is_signup_existing_account: true,
+											redirect_to: queryArgs?.redirect_to,
+										},
+										logInUrl
+									)
+								);
+							}
+						} }
+						onCreateAccountSuccess={ onCreateAccountSuccess }
+						inputPlaceholder={ isGravatar ? __( 'Enter your email address' ) : undefined }
+						submitButtonLoadingLabel={ isGravatar ? __( 'Continue' ) : undefined }
+					/>
+					{ backButtonInFooter ? (
+						<Button
+							onClick={ () => setCurrentStep( 'initial' ) }
+							className="back-button"
+							variant="link"
+						>
+							<span>{ __( 'Back' ) }</span>
+						</Button>
+					) : null }
+				</div>
 			</div>
 		</div>
 	);

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -4,7 +4,6 @@ import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { CSSProperties } from 'react';
 import { isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
@@ -14,6 +13,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import PasswordlessSignupForm from './passwordless';
 import SocialSignupForm from './social';
+import type { CSSProperties } from 'react';
 import './style.scss';
 
 interface QueryArgs {
@@ -66,6 +66,8 @@ const options = {
 	),
 };
 
+type Screen = 'initial' | 'email';
+
 const SignupFormSocialFirst = ( {
 	goToNextStep,
 	stepName,
@@ -83,7 +85,7 @@ const SignupFormSocialFirst = ( {
 	backButtonInFooter = true,
 	emailLabelText,
 }: SignupFormSocialFirst ) => {
-	const [ currentStep, setCurrentStep ] = useState( 'initial' );
+	const [ currentStep, setCurrentStep ] = useState< Screen >( 'initial' );
 	const { __ } = useI18n();
 	const oauth2Client = useSelector( getCurrentOAuth2Client );
 	const isWoo = useSelector( getIsWoo );

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -4,6 +4,7 @@ import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { CSSProperties } from 'react';
 import { isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { AccountCreateReturn } from 'calypso/lib/signup/api/type';
 import { isExistingAccountError } from 'calypso/lib/signup/is-existing-account-error';
@@ -103,7 +104,7 @@ const SignupFormSocialFirst = ( {
 				),
 				options
 			);
-		} else if ( currentStep === 'initial' ) {
+		} else {
 			tosText = createInterpolateElement(
 				__(
 					'If you continue with Google, Apple or GitHub, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
@@ -112,107 +113,88 @@ const SignupFormSocialFirst = ( {
 			);
 		}
 
-		if ( ! tosText ) {
-			return null;
-		}
-
 		return <p className="signup-form-social-first__tos-link">{ tosText }</p>;
 	};
 
 	const renderEmailStepTermsOfService = () => {
-		if ( currentStep === 'email' ) {
-			return (
-				<p className="signup-form-social-first__email-tos-link">
-					{ createInterpolateElement(
-						__(
-							'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-						),
-						options
-					) }
-				</p>
-			);
-		}
+		return (
+			<p className="signup-form-social-first__email-tos-link">
+				{ createInterpolateElement(
+					__(
+						'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					),
+					options
+				) }
+			</p>
+		);
 	};
 
-	const renderContent = () => {
-		if ( currentStep === 'initial' ) {
-			return (
-				<>
-					{ notice }
-					<SocialSignupForm
-						handleResponse={ handleSocialResponse }
-						setCurrentStep={ setCurrentStep }
-						socialServiceResponse={ socialServiceResponse }
-						redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
-						disableTosText
-						compact
-						isSocialFirst={ isSocialFirst }
-					/>
-				</>
-			);
-		} else if ( currentStep === 'email' ) {
-			const gravatarProps = isGravatar
-				? {
-						inputPlaceholder: __( 'Enter your email address' ),
-						submitButtonLoadingLabel: __( 'Continue' ),
-				  }
-				: {};
-
-			return (
-				<div className="signup-form-social-first-email">
-					<PasswordlessSignupForm
-						stepName={ stepName }
-						flowName={ flowName }
-						goToNextStep={ goToNextStep }
-						logInUrl={ logInUrl }
-						queryArgs={ queryArgs }
-						labelText={ emailLabelText ?? __( 'Your email' ) }
-						submitButtonLabel={ __( 'Continue' ) }
-						userEmail={ userEmail }
-						renderTerms={ renderEmailStepTermsOfService }
-						secondaryFooterButton={
-							backButtonInFooter ? undefined : (
-								<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
-									{ __( 'See all options' ) }
-								</Button>
-							)
-						}
-						passDataToNextStep={ passDataToNextStep }
-						onCreateAccountError={ ( error: { error: string }, email: string ) => {
-							if ( isExistingAccountError( error.error ) ) {
-								window.location.assign(
-									addQueryArgs(
-										{
-											email_address: email,
-											is_signup_existing_account: true,
-											redirect_to: queryArgs?.redirect_to,
-										},
-										logInUrl
-									)
-								);
-							}
-						} }
-						onCreateAccountSuccess={ onCreateAccountSuccess }
-						{ ...gravatarProps }
-					/>
-					{ backButtonInFooter ? (
-						<Button
-							onClick={ () => setCurrentStep( 'initial' ) }
-							className="back-button"
-							variant="link"
-						>
-							<span>{ __( 'Back' ) }</span>
-						</Button>
-					) : null }
-				</div>
-			);
-		}
-	};
+	const getStepStyle = ( step: 'initial' | 'email' ): CSSProperties => ( {
+		visibility: step === currentStep ? 'visible' : 'hidden',
+	} );
 
 	return (
 		<div className="signup-form signup-form-social-first">
-			{ renderContent() }
-			{ renderTermsOfService() }
+			<div className="signup-form-social-first-initial" style={ getStepStyle( 'initial' ) }>
+				{ notice }
+				<SocialSignupForm
+					handleResponse={ handleSocialResponse }
+					setCurrentStep={ setCurrentStep }
+					socialServiceResponse={ socialServiceResponse }
+					redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
+					disableTosText
+					compact
+					isSocialFirst={ isSocialFirst }
+				/>
+				{ renderTermsOfService() }
+			</div>
+			<div className="signup-form-social-first-email" style={ getStepStyle( 'email' ) }>
+				<PasswordlessSignupForm
+					stepName={ stepName }
+					flowName={ flowName }
+					goToNextStep={ goToNextStep }
+					logInUrl={ logInUrl }
+					queryArgs={ queryArgs }
+					labelText={ emailLabelText ?? __( 'Your email' ) }
+					submitButtonLabel={ __( 'Continue' ) }
+					userEmail={ userEmail }
+					renderTerms={ renderEmailStepTermsOfService }
+					secondaryFooterButton={
+						backButtonInFooter ? undefined : (
+							<Button onClick={ () => setCurrentStep( 'initial' ) } icon={ chevronLeft }>
+								{ __( 'See all options' ) }
+							</Button>
+						)
+					}
+					passDataToNextStep={ passDataToNextStep }
+					onCreateAccountError={ ( error: { error: string }, email: string ) => {
+						if ( isExistingAccountError( error.error ) ) {
+							window.location.assign(
+								addQueryArgs(
+									{
+										email_address: email,
+										is_signup_existing_account: true,
+										redirect_to: queryArgs?.redirect_to,
+									},
+									logInUrl
+								)
+							);
+						}
+					} }
+					onCreateAccountSuccess={ onCreateAccountSuccess }
+					inputPlaceholder={ isGravatar ? __( 'Enter your email address' ) : undefined }
+					submitButtonLoadingLabel={ isGravatar ? __( 'Continue' ) : undefined }
+				/>
+				{ backButtonInFooter ? (
+					<Button
+						onClick={ () => setCurrentStep( 'initial' ) }
+						className="back-button"
+						variant="link"
+					>
+						<span>{ __( 'Back' ) }</span>
+					</Button>
+				) : null }
+			</div>
 		</div>
 	);
 };

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -2,6 +2,20 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/onboarding/styles/mixins";
 
+.signup-form-social-first {
+	display: grid;
+	grid-template-areas: "stack";
+
+	&-initial, &-email {
+		grid-area: stack;
+		visibility: hidden;
+	}
+
+	.signup-form__passwordless-email {
+		transition: none !important; // The default form element transition breaks the visibility transition between steps.
+	}
+}
+
 .signup-form .signup-form__input.form-text-input {
 	margin-bottom: 20px;
 	transition: none;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -6,9 +6,13 @@
 	display: grid;
 	grid-template-areas: "stack";
 
-	&-initial, &-email {
+	&-screen {
 		grid-area: stack;
 		visibility: hidden;
+
+		&.visible {
+			visibility: visible;
+		}
 	}
 
 	.signup-form__passwordless-email {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/102398.

## Proposed Changes

The trick here is to use overlapping divs (a stacked grid) and CSS visibility to render both divs simultaneously, but paint only one of them. The taller one defines the height of the container. Courtesy of https://www.youtube.com/watch?v=8327_1PINWI.

| Before | After |
| ------ | ------ |
| <video src="https://github.com/user-attachments/assets/3ddb912a-6b23-448d-b8f5-8f933ea841d1" /> | <video src="https://github.com/user-attachments/assets/80cb4223-7da7-4556-bcae-ca9228539362" /> |

## Testing Instructions

Enter `/setup/onboarding` and click "Continue with email". You should notice the "Create your account" heading remains in place instead of jumping around.

Try it with the `onboarding/step-container-v2` feature flag enabled and disabled.