### PR TITLE
i18n: Wrap the filters for marketing tools in translate calls

### DIFF
--- a/client/sites/marketing/tools/index.tsx
+++ b/client/sites/marketing/tools/index.tsx
@@ -20,12 +20,6 @@ import { getMarketingFeaturesData } from './marketing-features-data';
 
 import './style.scss';
 
-const items = [
-	{ key: '', text: 'All' },
-	{ key: 'new', text: 'New tools' },
-	{ key: 'favourite', text: 'User favorites' },
-];
-
 export default function MarketingTools() {
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
@@ -34,6 +28,11 @@ export default function MarketingTools() {
 	const searchRef = useRef< ImperativeHandle >( null );
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
+	const items = [
+		{ key: '', text: translate( 'All' ) },
+		{ key: 'new', text: translate( 'New tools' ) },
+		{ key: 'favourite', text: translate( 'User favorites' ) },
+	];
 
 	const marketingFeatures = getMarketingFeaturesData( selectedSiteSlug, translate, localizeUrl );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 968-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap the titles of the marketing tools filters in translate calls

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Currently the titles always appear in English, which is a problem for our non-English users.

## Testing Instructions
<img width="1115" alt="Screenshot 2025-04-07 at 15 06 36" src="https://github.com/user-attachments/assets/e42f20eb-7bb9-4947-a374-19db4b1fd574" />


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-English locale in wordpress.com.
* Open calypso.live and navigate to one of your sites, `/marketing/tools/{site}` URL.
* Confirm that the "All", "New tools", "User favorites" links still work and that the "All" label is translated into your selected language. The other labels would be translated this week.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
