### PR TITLE
E2E: Increase specificity of SEO title selector

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -94,14 +94,14 @@ export class EditorSettingsSidebarComponent {
 	 * text box.
 	 *
 	 * @param {string} text Text to enter.
-	 * @param param1 Keyed object parametr.
+	 * @param param1 Keyed object parameter.
 	 * @param {string} param1.label Locate text field by label.
 	 */
 	async enterText( text: string, { label }: { label: string } ): Promise< void > {
 		const editorParent = await this.editor.parent();
 
 		if ( label ) {
-			return await editorParent.getByLabel( label ).fill( text );
+			return await editorParent.getByRole( 'textbox', { name: label } ).fill( text );
 		}
 
 		throw new Error( 'Must specify a method to locate the text field.' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

There are two elements that match the "SEO TITLE" label. This PR ensures we select the textarea.

## Proposed Changes

This was the error:
```
locator.fill: Error: strict mode violation: locator('body.block-editor-page').getByLabel('SEO TITLE') resolved to 2 elements:
  1) <input checked value="1" type="checkbox" id="inspector-checkbox-control-3" class="components-checkbox-control__input"/> aka getByLabel('SEO title', { exact: true })
      2) <textarea rows="2" id="inspector-textarea-control-0" aria-describedby="inspector-textarea-control-0__help" class="components-textarea-control__input css-1rsh645 e1w5nnrk0" placeholder="Enter a clear, keyword-focused title (ideally under 70 characters)"></textarea> aka getByPlaceholder('Enter a clear, keyword-')
```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION="wp-beta" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__post-basic-flow.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?