### PR TITLE
Sharing settings: update legacy Twitter button

### DIFF
--- a/client/sites/marketing/sharing/preview-button.jsx
+++ b/client/sites/marketing/sharing/preview-button.jsx
@@ -34,7 +34,7 @@ class SharingButtonsPreviewButton extends Component {
 			tumblr: 'tumblr-alt',
 			'jetpack-whatsapp': 'whatsapp',
 			'press-this': 'wordpress',
-			twitter: 'twitter-alt',
+			twitter: 'x',
 			more: 'share',
 		};
 		if ( ! this.props.button.custom ) {

--- a/client/sites/marketing/sharing/tray.jsx
+++ b/client/sites/marketing/sharing/tray.jsx
@@ -181,6 +181,11 @@ class SharingButtonsTray extends Component {
 	};
 
 	getButtonElements = () => {
+		// Hide the Twitter button, it's now replaced by X.
+		const filteredButtons = this.props.buttons.filter( ( button ) => {
+			return ! ( button.ID === 'twitter' && button.enabled === false );
+		} );
+
 		if ( this.state.isReordering ) {
 			const buttons = this.getButtonsOfCurrentVisibility().map( function ( button ) {
 				return <ButtonsPreviewButton key={ button.ID } button={ button } enabled style="text" />;
@@ -190,7 +195,7 @@ class SharingButtonsTray extends Component {
 		}
 		return (
 			<ButtonsPreviewButtons
-				buttons={ this.props.buttons }
+				buttons={ filteredButtons }
 				visibility={ this.props.visibility }
 				style="text"
 				showMore={ false }


### PR DESCRIPTION
## Proposed Changes

- Hide the button when it is not already in use
- Update the button's icon to use the new X logo

## Why are these changes being made?

This is done to match changes made in the Jetpack plugin, for the frontend side of the buttons:
https://github.com/Automattic/jetpack/pull/42813

## Testing Instructions

* Start with a test Jetpack site, connected to WordPress.com, and running the branch from the PR above. 
* Go to Jetpack > Settings > Sharing on that site's wp-admin dashboard, and enable the legacy sharing module.
* Follow the configuration link that appears to be redirected to Calypso. 
* Replace the Calypso URL domain to use the domain from your local insallation of Calypso, running `trunk`.
* You should see the legacy Twitter button available in the list of available sharing buttons, and you can add it as an active button.
* Save your changes.
* Now switch your Calypso install to run this branch.
* Refresh the Calypso URL
* You should still see the Twitter button, but it now uses the X icon. 
* Remove the button from the list of active sharing buttons on your site.
* You should not be able to add it back ; only the X button is available to add back.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
