### PR TITLE
Remove unused `createWithBigSky` from onboard datastore

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -16,7 +16,6 @@ type Props = {
 	paidDomainName?: string | null;
 	intent?: string | null;
 	selectedThemeType?: string;
-	createWithBigSky?: boolean;
 };
 
 /**
@@ -28,7 +27,6 @@ export function useModalResolutionCallback( {
 	paidDomainName,
 	intent,
 	selectedThemeType,
-	createWithBigSky,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
@@ -47,10 +45,6 @@ export function useModalResolutionCallback( {
 				return FREE_PLAN_FREE_DOMAIN_DIALOG;
 			}
 
-			if ( createWithBigSky && ONBOARDING_FLOW === flowName ) {
-				return PAID_PLAN_IS_REQUIRED_DIALOG;
-			}
-
 			// TODO: look into decoupling the flowName from here as well.
 			if (
 				paidDomainName &&
@@ -64,13 +58,6 @@ export function useModalResolutionCallback( {
 
 			return null;
 		},
-		[
-			isCustomDomainAllowedOnFreePlan,
-			flowName,
-			paidDomainName,
-			intent,
-			selectedThemeType,
-			createWithBigSky,
-		]
+		[ isCustomDomainAllowedOnFreePlan, flowName, paidDomainName, intent, selectedThemeType ]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -1,11 +1,8 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { type OnboardSelect } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import { PlanButton } from '@automattic/plans-grid-next';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getHidePlanPropsBasedOnThemeType } from '../utils/utils';
 import { ButtonContainer, DialogContainer, Heading, Row } from './components';
@@ -24,11 +21,6 @@ export const PaidPlanIsRequiredDialog = ( {
 	const [ isBusy, setIsBusy ] = useState( false );
 	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
 	const hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
-	const { setCreateWithBigSky } = useDispatch( ONBOARD_STORE );
-	const createWithBigSky = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
-		const { getCreateWithBigSky } = select( ONBOARD_STORE );
-		return getCreateWithBigSky();
-	}, [] );
 
 	const getUpsellTitle = () => {
 		if ( isPaidTheme && paidDomainName ) {
@@ -39,24 +31,12 @@ export const PaidPlanIsRequiredDialog = ( {
 			return translate( 'Premium themes are only available with a paid plan' );
 		}
 
-		if ( createWithBigSky && paidDomainName ) {
-			return translate( 'Domains and our AI Website Builder are only available with a paid plan' );
-		}
-
-		if ( createWithBigSky ) {
-			return translate( 'Our AI Website Builder is only available with a paid plan' );
-		}
-
 		return translate( 'Custom domains are only available with a paid plan' );
 	};
 
 	const handleFreeDomainClick = () => {
 		setIsBusy( true );
 		onFreePlanSelected();
-
-		if ( createWithBigSky ) {
-			setCreateWithBigSky( false );
-		}
 	};
 
 	useEffect( () => {

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -1,13 +1,10 @@
 import { Button, Gridicon } from '@automattic/components';
-import { OnboardSelect } from '@automattic/data-stores';
 import { isOnboardingFlow } from '@automattic/onboarding';
 import styled from '@emotion/styled';
-import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { SelectedFeatureData } from '../hooks/use-selected-feature';
 
 const Subheader = styled.p< { isUsingStepContainerV2?: boolean } >`
@@ -149,32 +146,12 @@ const PlansPageSubheader = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const createWithBigSky = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
-		const { getCreateWithBigSky } = select( ONBOARD_STORE );
-		return getCreateWithBigSky();
-	}, [] );
-
 	const isOnboarding = isOnboardingFlow( flowName ?? null );
 
 	const isUsingStepContainerV2 = Boolean( flowName && shouldUseStepContainerV2( flowName ) );
 
 	const renderSubheader = () => {
-		if ( createWithBigSky ) {
-			return (
-				<Subheader isUsingStepContainerV2={ isUsingStepContainerV2 }>
-					{ translate(
-						'Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.',
-						{
-							components: {
-								link: <Button onClick={ onFreePlanCTAClick } borderless />,
-							},
-						}
-					) }
-				</Subheader>
-			);
-		}
-
-		if ( ! createWithBigSky && deemphasizeFreePlan && offeringFreePlan ) {
+		if ( deemphasizeFreePlan && offeringFreePlan ) {
 			return (
 				<Subheader isUsingStepContainerV2={ isUsingStepContainerV2 }>
 					{ translate(

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -19,7 +19,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
-import { WpcomPlansUI, AddOns, Plans, OnboardSelect } from '@automattic/data-stores';
+import { WpcomPlansUI, AddOns, Plans } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
@@ -32,7 +32,7 @@ import {
 } from '@automattic/plans-grid-next';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import {
 	useCallback,
 	useEffect,
@@ -50,7 +50,6 @@ import QueryActivePromotions from 'calypso/components/data/query-active-promotio
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
@@ -247,20 +246,12 @@ const PlansFeaturesMain = ( {
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
 
-	const { createWithBigSky } = useSelect(
-		( select ) => ( {
-			createWithBigSky: ( select( ONBOARD_STORE ) as OnboardSelect ).getCreateWithBigSky(),
-		} ),
-		[]
-	);
-
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
 		flowName,
 		paidDomainName,
 		intent: intentFromProps,
 		selectedThemeType,
-		createWithBigSky,
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -381,12 +381,6 @@ export const setPartnerBundle = ( partnerBundle: string | null ) => ( {
 	partnerBundle,
 } );
 
-export const setCreateWithBigSky = ( createWithBigSky: boolean ) => ( {
-	// TODO: we could be able to delete this, at the moment it's never set to true
-	type: 'SET_CREATE_WITH_BIG_SKY' as const,
-	createWithBigSky,
-} );
-
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -447,5 +441,4 @@ export type OnboardAction = ReturnType<
 	| typeof setPaidSubscribers
 	| typeof setPartnerBundle
 	| typeof setSignupDomainOrigin
-	| typeof setCreateWithBigSky
 >;

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -62,7 +62,6 @@ export function register(): typeof STORE_KEY {
 			'domainCartItem',
 			'planCartItem',
 			'productCartItems',
-			'createWithBigSky',
 			'partnerBundle',
 		],
 	} );

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -622,20 +622,6 @@ const signupDomainOrigin: Reducer< string | undefined, OnboardAction > = (
 	return state;
 };
 
-const createWithBigSky: Reducer< boolean | undefined, OnboardAction > = (
-	state = undefined,
-	action
-) => {
-	if ( action.type === 'SET_CREATE_WITH_BIG_SKY' ) {
-		return action.createWithBigSky;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return undefined;
-	}
-
-	return state;
-};
-
 const reducer = combineReducers( {
 	domain,
 	domainCartItem,
@@ -685,7 +671,6 @@ const reducer = combineReducers( {
 	paidSubscribers,
 	partnerBundle,
 	signupDomainOrigin,
-	createWithBigSky,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -82,4 +82,3 @@ export const getPluginsToVerify = ( state: State ) => state.pluginsToVerify;
 export const getProfilerData = ( state: State ) => state.profilerData;
 export const getPaidSubscribers = ( state: State ) => state.paidSubscribers;
 export const getPartnerBundle = ( state: State ) => state.partnerBundle;
-export const getCreateWithBigSky = ( state: State ) => state.createWithBigSky;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101759 
Related to DOTOBRD-36
Extracted from #101921


## Proposed Changes

Remove unused `createWithBigSky` from onboard datastore

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

With the removal of goals-first onboarding (see https://github.com/Automattic/wp-calypso/issues/101759#issue-2941629656) , I realized that `setCreateWithBigSky` action is only called once, with `false` — meaning that we can clean up all usages of `getCreateWithBigSky`, assuming that it will always return `false` (and we can clean up the data-store too).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the `createWithBigSky` data from the onboard data store is never set to anything different than `false`
* Make sure that code changes make sense and that there are no leftover usages
* Smoke test the affected files (mostly the plans overview and the upsell modal), make sure that they behave exactly as on `trunk`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
