### PR TITLE
StepContainerV2 Checkout: Remove hasContentPadding prop and rework layout

### DIFF
--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
@@ -6,6 +6,7 @@ import { CheckoutSummaryRefundWindows } from './wp-checkout-order-summary';
 const CheckoutMoneyBackGuaranteeWrapper = styled.div`
 	display: flex;
 	justify-content: center;
+	align-items: center;
 	margin: 1.5em 0 0;
 
 	& li {

--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
@@ -15,9 +15,6 @@ const CheckoutMoneyBackGuaranteeWrapper = styled.div`
 		font-size: 14px;
 		margin-bottom: 0;
 		padding: 0;
-		svg {
-			display: none;
-		}
 	}
 
 	.rtl & {

--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.tsx
@@ -4,35 +4,15 @@ import styled from '@emotion/styled';
 import { CheckoutSummaryRefundWindows } from './wp-checkout-order-summary';
 
 const CheckoutMoneyBackGuaranteeWrapper = styled.div`
-	display: grid;
-	grid-template-columns: 20px 1fr 70px;
-	column-gap: 1em;
-	align-items: center;
+	display: flex;
+	justify-content: center;
 	margin: 1.5em 0 0;
 
 	& li {
 		list-style: none;
 		font-size: 14px;
-		margin-bottom: 0;
+		margin: 0 0 0 0.5rem;
 		padding: 0;
-	}
-
-	.rtl & {
-		grid-template-columns: 20px 1fr;
-		padding: 10px 80px 10px 20px;
-
-		& li {
-			padding: 0;
-		}
-	}
-
-	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
-		grid-template-columns: 20px minmax( min-content, 300px ) 70px;
-	}
-
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		grid-template-columns: 20px minmax( 150px, max-content );
-		justify-content: center;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -842,8 +842,9 @@ export default function CheckoutMainContent( {
 
 	return (
 		<StepContainerV2CheckoutFixer isLargeViewport={ isLargeViewport }>
-			<Step.CenteredColumnLayout
-				columnWidth={ 12 }
+			<Step.TwoColumnLayout
+				firstColumnWidth={ 8 }
+				secondColumnWidth={ 4 }
 				topBar={ ( { isLargeViewport } ) => {
 					const topBar = (
 						<Step.TopBar
@@ -874,32 +875,20 @@ export default function CheckoutMainContent( {
 				{ ( { isLargeViewport } ) => {
 					if ( isLargeViewport ) {
 						return (
-							<StepContainerV2CheckoutWrapper>
+							<>
 								{ checkoutMainContent }
 								{ checkoutSummary }
-							</StepContainerV2CheckoutWrapper>
+							</>
 						);
 					}
 
 					return checkoutMainContent;
 				} }
-			</Step.CenteredColumnLayout>
+			</Step.TwoColumnLayout>
 			<LeaveCheckoutModal { ...leaveModalProps } />
 		</StepContainerV2CheckoutFixer>
 	);
 }
-
-const StepContainerV2CheckoutWrapper = styled.div`
-	display: flex;
-
-	.checkout-main-content {
-		flex: 2;
-	}
-
-	.checkout-sidebar-content {
-		flex: 1;
-	}
-`;
 
 const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 	background: ${ colorStudio.colors[ 'White' ] };
@@ -995,12 +984,13 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 		props.isLargeViewport &&
 		css`
 			.checkout-main-content {
-				padding-left: 0;
+				padding: 0;
 				margin-top: 1rem;
+				max-width: 100%;
 			}
 
 			.checkout-sidebar-content {
-				--left-padding: 3.875rem;
+				--left-padding: 4rem;
 				padding: 0 0 0 var( --left-padding );
 				background: none;
 				position: relative;
@@ -1021,6 +1011,10 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 			.checkout__summary-area,
 			.checkout__summary-body {
 				max-width: 100%;
+			}
+
+			.checkout__summary-area {
+				min-width: 300px;
 			}
 
 			.checkout__summary-body {

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -933,6 +933,7 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 
 			.checkout__summary-features {
 				padding: 0;
+				padding-bottom: 24px;
 				width: 100%;
 			}
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -578,284 +578,310 @@ export default function CheckoutMainContent( {
 		return true;
 	};
 
-	const content = (
-		<WPCheckoutWrapper className="checkout-wrapper">
-			<WPCheckoutSidebarContent className="checkout-sidebar-content">
-				{ isLoading && <LoadingSidebarContent /> }
-				{ ! isLoading && (
-					<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
-						<CheckoutErrorBoundary
-							errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
-							onError={ onSummaryError }
+	const checkoutSummary = (
+		<WPCheckoutSidebarContent className="checkout-sidebar-content">
+			{ isLoading && <LoadingSidebarContent /> }
+			{ ! isLoading && (
+				<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
+					<CheckoutErrorBoundary
+						errorMessage={ translate( 'Sorry, there was an error loading this information.' ) }
+						onError={ onSummaryError }
+					>
+						<CheckoutSummaryTitleLink
+							className="checkout__summary-button"
+							onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }
 						>
-							<CheckoutSummaryTitleLink
-								className="checkout__summary-button"
-								onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }
-							>
-								<CheckoutSummaryTitleContent className="checkout__summary-title">
-									<CheckoutSummaryTitle>
-										{ ! isStepContainerV2 && (
-											<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
-										) }
-										{ translate( 'Purchase Details' ) }
-										<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
-									</CheckoutSummaryTitle>
-									<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
-										{ formatCurrency( responseCart.total_cost_integer, responseCart.currency, {
-											isSmallestUnit: true,
-											stripZeros: true,
-										} ) }
-									</CheckoutSummaryTitlePrice>
-								</CheckoutSummaryTitleContent>
-							</CheckoutSummaryTitleLink>
+							<CheckoutSummaryTitleContent className="checkout__summary-title">
+								<CheckoutSummaryTitle>
+									{ ! isStepContainerV2 && (
+										<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
+									) }
+									{ translate( 'Purchase Details' ) }
+									<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
+								</CheckoutSummaryTitle>
+								<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
+									{ formatCurrency( responseCart.total_cost_integer, responseCart.currency, {
+										isSmallestUnit: true,
+										stripZeros: true,
+									} ) }
+								</CheckoutSummaryTitlePrice>
+							</CheckoutSummaryTitleContent>
+						</CheckoutSummaryTitleLink>
 
-							<CheckoutSummaryBody className="checkout__summary-body">
-								{ shouldShowSitePreview && (
-									<div className="checkout-site-preview">
-										<SitePreviewWrapper>
-											<SitePreview showEditSite={ false } showSiteDetails={ false } />
-										</SitePreviewWrapper>
-									</div>
-								) }
-
-								<WPCheckoutOrderSummary
-									siteId={ siteId }
-									onChangeSelection={ changeSelection }
-									showFeaturesList
-								/>
-								<CheckoutSidebarNudge
-									addItemToCart={ addItemToCart }
-									areThereDomainProductsInCart={ areThereDomainProductsInCart }
-								/>
-							</CheckoutSummaryBody>
-						</CheckoutErrorBoundary>
-					</CheckoutSummaryArea>
-				) }
-			</WPCheckoutSidebarContent>
-
-			<WPCheckoutMainContent className="checkout-main-content">
-				<CheckoutOrderBanner />
-				{ isStepContainerV2 ? (
-					<Step.Heading
-						text={ translate( 'Checkout' ) }
-						align="left"
-						size={ ! isLargeViewport ? 'small' : undefined }
-					/>
-				) : (
-					<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
-				) }
-				<CheckoutStepGroup loadingHeader={ loadingHeader } onStepChanged={ onStepChanged }>
-					<PerformanceTrackerStop />
-					{ infoMessage }
-
-					<CheckoutStepBody
-						onError={ onReviewError }
-						className="wp-checkout__review-order-step"
-						stepId="review-order-step"
-						isStepActive={ false }
-						isStepComplete
-						titleContent={ <OrderReviewTitle /> }
-						completeStepContent={
-							<WPCheckoutOrderReview
-								removeProductFromCart={ removeProductFromCart }
-								replaceProductInCart={ replaceProductInCart }
-								couponFieldStateProps={ couponFieldStateProps }
-								removeCouponAndClearField={ removeCouponAndClearField }
-								isCouponFieldVisible={ isCouponFieldVisible }
-								setCouponFieldVisible={ setCouponFieldVisible }
-								onChangeSelection={ changeSelection }
-								siteUrl={ siteUrl }
-								createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-							/>
-						}
-						formStatus={ formStatus }
-					/>
-
-					{ contactDetailsType !== 'none' && (
-						<CheckoutStep
-							className="checkout-contact-form-step"
-							stepId="contact-form"
-							isCompleteCallback={ async () => {
-								// Touch the fields so they display validation errors
-								shouldShowContactDetailsValidationErrors && touchContactFields();
-								const validationResponse = await validateContactDetails(
-									contactInfo,
-									isLoggedOutCart,
-									responseCart,
-									showErrorMessageBriefly,
-									applyDomainContactValidationResults,
-									clearDomainContactErrorMessages,
-									reduxDispatch,
-									translate,
-									shouldShowContactDetailsValidationErrors
-								);
-								if ( validationResponse ) {
-									// When the contact details change, update the VAT details on the server.
-									try {
-										if (
-											! isLoggedOutCart &&
-											vatDetailsInForm.id &&
-											! areVatDetailsSame( vatDetailsInForm, vatDetailsFromServer )
-										) {
-											await setVatDetails( vatDetailsInForm );
-										}
-									} catch ( error ) {
-										reduxDispatch( removeNotice( 'vat_info_notice' ) );
-										if ( shouldShowContactDetailsValidationErrors ) {
-											reduxDispatch(
-												errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
-											);
-										}
-										return false;
-									}
-									reduxDispatch( removeNotice( 'vat_info_notice' ) );
-
-									// When the contact details change, update the cart's tax location to match.
-									try {
-										await updateCartContactDetailsForCheckout(
-											countriesList,
-											responseCart,
-											updateLocation,
-											contactInfo,
-											vatDetailsInForm
-										);
-									} catch {
-										// If updating the cart fails, we should not continue. No need
-										// to do anything else, though, because CartMessages will
-										// display the error.
-										return false;
-									}
-
-									// When the contact details change, update the cached contact details on
-									// the server. This can fail if validation fails but we will silently
-									// ignore failures here because the validation call will handle them better
-									// than this will.
-									updateCachedContactDetails(
-										prepareDomainContactValidationRequest( contactInfo )
-									);
-
-									reduxDispatch(
-										recordTracksEvent( 'calypso_checkout_composite_step_complete', {
-											step: 1,
-											step_name: 'contact-form',
-										} )
-									);
-								}
-								return validationResponse;
-							} }
-							activeStepContent={
-								<>
-									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
-									<WPContactForm
-										countriesList={ countriesList }
-										shouldShowContactDetailsValidationErrors={
-											shouldShowContactDetailsValidationErrors
-										}
-										contactDetailsType={ contactDetailsType }
-										isLoggedOutCart={ isLoggedOutCart }
-										setShouldShowContactDetailsValidationErrors={
-											setShouldShowContactDetailsValidationErrors
-										}
-									/>
-								</>
-							}
-							completeStepContent={
-								<>
-									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
-									<WPContactFormSummary
-										areThereDomainProductsInCart={ areThereDomainProductsInCart }
-										isGSuiteInCart={ isGSuiteInCart }
-										isLoggedOutCart={ isLoggedOutCart }
-									/>
-								</>
-							}
-							titleContent={ <ContactFormTitle /> }
-							editButtonText={ String( translate( 'Edit' ) ) }
-							editButtonAriaLabel={ String( translate( 'Edit the contact details' ) ) }
-							nextStepButtonText={ nextStepButtonText }
-							nextStepButtonAriaLabel={ String(
-								translate( 'Continue with the entered contact details' )
+						<CheckoutSummaryBody className="checkout__summary-body">
+							{ shouldShowSitePreview && (
+								<div className="checkout-site-preview">
+									<SitePreviewWrapper>
+										<SitePreview showEditSite={ false } showSiteDetails={ false } />
+									</SitePreviewWrapper>
+								</div>
 							) }
-							validatingButtonText={ validatingButtonText }
-							validatingButtonAriaLabel={ validatingButtonText }
+
+							<WPCheckoutOrderSummary
+								siteId={ siteId }
+								onChangeSelection={ changeSelection }
+								showFeaturesList
+							/>
+							<CheckoutSidebarNudge
+								addItemToCart={ addItemToCart }
+								areThereDomainProductsInCart={ areThereDomainProductsInCart }
+							/>
+						</CheckoutSummaryBody>
+					</CheckoutErrorBoundary>
+				</CheckoutSummaryArea>
+			) }
+		</WPCheckoutSidebarContent>
+	);
+
+	const checkoutMainContent = (
+		<WPCheckoutMainContent className="checkout-main-content">
+			<CheckoutOrderBanner />
+			{ isStepContainerV2 ? (
+				<Step.Heading
+					text={ translate( 'Checkout' ) }
+					align="left"
+					size={ ! isLargeViewport ? 'small' : undefined }
+				/>
+			) : (
+				<WPCheckoutTitle>{ translate( 'Checkout' ) }</WPCheckoutTitle>
+			) }
+			<CheckoutStepGroup loadingHeader={ loadingHeader } onStepChanged={ onStepChanged }>
+				<PerformanceTrackerStop />
+				{ infoMessage }
+
+				<CheckoutStepBody
+					onError={ onReviewError }
+					className="wp-checkout__review-order-step"
+					stepId="review-order-step"
+					isStepActive={ false }
+					isStepComplete
+					titleContent={ <OrderReviewTitle /> }
+					completeStepContent={
+						<WPCheckoutOrderReview
+							removeProductFromCart={ removeProductFromCart }
+							replaceProductInCart={ replaceProductInCart }
+							couponFieldStateProps={ couponFieldStateProps }
+							removeCouponAndClearField={ removeCouponAndClearField }
+							isCouponFieldVisible={ isCouponFieldVisible }
+							setCouponFieldVisible={ setCouponFieldVisible }
+							onChangeSelection={ changeSelection }
+							siteUrl={ siteUrl }
+							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						/>
-					) }
-					<PaymentMethodStep
-						activeStepHeader={ <GoogleDomainsCopy responseCart={ responseCart } /> }
-						canEditStep={ canEditPaymentStep() }
+					}
+					formStatus={ formStatus }
+				/>
+
+				{ contactDetailsType !== 'none' && (
+					<CheckoutStep
+						className="checkout-contact-form-step"
+						stepId="contact-form"
+						isCompleteCallback={ async () => {
+							// Touch the fields so they display validation errors
+							shouldShowContactDetailsValidationErrors && touchContactFields();
+							const validationResponse = await validateContactDetails(
+								contactInfo,
+								isLoggedOutCart,
+								responseCart,
+								showErrorMessageBriefly,
+								applyDomainContactValidationResults,
+								clearDomainContactErrorMessages,
+								reduxDispatch,
+								translate,
+								shouldShowContactDetailsValidationErrors
+							);
+							if ( validationResponse ) {
+								// When the contact details change, update the VAT details on the server.
+								try {
+									if (
+										! isLoggedOutCart &&
+										vatDetailsInForm.id &&
+										! areVatDetailsSame( vatDetailsInForm, vatDetailsFromServer )
+									) {
+										await setVatDetails( vatDetailsInForm );
+									}
+								} catch ( error ) {
+									reduxDispatch( removeNotice( 'vat_info_notice' ) );
+									if ( shouldShowContactDetailsValidationErrors ) {
+										reduxDispatch(
+											errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
+										);
+									}
+									return false;
+								}
+								reduxDispatch( removeNotice( 'vat_info_notice' ) );
+
+								// When the contact details change, update the cart's tax location to match.
+								try {
+									await updateCartContactDetailsForCheckout(
+										countriesList,
+										responseCart,
+										updateLocation,
+										contactInfo,
+										vatDetailsInForm
+									);
+								} catch {
+									// If updating the cart fails, we should not continue. No need
+									// to do anything else, though, because CartMessages will
+									// display the error.
+									return false;
+								}
+
+								// When the contact details change, update the cached contact details on
+								// the server. This can fail if validation fails but we will silently
+								// ignore failures here because the validation call will handle them better
+								// than this will.
+								updateCachedContactDetails( prepareDomainContactValidationRequest( contactInfo ) );
+
+								reduxDispatch(
+									recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+										step: 1,
+										step_name: 'contact-form',
+									} )
+								);
+							}
+							return validationResponse;
+						} }
+						activeStepContent={
+							<>
+								<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
+								<WPContactForm
+									countriesList={ countriesList }
+									shouldShowContactDetailsValidationErrors={
+										shouldShowContactDetailsValidationErrors
+									}
+									contactDetailsType={ contactDetailsType }
+									isLoggedOutCart={ isLoggedOutCart }
+									setShouldShowContactDetailsValidationErrors={
+										setShouldShowContactDetailsValidationErrors
+									}
+								/>
+							</>
+						}
+						completeStepContent={
+							<>
+								<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
+								<WPContactFormSummary
+									areThereDomainProductsInCart={ areThereDomainProductsInCart }
+									isGSuiteInCart={ isGSuiteInCart }
+									isLoggedOutCart={ isLoggedOutCart }
+								/>
+							</>
+						}
+						titleContent={ <ContactFormTitle /> }
 						editButtonText={ String( translate( 'Edit' ) ) }
-						editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
-						nextStepButtonText={ String( translate( 'Continue' ) ) }
+						editButtonAriaLabel={ String( translate( 'Edit the contact details' ) ) }
+						nextStepButtonText={ nextStepButtonText }
 						nextStepButtonAriaLabel={ String(
-							translate( 'Continue with the selected payment method' )
+							translate( 'Continue with the entered contact details' )
 						) }
 						validatingButtonText={ validatingButtonText }
 						validatingButtonAriaLabel={ validatingButtonText }
-						isCompleteCallback={ () => {
-							// We want to consider this step complete only if there is a
-							// payment method selected and it does not have required fields.
-							// This will not prevent the form from being submitted because
-							// the submit button will be active as long as the last step is
-							// shown, but it will prevent the payment method step from
-							// automatically collapsing when checkout loads.
-							return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
-						} }
 					/>
+				) }
+				<PaymentMethodStep
+					activeStepHeader={ <GoogleDomainsCopy responseCart={ responseCart } /> }
+					canEditStep={ canEditPaymentStep() }
+					editButtonText={ String( translate( 'Edit' ) ) }
+					editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }
+					nextStepButtonText={ String( translate( 'Continue' ) ) }
+					nextStepButtonAriaLabel={ String(
+						translate( 'Continue with the selected payment method' )
+					) }
+					validatingButtonText={ validatingButtonText }
+					validatingButtonAriaLabel={ validatingButtonText }
+					isCompleteCallback={ () => {
+						// We want to consider this step complete only if there is a
+						// payment method selected and it does not have required fields.
+						// This will not prevent the form from being submitted because
+						// the submit button will be active as long as the last step is
+						// shown, but it will prevent the payment method step from
+						// automatically collapsing when checkout loads.
+						return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
+					} }
+				/>
 
-					<CouponFieldArea
-						isCouponFieldVisible={ isCouponFieldVisible }
-						setCouponFieldVisible={ setCouponFieldVisible }
-						isPurchaseFree={ isPurchaseFree }
-						couponStatus={ couponStatus }
-						couponFieldStateProps={ couponFieldStateProps }
-					/>
+				<CouponFieldArea
+					isCouponFieldVisible={ isCouponFieldVisible }
+					setCouponFieldVisible={ setCouponFieldVisible }
+					isPurchaseFree={ isPurchaseFree }
+					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
+				/>
 
-					<CheckoutTermsAndCheckboxes
-						is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
-						setIs3PDAccountConsentAccepted={ setIs3PDAccountConsentAccepted }
-						is100YearPlanTermsAccepted={ is100YearPlanTermsAccepted }
-						setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
-						isSubmitted={ isSubmitted }
-					/>
-					<CheckoutFormSubmit
-						validateForm={ validateForm }
-						submitButtonHeader={ <SubmitButtonHeader /> }
-						submitButtonFooter={
-							hasCartJetpackProductsOnly ? (
-								<JetpackCheckoutSeals />
-							) : (
-								<CheckoutMoneyBackGuarantee cart={ responseCart } />
-							)
-						}
-					/>
-				</CheckoutStepGroup>
-			</WPCheckoutMainContent>
-		</WPCheckoutWrapper>
+				<CheckoutTermsAndCheckboxes
+					is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
+					setIs3PDAccountConsentAccepted={ setIs3PDAccountConsentAccepted }
+					is100YearPlanTermsAccepted={ is100YearPlanTermsAccepted }
+					setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
+					isSubmitted={ isSubmitted }
+				/>
+				<CheckoutFormSubmit
+					validateForm={ validateForm }
+					submitButtonHeader={ <SubmitButtonHeader /> }
+					submitButtonFooter={
+						hasCartJetpackProductsOnly ? (
+							<JetpackCheckoutSeals />
+						) : (
+							<CheckoutMoneyBackGuarantee cart={ responseCart } />
+						)
+					}
+				/>
+			</CheckoutStepGroup>
+		</WPCheckoutMainContent>
 	);
 
 	if ( ! isStepContainerV2 ) {
-		return content;
+		return (
+			<WPCheckoutWrapper className="checkout-wrapper">
+				{ checkoutSummary }
+				{ checkoutMainContent }
+			</WPCheckoutWrapper>
+		);
 	}
 
 	return (
 		<StepContainerV2CheckoutFixer isLargeViewport={ isLargeViewport }>
 			<Step.WideLayout
-				hasContentPadding={ false }
-				topBar={
-					<Step.TopBar
-						leftElement={ <Step.BackButton onClick={ leaveModalProps.clickClose } /> }
-						rightElement={
-							<span className="checkout-skip-button">
-								<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) } </label>
-								<Step.LinkButton onClick={ toggleHelpCenter }>
-									{ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }
-								</Step.LinkButton>
-							</span>
-						}
-					/>
-				}
+				topBar={ ( { isLargeViewport } ) => {
+					const topBar = (
+						<Step.TopBar
+							leftElement={ <Step.BackButton onClick={ leaveModalProps.clickClose } /> }
+							rightElement={
+								<span className="checkout-skip-button">
+									<label>{ helpCenterButtonCopy ?? translate( 'Need extra help?' ) } </label>
+									<Step.LinkButton onClick={ toggleHelpCenter }>
+										{ helpCenterButtonLink ?? translate( 'Visit Help Center' ) }
+									</Step.LinkButton>
+								</span>
+							}
+						/>
+					);
+
+					if ( isLargeViewport ) {
+						return topBar;
+					}
+
+					return (
+						<>
+							{ topBar }
+							{ checkoutSummary }
+						</>
+					);
+				} }
 			>
-				{ content }
+				{ ( { isLargeViewport } ) => {
+					if ( isLargeViewport ) {
+						return (
+							<WPCheckoutWrapper className="checkout-wrapper">
+								{ checkoutSummary }
+								{ checkoutMainContent }
+							</WPCheckoutWrapper>
+						);
+					}
+
+					return checkoutMainContent;
+				} }
 			</Step.WideLayout>
 			<LeaveCheckoutModal { ...leaveModalProps } />
 		</StepContainerV2CheckoutFixer>
@@ -920,9 +946,8 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 			}
 
 			.checkout-main-content {
-				margin-top: 0;
-				padding: var( --step-container-v2-content-block-padding )
-					var( --step-container-v2-content-inline-padding );
+				margin: 0;
+				padding: 0;
 				max-width: 100%;
 			}
 
