### PR TITLE
A4A: Fix Client checkout v2 post-redirect flow.

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -142,7 +142,7 @@ function ClientCheckoutContent() {
 		<div className="client-checkout-v2">
 			<CheckoutMain
 				sitelessCheckoutType="a4a"
-				redirectTo="/client/subscriptions"
+				redirectTo={ window.location.origin + '/client/subscriptions' }
 				isInModal={ false }
 				siteSlug=""
 				siteId={ 0 }

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -235,6 +235,7 @@ export default function useCreatePaymentCompleteCallback( {
 					siteSlug,
 					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
 					receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
+					fromExternalCheckout: sitelessCheckoutType === 'a4a',
 				} );
 				return;
 			}
@@ -252,6 +253,7 @@ export default function useCreatePaymentCompleteCallback( {
 					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
 					receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
 					fromSiteSlug,
+					fromExternalCheckout: sitelessCheckoutType === 'a4a',
 				} );
 				return;
 			}
@@ -259,10 +261,14 @@ export default function useCreatePaymentCompleteCallback( {
 			reloadCart().catch( () => {
 				// No need to do anything here. CartMessages will report this error to the user.
 			} );
+
+			debug( 'redirect through pending' );
+
 			redirectThroughPending( url, {
 				siteSlug,
 				orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,
 				receiptId: 'receipt_id' in transactionResult ? transactionResult.receipt_id : undefined,
+				fromExternalCheckout: sitelessCheckoutType === 'a4a',
 			} );
 		},
 		[

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -261,9 +261,6 @@ export default function useCreatePaymentCompleteCallback( {
 			reloadCart().catch( () => {
 				// No need to do anything here. CartMessages will report this error to the user.
 			} );
-
-			debug( 'redirect through pending' );
-
 			redirectThroughPending( url, {
 				siteSlug,
 				orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -213,13 +213,8 @@ export function addUrlToPendingPageRedirect(
 	if ( fromSiteSlug ) {
 		successUrlObject.searchParams.set( 'from_site_slug', fromSiteSlug );
 	}
-	if ( urlType === 'relative' ) {
-		return (
-			( fromExternalCheckout ? 'https://wordpress.com' : '' ) +
-			successUrlObject.pathname +
-			successUrlObject.search +
-			successUrlObject.hash
-		);
+	if ( urlType === 'relative' && ! fromExternalCheckout ) {
+		return successUrlObject.pathname + successUrlObject.search + successUrlObject.hash;
 	}
 	return successUrlObject.href;
 }

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -21,6 +21,11 @@ export interface PendingPageRedirectOptions {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
+	/**
+	 * `fromExternalCheckout` is a boolean that indicates if the checkout is coming from an external checkout (e.g. A4A client checkout).
+	 *  If this is true, we will force to use https://wordpress.com as the origin for the pending page.
+	 */
+	fromExternalCheckout?: boolean;
 }
 
 export interface RedirectInstructions {
@@ -176,6 +181,9 @@ export function absoluteRedirectThroughPending(
  * If `receiptId` is provided, it means the transaction is already complete and
  * may cause the pending page to redirect immediately to the `url`.
  *
+ * If `fromExternalCheckout` is true, it means the checkout is coming from an external checkout (e.g. A4A client checkout).
+ * In this case, we will force to use https://wordpress.com as the origin for the pending page.
+ *
  * You should always specify `urlType` as either 'absolute' or 'relative' but
  * it will default to 'absolute'.
  */
@@ -189,13 +197,16 @@ export function addUrlToPendingPageRedirect(
 		urlType = 'absolute',
 		receiptId = ':receiptId',
 		fromSiteSlug,
+		fromExternalCheckout,
 	} = options;
 
 	const { origin = 'https://wordpress.com' } = typeof window !== 'undefined' ? window.location : {};
 	const successUrlPath =
 		`/checkout/thank-you/${ siteSlug || 'no-site' }/pending/` +
 		( orderId ? `${ orderId }` : ':orderId' );
-	const successUrlBase = `${ origin }${ successUrlPath }`;
+	const successUrlBase = `${
+		fromExternalCheckout ? 'https://wordpress.com' : origin
+	}${ successUrlPath }`;
 	const successUrlObject = new URL( successUrlBase );
 	successUrlObject.searchParams.set( 'redirect_to', url );
 	successUrlObject.searchParams.set( 'receiptId', String( receiptId ) );
@@ -203,7 +214,12 @@ export function addUrlToPendingPageRedirect(
 		successUrlObject.searchParams.set( 'from_site_slug', fromSiteSlug );
 	}
 	if ( urlType === 'relative' ) {
-		return successUrlObject.pathname + successUrlObject.search + successUrlObject.hash;
+		return (
+			( fromExternalCheckout ? 'https://wordpress.com' : '' ) +
+			successUrlObject.pathname +
+			successUrlObject.search +
+			successUrlObject.hash
+		);
 	}
 	return successUrlObject.href;
 }
@@ -255,6 +271,8 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 		'cloud.jetpack.com',
 		'jetpack.com',
 		'akismet.com',
+		'agencies.automattic.com',
+		'agencies.localhost',
 		siteSlug,
 	];
 


### PR DESCRIPTION
This PR addresses the post-redirect bug from the new checkout page https://github.com/Automattic/wp-calypso/pull/101385.

Depends on https://github.com/Automattic/wp-calypso/pull/101385


## Proposed Changes

* To ensure the dotcom checkout process operates properly, we need to direct users to the Pending page for post-processing. However, because the A4A client checkout operates outside the dotcom domain, we must modify the logic to allow the Checkout component to identify an A4A siteless checkout and automatically redirect to the dotcom Pending page. Currently, the page redirects to `/thank-you/no-site/pending/:orderId`, which is not available in the **agencies.automattic.com** domain, so we must ensure the logic incorporates the absolute path `https://wordpress.com/thank-you/no-site/pending/:orderId`.
* Furthermore, it is essential to provide the absolute path for the `redirectTo` property. This will enable the Pending page to correctly determine where to redirect the user following post-processing. 

## Why are these changes being made?

* This modification is essential for enabling external checkouts, such as the A4A client, to operate with the current dotcom checkout components.

## Testing Instructions


* Follow the test instructions from https://github.com/Automattic/wp-calypso/pull/101385
* And complete a checkout.
* Confirm that you are not redirected to a missing page. See the example image below. 
   ![Screenshot 2025-04-01 at 7 52 39 PM](https://github.com/user-attachments/assets/42032b43-2b5f-4978-8dda-08c53fc8cba4)
* You should see the screen displayed below. (**NOTE: The final flow will redirect back to the Subscription page. However, since we are redirecting to https://wordpress.com, which does not have the complete changes, it doesn't recognize 'redirectTo' as an allowable host. This issue should be resolved once we merge this PR.**)
   <img width="1710" alt="Screenshot 2025-04-08 at 7 27 23 PM" src="https://github.com/user-attachments/assets/bb1faca3-d633-433e-88ed-ede631ef71f1" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
