### PR TITLE
Domains: Update the `Change your site address` modal

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -58,6 +58,7 @@ export class SiteAddressChanger extends Component {
 		domainFieldValue: '',
 		newDomainSuffix: this.props.currentDomainSuffix,
 		confirmEmailSent: 0,
+		isConfirmationChecked: false,
 	};
 
 	componentDidMount() {

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,5 +1,5 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
-import { Button, Icon, Modal } from '@wordpress/components';
+import { Button, CheckboxControl, Icon, Modal } from '@wordpress/components';
 import { check, closeSmall, chevronDown, info } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { debounce, get, isEmpty } from 'lodash';
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Banner from 'calypso/components/banner';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -510,13 +509,11 @@ export class SiteAddressChanger extends Component {
 						{ newDomainSuffix }
 					</p>
 				</div>
-				<FormLabel>
-					<FormInputCheckbox
-						checked={ this.state.isConfirmationChecked }
-						onChange={ this.toggleConfirmationChecked }
-					/>
-					<span>{ translate( "I understand that I won't be able to undo this change." ) }</span>
-				</FormLabel>
+				<CheckboxControl
+					label={ translate( "I understand that I won't be able to undo this change." ) }
+					checked={ this.state.isConfirmationChecked }
+					onChange={ this.toggleConfirmationChecked }
+				/>
 			</form>
 		);
 	};

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -356,7 +356,7 @@ export class SiteAddressChanger extends Component {
 					variant: 'primary',
 					isBusy: isSiteAddressChangeRequesting,
 					onClick: this.onConfirm,
-					label: translate( 'Change site address' ),
+					label: translate( 'Confirm' ),
 				},
 			];
 		}

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -377,6 +377,8 @@ export class SiteAddressChanger extends Component {
 			isEmailVerified,
 		} = this.props;
 