@@ -957,13 +982,13 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 		props.isLargeViewport &&
 		css`
 			.checkout-main-content {
-				padding-left: var( --step-container-v2-content-inline-padding );
+				padding-left: 0;
 				margin-top: 3rem;
 			}
 
 			.checkout-sidebar-content {
 				--left-padding: 3.875rem;
-				padding: 2.25rem var( --step-container-v2-content-inline-padding ) 0 var( --left-padding );
+				padding: 0 0 0 var( --left-padding );
 				background: none;
 				position: relative;
 				height: 100%;
@@ -980,12 +1005,14 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 				}
 			}
 
-			.checkout-summary-area {
+			.checkout-summary-area,
+			.checkout__summary-area {
 				max-width: 100%;
 			}
 
 			.checkout__summary-body {
 				margin: 0;
+				max-width: 100%;
 			}
 		` }
 `;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -860,7 +860,7 @@ export default function CheckoutMainContent( {
 					);
 
 					if ( isLargeViewport ) {
-						return topBar;
+						return <div className="checkout-top-bar-wrapper">{ topBar }</div>;
 					}
 
 					return (
@@ -905,7 +905,7 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 	background: ${ colorStudio.colors[ 'White' ] };
 
 	// This shouldn't exist. It's a hack to make the top bar appear on top of the checkout sidebar, which extends from the top of the page.
-	.step-container-v2__top-bar {
+	.checkout-top-bar-wrapper {
 		position: relative;
 		z-index: 1;
 	}

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -842,7 +842,8 @@ export default function CheckoutMainContent( {
 
 	return (
 		<StepContainerV2CheckoutFixer isLargeViewport={ isLargeViewport }>
-			<Step.WideLayout
+			<Step.CenteredColumnLayout
+				columnWidth={ 12 }
 				topBar={ ( { isLargeViewport } ) => {
 					const topBar = (
 						<Step.TopBar
@@ -873,20 +874,32 @@ export default function CheckoutMainContent( {
 				{ ( { isLargeViewport } ) => {
 					if ( isLargeViewport ) {
 						return (
-							<WPCheckoutWrapper className="checkout-wrapper">
-								{ checkoutSummary }
+							<StepContainerV2CheckoutWrapper>
 								{ checkoutMainContent }
-							</WPCheckoutWrapper>
+								{ checkoutSummary }
+							</StepContainerV2CheckoutWrapper>
 						);
 					}
 
 					return checkoutMainContent;
 				} }
-			</Step.WideLayout>
+			</Step.CenteredColumnLayout>
 			<LeaveCheckoutModal { ...leaveModalProps } />
 		</StepContainerV2CheckoutFixer>
 	);
 }
+
+const StepContainerV2CheckoutWrapper = styled.div`
+	display: flex;
+
+	.checkout-main-content {
+		flex: 2;
+	}
+
+	.checkout-sidebar-content {
+		flex: 1;
+	}
+`;
 
 const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 	background: ${ colorStudio.colors[ 'White' ] };
@@ -983,7 +996,7 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 		css`
 			.checkout-main-content {
 				padding-left: 0;
-				margin-top: 3rem;
+				margin-top: 1rem;
 			}
 
 			.checkout-sidebar-content {
@@ -1005,14 +1018,17 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 				}
 			}
 
