### PR TITLE
A4A: Fix the 'Site settings' site list action to point to the the untangled page

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -405,7 +405,7 @@ export function useSiteActionsDataViews( {
 					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
-					window.open( `https://wordpress.com/settings/general/${ getBlogId( items[ 0 ] ) }` );
+					window.open( `https://wordpress.com/sites/settings/site/${ getSiteSlug( items[ 0 ] ) }` );
 					dispatch( recordTracksEvent( getActionEventName( 'site_settings', isLargeScreen ) ) );
 				},
 			},


### PR DESCRIPTION
Fixes DOTCOM-1860

## Proposed Changes

This PR updates the 'Site settings' action in the A4A sites list:

|Before|After|
|-|-|
|`/settings/general/`|`/sites/settings/site/`|

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/f5ca13aa-f48d-466c-884a-7973c2db7e3b" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes a regression, as the old URL will just redirect to `wp-admin/options-general.php`.

## Testing Instructions

Follow the instructions in the original issue, and verify that you can click on the `Site settings` action above and can still manage the settings:

<img width="976" alt="image" src="https://github.com/user-attachments/assets/059c696a-c6c0-4b81-8df1-619551004a5a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
