### PR TITLE
Jetpack AI Logo Generator: Open Help Center on Learn More

### DIFF
--- a/packages/jetpack-ai-calypso/jest.config.js
+++ b/packages/jetpack-ai-calypso/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
 };

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -43,7 +43,9 @@ export const UpgradeScreen: React.FC< {
 		onCancel();
 	};
 
-	const learnMoreLink = localizeUrl( 'https://wordpress.com/support/stats/' );
+	const learnMoreLink = localizeUrl(
+		'https://wordpress.com/support/create-a-logo-with-jetpack-ai/'
+	);
 	const onLearnMoreClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
 		event.preventDefault();
 		onCancel();
@@ -58,7 +60,7 @@ export const UpgradeScreen: React.FC< {
 					{ reason === 'feature' ? upgradeMessageFeature : upgradeMessageRequests }
 				</span>
 				&nbsp;
-				<Button variant="link" href="https://jetpack.com/ai/" onClick={ onLearnMoreClick }>
+				<Button variant="link" href={ learnMoreLink } onClick={ onLearnMoreClick }>
 					{ __( 'Learn more', 'jetpack' ) }
 				</Button>
 			</div>

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { HelpCenter } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -14,11 +17,15 @@ import useLogoGenerator from '../hooks/use-logo-generator';
  */
 import type React from 'react';
 
+const HELP_CENTER_STORE = HelpCenter.register();
+
 export const UpgradeScreen: React.FC< {
 	onCancel: () => void;
 	upgradeURL: string;
 	reason: 'feature' | 'requests';
 } > = ( { onCancel, upgradeURL, reason } ) => {
+	const { setShowHelpCenter, setShowSupportDoc } = useDispatch( HELP_CENTER_STORE );
+
 	const upgradeMessageFeature = __(
 		'Upgrade your Jetpack AI for access to exclusive features, including logo generation. This upgrade will also increase the amount of requests you can use in all AI-powered features.',
 		'jetpack'
@@ -36,6 +43,14 @@ export const UpgradeScreen: React.FC< {
 		onCancel();
 	};
 
+	const learnMoreLink = localizeUrl( 'https://wordpress.com/support/stats/' );
+	const onLearnMoreClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
+		event.preventDefault();
+		onCancel();
+		setShowHelpCenter( true );
+		setShowSupportDoc( learnMoreLink );
+	};
+
 	return (
 		<div className="jetpack-ai-logo-generator-modal__notice-message-wrapper">
 			<div className="jetpack-ai-logo-generator-modal__notice-message">
@@ -43,7 +58,7 @@ export const UpgradeScreen: React.FC< {
 					{ reason === 'feature' ? upgradeMessageFeature : upgradeMessageRequests }
 				</span>
 				&nbsp;
-				<Button variant="link" href="https://jetpack.com/ai/">
+				<Button variant="link" href="https://jetpack.com/ai/" onClick={ onLearnMoreClick }>
 					{ __( 'Learn more', 'jetpack' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/99791

## Proposed Changes

On a free plan site, the My Home page has an option to create a logo with Jetpack AI.

Clicking it opens this modal.

<img width="526" alt="image" src="https://github.com/user-attachments/assets/d1bcde42-53e5-416f-bd17-66af7d422b8b" />

This PR makes the "Learn more" link open the Help Center with https://wordpress.com/support/stats/

![image](https://github.com/user-attachments/assets/05c1e33b-6ba4-439d-904f-32db4eb5a9f1)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a free site
* Click on the option in the dashboard
* Click on "Learn more"