### PR TITLE
Site Migration: Use helpers to generate paths

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -24,7 +24,7 @@ import { addQueryArgs } from 'calypso/lib/url';
  */
 export function buildPathHelper<
 	T extends { queryParams?: Record< string, Primitive >; params?: Record< string, Primitive > },
->( path: string, defaultQueryParams?: T[ 'queryParams' ] ) {
+>( path: string ) {
 	return ( queryParams?: T[ 'queryParams' ] | null, params?: T[ 'params' ] | null ) => {
 		const pathWithParams = generatePath( path, params as Record< string, string > );
 
@@ -32,7 +32,7 @@ export function buildPathHelper<
 			return pathWithParams;
 		}
 
-		return addQueryArgs( { ...defaultQueryParams, ...queryParams }, pathWithParams );
+		return addQueryArgs( queryParams, pathWithParams );
 	};
 }
 
@@ -175,7 +175,7 @@ export const siteSetupImportWordpressPath = buildPathHelper< {
 
 export const calypsoOverviewPath = buildPathHelper< {
 	queryParams: { ref: string };
-} >( '/overview/:siteSlug', { ref: 'site-migration' } );
+} >( '/overview/:siteSlug' );
 
 export const siteSetupGoalsPath = buildPathHelper< {
 	queryParams: {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -175,6 +175,7 @@ export const siteSetupImportWordpressPath = buildPathHelper< {
 
 export const calypsoOverviewPath = buildPathHelper< {
 	queryParams: { ref: string };
+	params: { siteSlug: string };
 } >( '/overview/:siteSlug' );
 
 export const siteSetupGoalsPath = buildPathHelper< {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -1,0 +1,178 @@
+import { generatePath } from 'react-router';
+import { Primitive } from 'utility-types';
+import { STEPS } from 'calypso/landing/stepper/declarative-flow/internals/steps';
+import { ImporterPlatform } from 'calypso/lib/importer/types';
+import { addQueryArgs } from 'calypso/lib/url';
+
+/**
+ * Builds a path helper function that can be used to build paths with query params and path params.
+ * @param path - The path to build.
+ * @returns A function that can be used to build paths with query params and path params.
+ * @example
+ * const path = buildPathHelper<{
+ * 	queryParams: {
+ * 		from: string;
+ * 	};
+ * 	params: {
+ * 		id: string;
+ * 	};
+ * }>( '/test/:id' );
+ *
+ * path( { from: 'test' }, { id: '123' } ); // '/test/123?from=test'
+ * path( { from: 'test' } ); // '/test?from=test'
+ * path( null, { id: '123' } ); // '/test/123'
+ */
+export function buildPathHelper<
+	T extends { queryParams?: Record< string, Primitive >; params?: Record< string, Primitive > },
+>( path: string, defaultQueryParams?: T[ 'queryParams' ] ) {
+	return ( queryParams?: T[ 'queryParams' ] | null, params?: T[ 'params' ] | null ) => {
+		const pathWithParams = generatePath( path, params as Record< string, string > );
+
+		if ( ! queryParams ) {
+			return pathWithParams;
+		}
+
+		return addQueryArgs( { ...defaultQueryParams, ...queryParams }, pathWithParams );
+	};
+}
+
+export const siteCreationPath = buildPathHelper< {
+	queryParams: {
+		from?: string | null;
+		skipMigration?: boolean;
+	};
+} >( STEPS.SITE_CREATION_STEP.slug );
+
+export const sitePickerPath = buildPathHelper< {
+	queryParams: { from: string };
+} >( STEPS.PICK_SITE.slug );
+
+export const importOrMigratePath = buildPathHelper< {
+	queryParams: {
+		from?: string;
+		siteSlug: string;
+		siteId?: number | string;
+	};
+} >( STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug );
+
+export const howToMigratePath = buildPathHelper< {
+	queryParams: {
+		from?: string | null;
+		siteSlug: string;
+		siteId?: number | string;
+	};
+} >( STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug );
+
+export const processingPath = buildPathHelper< {
+	queryParams: {
+		from?: string | null;
+		skipMigration?: boolean;
+	};
+} >( STEPS.PROCESSING.slug );
+
+export const credentialsPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+		authorizationUrl?: string;
+		backTo?: string;
+	};
+} >( STEPS.SITE_MIGRATION_CREDENTIALS.slug );
+
+export const upgradePlanPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+		destination?: string;
+		how?: string;
+	};
+} >( STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug );
+
+export const alreadyWpcomPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+	};
+} >( STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug );
+
+export const instructionsPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+	};
+} >( STEPS.SITE_MIGRATION_INSTRUCTIONS.slug );
+
+export const otherPlatformDetectedImportPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+		platform?: ImporterPlatform;
+	};
+} >( STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT.slug );
+
+export const applicationPasswordAuthorizationPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+		authorizationUrl?: string | null;
+		success?: string | null;
+		password?: string | null;
+		user_login?: string | null;
+	};
+} >( STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug );
+
+export const fallbackCredentialsPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+	};
+} >( STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug );
+
+export const supportInstructionsPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug?: string;
+		from?: string | null;
+		preventTicketCreation?: boolean;
+	};
+} >( STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug );
+
+export const identifyPath = buildPathHelper< {
+	queryParams: { from: string | null };
+} >( STEPS.SITE_MIGRATION_IDENTIFY.slug );
+
+export const siteSetupImportListPath = buildPathHelper< {
+	queryParams: {
+		from: string | null;
+		siteId?: number | string;
+		siteSlug: string;
+		origin: string;
+		backToFlow: string;
+	};
+} >( `/setup/site-setup/${ STEPS.IMPORT_LIST.slug }` );
+
+export const calypsoImporterPath = buildPathHelper< {
+	queryParams: { engine: string; ref: string };
+	params: { siteSlug: string };
+} >( '/import/:siteSlug' );
+
+export const siteSetupImportWordpressPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug: string;
+		from: string;
+		option: 'content';
+		backToFlow: string;
+	};
+} >( '/setup/site-setup/importerWordpress' );
+
+export const calypsoOverviewPath = buildPathHelper< {
+	queryParams: { ref: string };
+} >( '/overview/:siteSlug', { ref: 'site-migration' } );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/index.ts
@@ -44,7 +44,7 @@ export const siteCreationPath = buildPathHelper< {
 } >( STEPS.SITE_CREATION_STEP.slug );
 
 export const sitePickerPath = buildPathHelper< {
-	queryParams: { from: string };
+	queryParams: { from: string | null };
 } >( STEPS.PICK_SITE.slug );
 
 export const importOrMigratePath = buildPathHelper< {
@@ -176,3 +176,10 @@ export const siteSetupImportWordpressPath = buildPathHelper< {
 export const calypsoOverviewPath = buildPathHelper< {
 	queryParams: { ref: string };
 } >( '/overview/:siteSlug', { ref: 'site-migration' } );
+
+export const siteSetupGoalsPath = buildPathHelper< {
+	queryParams: {
+		siteId?: number | string;
+		siteSlug: string;
+	};
+} >( '/setup/site-setup/goals' );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/test/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/test/index.ts
@@ -35,4 +35,14 @@ describe( 'paths helpers', () => {
 		} >( '/test/:id' );
 		expect( testPath( { from: 'test' }, { id: '123' } ) ).toBe( '/test/123?from=test' );
 	} );
+
+	it( 'return path without query params set as null', () => {
+		const testPath = buildPathHelper< {
+			queryParams: {
+				from: string | null;
+			};
+		} >( '/test' );
+
+		expect( testPath( null ) ).toBe( '/test' );
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/test/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/test/index.ts
@@ -1,0 +1,38 @@
+import { buildPathHelper } from '../index';
+
+describe( 'paths helpers', () => {
+	it( 'adds returns the path without query params', () => {
+		const testPath = buildPathHelper( '/test' );
+		expect( testPath() ).toBe( '/test' );
+	} );
+
+	it( 'adds returns the path with query params', () => {
+		const testPath = buildPathHelper< {
+			queryParams: {
+				from: string;
+			};
+		} >( '/test' );
+		expect( testPath( { from: 'test' } ) ).toBe( '/test?from=test' );
+	} );
+
+	it( 'returns the path with path params', () => {
+		const testPath = buildPathHelper< {
+			params: {
+				id: string;
+			};
+		} >( '/test/:id' );
+		expect( testPath( null, { id: '123' } ) ).toBe( '/test/123' );
+	} );
+
+	it( 'returns path with query params and path params', () => {
+		const testPath = buildPathHelper< {
+			queryParams: {
+				from: string;
+			};
+			params: {
+				id: string;
+			};
+		} >( '/test/:id' );
+		expect( testPath( { from: 'test' }, { id: '123' } ) ).toBe( '/test/123?from=test' );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/test/index.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/test/index.ts
@@ -1,7 +1,7 @@
 import { buildPathHelper } from '../index';
 
 describe( 'paths helpers', () => {
-	it( 'adds returns the path without query params', () => {
+	it( 'returns the path without query params', () => {
 		const testPath = buildPathHelper( '/test' );
 		expect( testPath() ).toBe( '/test' );
 	} );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -578,15 +578,13 @@ const siteMigration: FlowV2 = {
 						urlQueryParams.get( 'backTo' ) ===
 						STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug
 					) {
+						const queryParams = Object.fromEntries( urlQueryParams );
 						return navigate(
 							paths.applicationPasswordAuthorizationPath( {
 								siteId,
 								siteSlug,
 								from: fromQueryParam,
-								authorizationUrl: urlQueryParams.get( 'authorizationUrl' ),
-								success: urlQueryParams.get( 'success' ),
-								password: urlQueryParams.get( 'password' ),
-								user_login: urlQueryParams.get( 'user_login' ),
+								...queryParams,
 							} )
 						);
 					}
@@ -601,21 +599,27 @@ const siteMigration: FlowV2 = {
 				}
 
 				case STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug: {
+					const queryParams = Object.fromEntries( urlQueryParams );
+
 					return navigate(
 						paths.credentialsPath( {
 							siteId,
 							siteSlug,
 							from: fromQueryParam,
+							...queryParams,
 						} )
 					);
 				}
 
 				case STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug: {
+					const queryParams = Object.fromEntries( urlQueryParams );
+
 					return navigate(
 						paths.credentialsPath( {
 							siteId,
 							siteSlug,
 							from: fromQueryParam,
+							...queryParams,
 						} )
 					);
 				}

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -21,11 +21,11 @@ import { USER_STORE, SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/s
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
-//TODO: Move to a shared place
 import { ImporterPlatform } from 'calypso/lib/importer/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
+import * as paths from './paths';
 import type {
 	AssertConditionResult,
 	FlowV2,
@@ -155,45 +155,35 @@ const siteMigration: FlowV2 = {
 							// siteId/siteSlug wont be defined here if coming from a direct link/signup.
 							// We need to make sure there's a site to import into.
 							if ( ! siteSlugParam ) {
-								return navigate(
-									addQueryArgs( { from, skipMigration: true }, STEPS.SITE_CREATION_STEP.slug )
-								);
+								return navigate( paths.siteCreationPath( { from, skipMigration: true } ) );
 							}
 						}
 						return exitFlow(
-							addQueryArgs(
-								{
-									siteId,
-									siteSlug,
-									from,
-									origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
-									backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
-								},
-								'/setup/site-setup/importList'
-							)
+							paths.siteSetupImportListPath( {
+								siteId,
+								siteSlug,
+								from,
+								origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+								backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+							} )
 						);
 					}
 
 					if ( isHostedSiteMigrationFlow( variantSlug ?? '' ) ) {
 						if ( ! siteSlugParam ) {
 							if ( siteCount > 0 ) {
-								return navigate( `sitePicker?from=${ encodeURIComponent( from ) }` );
+								return navigate( paths.sitePickerPath( { from } ) );
 							}
 
 							if ( from ) {
-								return navigate( addQueryArgs( { from }, STEPS.SITE_CREATION_STEP.slug ) );
+								return navigate( paths.siteCreationPath( { from } ) );
 							}
 
 							return navigate( 'error' );
 						}
 					}
 
-					return navigate(
-						addQueryArgs(
-							{ from: from, siteSlug, siteId },
-							STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
-						)
-					);
+					return navigate( paths.importOrMigratePath( { from, siteSlug, siteId } ) );
 				}
 
 				case STEPS.PICK_SITE.slug: {
@@ -208,32 +198,27 @@ const siteMigration: FlowV2 = {
 									: urlQueryParams.delete( key );
 							} );
 
-							return navigate( `sitePicker?${ urlQueryParams.toString() }` );
+							return navigate( paths.sitePickerPath() );
 						}
 						case 'select-site': {
 							const { ID: newSiteId, slug: newSiteSlug } =
 								providedDependencies.site as SiteExcerptData;
 
-							// If the action is migrate, navigate to the DIY/DIFM selector screen.
 							if ( 'migrate' === actionQueryParam ) {
 								return navigate(
-									addQueryArgs(
-										{ siteId: newSiteId, siteSlug: newSiteSlug, from: fromQueryParam },
-										STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug
-									)
+									paths.howToMigratePath( {
+										siteSlug: newSiteSlug,
+										siteId: newSiteId,
+										from: fromQueryParam,
+									} )
 								);
 							}
 							return navigate(
-								addQueryArgs(
-									{ siteId: newSiteId, siteSlug: newSiteSlug, from: fromQueryParam },
-									STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
-								)
+								paths.importOrMigratePath( { siteSlug: newSiteSlug, siteId: newSiteId } )
 							);
 						}
 						case 'create-site':
-							return navigate(
-								addQueryArgs( { from: fromQueryParam }, STEPS.SITE_CREATION_STEP.slug )
-							);
+							return navigate( paths.siteCreationPath( { from: fromQueryParam } ) );
 					}
 				}
 
@@ -243,7 +228,7 @@ const siteMigration: FlowV2 = {
 						skipMigration: 'import' === actionQueryParam ? true : undefined,
 					};
 
-					return navigate( addQueryArgs( queryArgs, STEPS.PROCESSING.slug ) );
+					return navigate( paths.processingPath( queryArgs ) );
 				}
 
 				case STEPS.PROCESSING.slug: {
@@ -252,34 +237,29 @@ const siteMigration: FlowV2 = {
 							// If we get to this point without a fromQueryParam then we are coming from a direct
 							// pick your current platform link. That's why we navigate to the importList step.
 							return exitFlow(
-								addQueryArgs(
-									{
-										siteId,
-										siteSlug,
-										origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
-										backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
-										...( fromQueryParam && { from: fromQueryParam } ),
-									},
-									'/setup/site-setup/importList'
-								)
+								paths.siteSetupImportListPath( {
+									siteId,
+									siteSlug,
+									origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+									backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+									from: fromQueryParam,
+								} )
 							);
 						}
 
 						// If the action is migrate, navigate to the DIY/DIFM selector screen.
 						if ( 'migrate' === actionQueryParam ) {
 							return navigate(
-								addQueryArgs(
-									{ siteId, siteSlug, from: fromQueryParam },
-									STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug
-								)
+								paths.howToMigratePath( {
+									siteSlug: siteSlug,
+									siteId: siteId,
+									from: fromQueryParam,
+								} )
 							);
 						}
 
 						return navigate(
-							addQueryArgs(
-								{ siteId, siteSlug, from: fromQueryParam },
-								STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
-							)
+							paths.importOrMigratePath( { siteSlug, siteId, from: fromQueryParam } )
 						);
 					}
 				}
@@ -289,77 +269,48 @@ const siteMigration: FlowV2 = {
 					if ( providedDependencies?.destination === 'import' ) {
 						if ( urlQueryParams.get( 'ref' ) === 'calypso-importer' ) {
 							return exitFlow(
-								addQueryArgs(
+								paths.calypsoImporterPath(
 									{ engine: 'wordpress', ref: 'site-migration' },
-									`/import/${ siteSlug }`
+									{ siteSlug }
 								)
 							);
 						}
 
 						return exitFlow(
-							addQueryArgs(
-								{
-									siteId,
-									siteSlug,
-									from: fromQueryParam ?? '',
-									option: 'content',
-									backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
-								},
-								'/setup/site-setup/importerWordpress'
-							)
+							paths.siteSetupImportWordpressPath( {
+								siteId,
+								siteSlug,
+								from: fromQueryParam ?? '',
+								option: 'content',
+								backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }`,
+							} )
 						);
 					}
 
-					return navigate(
-						addQueryArgs(
-							{
-								siteId,
-								siteSlug,
-								from: fromQueryParam,
-							},
-							STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug
-						)
-					);
+					return navigate( paths.howToMigratePath( { siteId, siteSlug, from: fromQueryParam } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug: {
 					// Take the user to the upgrade plan step.
 					if ( providedDependencies?.destination === 'upgrade' ) {
 						return navigate(
-							addQueryArgs(
-								{
-									siteId,
-									siteSlug,
-									from: fromQueryParam,
-									destination: providedDependencies?.destination,
-									how: providedDependencies?.how as string,
-								},
-								STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug
-							)
+							paths.upgradePlanPath( {
+								siteId,
+								siteSlug,
+								from: fromQueryParam,
+								destination: providedDependencies?.destination,
+								how: providedDependencies?.how as string,
+							} )
 						);
 					}
 
 					// Do it for me option.
 					if ( providedDependencies?.how === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
-						return navigate(
-							addQueryArgs(
-								{
-									siteSlug,
-									from: fromQueryParam,
-									siteId,
-								},
-								STEPS.SITE_MIGRATION_CREDENTIALS.slug
-							)
-						);
+						return navigate( paths.credentialsPath( { siteId, from: fromQueryParam, siteSlug } ) );
 					}
 
 					// Continue with the migration flow.
-					return navigate(
-						addQueryArgs(
-							{ siteId, siteSlug, from: fromQueryParam },
-							STEPS.SITE_MIGRATION_INSTRUCTIONS.slug
-						)
-					);
+					return navigate( paths.instructionsPath( { siteId, siteSlug, from: fromQueryParam } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
@@ -402,22 +353,13 @@ const siteMigration: FlowV2 = {
 				case STEPS.SITE_MIGRATION_INSTRUCTIONS.slug: {
 					// User decided to ask for an assisted migration - try to collect credentials.
 					if ( providedDependencies?.how === HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME ) {
-						return navigate(
-							addQueryArgs(
-								{
-									siteId,
-									from: fromQueryParam,
-									siteSlug,
-								},
-								STEPS.SITE_MIGRATION_CREDENTIALS.slug
-							)
-						);
+						return navigate( paths.credentialsPath( { siteId, from: fromQueryParam, siteSlug } ) );
 					}
-					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
+					return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {
-					const { action, from, authorizationUrl } = providedDependencies as {
+					const { action, from, authorizationUrl, platform } = providedDependencies as {
 						action:
 							| 'skip'
 							| 'submit'
@@ -427,71 +369,66 @@ const siteMigration: FlowV2 = {
 							| 'site-is-not-using-wordpress';
 						from: string;
 						authorizationUrl: string;
+						platform: ImporterPlatform;
 					};
 
 					if ( action === 'skip' ) {
-						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
+						return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
 					}
 
 					if ( action === 'already-wpcom' ) {
 						return navigate(
-							addQueryArgs(
-								{ siteId, from: from || fromQueryParam, siteSlug },
-								STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug
-							)
+							paths.alreadyWpcomPath( { siteId, from: from || fromQueryParam, siteSlug } )
 						);
 					}
 
 					if ( action === 'site-is-not-using-wordpress' ) {
 						return navigate(
-							addQueryArgs(
-								{
-									siteId,
-									from: from || fromQueryParam,
-									siteSlug,
-									platform: providedDependencies.platform as string,
-								},
-								STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT.slug
-							)
+							paths.otherPlatformDetectedImportPath( {
+								siteId,
+								from: from || fromQueryParam,
+								siteSlug,
+								platform,
+							} )
 						);
 					}
 
 					if ( action === 'application-passwords-approval' ) {
 						return navigate(
-							addQueryArgs(
-								{
-									siteId,
-									from: from || fromQueryParam,
-									siteSlug,
-									authorizationUrl,
-								},
-								STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug
-							)
+							paths.applicationPasswordAuthorizationPath( {
+								siteId,
+								from: from || fromQueryParam,
+								siteSlug,
+								authorizationUrl,
+							} )
 						);
 					}
 
 					if ( action === 'credentials-required' ) {
 						return navigate(
-							addQueryArgs(
-								{ siteId, from: from || fromQueryParam, siteSlug },
-								STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug
-							)
+							paths.fallbackCredentialsPath( {
+								siteId,
+								from: from || fromQueryParam,
+								siteSlug,
+							} )
 						);
 					}
 
-					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
+					return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug: {
-					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
+					return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug: {
 					return navigate(
-						addQueryArgs(
-							{ siteId, from: fromQueryParam, siteSlug, preventTicketCreation: true },
-							STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug
-						)
+						paths.supportInstructionsPath( {
+							siteId,
+							from: fromQueryParam,
+							siteSlug,
+							preventTicketCreation: true,
+						} )
 					);
 				}
 				case STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT.slug: {
@@ -507,10 +444,11 @@ const siteMigration: FlowV2 = {
 					}
 
 					return navigate(
-						addQueryArgs(
-							{ siteId, from: fromQueryParam, siteSlug },
-							STEPS.SITE_MIGRATION_SUPPORT_INSTRUCTIONS.slug
-						)
+						paths.supportInstructionsPath( {
+							siteId,
+							from: fromQueryParam,
+							siteSlug,
+						} )
 					);
 				}
 
@@ -528,20 +466,15 @@ const siteMigration: FlowV2 = {
 
 					if ( action === 'fallback-credentials' ) {
 						return navigate(
-							addQueryArgs(
-								{
-									siteId,
-									siteSlug,
-									authorizationUrl,
-									backTo: STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug,
-									from: fromQueryParam,
-								},
-								STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug
-							)
+							paths.fallbackCredentialsPath( {
+								siteId,
+								siteSlug,
+								from: fromQueryParam,
+							} )
 						);
 					}
 
-					return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/overview/${ siteSlug }` ) );
+					return exitFlow( paths.calypsoOverviewPath( { ref: 'site-migration' }, { siteSlug } ) );
 				}
 			}
 		}
@@ -554,12 +487,23 @@ const siteMigration: FlowV2 = {
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
 					if ( entryPoint === 'calypso-importer' ) {
-						return exitFlow( addQueryArgs( { ref: 'site-migration' }, `/import/${ siteSlug }` ) );
+						return exitFlow(
+							paths.calypsoImporterPath(
+								{ engine: 'wordpress', ref: 'site-migration' },
+								{ siteSlug }
+							)
+						);
 					}
 
 					if ( entryPoint === 'wp-admin-importers-list' ) {
 						return exitFlow(
-							addQueryArgs( { siteSlug, siteId, ref: entryPoint }, '/setup/site-setup/importList' )
+							paths.siteSetupImportListPath( {
+								siteId,
+								siteSlug,
+								origin: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+								backToFlow: `/${ flowPath }/${ STEPS.SITE_MIGRATION_IDENTIFY.slug }`,
+								from: fromQueryParam,
+							} )
 						);
 					}
 
@@ -572,15 +516,11 @@ const siteMigration: FlowV2 = {
 						return exitFlow( '/start' );
 					}
 
-					return navigate(
-						addQueryArgs( { siteSlug, siteId }, STEPS.SITE_MIGRATION_IDENTIFY.slug )
-					);
+					return navigate( paths.identifyPath( { from: fromQueryParam } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug: {
-					return navigate(
-						addQueryArgs( { siteSlug, siteId }, STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug )
-					);
+					return navigate( paths.importOrMigratePath( { siteSlug, siteId } ) );
 				}
 
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
@@ -592,7 +532,13 @@ const siteMigration: FlowV2 = {
 				}
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
-					return navigate( `${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }` );
+					return navigate(
+						paths.howToMigratePath( {
+							siteSlug,
+							siteId,
+							from: fromQueryParam,
+						} )
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_CREDENTIALS.slug: {
@@ -608,11 +554,23 @@ const siteMigration: FlowV2 = {
 						return exitFlow( `/home/${ siteId }` );
 					}
 
-					return navigate( `${ STEPS.SITE_MIGRATION_HOW_TO_MIGRATE.slug }?${ urlQueryParams }` );
+					return navigate(
+						paths.howToMigratePath( {
+							siteSlug,
+							siteId,
+							from: fromQueryParam,
+						} )
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_OTHER_PLATFORM_DETECTED_IMPORT.slug: {
-					return navigate( `${ STEPS.SITE_MIGRATION_CREDENTIALS.slug }?${ urlQueryParams }` );
+					return navigate(
+						paths.credentialsPath( {
+							siteId,
+							siteSlug,
+							from: fromQueryParam,
+						} )
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_FALLBACK_CREDENTIALS.slug: {
@@ -621,19 +579,45 @@ const siteMigration: FlowV2 = {
 						STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug
 					) {
 						return navigate(
-							`${ STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug }?${ urlQueryParams }`
+							paths.applicationPasswordAuthorizationPath( {
+								siteId,
+								siteSlug,
+								from: fromQueryParam,
+								authorizationUrl: urlQueryParams.get( 'authorizationUrl' ),
+								success: urlQueryParams.get( 'success' ),
+								password: urlQueryParams.get( 'password' ),
+								user_login: urlQueryParams.get( 'user_login' ),
+							} )
 						);
 					}
 
-					return navigate( `${ STEPS.SITE_MIGRATION_CREDENTIALS.slug }?${ urlQueryParams }` );
+					return navigate(
+						paths.credentialsPath( {
+							siteId,
+							siteSlug,
+							from: fromQueryParam,
+						} )
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_APPLICATION_PASSWORD_AUTHORIZATION.slug: {
-					return navigate( `${ STEPS.SITE_MIGRATION_CREDENTIALS.slug }?${ urlQueryParams }` );
+					return navigate(
+						paths.credentialsPath( {
+							siteId,
+							siteSlug,
+							from: fromQueryParam,
+						} )
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_ALREADY_WPCOM.slug: {
-					return navigate( `${ STEPS.SITE_MIGRATION_CREDENTIALS.slug }?${ urlQueryParams }` );
+					return navigate(
+						paths.credentialsPath( {
+							siteId,
+							siteSlug,
+							from: fromQueryParam,
+						} )
+					);
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -198,7 +198,14 @@ const siteMigration: FlowV2 = {
 									: urlQueryParams.delete( key );
 							} );
 
-							return navigate( paths.sitePickerPath() );
+							const queryParams = Object.fromEntries( urlQueryParams );
+
+							return navigate(
+								paths.sitePickerPath( {
+									from: fromQueryParam,
+									...queryParams,
+								} )
+							);
 						}
 						case 'select-site': {
 							const { ID: newSiteId, slug: newSiteSlug } =
@@ -528,7 +535,14 @@ const siteMigration: FlowV2 = {
 						return window.location.assign( `${ siteAdminUrl }import.php` );
 					}
 
-					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
+					const queryParams = Object.fromEntries( urlQueryParams );
+
+					return exitFlow(
+						paths.siteSetupGoalsPath( {
+							siteSlug,
+							...queryParams,
+						} )
+					);
 				}
 
 				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {


### PR DESCRIPTION
Related to DOTOBRD-91

## Proposed Changes
* Add helpers to generate step paths instead of repeatedly
* Introduce a buildPathHelper to build strong typed path generation methods quickly. 

## Why are these changes being made?
The flow file is pretty complex, and URL generation is one of the most critical parts. We can easily forget to use all required query parameters. This PR aims to reduce this and simplify further flow refactoring.

I extracted this change from another PR when I saw I was quickly forgetting to use all required parameters.  
The PR is using it is [WIP] https://github.com/Automattic/wp-calypso/pull/102485


Example:

```tsx
export const createSitePath = buildPathHelper< {
	queryParams: {
		siteId?: number | string;
		siteSlug: string;
	};
} >( STEPS.SITE_CREATION_STEP.slug );


✅ createSitePath({siteId: 123, siteSlug: 'some-site'}) // returns "create-site?siteId=123&siteSlug=some-site"
❌ createSitePath({siteId2: 123, siteSlug: 'some-site'}) 

/**Typescript error: 
Object literal may only specify known properties, but 'siteId2' does not exist in type '{
Isiteld?: string | number I undefined; siteSlug: string; }'. Did you mean to write 'siteId'?
ts(2561)
**/
```
You can see more usages on the test suite https://github.com/Automattic/wp-calypso/blob/d8c2df0df6afc5ca88a5a306b5f11ad8cb611a73/client/landing/stepper/declarative-flow/flows/site-migration-flow/paths/test/index.ts#L3


## Testing Instructions
* Go to /setup/hosted-site-migration
* Choose the DIFM option and finish the migration; just check if the flow was finished properly.

No UI change is expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
