### PR TITLE
Magic login: Redesign the check your inbox step

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
+++ b/client/login/magic-login/emailed-login-link-successfully-jetpack-connect.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useEffect } from 'react';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
@@ -12,11 +13,13 @@ import { withEnhancers } from 'calypso/state/utils';
 interface Props {
 	emailAddress: string;
 	shouldRedirect?: boolean;
+	onResendEmail: () => void;
 }
 
 const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 	emailAddress,
 	shouldRedirect = true,
+	onResendEmail,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -36,23 +39,49 @@ const EmailedLoginLinkSuccessfullyJetpackConnect: FC< Props > = ( {
 				/>
 			) }
 
-			<h1 className="magic-login__form-header">{ translate( 'Check your email!' ) }</h1>
+			<h1 className="magic-login__form-header">{ translate( 'Check your inbox' ) }</h1>
 
 			<p>
 				{ emailAddress
-					? translate( 'We just emailed a link to {{strong}}%(emailAddress)s{{/strong}}.', {
-							args: {
-								emailAddress,
-							},
+					? translate(
+							'We sent a message to {{strong}}%(emailAddress)s{{/strong}} with a link to log in to WordPress.com.',
+							{
+								args: {
+									emailAddress,
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+					  )
+					: translate( 'We sent a message to log in to WordPress.com' ) }
+			</p>
+			<p>{ preventWidows( translate( "Only one step left—we'll connect your site next." ) ) }</p>
+			<div className="magic-login__successfully-jetpack-actions">
+				<p>
+					{ translate(
+						"Didn't get the code? Check your spam folder or {{button}}resend the email{{/button}}",
+						{
 							components: {
-								strong: <strong />,
+								button: (
+									<Button
+										className="magic-login__resend-button"
+										variant="link"
+										onClick={ onResendEmail }
+									/>
+								),
 							},
-					  } )
-					: translate( 'We just emailed you a link.' ) }
-			</p>
-			<p>
-				{ preventWidows( translate( 'Please check your inbox and click the link to log in.' ) ) }
-			</p>
+						}
+					) }
+				</p>
+				<p>
+					{ translate( 'Wrong email or account? {{link}}Use a different account{{/link}}', {
+						components: {
+							link: <a className="magic-login__log-in-link" href="/log-in" />,
+						},
+					} ) }
+				</p>
+			</div>
 		</div>
 	);
 };

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -14,7 +14,6 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import GlobalNotices from 'calypso/components/global-notices';
 import GravatarLoginLogo from 'calypso/components/gravatar-login-logo';
