### PR TITLE
Untangled Plans: show current plan panel only for 100-Year plan

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_100_YEARS, isValidFeatureKey } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
@@ -24,7 +25,7 @@ function is100YearPlanUser( context ) {
 
 export function plans( context, next ) {
 	// Redirecting users for the 100-Year plan to the my-plan page.
-	if ( is100YearPlanUser( context ) ) {
+	if ( is100YearPlanUser( context ) && ! isEnabled( 'untangling/plans' ) ) {
 		return page.redirect( `/plans/my-plan/${ context.params.site }` );
 	}
 	if ( showJetpackPlans( context ) ) {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -3,6 +3,7 @@ import {
 	FEATURE_LEGACY_STORAGE_200GB,
 	getIntervalTypeForTerm,
 	getPlan,
+	is100Year,
 	isFreePlanProduct,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
@@ -350,7 +351,13 @@ class PlansComponent extends Component {
 		);
 	}
 
-	renderMainContent( { isEcommerceTrial, isBusinessTrial, isWooExpressPlan, isA4APlan } ) {
+	renderMainContent( {
+		isEcommerceTrial,
+		isBusinessTrial,
+		isWooExpressPlan,
+		isA4APlan,
+		is100YearPlan,
+	} ) {
 		if ( isEcommerceTrial ) {
 			return this.renderEcommerceTrialPage();
 		}
@@ -360,7 +367,7 @@ class PlansComponent extends Component {
 		if ( isBusinessTrial ) {
 			return this.renderBusinessTrialPage();
 		}
-		if ( isA4APlan ) {
+		if ( isA4APlan || is100YearPlan ) {
 			return null;
 		}
 
@@ -427,6 +434,7 @@ class PlansComponent extends Component {
 
 		const isWooExpressTrial = purchase?.isWooExpressTrial;
 		const isA4APlan = purchase && isPartnerPurchase( purchase );
+		const is100YearPlan = purchase && is100Year( purchase );
 
 		// Use the Woo Express subheader text if the current plan has the Performance or trial plans or fallback to the default subheader text.
 		let subHeaderText = null;
@@ -510,6 +518,7 @@ class PlansComponent extends Component {
 									isBusinessTrial,
 									isWooExpressPlan,
 									isA4APlan,
+									is100YearPlan,
 								} ) }
 								<PerformanceTrackerStop />
 							</Main>

--- a/client/sites/components/plan-pricing/index.tsx
+++ b/client/sites/components/plan-pricing/index.tsx
@@ -1,4 +1,4 @@
-import { getPlan, PlanSlug, PLAN_MONTHLY_PERIOD } from '@automattic/calypso-products';
+import { getPlan, PlanSlug, PLAN_MONTHLY_PERIOD, is100Year } from '@automattic/calypso-products';
 import { Button, PlanPrice, LoadingPlaceholder } from '@automattic/components';
 import { usePricingMetaForGridPlans } from '@automattic/data-stores/src/plans';
 import { usePlanBillingDescription } from '@automattic/plans-grid-next';
@@ -32,6 +32,9 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 		siteId: site?.ID,
 		useCheckPlanAvailabilityForPurchase,
 	} )?.[ planSlug ];
+
+	const is100YearPlan = planPurchase && is100Year( planPurchase );
+
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
 	const isLoading = ! pricing || ! planData || planPurchaseLoading;
 
@@ -63,6 +66,10 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 	};
 
 	const renderPrice = () => {
+		if ( is100YearPlan ) {
+			return null;
+		}
+
 		const price = (
 			<PlanPrice
 				currencyCode={ pricing?.currencyCode }

--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -1,3 +1,4 @@
+import { is100Year } from '@automattic/calypso-products';
 import { LoadingPlaceholder } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -24,6 +25,7 @@ export default function CurrentPlanPanel() {
 		getCurrentPlanPurchaseId( state, site?.ID ?? 0 )
 	);
 	const isA4APlan = planPurchase && isPartnerPurchase( planPurchase );
+	const is100YearPlan = planPurchase && is100Year( planPurchase );
 
 	const planName = isA4APlan ? purchaseType( planPurchase ) : planDetails?.product_name_short ?? '';
 	const planPurchaseLoading = ! isFreePlan && planPurchase === null;
@@ -56,7 +58,7 @@ export default function CurrentPlanPanel() {
 	};
 
 	const renderManageAddOnsButton = () => {
-		if ( isA4APlan ) {
+		if ( isA4APlan || is100YearPlan ) {
 			return null;
 		}
 		return (
@@ -87,7 +89,9 @@ export default function CurrentPlanPanel() {
 						) : (
 							<>
 								<h3>{ planName }</h3>
-								{ ! isA4APlan && <CoreBadge>{ translate( 'Current plan' ) }</CoreBadge> }
+								{ ! isA4APlan && ! is100YearPlan && (
+									<CoreBadge>{ translate( 'Current plan' ) }</CoreBadge>
+								) }
 							</>
 						) }
 					</div>
@@ -104,7 +108,7 @@ export default function CurrentPlanPanel() {
 			</div>
 
 			<PlanStats />
-			{ ! isA4APlan && <hr /> }
+			{ ! isA4APlan && ! is100YearPlan && <hr /> }
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/101943
Fixes DOTCOM-773

## Proposed Changes

This PR "improves" the new Plans page for 100-year-plan sites, by skipping the legacy My Plan page altogether and showing a "minimalist" page. See the linked issue above for discussion.

|Before|After|
|-|-|
|<img width="1250" alt="image" src="https://github.com/user-attachments/assets/4edf7e08-f7ee-4640-9d66-df5f302dbb30" />|<img width="1254" alt="image" src="https://github.com/user-attachments/assets/f08dd335-84f3-4ef4-83c8-6b756eda135a" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

pbxlJb-6Xi-p2

## Testing Instructions

1. Prepare an Atomic site.
2. Add a `WordPress.com 100-Year Plan` product manually to the site via Store Admin.
3. Delete the `Business` product for that site.
4. Open `/plans/:siteSlug?flags=untangling/plans`.
   - Verify you see the new Plans page as per above screenshot (AFTER).
5. Regression: open `/plans/:siteSlug`.
   - Verify you see the existing Plans page as per above screenshot (BEFORE).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?