### PR TITLE
Update site-editor-quick-start course

### DIFF
--- a/client/components/videos-ui/style.scss
+++ b/client/components/videos-ui/style.scss
@@ -133,6 +133,17 @@
 				width: 100%;
 				height: auto;
 			}
+
+			.videos-ui__resource-links {
+				ul {
+					margin: 0;
+
+					li {
+						list-style: none;
+						margin-bottom: 8px;
+					}
+				}
+			}
 		}
 
 		.videos-ui__chapters {

--- a/client/components/videos-ui/test/video-player.jsx
+++ b/client/components/videos-ui/test/video-player.jsx
@@ -26,7 +26,8 @@ describe( 'Video player', () => {
 		renderer.render( <VideoPlayer intent="build" course={ course } videoData={ videoData } /> );
 		const result = renderer.getRenderOutput();
 
-		result.props.children.props.onPlay();
+		// Video element.
+		result.props.children[ 0 ].props.onPlay();
 
 		expect( window._tkq.push ).toHaveBeenCalledWith( [
 			'recordEvent',
@@ -42,7 +43,8 @@ describe( 'Video player', () => {
 		renderer.render( <VideoPlayer course={ course } videoData={ videoData } /> );
 		const result = renderer.getRenderOutput();
 
-		result.props.children.props.onPlay();
+		// Video element.
+		result.props.children[ 0 ].props.onPlay();
 
 		expect( window._tkq.push ).toHaveBeenCalledWith( [
 			'recordEvent',

--- a/client/components/videos-ui/video-player.jsx
+++ b/client/components/videos-ui/video-player.jsx
@@ -1,3 +1,5 @@
+import { ExternalLink } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import { createRef, useEffect, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
@@ -9,9 +11,11 @@ const VideoPlayer = ( {
 	onVideoCompleted,
 	intent,
 } ) => {
+	const translate = useTranslate();
 	const [ shouldCheckForVideoComplete, setShouldCheckForVideoComplete ] = useState( true );
 
 	const videoRef = createRef();
+	const resourceLinks = videoData.resource_links || [];
 
 	const markVideoAsComplete = () => {
 		if ( videoRef.current.currentTime < videoData.completed_seconds ) {
@@ -51,6 +55,14 @@ const VideoPlayer = ( {
 		} );
 	};
 
+	const trackResourceLinkClick = ( url ) => {
+		recordTracksEvent( 'calypso_courses_video_resource_link_click', {
+			course: course.slug,
+			video: videoData.slug,
+			url,
+		} );
+	};
+
 	return (
 		<div key={ videoData.url } className="videos-ui__video">
 			<video
@@ -65,6 +77,26 @@ const VideoPlayer = ( {
 				{ /* @TODO: check if tracks are available, the linter demands one */ }
 				<track src="caption.vtt" kind="captions" srcLang="en" label="english_captions" />
 			</video>
+
+			{ resourceLinks.length > 0 && (
+				<div className="videos-ui__resource-links">
+					<h3>{ translate( 'Resource links' ) }</h3>
+					<ul>
+						{ resourceLinks.map( ( link, index ) => (
+							<li key={ index }>
+								<ExternalLink
+									href={ link.url }
+									target="_blank"
+									icon
+									onClick={ () => trackResourceLinkClick( link.url ) }
+								>
+									{ link.text }
+								</ExternalLink>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/data/courses/use-course-details.ts
+++ b/client/data/courses/use-course-details.ts
@@ -41,13 +41,13 @@ const useCourseDetails = ( courseSlug: CourseSlug ): CourseDetails | undefined =
 		};
 	} else if ( courseSlug === COURSE_SLUGS.SITE_EDITOR_QUICK_START ) {
 		return {
-			headerTitle: translate( 'Watch four videos.' ),
-			headerSubtitle: translate( 'Save yourself hours.' ),
+			headerTitle: translate( 'Build your website.' ),
+			headerSubtitle: translate( 'Launch your dream.' ),
 			headerSummary: [
-				translate( 'Master the building blocks of a WordPress site' ),
-				translate( 'Understand how to add your style to your site' ),
-				translate( 'Upskill now to save hours later' ),
-				translate( 'Set yourself up for creative success' ),
+				translate( 'Choose a theme to suit your vision' ),
+				translate( 'Set up your site’s essential pages' ),
+				translate( 'Customize the design to suit your needs' ),
+				translate( 'Share your website with the world' ),
 			],
 		};
 	}

--- a/client/my-sites/customer-home/cards/education/site-editor-quick-start/index.jsx
+++ b/client/my-sites/customer-home/cards/education/site-editor-quick-start/index.jsx
@@ -15,9 +15,9 @@ const SiteEditorQuickStart = () => {
 
 	return (
 		<EducationalContent
-			title={ translate( 'Design like an expert' ) }
+			title={ translate( 'Course: Create your website' ) }
 			description={ translate(
-				'Master the basics of Site Editing with four short videos. Learn how to edit colors, fonts, layouts, and bring your style to your site.'
+				'In this series of videos, we’ll walk you through the process of designing your website and publishing it online.'
 			) }
 			modalLinks={ [
 				{
@@ -31,7 +31,7 @@ const SiteEditorQuickStart = () => {
 						courseSlug: COURSE_SLUGS.SITE_EDITOR_QUICK_START,
 					},
 					onClick: openModal,
-					text: translate( 'Start learning' ),
+					text: translate( 'Start course' ),
 				},
 			] }
 			illustration={ startLearningPrompt }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://linear.app/a8c/issue/DOTCOM-1818/task-update-quick-start-videos-on-calypso-my-home

## Proposed Changes

Site Editor Quick Start course update.

| Before | After |
| --- | --- |
| ![Screenshot 2025-04-08 at 7 43 31 PM](https://github.com/user-attachments/assets/aedfff67-d751-4f64-9a22-7a8b6c8eef5b) | ![Screenshot 2025-04-08 at 7 42 35 PM](https://github.com/user-attachments/assets/b79832b3-5a84-4e9c-a1c9-a61d5b08d72c) |

| Before | After |
| --- | --- |
| ![Screenshot 2025-04-08 at 7 44 11 PM](https://github.com/user-attachments/assets/285868c7-70f3-4bae-a9a6-ec06ee88006c) | ![Screenshot 2025-04-08 at 7 41 19 PM](https://github.com/user-attachments/assets/afa90dff-17a7-475a-a353-0f303c09da21) | 

This PR also introduces a "Resource links" section

![Screenshot 2025-04-10 at 3 34 49 PM](https://github.com/user-attachments/assets/723e4031-3df3-40e9-ad24-a6bb62733d70)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Learning resources update.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /home/:domain
* Ensure that the card is updated as shown above
* Click the card CTA
* Ensure that the course is updated as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
