### PR TITLE
Domains: Fix page reload on domain action menu click

### DIFF
--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row-actions.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { screen, act } from '@testing-library/react';
+import { renderWithProvider } from '../../test-utils';
+import { ResponseDomain } from '../../utils/types';
+import { DomainsTableStateContext, useGenerateDomainsTableState } from '../domains-table';
+import { DomainsTableRowActions } from '../domains-table-row-actions';
+
+jest.mock( '@automattic/calypso-router' );
+
+const render = ( el, props ) =>
+	renderWithProvider( el, {
+		wrapper: function Wrapper( { children } ) {
+			return (
+				<DomainsTableStateContext.Provider value={ useGenerateDomainsTableState( props ) }>
+					{ children }
+				</DomainsTableStateContext.Provider>
+			);
+		},
+	} );
+
+const domain = {
+	name: 'example.com',
+	domain: 'example.com',
+	type: 'registered',
+	canManageDnsRecords: true,
+} as ResponseDomain;
+
+const defaultProps = {
+	domain,
+	siteSlug: 'example',
+};
+
+test( 'when settings action is clicked it should show the settings page', async () => {
+	render( <DomainsTableRowActions { ...defaultProps } />, defaultProps );
+
+	const domainAction = screen.getByRole( 'button', {
+		name: 'Domain actions',
+	} );
+
+	await act( async () => {
+		domainAction.click();
+	} );
+
+	const settingsAction = screen.getByText( 'View settings' );
+	settingsAction.click();
+
+	expect( page ).toHaveBeenCalledWith( '/domains/manage/example.com/edit/example' );
+} );
+
+test( 'when dns action is clicked it should show the dns page', async () => {
+	render( <DomainsTableRowActions { ...defaultProps } />, defaultProps );
+
+	const domainAction = screen.getByRole( 'button', {
+		name: 'Domain actions',
+	} );
+
+	await act( async () => {
+		domainAction.click();
+	} );
+
+	const dnsAction = screen.getByText( 'Manage DNS' );
+	dnsAction.click();
+
+	expect( page ).toHaveBeenCalledWith( '/domains/manage/example.com/dns/example' );
+} );
+
+test( 'when contact action is clicked it should show the contact page', async () => {
+	render( <DomainsTableRowActions { ...defaultProps } />, defaultProps );
+
+	const domainAction = screen.getByRole( 'button', {
+		name: 'Domain actions',
+	} );
+
+	await act( async () => {
+		domainAction.click();
+	} );
+
+	const contactAction = screen.getByText( 'Manage contact information' );
+	contactAction.click();
+
+	expect( page ).toHaveBeenCalledWith( '/domains/manage/example.com/edit-contact-info/example' );
+} );
+
+test( 'when transfer action is clicked it should show the transfer page', async () => {
+	const transferDomain = {
+		...domain,
+		type: 'mapping',
+		isEligibleForInboundTransfer: true,
+	} as ResponseDomain;
+
+	const props = {
+		...defaultProps,
+		domain: transferDomain,
+	};
+
+	render( <DomainsTableRowActions { ...props } />, props );
+
+	const domainAction = screen.getByRole( 'button', {
+		name: 'Domain actions',
+	} );
+
+	await act( async () => {
+		domainAction.click();
+	} );
+
+	const transferAction = screen.getByText( 'Transfer to WordPress.com' );
+	transferAction.click();
+
+	expect( page ).toHaveBeenCalledWith(
+		'/domains/add/use-my-domain/example?initialQuery=example.com&initialMode=transfer-domain'
+	);
+} );

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -85,11 +86,21 @@ export const DomainsTableRowActions = ( {
 	const canChangeSiteAddress =
 		! isAllSitesView && isSimpleSite && isFreeUrlDomainName( domain.name );
 	const canRenewDomain = isDomainRenewable( domain );
+	const handleMenuItemClick = ( event: React.MouseEvent< HTMLButtonElement > ) => {
+		const url = event.target?.parentElement?.getAttribute( 'href' );
+
+		if ( url ) {
+			event.preventDefault();
+			page( url );
+		}
+	};
+
 	const getActions = ( onClose?: () => void ) => {
 		return [
 			canViewDetails && (
 				<MenuItemLink
 					key="actionDetails"
+					onClick={ handleMenuItemClick }
 					href={ domainManagementLink(
 						domain,
 						siteSlug,
@@ -104,7 +115,10 @@ export const DomainsTableRowActions = ( {
 			canManageDNS && (
 				<MenuItemLink
 					key="manageDNS"
-					onClick={ () => onDomainAction?.( 'manage-dns-settings', domain ) }
+					onClick={ ( event ) => {
+						onDomainAction?.( 'manage-dns-settings', domain );
+						handleMenuItemClick( event );
+					} }
 					href={ domainManagementDNS( siteSlug, domain.name, context ) }
 				>
 					{ __( 'Manage DNS' ) }
@@ -113,6 +127,7 @@ export const DomainsTableRowActions = ( {
 			canManageContactInfo && (
 				<MenuItemLink
 					key="manageContactInfo"
+					onClick={ handleMenuItemClick }
 					href={ domainManagementEditContactInfo( siteSlug, domain.name, null, context ) }
 				>
 					{ __( 'Manage contact information' ) }
@@ -133,6 +148,7 @@ export const DomainsTableRowActions = ( {
 			canTransferToWPCOM && (
 				<MenuItemLink
 					key="transferToWPCOM"
+					onClick={ handleMenuItemClick }
 					href={ domainUseMyDomain( siteSlug, domain.name, useMyDomainInputMode.transferDomain ) }
 				>
 					{ __( 'Transfer to WordPress.com' ) }

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -86,8 +86,8 @@ export const DomainsTableRowActions = ( {
 	const canChangeSiteAddress =
 		! isAllSitesView && isSimpleSite && isFreeUrlDomainName( domain.name );
 	const canRenewDomain = isDomainRenewable( domain );
-	const handleMenuItemClick = ( event: React.MouseEvent< HTMLButtonElement > ) => {
-		const url = event.target?.parentElement?.getAttribute( 'href' );
+	const handleMenuItemClick = ( event: React.MouseEvent ) => {
+		const url = ( event.target as HTMLElement ).parentElement?.getAttribute( 'href' );
 
 		if ( url ) {
 			event.preventDefault();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/101872

## Proposed Changes

This PR fixes the domain action menu item click handler. It was forcing a full-page reload when an item was clicked.

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/3d299b75-aca2-4c89-b126-77a6eaf4a217" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This makes it consistent with the other screens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have a site with multiple domains.
* Go to /domains/manage/[site].
* Click on the 3 dots to open the action menu and click on all items.
* Make sure the page is not refreshed and the correct page is rendered.
* Go to /overview/[site], scroll down to "Active domains" and repeat the above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