+		//const truer = true;
+
 		if ( isAtomicSite ) {
 			return (
 				<div className="site-address-changer__content">
@@ -448,14 +450,11 @@ export class SiteAddressChanger extends Component {
 						<FormInputValidation isError={ ! isAvailable } text={ validationMessage || '\u00A0' } />
 					) }
 					<div className="site-address-changer__info">
-						<p>
+						<p className="site-address-changer__message">
 							{ translate(
-								'Keep in mind that once you change your site address, {{br/}}%(currentDomainName)s will no longer be available.',
+								'Keep in mind that once you change your site address, %(currentDomainName)s will no longer be available.',
 								{
 									args: { currentDomainName },
-									components: {
-										br: <br />,
-									},
 								}
 							) }
 						</p>

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -480,7 +480,7 @@ export class SiteAddressChanger extends Component {
 		const currentDomainPrefix = this.getCurrentDomainPrefix();
 
 		return (
-			<form className="site-address-changer__dialog">
+			<form className="site-address-changer__content">
 				<TrackComponentView
 					eventName="calypso_siteaddresschange_areyousure_view"
 					eventProperties={ {

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -514,6 +514,7 @@ export class SiteAddressChanger extends Component {
 					label={ translate( "I understand that I won't be able to undo this change." ) }
 					checked={ this.state.isConfirmationChecked }
 					onChange={ this.toggleConfirmationChecked }
+					__nextHasNoMarginBottom
 				/>
 			</form>
 		);

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -529,7 +529,6 @@ export class SiteAddressChanger extends Component {
 
 		return (
 			<Modal
-				className="site-address-changer"
 				title={ modalTitle }
 				size="medium"
 				isVisible={ isDialogVisible }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -551,11 +551,15 @@ export class SiteAddressChanger extends Component {
 	render() {
 		const { isDialogVisible, onClose, translate } = this.props;
 		const buttons = this.getStepButtons();
+		const modalTitle =
+			this.state.step === 0
+				? translate( 'Change your site address' )
+				: translate( 'Confirm the address change' );
 
 		return (
 			<Modal
 				className="site-address-changer"
-				title={ translate( 'Change your site address' ) }
+				title={ modalTitle }
 				size="medium"
 				isVisible={ isDialogVisible }
 				onRequestClose={ onClose }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -450,9 +450,12 @@ export class SiteAddressChanger extends Component {
 					<div className="site-address-changer__info">
 						<p>
 							{ translate(
-								'Keep in mind that once you change your site address, %(currentDomainName)s will no longer be available.',
+								'Keep in mind that once you change your site address, {{br/}}%(currentDomainName)s will no longer be available.',
 								{
 									args: { currentDomainName },
+									components: {
+										br: <br />,
+									},
 								}
 							) }
 						</p>

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -510,7 +510,6 @@ export class SiteAddressChanger extends Component {
 						{ newDomainSuffix }
 					</p>
 				</div>
-				<h2>{ translate( 'Check the box to confirm' ) }</h2>
 				<FormLabel>
 					<FormInputCheckbox
 						checked={ this.state.isConfirmationChecked }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -557,6 +557,7 @@ export class SiteAddressChanger extends Component {
 			<Modal
 				className="site-address-changer"
 				title={ translate( 'Change your site address' ) }
+				size="medium"
 				isVisible={ isDialogVisible }
 				onRequestClose={ onClose }
 				showCloseIcon

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -487,9 +487,7 @@ export class SiteAddressChanger extends Component {
 						new_domain: newDomainName,
 					} }
 				/>
-				<h1 className="site-address-changer__dialog-heading">
-					{ translate( 'Confirm your decision' ) }
-				</h1>
+				<p>{ translate( 'Once you confirm, this will be the new address for your site:' ) }</p>
 				<div className="site-address-changer__confirmation-detail">
 					<Gridicon
 						icon="cross-circle"
@@ -497,20 +495,13 @@ export class SiteAddressChanger extends Component {
 						className="site-address-changer__copy-deletion"
 					/>
 					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-deletion">
-						{ translate(
-							'{{strong}}%(currentDomainPrefix)s{{/strong}}%(currentDomainSuffix)s will be removed and unavailable for use.',
-							{
-								components: {
-									strong: <strong />,
-								},
-								args: {
-									currentDomainPrefix,
-									currentDomainSuffix,
-								},
-							}
-						) }
+						<strong>{ currentDomainPrefix }</strong>
+						{ currentDomainSuffix }
 					</p>
 				</div>
+
+				<p>{ translate( 'And this address will be removed and unavailable for use:' ) }</p>
+
 				<div className="site-address-changer__confirmation-detail">
 					<Gridicon
 						icon="checkmark-circle"
@@ -518,18 +509,8 @@ export class SiteAddressChanger extends Component {
 						className="site-address-changer__copy-addition"
 					/>
 					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-addition">
-						{ translate(
-							'{{strong}}%(newDomainName)s{{/strong}}%(newDomainSuffix)s will be your new site address.',
-							{
-								components: {
-									strong: <strong />,
-								},
-								args: {
-									newDomainName,
-									newDomainSuffix,
-								},
-							}
-						) }
+						<strong>{ newDomainName }</strong>
+						{ newDomainSuffix }
 					</p>
 				</div>
 				<h2>{ translate( 'Check the box to confirm' ) }</h2>
@@ -538,11 +519,7 @@ export class SiteAddressChanger extends Component {
 						checked={ this.state.isConfirmationChecked }
 						onChange={ this.toggleConfirmationChecked }
 					/>
-					<span>
-						{ translate(
-							"I understand that I won't be able to undo this change to my site address."
-						) }
-					</span>
+					<span>{ translate( "I understand that I won't be able to undo this change." ) }</span>
 				</FormLabel>
 			</form>
 		);

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -491,9 +491,9 @@ export class SiteAddressChanger extends Component {
 				<p>{ translate( 'Once you confirm, this will be the new address for your site:' ) }</p>
 				<div className="site-address-changer__confirmation-detail">
 					<span className="site-address-changer__icon-wrapper">
-						<Icon icon={ closeSmall } size={ 24 } className="site-address-changer__copy-deletion" />
+						<Icon icon={ check } size={ 24 } className="site-address-changer__copy-addition" />
 					</span>
-					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-deletion">
+					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-addition">
 						<strong>{ currentDomainPrefix }</strong>
 						{ currentDomainSuffix }
 					</p>
@@ -503,9 +503,9 @@ export class SiteAddressChanger extends Component {
 
 				<div className="site-address-changer__confirmation-detail">
 					<span className="site-address-changer__icon-wrapper">
-						<Icon icon={ check } size={ 24 } className="site-address-changer__copy-addition" />
+						<Icon icon={ closeSmall } size={ 24 } className="site-address-changer__copy-deletion" />
 					</span>
-					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-addition">
+					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-deletion">
 						<strong>{ newDomainName }</strong>
 						{ newDomainSuffix }
 					</p>

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -494,8 +494,8 @@ export class SiteAddressChanger extends Component {
 						<Icon icon={ check } size={ 24 } className="site-address-changer__copy-addition" />
 					</span>
 					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-addition">
-						<strong>{ currentDomainPrefix }</strong>
-						{ currentDomainSuffix }
+						<strong>{ newDomainName }</strong>
+						{ newDomainSuffix }
 					</p>
 				</div>
 
@@ -506,8 +506,8 @@ export class SiteAddressChanger extends Component {
 						<Icon icon={ closeSmall } size={ 24 } className="site-address-changer__copy-deletion" />
 					</span>
 					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-deletion">
-						<strong>{ newDomainName }</strong>
-						{ newDomainSuffix }
+						<strong>{ currentDomainPrefix }</strong>
+						{ currentDomainSuffix }
 					</p>
 				</div>
 				<CheckboxControl

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -374,30 +374,34 @@ export class SiteAddressChanger extends Component {
 			isEmailVerified,
 		} = this.props;
 
-		//const truer = true;
-
 		if ( isAtomicSite ) {
 			return (
-				<div className="site-address-changer__content">
-					<Icon icon={ info } size={ 18 } />
-					{ translate( 'wpcomstaging.com addresses cannot be changed.' ) }
+				<div className="site-address-changer__info-message">
+					<span className="site-address-changer__info-icon">
+						<Icon icon={ info } size={ 18 } />
+					</span>
+					<span>{ translate( 'wpcomstaging.com addresses cannot be changed.' ) }</span>
 				</div>
 			);
 		}
 
 		if ( ! currentDomain.currentUserCanManage ) {
 			return (
-				<div className="site-address-changer site-address-changer__only-owner-info">
-					<Icon icon={ info } size={ 18 } />
-					{ isEmpty( currentDomain.owner )
-						? translate( 'Only the site owner can edit this domain name.' )
-						: translate(
-								'Only the site owner ({{strong}}%(ownerInfo)s{{/strong}}) can edit this domain name.',
-								{
-									args: { ownerInfo: currentDomain.owner },
-									components: { strong: <strong /> },
-								}
-						  ) }
+				<div className="site-address-changer__info-message site-address-changer__only-owner-info">
+					<span className="site-address-changer__info-icon">
+						<Icon icon={ info } size={ 18 } />
+					</span>
+					<span>
+						{ isEmpty( currentDomain.owner )
+							? translate( 'Only the site owner can edit this domain name.' )
+							: translate(
+									'Only the site owner ({{strong}}%(ownerInfo)s{{/strong}}) can edit this domain name.',
+									{
+										args: { ownerInfo: currentDomain.owner },
+										components: { strong: <strong /> },
+									}
+							  ) }
+					</span>
 				</div>
 			);
 		}

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -151,6 +151,12 @@ export class SiteAddressChanger extends Component {
 		} );
 	};
 
+	goBackToFirstStep = () => {
+		this.setState( {
+			step: 0,
+		} );
+	};
+
 	handleDomainChange( domainFieldValue ) {
 		if ( this.props.isAvailabilityPending || this.props.isSiteAddressChangeRequesting ) {
 			return;
@@ -340,7 +346,7 @@ export class SiteAddressChanger extends Component {
 			return [
 				{
 					action: 'cancel',
-					onClick: this.onConfirmationFormClose,
+					onClick: this.goBackToFirstStep,
 					variant: 'tertiary',
 					label: translate( 'Cancel' ),
 				},

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -145,21 +145,10 @@ export class SiteAddressChanger extends Component {
 		}
 	};
 
-	onConfirmationFormClose = () => {
-		this.setState( {
-			step: 0,
-		} );
-	};
-
 	toggleConfirmationChecked = () => {
 		this.setState( {
 			isConfirmationChecked: ! this.state.isConfirmationChecked,
 		} );
-	};
-
-	onConfirmationFormSubmit = () => {
-		this.onConfirmationFormClose();
-		this.onConfirm();
 	};
 
 	handleDomainChange( domainFieldValue ) {
@@ -339,14 +328,15 @@ export class SiteAddressChanger extends Component {
 				},
 				{
 					action: 'confirm',
-					additionalClassNames: [ isBusy ? 'is-busy' : '' ],
 					variant: 'primary',
 					disabled: isDisabled,
+					isBusy: isBusy,
 					label: translate( 'Next' ),
 					onClick: this.onSubmit,
 				},
 			];
 		} else if ( 1 === this.state.step ) {
+			const { isSiteAddressChangeRequesting } = this.props;
 			return [
 				{
 					action: 'cancel',
@@ -358,7 +348,8 @@ export class SiteAddressChanger extends Component {
 					action: 'confirm',
 					disabled: ! this.state.isConfirmationChecked,
 					variant: 'primary',
-					onClick: this.onConfirmationFormSubmit,
+					isBusy: isSiteAddressChangeRequesting,
+					onClick: this.onConfirm,
 					label: translate( 'Change site address' ),
 				},
 			];
@@ -544,6 +535,7 @@ export class SiteAddressChanger extends Component {
 							key={ button.action }
 							variant={ button.variant }
 							disabled={ button.disabled }
+							isBusy={ button.isBusy }
 							onClick={ button.onClick }
 						>
 							{ button.label }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -334,13 +334,13 @@ export class SiteAddressChanger extends Component {
 				{
 					action: 'cancel',
 					onClick: onClose,
-					isPrimary: false,
+					variant: 'tertiary',
 					label: translate( 'Cancel' ),
 				},
 				{
 					action: 'confirm',
 					additionalClassNames: [ isBusy ? 'is-busy' : '' ],
-					isPrimary: true,
+					variant: 'primary',
 					disabled: isDisabled,
 					label: translate( 'Next' ),
 					onClick: this.onSubmit,
@@ -351,13 +351,13 @@ export class SiteAddressChanger extends Component {
 				{
 					action: 'cancel',
 					onClick: this.onConfirmationFormClose,
-					isPrimary: false,
+					variant: 'tertiary',
 					label: translate( 'Cancel' ),
 				},
 				{
 					action: 'confirm',
 					disabled: ! this.state.isConfirmationChecked,
-					isPrimary: true,
+					variant: 'primary',
 					onClick: this.onConfirmationFormSubmit,
 					label: translate( 'Change site address' ),
 				},
@@ -568,7 +568,7 @@ export class SiteAddressChanger extends Component {
 					{ buttons.map( ( button ) => (
 						<Button
 							key={ button.action }
-							variant={ button.isPrimary ? 'primary' : 'tertiary' }
+							variant={ button.variant }
 							disabled={ button.disabled }
 							onClick={ button.onClick }
 						>

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -455,16 +455,16 @@ export class SiteAddressChanger extends Component {
 								}
 							) }
 						</p>
+						{ ! hasNonWpcomDomains && (
+							<p>
+								{ translate( '{{a}}Add a custom domain{{/a}} instead?', {
+									components: {
+										a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
+									},
+								} ) }
+							</p>
+						) }
 					</div>
-					{ ! hasNonWpcomDomains && (
-						<div className="site-address-changer__info-custom-domain">
-							{ translate( '{{a}}Add a custom domain{{/a}} instead?', {
-								components: {
-									a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
-								},
-							} ) }
-						</div>
-					) }
 				</div>
 			</div>
 		);

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -352,7 +352,7 @@ export class SiteAddressChanger extends Component {
 				},
 				{
 					action: 'confirm',
-					disabled: ! this.state.isConfirmationChecked,
+					disabled: ! this.state.isConfirmationChecked || isSiteAddressChangeRequesting,
 					variant: 'primary',
 					isBusy: isSiteAddressChangeRequesting,
 					onClick: this.onConfirm,

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,4 +1,5 @@
-import { Dialog, FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
+import { FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
+import { Button, Modal } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { debounce, get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -6,7 +7,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -314,7 +314,7 @@ export class SiteAddressChanger extends Component {
 	};
 
 	getStepButtons = () => {
-		const { translate, isEmailVerified } = this.props;
+		const { translate, isEmailVerified, onClose } = this.props;
 
 		if ( 0 === this.state.step ) {
 			const { isAvailabilityPending, isAvailable, isSiteAddressChangeRequesting } = this.props;
@@ -333,7 +333,7 @@ export class SiteAddressChanger extends Component {
 			return [
 				{
 					action: 'cancel',
-					onClick: this.onClose,
+					onClick: onClose,
 					isPrimary: false,
 					label: translate( 'Cancel' ),
 				},
@@ -429,9 +429,6 @@ export class SiteAddressChanger extends Component {
 						disableHref
 					/>
 				) }
-				<FormSectionHeading>
-					<strong>{ translate( 'Change your site address' ) }</strong>
-				</FormSectionHeading>
 				<div className="site-address-changer__info">
 					<p>
 						{ translate(
@@ -550,19 +547,33 @@ export class SiteAddressChanger extends Component {
 	};
 
 	render() {
-		const { isDialogVisible, onClose } = this.props;
+		const { isDialogVisible, onClose, translate } = this.props;
+		const buttons = this.getStepButtons();
 
 		return (
-			<Dialog
-				buttons={ this.getStepButtons() }
+			<Modal
+				className="site-address-changer"
+				title={ translate( 'Change your site address' ) }
 				isVisible={ isDialogVisible }
-				onClose={ onClose }
-				leaveTimeout={ 0 }
+				onRequestClose={ onClose }
 				showCloseIcon
 			>
 				{ 0 === this.state.step && this.renderNewAddressForm() }
 				{ 1 === this.state.step && this.renderConfirmationForm() }
-			</Dialog>
+
+				<div className="site-address-changer__modal-buttons">
+					{ buttons.map( ( button ) => (
+						<Button
+							key={ button.action }
+							variant={ button.isPrimary ? 'primary' : 'tertiary' }
+							disabled={ button.disabled }
+							onClick={ button.onClick }
+						>
+							{ button.label }
+						</Button>
+					) ) }
+				</div>
+			</Modal>
 		);
 	}
 }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,5 +1,6 @@
-import { FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
-import { Button, Modal } from '@wordpress/components';
+import { FormInputValidation, FormLabel } from '@automattic/components';
+import { Button, Icon, Modal } from '@wordpress/components';
+import { check, closeSmall, chevronDown, info } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { debounce, get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -290,7 +291,7 @@ export class SiteAddressChanger extends Component {
 		return (
 			<span className="site-address-changer__affix">
 				{ newDomainSuffix }
-				<Gridicon icon="chevron-down" size={ 18 } className="site-address-changer__select-icon" />
+				<Icon icon={ chevronDown } size={ 18 } className="site-address-changer__select-icon" />
 				<FormSelect
 					className="site-address-changer__select"
 					value={ newDomainSuffix }
@@ -382,7 +383,7 @@ export class SiteAddressChanger extends Component {
 		if ( isAtomicSite ) {
 			return (
 				<div className="site-address-changer__content">
-					<Gridicon icon="info-outline" />
+					<Icon icon={ info } size={ 18 } />
 					{ translate( 'wpcomstaging.com addresses cannot be changed.' ) }
 				</div>
 			);
@@ -391,7 +392,7 @@ export class SiteAddressChanger extends Component {
 		if ( ! currentDomain.currentUserCanManage ) {
 			return (
 				<div className="site-address-changer site-address-changer__only-owner-info">
-					<Gridicon icon="info-outline" />
+					<Icon icon={ info } size={ 18 } />
 					{ isEmpty( currentDomain.owner )
 						? translate( 'Only the site owner can edit this domain name.' )
 						: translate(
@@ -489,11 +490,9 @@ export class SiteAddressChanger extends Component {
 				/>
 				<p>{ translate( 'Once you confirm, this will be the new address for your site:' ) }</p>
 				<div className="site-address-changer__confirmation-detail">
-					<Gridicon
-						icon="cross-circle"
-						size={ 18 }
-						className="site-address-changer__copy-deletion"
-					/>
+					<span className="site-address-changer__icon-wrapper">
+						<Icon icon={ closeSmall } size={ 24 } className="site-address-changer__copy-deletion" />
+					</span>
 					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-deletion">
 						<strong>{ currentDomainPrefix }</strong>
 						{ currentDomainSuffix }
@@ -503,11 +502,9 @@ export class SiteAddressChanger extends Component {
 				<p>{ translate( 'And this address will be removed and unavailable for use:' ) }</p>
 
 				<div className="site-address-changer__confirmation-detail">
-					<Gridicon
-						icon="checkmark-circle"
-						size={ 18 }
-						className="site-address-changer__copy-addition"
-					/>
+					<span className="site-address-changer__icon-wrapper">
+						<Icon icon={ check } size={ 24 } className="site-address-changer__copy-addition" />
+					</span>
 					<p className="site-address-changer__confirmation-detail-copy site-address-changer__copy-addition">
 						<strong>{ newDomainName }</strong>
 						{ newDomainSuffix }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -429,19 +429,9 @@ export class SiteAddressChanger extends Component {
 						disableHref
 					/>
 				) }
-				<div className="site-address-changer__info">
-					<p>
-						{ translate(
-							'Once you change your site address, %(currentDomainName)s will no longer be available.',
-							{
-								args: { currentDomainName },
-							}
-						) }
-					</p>
-				</div>
 				<div className="site-address-changer__details">
 					<FormLabel htmlFor="site-address-changer__text-input">
-						{ translate( 'Enter your new site address' ) }
+						{ translate( 'New site address' ) }
 					</FormLabel>
 					<FormTextInputWithAffixes
 						id="site-address-changer__text-input"
@@ -457,9 +447,19 @@ export class SiteAddressChanger extends Component {
 					{ shouldShowValidationMessage && (
 						<FormInputValidation isError={ ! isAvailable } text={ validationMessage || '\u00A0' } />
 					) }
+					<div className="site-address-changer__info">
+						<p>
+							{ translate(
+								'Keep in mind that once you change your site address, %(currentDomainName)s will no longer be available.',
+								{
+									args: { currentDomainName },
+								}
+							) }
+						</p>
+					</div>
 					{ ! hasNonWpcomDomains && (
 						<div className="site-address-changer__info-custom-domain">
-							{ translate( 'Did you want to {{a}}add a custom domain{{/a}} instead?', {
+							{ translate( '{{a}}Add a custom domain{{/a}} instead?', {
 								components: {
 									a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
 								},

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -97,7 +97,6 @@
 }
 
 .site-address-changer__info {
-	word-break: break-word;
 	font-size: $font-body-small;
 	margin-top: 24px;
 	margin-bottom: 24px;
@@ -107,6 +106,7 @@
 			display: flex;
 			flex-direction: column;
 		}
+		margin-bottom: 24px;
 	}
 }
 
@@ -140,12 +140,6 @@
 			cursor: pointer;
 			font-size: $font-body-small;
 		}
-	}
-
-	.site-address-changer__info-custom-domain {
-		margin-top: 10px;
-		font-size: 0.875rem;
-		color: $gray-60;
 	}
 }
 

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -38,7 +38,7 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	margin-bottom: 16px;
+	margin-bottom: 24px;
 
 	.site-address-changer__icon-wrapper {
 		display: flex;

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -60,10 +60,16 @@
 
 .site-address-changer__info {
 	word-break: break-word;
+	font-size: $font-body-small;
+	margin-top: 24px;
+	margin-bottom: 24px;
 }
 
 .site-address-changer__details {
-	margin-top: 32px;
+	.form-input-validation {
+		padding-top: 6px;
+		padding-right: 24px;
+	}
 
 	.form-input-validation.email-not-verified {
 		padding-bottom: 0;
@@ -191,11 +197,6 @@
 			margin-left: 24px;
 		}
 	}
-}
-
-.dialog__content h1.site-address-changer__dialog-heading {
-	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-	line-height: 1.4em;
 }
 
 .site-address-changer__modal-buttons {

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -2,23 +2,6 @@
 @import '@wordpress/base-styles/colors.native';
 @import '@wordpress/base-styles/breakpoints';
 
-.site-address-changer__dialog {
-	text-align: left;
-
-	p {
-		margin-bottom: 8px;
-		font-size: $font-body-small;
-	}
-
-	h2 {
-		border-top: 1px solid var( --color-border-subtle );
-		font-weight: 600;
-		margin-top: 1.5em;
-		margin-bottom: 1em;
-		padding-top: 1.5em;
-	}
-}
-
 .site-address-changer__copy-addition,
 .site-address-changer__copy-addition svg {
 	color: var( --color-success );
@@ -38,7 +21,7 @@
 .site-address-changer__confirmation-detail {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: 4px;
 	margin-bottom: 24px;
 
 	.site-address-changer__icon-wrapper {
@@ -60,6 +43,23 @@
 .site-address-changer__affix {
 	display: flex;
 	align-items: center;
+}
+
+.site-address-changer__info-message {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+
+	.site-address-changer__info-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+
+	svg {
+		fill: currentColor;
+	}
 }
 
 .site-address-changer__select-icon {
@@ -149,15 +149,6 @@
 
 	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0;
-	}
-
-	.gridicon {
-		float: left;
-		margin: auto 12px auto 10px;
-
-		@include breakpoint-deprecated( '<660px' ) {
-			margin: auto 6px auto 4px;
-		}
 	}
 }
 

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -7,6 +7,7 @@
 
 	p {
 		margin-bottom: 8px;
+		font-size: $font-body-small;
 	}
 
 	h2 {
@@ -52,6 +53,7 @@
 		margin: 0;
 		line-height: 1.5;
 		display: flex;
+		font-size: $font-body;
 	}
 }
 

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -14,12 +14,12 @@
 	}
 }
 
-.site-address-changer__copy-addition strong,
+.site-address-changer__copy-addition,
 .site-address-changer__copy-addition.gridicon {
 	color: var( --color-success );
 }
 
-.site-address-changer__copy-deletion strong,
+.site-address-changer__copy-deletion,
 .site-address-changer__copy-deletion.gridicon {
 	color: var( --color-error );
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -1,5 +1,6 @@
 @import '@automattic/typography/styles/variables';
 @import '@wordpress/base-styles/colors.native';
+@import '@wordpress/base-styles/breakpoints';
 
 .site-address-changer__dialog {
 	text-align: left;
@@ -63,6 +64,13 @@
 	font-size: $font-body-small;
 	margin-top: 24px;
 	margin-bottom: 24px;
+
+	.site-address-changer__message {
+		@media ( min-width: $break-small ) {
+			display: flex;
+			flex-direction: column;
+		}
+	}
 }
 
 .site-address-changer__details {

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -14,10 +14,6 @@
 	fill: currentColor;
 }
 
-.card.site-address-changer__content {
-	margin-bottom: 0;
-}
-
 .site-address-changer__confirmation-detail {
 	display: flex;
 	align-items: center;
@@ -153,6 +149,11 @@
 }
 
 .site-address-changer__content {
+	p {
+		font-size: $font-body-small;
+		margin-bottom: 8px;
+	}
+
 	.form-section-heading {
 		font-size: 1.25rem;
 		margin: 0;
@@ -173,44 +174,6 @@
 		.form-text-input-with-affixes__suffix {
 			padding-left: 8px;
 			padding-right: 8px;
-		}
-	}
-}
-
-.site-address-changer__form-footer {
-	border-top: 1px solid var( --color-neutral-0 );
-	margin: 0 -16px -16px;
-	padding: 16px;
-	display: flex;
-	justify-content: flex-start;
-
-	@include breakpoint-deprecated( '>480px' ) {
-		padding: 24px;
-		margin: 0 -24px -24px;
-	}
-
-	@include breakpoint-deprecated( '<480px' ) {
-		flex-direction: column;
-	}
-
-	.button {
-		margin: 0 0 0 15px;
-
-		&.is-primary {
-			margin: 0 0 15px;
-
-			@include breakpoint-deprecated( '>480px' ) {
-				margin: 0;
-			}
-
-			@include breakpoint-deprecated( '<480px' ) {
-				order: 1;
-			}
-		}
-
-		@include breakpoint-deprecated( '<480px' ) {
-			width: 100%;
-			order: 2;
 		}
 	}
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -170,6 +170,10 @@
 		}
 	}
 
+	.components-checkbox-control__label {
+		font-size: $font-body-small;
+	}
+
 	@include breakpoint-deprecated( '<480px' ) {
 		.form-text-input-with-affixes__suffix {
 			padding-left: 8px;

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -1,11 +1,11 @@
-@import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/colors.native";
+@import '@automattic/typography/styles/variables';
+@import '@wordpress/base-styles/colors.native';
 
 .site-address-changer__dialog {
 	text-align: left;
 
 	h2 {
-		border-top: 1px solid var(--color-border-subtle);
+		border-top: 1px solid var( --color-border-subtle );
 		font-weight: 600;
 		margin-top: 1.5em;
 		margin-bottom: 1em;
@@ -15,12 +15,12 @@
 
 .site-address-changer__copy-addition strong,
 .site-address-changer__copy-addition.gridicon {
-	color: var(--color-success);
+	color: var( --color-success );
 }
 
 .site-address-changer__copy-deletion strong,
 .site-address-changer__copy-deletion.gridicon {
-	color: var(--color-error);
+	color: var( --color-error );
 }
 
 .card.site-address-changer__content {
@@ -33,7 +33,7 @@
 }
 
 .site-address-changer__select-icon {
-	color: var(--color-neutral-light);
+	color: var( --color-neutral-light );
 	margin-left: 6px;
 	align-self: center;
 }
@@ -41,7 +41,7 @@
 .form-text-input-with-affixes__prefix,
 .form-text-input-with-affixes__suffix {
 	&:hover .site-address-changer__select-icon {
-		color: var(--color-neutral-50);
+		color: var( --color-neutral-50 );
 	}
 }
 
@@ -78,7 +78,7 @@
 		margin-bottom: 16px;
 
 		button {
-			color: var(--color-link);
+			color: var( --color-link );
 			cursor: pointer;
 			font-size: $font-body-small;
 		}
@@ -95,7 +95,7 @@
 	margin: 0 auto 10px;
 	padding: 16px;
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0;
 	}
 
@@ -103,7 +103,7 @@
 		float: left;
 		margin: auto 12px auto 10px;
 
-		@include breakpoint-deprecated( "<660px" ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin: auto 6px auto 4px;
 		}
 	}
@@ -117,9 +117,8 @@
 	}
 
 	.site-address-changer__email-confirmation-banner {
-
 		.gridicon {
-			fill: var(--color-accent);
+			fill: var( --color-accent );
 		}
 
 		.banner__icon-circle {
@@ -127,7 +126,7 @@
 		}
 	}
 
-	@include breakpoint-deprecated( "<480px" ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.form-text-input-with-affixes__suffix {
 			padding-left: 8px;
 			padding-right: 8px;
@@ -136,18 +135,18 @@
 }
 
 .site-address-changer__form-footer {
-	border-top: 1px solid var(--color-neutral-0);
+	border-top: 1px solid var( --color-neutral-0 );
 	margin: 0 -16px -16px;
 	padding: 16px;
 	display: flex;
 	justify-content: flex-start;
 
-	@include breakpoint-deprecated( ">480px" ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 		margin: 0 -24px -24px;
 	}
 
-	@include breakpoint-deprecated( "<480px" ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -157,16 +156,16 @@
 		&.is-primary {
 			margin: 0 0 15px;
 
-			@include breakpoint-deprecated( ">480px" ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin: 0;
 			}
 
-			@include breakpoint-deprecated( "<480px" ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				order: 1;
 			}
 		}
 
-		@include breakpoint-deprecated( "<480px" ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			order: 2;
 		}
@@ -180,7 +179,7 @@
 		float: left;
 		margin-top: 4px;
 
-		@include breakpoint-deprecated( "<660px" ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -188,7 +187,7 @@
 	.site-address-changer__confirmation-detail-copy {
 		word-break: break-word;
 
-		@include breakpoint-deprecated( ">660px" ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-left: 24px;
 		}
 	}
@@ -197,4 +196,14 @@
 .dialog__content h1.site-address-changer__dialog-heading {
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	line-height: 1.4em;
+}
+
+.site-address-changer__modal-buttons {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 24px;
+
+	.components-button + .components-button {
+		margin-left: 8px;
+	}
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -66,9 +66,16 @@
 }
 
 .site-address-changer__details {
+	.form-label {
+		text-transform: uppercase;
+		font-size: $font-body-extra-small;
+		font-weight: 500;
+	}
+
 	.form-input-validation {
 		padding-top: 6px;
 		padding-right: 24px;
+		padding-bottom: 0;
 	}
 
 	.form-input-validation.email-not-verified {

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -5,6 +5,10 @@
 .site-address-changer__dialog {
 	text-align: left;
 
+	p {
+		margin-bottom: 8px;
+	}
+
 	h2 {
 		border-top: 1px solid var( --color-border-subtle );
 		font-weight: 600;
@@ -15,17 +19,40 @@
 }
 
 .site-address-changer__copy-addition,
-.site-address-changer__copy-addition.gridicon {
+.site-address-changer__copy-addition svg {
 	color: var( --color-success );
+	fill: currentColor;
 }
 
 .site-address-changer__copy-deletion,
-.site-address-changer__copy-deletion.gridicon {
+.site-address-changer__copy-deletion svg {
 	color: var( --color-error );
+	fill: currentColor;
 }
 
 .card.site-address-changer__content {
 	margin-bottom: 0;
+}
+
+.site-address-changer__confirmation-detail {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 16px;
+
+	.site-address-changer__icon-wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+	}
+
+	.site-address-changer__confirmation-detail-copy {
+		margin: 0;
+		line-height: 1.5;
+		display: flex;
+	}
 }
 
 .site-address-changer__affix {
@@ -37,12 +64,20 @@
 	color: var( --color-neutral-light );
 	margin-left: 6px;
 	align-self: center;
+
+	svg {
+		fill: currentColor;
+	}
 }
 
 .form-text-input-with-affixes__prefix,
 .form-text-input-with-affixes__suffix {
 	&:hover .site-address-changer__select-icon {
 		color: var( --color-neutral-50 );
+
+		svg {
+			fill: currentColor;
+		}
 	}
 }
 
@@ -189,27 +224,6 @@
 		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			order: 2;
-		}
-	}
-}
-
-.site-address-changer__confirmation-detail {
-	margin-bottom: 1em;
-
-	.gridicon {
-		float: left;
-		margin-top: 4px;
-
-		@include breakpoint-deprecated( '<660px' ) {
-			display: none;
-		}
-	}
-
-	.site-address-changer__confirmation-detail-copy {
-		word-break: break-word;
-
-		@include breakpoint-deprecated( '>660px' ) {
-			margin-left: 24px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/100270.

## Proposed Changes

Update the modal that handles site address change based on the new design: ePfz53j71KKDLWtuSm567A-fi-5971_15946.

| Before | After |
|--------|--------|
| ![Markup on 2025-04-11 at 13:06:24](https://github.com/user-attachments/assets/0002b193-b1bb-4353-b635-418ebb88aa36) | ![Markup on 2025-04-11 at 13:10:42](https://github.com/user-attachments/assets/39bbf959-91c6-4771-9d54-1abc5b549ad2) |
| ![Markup on 2025-04-11 at 13:06:52](https://github.com/user-attachments/assets/b6724d94-ce3b-46dd-aa60-a7e8c5b00844) | ![Markup on 2025-04-11 at 13:11:04](https://github.com/user-attachments/assets/400b75f4-c1c7-4307-a62b-1f2166d1ce3f) | 

* replace `Dialog` with `Modal` component (WP Core)
* replace `Gridicon` with `Icon` component (WP Core)
* replace `FormInputCheckbox` with `CheckboxControl` component (WP Core)
* adjust bit of a logic that handles site address change
* update and clean up styling

> [!NOTE]
> We are not replacing `FormTextInputWithAffixes` and `FormInputValidation` Automattic Calypso components as we don't have suitable alternatives available at the moment (More context is available in the design discussion in ePfz53j71KKDLWtuSm567A-fi-5971_15946).

> [!NOTE]
> The PR will be marked for string freeze as it is not urgent and we are introducing new strings.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/100270

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start`. Alternatively, use Calypso Live link below.
2. Head over to http://calypso.localhost:3000/overview/{site-slug} of a test Simple site.
3. Scroll down to the `Active domains` section and open the modal through the `Change site address` button:

![Markup on 2025-04-11 at 13:44:50](https://github.com/user-attachments/assets/c9dd7ed5-c1e7-48c9-8ad8-63aa9a9a2224)

4. Try to go through the process of changing the site address, click through all the buttons, close the modal, open modal again, etc. There should be no regressions and the modal should work correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?