### PR TITLE
Remove Free entirely from the onboarding-affiliate flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -577,7 +577,7 @@ export function generateFlows( {
 			enableHotjar: true,
 			props: {
 				[ 'plans-affiliate' ]: {
-					deemphasizeFreePlan: true,
+					offeringFreePlan: false,
 				},
 				domains: {
 					allowSkipWithoutSearch: true,

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -199,7 +199,7 @@ export const usePlanTypesWithIntent = ( {
 			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
 		case 'plans-affiliate':
-			planTypes = [ TYPE_FREE, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-site-selected-legacy':
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];


### PR DESCRIPTION
Follow-up to #102264

## Proposed Changes

* Remove the Free plan from the onboarding-affiliate flow

## Why are these changes being made?

* Per Kei's request on pau2Xa-6Rd-p2


## Testing Instructions

* In a new incognito window, start a site using `/start/onboarding-affiliate`
* Free should not be an option

<img width="1399" alt="Screenshot 2025-04-08 at 15 18 21" src="https://github.com/user-attachments/assets/1eb0f0d2-b984-4177-9d38-cb4c3d458d6e" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