-import JetpackHeader from 'calypso/components/jetpack-header';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -357,6 +356,25 @@ class MagicLogin extends Component {
 	renderGutenboardingLogo() {
 		if ( this.props.isWCCOM ) {
 			return null;
+		}
+
+		if ( this.props.isJetpackLogin ) {
+			return (
+				<div className="magic-login__gutenboarding-wordpress-logo">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+						fill="none"
+					>
+						<path
+							d="M12 0C9.62663 0 7.30655 0.703788 5.33316 2.02236C3.35977 3.34094 1.8217 5.21508 0.913451 7.4078C0.00519938 9.60051 -0.232441 12.0133 0.230582 14.3411C0.693605 16.6689 1.83649 18.807 3.51472 20.4853C5.19295 22.1635 7.33115 23.3064 9.65892 23.7694C11.9867 24.2324 14.3995 23.9948 16.5922 23.0865C18.7849 22.1783 20.6591 20.6402 21.9776 18.6668C23.2962 16.6934 24 14.3734 24 12C24 8.8174 22.7357 5.76515 20.4853 3.51472C18.2348 1.26428 15.1826 0 12 0ZM11.3684 13.9895H5.40632L11.3684 2.35579V13.9895ZM12.5811 21.6189V9.98526H18.5621L12.5811 21.6189Z"
+							fill="#069E08"
+						/>
+					</svg>
+				</div>
+			);
 		}
 
 		return (
@@ -1363,9 +1381,6 @@ class MagicLogin extends Component {
 
 		return (
 			<Main className="magic-login magic-login__request-link is-white-login">
-				{ this.props.isJetpackLogin && ! this.props.isFromAutomatticForAgenciesPlugin && (
-					<JetpackHeader />
-				) }
 				{ this.renderGutenboardingLogo() }
 				{ this.props.isFromAutomatticForAgenciesPlugin && (
 					<A4ALogo fullA4A size={ 58 } className="magic-login__a4a-logo" />

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -358,7 +358,7 @@ class MagicLogin extends Component {
 			return null;
 		}
 
-		if ( this.props.isJetpackLogin ) {
+		if ( this.props.isJetpackLogin && ! this.props.isFromAutomatticForAgenciesPlugin ) {
 			return (
 				<div className="magic-login__gutenboarding-wordpress-logo">
 					<svg

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -193,6 +193,7 @@ class RequestLoginEmailForm extends Component {
 				<EmailedLoginLinkSuccessfullyJetpackConnect
 					emailAddress={ emailAddress }
 					shouldRedirect={ ! isFromJetpackOnboarding }
+					onResendEmail={ this.onSubmit }
 				/>
 			) : (
 				<EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -237,16 +237,20 @@ class RequestLoginEmailForm extends Component {
 				<h1 className="magic-login__form-header">
 					{ headerText || translate( 'Email me a login link' ) }
 				</h1>
-				{ currentUser && currentUser.username && (
-					<p>
-						{ translate( 'NOTE: You are already logged in as user: %(user)s', {
-							args: {
-								user: currentUser.username,
-							},
-						} ) }
-					</p>
-				) }
 				<LoggedOutForm onSubmit={ onSubmit }>
+					{ currentUser && currentUser.username && (
+						<Notice
+							showDismiss={ false }
+							className="magic-login__form-header-notice"
+							status="is-info"
+							theme="light"
+							text={ translate( 'You are already logged in as user: %(user)s', {
+								args: {
+									user: currentUser.username,
+								},
+							} ) }
+						></Notice>
+					) }
 					{ ! hideSubHeaderText && (
 						<p className="magic-login__form-sub-header">{ this.getSubHeaderText() }</p>
 					) }

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -207,6 +207,10 @@
 			margin-bottom: 20px;
 		}
 	}
+
+	.magic-login__form-header-notice {
+		margin-top: 16px;
+	}
 }
 
 .magic-login__form-header {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -23,7 +23,54 @@
 }
 
 .layout.is-jetpack-login {
+	background-color: #fff;
+
 	.magic-login {
+		max-width: calc(450px + 48px);
+		margin-top: calc(96px - 48px);
+
+		@include break-small {
+			margin-top: calc(160px - 48px);
+		}
+
+		&.is-section-login {
+			min-height: 100%;
+			padding-bottom: 0;
+		}
+
+		.magic-login__form {
+			.magic-login__form-header {
+				padding: 0 24px 0 24px;
+			}
+		}
+
+		.magic-login__form-header {
+			margin-top: 0;
+			margin-bottom: 16px;
+
+			font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: 32px;
+			font-weight: 500;
+
+			text-align: initial;
+		}
+
+		.logged-out-form {
+			max-width: calc(450px + 48px);
+
+			> form {
+				margin: 0;
+			}
+		}
+
+		.magic-login__successfully-jetpack {
+			padding: 0 24px 0 24px;
+		}
+
+		.magic-login__footer {
+			max-width: 450px;
+		}
+
 		&__loading-spinner--jetpack {
 			color: var(--studio-jetpack-green-40, #069e08 );
 			height: 48px;
@@ -32,8 +79,34 @@
 			transform: translateX(-50%);
 			width: 48px;
 		}
-
 	}	
+}
+.magic-login__successfully-jetpack-actions {
+	color: var(--studio-jetpack-grey-50, #646970 );
+	font-size: 14px;
+	font-weight: 400;
+	line-height: 20px;
+	word-wrap: break-word;
+
+	margin-top: 45px;
+	margin-bottom: 45px;
+
+	.magic-login__resend-button {
+		font-size: 100%;
+		color: var(--studio-jetpack-green-60, #007117 );
+
+		&:hover {
+			color: var(--studio-jetpack-green-60, #007117 );
+		}
+	}
+
+	.magic-login__log-in-link {
+		color: var(--studio-jetpack-green-60, #007117 );
+	}
+
+	> p {
+		margin-bottom: 4px;
+	}
 }
 
 .layout.is-wpcom-magic-login {
@@ -128,11 +201,7 @@
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 		margin: 0 auto;
 		max-width: 400px;
-		padding: 16px;
-
-		@include breakpoint-deprecated( ">480px" ) {
-			padding: 24px;
-		}
+		padding: 0 24px;
 
 		p {
 			margin-bottom: 20px;
@@ -291,7 +360,7 @@
 	position: absolute;
 	left: 0;
 	top: 0;
-	padding: 0 16px;
+	padding: 0 24px;
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
@@ -311,12 +380,6 @@
 		@include break-mobile {
 			white-space: pre;
 		}
-	}
-}
-
-.magic-login__successfully-jetpack {
-	p {
-		text-align: center;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes MARTECH-68

Figma: rFuCe8Du2Ye6TMLP2kGwVO-fi-5135_9500

## Proposed Changes

* Hid the big Jetpack header image -- 248f75ccd4d5d164a3339b665de6d25ea78d56ee
* Updated the success compoenent -- 8aba2032ebc19b16e72575e82ec3be9adda2d966
  * Added the new button + link resend, or go back to user selection
  * Updated the text based on the figma files
* CSS changes to match designs  -- 1274690e8dfdc8ab93be2f716e4c0404e3ce0873

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Jurassic Ninja site and start the onboarding flow, and get to the magic link step, it should have `/log-in/jetpack` in the path.
* In an incognito tab change the url so the host is pointing to your local running Calypso with this PR, or the live branch address.
* You can use your a8c address and click send link.
* Make sure that the "Email sent" page looks like the designs, also check the mobile view - rFuCe8Du2Ye6TMLP2kGwVO-fi-5135_10259
* Make sure that the resend email button works as expected.
* Make sure that the use different account works as expected.
* Now check `log-in/link` and make sure that looks the same as before.

| Before | After |
|--------|--------|
| ![CleanShot 2025-04-07 at 21 44 24 png](https://github.com/user-attachments/assets/5eaef0e8-9920-4bfc-aba2-2d558188dc80) | ![CleanShot 2025-04-07 at 21 43 28 png](https://github.com/user-attachments/assets/c39723f4-4217-44bb-b6b8-c34abeacccf5) |
| ![CleanShot 2025-04-07 at 21 44 30 png](https://github.com/user-attachments/assets/35e7b384-986f-45df-9a55-c1d4d7982cb6) | ![CleanShot 2025-04-07 at 22 43 29 png](https://github.com/user-attachments/assets/bfb42a3a-df89-4881-8427-9df8339e783c) |
| ![CleanShot 2025-04-07 at 21 44 39 png](https://github.com/user-attachments/assets/682cb00b-a207-4277-9cca-04240c463235) | ![CleanShot 2025-04-07 at 21 43 50 png](https://github.com/user-attachments/assets/42249b9c-c1a3-41f6-a5fb-8504dcca0c77) |
| ![CleanShot 2025-04-07 at 21 44 48 png](https://github.com/user-attachments/assets/897d23df-dfb6-4624-a7c9-63f57a4455b6) | ![CleanShot 2025-04-07 at 22 44 44 png](https://github.com/user-attachments/assets/effad895-da37-4d79-889d-7304d6666fae) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?