### PR TITLE
Left align plan step subheader on mobile

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -6,14 +6,15 @@ import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { SelectedFeatureData } from '../hooks/use-selected-feature';
 
-const Subheader = styled.p`
+const Subheader = styled.p< { isUsingStepContainerV2?: boolean } >`
 	margin: -32px 0 40px 0;
 	color: var( --studio-gray-60 );
 	font-size: 1rem;
-	text-align: center;
+	text-align: ${ ( props ) => ( props.isUsingStepContainerV2 ? 'left' : 'center' ) };
 	button.is-borderless {
 		font-weight: 500;
 		color: var( --studio-gray-90 );
@@ -23,6 +24,9 @@ const Subheader = styled.p`
 	}
 	@media ( max-width: 960px ) {
 		margin-top: -16px;
+	}
+	@media ( min-width: 600px ) {
+		text-align: center;
 	}
 `;
 
@@ -152,10 +156,12 @@ const PlansPageSubheader = ( {
 
 	const isOnboarding = isOnboardingFlow( flowName ?? null );
 
+	const isUsingStepContainerV2 = Boolean( flowName && shouldUseStepContainerV2( flowName ) );
+
 	const renderSubheader = () => {
 		if ( createWithBigSky ) {
 			return (
-				<Subheader>
+				<Subheader isUsingStepContainerV2={ isUsingStepContainerV2 }>
 					{ translate(
 						'Build your site quickly with our AI Website Builder or {{link}}start with a free plan{{/link}}.',
 						{
@@ -170,7 +176,7 @@ const PlansPageSubheader = ( {
 
 		if ( ! createWithBigSky && deemphasizeFreePlan && offeringFreePlan ) {
 			return (
-				<Subheader>
+				<Subheader isUsingStepContainerV2={ isUsingStepContainerV2 }>
 					{ translate(
 						'Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.',
 						{
@@ -189,7 +195,7 @@ const PlansPageSubheader = ( {
 
 		if ( isOnboarding ) {
 			return (
-				<Subheader>
+				<Subheader isUsingStepContainerV2={ isUsingStepContainerV2 }>
 					{ translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' ) }
 				</Subheader>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/102401

## Proposed Changes

Quick hack. Align plans step subheader to the left on mobile.

![CleanShot 2025-04-07 at 22 10 10@2x](https://github.com/user-attachments/assets/bd4ed7e2-809b-4b09-b1de-95d3378856b7)

![CleanShot 2025-04-07 at 22 10 30@2x](https://github.com/user-attachments/assets/00bc0d4f-e78c-46e9-9aa8-79a1f9fa8acd)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is only a quick fix for https://github.com/Automattic/wp-calypso/issues/102401, to ensure both heading and subheading align left on mobile

I'm trying out a larger refactor in https://github.com/Automattic/wp-calypso/pull/102443 which is trying to lift the subheading data out of the main plans grid component. It's a bit more complicated though.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `http://calypso.localhost:3000/setup/onboarding`
* Test using a free domain, the sub heading has no text link and is left aligned on mobile
* Test using a paid domain, the sub heading has a text link and is left aligned on mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
