### PR TITLE
Stats RED-4: Fixes segment control having weird underline style

### DIFF
--- a/packages/components/src/segmented-control/style.scss
+++ b/packages/components/src/segmented-control/style.scss
@@ -1,4 +1,3 @@
-
 @import "@automattic/typography/styles/variables";
 
 /**
@@ -43,6 +42,7 @@
 	line-height: 18px;
 	color: var(--color-text-subtle);
 	text-align: center;
+	text-decoration: none;
 	transition: color 0.1s linear, background-color 0.1s linear;
 
 	.segmented-control__item:not(.is-selected) &:focus {


### PR DESCRIPTION
Related to #RED-4

## Proposed Changes

* Resolves the underline that has recently appeared in the segment controls. 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso live link
* Navigate to subscribers pag
* Check links in the segment controls are not underlined

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/c0c6252a-a832-483f-bc35-faa448d83ff1) | ![image](https://github.com/user-attachments/assets/95aba95a-e355-44b3-9592-1c2f0ef595f1)
 |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
