### PR TITLE
i18n: Bring `@automattic/number-formatters` – use in section stats > insights

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -5,12 +5,12 @@ import {
 	isTranslatedIncompletely,
 	getLanguageSlugs,
 } from '@automattic/i18n-utils';
+import { setLocale as setLocaleNumberFormatters } from '@automattic/number-formatters';
 import i18n from 'i18n-calypso';
 import { initLanguageEmpathyMode } from 'calypso/lib/i18n-utils/empathy-mode';
 import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-locale';
 import { LOCALE_SET } from 'calypso/state/action-types';
 import { setLocale } from 'calypso/state/ui/language/actions';
-
 export function getLocaleFromPathname() {
 	const pathname = window.location.pathname.replace( /\/$/, '' );
 	const lastPathSegment = pathname.substr( pathname.lastIndexOf( '/' ) + 1 );
@@ -50,6 +50,8 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		const localeSlug = i18n.getLocaleSlug();
 		const localeVariant = i18n.getLocaleVariant();
 		reduxStore.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
+		// Propagate the locale to @automattic/number-formatters
+		setLocaleNumberFormatters( localeVariant || localeSlug );
 
 		if ( localeSlug ) {
 			loadUserUndeployedTranslations( localeSlug );

--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -1,4 +1,5 @@
 import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
+import { setLocale as setLocaleNumberFormatters } from '@automattic/number-formatters';
 import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
@@ -27,6 +28,11 @@ const CalypsoI18nProvider: FunctionComponent< { i18n?: I18N; children?: React.Re
 
 	useEffect( () => {
 		defaultI18n.resetLocaleData( i18n.getLocale() );
+
+		if ( localeSlug ) {
+			// Propagate the locale to @automattic/number-formatters
+			setLocaleNumberFormatters( localeSlug );
+		}
 	}, [ localeSlug ] );
 
 	return (

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -2,10 +2,10 @@ import config from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { getUrlFromParts, getUrlParts } from '@automattic/calypso-url';
 import { isDefaultLocale, getLanguage } from '@automattic/i18n-utils';
+import { setLocale as setLocaleNumberFormatters } from '@automattic/number-formatters';
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import { forEach, throttle } from 'lodash';
-
 const debug = debugFactory( 'calypso:i18n' );
 
 const getPromises = {};
@@ -336,6 +336,9 @@ export default async function switchLocale( localeSlug ) {
 	if ( typeof document === 'undefined' ) {
 		return;
 	}
+
+	// Propagate the locale to @automattic/number-formatters
+	setLocaleNumberFormatters( localeSlug );
 
 	lastRequestedLocale = localeSlug;
 

--- a/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
@@ -4,9 +4,10 @@ import {
 	percentCalculator,
 } from '@automattic/components/src/highlight-cards/lib/numbers';
 import { eye } from '@automattic/components/src/icons';
+import { formatNumber } from '@automattic/number-formatters';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate, numberFormat, numberFormatCompact } from 'i18n-calypso';
+import { useTranslate, numberFormatCompact } from 'i18n-calypso';
 import React, { useMemo } from 'react';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -245,7 +246,7 @@ function AllTimeStatsCard( { infoItems, siteId }: AllTimeStatsCardProps ) {
 										className="highlight-card-info-item-count"
 										title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
 									>
-										{ numberFormat( info.count ) }
+										{ formatNumber( info.count ) }
 									</span>
 								</div>
 							);

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -52,6 +52,10 @@ function getExternals() {
 				// (there are symlinks into `packages/` from the `node_modules` folder)
 				...packagesInMonorepo().map( ( pkg ) => new RegExp( `^${ pkg.name }(/|$)` ) ),
 
+				// Bundle the `@automattic/number-formatters` package as it comes from Jetpack and
+				// is also safe to bundle although it's not a monorepo package.
+				/^@automattic\/number-formatters(\/|$)/,
+
 				// bundle the core-js polyfills. We pick only a very small subset of the library
 				// to polyfill a few things that are not supported by the latest LTS Node.js,
 				// and this avoids shipping the entire library which is fairly big.

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
+		"@automattic/number-formatters": "^1.0.0",
 		"@automattic/plans-grid-next": "workspace:^",
 		"@automattic/privacy-toolset": "workspace:^",
 		"@automattic/typography": "workspace:^",

--- a/packages/calypso-typescript-config/ts-package.json
+++ b/packages/calypso-typescript-config/ts-package.json
@@ -1,28 +1,22 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
-
 	"compilerOptions": {
 		"composite": true,
 		"disableReferencedProjectLoad": true,
-
 		"declaration": true,
 		"declarationMap": true,
 		"sourceMap": true,
-
 		"importHelpers": true,
 		"noEmitHelpers": true,
 		"skipLibCheck": true,
-
 		"lib": [ "ES2022", "DOM", "DOM.Iterable" ],
 		"module": "ES2022",
 		"target": "ES2022",
 		"esModuleInterop": true,
 		"jsx": "react-jsx",
 		"resolveJsonModule": true,
-
 		"strict": true,
 		"isolatedModules": true,
-
 		"moduleResolution": "node",
 		"types": [],
 		"forceConsistentCasingInFileNames": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,6 +1502,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/number-formatters@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@automattic/number-formatters@npm:1.0.0"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: f591460cf08ff24434235fa797634620904a935bf2f31ab3a6b3bfa76e827168e09e698d8f774cf1c2689be31fa0be980646cece4052da630652503269a91b6c
+  languageName: node
+  linkType: hard
+
 "@automattic/o2-blocks@workspace:apps/o2-blocks":
   version: 0.0.0-use.local
   resolution: "@automattic/o2-blocks@workspace:apps/o2-blocks"
@@ -35373,6 +35384,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/launchpad": "workspace:^"
+    "@automattic/number-formatters": "npm:^1.0.0"
     "@automattic/plans-grid-next": "workspace:^"
     "@automattic/privacy-toolset": "workspace:^"
     "@automattic/typography": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See PT: pxLjZ-9ME-p2
Part of addressing https://github.com/Automattic/i18n-issues/issues/942

## Proposed Changes

- Introduce `@automattic/number-formatters` to the repo
- Connect to switch locale state
- Connect to a section as first use: All-time stats -> Views under `/stats/insights/:site`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/942

## Media

**`/stats/insights/:site` All-time stats**

| EN | DE |
|--------|--------|
| <img width="434" alt="Screenshot 2025-04-08 at 3 39 17 PM" src="https://github.com/user-attachments/assets/cf23d88a-52db-4512-a88b-7ac821b7f746" /> | <img width="445" alt="Screenshot 2025-04-29 at 7 11 06 PM" src="https://github.com/user-attachments/assets/d439841b-1dbe-4f9a-9e93-0da396defc33" /> | 



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/stats/insights/:site` (use FG)
* Confirm the rendering the `Views` count in `All-time stats` card
* Switch locale to `DE` and confirm it renders with `.` for thousandth separator

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?