### PR TITLE
Avoid re-render of socialServiceResponse

### DIFF
--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -127,8 +127,11 @@ const GitHubLoginButton = ( {
 	};
 
 	useEffect( () => {
-		if ( service === 'github' && socialServiceResponse ) {
-			responseHandler( { ...socialServiceResponse, service: 'github' } );
+		// check if socialServiceResponse is not an empty object
+		if ( Object.keys( socialServiceResponse ?? {} ).length > 0 ) {
+			if ( service === 'github' ) {
+				responseHandler( { ...socialServiceResponse, service: 'github' } );
+			}
 		}
 	}, [ socialServiceResponse, service, responseHandler ] );
 

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -127,11 +127,11 @@ const GitHubLoginButton = ( {
 	};
 
 	useEffect( () => {
-		// check if socialServiceResponse is not an empty object
-		if ( Object.keys( socialServiceResponse ?? {} ).length > 0 ) {
-			if ( service === 'github' ) {
-				responseHandler( { ...socialServiceResponse, service: 'github' } );
-			}
+		if ( service === 'github' && socialServiceResponse?.access_token ) {
+			responseHandler( {
+				access_token: socialServiceResponse.access_token,
+				service: 'github',
+			} );
 		}
 	}, [ socialServiceResponse, service, responseHandler ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to this escalation issue: p1744215032769339-slack-C02FMH4G8

## Proposed Changes

* We're avoiding GitHub Login to enter on an infinite loop as [the socialServiceResponse](https://github.com/Automattic/wp-calypso/blob/trunk/client/components/social-buttons/github.tsx#L133) is returning null sometimes.

This isn't a proper fix, we need to understand what's causing it to be null. But for a quick fix, it works.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/onboarding/user and try to log in with GitHub

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?