### PR TITLE
Fixes the alignment in the Blaze campaign payment section

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -6,6 +6,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, DropdownMenu, Spinner } from '@wordpress/components';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { chevronDown, chevronLeft, Icon } from '@wordpress/icons';
+import clsx from 'clsx';
 import cookie from 'cookie';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment/moment';
@@ -1390,7 +1391,11 @@ export default function CampaignItemDetails( props: Props ) {
 												<div className="campaign-item-details__weekly-orders-seperator"></div>
 											</div>
 										) }
-										<div className="campaign-item-details__secondary-payment-row">
+										<div
+											className={ clsx( 'campaign-item-details__secondary-payment-row', {
+												'no-payment-method': ! payment_method || ! card_name,
+											} ) }
+										>
 											{ payment_method && card_name && (
 												<>
 													<div className="campaign-item-details__payment-method">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -538,6 +538,11 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			justify-content: space-between;
 			width: 100%;
 
+			&.no-payment-method {
+				display: grid;
+				grid-template-columns: 100%;
+			}
+
 			@media (max-width: ($break-medium + 425)) {
 				display: grid;
 				grid-template-columns: 100%;


### PR DESCRIPTION
Related to DSP #3377

## Proposed Changes

* Fixes an alignment issue in the payment section for the campaign details page that only happens when the DSP returns partial information in the billing data section.

## Why are these changes being made?

There is an alignment issue when the DSP sends incomplete information in the Blaze campaign payment section on the campaign details page:

![Screenshot 2025-04-07 at 12 17 03 PM](https://github.com/user-attachments/assets/d34cd4d9-b51a-4820-9939-532a7ffcd936)

This only happens if the DSP doesn't send payment method information, which is not happening in production. 

However, we are working on changing that on the DSP side, and we will start always sending the payment information (regardless of whether we have payment method data). The main idea here is to provide users as much information as we can, even if we are not able to get the payment method name (e.g., if a user chooses not to store the credit card information in our systems).


## Testing Instructions

* Checkout this branch and start calypso locally
* Go to the file `client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx` line 241, and make these changes:
```
	const { credits, total, orders, payment_links } = billing_data || {};
	const payment_method = undefined;
	const card_name = undefined;
```
* Now, go to the campaign details page for one of your completed campaigns (with at least one payment associated with it)
* Verify that the section is correctly aligned
![Screenshot 2025-04-07 at 1 23 35 PM](https://github.com/user-attachments/assets/cf287300-cf04-4455-b8b9-9554af0e85d7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
