### PR TITLE
Domains: Add `Transfer domain` button to Active domains card in site Overview

### DIFF
--- a/client/sites/overview/components/active-domains-card.tsx
+++ b/client/sites/overview/components/active-domains-card.tsx
@@ -65,6 +65,15 @@ const ActiveDomainsCard: FC = () => {
 					{ translate( 'Add new domain' ) }
 				</HostingCardLinkButton>
 				<HostingCardLinkButton
+					to={ `/domains/add/use-my-domain/${ site?.slug }?redirect_to=${ window.location.pathname }` }
+					hideOnMobile
+					onClick={ () =>
+						dispatch( recordTracksEvent( 'calypso_overview_transfer_domain_button_click' ) )
+					}
+				>
+					{ translate( 'Transfer domain' ) }
+				</HostingCardLinkButton>
+				<HostingCardLinkButton
 					to={ `/domains/manage/${ site?.slug }` }
 					onClick={ () =>
 						dispatch( recordTracksEvent( 'calypso_overview_manage_domains_button_click' ) )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100270#issuecomment-2776243137.

## Proposed Changes

* introduce a new `Transfer domain` link to the `Active domains` card:

![Markup on 2025-04-08 at 11:15:11](https://github.com/user-attachments/assets/8101fc17-df3e-4e03-be20-0bb291f74ed8)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This change is first of the updates outlined in https://github.com/Automattic/wp-calypso/issues/100270#issuecomment-2750646957.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch PR and build the app with `yarn start` (or use the Calypso Live link).
2. Head over to `http://calypso.localhost:3000/overview/{site-slug}` and scroll down to the `Active domains` card.
3. There should be a new `Transfer domain` button that should lead to the flow of transferring a an existing domain from elsewhere to WordPress.com.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
