### PR TITLE
Revert "resolve infinite update loop in GitHubLoginButton"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-social-service.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-social-service.ts
@@ -1,24 +1,16 @@
-import { useEffect, useState } from 'react';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 
 export function useSocialService() {
-	const [ state, setState ] = useState( { socialService: '', socialServiceResponse: {} } );
+	const hashEntries = new globalThis.URLSearchParams( window.location.hash.substring( 1 ) );
 
-	useEffect( () => {
-		const hashEntries = new globalThis.URLSearchParams( window.location.hash.substring( 1 ) );
-
-		if ( hashEntries.size > 0 ) {
-			const socialServiceResponse = Object.fromEntries( hashEntries.entries() );
-			const clientId = socialServiceResponse.client_id;
-			const socialService = getSocialServiceFromClientId( clientId ) ?? '';
-
-			if ( socialService ) {
-				setState( { socialService, socialServiceResponse } );
-				// Clear the hash to prevent reprocessing
-				window.location.hash = '';
-			}
+	if ( hashEntries.size > 0 ) {
+		const socialServiceResponse = Object.fromEntries( hashEntries.entries() );
+		const clientId = socialServiceResponse.client_id;
+		const socialService = getSocialServiceFromClientId( clientId ) ?? '';
+		if ( socialService ) {
+			return { socialService, socialServiceResponse };
 		}
-	}, [] );
+	}
 
-	return state;
+	return { socialService: '', socialServiceResponse: {} };
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#102511 - it fixes GitHub but introduces a problem in Apple login that isn't always reliably triggered.