### PR TITLE
Fix the Quick Links border for hosted sites on the Customer Home page

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
@@ -30,7 +30,7 @@ const ActionBox = ( {
 
 		if ( svgIcon ) {
 			return React.cloneElement( svgIcon, {
-				className: `${ svgIcon.props.className || '' } quick-links__action-box-icon`.trim(),
+				className: clsx( svgIcon.props.className || '', 'quick-links__action-box-icon' ),
 			} );
 		}
 

--- a/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
@@ -30,7 +30,7 @@ const ActionBox = ( {
 
 		if ( svgIcon ) {
 			return React.cloneElement( svgIcon, {
-				className: clsx( svgIcon.props.className || '', 'quick-links__action-box-icon' ),
+				className: clsx( svgIcon.props.className, 'quick-links__action-box-icon' ),
 			} );
 		}
 

--- a/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/action-box.jsx
@@ -1,5 +1,6 @@
 import { CompactCard, Gridicon, MaterialIcon } from '@automattic/components';
 import clsx from 'clsx';
+import React from 'react';
 
 const ActionBox = ( {
 	href,
@@ -11,6 +12,7 @@ const ActionBox = ( {
 	gridicon,
 	iconComponent,
 	hideLinkIndicator,
+	svgIcon,
 } ) => {
 	const buttonAction = { href, onClick, target };
 	const getIcon = () => {
@@ -24,6 +26,12 @@ const ActionBox = ( {
 
 		if ( iconComponent ) {
 			return iconComponent;
+		}
+
+		if ( svgIcon ) {
+			return React.cloneElement( svgIcon, {
+				className: `${ svgIcon.props.className || '' } quick-links__action-box-icon`.trim(),
+			} );
 		}
 
 		return <img className="quick-links__action-box-icon" src={ iconSrc } alt="" />;

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,13 +1,13 @@
 import config from '@automattic/calypso-config';
 import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
 import { JetpackLogo, FoldableCard } from '@automattic/components';
+import { blaze } from '@automattic/components/src/icons';
 import { GeneratorModal } from '@automattic/jetpack-ai-calypso';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
 import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
-import blazeIcon from 'calypso/assets/images/icons/blaze-icon.svg';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
@@ -128,7 +128,7 @@ export const QuickLinks = ( {
 					hideLinkIndicator
 					onClick={ trackPromotePostAction }
 					label={ translate( 'Promote with Blaze' ) }
-					iconSrc={ blazeIcon }
+					svgIcon={ blaze }
 				/>
 			) }
 			{ ! isStaticHomePage && canModerateComments && (

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -3,10 +3,10 @@
 
 .quick-links.foldable-card.card {
 	padding: 1rem;
-	border-radius: 3px;
+	border-radius: 0;
 
-	@media only screen and (max-width: $break-small) {
-		border-radius: 0;
+	@media only screen and (min-width: $break-small) {
+		border-radius: 3px;
 	}
 
 	@media only screen and (min-width: $break-xlarge) {

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -1,14 +1,17 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-$breakpoint-mobile: 782px;
 
 .quick-links.foldable-card.card {
-	@media only screen and (max-width: $breakpoint-mobile) {
-		padding: 1rem;
+	padding: 1rem;
+	border-radius: 3px;
+
+	@media only screen and (max-width: $break-small) {
+		border-radius: 0;
 	}
 
-	@include breakpoint-deprecated( ">660px" ) {
-		border-radius: 3px;
+	@media only screen and (min-width: $break-xlarge) {
+		padding: 0;
+		box-shadow: none;
 	}
 
 	.foldable-card__header {
@@ -43,7 +46,6 @@ $breakpoint-mobile: 782px;
 
 .quick-links__boxes {
 	margin-left: -16px;
-	margin-right: -16px;
 }
 
 .card.quick-links__action-box {
@@ -142,6 +144,3 @@ $breakpoint-mobile: 782px;
 	margin-left: 2px;
 }
 
-.card.quick-links-for-hosted-sites {
-	box-shadow: none;
-}

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -1,7 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+$breakpoint-mobile: 782px;
 
 .quick-links.foldable-card.card {
+	@media only screen and (max-width: $breakpoint-mobile) {
+		padding: 1rem;
+	}
+
 	@include breakpoint-deprecated( ">660px" ) {
 		border-radius: 3px;
 	}

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -108,14 +108,12 @@
 	}
 
 	&:hover {
-		background: var(--color-neutral-0);
-
 		.quick-links__action-box-icon {
-			fill: var(--color-neutral-80);
-
-			&.dashicons {
-				color: var(--color-neutral-80);
-			}
+			color: var(--color-primary-60);
+			fill: var(--color-primary-60);
+		}
+		.quick-links__action-box-label {
+			color: var(--color-primary-60);
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -138,3 +138,7 @@
 	height: 16px;
 	margin-left: 2px;
 }
+
+.card.quick-links-for-hosted-sites {
+	box-shadow: none;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101815

## Proposed Changes

* Fixes the Quick Links card border for hosted sites. It was actually a box-shadow prevenient from the Card component that was not being overridden.
* Remove the hover background for the Quick Links items and make it blue when hovering instead.
* Fixes the Quick Links padding on the Mobile version.
* I also had to update the Blaze icon, as it used a URL to display it. And now, we use an SVG directly so we can change the color.

#### Before

<img width="482" alt="Captura de Tela 2025-04-09 às 18 06 49" src="https://github.com/user-attachments/assets/270ae65e-5f6f-4f0d-be87-365d0163a1b7" />

<img width="325" alt="Captura de Tela 2025-04-14 às 12 16 03" src="https://github.com/user-attachments/assets/e638cf1d-9fbc-4626-bd9b-75d883fcca2b" />

<img width="397" alt="Captura de Tela 2025-04-14 às 12 16 24" src="https://github.com/user-attachments/assets/9a0c45ce-c211-4986-83f9-a66e2d7ef53a" />


#### After

<img width="485" alt="Captura de Tela 2025-04-09 às 18 05 47" src="https://github.com/user-attachments/assets/d055787e-e289-484c-857f-77e41c5fe111" />

<img width="326" alt="Captura de Tela 2025-04-14 às 12 15 23" src="https://github.com/user-attachments/assets/2c04c4bd-2512-47fd-afdb-e34d5fb6b05c" />

<img width="385" alt="Captura de Tela 2025-04-14 às 12 20 05" src="https://github.com/user-attachments/assets/5f71121c-72f7-4756-a441-61072b5e5a67" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is a bug reported here: https://github.com/Automattic/wp-calypso/issues/101815

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso live to test this PR
* Navigate to `/home/{SITE}`, where the SITE is an atomic site
* You should no longer see the border in the Quick Links component

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
