### PR TITLE
Remove useGoalsFirstExperiment from stepper boot

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/boot/index.tsx
@@ -1,5 +1,4 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import {
 	type ComponentProps,
 	Suspense,
@@ -8,11 +7,8 @@ import {
 	useTransition,
 	type FC,
 	type PropsWithChildren,
-	useMemo,
 } from 'react';
 import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
-import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
-import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 
 interface Props extends PropsWithChildren {
 	fallback: ComponentProps< typeof Suspense >[ 'fallback' ];
@@ -26,20 +22,13 @@ export const Boot: FC< Props > = ( { children, fallback } ) => {
 	const locale = useLocale();
 	const newLocale = useFlowLocale();
 
-	const [ isLoadingGoalsFirst ] = useGoalsFirstExperiment();
-	const flowName = useMemo( () => getFlowFromURL(), [] );
-
 	useEffect( () => {
-		if (
-			! isReady &&
-			newLocale === locale &&
-			( flowName !== ONBOARDING_FLOW || ! isLoadingGoalsFirst )
-		) {
+		if ( ! isReady && newLocale === locale ) {
 			setTransition( () => {
 				setIsReady( true );
 			} );
 		}
-	}, [ locale, newLocale, isReady, isLoadingGoalsFirst, flowName ] );
+	}, [ locale, newLocale, isReady ] );
 
 	// Continue to show the fallback UI while we are still loading the new locale or when we're first transitioning to the new locale (i.e. the transition is still in process)
 	if ( ! isReady || isPending ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101759 
Related to DOTOBRD-36
Extracted from #101921

## Proposed Changes

Remove the use of the `useGoalsFirstExperiment ` hook from the Stepper boot logic

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're cleaning up unused code related to the concluded goals-first experiment.

The return value of `useGoalsFirstExperiment` is hardcoded to `[false, false]` — meaning that we can actually remove it, update the logic in the code accordingly, and perform any extra cleanup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke-test Stepper flows and make sure that there is no difference with `trunk`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
