### PR TITLE
Command Palette: Remove admin interface check on editor commands

### DIFF
--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -928,10 +928,7 @@ export function useCommands() {
 					'wp post create', // WP-CLI command
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/posts', { path: '/wp-admin/edit.php', match: 'exact' } ],
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/post-new.php' : '/post/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/post-new.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to add new post', __i18n_text_domain__ ),
 				capability: SiteCapabilities.EDIT_POSTS,
@@ -945,10 +942,7 @@ export function useCommands() {
 					_x( 'edit posts', 'Keyword for the Manage posts command', __i18n_text_domain__ ),
 					'wp post*', // WP-CLI command
 				].join( KEYWORD_SEPARATOR ),
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/edit.php' : '/posts/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/edit.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage posts', __i18n_text_domain__ ),
 				capability: SiteCapabilities.EDIT_POSTS,
@@ -1059,12 +1053,7 @@ export function useCommands() {
 					_x( 'edit pages', 'Keyword for the Manage pages command', __i18n_text_domain__ ),
 					_x( 'delete pages', 'Keyword for the Manage pages command', __i18n_text_domain__ ),
 				].join( KEYWORD_SEPARATOR ),
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/edit.php?post_type=page'
-							: '/pages/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/edit.php?post_type=page' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage pages', __i18n_text_domain__ ),
 				capability: SiteCapabilities.EDIT_PAGES,
@@ -1080,11 +1069,7 @@ export function useCommands() {
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/pages', '/wp-admin/edit.php?post_type=page' ],
 				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/post-new.php?post_type=page'
-							: '/page/:site'
-					)( params ),
+					commandNavigation( '/wp-admin/post-new.php?post_type=page' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to add new page', __i18n_text_domain__ ),
 				capability: SiteCapabilities.EDIT_PAGES,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DOTCOM-1720/remove-editor-iframe-entrypoints

## Proposed Changes

* As part of the RDV effort, we now want to remove entry points to the iframed editor to avoid unnecessary redirections.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to your site's home
* Open the command palette (`Ctrl + K`)
* For the following commands, check that they take you to the related wp-admin pages without a redirection:

|Command|Page|
|---|---|
|Add new post|`/wp-admin/post-new.php`|
|Manage posts|`/wp-admin/edit.php`|
|Manage pages|`/wp-admin/edit.php?post_type=page`|
|Add new page|`/wp-admin/post-new.php?post_type=page`|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
