### PR TITLE
Odie 20 percent time suggested responses

### DIFF
--- a/packages/help-center/src/components/help-center-chat.scss
+++ b/packages/help-center/src/components/help-center-chat.scss
@@ -35,7 +35,7 @@
 		}
 
 		.odie-send-message-input-spinner {
-			top: 28px;
+			top: 21px;
 			/* stylelint-disable-next-line length-zero-no-unit */
 			margin: 0px 11px 0px 0px;
 		}

--- a/packages/help-center/src/components/help-center-chat.scss
+++ b/packages/help-center/src/components/help-center-chat.scss
@@ -13,6 +13,7 @@
 
 	.odie-chat-message-input-container {
 		border-radius: 0;
+		min-height: 73px;
 
 		@media screen and (max-width: 660px) {
 			max-width: 100%;

--- a/packages/help-center/src/components/help-center-content.scss
+++ b/packages/help-center/src/components/help-center-content.scss
@@ -6,7 +6,7 @@
 		padding: 0;
 
 		.help-center__container-content-wrapper {
-			height: auto;
+			height: 100%;
 
 			> * {
 				box-sizing: border-box;

--- a/packages/odie-client/src/components/message/jump-to-recent.scss
+++ b/packages/odie-client/src/components/message/jump-to-recent.scss
@@ -2,7 +2,7 @@
 
 .odie-gradient-to-white {
 	position: absolute;
-	bottom: 0;
+	bottom: 60px;
 	left: 0;
 	right: 0;
 	z-index: 15;

--- a/packages/odie-client/src/components/message/jump-to-recent.scss
+++ b/packages/odie-client/src/components/message/jump-to-recent.scss
@@ -1,0 +1,68 @@
+@import '@automattic/color-studio/dist/color-variables';
+
+.odie-gradient-to-white {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	z-index: 15;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 16px 0;
+	background: linear-gradient( to bottom, rgba( 255, 255, 255, 0 ), rgba( 255, 255, 255, 0.95 ) );
+	pointer-events: none;
+	transform: translateY( 60px );
+
+	/* Animation for sliding up/down */
+	transition-property: transform;
+	transition-duration: 0.6s;
+	transition-timing-function: ease-out;
+
+	/* When visible, slide up to natural position */
+	&.is-visible {
+		transform: translateY( 0 );
+		opacity: 1;
+		pointer-events: auto;
+	}
+
+	/* Add a delay for pointer-events when disappearing */
+	&:not( .is-visible ) {
+		transition-property: transform;
+		transition-duration: 0.6s;
+		transition-timing-function: ease-out;
+		pointer-events: none;
+	}
+}
+
+.odie-jump-to-recent-message-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	background-color: #3858e9;
+	color: $studio-white;
+	border: none;
+	border-radius: 4px;
+	padding: 8px 16px;
+	font-size: 14px;
+	cursor: pointer;
+	box-shadow: 0 2px 4px rgba( 0, 0, 0, 0.1 );
+	transition:
+		transform 0.2s ease,
+		background-color 0.6s ease;
+
+	&:hover {
+		transform: translateY( -2px );
+		background-color: #2a48d9;
+	}
+
+	&:disabled {
+		pointer-events: none;
+	}
+
+	svg {
+		width: 16px;
+		height: 16px;
+	}
+}

--- a/packages/odie-client/src/components/message/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/jump-to-recent.tsx
@@ -62,7 +62,7 @@ export const JumpToRecent = ( {
 		} );
 	}, [] );
 
-	// Handle scrolling
+	// Handle scrolling using Intersection Observer on the last message
 	useEffect( () => {
 		const container = containerReference.current;
 		if ( ! container || isMinimized || chat.messages.length < 2 || chat.status !== 'loaded' ) {
@@ -73,49 +73,83 @@ export const JumpToRecent = ( {
 		// Update position initially
 		updatePosition();
 
-		const handleScroll = () => {
-			// If we're in the middle of jumping, skip the check
-			if ( isJumpingRef.current ) {
-				return;
-			}
-
-			// Get current scroll position and total height
-			const { scrollTop, scrollHeight, clientHeight } = container;
-
-			// Calculate how far we are from the bottom
-			const scrollBottom = scrollHeight - scrollTop - clientHeight;
-
-			// If we're at least 150px away from the bottom, show the button
-			const shouldBeVisible = scrollBottom > 150;
-
-			if ( shouldBeVisible && ! isVisible ) {
-				// Update position before showing
-				updatePosition();
-
-				// Show immediately
-				setIsVisible( true );
-
-				// Clear any pending hide
-				if ( visibilityTimeoutRef.current ) {
-					clearTimeout( visibilityTimeoutRef.current );
-					visibilityTimeoutRef.current = null;
+		// Create intersection observer
+		const observer = new IntersectionObserver(
+			( entries ) => {
+				// If we're in the middle of jumping, skip the check
+				if ( isJumpingRef.current ) {
+					return;
 				}
-			} else if ( ! shouldBeVisible && isVisible ) {
-				// Hide after a slight delay
-				if ( ! visibilityTimeoutRef.current ) {
-					visibilityTimeoutRef.current = setTimeout( () => {
-						setIsVisible( false );
+
+				const entry = entries[ 0 ];
+				// Show button when less than 10% of last message is visible
+				const shouldBeVisible = entry.intersectionRatio < 0.1;
+
+				if ( shouldBeVisible && ! isVisible ) {
+					// Update position before showing
+					updatePosition();
+
+					// Show immediately
+					setIsVisible( true );
+
+					// Clear any pending hide
+					if ( visibilityTimeoutRef.current ) {
+						clearTimeout( visibilityTimeoutRef.current );
 						visibilityTimeoutRef.current = null;
-					}, 300 ) as unknown as number;
+					}
+				} else if ( ! shouldBeVisible && isVisible ) {
+					// Hide after a slight delay
+					if ( ! visibilityTimeoutRef.current ) {
+						visibilityTimeoutRef.current = setTimeout( () => {
+							setIsVisible( false );
+							visibilityTimeoutRef.current = null;
+						}, 300 ) as unknown as number;
+					}
+				}
+			},
+			{
+				root: container,
+				threshold: [ 0, 0.1 ],
+			}
+		);
+
+		// Function to find and observe the last message
+		const observeLastMessage = () => {
+			// Simply get all children of the container
+			const children = Array.from( container.children );
+
+			if ( children.length > 0 ) {
+				// Get the last child element that is visible
+				for ( let i = children.length - 1; i >= 0; i-- ) {
+					const lastElement = children[ i ] as HTMLElement;
+					if ( lastElement.offsetParent !== null ) {
+						// Start observing the last visible element
+						observer.observe( lastElement );
+						return lastElement;
+					}
 				}
 			}
+			return null;
 		};
 
-		// Add scroll listener
-		container.addEventListener( 'scroll', handleScroll );
+		// Find and observe the last message
+		let lastMessageObserved = observeLastMessage();
 
-		// Check on initial render
-		const initialCheck = setTimeout( handleScroll, 500 );
+		// Set up a mutation observer to detect when new messages are added
+		const mutationObserver = new MutationObserver( () => {
+			// If we already have a last message, disconnect from it
+			if ( lastMessageObserved ) {
+				observer.unobserve( lastMessageObserved );
+			}
+			// Find and observe the new last message
+			lastMessageObserved = observeLastMessage();
+		} );
+
+		// Start observing changes to the container for any new messages
+		mutationObserver.observe( container, {
+			childList: true,
+			subtree: true,
+		} );
 
 		// Listen for resize and element changes
 		const resizeObserver = new ResizeObserver( () => {
@@ -138,8 +172,8 @@ export const JumpToRecent = ( {
 
 		// Clean up
 		return () => {
-			container.removeEventListener( 'scroll', handleScroll );
-			clearTimeout( initialCheck );
+			observer.disconnect();
+			mutationObserver.disconnect();
 			if ( visibilityTimeoutRef.current ) {
 				clearTimeout( visibilityTimeoutRef.current );
 			}

--- a/packages/odie-client/src/components/message/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/jump-to-recent.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
-import { RefObject, useCallback, useRef, useEffect, useState } from 'react';
+import { RefObject, useCallback, useEffect, useState, useRef } from 'react';
 import { useOdieAssistantContext } from '../../context';
+import './jump-to-recent.scss';
 
 export const JumpToRecent = ( {
 	containerReference,
@@ -10,63 +11,160 @@ export const JumpToRecent = ( {
 	containerReference: RefObject< HTMLDivElement >;
 } ) => {
 	const { trackEvent, isMinimized, chat } = useOdieAssistantContext();
-	const lastMessageRef = useRef< Element | null >( null );
-	const [ isLastMessageVisible, setIsLastMessageVisible ] = useState( false );
+	const [ isVisible, setIsVisible ] = useState( false );
+	const [ offsetStyle, setOffsetStyle ] = useState< React.CSSProperties >( {} );
+	const isJumpingRef = useRef( false );
+	const visibilityTimeoutRef = useRef< number | null >( null );
+	const buttonRef = useRef< HTMLDivElement >( null );
 
+	// Function to scroll to the most recent message
 	const jumpToRecent = useCallback( () => {
 		if ( containerReference.current && chat.messages.length > 0 ) {
-			const messages = containerReference.current?.querySelectorAll( '[data-is-message="true"]' );
-			const lastMessage = messages?.length ? messages[ messages.length - 1 ] : null;
-			lastMessage?.scrollIntoView( { behavior: 'smooth', block: 'start', inline: 'nearest' } );
+			// Mark that we're jumping
+			isJumpingRef.current = true;
+
+			// Scroll to bottom
+			containerReference.current.scrollTo( {
+				top: containerReference.current.scrollHeight,
+				behavior: 'smooth',
+			} );
+
+			trackEvent( 'chat_jump_to_recent_click' );
+
+			// Reset after animation completes
+			setTimeout( () => {
+				isJumpingRef.current = false;
+				setIsVisible( false );
+			}, 1000 );
 		}
-		trackEvent( 'chat_jump_to_recent_click' );
 	}, [ containerReference, trackEvent, chat.messages.length ] );
 
-	useEffect( () => {
-		if (
-			! containerReference.current ||
-			isMinimized ||
-			! chat.messages.length ||
-			chat.status !== 'loaded'
-		) {
+	// Calculate and update position based on other elements
+	const updatePosition = useCallback( () => {
+		const chatbox = document.querySelector( '.chatbox' );
+		if ( ! chatbox ) {
 			return;
 		}
 
-		const observer = new IntersectionObserver( ( entries ) => {
-			entries.forEach( ( entry ) => {
-				setIsLastMessageVisible( entry.isIntersecting );
-			} );
-		} );
+		// Get heights of dynamic elements
+		const noticeEl = chatbox.querySelector( '.odie-notice__container' );
+		const inputEl = chatbox.querySelector( '.odie-chat-message-input-container' );
 
-		const messages = containerReference.current?.querySelectorAll( '[data-is-message="true"]' );
-		const lastMessage = messages?.length ? messages[ messages.length - 1 ] : null;
-		if ( lastMessage ) {
-			lastMessageRef.current = lastMessage;
-			observer.observe( lastMessage );
+		const noticeHeight = noticeEl ? noticeEl.clientHeight : 0;
+		const inputHeight = inputEl ? inputEl.clientHeight : 0;
+
+		// Calculate total offset - we'll position the button above these elements
+		const totalOffset = noticeHeight + inputHeight;
+
+		// Apply position
+		setOffsetStyle( {
+			bottom: `${ totalOffset }px`,
+		} );
+	}, [] );
+
+	// Handle scrolling
+	useEffect( () => {
+		const container = containerReference.current;
+		if ( ! container || isMinimized || chat.messages.length < 2 || chat.status !== 'loaded' ) {
+			setIsVisible( false );
+			return;
 		}
 
-		return () => {
-			if ( lastMessageRef.current ) {
-				observer.unobserve( lastMessageRef.current );
+		// Update position initially
+		updatePosition();
+
+		const handleScroll = () => {
+			// If we're in the middle of jumping, skip the check
+			if ( isJumpingRef.current ) {
+				return;
+			}
+
+			// Get current scroll position and total height
+			const { scrollTop, scrollHeight, clientHeight } = container;
+
+			// Calculate how far we are from the bottom
+			const scrollBottom = scrollHeight - scrollTop - clientHeight;
+
+			// If we're at least 150px away from the bottom, show the button
+			const shouldBeVisible = scrollBottom > 150;
+
+			if ( shouldBeVisible && ! isVisible ) {
+				// Update position before showing
+				updatePosition();
+
+				// Show immediately
+				setIsVisible( true );
+
+				// Clear any pending hide
+				if ( visibilityTimeoutRef.current ) {
+					clearTimeout( visibilityTimeoutRef.current );
+					visibilityTimeoutRef.current = null;
+				}
+			} else if ( ! shouldBeVisible && isVisible ) {
+				// Hide after a slight delay
+				if ( ! visibilityTimeoutRef.current ) {
+					visibilityTimeoutRef.current = setTimeout( () => {
+						setIsVisible( false );
+						visibilityTimeoutRef.current = null;
+					}, 300 ) as unknown as number;
+				}
 			}
 		};
-	}, [ chat.messages.length ] );
 
-	if ( isMinimized || chat.messages.length < 2 || chat.status !== 'loaded' ) {
-		return null;
-	}
+		// Add scroll listener
+		container.addEventListener( 'scroll', handleScroll );
 
-	const className = clsx( 'odie-gradient-to-white', {
-		'is-visible': ! isLastMessageVisible,
-		'is-hidden': isLastMessageVisible,
-	} );
+		// Check on initial render
+		const initialCheck = setTimeout( handleScroll, 500 );
 
+		// Listen for resize and element changes
+		const resizeObserver = new ResizeObserver( () => {
+			updatePosition();
+		} );
+
+		// Observe the input container and notice for size changes
+		const chatbox = container.closest( '.chatbox' );
+		if ( chatbox ) {
+			const noticeEl = chatbox.querySelector( '.odie-notice__container' );
+			const inputEl = chatbox.querySelector( '.odie-chat-message-input-container' );
+
+			if ( noticeEl ) {
+				resizeObserver.observe( noticeEl );
+			}
+			if ( inputEl ) {
+				resizeObserver.observe( inputEl );
+			}
+		}
+
+		// Clean up
+		return () => {
+			container.removeEventListener( 'scroll', handleScroll );
+			clearTimeout( initialCheck );
+			if ( visibilityTimeoutRef.current ) {
+				clearTimeout( visibilityTimeoutRef.current );
+			}
+			resizeObserver.disconnect();
+		};
+	}, [
+		containerReference,
+		chat.messages.length,
+		chat.status,
+		isMinimized,
+		isVisible,
+		updatePosition,
+	] );
+
+	// Always render, but control visibility with CSS class
 	return (
-		<div className={ className }>
+		<div
+			ref={ buttonRef }
+			className={ clsx( 'odie-gradient-to-white', { 'is-visible': isVisible } ) }
+			style={ offsetStyle }
+		>
 			<button
 				className="odie-jump-to-recent-message-button"
-				disabled={ isLastMessageVisible }
 				onClick={ jumpToRecent }
+				disabled={ ! isVisible }
 			>
 				{ __( 'Jump to recent', __i18n_text_domain__ ) }
 				<Icon icon={ chevronDown } fill="white" />

--- a/packages/odie-client/src/components/message/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/jump-to-recent.tsx
@@ -65,7 +65,13 @@ export const JumpToRecent = ( {
 	// Handle scrolling using Intersection Observer on the last message
 	useEffect( () => {
 		const container = containerReference.current;
-		if ( ! container || isMinimized || chat.messages.length < 2 || chat.status !== 'loaded' ) {
+		if (
+			! container ||
+			isMinimized ||
+			chat.messages.length < 2 ||
+			chat.status !== 'loaded' ||
+			! chat.odieId
+		) {
 			setIsVisible( false );
 			return;
 		}
@@ -183,6 +189,7 @@ export const JumpToRecent = ( {
 		containerReference,
 		chat.messages.length,
 		chat.status,
+		chat.odieId, // Add odieId to dependencies to detect when chat is cleared
 		isMinimized,
 		isVisible,
 		updatePosition,
@@ -192,13 +199,15 @@ export const JumpToRecent = ( {
 	return (
 		<div
 			ref={ buttonRef }
-			className={ clsx( 'odie-gradient-to-white', { 'is-visible': isVisible } ) }
+			className={ clsx( 'odie-gradient-to-white', {
+				'is-visible': isVisible && chat.odieId, // Only show if chat is active and button should be visible
+			} ) }
 			style={ offsetStyle }
 		>
 			<button
 				className="odie-jump-to-recent-message-button"
 				onClick={ jumpToRecent }
-				disabled={ ! isVisible }
+				disabled={ ! isVisible || ! chat.odieId } // Disable if not visible or no active chat
 			>
 				{ __( 'Jump to recent', __i18n_text_domain__ ) }
 				<Icon icon={ chevronDown } fill="white" />

--- a/packages/odie-client/src/components/message/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/jump-to-recent.tsx
@@ -65,13 +65,7 @@ export const JumpToRecent = ( {
 	// Handle scrolling using Intersection Observer on the last message
 	useEffect( () => {
 		const container = containerReference.current;
-		if (
-			! container ||
-			isMinimized ||
-			chat.messages.length < 2 ||
-			chat.status !== 'loaded' ||
-			! chat.odieId
-		) {
+		if ( ! container || isMinimized || chat.messages.length < 2 || ! chat.odieId ) {
 			setIsVisible( false );
 			return;
 		}

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -4,7 +4,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { getShortDateString } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, forwardRef, ForwardedRef } from 'react';
 import { NavigationType, useNavigationType, useSearchParams } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import {
@@ -19,9 +19,7 @@ import {
 	interactionHasZendeskEvent,
 	interactionHasEnded,
 } from '../../utils';
-import { ViewMostRecentOpenConversationNotice } from '../odie-notice/view-most-recent-conversation-notice';
 import { DislikeFeedbackMessage } from './dislike-feedback-message';
-import { JumpToRecent } from './jump-to-recent';
 import { ThinkingPlaceholder } from './thinking-placeholder';
 import ChatMessage from '.';
 import type { Chat, CurrentUser } from '../../types';
@@ -46,175 +44,179 @@ interface ChatMessagesProps {
 	currentUser: CurrentUser;
 }
 
-export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport } =
-		useOdieAssistantContext();
-	const createZendeskConversation = useCreateZendeskConversation();
-	const resetSupportInteraction = useResetSupportInteraction();
-	const [ searchParams, setSearchParams ] = useSearchParams();
-	const isForwardingToZendesk =
-		searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk';
-	const [ hasForwardedToZendesk, setHasForwardedToZendesk ] = useState( false );
-	const [ chatMessagesLoaded, setChatMessagesLoaded ] = useState( false );
-	const [ shouldEnableAutoScroll, setShouldEnableAutoScroll ] = useState( true );
-	const navType: NavigationType = useNavigationType();
+export const MessagesContainer = forwardRef(
+	( { currentUser }: ChatMessagesProps, forwardedRef: ForwardedRef< HTMLDivElement > ) => {
+		const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport } =
+			useOdieAssistantContext();
+		const createZendeskConversation = useCreateZendeskConversation();
+		const resetSupportInteraction = useResetSupportInteraction();
+		const [ searchParams, setSearchParams ] = useSearchParams();
+		const isForwardingToZendesk =
+			searchParams.get( 'provider' ) === 'zendesk' && chat.provider !== 'zendesk';
+		const [ hasForwardedToZendesk, setHasForwardedToZendesk ] = useState( false );
+		const [ chatMessagesLoaded, setChatMessagesLoaded ] = useState( false );
+		const [ shouldEnableAutoScroll, setShouldEnableAutoScroll ] = useState( true );
+		const navType: NavigationType = useNavigationType();
 
-	const messagesContainerRef = useRef< HTMLDivElement >( null );
-	const scrollParentRef = useRef< HTMLElement | null >( null );
+		const scrollParentRef = useRef< HTMLElement | null >( null );
 
-	const { alreadyHasActiveZendeskChat, chatHasEnded } = useSelect( ( select ) => {
-		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
-		const currentInteraction = helpCenterSelect.getCurrentSupportInteraction();
-		return {
-			alreadyHasActiveZendeskChat:
-				interactionHasZendeskEvent( currentInteraction ) &&
-				! interactionHasEnded( currentInteraction ),
-			chatHasEnded: interactionHasEnded( currentInteraction ),
-		};
-	}, [] );
+		const { alreadyHasActiveZendeskChat, chatHasEnded } = useSelect( ( select ) => {
+			const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+			const currentInteraction = helpCenterSelect.getCurrentSupportInteraction();
+			return {
+				alreadyHasActiveZendeskChat:
+					interactionHasZendeskEvent( currentInteraction ) &&
+					! interactionHasEnded( currentInteraction ),
+				chatHasEnded: interactionHasEnded( currentInteraction ),
+			};
+		}, [] );
 
-	useZendeskMessageListener();
-	useAutoScroll( messagesContainerRef, shouldEnableAutoScroll );
-	useHelpCenterChatScroll( chat?.supportInteractionId, scrollParentRef, ! shouldEnableAutoScroll );
+		useZendeskMessageListener();
+		useAutoScroll( forwardedRef, shouldEnableAutoScroll );
+		useHelpCenterChatScroll(
+			chat?.supportInteractionId,
+			scrollParentRef,
+			! shouldEnableAutoScroll
+		);
 
-	useEffect( () => {
-		if ( navType === 'POP' && ( isChatLoaded || ! isUserEligibleForPaidSupport ) ) {
-			setShouldEnableAutoScroll( false );
-		}
-	}, [ navType, isUserEligibleForPaidSupport, shouldEnableAutoScroll, isChatLoaded ] );
-
-	useEffect( () => {
-		if ( messagesContainerRef.current && scrollParentRef.current === null ) {
-			scrollParentRef.current = messagesContainerRef.current?.closest(
-				'.help-center__container-content'
-			);
-		}
-	}, [ messagesContainerRef ] );
-	useUpdateDocumentTitle();
-
-	// prevent zd transfer for non-eligible users
-	useEffect( () => {
-		if ( isForwardingToZendesk && ! isUserEligibleForPaidSupport ) {
-			searchParams.delete( 'provider' );
-			setChatMessagesLoaded( true );
-		}
-	}, [ isForwardingToZendesk, isUserEligibleForPaidSupport, setChatMessagesLoaded ] );
-
-	useEffect( () => {
-		if ( isForwardingToZendesk || hasForwardedToZendesk ) {
-			return;
-		}
-
-		( chat?.status === 'loaded' || chat?.status === 'closed' ) && setChatMessagesLoaded( true );
-	}, [ chat?.status, isForwardingToZendesk, hasForwardedToZendesk ] );
-
-	/**
-	 * Handle the case where we are forwarding to Zendesk.
-	 */
-	useEffect( () => {
-		if (
-			isForwardingToZendesk &&
-			! hasForwardedToZendesk &&
-			! chat.conversationId &&
-			createZendeskConversation &&
-			resetSupportInteraction &&
-			isChatLoaded
-		) {
-			searchParams.delete( 'provider' );
-			searchParams.set( 'direct-zd-chat', '1' );
-			setSearchParams( searchParams );
-			setHasForwardedToZendesk( true );
-
-			// when forwarding to zd avoid creating new chats
-			if ( alreadyHasActiveZendeskChat ) {
-				setChatMessagesLoaded( true );
-			} else {
-				resetSupportInteraction().then( ( interaction ) => {
-					if ( isChatLoaded ) {
-						createZendeskConversation( {
-							avoidTransfer: true,
-							interactionId: interaction?.uuid,
-							section: searchParams.get( 'section' ),
-							createdFrom: 'direct_url',
-						} ).then( () => {
-							setChatMessagesLoaded( true );
-						} );
-					}
-				} );
+		useEffect( () => {
+			if ( navType === 'POP' && ( isChatLoaded || ! isUserEligibleForPaidSupport ) ) {
+				setShouldEnableAutoScroll( false );
 			}
-		}
-	}, [
-		isForwardingToZendesk,
-		hasForwardedToZendesk,
-		isChatLoaded,
-		chat?.conversationId,
-		resetSupportInteraction,
-		createZendeskConversation,
-		alreadyHasActiveZendeskChat,
-	] );
+		}, [ navType, isUserEligibleForPaidSupport, shouldEnableAutoScroll, isChatLoaded ] );
 
-	// Used to apply the correct styling on messages
-	const isNextMessageFromSameSender = ( currentMessage: string, nextMessage: string ) => {
-		return currentMessage === nextMessage;
-	};
+		useEffect( () => {
+			if ( forwardedRef && scrollParentRef.current === null ) {
+				scrollParentRef.current =
+					( forwardedRef as React.RefObject< HTMLDivElement > ).current?.closest(
+						'.help-center__container-content'
+					) ?? null;
+			}
+		}, [ forwardedRef ] );
+		useUpdateDocumentTitle();
 
-	const availableStatusWithFeedback = [ 'sending', 'transfer' ];
+		// prevent zd transfer for non-eligible users
+		useEffect( () => {
+			if ( isForwardingToZendesk && ! isUserEligibleForPaidSupport ) {
+				searchParams.delete( 'provider' );
+				setChatMessagesLoaded( true );
+			}
+		}, [ isForwardingToZendesk, isUserEligibleForPaidSupport, setChatMessagesLoaded ] );
 
-	return (
-		<>
-			<div className="chatbox-messages" ref={ messagesContainerRef }>
-				<ChatDate chat={ chat } />
-				{ ! chatMessagesLoaded ? (
-					<LoadingChatSpinner />
-				) : (
-					<>
-						{ ( chat.odieId || chat.provider === 'odie' ) && (
-							<ChatMessage
-								message={ getOdieInitialMessage( botNameSlug ) }
-								key={ 0 }
-								currentUser={ currentUser }
-								isNextMessageFromSameSender={ false }
-								displayChatWithSupportLabel={ false }
-							/>
-						) }
-						{ chat.messages.map( ( message, index ) => {
-							const nextMessage = chat.messages[ index + 1 ];
-							const displayChatWithSupportLabel =
-								! nextMessage?.context?.flags?.show_contact_support_msg &&
-								message.context?.flags?.show_contact_support_msg &&
-								! chatHasEnded;
+		useEffect( () => {
+			if ( isForwardingToZendesk || hasForwardedToZendesk ) {
+				return;
+			}
 
-							const displayChatWithSupportEndedLabel = ! nextMessage && chatHasEnded;
+			( chat?.status === 'loaded' || chat?.status === 'closed' ) && setChatMessagesLoaded( true );
+		}, [ chat?.status, isForwardingToZendesk, hasForwardedToZendesk ] );
 
-							return (
+		/**
+		 * Handle the case where we are forwarding to Zendesk.
+		 */
+		useEffect( () => {
+			if (
+				isForwardingToZendesk &&
+				! hasForwardedToZendesk &&
+				! chat.conversationId &&
+				createZendeskConversation &&
+				resetSupportInteraction &&
+				isChatLoaded
+			) {
+				searchParams.delete( 'provider' );
+				searchParams.set( 'direct-zd-chat', '1' );
+				setSearchParams( searchParams );
+				setHasForwardedToZendesk( true );
+
+				// when forwarding to zd avoid creating new chats
+				if ( alreadyHasActiveZendeskChat ) {
+					setChatMessagesLoaded( true );
+				} else {
+					resetSupportInteraction().then( ( interaction ) => {
+						if ( isChatLoaded ) {
+							createZendeskConversation( {
+								avoidTransfer: true,
+								interactionId: interaction?.uuid,
+								section: searchParams.get( 'section' ),
+								createdFrom: 'direct_url',
+							} ).then( () => {
+								setChatMessagesLoaded( true );
+							} );
+						}
+					} );
+				}
+			}
+		}, [
+			isForwardingToZendesk,
+			hasForwardedToZendesk,
+			isChatLoaded,
+			chat?.conversationId,
+			resetSupportInteraction,
+			createZendeskConversation,
+			alreadyHasActiveZendeskChat,
+		] );
+
+		// Used to apply the correct styling on messages
+		const isNextMessageFromSameSender = ( currentMessage: string, nextMessage: string ) => {
+			return currentMessage === nextMessage;
+		};
+
+		const availableStatusWithFeedback = [ 'sending', 'transfer' ];
+
+		return (
+			<>
+				<div className="chatbox-messages" ref={ forwardedRef }>
+					<ChatDate chat={ chat } />
+					{ ! chatMessagesLoaded ? (
+						<LoadingChatSpinner />
+					) : (
+						<>
+							{ ( chat.odieId || chat.provider === 'odie' ) && (
 								<ChatMessage
-									message={ message }
-									key={ index }
+									message={ getOdieInitialMessage( botNameSlug ) }
+									key={ 0 }
 									currentUser={ currentUser }
-									isNextMessageFromSameSender={ isNextMessageFromSameSender(
-										message.role,
-										chat.messages[ index + 1 ]?.role
-									) }
-									displayChatWithSupportLabel={ displayChatWithSupportLabel }
-									displayChatWithSupportEndedLabel={ displayChatWithSupportEndedLabel }
+									isNextMessageFromSameSender={ false }
+									displayChatWithSupportLabel={ false }
 								/>
-							);
-						} ) }
-						<JumpToRecent containerReference={ messagesContainerRef } />
-						{ chat.provider === 'odie' && (
-							<>
-								<ViewMostRecentOpenConversationNotice />
-								{ availableStatusWithFeedback.includes( chat.status ) && (
-									<div className="odie-chatbox__action-message">
-										{ chat.status === 'sending' && <ThinkingPlaceholder /> }
-										{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }
-									</div>
-								) }
-							</>
-						) }
-					</>
-				) }
-			</div>
-		</>
-	);
-};
+							) }
+							{ chat.messages.map( ( message, index ) => {
+								const nextMessage = chat.messages[ index + 1 ];
+								const displayChatWithSupportLabel =
+									! nextMessage?.context?.flags?.show_contact_support_msg &&
+									message.context?.flags?.show_contact_support_msg &&
+									! chatHasEnded;
+
+								const displayChatWithSupportEndedLabel = ! nextMessage && chatHasEnded;
+
+								return (
+									<ChatMessage
+										message={ message }
+										key={ index }
+										currentUser={ currentUser }
+										isNextMessageFromSameSender={ isNextMessageFromSameSender(
+											message.role,
+											chat.messages[ index + 1 ]?.role
+										) }
+										displayChatWithSupportLabel={ displayChatWithSupportLabel }
+										displayChatWithSupportEndedLabel={ displayChatWithSupportEndedLabel }
+									/>
+								);
+							} ) }
+							{ chat.provider === 'odie' && (
+								<>
+									{ availableStatusWithFeedback.includes( chat.status ) && (
+										<div className="odie-chatbox__action-message">
+											{ chat.status === 'sending' && <ThinkingPlaceholder /> }
+											{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }
+										</div>
+									) }
+								</>
+							) }
+						</>
+					) }
+				</div>
+			</>
+		);
+	}
+);

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -12,6 +12,7 @@ import {
 	useCreateZendeskConversation,
 	useZendeskMessageListener,
 	useUpdateDocumentTitle,
+	useSendChatMessage,
 } from '../../hooks';
 import { useHelpCenterChatScroll } from '../../hooks/use-help-center-chat-scroll';
 import {
@@ -47,8 +48,9 @@ interface ChatMessagesProps {
 
 export const MessagesContainer = forwardRef(
 	( { currentUser }: ChatMessagesProps, forwardedRef: ForwardedRef< HTMLDivElement > ) => {
-		const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport, sendMessage } =
+		const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport } =
 			useOdieAssistantContext();
+		const sendMessage = useSendChatMessage();
 		const createZendeskConversation = useCreateZendeskConversation();
 		const resetSupportInteraction = useResetSupportInteraction();
 		const [ searchParams, setSearchParams ] = useSearchParams();

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -4,7 +4,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { getShortDateString } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState, forwardRef, ForwardedRef } from 'react';
+import { useEffect, useRef, useState, forwardRef, ForwardedRef, useCallback } from 'react';
 import { NavigationType, useNavigationType, useSearchParams } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import {
@@ -19,6 +19,7 @@ import {
 	interactionHasZendeskEvent,
 	interactionHasEnded,
 } from '../../utils';
+import { PredictionLinks } from '../prediction-links';
 import { DislikeFeedbackMessage } from './dislike-feedback-message';
 import { ThinkingPlaceholder } from './thinking-placeholder';
 import ChatMessage from '.';
@@ -46,7 +47,7 @@ interface ChatMessagesProps {
 
 export const MessagesContainer = forwardRef(
 	( { currentUser }: ChatMessagesProps, forwardedRef: ForwardedRef< HTMLDivElement > ) => {
-		const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport } =
+		const { chat, botNameSlug, isChatLoaded, isUserEligibleForPaidSupport, sendMessage } =
 			useOdieAssistantContext();
 		const createZendeskConversation = useCreateZendeskConversation();
 		const resetSupportInteraction = useResetSupportInteraction();
@@ -70,6 +71,16 @@ export const MessagesContainer = forwardRef(
 				chatHasEnded: interactionHasEnded( currentInteraction ),
 			};
 		}, [] );
+
+		const lastMessage = chat.messages?.[ chat.messages.length - 1 ];
+		const predictions = lastMessage?.predictions;
+
+		const handlePredictionClick = useCallback(
+			( prediction: string, predictionKey: string ) => {
+				sendMessage( { content: prediction, role: 'user', type: 'message', predictionKey } );
+			},
+			[ sendMessage ]
+		);
 
 		useZendeskMessageListener();
 		useAutoScroll( forwardedRef, shouldEnableAutoScroll );
@@ -210,6 +221,13 @@ export const MessagesContainer = forwardRef(
 											{ chat.status === 'sending' && <ThinkingPlaceholder /> }
 											{ chat.status === 'dislike' && <DislikeFeedbackMessage /> }
 										</div>
+									) }
+									{ predictions && (
+										<PredictionLinks
+											predictions={ predictions }
+											onPredictionClick={ handlePredictionClick }
+											className="odie-prediction-links"
+										/>
 									) }
 								</>
 							) }

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -104,15 +104,16 @@ $blueberry-color: #3858e9;
 				margin-top: 0;
 			}
 
-			> *:not(:first-child) {
+			> *:not( :first-child ) {
 				padding-top: 8px;
 			}
 
-			> *:not(:last-child) {
+			> *:not( :last-child ) {
 				padding-bottom: 8px;
 			}
 
-			ol, ul {
+			ol,
+			ul {
 				padding-left: 20px;
 				padding-right: 20px;
 			}
@@ -157,7 +158,7 @@ $blueberry-color: #3858e9;
 						outline: none;
 					}
 					.gridicon {
-						fill: #1E1E1E;
+						fill: #1e1e1e;
 					}
 				}
 			}
@@ -182,7 +183,6 @@ $blueberry-color: #3858e9;
 					}
 				}
 			}
-
 		}
 
 		.disclaimer {
@@ -193,7 +193,8 @@ $blueberry-color: #3858e9;
 			text-align: start;
 			margin: 8px 0;
 
-			.odie-button-link, .components-external-link {
+			.odie-button-link,
+			.components-external-link {
 				color: $blueberry-color;
 			}
 
@@ -204,9 +205,9 @@ $blueberry-color: #3858e9;
 					text-decoration: none;
 				}
 
-				& > span:first-child::after { 
-					content: "\00a0";
-	
+				& > span:first-child::after {
+					content: '\00a0';
+
 					&:hover {
 						text-decoration: none;
 					}
@@ -220,7 +221,6 @@ $blueberry-color: #3858e9;
 					margin-left: 0;
 				}
 			}
-			
 		}
 	}
 
@@ -241,8 +241,8 @@ $blueberry-color: #3858e9;
 		}
 		.message-feedback-submit {
 			margin-left: 46px;
-			align-items: start ;
-	
+			align-items: start;
+
 			a {
 				gap: 4px;
 			}
@@ -559,19 +559,16 @@ $custom-border-corner-size: 16px;
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	height: 100px;
+	max-height: 73px;
 	justify-content: center;
-	z-index: 5;
+	z-index: 0;
 	pointer-events: none;
 	position: fixed;
 	width: 100%;
 
 	&.is-hidden {
-		opacity: 0;
-		bottom: 0 !important;
-		transition:
-			opacity 0.3s ease 0.3s,
-			bottom 0.3s ease 0.3s;
+		bottom: -48px !important;
+		transition: transform 0.3s ease 0.6s;
 
 		.odie-jump-to-recent-message-button {
 			pointer-events: none;
@@ -579,17 +576,13 @@ $custom-border-corner-size: 16px;
 	}
 
 	&.is-visible {
-		opacity: 1;
-		bottom: 24px;
-		transition:
-			opacity 0.3s ease 1.2s,
-			bottom 0.3s ease 1.2s;
+		bottom: -18px;
+		transition: transform 0.3s ease 0.6s;
 	}
 
 	.odie-jump-to-recent-message-button {
 		pointer-events: auto;
 		position: relative;
-		bottom: 24px;
 		font-family: $a8c-font-family-sans;
 		cursor: pointer;
 		margin: 0;
@@ -797,7 +790,7 @@ $custom-border-corner-size: 16px;
 }
 
 .odie__transfer-chat {
-	width: calc(100% - 80px)!important;
+	width: calc( 100% - 80px ) !important;
 	margin-top: 16px;
-    margin-left: 46px;
+	margin-left: 46px;
 }

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -191,7 +191,7 @@ $blueberry-color: #3858e9;
 			color: #000;
 			font-size: $font-body-extra-small;
 			text-align: start;
-			margin: 16px 0;
+			margin: 8px 0;
 
 			.odie-button-link, .components-external-link {
 				color: $blueberry-color;
@@ -228,7 +228,7 @@ $blueberry-color: #3858e9;
 		&.odie-question-collapse {
 			margin-top: 0;
 		}
-		margin-top: 32px;
+		margin-top: 8px;
 		font-size: 1rem;
 	}
 
@@ -749,7 +749,7 @@ $custom-border-corner-size: 16px;
 }
 
 .odie-chatbox-message-sources-container {
-	padding-bottom: 28px;
+	padding-bottom: 16px;
 
 	.foldable-card {
 		margin: 0 !important;

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -1,6 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import Markdown from 'react-markdown';
 import { ODIE_FORWARD_TO_FORUMS_MESSAGE, ODIE_FORWARD_TO_ZENDESK_MESSAGE } from '../../constants';
@@ -9,7 +6,6 @@ import { userProvidedEnoughInformation } from '../../utils';
 import CustomALink from './custom-a-link';
 import { DirectEscalationLink } from './direct-escalation-link';
 import { GetSupport } from './get-support';
-import Sources from './sources';
 import { uriTransformer } from './uri-transformer';
 import WasThisHelpfulButtons from './was-this-helpful-buttons';
 import type { Message } from '../../types';
@@ -63,29 +59,8 @@ export const UserMessage = ( {
 	const isMessageShowingDisclaimer =
 		message.context?.question_tags?.inquiry_type !== 'request-for-human-support';
 
-	const handleGuidelinesClick = () => {
-		trackEvent?.( 'ai_guidelines_link_clicked' );
-	};
-
 	const renderDisclaimers = () => (
 		<>
-			<div className="disclaimer">
-				{ createInterpolateElement(
-					__(
-						'Powered by Support AI. Some responses may be inaccurate. <a>Learn more</a>.',
-						__i18n_text_domain__
-					),
-					{
-						a: (
-							// @ts-expect-error Children must be passed to External link. This is done by createInterpolateElement, but the types don't see that.
-							<ExternalLink
-								href="https://automattic.com/ai-guidelines"
-								onClick={ handleGuidelinesClick }
-							/>
-						),
-					}
-				) }
-			</div>
 			{ showDirectEscalationLink && <DirectEscalationLink messageId={ message.message_id } /> }
 			{ ! isConnectedToZendesk && (
 				<WasThisHelpfulButtons message={ message } isDisliked={ isDisliked } />
@@ -113,7 +88,6 @@ export const UserMessage = ( {
 						'chat-feedback-wrapper-no-extra-contact': ! showExtraContactOptions,
 					} ) }
 				>
-					<Sources message={ message } />
 					{ showExtraContactOptions && renderExtraContactOptions() }
 					{ isMessageShowingDisclaimer && renderDisclaimers() }
 				</div>

--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { ODIE_THUMBS_DOWN_RATING_VALUE, ODIE_THUMBS_UP_RATING_VALUE } from '../../constants';
 import { useOdieAssistantContext } from '../../context';

--- a/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
+++ b/packages/odie-client/src/components/message/was-this-helpful-buttons.tsx
@@ -52,16 +52,6 @@ const WasThisHelpfulButtons = ( {
 		'odie-feedback-component-button-icon-pressed': rated && notLiked,
 	} );
 
-	const questionClasses = clsx( 'odie-feedback-component-question', {
-		'odie-question-out': rated,
-		'odie-question-hidden': rated,
-	} );
-
-	const thanksClasses = clsx( 'odie-feedback-component-thanks', {
-		'odie-thanks-in': rated,
-		'odie-thanks-hidden': ! rated,
-	} );
-
 	const buttonLikedClasses = clsx( 'odie-feedback-component-button', {
 		'odie-feedback-component-button-liked-pressed': rated && liked,
 		'odie-feedback-component-button-liked-disabled': rated && notLiked,
@@ -78,14 +68,6 @@ const WasThisHelpfulButtons = ( {
 
 	return (
 		<div className={ containerClasses }>
-			<div className="odie-feedback-message">
-				<span className={ questionClasses }>
-					{ __( 'Was this helpful?', __i18n_text_domain__ ) }
-				</span>
-				<span className={ thanksClasses }>
-					{ __( 'We appreciate your feedback.', __i18n_text_domain__ ) }
-				</span>
-			</div>
 			<span className="odie-feedback-component-button-container">
 				<button
 					className={ buttonLikedClasses }

--- a/packages/odie-client/src/components/odie-notice/style.scss
+++ b/packages/odie-client/src/components/odie-notice/style.scss
@@ -1,9 +1,10 @@
 .odie-notice {
 	display: flex;
-	padding: 0 16px;
 	font-size: 0.75rem;
-	position: absolute;
-	bottom: 86px;
+	width: 100%;
+	left: 0;
+	right: 0;
+	z-index: 20;
 
 	.odie-notice__container {
 		display: flex;
@@ -20,7 +21,7 @@
 		button {
 			align-self: flex-start;
 			background: none;
-    		border: none;
+			border: none;
 			&:hover {
 				cursor: pointer;
 			}

--- a/packages/odie-client/src/components/prediction-links/index.tsx
+++ b/packages/odie-client/src/components/prediction-links/index.tsx
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import type { MessagePrediction } from '../../types';
 import './styles.scss';
 
@@ -23,6 +22,7 @@ export const PredictionLinks = ( {
 
 	return (
 		<div className={ `odie-prediction-links ${ className }` }>
+			<p className="odie-prediction-links__title">SUGGESTED FOLLOW UPS</p>
 			{ predictionContent.map( ( prediction, index ) => (
 				<button
 					key={ index }
@@ -32,13 +32,6 @@ export const PredictionLinks = ( {
 					{ prediction }
 				</button>
 			) ) }
-
-			<button
-				className="odie-prediction-link odie-prediction-link__type-reply"
-				onClick={ () => onPredictionClick( 'custom-reply', 'custom_reply' ) }
-			>
-				{ __( 'Type your reply', __i18n_text_domain__ ) }
-			</button>
 		</div>
 	);
 };

--- a/packages/odie-client/src/components/prediction-links/index.tsx
+++ b/packages/odie-client/src/components/prediction-links/index.tsx
@@ -1,0 +1,41 @@
+import { __ } from '@wordpress/i18n';
+import type { MessagePrediction } from '../../types';
+
+type PredictionLinksProps = {
+	predictions: MessagePrediction;
+	onPredictionClick: ( prediction: string ) => void;
+	className?: string;
+};
+
+export const PredictionLinks = ( {
+	predictions,
+	onPredictionClick,
+	className = '',
+}: PredictionLinksProps ) => {
+	const predictionContent = [
+		predictions.best_reply,
+		predictions.best_second_reply,
+		predictions.best_third_reply,
+	];
+
+	return (
+		<div className={ `odie-prediction-links ${ className }` }>
+			{ predictionContent.map( ( prediction, index ) => (
+				<button
+					key={ index }
+					className="odie-prediction-link"
+					onClick={ () => onPredictionClick( prediction ) }
+				>
+					{ prediction }
+				</button>
+			) ) }
+
+			<button
+				className="odie-prediction-link odie-prediction-link__type-reply"
+				onClick={ () => onPredictionClick( 'custom-reply' ) }
+			>
+				{ __( 'Type your reply', __i18n_text_domain__ ) }
+			</button>
+		</div>
+	);
+};

--- a/packages/odie-client/src/components/prediction-links/index.tsx
+++ b/packages/odie-client/src/components/prediction-links/index.tsx
@@ -1,9 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import type { MessagePrediction } from '../../types';
+import './styles.scss';
 
 type PredictionLinksProps = {
 	predictions: MessagePrediction;
-	onPredictionClick: ( prediction: string ) => void;
+	onPredictionClick: ( prediction: string, predictionKey: string ) => void;
 	className?: string;
 };
 
@@ -18,13 +19,15 @@ export const PredictionLinks = ( {
 		predictions.best_third_reply,
 	];
 
+	const predictionKeys = [ 'best_reply_key', 'best_second_reply_key', 'best_third_reply_key' ];
+
 	return (
 		<div className={ `odie-prediction-links ${ className }` }>
 			{ predictionContent.map( ( prediction, index ) => (
 				<button
 					key={ index }
 					className="odie-prediction-link"
-					onClick={ () => onPredictionClick( prediction ) }
+					onClick={ () => onPredictionClick( prediction, predictionKeys[ index ] ) }
 				>
 					{ prediction }
 				</button>
@@ -32,7 +35,7 @@ export const PredictionLinks = ( {
 
 			<button
 				className="odie-prediction-link odie-prediction-link__type-reply"
-				onClick={ () => onPredictionClick( 'custom-reply' ) }
+				onClick={ () => onPredictionClick( 'custom-reply', 'custom_reply' ) }
 			>
 				{ __( 'Type your reply', __i18n_text_domain__ ) }
 			</button>

--- a/packages/odie-client/src/components/prediction-links/styles.scss
+++ b/packages/odie-client/src/components/prediction-links/styles.scss
@@ -1,0 +1,63 @@
+@import "@automattic/typography/styles/variables";
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.odie-prediction-links {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    padding: 0;
+    transition: all 0.3s ease-in-out;
+}
+
+.odie-prediction-link {
+    background: var(--color-surface, #fff);
+    border: 1px solid var(--color-border, #dcdcde);
+    color: var(--color-text, #1e1e1e);
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    width: 100%;
+    opacity: 0;
+    animation: fadeInUp 0.4s ease-out forwards;
+    
+    &:nth-child(1) {
+        animation-delay: 0.3s;
+    }
+    
+    &:nth-child(2) {
+        animation-delay: 0.6s;
+    }
+    
+    &:nth-child(3) {
+        animation-delay: 0.9s;
+    }
+    
+    &:nth-child(4) {
+        animation-delay: 1.2s;
+    }
+    
+    &:hover {
+        background: var(--color-surface-subtle, #f6f7f7);
+        border-color: var(--color-border-hover, #b3b3b3);
+        transform: translateY(-2px);
+    }
+}
+
+.odie-prediction-link__type-reply {
+    font-weight: 500;
+    color: var(--color-primary, var(--wp-admin-theme-color, #0073aa));
+}

--- a/packages/odie-client/src/components/prediction-links/styles.scss
+++ b/packages/odie-client/src/components/prediction-links/styles.scss
@@ -13,6 +13,7 @@
 
 .odie-prediction-links {
     padding-left: 64px;
+    padding-bottom: 16px;
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/packages/odie-client/src/components/prediction-links/styles.scss
+++ b/packages/odie-client/src/components/prediction-links/styles.scss
@@ -12,27 +12,26 @@
 }
 
 .odie-prediction-links {
+    padding-left: 32px;
     display: flex;
     flex-direction: column;
     gap: 8px;
-    width: 100%;
-    padding: 0;
     transition: all 0.3s ease-in-out;
 }
 
 .odie-prediction-link {
     background: var(--color-surface, #fff);
-    border: 1px solid var(--color-border, #dcdcde);
-    color: var(--color-text, #1e1e1e);
+    border: 1px solid var(--color-link, #dcdcde);
+    color: var(--color-link, #1e1e1e);
     text-align: left;
     padding: 0.75rem 1rem;
     border-radius: 4px;
     cursor: pointer;
     font-size: 14px;
     transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-    width: 100%;
     opacity: 0;
     animation: fadeInUp 0.4s ease-out forwards;
+    width: fit-content;
     
     &:nth-child(1) {
         animation-delay: 0.3s;
@@ -60,4 +59,11 @@
 .odie-prediction-link__type-reply {
     font-weight: 500;
     color: var(--color-primary, var(--wp-admin-theme-color, #0073aa));
+}
+
+.odie-prediction-links__title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text-subtle, #5a5a5a);
+    margin-bottom: 4px;
 }

--- a/packages/odie-client/src/components/prediction-links/styles.scss
+++ b/packages/odie-client/src/components/prediction-links/styles.scss
@@ -12,7 +12,7 @@
 }
 
 .odie-prediction-links {
-    padding-left: 32px;
+    padding-left: 64px;
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/zendesk-client';
 import { DropZone, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useRef, useState, useEffect } from '@wordpress/element';
+import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import React from 'react';
@@ -16,7 +16,6 @@ import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import { Message } from '../../types';
 import { zendeskMessageConverter } from '../../utils';
-import { PredictionLinks } from '../prediction-links';
 import { AttachmentButton } from './attachment-button';
 import { ResizableTextarea } from './resizable-textarea';
 
@@ -68,21 +67,6 @@ export const OdieSendMessageButton = () => {
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
 	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
 	const [ submitDisabled, setSubmitDisabled ] = useState( true );
-	const [ showTextarea, setShowTextarea ] = useState( false );
-
-	const lastMessage = chat.messages?.[ chat.messages.length - 1 ];
-	const predictions = lastMessage?.predictions;
-
-	useEffect( () => {
-		if ( chat?.messages?.length > 0 ) {
-			const lastMessage = chat.messages[ chat.messages.length - 1 ];
-			if ( lastMessage?.predictions ) {
-				setShowTextarea( false );
-			} else {
-				setShowTextarea( true );
-			}
-		}
-	}, [ chat?.messages ] );
 
 	const { data: authData } = useAuthenticateZendeskMessaging(
 		isUserEligibleForPaidSupport,
@@ -184,7 +168,6 @@ export const OdieSendMessageButton = () => {
 			}
 
 			trackEvent( 'chat_message_action_receive' );
-			setShowTextarea( false );
 		} catch ( e ) {
 			const error = e as Error;
 			trackEvent( 'chat_message_error', {
@@ -196,24 +179,9 @@ export const OdieSendMessageButton = () => {
 		}
 	}, [ isChatBusy, chat?.provider, trackEvent, sendMessage ] );
 
-	const handlePredictionClick = useCallback(
-		( prediction: string, predictionKey: string ) => {
-			if ( prediction === 'custom-reply' ) {
-				setShowTextarea( true );
-				setTimeout( () => {
-					inputRef.current?.focus();
-				}, 300 );
-			} else {
-				sendMessage( { content: prediction, role: 'user', type: 'message', predictionKey } );
-			}
-		},
-		[ sendMessage ]
-	);
-
 	const inputContainerClasses = clsx(
 		'odie-chat-message-input-container',
-		attachmentButtonRef?.current && 'odie-chat-message-input-container__attachment-button-visible',
-		! showTextarea && predictions && 'odie-chat-message-input-container__predictions-padding'
+		attachmentButtonRef?.current && 'odie-chat-message-input-container__attachment-button-visible'
 	);
 
 	const buttonClasses = clsx(
@@ -232,43 +200,35 @@ export const OdieSendMessageButton = () => {
 			) }
 
 			<div className={ inputContainerClasses } ref={ divContainerRef }>
-				{ ! showTextarea && predictions ? (
-					<PredictionLinks
-						predictions={ predictions }
-						onPredictionClick={ handlePredictionClick }
-						className="odie-prediction-links"
+				<form
+					onSubmit={ ( event ) => {
+						event.preventDefault();
+						sendMessageHandler();
+					} }
+					className="odie-send-message-input-container"
+				>
+					<ResizableTextarea
+						shouldDisableInputField={ isChatBusy || isAttachingFile || cantTransferToZendesk }
+						sendMessageHandler={ sendMessageHandler }
+						className="odie-send-message-input"
+						inputRef={ inputRef }
+						setSubmitDisabled={ setSubmitDisabled }
+						keyUpHandle={ onKeyUp }
+						onPasteHandle={ onPaste }
+						placeholder={ textAreaPlaceholder }
 					/>
-				) : (
-					<form
-						onSubmit={ ( event ) => {
-							event.preventDefault();
-							sendMessageHandler();
-						} }
-						className="odie-send-message-input-container"
-					>
-						<ResizableTextarea
-							shouldDisableInputField={ isChatBusy || isAttachingFile || cantTransferToZendesk }
-							sendMessageHandler={ sendMessageHandler }
-							className="odie-send-message-input"
-							inputRef={ inputRef }
-							setSubmitDisabled={ setSubmitDisabled }
-							keyUpHandle={ onKeyUp }
-							onPasteHandle={ onPaste }
-							placeholder={ textAreaPlaceholder }
+					{ isChatBusy && <Spinner className="odie-send-message-input-spinner" /> }
+					{ showAttachmentButton && (
+						<AttachmentButton
+							attachmentButtonRef={ attachmentButtonRef }
+							onFileUpload={ handleFileUpload }
+							isAttachingFile={ isAttachingFile }
 						/>
-						{ isChatBusy && <Spinner className="odie-send-message-input-spinner" /> }
-						{ showAttachmentButton && (
-							<AttachmentButton
-								attachmentButtonRef={ attachmentButtonRef }
-								onFileUpload={ handleFileUpload }
-								isAttachingFile={ isAttachingFile }
-							/>
-						) }
-						<button type="submit" className={ buttonClasses } disabled={ submitDisabled }>
-							<SendMessageIcon />
-						</button>
-					</form>
-				) }
+					) }
+					<button type="submit" className={ buttonClasses } disabled={ submitDisabled }>
+						<SendMessageIcon />
+					</button>
+				</form>
 			</div>
 
 			{ showAttachmentButton && (

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -6,15 +6,17 @@ import {
 } from '@automattic/zendesk-client';
 import { DropZone, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useCallback, useRef, useState } from '@wordpress/element';
+import { useCallback, useRef, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import React from 'react';
 import { SendMessageIcon } from '../../assets/send-message-icon';
 import { ODIE_WRONG_FILE_TYPE_MESSAGE } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import { Message } from '../../types';
 import { zendeskMessageConverter } from '../../utils';
+import { PredictionLinks } from '../prediction-links';
 import { AttachmentButton } from './attachment-button';
 import { ResizableTextarea } from './resizable-textarea';
 
@@ -24,7 +26,6 @@ const getFileType = ( file: File ) => {
 	if ( file.type.startsWith( 'image/' ) ) {
 		return 'image-placeholder';
 	}
-
 	return 'text';
 };
 
@@ -67,17 +68,34 @@ export const OdieSendMessageButton = () => {
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
 	const [ isMessageSizeValid, setIsMessageSizeValid ] = useState( true );
 	const [ submitDisabled, setSubmitDisabled ] = useState( true );
+	const [ showTextarea, setShowTextarea ] = useState( false );
+
+	const lastMessage = chat.messages?.[ chat.messages.length - 1 ];
+	const predictions = lastMessage?.predictions;
+
+	useEffect( () => {
+		if ( chat?.messages?.length > 0 ) {
+			const lastMessage = chat.messages[ chat.messages.length - 1 ];
+			if ( lastMessage?.predictions ) {
+				setShowTextarea( false );
+			} else {
+				setShowTextarea( true );
+			}
+		}
+	}, [ chat?.messages ] );
 
 	const { data: authData } = useAuthenticateZendeskMessaging(
 		isUserEligibleForPaidSupport,
 		'messenger'
 	);
+
 	const { zendeskClientId } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
 			zendeskClientId: helpCenterSelect.getZendeskClientId(),
 		};
 	}, [] );
+
 	const inferredClientId = chat.clientId ? chat.clientId : zendeskClientId;
 
 	const { isPending: isAttachingFile, mutateAsync: attachFileToConversation } =
@@ -130,23 +148,21 @@ export const OdieSendMessageButton = () => {
 	};
 
 	const onKeyUp = useCallback( () => {
-		// Only triggered when the message is empty
-		// used to remove validation message.
 		setIsMessageSizeValid( true );
 	}, [] );
 
 	const sendMessageHandler = useCallback( async () => {
 		const message = inputRef.current?.value.trim();
 		const messageLength = message?.length || 0;
-		const isMessageLengthValid = messageLength <= 4096; // zendesk api validation
+		const isMessageLengthValid = messageLength <= 4096;
 
 		setIsMessageSizeValid( isMessageLengthValid );
 
 		if ( message === '' || isChatBusy || ! isMessageLengthValid ) {
 			return;
 		}
+
 		const messageString = inputRef.current?.value;
-		// Immediately remove the message from the input field
 		if ( chat?.provider === 'odie' ) {
 			inputRef.current!.value = '';
 		}
@@ -161,14 +177,14 @@ export const OdieSendMessageButton = () => {
 			} as Message;
 
 			setSubmitDisabled( true );
-
 			await sendMessage( message );
-			// Removes the message from the input field after it has been sent
+
 			if ( chat?.provider === 'zendesk' ) {
 				inputRef.current!.value = '';
 			}
 
 			trackEvent( 'chat_message_action_receive' );
+			setShowTextarea( false );
 		} catch ( e ) {
 			const error = e as Error;
 			trackEvent( 'chat_message_error', {
@@ -179,6 +195,20 @@ export const OdieSendMessageButton = () => {
 			inputRef.current?.focus();
 		}
 	}, [ isChatBusy, chat?.provider, trackEvent, sendMessage ] );
+
+	const handlePredictionClick = useCallback(
+		( prediction: string ) => {
+			if ( prediction === 'custom-reply' ) {
+				setShowTextarea( true );
+				setTimeout( () => {
+					inputRef.current?.focus();
+				}, 300 );
+			} else {
+				sendMessage( { content: prediction, role: 'user', type: 'message' } );
+			}
+		},
+		[ sendMessage ]
+	);
 
 	const inputContainerClasses = clsx(
 		'odie-chat-message-input-container',
@@ -199,37 +229,47 @@ export const OdieSendMessageButton = () => {
 					{ __( 'Message exceeds 4096 characters limit.' ) }
 				</div>
 			) }
+
 			<div className={ inputContainerClasses } ref={ divContainerRef }>
-				<form
-					onSubmit={ ( event ) => {
-						event.preventDefault();
-						sendMessageHandler();
-					} }
-					className="odie-send-message-input-container"
-				>
-					<ResizableTextarea
-						shouldDisableInputField={ isChatBusy || isAttachingFile || cantTransferToZendesk }
-						sendMessageHandler={ sendMessageHandler }
-						className="odie-send-message-input"
-						inputRef={ inputRef }
-						setSubmitDisabled={ setSubmitDisabled }
-						keyUpHandle={ onKeyUp }
-						onPasteHandle={ onPaste }
-						placeholder={ textAreaPlaceholder }
+				{ ! showTextarea && predictions ? (
+					<PredictionLinks
+						predictions={ predictions }
+						onPredictionClick={ handlePredictionClick }
+						className="odie-prediction-links"
 					/>
-					{ isChatBusy && <Spinner className="odie-send-message-input-spinner" /> }
-					{ showAttachmentButton && (
-						<AttachmentButton
-							attachmentButtonRef={ attachmentButtonRef }
-							onFileUpload={ handleFileUpload }
-							isAttachingFile={ isAttachingFile }
+				) : (
+					<form
+						onSubmit={ ( event ) => {
+							event.preventDefault();
+							sendMessageHandler();
+						} }
+						className="odie-send-message-input-container"
+					>
+						<ResizableTextarea
+							shouldDisableInputField={ isChatBusy || isAttachingFile || cantTransferToZendesk }
+							sendMessageHandler={ sendMessageHandler }
+							className="odie-send-message-input"
+							inputRef={ inputRef }
+							setSubmitDisabled={ setSubmitDisabled }
+							keyUpHandle={ onKeyUp }
+							onPasteHandle={ onPaste }
+							placeholder={ textAreaPlaceholder }
 						/>
-					) }
-					<button type="submit" className={ buttonClasses } disabled={ submitDisabled }>
-						<SendMessageIcon />
-					</button>
-				</form>
+						{ isChatBusy && <Spinner className="odie-send-message-input-spinner" /> }
+						{ showAttachmentButton && (
+							<AttachmentButton
+								attachmentButtonRef={ attachmentButtonRef }
+								onFileUpload={ handleFileUpload }
+								isAttachingFile={ isAttachingFile }
+							/>
+						) }
+						<button type="submit" className={ buttonClasses } disabled={ submitDisabled }>
+							<SendMessageIcon />
+						</button>
+					</form>
+				) }
 			</div>
+
 			{ showAttachmentButton && (
 				<DropZone
 					onFilesDrop={ onFilesDrop }

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -197,14 +197,14 @@ export const OdieSendMessageButton = () => {
 	}, [ isChatBusy, chat?.provider, trackEvent, sendMessage ] );
 
 	const handlePredictionClick = useCallback(
-		( prediction: string ) => {
+		( prediction: string, predictionKey: string ) => {
 			if ( prediction === 'custom-reply' ) {
 				setShowTextarea( true );
 				setTimeout( () => {
 					inputRef.current?.focus();
 				}, 300 );
 			} else {
-				sendMessage( { content: prediction, role: 'user', type: 'message' } );
+				sendMessage( { content: prediction, role: 'user', type: 'message', predictionKey } );
 			}
 		},
 		[ sendMessage ]
@@ -212,7 +212,8 @@ export const OdieSendMessageButton = () => {
 
 	const inputContainerClasses = clsx(
 		'odie-chat-message-input-container',
-		attachmentButtonRef?.current && 'odie-chat-message-input-container__attachment-button-visible'
+		attachmentButtonRef?.current && 'odie-chat-message-input-container__attachment-button-visible',
+		! showTextarea && predictions && 'odie-chat-message-input-container__predictions-padding'
 	);
 
 	const buttonClasses = clsx(

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -7,6 +7,7 @@ $blueberry-color: #3858e9;
 	align-items: flex-end;
 	gap: 8px;
 	z-index: 10;
+	position: relative; /* Add positioning context for the spinner */
 
 	.odie-send-message-input {
 		resize: none;
@@ -41,8 +42,8 @@ $blueberry-color: #3858e9;
 
 .odie-send-message-input-spinner {
 	position: absolute !important;
-	right: 60px;
-	top: 20px;
+	right: 50px; /* Position it to the left of the send button */
+	transform: translateY(-50%); /* Fine-tune vertical centering */
 }
 
 .odie-send-message-input-container textarea {

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -18,6 +18,7 @@ $blueberry-color: #3858e9;
 		min-height: 40px !important;
 		height: 40px;
 		max-height: 210px;
+		overflow-y: auto;
 	}
 
 	.components-form-file-upload {
@@ -56,6 +57,8 @@ $blueberry-color: #3858e9;
 	transition: all .15s ease-in-out;
 	width: 100%;
 	font-family: inherit;
+	overflow: auto;
+	max-height: 210px;
 
 	&:focus {
 		box-shadow: 0 0 0 2px var(--color-primary-10);

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -7,7 +7,7 @@ $blueberry-color: #3858e9;
 	align-items: flex-end;
 	gap: 8px;
 	z-index: 10;
-	position: relative; /* Add positioning context for the spinner */
+	position: relative;
 
 	.odie-send-message-input {
 		resize: none;
@@ -42,8 +42,8 @@ $blueberry-color: #3858e9;
 
 .odie-send-message-input-spinner {
 	position: absolute !important;
-	right: 50px; /* Position it to the left of the send button */
-	transform: translateY(-50%); /* Fine-tune vertical centering */
+	right: 50px;
+	transform: translateY(-50%);
 }
 
 .odie-send-message-input-container textarea {
@@ -99,36 +99,4 @@ $blueberry-color: #3858e9;
 .odie-send-message-input-container .odie-send-message-inner-button img {
 	width: 24px;
 	height: 24px;
-}
-
-
-.odie-prediction-links {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-	width: 100%;
-	padding: 0;
-}
-
-.odie-prediction-link {
-	background: var(--color-surface, #fff);
-	border: 1px solid var(--color-border, #dcdcde);
-	color: var(--color-text, #1e1e1e);
-	text-align: left;
-	padding: 0.5rem 0.5rem;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 14px;
-	transition: background 0.2s ease, border-color 0.2s ease;
-	width: 100%;
-}
-
-.odie-prediction-link:hover {
-	background: var(--color-surface-subtle, #f6f7f7);
-	border-color: var(--color-border-hover, #b3b3b3);
-}
-
-.odie-prediction-link__type-reply {
-	font-weight: 500;
-	color: var(--color-primary, var(--wp-admin-theme-color, #0073aa));
 }

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -105,9 +105,9 @@ $blueberry-color: #3858e9;
 .odie-prediction-links {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 6px;
 	width: 100%;
-	padding: 0.5rem 0;
+	padding: 0;
 }
 
 .odie-prediction-link {
@@ -115,7 +115,7 @@ $blueberry-color: #3858e9;
 	border: 1px solid var(--color-border, #dcdcde);
 	color: var(--color-text, #1e1e1e);
 	text-align: left;
-	padding: 0.75rem 1rem;
+	padding: 0.5rem 0.5rem;
 	border-radius: 4px;
 	cursor: pointer;
 	font-size: 14px;

--- a/packages/odie-client/src/components/send-message-input/style.scss
+++ b/packages/odie-client/src/components/send-message-input/style.scss
@@ -96,3 +96,35 @@ $blueberry-color: #3858e9;
 	width: 24px;
 	height: 24px;
 }
+
+
+.odie-prediction-links {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	width: 100%;
+	padding: 0.5rem 0;
+}
+
+.odie-prediction-link {
+	background: var(--color-surface, #fff);
+	border: 1px solid var(--color-border, #dcdcde);
+	color: var(--color-text, #1e1e1e);
+	text-align: left;
+	padding: 0.75rem 1rem;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 14px;
+	transition: background 0.2s ease, border-color 0.2s ease;
+	width: 100%;
+}
+
+.odie-prediction-link:hover {
+	background: var(--color-surface-subtle, #f6f7f7);
+	border-color: var(--color-border-hover, #b3b3b3);
+}
+
+.odie-prediction-link__type-reply {
+	font-weight: 500;
+	color: var(--color-primary, var(--wp-admin-theme-color, #0073aa));
+}

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -126,6 +126,7 @@ export const useSendOdieMessage = () => {
 				simulateTyping: returnedChat.messages[ 0 ].simulateTyping,
 				type: 'message',
 				context: returnedChat.messages[ 0 ].context,
+				predictions: returnedChat.messages[ 0 ].predictions,
 			};
 			setExperimentVariationName( returnedChat.experiment_name );
 			addMessage( botMessage, { odieId: returnedChat.chat_id } );

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -72,6 +72,7 @@ export const useSendOdieMessage = () => {
 						apiNamespace: 'wpcom/v2',
 						body: {
 							message: message.content,
+							predictionKey: message.predictionKey,
 							...( version && { version } ),
 							context: { selectedSiteId },
 						},
@@ -81,6 +82,7 @@ export const useSendOdieMessage = () => {
 						method: 'POST',
 						data: {
 							message: message.content,
+							predictionKey: message.predictionKey,
 							...( version && { version } ),
 							context: { selectedSiteId },
 						},

--- a/packages/odie-client/src/hooks/use-auto-scroll.ts
+++ b/packages/odie-client/src/hooks/use-auto-scroll.ts
@@ -1,8 +1,8 @@
-import { RefObject, useEffect, useRef } from 'react';
+import { ForwardedRef, useEffect, useRef } from 'react';
 import { useOdieAssistantContext } from '../context';
 
 export const useAutoScroll = (
-	messagesContainerRef: RefObject< HTMLDivElement >,
+	messagesContainerRef: ForwardedRef< HTMLDivElement >,
 	isEnabled: boolean
 ) => {
 	const { chat } = useOdieAssistantContext();
@@ -37,9 +37,15 @@ export const useAutoScroll = (
 		debounceTimeoutIdRef.current = setTimeout( () => {
 			debounceTimeoutRef.current = 0;
 			requestAnimationFrame( () => {
-				const messages = messagesContainerRef.current?.querySelectorAll(
-					'[data-is-message="true"],.odie-chatbox__action-message'
-				);
+				const messages =
+					messagesContainerRef &&
+					'current' in messagesContainerRef &&
+					messagesContainerRef.current &&
+					messagesContainerRef.current instanceof HTMLDivElement
+						? messagesContainerRef.current.querySelectorAll(
+								'[data-is-message="true"],.odie-chatbox__action-message'
+						  )
+						: null;
 				let lastMessage = messages?.length ? messages[ messages.length - 1 ] : null;
 
 				if ( hasOdieReplied ) {
@@ -51,5 +57,5 @@ export const useAutoScroll = (
 			} );
 		}, debounceTimeoutRef.current ) as unknown as number;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ chat.messages.length, chat.status, messagesContainerRef.current, isEnabled ] );
+	}, [ chat.messages.length, chat.status, messagesContainerRef, isEnabled ] );
 };

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -28,9 +28,7 @@ export const OdieAssistant: React.FC = () => {
 
 	return (
 		<div className="chatbox">
-			<div className="chat-box-message-container" id="odie-messages-container">
-				<MessagesContainer currentUser={ currentUser } />
-			</div>
+			<MessagesContainer currentUser={ currentUser } />
 			{ showClosedConversationFooter ? <ClosedConversationFooter /> : <OdieSendMessageButton /> }
 		</div>
 	);

--- a/packages/odie-client/src/index.tsx
+++ b/packages/odie-client/src/index.tsx
@@ -1,9 +1,11 @@
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { useSelect } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { ClosedConversationFooter } from './components/closed-conversation-footer';
+import { JumpToRecent } from './components/message/jump-to-recent';
 import { MessagesContainer } from './components/message/messages-container';
+import { ViewMostRecentOpenConversationNotice } from './components/odie-notice/view-most-recent-conversation-notice';
 import { OdieSendMessageButton } from './components/send-message-input';
 import { useOdieAssistantContext, OdieAssistantProvider } from './context';
 import { interactionHasEnded } from './utils';
@@ -11,7 +13,8 @@ import { interactionHasEnded } from './utils';
 import './style.scss';
 
 export const OdieAssistant: React.FC = () => {
-	const { trackEvent, currentUser } = useOdieAssistantContext();
+	const { trackEvent, currentUser, chat } = useOdieAssistantContext();
+	const messagesContainerRef = useRef< HTMLDivElement >( null );
 	const { currentSupportInteraction } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -28,8 +31,14 @@ export const OdieAssistant: React.FC = () => {
 
 	return (
 		<div className="chatbox">
-			<MessagesContainer currentUser={ currentUser } />
-			{ showClosedConversationFooter ? <ClosedConversationFooter /> : <OdieSendMessageButton /> }
+			<div className="messages-wrapper">
+				<MessagesContainer currentUser={ currentUser } ref={ messagesContainerRef } />
+				<JumpToRecent containerReference={ messagesContainerRef } />
+			</div>
+			<div className="chatbox-footer">
+				{ chat.provider === 'odie' && <ViewMostRecentOpenConversationNotice /> }
+				{ showClosedConversationFooter ? <ClosedConversationFooter /> : <OdieSendMessageButton /> }
+			</div>
 		</div>
 	);
 };

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -106,4 +106,8 @@ $blueberry-blue: #3858e9;
 	padding: 16px;
 	background: var(--black-white-white, #fff);
 	border-top: 1px solid var(--gray-gray-5, #dcdcde);
+
+	&.odie-chat-message-input-container__predictions-padding {
+		padding: 8px;
+	}	
 }

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -2,12 +2,12 @@ $blueberry-blue: #3858e9;
 
 .chatbox {
 	width: 100%;
-	height: calc(100% - 138px);
+	height: 100%;
 	background-color: #f8f9fa;
 	display: flex;
 	flex-direction: column;
+	overflow: hidden;
 	justify-content: space-between;
-	align-items: flex-end;
 }
 
 .chatbox-toggle {
@@ -25,6 +25,7 @@ $blueberry-blue: #3858e9;
 }
 
 .chatbox-messages {
+	flex: 1;
 	overflow-y: auto;
 	overflow-x: hidden;
 	word-wrap: break-word;
@@ -34,13 +35,11 @@ $blueberry-blue: #3858e9;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	height: 100%;
 	overscroll-behavior: contain;
 	padding-top: 16px;
-
-	&:has(.odie-notice) {
-		margin-bottom: 135px;
-	}
+	background-color: #fff;
+	min-height: 0;
+	justify-content: flex-start;
 
 	.odie-chatbox-bottom-edge {
 		min-height: 8px;
@@ -52,9 +51,6 @@ $blueberry-blue: #3858e9;
 		display: flex;
 		flex-direction: column;
 		align-items: flex-end;
-		&:last-of-type > .odie-chatbox-message-sources-container {
-			margin-bottom: 64px;
-		}
 	}
 	
 	.chatbox-loading-chat__spinner {
@@ -85,12 +81,6 @@ $blueberry-blue: #3858e9;
 	justify-content: flex-start;
 }
 
-.chat-box-message-container {
-	width: 100%;
-	height: 100%;
-	background-color: #fff;
-}
-
 .using-environment-badge {
 	margin-bottom: 86px;
 	height: calc(100vh - 120px - 86px);
@@ -110,18 +100,10 @@ $blueberry-blue: #3858e9;
 }
 
 .odie-chat-message-input-container, .odie-closed-conversation-footer {
-	z-index: 10;
-	position: fixed;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	max-width: 410px;
 	flex-shrink: 0;
+	width: 100%;
 	box-sizing: border-box;
-	border-radius: 4px;
-	border-top-left-radius: 0;
-	border-top-right-radius: 0;
 	padding: 16px;
-	border-top: 1px solid var(--gray-gray-5, #dcdcde);
 	background: var(--black-white-white, #fff);
+	border-top: 1px solid var(--gray-gray-5, #dcdcde);
 }

--- a/packages/odie-client/src/style.scss
+++ b/packages/odie-client/src/style.scss
@@ -8,13 +8,28 @@ $blueberry-blue: #3858e9;
 	flex-direction: column;
 	overflow: hidden;
 	justify-content: space-between;
+	position: relative;
+}
+
+.messages-wrapper {
+	flex: 1;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.chatbox-footer {
+	flex-shrink: 0;
+	position: relative;
+	background: #fff;
 }
 
 .chatbox-toggle {
 	padding: 0;
 	background-color: transparent;
 	z-index: 999;
-	transform: translateX(0);
+	transform: translateX( 0 );
 	transition: transform 0.5s ease-in-out;
 	outline: none !important;
 	box-shadow: none !important;
@@ -52,7 +67,7 @@ $blueberry-blue: #3858e9;
 		flex-direction: column;
 		align-items: flex-end;
 	}
-	
+
 	.chatbox-loading-chat__spinner {
 		display: flex;
 		width: 100%;
@@ -70,7 +85,7 @@ $blueberry-blue: #3858e9;
 		justify-content: center;
 		width: 100%;
 		padding-bottom: 16px;
-		color: var(--studio-gray-50);
+		color: var( --studio-gray-50 );
 		font-size: 0.75rem;
 	}
 }
@@ -83,7 +98,7 @@ $blueberry-blue: #3858e9;
 
 .using-environment-badge {
 	margin-bottom: 86px;
-	height: calc(100vh - 120px - 86px);
+	height: calc( 100vh - 120px - 86px );
 }
 
 .chatbox-header-button {
@@ -99,15 +114,18 @@ $blueberry-blue: #3858e9;
 	width: 100%;
 }
 
-.odie-chat-message-input-container, .odie-closed-conversation-footer {
+.odie-chat-message-input-container,
+.odie-closed-conversation-footer {
 	flex-shrink: 0;
 	width: 100%;
 	box-sizing: border-box;
 	padding: 16px;
-	background: var(--black-white-white, #fff);
-	border-top: 1px solid var(--gray-gray-5, #dcdcde);
+	background: var( --black-white-white, #fff );
+	border-top: 1px solid var( --gray-gray-5, #dcdcde );
+	position: relative;
+	z-index: 10;
 
 	&.odie-chat-message-input-container__predictions-padding {
 		padding: 8px;
-	}	
+	}
 }

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -147,6 +147,12 @@ export type MessageType =
 	| 'image'
 	| 'introduction';
 
+export type MessagePrediction = {
+	best_reply: string;
+	best_second_reply: string;
+	best_third_reply: string;
+};
+
 export type Message = {
 	content: string;
 	context?: Context;
@@ -160,6 +166,7 @@ export type Message = {
 	type: MessageType;
 	directEscalationSupport?: boolean;
 	created_at?: string;
+	predictions?: MessagePrediction | null;
 };
 
 export type ChatStatus = 'loading' | 'loaded' | 'sending' | 'dislike' | 'transfer' | 'closed';

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -4,7 +4,7 @@ import type { ReactNode, PropsWithChildren, SetStateAction } from 'react';
 export type OdieAssistantContextInterface = {
 	isChatLoaded: boolean;
 	canConnectToZendesk: boolean;
-	addMessage: ( message: Message | Message[] ) => void;
+	addMessage: ( message: Message | Message[], prediction?: string ) => void;
 	botName?: string;
 	botNameSlug: OdieAllowedBots;
 	chat: Chat;
@@ -167,6 +167,7 @@ export type Message = {
 	directEscalationSupport?: boolean;
 	created_at?: string;
 	predictions?: MessagePrediction | null;
+	predictionKey?: string | null;
 };
 
 export type ChatStatus = 'loading' | 'loaded' | 'sending' | 'dislike' | 'transfer' | 'closed';

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -15,6 +15,7 @@ export type OdieAssistantContextInterface = {
 	isMinimized?: boolean;
 	isUserEligibleForPaidSupport: boolean;
 	extraContactOptions?: ReactNode;
+	messagesContainerRef?: React.RefObject< HTMLDivElement > | null;
 	odieBroadcastClientId: string;
 	selectedSiteId?: number | null;
 	selectedSiteURL?: string | null;
@@ -25,6 +26,7 @@ export type OdieAssistantContextInterface = {
 	setMessageLikedStatus: ( message: Message, liked: boolean ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
+	setMessagesContainerRef?: ( ref: React.RefObject< HTMLDivElement > ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
 	version?: string | null;
 	setWaitAnswerToFirstMessageFromHumanSupport: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Rework the chat container so that the scrollbar fits correctly and adds future possible predictions

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These changes were part of the 20% time

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please test the whole experience
1. Chat with the assistant
2. Clear conversations
3. Rate messages
4. Start new conversation
5. Transfero to ZD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
