### PR TITLE
Command Palette: Remove admin interface check on editor commands

### DIFF
--- a/packages/command-palette/src/commands.tsx
+++ b/packages/command-palette/src/commands.tsx
@@ -904,12 +904,7 @@ export function useCommands() {
 						__i18n_text_domain__
 					),
 				].join( KEYWORD_SEPARATOR ),
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/options-general.php'
-							: '/settings/general/:site#admin-interface-style'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/options-general.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __(
 					'Select site to change admin interface style',
@@ -973,11 +968,7 @@ export function useCommands() {
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/posts', { path: '/wp-admin/edit.php', match: 'exact' } ],
 				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/edit-tags.php?taxonomy=category'
-							: '/settings/taxonomies/category/:site'
-					)( params ),
+					commandNavigation( '/wp-admin/edit-tags.php?taxonomy=category' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage categories', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_CATEGORIES,
@@ -997,11 +988,7 @@ export function useCommands() {
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/posts', { path: '/wp-admin/edit.php', match: 'exact' } ],
 				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/edit-tags.php?taxonomy=post_tag'
-							: '/settings/taxonomies/post_tag/:site'
-					)( params ),
+					commandNavigation( '/wp-admin/edit-tags.php?taxonomy=post_tag' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage tags', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_CATEGORIES,
@@ -1024,10 +1011,7 @@ export function useCommands() {
 					),
 					'wp media*', // WP-CLI command
 				].join( KEYWORD_SEPARATOR ),
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/upload.php' : '/media/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/upload.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to view media uploads', __i18n_text_domain__ ),
 				capability: SiteCapabilities.UPLOAD_FILES,
@@ -1036,10 +1020,7 @@ export function useCommands() {
 			uploadMedia: {
 				name: 'uploadMedia',
 				label: __( 'Upload media', __i18n_text_domain__ ),
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/media-new.php' : '/media/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/media-new.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to upload media', __i18n_text_domain__ ),
 				capability: SiteCapabilities.UPLOAD_FILES,
@@ -1084,12 +1065,7 @@ export function useCommands() {
 					_x( 'delete comments', 'Keyword for the Manage comments command', __i18n_text_domain__ ),
 					'wp comment*', // WP-CLI command
 				].join( KEYWORD_SEPARATOR ),
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/edit-comments.php'
-							: '/comments/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/edit-comments.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage comments', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MODERATE_COMMENTS,
@@ -1463,10 +1439,7 @@ export function useCommands() {
 				name: 'export',
 				label: __( 'Export content from the site', __i18n_text_domain__ ),
 				searchLabel: 'wp export', // WP-CLI command
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site ) ? '/wp-admin/export.php' : '/export/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/export.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to export content from', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,
@@ -1529,12 +1502,7 @@ export function useCommands() {
 					),
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/options-general.php'
-							: '/settings/general/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/options-general.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage general settings', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,
@@ -1571,12 +1539,7 @@ export function useCommands() {
 					),
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/options-writing.php'
-							: '/settings/writing/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/options-writing.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage writing settings', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,
@@ -1613,12 +1576,7 @@ export function useCommands() {
 					),
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/options-reading.php'
-							: '/settings/writing/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/options-reading.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage reading settings', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,
@@ -1650,12 +1608,7 @@ export function useCommands() {
 					),
 				].join( KEYWORD_SEPARATOR ),
 				context: [ '/settings', '/wp-admin/options-' ],
-				callback: ( params ) =>
-					commandNavigation(
-						siteUsesWpAdminInterface( params.site )
-							? '/wp-admin/options-discussion.php'
-							: '/settings/discussion/:site'
-					)( params ),
+				callback: ( params ) => commandNavigation( '/wp-admin/options-discussion.php' )( params ),
 				siteSelector: true,
 				siteSelectorLabel: __( 'Select site to manage discussion settings', __i18n_text_domain__ ),
 				capability: SiteCapabilities.MANAGE_OPTIONS,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCOM-1720

## Proposed Changes

* As part of the RDV effort, we now want to remove entry points to deprecated calypso views to avoid unnecessary redirections.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to your site's home
* Open the command palette (`Ctrl + K`)
* For the following commands, check that they take you to wp-admin pages without a redirection:
  * Change admin interface style
  * Manage categories
  * Manage tags
  * View media uploads
  * Upload media
  * Manage comments
  * Export content from the site
  * Manage general settings
  * Manage writing settings
  * Manage reading settings
  * Manage discussion settings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
