### PR TITLE
Update automated transfer warnings copy and styles

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -167,25 +167,6 @@ export const EligibilityWarnings = ( {
 					/>
 				</CompactCard>
 			) }
-			{ ! isPlaceholder && context === 'plugin-details' && (
-				<CompactCard>
-					<div className="eligibility-warnings__header">
-						<div className="eligibility-warnings__title">
-							{ translate( 'Before you continue' ) }
-						</div>
-					</div>
-				</CompactCard>
-			) }
-
-			{ context === 'hosting-features' && (
-				<CompactCard>
-					<div className="eligibility-warnings__header">
-						<div className="eligibility-warnings__title">
-							{ translate( 'Activate hosting features' ) }
-						</div>
-					</div>
-				</CompactCard>
-			) }
 
 			{ ( isPlaceholder || filteredHolds.length > 0 ) && ! showFreeTrial && (
 				<CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -6,8 +6,6 @@ import {
 	FEATURE_INSTALL_PLUGINS,
 	PLAN_BUSINESS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
-	PLAN_BUSINESS_MONTHLY,
-	getPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
@@ -19,13 +17,11 @@ import { connect } from 'react-redux';
 import DataCenterPicker from 'calypso/blocks/data-center-picker';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	getEligibility,
 	isEligibleForAutomatedTransfer,
 } from 'calypso/state/automated-transfer/selectors';
-import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import getRequest from 'calypso/state/selectors/get-request';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { saveSiteSettings } from 'calypso/state/site-settings/actions';
@@ -154,10 +150,6 @@ export const EligibilityWarnings = ( {
 		filteredHolds = listHolds.filter( ( hold ) => hold !== 'NO_BUSINESS_PLAN' );
 	}
 
-	const monthlyCost = useSelector( ( state ) =>
-		getProductDisplayCost( state, PLAN_BUSINESS_MONTHLY )
-	) as string;
-
 	return (
 		<div className={ classes }>
 			<QueryEligibility siteId={ siteId } />
@@ -178,23 +170,7 @@ export const EligibilityWarnings = ( {
 				<CompactCard>
 					<div className="eligibility-warnings__header">
 						<div className="eligibility-warnings__title">
-							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
-								? translate( 'Upgrade your plan to install plugins' )
-								: translate( 'Before you continue' ) }
-						</div>
-						<div className="eligibility-warnings__primary-text">
-							{ listHolds.indexOf( 'NO_BUSINESS_PLAN' ) !== -1
-								? translate(
-										// Translators: %(planName)s is the plan - Business or Creator, and %(monthlyCost)s is the monthly cost.
-										'Installing plugins is a premium feature. Unlock the ability to install this and 50,000 other plugins by upgrading to the %(planName)s plan for %(monthlyCost)s/month.',
-										{
-											args: {
-												monthlyCost,
-												planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-											},
-										}
-								  )
-								: '' }
+							{ translate( 'Before you continue' ) }
 						</div>
 					</div>
 				</CompactCard>

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -8,7 +8,8 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, CompactCard, Gridicon } from '@automattic/components';
+import { CompactCard, Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
@@ -234,14 +235,15 @@ export const EligibilityWarnings = ( {
 						onShowHelpAssistant={ onDismiss }
 					/>
 					<Button
-						primary
+						variant="primary"
+						__next40pxDefaultSize
 						disabled={
 							isProceedButtonDisabled( isEligible, listHolds ) ||
 							siteIsSavingSettings ||
 							siteIsLaunching ||
 							disableContinueButton
 						}
-						busy={ siteIsLaunching || siteIsSavingSettings || disableContinueButton }
+						isBusy={ siteIsLaunching || siteIsSavingSettings || disableContinueButton }
 						onClick={ logEventAndProceed }
 					>
 						{ getProceedButtonText( listHolds, translate, context, showFreeTrial ) }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,7 +1,7 @@
 .eligibility-warnings {
 	// 16px from card padding + 32 = 48 gap from top|bottom
 	// 24px from card padding + 24 = 48 gab from left|right
-	padding: 8px 0;
+	padding: 0;
 	overflow-wrap: anywhere;
 	background: #fff;
 	font-size: $font-body-small;
@@ -12,7 +12,7 @@
 	}
 
 	> .card {
-		padding: 8px 0 0;
+		padding: 0;
 	}
 
 	.eligibility-warnings__confirm-buttons {
@@ -87,14 +87,10 @@
 	}
 
 	&.eligibility-warnings--without-title {
-		padding-top: 3em;
+		padding: 24px 16px 16px;
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 
-		.card {
-			padding: 8px 16px;
-		}
-
-		.eligibility-warnings__address {
+		.eligibility-warnings__address-first {
 			// The width of the parent element is much greater for the without title format
 			// so we don't need an ellipsis text-overflow here.
 			max-width: none;
@@ -231,7 +227,7 @@
 }
 
 .eligibility-warnings__domain-names {
-	margin-top: 20px;
+	margin: 24px 0;
 
 	.card {
 		background-color: #f6f7f7;
@@ -262,6 +258,8 @@
 		font-size: $font-body-extra-small;
 		padding-top: 0;
 		padding-bottom: 0;
+		line-height: unset;
+    	height: unset;
 
 		&.badge--success {
 			background: var(--studio-green-5);
@@ -311,5 +309,5 @@
 }
 
 .card.eligibility-warnings__data-center-picker.is-compact {
-	padding-bottom: 8px;
+	margin-bottom: 24px;
 }

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,6 +1,6 @@
 .eligibility-warnings {
 	// 16px from card padding + 32 = 48 gap from top|bottom
-	// 24px from card padding + 24 = 48 gab from left|right
+	// 24px from card padding + 24 = 48 gap from left|right
 	padding: 0;
 	overflow-wrap: anywhere;
 	background: #fff;

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -6,7 +6,6 @@
 	background: #fff;
 	font-size: $font-body-small;
 	margin: 0;
-	box-shadow: 0 0 0 1px var(--color-border-subtle);
 
 	@media (max-width: 660px) {
 		padding: 0;
@@ -85,6 +84,7 @@
 
 	&.eligibility-warnings--without-title {
 		padding-top: 3em;
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
 	}
 }
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -238,7 +238,6 @@
 		padding: 12px;
 		margin-bottom: 4px;
 		display: flex;
-		justify-content: space-between;
 		align-items: center;
 
 		&::after {
@@ -246,11 +245,15 @@
 		}
 	}
 
-	.eligibility-warnings__address {
+	.eligibility-warnings__address-first {
 		text-overflow: ellipsis;
-		max-width: 350px;
+		max-width: 240px;
 		overflow: hidden;
 		white-space: nowrap;
+	}
+
+	.eligibility-warnings__address-second {
+		margin-right: auto;
 	}
 
 	.badge {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -237,6 +237,7 @@
 	margin-top: 20px;
 
 	.card {
+		background-color: #f6f7f7;
 		padding: 12px 16px;
 		margin-bottom: 4px;
 	}
@@ -272,7 +273,6 @@
 }
 
 .eligibility-warnings__warnings-card {
-	background: #f6f7f7;
 	margin: 0 24px;
 	border-radius: 4px;
 

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -11,6 +11,10 @@
 		padding: 0;
 	}
 
+	> .card {
+		padding: 8px 0 0;
+	}
+
 	.eligibility-warnings__confirm-buttons {
 		display: flex;
 		justify-content: space-between;
@@ -85,6 +89,16 @@
 	&.eligibility-warnings--without-title {
 		padding-top: 3em;
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
+
+		.card {
+			padding: 8px 16px;
+		}
+
+		.eligibility-warnings__address {
+			// The width of the parent element is much greater for the without title format
+			// so we don't need an ellipsis text-overflow here.
+			max-width: none;
+		}
 	}
 }
 
@@ -169,18 +183,6 @@
 	line-height: 24px;
 	padding: 0;
 	margin-bottom: 10px;
-
-	.eligibility-warnings__message-title {
-		font-weight: 600;
-	}
-
-	.eligibility-warnings__message-description {	
-		font-size: $font-body;
-
-		&--hosting-features {
-			font-weight: 500;
-		}
-	}
 }
 
 .eligibility-warnings__inline-link {
@@ -233,16 +235,30 @@
 
 	.card {
 		background-color: #f6f7f7;
-		padding: 12px 16px;
+		padding: 12px;
 		margin-bottom: 4px;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		&::after {
+			content: none;
+		}
+	}
+
+	.eligibility-warnings__address {
+		text-overflow: ellipsis;
+		max-width: 350px;
+		overflow: hidden;
+		white-space: nowrap;
 	}
 
 	.badge {
-		position: absolute;
-		right: 20px;
 		border-radius: 4px;
 		font-weight: 500;
 		font-size: $font-body-extra-small;
+		padding-top: 0;
+		padding-bottom: 0;
 
 		&.badge--success {
 			background: var(--studio-green-5);
@@ -268,7 +284,6 @@
 }
 
 .eligibility-warnings__warnings-card {
-	margin: 0 24px;
 	border-radius: 4px;
 
 	@media (max-width: 480px) {

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -31,7 +31,6 @@
 		align-items: center;
 		display: flex;
 		gap: 5px;
-		color: var(--color-text-subtle);
 		font-size: 0.875rem;
 
 		a {
@@ -103,8 +102,7 @@
 	font-weight: 400;
 }
 
-.eligibility-warnings__primary-text {
-	color: var(--color-text-subtle);
+.eligibility-warnings__primary-text {	
 	font-size: 1rem;
 	margin-top: 16px;
 }
@@ -176,8 +174,7 @@
 		font-weight: 600;
 	}
 
-	.eligibility-warnings__message-description {
-		color: var(--color-text-subtle);
+	.eligibility-warnings__message-description {	
 		font-size: $font-body;
 
 		&--hosting-features {
@@ -187,7 +184,6 @@
 }
 
 .eligibility-warnings__inline-link {
-	color: var(--color-text-subtle);
 	text-decoration: underline;
 }
 
@@ -210,8 +206,7 @@
 	align-items: center;
 	display: flex;
 
-	.gridicon {
-		color: var(--color-text-subtle);
+	.gridicon {		
 		flex-shrink: 0;
 	}
 	span {

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -60,11 +60,11 @@ function displayDomainNames( domainNames: DomainNames ) {
 	return (
 		<div className="eligibility-warnings__domain-names">
 			<Card compact>
-				<span>{ domainNames.current }</span>
+				<span className="eligibility-warnings__address">{ domainNames.current }</span>
 				<Badge type="info">{ translate( 'current' ) }</Badge>
 			</Card>
 			<Card compact>
-				<span>{ domainNames.new }</span>
+				<span className="eligibility-warnings__address">{ domainNames.new }</span>
 				<Badge type="success">{ translate( 'new' ) }</Badge>
 			</Card>
 		</div>

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -57,14 +57,24 @@ export const WarningList = ( { context, translate, warnings, showContact = true 
 };
 
 function displayDomainNames( domainNames: DomainNames ) {
+	//Split out the first part of the domain names and then join the rest back together.
+	const domainNamesArrayCurrent = domainNames.current.split( '.' );
+	const domainNamesArrayNew = domainNames.new.split( '.' );
+	const firstPartCurrent = domainNamesArrayCurrent.shift();
+	const firstPartNew = domainNamesArrayNew.shift();
+	const secondPartCurrent = '.' + domainNamesArrayCurrent.join( '.' );
+	const secondPartNew = '.' + domainNamesArrayNew.join( '.' );
+
 	return (
 		<div className="eligibility-warnings__domain-names">
 			<Card compact>
-				<span className="eligibility-warnings__address">{ domainNames.current }</span>
+				<span className="eligibility-warnings__address-first">{ firstPartCurrent }</span>
+				<span className="eligibility-warnings__address-second">{ secondPartCurrent }</span>
 				<Badge type="info">{ translate( 'current' ) }</Badge>
 			</Card>
 			<Card compact>
-				<span className="eligibility-warnings__address">{ domainNames.new }</span>
+				<span className="eligibility-warnings__address-first">{ firstPartNew }</span>
+				<span className="eligibility-warnings__address-second">{ secondPartNew }</span>
 				<Badge type="success">{ translate( 'new' ) }</Badge>
 			</Card>
 		</div>

--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -16,21 +16,6 @@ type Props = ExternalProps & LocalizeProps;
 export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
 	return (
 		<div>
-			{ getWarningDescription( context, warnings.length, translate ) && (
-				<div className="eligibility-warnings__warning">
-					<div className="eligibility-warnings__message">
-						<span
-							className={ `eligibility-warnings__message-description ${
-								context === 'hosting-features' &&
-								'eligibility-warnings__message-description--hosting-features'
-							}` }
-						>
-							{ getWarningDescription( context, warnings.length, translate ) }
-						</span>
-					</div>
-				</div>
-			) }
-
 			{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
 				<div className="eligibility-warnings__warning" key={ index }>
 					<div className="eligibility-warnings__message">
@@ -84,59 +69,6 @@ function displayDomainNames( domainNames: DomainNames ) {
 			</Card>
 		</div>
 	);
-}
-
-function getWarningDescription(
-	context: string | null,
-	warningCount: number,
-	translate: LocalizeProps[ 'translate' ]
-) {
-	const defaultCopy = translate(
-		'By proceeding the following change will be made to the site:',
-		'By proceeding the following changes will be made to the site:',
-		{
-			count: warningCount,
-			args: warningCount,
-		}
-	);
-	switch ( context ) {
-		case 'plugin-details':
-		case 'plugins':
-			return '';
-
-		case 'themes':
-			return translate(
-				'By installing a theme the following change will be made to the site:',
-				'By installing a theme the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
-
-		case 'hosting':
-			return translate(
-				'By activating hosting access the following change will be made to the site:',
-				'By activating hosting access the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
-
-		case 'hosting-features':
-			return translate(
-				'By proceeding the following change will be made to the site:',
-				'By proceeding the following changes will be made to the site:',
-				{
-					count: warningCount,
-					args: warningCount,
-				}
-			);
-
-		default:
-			return defaultCopy;
-	}
 }
 
 export default localize( WarningList );

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -4,8 +4,8 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, Dialog } from '@automattic/components';
-import { ToggleControl } from '@wordpress/components';
+import { Button } from '@automattic/components';
+import { ToggleControl, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -154,32 +154,32 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 				domains={ domains }
 				closeDialog={ () => setShowAddCustomDomain( false ) }
 			/>
-			<Dialog
-				additionalClassNames="plugin-details-cta__dialog-content"
-				additionalOverlayClassNames="plugin-details-cta__modal-overlay"
-				isVisible={ showEligibility }
-				title={ translate( 'Eligibility' ) }
-				onClose={ () => setShowEligibility( false ) }
-				showCloseIcon
-			>
-				<EligibilityWarnings
-					currentContext="plugin-details"
-					isMarketplace={ isMarketplaceProduct }
-					standaloneProceed
-					onDismiss={ handleDismissEligibilityWarnings }
-					onProceed={ () =>
-						onClickInstallPlugin( {
-							dispatch,
-							selectedSite,
-							plugin,
-							upgradeAndInstall: shouldUpgrade,
-							isMarketplaceProduct,
-							billingPeriod,
-							productsList,
-						} )
-					}
-				/>
-			</Dialog>
+			{ showEligibility && (
+				<Modal
+					className="plugin-details-cta__dialog-content"
+					title={ translate( 'Before you continue' ) }
+					onRequestClose={ () => setShowEligibility( false ) }
+					size="large"
+				>
+					<EligibilityWarnings
+						currentContext="plugin-details"
+						isMarketplace={ isMarketplaceProduct }
+						standaloneProceed
+						onDismiss={ handleDismissEligibilityWarnings }
+						onProceed={ () =>
+							onClickInstallPlugin( {
+								dispatch,
+								selectedSite,
+								plugin,
+								upgradeAndInstall: shouldUpgrade,
+								isMarketplaceProduct,
+								billingPeriod,
+								productsList,
+							} )
+						}
+					/>
+				</Modal>
+			) }
 			<Button
 				className="plugin-details-cta__install-button"
 				primary

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -159,7 +159,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 					className="plugin-details-cta__dialog-content"
 					title={ translate( 'Before you continue' ) }
 					onRequestClose={ () => setShowEligibility( false ) }
-					size="large"
+					size="medium"
 				>
 					<EligibilityWarnings
 						currentContext="plugin-details"

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -194,7 +194,7 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 				className="plugin-details-cta__dialog-content"
 				title={ translate( 'Before you continue' ) }
 				onRequestClose={ () => this.handleDismiss() }
-				size="large"
+				size="medium"
 			>
 				{ this.renderActivationInProgress() }
 				{ this.renderSuccessfulTransfer() }

--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from '@automattic/components';
+import { Modal } from '@wordpress/components';
 import { localize, translate } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -183,15 +183,18 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 	}
 
 	render() {
-		const { showEligibility, isMarketplaceProduct, inProgress } = this.props;
+		const { showEligibility, isMarketplaceProduct } = this.props;
+
+		if ( ! showEligibility ) {
+			return null;
+		}
 
 		return (
-			<Dialog
-				isVisible={ showEligibility }
-				onClose={ () => this.handleDismiss() }
-				shouldCloseOnEsc={ ! inProgress }
-				showCloseIcon={ ! inProgress }
-				shouldCloseOnOverlayClick={ ! inProgress }
+			<Modal
+				className="plugin-details-cta__dialog-content"
+				title={ translate( 'Before you continue' ) }
+				onRequestClose={ () => this.handleDismiss() }
+				size="large"
 			>
 				{ this.renderActivationInProgress() }
 				{ this.renderSuccessfulTransfer() }
@@ -206,7 +209,7 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 					onProceed={ () => this.handleAccept() }
 					backUrl="#"
 				/>
-			</Dialog>
+			</Modal>
 		);
 	}
 }

--- a/client/sites/hosting/components/hosting-activation-button.tsx
+++ b/client/sites/hosting/components/hosting-activation-button.tsx
@@ -52,7 +52,7 @@ export default function HostingActivationButton( { redirectUrl }: HostingActivat
 					className="plugin-details-cta__dialog-content"
 					title={ translate( 'Before you continue' ) }
 					onRequestClose={ () => setShowEligibility( false ) }
-					size="large"
+					size="medium"
 				>
 					<EligibilityWarnings
 						className="hosting__activating-warnings"

--- a/client/sites/hosting/components/hosting-activation-button.tsx
+++ b/client/sites/hosting/components/hosting-activation-button.tsx
@@ -1,6 +1,6 @@
 import { FEATURE_SFTP } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Dialog } from '@automattic/components';
+import { Modal } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -47,22 +47,23 @@ export default function HostingActivationButton( { redirectUrl }: HostingActivat
 				{ translate( 'Activate now' ) }
 			</HostingHeroButton>
 
-			<Dialog
-				additionalClassNames="plugin-details-cta__dialog-content"
-				additionalOverlayClassNames="plugin-details-cta__modal-overlay"
-				isVisible={ showEligibility }
-				onClose={ () => setShowEligibility( false ) }
-				showCloseIcon
-			>
-				<EligibilityWarnings
-					className="hosting__activating-warnings"
-					onProceed={ handleTransfer }
-					backUrl={ redirectUrl }
-					showDataCenterPicker
-					standaloneProceed
-					currentContext="hosting-features"
-				/>
-			</Dialog>
+			{ showEligibility && (
+				<Modal
+					className="plugin-details-cta__dialog-content"
+					title={ translate( 'Before you continue' ) }
+					onRequestClose={ () => setShowEligibility( false ) }
+					size="large"
+				>
+					<EligibilityWarnings
+						className="hosting__activating-warnings"
+						onProceed={ handleTransfer }
+						backUrl={ redirectUrl }
+						showDataCenterPicker
+						standaloneProceed
+						currentContext="hosting-features"
+					/>
+				</Modal>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #100455.

## Proposed Changes

This is a very early iteration on simplifying the warning modals and messages when transferring a site to atomic.
To start with, I've only reduced the copy and updated the background colors. 

<details>
<summary>These are the results</summary>

Activate Hosting Features CTA:

<img width="729" alt="Screenshot 2025-04-07 at 4 43 05 pm" src="https://github.com/user-attachments/assets/4ac41a40-45d0-4a0d-ad33-6d7b32dec48b" />

Plugin details screen CTA AND theme details screen CTA (I updated the title of the plugin details screen to be generic):
 
<img width="687" alt="Screenshot 2025-04-07 at 4 43 35 pm" src="https://github.com/user-attachments/assets/4edff4a3-3e04-46b7-9cfe-4a883ac5a306" />

"Install new theme" from Themes Marketplace:

<img width="768" alt="Screenshot 2025-04-07 at 4 45 14 pm" src="https://github.com/user-attachments/assets/af0125fe-0a33-47b0-a17a-150fd83236a3" />

"Upload" from Plugins Marketplace:

<img width="760" alt="Screenshot 2025-04-07 at 4 45 39 pm" src="https://github.com/user-attachments/assets/182b9e63-cddb-4b5b-8e08-849bc6f63734" />

There's also the possibility that multiple warnings may appear, particularly for legacy sites that may be using unsupported plugins or widgets. In that case, the warnings will look something like this (example modal from plugin details screen):

<img width="684" alt="Screenshot 2025-04-07 at 4 47 27 pm" src="https://github.com/user-attachments/assets/aee090d9-1417-470d-a8d3-dc986d183759" />

</details>

TODO (as per the issue):

* Update the modals to use the Modal from `@wordpress/components`
* Update buttons and badges to use `@wordpress/components`.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test on a site with a business plan that hasn't been transferred to atomic yet (the site URL should be `[sitename].wordpress.com`)
2. Go to the Hosting Overview screen and, under "Hosting Features", click "Activate now" to show the modal;
3. In the Plugins Marketplace, click "Upload" at the top right to navigate to the inline warning;
4. Back in Plugins Marketplace, choose a plugin and click "Install and activate" to show the modal;
5. In the Themes Marketplace, click "Install new theme" at the top right to navigate to the inline warning;
6. Back in the Themes Marketplace, search for and select "Kiosko". Click "Activate" to show the modal.

To test the extra warnings I had to to a code hack. In [this function](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/data-layer/wpcom/sites/automated-transfer/eligibility/index.js#L123), I replaced `data` with the following:
<details>
<summary>alternativeData</summary>

```
const alternativeData = {
			errors: [
				{
					code: 'no_business_plan',
					message: 'Only sites with an eligible plan can be transferred.',
				},
			],
			warnings: {
				plugins: [
					{
						id: 'comment_reply_via_email',
						name: 'Comment Reply via Email',
						description:
							'The ability to reply to comments directly from comment notifications email will no longer be available.',
						supportUrl: 'https://support.wordpress.com/comment-reply-via-email/',
					},
					{
						id: 'writing_helper',
						name: 'Writing Helper',
						description:
							'You will no longer be able to copy posts or seek feedback via the Writing Helper.',
						supportUrl: 'https://support.wordpress.com/writing-helper/',
					},
				],
				widgets: [
					{
						id: 'eventbrite',
						name: 'EventBrite: Event Calendar/Listing',
						description:
							'You will no longer have access to the Eventbrite widget for displaying a calendar of upcoming events.',
						supportUrl:
							'https://en.support.wordpress.com/widgets/eventbrite-event-calendarlisting-widget/',
					},
				],
				subdomain: [
					{
						id: 'wordpress_subdomain',
						name: 'WordPress.com Subdomains',
						description:
							'When you install a plugin, theme, or activate hosting features, <strong>your default site address will change</strong>. We’ll make sure that your site visitors are redirected to the new domain. <a href="https://wordpress.com/support/changing-site-address/#change-a-wpcomstaging-com-address" target="_blank" rel="noreferrer">Learn more ↗</a>',
						domain_names: {
							current: 'somerandomdomainnamefortesting.wordpress.com',
							new: 'somerandomdomainnamefortesting.wpcomstaging.com',
						},
					},
				],
			},
			is_eligible: true,
		};
```

</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
