### PR TITLE
Remove useGoalsFirstExperiment and useBigSkyBeforePlans hooks from onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,5 +1,4 @@
-import { PLAN_PERSONAL } from '@automattic/calypso-products';
-import { OnboardSelect, Onboard, UserSelect, ProductsList } from '@automattic/data-stores';
+import { OnboardSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -24,20 +23,14 @@ import {
 	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
 } from '../../../constants';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
-import { useIsBigSkyEligible } from '../../../hooks/use-is-site-big-sky-eligible';
 import { useMarketplaceThemeProducts } from '../../../hooks/use-marketplace-theme-products';
 import { useQuery } from '../../../hooks/use-query';
-import { ONBOARD_STORE, USER_STORE } from '../../../stores';
-import { getLoginUrl } from '../../../utils/path';
+import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
-import { useBigSkyBeforePlans } from '../../helpers/use-bigsky-before-plans-experiment';
-import { useGoalsFirstExperiment } from '../../helpers/use-goals-first-experiment';
 import { useRedirectDesignSetupOldSlug } from '../../helpers/use-redirect-design-setup-old-slug';
 import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { STEPS } from '../../internals/steps';
-import { AssertConditionState, Flow, ProvidedDependencies } from '../../internals/types';
-
-const SiteIntent = Onboard.SiteIntent;
+import { Flow, ProvidedDependencies } from '../../internals/types';
 
 const clearUseMyDomainsQueryParams = ( currentStepSlug: string | undefined ) => {
 	const isDomainsStep = currentStepSlug === 'domains';
@@ -60,7 +53,6 @@ const onboarding: Flow = {
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
 	useTracksEventProps() {
-		const [ isLoading, isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 		const userIsLoggedIn = useSelector( isUserLoggedIn );
 		const goals = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
@@ -73,30 +65,22 @@ const onboarding: Flow = {
 
 		return useMemo(
 			() => ( {
-				isLoading,
 				eventsProperties: {
 					[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
-						is_goals_first: isGoalsAtFrontExperiment.toString(),
-						...( isGoalsAtFrontExperiment && { step: 'goals' } ),
 						is_logged_out: initialLoggedOut.current.toString(),
 					},
 
 					[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
-						...( isGoalsAtFrontExperiment && {
-							is_goals_first: 'true',
-						} ),
 						...( initialGoals.current.length && {
 							goals: initialGoals.current.join( ',' ),
 						} ),
 					},
 				},
 			} ),
-			[ isGoalsAtFrontExperiment, initialLoggedOut, initialGoals, isLoading ]
+			[ initialLoggedOut, initialGoals ]
 		);
 	},
 	useSteps() {
-		// We have already checked the value has loaded in useAssertConditions
-		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
 		const isPlaygroundEligible = useIsPlaygroundEligible();
 
 		const steps = stepsWithRequiredLogin( [
@@ -107,16 +91,6 @@ const onboarding: Flow = {
 			STEPS.PROCESSING,
 			STEPS.POST_CHECKOUT_ONBOARDING,
 		] );
-
-		if ( isGoalsAtFrontExperiment ) {
-			// Note: these steps are not wrapped in `stepsWithRequiredLogin`
-			steps.unshift(
-				STEPS.GOALS,
-				STEPS.DESIGN_CHOICES,
-				STEPS.DESIGN_SETUP,
-				STEPS.DIFM_STARTING_POINT
-			);
-		}
 
 		if ( isPlaygroundEligible ) {
 			steps.push( STEPS.PLAYGROUND );
@@ -136,27 +110,19 @@ const onboarding: Flow = {
 			setProductCartItems,
 			setSiteUrl,
 			setSignupDomainOrigin,
-			setCreateWithBigSky,
 		} = useDispatch( ONBOARD_STORE );
 		const locale = useFlowLocale();
 
-		const { planCartItem, signupDomainOrigin, isUserLoggedIn, createWithBigSky } = useSelect(
+		const { planCartItem, signupDomainOrigin } = useSelect(
 			( select ) => ( {
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
-				isUserLoggedIn: ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-				createWithBigSky: ( select( ONBOARD_STORE ) as OnboardSelect ).getCreateWithBigSky(),
 			} ),
 			[]
 		);
 		const coupon = useQuery().get( 'coupon' );
 
 		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
-
-		const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-		const [ , isBigSkyBeforePlansExperiment ] = useBigSkyBeforePlans();
-		const { isEligible: isBigSkyEligible } = useIsBigSkyEligible();
-		const isDesignChoicesStepEnabled = isBigSkyEligible && isGoalsAtFrontExperiment;
 
 		const { selectedMarketplaceProduct } = useMarketplaceThemeProducts();
 
@@ -167,24 +133,6 @@ const onboarding: Flow = {
 			providedDependencies: ProvidedDependencies,
 			isPlaygroundEligible: boolean
 		): [ string, string | null ] => {
-			if ( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment ) {
-				const destination = addQueryArgs(
-					withLocale( '/setup/site-setup/launch-big-sky', locale ),
-					{
-						siteSlug: providedDependencies.siteSlug,
-						isBigSkyBeforePlansFlow: true,
-					}
-				);
-
-				return [
-					destination,
-					addQueryArgs( withLocale( '/setup/onboarding/plans', locale ), {
-						skippedCheckout: 1,
-						isBigSkyBeforePlansFlow: true,
-					} ),
-				];
-			}
-
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
 				return [ `/home/${ providedDependencies.siteSlug }`, null ];
 			}
@@ -205,7 +153,6 @@ const onboarding: Flow = {
 
 			const destination = addQueryArgs( withLocale( '/setup/site-setup', locale ), {
 				siteSlug: providedDependencies.siteSlug,
-				...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
 			} );
 
 			return [ destination, addQueryArgs( destination, { skippedCheckout: 1 } ) ];
@@ -216,69 +163,6 @@ const onboarding: Flow = {
 
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( currentStepSlug ) {
-				case 'goals': {
-					const goalsUrl = withLocale( '/setup/onboarding/goals', locale );
-					const { intent } = providedDependencies;
-
-					switch ( intent ) {
-						case SiteIntent.Import: {
-							const migrationFlowLink = withLocale( '/setup/hosted-site-migration', locale );
-							return window.location.assign(
-								addQueryArgs( migrationFlowLink, {
-									back_to: goalsUrl,
-								} )
-							);
-						}
-
-						case SiteIntent.DIFM:
-							return navigate( 'difmStartingPoint' );
-
-						default: {
-							if ( isDesignChoicesStepEnabled ) {
-								return navigate( 'design-choices' );
-							}
-							return navigate( 'design-setup' );
-						}
-					}
-				}
-
-				case 'design-setup': {
-					return navigate( 'domains' );
-				}
-
-				case 'design-choices': {
-					if ( providedDependencies.destination === 'launch-big-sky' ) {
-						setCreateWithBigSky( true );
-						return navigate( 'domains' );
-					}
-					setCreateWithBigSky( false );
-					return navigate( providedDependencies.destination as string );
-				}
-
-				case 'difmStartingPoint': {
-					const difmFlowLink = addQueryArgs(
-						withLocale( '/start/website-design-services', locale ),
-						{
-							back_to: window.location.href.replace( window.location.origin, '' ),
-						}
-					);
-
-					if ( isUserLoggedIn ) {
-						return window.location.assign( difmFlowLink );
-					}
-
-					const loginUrl = getLoginUrl( {
-						variationName: flowName,
-						redirectTo: difmFlowLink,
-						locale,
-						extra: {
-							back_to: window.location.href.replace( window.location.origin, '' ),
-						},
-					} );
-
-					return window.location.assign( loginUrl );
-				}
-
 				case 'domains':
 					setSiteUrl( providedDependencies.siteUrl );
 					setDomain( providedDependencies.suggestion );
@@ -399,9 +283,6 @@ const onboarding: Flow = {
 								signup: 1,
 								checkoutBackUrl: pathToUrl( backDestination ?? '' ),
 								coupon,
-								...( createWithBigSky && isBigSkyBeforePlansExperiment && isGoalsAtFrontExperiment
-									? { [ 'big-sky-checkout' ]: 1 }
-									: {} ),
 							} )
 						);
 					} else {
@@ -418,13 +299,6 @@ const onboarding: Flow = {
 		};
 
 		return { submit };
-	},
-	useAssertConditions() {
-		const [ isLoading ] = useGoalsFirstExperiment();
-
-		return {
-			state: isLoading ? AssertConditionState.CHECKING : AssertConditionState.SUCCESS,
-		};
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();
@@ -445,19 +319,6 @@ const onboarding: Flow = {
 				clearSignupCompleteSlug();
 			}
 		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
-
-		const [ isGoalsFirstExperimentLoading, isGoalsFirstExperiment ] = useGoalsFirstExperiment();
-		// The personal plan price appears on the design choice step under these conditions. Pre-load it so it doesn't flash into existence
-		// Preload even before we know whether use is in the big-sky-before-plans experiment. By the time we know it will be too late.
-		const preloadPersonalProduct = ! isGoalsFirstExperimentLoading && isGoalsFirstExperiment;
-
-		useSelect(
-			( select ) =>
-				preloadPersonalProduct
-					? select( ProductsList.store ).getProductBySlug( PLAN_PERSONAL )
-					: undefined,
-			[ preloadPersonalProduct ]
-		);
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -52,6 +52,10 @@ const onboarding: Flow = {
 	name: ONBOARDING_FLOW,
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
+	// This entire hook can be removed as we are no longer tracking/setting
+	// these event props in the onboarding flow. This would be best in the
+	// site-setup flow where the goal step is now.
+	// https://github.com/Automattic/wp-calypso/pull/101921/files/35e9ff8020e748de100fa6ff07c70c46255221ee#r2021712784
 	useTracksEventProps() {
 		const userIsLoggedIn = useSelector( isUserLoggedIn );
 		const goals = useSelect(

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -2,7 +2,7 @@ import { OnboardSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useIsPlaygroundEligible } from 'calypso/landing/stepper/hooks/use-is-playground-eligible';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
@@ -14,14 +14,9 @@ import {
 	clearSignupCompleteFlowName,
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
-import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import {
-	STEPPER_TRACKS_EVENT_SIGNUP_START,
-	STEPPER_TRACKS_EVENT_SIGNUP_STEP_START,
-	STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT,
-} from '../../../constants';
+import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useMarketplaceThemeProducts } from '../../../hooks/use-marketplace-theme-products';
 import { useQuery } from '../../../hooks/use-query';
@@ -52,38 +47,6 @@ const onboarding: Flow = {
 	name: ONBOARDING_FLOW,
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
-	// This entire hook can be removed as we are no longer tracking/setting
-	// these event props in the onboarding flow. This would be best in the
-	// site-setup flow where the goal step is now.
-	// https://github.com/Automattic/wp-calypso/pull/101921/files/35e9ff8020e748de100fa6ff07c70c46255221ee#r2021712784
-	useTracksEventProps() {
-		const userIsLoggedIn = useSelector( isUserLoggedIn );
-		const goals = useSelect(
-			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
-			[]
-		);
-
-		// we are only interested in the initial values and not when they values change
-		const initialGoals = useRef( goals );
-		const initialLoggedOut = useRef( ! userIsLoggedIn );
-
-		return useMemo(
-			() => ( {
-				eventsProperties: {
-					[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
-						is_logged_out: initialLoggedOut.current.toString(),
-					},
-
-					[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
-						...( initialGoals.current.length && {
-							goals: initialGoals.current.join( ',' ),
-						} ),
-					},
-				},
-			} ),
-			[ initialLoggedOut, initialGoals ]
-		);
-	},
 	useSteps() {
 		const isPlaygroundEligible = useIsPlaygroundEligible();
 

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -1,12 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { SiteIntent } from '@automattic/data-stores/src/onboard/constants';
 import { ONBOARDING_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import onboarding from '../flows/onboarding/onboarding';
 import { STEPS } from '../internals/steps';
-import { getFlowLocation, renderFlow } from './helpers';
+import { renderFlow } from './helpers';
 
 const originalLocation = window.location;
 
@@ -47,49 +46,6 @@ describe( 'Onboarding Flow', () => {
 		it( 'should be configured as a signup flow', () => {
 			expect( onboarding.name ).toBe( ONBOARDING_FLOW );
 			expect( onboarding.isSignupFlow ).toBe( true );
-		} );
-	} );
-
-	describe( 'Goals step navigation', () => {
-		it( 'should redirect to migration flow when intent is Import', async () => {
-			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.GOALS.slug,
-				dependencies: {
-					intent: SiteIntent.Import,
-				},
-			} );
-
-			expect( window.location.assign ).toHaveBeenCalledWith(
-				'/setup/hosted-site-migration?back_to=%2Fsetup%2Fonboarding%2Fgoals'
-			);
-		} );
-
-		it( 'should redirect to DIFM flow when intent is DIFM', async () => {
-			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.GOALS.slug,
-				dependencies: {
-					intent: SiteIntent.DIFM,
-				},
-			} );
-
-			expect( getFlowLocation().path ).toBe( '/difmStartingPoint' );
-		} );
-
-		it( 'should navigate to design-setup step for other intents', async () => {
-			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
-
-			runUseStepNavigationSubmit( {
-				currentStep: STEPS.GOALS.slug,
-				dependencies: {
-					intent: SiteIntent.Write,
-				},
-			} );
-
-			expect( getFlowLocation().path ).toBe( '/design-setup' );
 		} );
 	} );
 

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -382,6 +382,7 @@ export const setPartnerBundle = ( partnerBundle: string | null ) => ( {
 } );
 
 export const setCreateWithBigSky = ( createWithBigSky: boolean ) => ( {
+	// TODO: we could be able to delete this, at the moment it's never set to true
 	type: 'SET_CREATE_WITH_BIG_SKY' as const,
 	createWithBigSky,
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101759 
Related to DOTOBRD-36
Extracted from #101921

## Proposed Changes

Remove `useGoalsFirstExperiment` and `useBigSkyBeforePlans` hooks from onboarding flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're cleaning up unused code related to the concluded goals-first experiment.

The return values of the `useGoalsFirstExperiment` and `useBigSkyBeforePlans` hooks are hardcoded to `[false, false]` — meaning that we can actually remove them, update the logic in the code accordingly, and perform any extra cleanup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke-test `/setup/onboarding` flow and make sure that there is no difference with `trunk`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
