### PR TITLE
Remove useBigSkyBeforePlans hook from useIsBigSkyEligible hook

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -46,16 +46,16 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 		[]
 	);
 
-	const { isEligible, isLoading } = useIsBigSkyEligible();
+	const { isEligible } = useIsBigSkyEligible();
 
 	useEffect( () => {
-		if ( ! isLoading && isEligible ) {
+		if ( isEligible ) {
 			recordTracksEvent( 'calypso_big_sky_view_choice', {
 				flow,
 				step: stepName,
 			} );
 		}
-	}, [ isEligible, isLoading, flow, stepName ] );
+	}, [ isEligible, flow, stepName ] );
 
 	const handleSubmit = ( destination: string ) => {
 		recordTracksEvent( 'calypso_signup_design_choices_submit', {
@@ -78,7 +78,7 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 				onSelect={ handleSubmit }
 			/>
 
-			{ ! isLoading && isEligible && (
+			{ isEligible && (
 				<DesignChoice
 					className="design-choices__try-big-sky"
 					title={ translate( 'Create your site with AI' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -28,7 +28,7 @@ const LaunchBigSky: Step = function ( props ) {
 	const { siteSlug, siteId, site } = useSiteData();
 	const translate = useTranslate();
 	const urlQuery = useQuery();
-	const { isEligible, isLoading } = useIsBigSkyEligible( flow );
+	const { isEligible } = useIsBigSkyEligible( flow );
 	const { setDesignOnSite, setStaticHomepageOnSite, setGoalsOnSite, setIntentOnSite } =
 		useDispatch( SITE_STORE );
 	const goals = useSelect(
@@ -55,10 +55,10 @@ const LaunchBigSky: Step = function ( props ) {
 	};
 
 	useEffect( () => {
-		if ( ! isLoading && ! isEligible ) {
+		if ( ! isEligible ) {
 			window.location.assign( '/start' );
 		}
-	}, [ isLoading, isEligible ] );
+	}, [ isEligible ] );
 
 	const exitFlow = useCallback(
 		async ( selectedSiteId: string, selectedSiteSlug: string ) => {
@@ -136,7 +136,7 @@ const LaunchBigSky: Step = function ( props ) {
 	);
 
 	useEffect( () => {
-		if ( isError || ! isEligible || isLoading ) {
+		if ( isError || ! isEligible ) {
 			return;
 		}
 		const syntheticEvent = {
@@ -146,9 +146,9 @@ const LaunchBigSky: Step = function ( props ) {
 			},
 		} as unknown as FormEvent;
 		onSubmit( syntheticEvent );
-	}, [ isError, isEligible, isLoading, onSubmit ] );
+	}, [ isError, isEligible, onSubmit ] );
 
-	if ( isLoading || ! isEligible ) {
+	if ( ! isEligible ) {
 		return null;
 	}
 

--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -4,7 +4,6 @@ import { Onboard } from '@automattic/data-stores';
 import { AI_SITE_BUILDER_FLOW } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import userAgent from 'calypso/lib/user-agent';
-import { useBigSkyBeforePlans } from '../declarative-flow/helpers/use-bigsky-before-plans-experiment';
 import { useIsSiteOwner } from '../hooks/use-is-site-owner';
 import { ONBOARD_STORE } from '../stores';
 import { useSite } from './use-site';
@@ -34,25 +33,16 @@ export function useIsBigSkyEligible( flowName?: string ) {
 
 	const isEligibleGoals = isGoalsBigSkyEligible( goals );
 	const isEligiblePlan = isPremiumPlan( product_slug ) || isBusinessPlan( product_slug );
-	const [ isLoadingBigsky, isBigSkyBeforePlansExperiment ] = useBigSkyBeforePlans();
-
-	if ( isLoadingBigsky ) {
-		return { isLoading: true, isEligible: null };
-	}
 
 	if ( flowName === AI_SITE_BUILDER_FLOW ) {
 		return { isLoading: false, isEligible: true };
 	}
 
-	if ( isBigSkyBeforePlansExperiment ) {
-		const eligibilityResult = featureFlagEnabled && isEligibleGoals && onSupportedDevice;
-		return { isLoading: false, isEligible: eligibilityResult };
-	}
-
-	const eligibilityResult =
-		featureFlagEnabled && isOwner && isEligiblePlan && isEligibleGoals && onSupportedDevice;
-
-	return { isLoading: false, isEligible: eligibilityResult };
+	return {
+		isLoading: false,
+		isEligible:
+			featureFlagEnabled && isOwner && isEligiblePlan && isEligibleGoals && onSupportedDevice,
+	};
 }
 
 export function isGoalsBigSkyEligible( goals: Onboard.SiteGoal[] ) {

--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -35,11 +35,10 @@ export function useIsBigSkyEligible( flowName?: string ) {
 	const isEligiblePlan = isPremiumPlan( product_slug ) || isBusinessPlan( product_slug );
 
 	if ( flowName === AI_SITE_BUILDER_FLOW ) {
-		return { isLoading: false, isEligible: true };
+		return { isEligible: true };
 	}
 
 	return {
-		isLoading: false,
 		isEligible:
 			featureFlagEnabled && isOwner && isEligiblePlan && isEligibleGoals && onSupportedDevice,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101759 
Related to DOTOBRD-36
Extracted from #101921

## Proposed Changes

Remove the use of the `useBigSkyBeforePlans ` hook from the `useIsBigSkyEligible ` hook

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're cleaning up unused code related to the concluded goals-first experiment.

The return value of `useBigSkyBeforePlans ` is hardcoded to `[false, false]` — meaning that we can actually remove it, update the logic in the code accordingly, and perform any extra cleanup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke-test Stepper steps and flows that rely on the `useIsBigSkyEligible` hook:

- `/setup/onboargin` flow
- `/setup/site-setup` flow
- `design-choices` step (used in `/setup/site-setup` and `/setup/onboarding` flows)
- `design-setup` step (used in `/setup/site-setup` and `/setup/update-design` flows)
- `launch-big-sky` step (used in `/setup/site-setup` flow)

Make sure everything behaves as on `trunk`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
