### PR TITLE
Odyssey Stats: use jetpack/v4/jitm endpoint for Jetpack version < 14.5

### DIFF
--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
 import version_compare from 'calypso/lib/version-compare';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getJetpackVersion, isJetpackSite } from 'calypso/state/sites/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 
 const version_greater_than_or_equal = (
@@ -15,6 +15,7 @@ const version_greater_than_or_equal = (
 function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
+	const jetpackVersion = getJetpackVersion( state, siteId );
 	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
 		treatAtomicAsJetpackSite: false,
 	} );
@@ -67,6 +68,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.21.0-alpha',
 			isOdysseyStats
 		),
+		supportsWpcomV3Jitm: version_greater_than_or_equal( jetpackVersion, '14.5', isOdysseyStats ),
 		isOldJetpack:
 			isSiteJetpackNotAtomic &&
 			!! statsAdminVersion &&
@@ -82,6 +84,7 @@ const getEnvStatsFeatureSupportChecksMemoized = createSelector(
 			treatAtomicAsJetpackSite: false,
 		} ),
 		config.isEnabled( 'is_running_in_jetpack_site' ),
+		getJetpackVersion( state, siteId ),
 	]
 );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101783

## Proposed Changes

* This is a follow up for https://github.com/Automattic/wp-calypso/pull/101783. The PR recovered the code for older Jetpack versions where there's no `wpcom/v3/jitm` endpoint. The compatibility code should be removed after a major Odyssey Stats release, which has never happened yet.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Compatibility

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please test the scenarios in https://github.com/Automattic/wp-calypso/pull/101783
* Change the Jetpack version to `14.4` - Tweak it [here](https://github.com/Automattic/jetpack/blob/92a7a5b6e95923082c705c39eab95250adb61bb0/projects/plugins/jetpack/jetpack.php#L37) or use Jetpack Beta Tester plugin
* Investigate the network request
* Ensure it's leveraging `jetpack/v4/jitm`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
