### PR TITLE
Fix: set Playground flow step container to 100%

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
@@ -1,4 +1,8 @@
-.playground__onboarding-iframe {
+.playground-v2 {
 	width: 100%;
-	height: 100%;
+
+	.playground__onboarding-iframe {
+		width: 100%;
+		height: 100%;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/102259

The PR above removed [this file](https://github.com/Automattic/wp-calypso/pull/102259/files#diff-7050ae94a8ace1b334fef20a2dc7d60f4306fd3158763355bcc02be570deae22) and then the Playground page became 300px wide.

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/a995e766-e9fc-4c54-aedf-4bc086445bf0" />

## Proposed Changes

* Add 100% width to Playground step container

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/setup/onboarding/playground and be sure the underlining iframe takes all the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
