### PR TITLE
Jetpack Search: fix checking module state for standalone plugin

### DIFF
--- a/client/my-sites/jetpack-search/main.tsx
+++ b/client/my-sites/jetpack-search/main.tsx
@@ -32,7 +32,7 @@ export default function SearchMain() {
 	const isSearchEnabled = useSelector( ( state ) => {
 		// On Jetpack sites, we need to check if the search module is active, rather than checking settings.
 		if ( isJetpack ) {
-			return Boolean( isJetpackModuleActive( state, siteId, 'search' ) );
+			return Boolean( isJetpackModuleActive( state, siteId, 'search', true ) );
 		}
 		return getSiteSetting( state, siteId, 'jetpack_search_enabled' );
 	} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100398 and relates to Automattic/jpop-issues#9638

## Proposed Changes

Use `active_modules` option fallback when checking whether Jetpack Search is enabled.

## Why are these changes being made?

Currently, we don't detect Jetpack Search status when using standalone plugin, causing us to show "Jetpack Search is disabled on your site" even when it's on.

## Testing Instructions

1. Create a test site with Jetpack Search standalone plugin, but without a main Jetpack plugin. You can do that using jurassic.ninja - click "See more options", uncheck Jetpack, check Jetpack Search.
2. Connect the site and activate Jetpack Search (you can use Jetpack Search Free or any other plan with Search).
3. Start regular calypso (`yarn start`).
4. Visit `https://wordpress.com/jetpack-search/:siteUrl`, which will always say that search is disabled.
5. Compare with `http://calypso.localhost:3000/jetpack-search/:siteUrl`. It should say that module is enabled. You can also verify that after disabling the module on site and refreshing it will say that module is disabled.
7. Start Jetpack Cloud (`yarn start-jetpack-cloud`).
8. Visit `https://cloud.jetpack.com/jetpack-search/:siteUrl`, which will always say that search is disabled.
9. Compare with `http://jetpack.cloud.localhost:3000/jetpack-search/:siteUrl`. It should say that module is enabled. You can also verify that after disabling the module on site and refreshing it will say that module is disabled. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
