### PR TITLE
Reader - reship notifications page restructure and 3pc notice

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -256,6 +256,10 @@ $z-layers: (
 	".reader-related-card__meta": (
 		".follow-button": 1,
 	),
+	".reader-notifications": (
+		".wpnc__single-view": 1,
+		".wpnc__note-list": 2,
+	),
 	".list-stream__header-follow": (
 		".follow-button": 1,
 	),

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -11,11 +11,13 @@
 
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { localizeUrl } from '@automattic/i18n-utils';
 import NotificationsPanel, {
 	refreshNotes,
 } from '@automattic/notifications/src/panel/Notifications';
 import clsx from 'clsx';
 import debugFactory from 'debug';
+import { useTranslate } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import localStorageHelper from 'store';
@@ -52,6 +54,26 @@ const getIsVisible = () => {
 const isDesktop = config.isEnabled( 'desktop' );
 
 const debug = debugFactory( 'notifications:panel' );
+
+const Notifications3PCNotice = ( { className } ) => {
+	const translate = useTranslate();
+	return (
+		<div className={ `reader-notifications__3pc-notice ${ className }` }>
+			<p>
+				{ translate(
+					"Didn't expect to see this page? {{learnMoreLink}}Learn about 3rd party cookies.{{/learnMoreLink}}",
+					{
+						components: {
+							learnMoreLink: (
+								<a href={ localizeUrl( 'https://wordpress.com/support/third-party-cookies/' ) } />
+							),
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};
 
 export class Notifications extends Component {
 	state = {
@@ -283,21 +305,30 @@ export class Notifications extends Component {
 		}
 
 		return (
-			<div
-				id="wpnc-panel"
-				className={ clsx( 'wide', 'wpnc__main', {
-					'wpnt-open': this.props.isShowing,
-					'wpnt-closed': ! this.props.isShowing,
-				} ) }
-			>
-				<NotificationsPanel
-					actionHandlers={ this.actionHandlers }
-					isShowing={ this.props.isShowing }
-					isVisible={ this.state.isVisible }
-					locale={ localeSlug }
-					wpcom={ wpcom }
-				/>
-			</div>
+			<>
+				{ /*
+					Due to how the notifs panel width is set differently on this page to control fly-out vs. in place
+					nested levels, this notice makes sense at different places in the DOM depending on the
+					breakpoint. We remove display for one or the other via CSS depending on the breakpoint.
+				*/ }
+				<Notifications3PCNotice className="reader-notifications__3pc-notice-external" />
+				<div
+					id="wpnc-panel"
+					className={ clsx( 'wide', 'wpnc__main', {
+						'wpnt-open': this.props.isShowing,
+						'wpnt-closed': ! this.props.isShowing,
+					} ) }
+				>
+					<Notifications3PCNotice className="reader-notifications__3pc-notice-internal" />
+					<NotificationsPanel
+						actionHandlers={ this.actionHandlers }
+						isShowing={ this.props.isShowing }
+						isVisible={ this.state.isVisible }
+						locale={ localeSlug }
+						wpcom={ wpcom }
+					/>
+				</div>
+			</>
 		);
 	}
 }

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -30,6 +30,7 @@ import { didForceRefresh } from 'calypso/state/notifications-panel/actions';
 import { shouldForceRefresh } from 'calypso/state/notifications-panel/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentLocaleVariant from 'calypso/state/selectors/get-current-locale-variant';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 import './style.scss';
@@ -297,6 +298,7 @@ export class Notifications extends Component {
 
 	render() {
 		const localeSlug = this.props.currentLocaleSlug || config( 'i18n_default_locale_slug' );
+		const isDedicatedReaderPage = this.props.currentRoute?.startsWith( '/reader/notifications' );
 
 		if ( this.props.forceRefresh ) {
 			debug( 'Refreshing notes panel...' );
@@ -311,7 +313,9 @@ export class Notifications extends Component {
 					nested levels, this notice makes sense at different places in the DOM depending on the
 					breakpoint. We remove display for one or the other via CSS depending on the breakpoint.
 				*/ }
-				<Notifications3PCNotice className="reader-notifications__3pc-notice-external" />
+				{ isDedicatedReaderPage && (
+					<Notifications3PCNotice className="reader-notifications__3pc-notice-external" />
+				) }
 				<div
 					id="wpnc-panel"
 					className={ clsx( 'wide', 'wpnc__main', {
@@ -319,7 +323,9 @@ export class Notifications extends Component {
 						'wpnt-closed': ! this.props.isShowing,
 					} ) }
 				>
-					<Notifications3PCNotice className="reader-notifications__3pc-notice-internal" />
+					{ isDedicatedReaderPage && (
+						<Notifications3PCNotice className="reader-notifications__3pc-notice-internal" />
+					) }
 					<NotificationsPanel
 						actionHandlers={ this.actionHandlers }
 						isShowing={ this.props.isShowing }
@@ -338,6 +344,7 @@ export default connect(
 		currentLocaleSlug: getCurrentLocaleVariant( state ) || getCurrentLocaleSlug( state ),
 		forceRefresh: shouldForceRefresh( state ),
 		selectedSiteId: getSelectedSiteId( state ),
+		currentRoute: getCurrentRoute( state ),
 	} ),
 	( dispatch ) => ( {
 		recordTracksEventAction: ( name, properties ) =>

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -164,73 +164,76 @@ html.touch #wpnc-panel {
 }
 
 div.reader-notifications__panel {
+	position: relative;
+
+	$breakpoint-flyout: 1114px;
+	$breakpoint-nested: 783px;
+	$breakpoint-mobile: 601px;
+
+	--3pc-notice-external-height: 50px;
+	@media only screen and (min-width: $breakpoint-flyout) {
+		--3pc-notice-external-height: 0px; /* stylelint-disable-line length-zero-no-unit */
+	}
+
 	#wpnc-panel.wpnc__main {
-		min-width: 410px;
+		top: calc(var(--masterbar-height) + var(--content-padding-top) + var(--3pc-notice-external-height));
+		height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom) - var(--3pc-notice-external-height));
+		box-shadow: -3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
+		border-top: 1px solid var(--color-neutral-0);
+		box-sizing: border-box;
 
 		&.wpnt-open {
-			position: fixed;
-			top: var(--masterbar-height);
-			right: auto;
-			left: var(--sidebar-width-max);
-			bottom: 0;
-
-			@media only screen and (max-width: 783px) {
-				left: 0;
+			@media only screen and (min-width: $breakpoint-mobile) {
+				right: 24px; // align with content frame padding.
+				border-radius: 8px; /* stylelint-disable-line scales/radii */
 			}
-			@media only screen and (min-width: 783px) {
-				top: calc(var(--masterbar-height) + 20px);
-				height: calc(100vh - var(--masterbar-height) - 36px);
-				border-bottom-left-radius: 8px; /* stylelint-disable-line scales/radii */
+			@media only screen and (min-width: $breakpoint-nested) {
+				right: 16px; // align with content frame padding.
 			}
-			@media only screen and (min-width: 601px) and (max-width: 783px) {
-				top: calc(var(--masterbar-height) + 24px);
-				height: calc(100vh - 50px - var(--masterbar-height));
-				left: 24px;
-				border-top-left-radius: 8px; /* stylelint-disable-line scales/radii */
-				border-bottom-left-radius: 8px; /* stylelint-disable-line scales/radii */
-			}
-		}
-		.wpnc__list-view {
-			border: none;
-			border-right: 1px solid var(--color-neutral-0);
-
-			.wpnc__note:focus,
-			.wpnc__selected-note {
-				box-shadow: inset -4px 0 0 var(--color-primary);
-			}
-		}
-
-		&.wpnc__note-list {
-			right: auto;
-			left: 0;
-		}
-
-		.wpnc__single-view {
-			min-width: 410px;
 		}
 	}
-
-	@media only screen and (min-width: 1114px) {
-		#wpnc-panel.wpnc__main {
-			background-color: unset;
-
-			.wpnc__note-list:not(.is-note-open) {
-				box-shadow: 3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
-			}
-
+	@media only screen and (min-width: $breakpoint-flyout) {
+		.wpnc__main {
+			width: calc(100vw - var(--sidebar-width-max) - 16px); // 16px for content frame padding.
+			// This ensures the single view flies out above the 3PC notice.
 			.wpnc__single-view {
-				animation-name: dedicated_wpnc__slideIn;
-				border-right: 1px solid var(--color-neutral-5);
-				right: inherit;
+				z-index: z-index( ".reader-notifications", ".wpnc__single-view" );
+			}
+			// This ensures the single view does not rise above the note list while animating outwards.
+			.wpnc__note-list {
+				z-index: z-index( ".reader-notifications", ".wpnc__note-list" );
 			}
 		}
 	}
-	@keyframes dedicated_wpnc__slideIn {
-		from {
-			transform: translateX(0%);
+	.reader-notifications__3pc-notice {
+		position: absolute;
+		top: 0;
+		left: 0;
+		justify-content: center;
+		align-items: center;
+		box-sizing: border-box;
+		padding: 0 10px;
+		font-size: $font-body;
+
+		&-internal {
+			display: none;
+			bottom: 0;
+			right: 400px; //width of main notifs panel
+
+			@media only screen and (min-width: $breakpoint-flyout) {
+				display: flex;
+			}
 		}
-		to {
-			transform: translateX(100%);
+		&-external {
+			display: flex;
+			right: 0;
+			height: var(--3pc-notice-external-height);
+			p {
+				margin-bottom: 5px;
+			}
+			@media only screen and (min-width: $breakpoint-flyout) {
+				display: none;
+			}
 		}
 	}
 }

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -190,18 +190,16 @@ div.reader-notifications__panel {
 			@media only screen and (min-width: $breakpoint-nested) {
 				right: 16px; // align with content frame padding.
 			}
-		}
-	}
-	@media only screen and (min-width: $breakpoint-flyout) {
-		.wpnc__main {
-			width: calc(100vw - var(--sidebar-width-max) - 16px); // 16px for content frame padding.
-			// This ensures the single view flies out above the 3PC notice.
-			.wpnc__single-view {
-				z-index: z-index( ".reader-notifications", ".wpnc__single-view" );
-			}
-			// This ensures the single view does not rise above the note list while animating outwards.
-			.wpnc__note-list {
-				z-index: z-index( ".reader-notifications", ".wpnc__note-list" );
+			@media only screen and (min-width: $breakpoint-flyout) {
+				width: calc(100vw - var(--sidebar-width-max) - 16px); // 16px for content frame padding.
+				// This ensures the single view flies out above the 3PC notice.
+				.wpnc__single-view {
+					z-index: z-index( ".reader-notifications", ".wpnc__single-view" );
+				}
+				// This ensures the single view does not rise above the note list while animating outwards.
+				.wpnc__note-list {
+					z-index: z-index( ".reader-notifications", ".wpnc__note-list" );
+				}
 			}
 		}
 	}

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -89,7 +89,7 @@ body.is-section-reader {
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			overflow: hidden;
 		}
-		.layout__primary > div > div:not(.tags__header) {
+		.layout__primary > div > div:not(.tags__header):not(.reader-notifications__3pc-notice) {
 			height: 100%;
 			overflow-y: auto;
 			overflow-x: hidden;
@@ -308,17 +308,6 @@ body.is-section-reader {
 
 	@media (min-width: 661px) and (max-width: 790px) {
 		@include hide-content-accessibly();
-	}
-}
-
-.is-group-reader .reader-notifications__panel {
-	@media only screen and (min-width: 1114px) {
-		.wpnc__main {
-			width: calc(100vw - 310px);
-			.wpnc__note-list {
-				left: 0;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#102418 (the revert), to resend the change but limit the notice being added only to the dedicated route.