### PR TITLE
E2E Tests: Fix Social tests for Manual Sharing

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -74,7 +74,7 @@ if ( envVariables.JETPACK_TARGET === 'wpcom-deployment' ) {
 /**
  * Tests features offered by Jetpack Social on a Simple site with Free plan.
  *
- * Keywords: Social, Jetpack, Publicize
+ * Keywords: Social, Jetpack, Publicize, Editor
  */
 describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () {
 	for ( const { plan, platform, testAccountName, features } of testCases ) {

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -253,11 +253,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 					name: 'Manual sharing',
 				} );
 
-				// For some reason the manual sharing is not visible on the post publish panel for Simple sites with a paid plan.
-				const isPostPublishManualSharingVisible =
-					features.manualSharing && ! ( platform === 'Simple' && plan !== 'Free' );
-
-				if ( isPostPublishManualSharingVisible ) {
+				if ( features.manualSharing ) {
 					await manualSharing.waitFor();
 				}
 


### PR DESCRIPTION
Currently, there is a special case for Social Manual sharing feature on some sites [here](https://github.com/Automattic/wp-calypso/blob/57688961668b1f5930bf6efabeebf19bf11ae352/test/e2e/specs/jetpack/social__editor-features.ts#L240-L242). It was actually a bug which is being fixed via https://github.com/Automattic/jetpack/pull/42958.

So, this PR removes that special case to have the tests reflect the expected behavior

## Proposed Changes

* Remove the special case for Social Manual sharing in E2E tests

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should be happy after https://github.com/Automattic/jetpack/pull/42958 is deployed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
