### PR TITLE
Purchases: Prevent showing "Renew now" buttons if canExplicitRenew is false

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -106,6 +106,7 @@ import {
 	getName,
 	shouldRenderMonthlyRenewalOption,
 	getDIFMTieredPurchaseDetails,
+	canExplicitRenew,
 } from 'calypso/lib/purchases';
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
@@ -374,6 +375,10 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
+		if ( ! canExplicitRenew( purchase ) ) {
+			return null;
+		}
+
 		if ( this.isPendingDomainRegistration( purchase ) ) {
 			return null;
 		}
@@ -458,6 +463,10 @@ class ManagePurchase extends Component<
 				! isMarketplaceTemporarySitePurchase( purchase ) ) ||
 			isAkismetFreeProduct( purchase )
 		) {
+			return null;
+		}
+
+		if ( ! canExplicitRenew( purchase ) ) {
 			return null;
 		}
 
@@ -1474,6 +1483,10 @@ class ManagePurchase extends Component<
 		) {
 			showExpiryNotice = isCloseToExpiration( purchase );
 			preventRenewal = ! isRenewable( purchase );
+		}
+
+		if ( ! canExplicitRenew( purchase ) ) {
+			preventRenewal = true;
 		}
 
 		return (


### PR DESCRIPTION
## Proposed Changes

This PR modifies the purchase management page so that if the `canExplicitRenew` property of the purchase (from the `can_explicit_renew` property returned by the `/me/purchases` endpoint) is false, the "Renew now" buttons will not be displayed.

Part of https://linear.app/a8c/issue/SHILL-652/cannot-change-auto-renewal-setting-for-recent-purchases

Before 179865-ghe-Automattic/wpcom            |  After 179865-ghe-Automattic/wpcom | After this PR
:-------------------------:|:-------------------------:|:-------------------------:
<img width="1057" alt="Screenshot 2025-04-07 at 3 32 11 PM" src="https://github.com/user-attachments/assets/50197287-9372-4631-8f48-1806f6ab91f1" /> | <img width="1052" alt="Screenshot 2025-04-07 at 3 32 30 PM" src="https://github.com/user-attachments/assets/3e55b78f-4f35-47da-b913-214e5bcfc87c" /> | <img width="1054" alt="Screenshot 2025-04-07 at 3 32 51 PM" src="https://github.com/user-attachments/assets/cccad432-b3ba-4c56-a0bb-8db2171b1e01" />


## Why are these changes being made?

The `can_explicit_renew` property determines if a subscription can be manually renewed right now (as opposed to the `is_renewable` property which determines if the subscription is the kind of subscription that can be manually renewed).

This is specifically so that 179865-ghe-Automattic/wpcom will work but it does not require that diff and it's probably a good idea anyway.

## Testing Instructions

- Apply 179865-ghe-Automattic/wpcom and sandbox the API.
- Purchase a renewing subscription.
- Visit the purchase management page in calypso for that subscription.
- Verify that you don't see any "Renew now" buttons (note that there are usually at least two: a small one in the header and a large one below the subscription information).
- View the purchase management page for a subscription that is no longer refundable.
- Verify that you see at least two "Renew now" buttons.