### PR TITLE
Remove useGoalsFirstExperiment from unified design picker step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -90,7 +90,6 @@ interface UnifiedDesignPickerPreviewProps {
 	flow: string;
 	isPremiumThemeAvailable: boolean;
 	stepName: string;
-	handleSubmit: () => void;
 	numOfSelectedGlobalStyles: number;
 	previewDesignVariation: ( variation: StyleVariation ) => void;
 	setSelectedColorVariation: ( colorVariation: GlobalStyles | null ) => void;
@@ -109,7 +108,6 @@ const UnifiedDesignPickerPreview = ( {
 	flow,
 	isPremiumThemeAvailable,
 	stepName,
-	handleSubmit,
 	numOfSelectedGlobalStyles,
 	previewDesignVariation,
 	setSelectedColorVariation,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -45,7 +45,6 @@ import { useSiteData } from '../../../../hooks/use-site-data';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { goToCheckout } from '../../../../utils/checkout';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
-import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import { STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
 import { EligibilityWarningsModal } from './eligibility-warnings-modal';
@@ -254,18 +253,14 @@ const UnifiedDesignPickerPreview = ( {
 	const isPluginBundleEligible = useIsPluginBundleEligible();
 	const isBundled = selectedDesign?.software_sets && selectedDesign.software_sets.length > 0;
 
-	const [ , isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-
 	const isLockedTheme =
-		// The exp moves the Design Picker step in front of the plan selection so people can unlock theme later.
-		! isGoalsAtFrontExperiment &&
-		( ! canSiteActivateTheme ||
-			( selectedDesign?.design_tier === THEME_TIER_PREMIUM &&
-				! isPremiumThemeAvailable &&
-				! didPurchaseSelectedTheme ) ||
-			( selectedDesign?.is_externally_managed &&
-				( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||
-			( ! isPluginBundleEligible && isBundled ) );
+		! canSiteActivateTheme ||
+		( selectedDesign?.design_tier === THEME_TIER_PREMIUM &&
+			! isPremiumThemeAvailable &&
+			! didPurchaseSelectedTheme ) ||
+		( selectedDesign?.is_externally_managed &&
+			( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||
+		( ! isPluginBundleEligible && isBundled );
 
 	const [ showUpgradeModal, setShowUpgradeModal ] = useState( false );
 
@@ -468,14 +463,9 @@ const UnifiedDesignPickerPreview = ( {
 
 	const getPrimaryActionButtonProps = () => {
 		const action = getPrimaryActionButtonAction();
-		const text =
-			action !== pickDesign && ! isGoalsAtFrontExperiment
-				? translate( 'Unlock theme' )
-				: translate( 'Continue' );
-
 		return {
 			action,
-			text,
+			text: action !== pickDesign ? translate( 'Unlock theme' ) : translate( 'Continue' ),
 		};
 	};
 
@@ -605,7 +595,7 @@ const UnifiedDesignPickerPreview = ( {
 
 	const stepContent = (
 		<>
-			{ requiredPlanSlug && ! isGoalsAtFrontExperiment && (
+			{ requiredPlanSlug && (
 				<UpgradeModal
 					slug={ selectedDesign.slug }
 					isOpen={ showUpgradeModal }
@@ -662,13 +652,6 @@ const UnifiedDesignPickerPreview = ( {
 					return (
 						<Step.TopBar
 							leftElement={ ! activeScreen && <Step.BackButton onClick={ handleBackClick } /> }
-							rightElement={
-								! isGoalsAtFrontExperiment ? undefined : (
-									<Step.SkipButton onClick={ () => handleSubmit() }>
-										{ translate( 'Skip setup' ) }
-									</Step.SkipButton>
-								)
-							}
 						/>
 					);
 				} }
@@ -728,7 +711,7 @@ const UnifiedDesignPickerPreview = ( {
 		<StepContainer
 			stepName={ STEP_NAME }
 			stepContent={ stepContent }
-			hideSkip={ ! isGoalsAtFrontExperiment }
+			hideSkip
 			skipLabelText={ translate( 'Skip setup' ) }
 			skipButtonAlign="top"
 			hideBack={ !! activeScreen }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -365,7 +365,6 @@ const UnifiedDesignPickerStep: StepType< {
 				flow={ flow }
 				isPremiumThemeAvailable={ isPremiumThemeAvailable }
 				stepName={ stepName }
-				handleSubmit={ handleSubmit }
 				numOfSelectedGlobalStyles={ numOfSelectedGlobalStyles }
 				previewDesignVariation={ previewDesignVariation }
 				setSelectedColorVariation={ setSelectedColorVariation }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101759 
Related to DOTOBRD-36
Extracted from #101921

## Proposed Changes

Remove the use of the `useGoalsFirstExperiment ` hook from the `design-setup` Stepper step

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're cleaning up unused code related to the concluded goals-first experiment.

The return value of `useGoalsFirstExperiment` is hardcoded to `[false, false]` — meaning that we can actually remove it, update the logic in the code accordingly, and perform any extra cleanup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke-test Stepper flows that include the `design-setup` step (like `/setup/site-setup` and `/setup/update-design`) and make sure that there is no difference with `trunk`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
