### PR TITLE
Replace the text for purchases page subheading

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -124,7 +124,7 @@ class PurchasesListDataView extends Component<
 					navigationItems={ [] }
 					title={ titles.sectionTitle }
 					subtitle={ translate(
-						'View, manage, or cancel your plan and other purchases. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'Manage your sites’ plans and upgrades. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
 								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,

--- a/client/me/purchases/purchases-list/index.tsx
+++ b/client/me/purchases/purchases-list/index.tsx
@@ -228,7 +228,7 @@ class PurchasesList extends Component<
 					navigationItems={ [] }
 					title={ titles.sectionTitle }
 					subtitle={ translate(
-						'View, manage, or cancel your plan and other purchases. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'Manage your sites’ plans and upgrades. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
 								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -64,7 +64,7 @@ export function Purchases() {
 					navigationItems={ [] }
 					title={ titles.sectionTitle }
 					subtitle={ translate(
-						'Manage your site’s plans and upgrades. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'Manage your site’s plan and upgrades. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
 								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -64,7 +64,7 @@ export function Purchases() {
 					navigationItems={ [] }
 					title={ titles.sectionTitle }
 					subtitle={ translate(
-						'View, manage, or cancel your plan and other purchases for this site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						'Manage your site’s plans and upgrades. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
 								learnMoreLink: <InlineSupportLink supportContext="purchases" showIcon={ false } />,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/100549

## Proposed Changes

Before:
<img width="551" alt="Screenshot 2025-04-06 at 22 47 41" src="https://github.com/user-attachments/assets/bb77b900-bed3-4b9a-bf9b-c0e0b44f3c61" />
<img width="551" alt="Screenshot 2025-04-06 at 22 46 57" src="https://github.com/user-attachments/assets/27f10900-75f0-4465-add7-326526d46b5c" />


After:
<img width="551" alt="Screenshot 2025-04-06 at 22 42 10" src="https://github.com/user-attachments/assets/8dc11723-6a10-474a-b624-74ec7a613fa9" />
<img width="551" alt="Screenshot 2025-04-06 at 22 34 34" src="https://github.com/user-attachments/assets/927bf848-1a8d-4dd5-9a14-f4af383f3be5" />


Update the subheading on the `/me/purchases` page and `/purchases/subscriptions/{site}` to: "Manage your sites’ plans and upgrades." and "Manage your site’s plans and upgrades."

This ensures consistency with the "Active Upgrades" tab and improves user understanding.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The previous subheading, "View, manage, or cancel your plan and other purchases," was inconsistent with the "Active Upgrades" tab and included extraneous actions like "View" and "Cancel." The updated subheading aligns better with the tab's purpose and simplifies the language.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- In calypso.live or local Calypso instance navigate to `/me/purchases` in the application.
- Verify that the subheading now reads: "Manage your sites’ plans and upgrades."
- Open a single site, navigate to Upgrades->Purchases and confirm that the subheading is now "Manage your site’s plans and upgrades."
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