-			.checkout-summary-area,
-			.checkout__summary-area {
+			.checkout__summary-area,
+			.checkout__summary-body {
 				max-width: 100%;
 			}
 
 			.checkout__summary-body {
 				margin: 0;
-				max-width: 100%;
+			}
+
+			.checkout__summary-features {
+				padding-top: 32px;
 			}
 		` }
 `;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -413,7 +413,7 @@ export function CheckoutSummaryRefundWindows( {
 		<>
 			{ includeRefundIcon && <StyledIcon icon={ reusableBlock } size={ 24 } /> }
 			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon />
+				{ ! includeRefundIcon && <WPCheckoutCheckIcon /> }
 				{ highlight ? <strong>{ text }</strong> : text }
 			</CheckoutSummaryFeaturesListItem>
 		</>

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/ContentWrapper.tsx
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/ContentWrapper.tsx
@@ -6,17 +6,14 @@ import './style.scss';
 export const ContentWrapper = ( {
 	children,
 	centerAligned,
-	hasPadding = true,
 }: {
 	children: ReactNode;
 	centerAligned?: boolean;
-	hasPadding?: boolean;
 } ) => {
 	return (
 		<div
 			className={ clsx( 'step-container-v2__content-wrapper', {
 				'center-aligned': centerAligned,
-				padding: hasPadding,
 			} ) }
 		>
 			{ children }

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
@@ -10,6 +10,9 @@
 	box-sizing: border-box;
 	flex: 1;
 
+	padding: var( --step-container-v2-content-block-padding )
+		var( --step-container-v2-content-inline-padding );
+
 	--step-container-v2-content-max-width: 1344px;
 
 	max-width: calc(
@@ -27,11 +30,6 @@
 	--step-container-v2-content-column-width: calc(
 		var( --step-container-v2-content-max-width-minus-column-gaps ) / 12
 	);
-
-	&.padding {
-		padding: var( --step-container-v2-content-block-padding )
-			var( --step-container-v2-content-inline-padding );
-	}
 
 	&.center-aligned {
 		justify-content: center;

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -12,7 +12,7 @@ interface CenteredColumnLayoutProps {
 	className?: string;
 	children?: ContentProp;
 	stickyBottomBar?: ContentProp;
-	columnWidth: 4 | 5 | 6 | 8 | 10;
+	columnWidth: 4 | 5 | 6 | 8 | 10 | 12;
 	verticalAlign?: 'center';
 }
 

--- a/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/CenteredColumnLayout/CenteredColumnLayout.tsx
@@ -12,7 +12,7 @@ interface CenteredColumnLayoutProps {
 	className?: string;
 	children?: ContentProp;
 	stickyBottomBar?: ContentProp;
-	columnWidth: 4 | 5 | 6 | 8 | 10 | 12;
+	columnWidth: 4 | 5 | 6 | 8 | 10;
 	verticalAlign?: 'center';
 }
 

--- a/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/WideLayout/WideLayout.tsx
@@ -12,11 +12,6 @@ interface WideLayoutProps {
 	className?: string;
 	children?: ContentProp;
 	stickyBottomBar?: ContentProp;
-
-	/**
-	 * @deprecated Do not use `hasContentPadding`. This was a special case for the checkout to support the background colors. It will be removed when checkout no longer needs it.
-	 */
-	hasContentPadding?: ContentProp< boolean >;
 }
 
 export const WideLayout = ( {
@@ -25,22 +20,16 @@ export const WideLayout = ( {
 	className,
 	children,
 	stickyBottomBar,
-	hasContentPadding: hasContentPaddingProp = true,
 }: WideLayoutProps ) => {
 	return (
 		<StepContainerV2>
 			{ ( context ) => {
 				const content = typeof children === 'function' ? children( context ) : children;
 
-				const hasContentPadding =
-					typeof hasContentPaddingProp === 'function'
-						? hasContentPaddingProp( context )
-						: hasContentPaddingProp;
-
 				return (
 					<>
 						<TopBarRenderer topBar={ topBar } />
-						<ContentWrapper hasPadding={ hasContentPadding }>
+						<ContentWrapper>
 							{ heading && <ContentRow columns={ 6 }>{ heading }</ContentRow> }
 							<ContentRow className={ className }>{ content }</ContentRow>
 						</ContentWrapper>


### PR DESCRIPTION
## Proposed Changes

Now that [we're defining narrower maximum widths for the container](https://github.com/Automattic/wp-calypso/pull/102512), I thought it'd make sense to rework the checkout page so it uses the new constraints.

That allowed me to remove the `hasContentPadding` prop since we actually want the padding now. It also led to a larger refactor to remove the CSS grid used in the non-SCv2 version.

This refactor look big-ish but it actually isn't. The bulk of changes are within `checkout-main-content` and it moves a bit of code around to let us isolate the sidebar and main content. The biggest difference is that the summary is now within the `topBar` area on small screens.


## Why are these changes being made?

Better code organization and proximity with the desired state for StepContainerV2's checkout.

## Testing Instructions

You should see no regressions compared to production, and the margins, paddings, and maximum width of the container should match the SCv2's constraints.