### PR TITLE
Fix Playground onboarding flow for container v1

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -66,6 +66,7 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 			<StepWrapper
 				hideBack
 				hideSkip
+				hideFormattedHeader
 				customizedActionButtons={
 					<Button
 						variant="primary"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
@@ -6,3 +6,14 @@
 		height: 100%;
 	}
 }
+
+// v1
+.playground__onboarding-page {
+	margin-top: 17px;
+	height: 100vh;
+
+	.playground__onboarding-iframe {
+		width: 100%;
+		height: 100%;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix Playground onboarding flow iframe page sizes in v1 flow.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set `"onboarding/step-container-v2": false` on `config/development.json` (like in production)
* Load http://calypso.localhost:3000/setup/onboarding/playground and be sure the iframe take all the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
