### PR TITLE
StepContainerV2: Fix max-width calculations which are supposed to be based on column widths

### DIFF
--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
@@ -9,7 +9,9 @@
 	width: 100%;
 	box-sizing: border-box;
 	flex: 1;
-	max-width: var( --step-container-v2-content-max-width );
+	max-width: calc(
+		var( --step-container-v2-content-max-width ) + 2 * var( --step-container-v2-content-inline-padding )
+	);
 
 	&.padding {
 		padding: var( --step-container-v2-content-block-padding )
@@ -17,21 +19,15 @@
 	}
 
 	&.wide {
-		--step-container-v2-content-max-width: calc(
-			#{$break-wide} + 2 * var( --step-container-v2-content-inline-padding )
-		);
+		--step-container-v2-content-max-width: #{$break-wide};
 	}
 
 	&.huge {
-		--step-container-v2-content-max-width: calc(
-			#{$break-huge} + 2 * var( --step-container-v2-content-inline-padding )
-		);
+		--step-container-v2-content-max-width: #{$break-huge};
 	}
 
 	&.xhuge {
-		--step-container-v2-content-max-width: calc(
-			#{$break-xhuge} + 2 * var( --step-container-v2-content-inline-padding )
-		);
+		--step-container-v2-content-max-width: #{$break-xhuge};
 	}
 
 	&.center-aligned {
@@ -41,8 +37,13 @@
 		);
 	}
 
-	--step-container-v2-content-column-width: calc(
-		var( --step-container-v2-content-max-width ) / 12
-	);
 	--step-container-v2-content-column-gap: 16px;
+
+	--step-container-v2-content-max-width-minus-column-gaps: calc(
+		var( --step-container-v2-content-max-width ) - 11 * var( --step-container-v2-content-column-gap )
+	);
+
+	--step-container-v2-content-column-width: calc(
+		var( --step-container-v2-content-max-width-minus-column-gaps ) / 12
+	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

Fixes bugs in width calculations of the `ContentWrapper` and `ContentRow` components from step container V2.

Previously the widths were failing to account for the gaps between the 12 columns.

Discovered here p1744063408526339/1744019850.570839-slack-C08HKNPL2BG

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `calypso.localhost:3000/setup/onboarding`
* Go through the onboarding flow
* Try logged out too to test the account step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?