### PR TITLE
StepContainerV2 Loading: Include styles during SSR

### DIFF
--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -1,3 +1,5 @@
+@import '@automattic/onboarding/src/step-container-v2/wireframes/Loading/style.ssr.scss';
+
 .wpcom-site__logo {
 	fill: var(--color-neutral-10);
 	color: var(--color-neutral-10);

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -196,19 +196,17 @@ class Document extends Component {
 									'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 								} ) }
 							>
-								<div className="layout__content">
-									{ shouldNotShowLoadingLogo ? (
-										<>
-											{ showStepContainerV2Loader ? (
-												<Step.Loading />
-											) : (
-												<Loading className="wpcom-loading__boot" />
-											) }
-										</>
-									) : (
-										<LoadingLogo size={ 72 } className="wpcom-site__logo" />
-									) }
-								</div>
+								{ shouldNotShowLoadingLogo ? (
+									<>
+										{ showStepContainerV2Loader ? (
+											<Step.Loading />
+										) : (
+											<Loading className="wpcom-loading__boot" />
+										) }
+									</>
+								) : (
+									<LoadingLogo size={ 72 } className="wpcom-site__logo" />
+								) }
 							</div>
 						</div>
 					) }

--- a/packages/onboarding/src/step-container-v2/wireframes/Loading/style.ssr.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/Loading/style.ssr.scss
@@ -1,3 +1,12 @@
+/**
+ * This wireframe is loaded in the server-side rendering (SSR) context where styles
+ * are ignored. We need to import its styles into the main bundle manually to ensure
+ * the wireframe and its components display correctly during SSR.
+
+ * Whenever you update the wireframe, make sure to update this file to include
+ * the stylesheets from the used components.
+ */
+
 @import '../../components/StepContainerV2/style.scss';
 @import '../../components/TopBar/style.scss';
 @import '../../components/Heading/style.scss';

--- a/packages/onboarding/src/step-container-v2/wireframes/Loading/style.ssr.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/Loading/style.ssr.scss
@@ -1,0 +1,5 @@
+@import '../../components/StepContainerV2/style.scss';
+@import '../../components/TopBar/style.scss';
+@import '../../components/Heading/style.scss';
+
+@import './style.scss';


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102347#pullrequestreview-2748811376.

## Proposed changes

The `<Step.Loading />` wireframe is loaded in the server-side rendering (SSR) context where styles are ignored.

Coincidentally, we've been visiting pages where the wireframe is actually being used, and that's why we haven't been seeing any issues. But once (and if) we make this loading experience the default, it might not be the case.

So, we need to import this wireframe's styles into the main bundle manually to ensure it and its components display correctly during SSR.

## Testing Instructions

The issue doesn't happen right now in contexts where the wireframe is used, so you'll need to make some tweaks in `document/index.jsx`.

On `trunk`, remove [this whole part](https://github.com/Automattic/wp-calypso/blob/trunk/client/document/index.jsx#L199-L211) and replace it with just `<Step.Loading />` to force show the wireframe. Restart the Calypso server. Once you browse `/sites`, you'll see this:

![image](https://github.com/user-attachments/assets/e22afbe9-3088-4575-97c7-695b115dcf83)

Now, checkout this branch and do the same code replacement. Restart the Calypso server. Navigate to `/sites` once again and you should see the correct styles (open the image to see the centered progress bar):

![image](https://github.com/user-attachments/assets/c0ef0c22-84da-4fb7-9885-a99f43b8b67a)
