### PR TITLE
Magic Link: refactor Jetpack loading indicator to use Spinner component

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,4 +1,5 @@
 import { FormLabel } from '@automattic/components';
+import { Spinner } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -6,7 +7,6 @@ import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import Notice from 'calypso/components/notice';
 import wpcom from 'calypso/lib/wp';
@@ -180,7 +180,7 @@ class RequestLoginEmailForm extends Component {
 		} = this.props;
 
 		if ( shouldShowLoadingEllipsis ) {
-			return <LoadingEllipsis className="magic-login__loading-ellipsis--jetpack" />;
+			return <Spinner className="magic-login__loading-spinner--jetpack" />;
 		}
 
 		const usernameOrEmail = this.getUsernameOrEmailFromState();

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -24,14 +24,14 @@
 
 .layout.is-jetpack-login {
 	.magic-login {
-		&__loading-ellipsis--jetpack {
+		&__loading-spinner--jetpack {
+			color: var(--studio-jetpack-green-40, #069e08 );
+			height: 48px;
 			left: 50%;
 			transform: translateX(-50%);
-
-			div {
-				background: var(--studio-jetpack-green-40, #069e08 );
-			}
+			width: 48px;
 		}
+
 	}	
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -28,6 +28,7 @@
 			color: var(--studio-jetpack-green-40, #069e08 );
 			height: 48px;
 			left: 50%;
+			margin-top: 40px;
 			transform: translateX(-50%);
 			width: 48px;
 		}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -71,6 +71,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
+		"jetpack/magic-link-signup": true,
 		"jetpack/manage-simple-sites": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes MARTECH-70

## Proposed Changes

* Replace `LoadingEllipsis` with core `Spinner` component for a more consistent loading experience.
* Update corresponding styles to reflect the new loading spinner design.
* Enable `jetpack/magic-link-signup` on Live Branches environment, so this PR could be tested there. This is a legacy feature flag that was available on all environment except `wpcalypso`.

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/871ebaf5-8041-4bb5-bdb5-1301885bc095" /> |  <video src="https://github.com/user-attachments/assets/c3f6f3a9-09a7-4254-b37f-32a6ac06e9ec" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to improve the Jetpack Onboarding experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a Calypso Live Branch (you will need it on step 6).
2. Spin up a Jurassic Ninja site using the latest Jetpack.
3. Go to `/wp-admin/admin.php?page=my-jetpack&step=onboarding` on the site.
4. Fill out your email and submit the form.
5. You should be redirected to the magic link page, where you receive the login e-mail.
6. On that page, replace the domain from wordpress.com to your Calypso Live Branch domain and navigate there.
7. Ensure the loading state uses the spinner instead of the ellipsis.

https://github.com/user-attachments/assets/6f179a9f-b182-466a-9db2-d418b731da2f

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
