### PR TITLE
WIP: Prototype: Move plans page subheader calculation up in the component tree

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { OnboardSelect } from '@automattic/data-stores';
 import { isOnboardingFlow } from '@automattic/onboarding';
 import styled from '@emotion/styled';
@@ -9,7 +9,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { SelectedFeatureData } from '../hooks/use-selected-feature';
 
-const Subheader = styled.p`
+export const Subheader = styled.p`
 	margin: -32px 0 40px 0;
 	color: var( --studio-gray-60 );
 	font-size: 1rem;
@@ -26,7 +26,7 @@ const Subheader = styled.p`
 	}
 `;
 
-const SecondaryFormattedHeader = ( {
+export const SecondaryFormattedHeader = ( {
 	siteSlug,
 	selectedFeature,
 }: {
@@ -67,82 +67,17 @@ const SecondaryFormattedHeader = ( {
 	);
 };
 
-const HeaderContainer = styled( Subheader )`
-	display: flex;
-	justify-content: center;
-	font-size: 16px;
-	font-weight: 500;
-	margin-bottom: 0;
-
-	// TODO:
-	// This value is grabbed directly from https://github.com/Automattic/wp-calypso/blob/trunk/packages/plans-grid-next/src/index.tsx#L109
-	// Ideally there should be a shared constant that can be reused from the CSS side.
-	@media ( max-width: 740px ) {
-		flex-direction: column;
-	}
-`;
-
-const PrefixSection = styled.p`
-	// TODO:
-	// The same as above.
-	@media ( max-width: 740px ) {
-		margin-bottom: 4px;
-	}
-`;
-
-const FeatureSection = styled.p`
-	.gridicon.gridicons-checkmark {
-		color: var( --studio-green-50 );
-		vertical-align: middle;
-		margin-left: 12px;
-		margin-right: 4px;
-		padding-bottom: 4px;
-	}
-`;
-
-const PlanBenefitHeader = () => {
-	const translate = useTranslate();
-
-	return (
-		<HeaderContainer>
-			<PrefixSection>{ translate( 'All plans include:' ) }</PrefixSection>
-			<FeatureSection>
-				{ translate(
-					'{{Checkmark}}{{/Checkmark}}Website Building{{Checkmark}}{{/Checkmark}}Hosting{{Checkmark}}{{/Checkmark}}eCommerce',
-					{
-						components: {
-							Checkmark: <Gridicon icon="checkmark" size={ 18 } />,
-						},
-						comment: 'Checkmark is an icon showing a green check mark.',
-					}
-				) }
-			</FeatureSection>
-		</HeaderContainer>
-	);
-};
-
-// TBD
-// It is actually questionable that we implement a subheader here instead of reusing the header mechanism
-// provided by the signup framework. How could we unify them?
-const PlansPageSubheader = ( {
-	siteSlug,
-	isDisplayingPlansNeededForFeature,
+export const usePlansPageSubheaderText = ( {
 	deemphasizeFreePlan,
-	showPlanBenefits,
 	offeringFreePlan,
 	flowName,
 	onFreePlanCTAClick,
-	selectedFeature,
 }: {
-	siteSlug?: string | null;
-	isDisplayingPlansNeededForFeature: boolean;
 	deemphasizeFreePlan?: boolean;
 	offeringFreePlan?: boolean;
-	showPlanBenefits?: boolean;
 	flowName?: string | null;
 	onFreePlanCTAClick: () => void;
-	selectedFeature: SelectedFeatureData | null;
-} ) => {
+} ): React.ReactNode => {
 	const translate = useTranslate();
 
 	const createWithBigSky = useSelect( ( select: ( key: string ) => OnboardSelect ) => {
@@ -152,60 +87,31 @@ const PlansPageSubheader = ( {
 
 	const isOnboarding = isOnboardingFlow( flowName ?? null );
 
-	const renderSubheader = () => {
-		if ( createWithBigSky ) {
-			return (
-				<Subheader>
-					{ translate(
-						'Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.',
-						{
-							components: {
-								link: <Button onClick={ onFreePlanCTAClick } borderless />,
-							},
-						}
-					) }
-				</Subheader>
-			);
-		}
+	if ( createWithBigSky ) {
+		return translate(
+			'Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.',
+			{
+				components: {
+					link: <Button onClick={ onFreePlanCTAClick } borderless />,
+				},
+			}
+		);
+	}
 
-		if ( ! createWithBigSky && deemphasizeFreePlan && offeringFreePlan ) {
-			return (
-				<Subheader>
-					{ translate(
-						'Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.',
-						{
-							components: {
-								link: <Button onClick={ onFreePlanCTAClick } borderless />,
-							},
-						}
-					) }
-				</Subheader>
-			);
-		}
+	if ( ! createWithBigSky && deemphasizeFreePlan && offeringFreePlan ) {
+		return translate(
+			'Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.',
+			{
+				components: {
+					link: <Button onClick={ onFreePlanCTAClick } borderless />,
+				},
+			}
+		);
+	}
 
-		if ( showPlanBenefits ) {
-			return <PlanBenefitHeader />;
-		}
+	if ( isOnboarding ) {
+		return translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' );
+	}
 
-		if ( isOnboarding ) {
-			return (
-				<Subheader>
-					{ translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' ) }
-				</Subheader>
-			);
-		}
-
-		return null;
-	};
-
-	return (
-		<>
-			{ renderSubheader() }
-			{ isDisplayingPlansNeededForFeature && (
-				<SecondaryFormattedHeader siteSlug={ siteSlug } selectedFeature={ selectedFeature } />
-			) }
-		</>
-	);
+	return null;
 };
-
-export default PlansPageSubheader;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -70,7 +70,11 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
-import PlansPageSubheader from './components/plans-page-subheader';
+import {
+	usePlansPageSubheaderText,
+	Subheader,
+	SecondaryFormattedHeader,
+} from './components/plans-page-subheader';
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useDefaultWpcomPlansIntent from './hooks/use-default-wpcom-plans-intent';
 import useEligibilityForTermSavingsPriceDisplay from './hooks/use-eligibility-for-term-savings-price-display';
@@ -766,6 +770,13 @@ const PlansFeaturesMain = ( {
 		selectedFeature,
 	} );
 
+	const subheaderText = usePlansPageSubheaderText( {
+		deemphasizeFreePlan,
+		offeringFreePlan,
+		flowName,
+		onFreePlanCTAClick,
+	} );
+
 	return (
 		<>
 			<div className={ clsx( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }>
@@ -816,15 +827,10 @@ const PlansFeaturesMain = ( {
 							} ) }
 					/>
 				) }
-				<PlansPageSubheader
-					siteSlug={ siteSlug }
-					isDisplayingPlansNeededForFeature={ isDisplayingPlansNeededForFeature }
-					selectedFeature={ selectedFeatureData }
-					offeringFreePlan={ offeringFreePlan }
-					flowName={ flowName }
-					deemphasizeFreePlan={ deemphasizeFreePlan }
-					onFreePlanCTAClick={ onFreePlanCTAClick }
-				/>
+				<Subheader>{ subheaderText }</Subheader>
+				{ isDisplayingPlansNeededForFeature && (
+					<SecondaryFormattedHeader siteSlug={ siteSlug } selectedFeature={ selectedFeatureData } />
+				) }
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (
 					<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Lifting the code which calculates the plans step's subheader up in the component tree, in the hopes that eventually I can lift it high enough that it can be rendered by the `Step.Header` component.

The main issue is that a lot of the data for determining whether to show free plan links in the subheader resides in `PlansFreaturesMain`, not in the stepper code.

The `PlansPageSubheader` prop `showPlanBenefits` was removed in #92055. No one calls it anymore. That's why I was able to remove it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
