### PR TITLE
Stats: Handle products endpoint error on Subscribers Stats

### DIFF
--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -65,14 +65,21 @@ export const handleMembershipProductsList = dispatchRequest( {
 			action
 		),
 	fromApi: function ( endpointResponse ) {
+		// If the response has an error, return an empty array for products.
+		if ( endpointResponse.hasOwnProperty( 'error' ) ) {
+			return [];
+		}
+
 		const products = endpointResponse.products.map( membershipProductFromApi );
 		return products;
 	},
-	onSuccess: ( { siteId }, products ) => ( {
-		type: MEMBERSHIPS_PRODUCTS_RECEIVE,
-		siteId,
-		products,
-	} ),
+	onSuccess: ( { siteId }, products ) => {
+		return {
+			type: MEMBERSHIPS_PRODUCTS_RECEIVE,
+			siteId,
+			products,
+		};
+	},
 	onError: noop,
 } );
 

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -73,13 +73,11 @@ export const handleMembershipProductsList = dispatchRequest( {
 		const products = endpointResponse.products.map( membershipProductFromApi );
 		return products;
 	},
-	onSuccess: ( { siteId }, products ) => {
-		return {
-			type: MEMBERSHIPS_PRODUCTS_RECEIVE,
-			siteId,
-			products,
-		};
-	},
+	onSuccess: ( { siteId }, products ) => ( {
+		type: MEMBERSHIPS_PRODUCTS_RECEIVE,
+		siteId,
+		products,
+	} ),
 	onError: noop,
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jpop-issues/issues/9681.

## Proposed Changes

* Handle the error within the successful API response to determine if the endpoint loading is finished.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The endpoint `/wpcom/v2/sites/{site-id}/memberships/products` returns an error within the status `200` response when the Jetpack API of the site is unavailable. So we need to [handle the exception like Odyssey Stats](https://github.com/Automattic/wp-calypso/blob/55f3537dbe62e399f86f6eaf7c237cc51098e710/apps/odyssey-stats/src/components/odyssey-query-memberships.ts#L22).

<img width="633" alt="截圖 2025-04-08 凌晨1 07 46" src="https://github.com/user-attachments/assets/58fb74be-7ee3-4162-8903-0809d24a271e" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the local Calypso.
* Navigate to Stats > Subscribers page of the reported user site using the Support User tool.
* Ensure the chart finishes loading when the API endpoint `/wpcom/v2/sites/{site-id}/memberships/products` is loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
