### PR TITLE
Onboarding consistency: Fix checkout blinks

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -7,11 +7,9 @@ import { getToken } from '@automattic/oauth-token';
 import { JETPACK_PRICING_PAGE } from '@automattic/urls';
 import debugFactory from 'debug';
 import defaultCalypsoI18n from 'i18n-calypso';
-import ReactDom from 'react-dom';
 import Modal from 'react-modal';
 import store from 'store';
 import emailVerification from 'calypso/components/email-verification';
-import { ProviderWrappedLayout } from 'calypso/controller';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { initializeAnalytics } from 'calypso/lib/analytics/init';
 import getSuperProps from 'calypso/lib/analytics/super-props';
@@ -314,13 +312,6 @@ const setupMiddlewares = ( currentUser, reduxStore, reactQueryClient ) => {
 	}
 };
 
-function renderLayout( reduxStore, reactQueryClient ) {
-	ReactDom.render(
-		<ProviderWrappedLayout store={ reduxStore } queryClient={ reactQueryClient } />,
-		document.getElementById( 'wpcom' )
-	);
-}
-
 const boot = async ( currentUser, registerRoutes ) => {
 	saveOauthFlags();
 	utils();
@@ -341,12 +332,6 @@ const boot = async ( currentUser, registerRoutes ) => {
 	detectHistoryNavigation.start();
 	if ( registerRoutes ) {
 		registerRoutes();
-	}
-
-	// Render initial `<Layout>` for non-isomorphic sections.
-	// Isomorphic sections will take care of rendering their `<Layout>` themselves.
-	if ( ! document.getElementById( 'primary' ) ) {
-		renderLayout( reduxStore, queryClient );
 	}
 
 	page.start();

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -1,9 +1,7 @@
 import config from '@automattic/calypso-config';
 import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
-import colorStudio from '@automattic/color-studio';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
@@ -20,14 +18,6 @@ import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 const logCheckoutError = ( error: Error ) => {
 	logStashLoadErrorEvent( 'checkout_system_decider', error );
 };
-
-const CheckoutMainWrapperStyles = styled.div`
-	background-color: ${ colorStudio.colors[ 'White' ] };
-
-	a {
-		color: ${ colorStudio.colors[ 'WordPress Blue 50' ] };
-	}
-`;
 
 export default function CheckoutMainWrapper( {
 	productAliasFromUrl,
@@ -112,7 +102,7 @@ export default function CheckoutMainWrapper( {
 	}
 
 	return (
-		<CheckoutMainWrapperStyles>
+		<>
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
@@ -147,6 +137,6 @@ export default function CheckoutMainWrapper( {
 				</CalypsoShoppingCartProvider>
 			</CheckoutErrorBoundary>
 			{ isLoggedOutCart && <Recaptcha badgePosition="bottomright" /> }
-		</CheckoutMainWrapperStyles>
+		</>
 	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -593,11 +593,16 @@
 }
 
 .is-section-checkout-thank-you {
-	background: var(--studio-white);
-
 	.layout__content {
 		padding-right: 0;
 		padding-left: 0;
+	}
+}
+
+.is-section-checkout-pending,
+.is-section-checkout-thank-you {
+	&:not( :has( .step-container-v2 ) ) {
+		background: var( --studio-white, #fff );
 	}
 }
 
@@ -615,7 +620,6 @@
 
 .is-section-checkout-pending {
 	&.has-no-sidebar {
-		background: var(--studio-white, #fff );
 		.layout__content {
 			padding: 0;
 			overflow: hidden;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -5,6 +5,7 @@ import {
 	isBiennially,
 	isTriennially,
 } from '@automattic/calypso-products';
+import colorStudio from '@automattic/color-studio';
 import { Gridicon, MaterialIcon } from '@automattic/components';
 import {
 	Button,
@@ -863,6 +864,8 @@ export default function CheckoutMainContent( {
 }
 
 const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
+	background: ${ colorStudio.colors[ 'White' ] };
+
 	// This shouldn't exist. It's a hack to make the top bar appear on top of the checkout sidebar, which extends from the top of the page.
 	.step-container-v2__top-bar {
 		position: relative;
@@ -1345,6 +1348,7 @@ const SubmitButtonHeaderWrapper = styled.div`
 `;
 
 const WPCheckoutWrapper = styled.div`
+	background: ${ colorStudio.colors[ 'White' ] };
 	display: grid;
 	grid-template-rows: auto;
 	grid-template-columns: 1fr;
@@ -1374,6 +1378,7 @@ const WPCheckoutWrapper = styled.div`
 `;
 
 const WPCheckoutCompletedWrapper = styled.div`
+	background: ${ colorStudio.colors[ 'White' ] };
 	display: flex;
 	justify-content: center;
 	justify-items: center;

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -147,6 +147,10 @@ $font-size: rem(14px);
 .theme-default {
 	// client/layout/style.scss
 	.layout__content {
+		min-height: 100vh;
+	}
+
+	&:has(.sidebar) .layout__content {
 		min-height: 101vh; // Hack to give JS the chance to trigger the scroll event when the content is short. JS code: client/layout/utils.ts:36.
 	}
 


### PR DESCRIPTION
Supersedes https://github.com/Automattic/wp-calypso/pull/102347.

## Proposed changes

Check the original PR. Here are the differences between that PR and this one:

- set the minimum height of the layout as `100vh`, which looks fine as it's expected that the layout stretches vertically. It fixes p1744114640074409/1744114154.570949-slack-C04H4NY6STW;
- make sure there are no background color changes after checkout when StepContainerV2's Loading is on the screen.


https://github.com/user-attachments/assets/f70bd760-e840-49db-8632-88f4c75b51b4



## Testing Instructions

Check the original PR. Also, test with the feature flag off to ensure the changes don't introduce any regressions.