### PR TITLE
Remove `<CheckIcon>` id prop

### DIFF
--- a/client/my-sites/checkout/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/purchase-modal/content.tsx
@@ -31,11 +31,11 @@ function formatDate( cardExpiry: string ): string {
 	return formattedDate;
 }
 
-function PurchaseModalStep( { children, id }: { children: ReactNode; id: string } ) {
+function PurchaseModalStep( { children }: { children: ReactNode } ) {
 	return (
 		<div className="purchase-modal__step">
 			<span className="purchase-modal__step-icon">
-				<CheckIcon id={ id } />
+				<CheckIcon />
 			</span>
 			{ children }
 		</div>
@@ -110,7 +110,7 @@ function OrderStep( {
 	const translate = useTranslate();
 
 	return (
-		<PurchaseModalStep id="purchase-modal-step">
+		<PurchaseModalStep>
 			<div className="purchase-modal__step-title">{ translate( 'Your order' ) }</div>
 			<div className="purchase-modal__step-content">
 				<div>{ translate( 'Site: %(siteSlug)s', { args: { siteSlug } } ) }</div>
@@ -138,7 +138,7 @@ function PaymentMethodStep( {
 	const maskedCard = sprintf( translate( '**** %s' ), card?.card_last_4 || '' );
 
 	return (
-		<PurchaseModalStep id="payment-method">
+		<PurchaseModalStep>
 			<div className="purchase-modal__step-title">
 				{ translate( 'Payment method' ) }
 				<a href={ `/checkout/${ siteSlug }` } onClick={ clickHandler }>

--- a/client/my-sites/checkout/src/components/check-icon.tsx
+++ b/client/my-sites/checkout/src/components/check-icon.tsx
@@ -1,13 +1,10 @@
 import styled from '@emotion/styled';
-import { useId } from 'react';
 
 const CheckIconSvg = styled.svg`
 	fill: #fff;
 `;
 
 export function CheckIcon( { className }: { className?: string } ) {
-	const id = useId();
-
 	return (
 		<CheckIconSvg
 			width="16"
@@ -17,20 +14,7 @@ export function CheckIcon( { className }: { className?: string } ) {
 			aria-hidden="true"
 			className={ className }
 		>
-			<mask
-				id={ id + '-check-icon-mask' }
-				mask-type="alpha"
-				maskUnits="userSpaceOnUse"
-				x="2"
-				y="4"
-				width="16"
-				height="12"
-			>
-				<path d="M7.32916 13.2292L3.85416 9.75417L2.67083 10.9292L7.32916 15.5875L17.3292 5.58751L16.1542 4.41251L7.32916 13.2292Z" />
-			</mask>
-			<g mask={ 'url(#' + id + '-check-icon-mask)' }>
-				<rect width="20" height="20" />
-			</g>
+			<path d="M7.32916 13.2292L3.85416 9.75417L2.67083 10.9292L7.32916 15.5875L17.3292 5.58751L16.1542 4.41251L7.32916 13.2292Z" />
 		</CheckIconSvg>
 	);
 }

--- a/client/my-sites/checkout/src/components/check-icon.tsx
+++ b/client/my-sites/checkout/src/components/check-icon.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled';
+import { useId } from 'react';
 
 const CheckIconSvg = styled.svg`
 	fill: #fff;
 `;
 
-export function CheckIcon( { className, id }: { className?: string; id: string } ) {
+export function CheckIcon( { className }: { className?: string } ) {
+	const id = useId();
+
 	return (
 		<CheckIconSvg
 			width="16"

--- a/client/my-sites/checkout/src/components/jetpack-pro-redirect-modal/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-pro-redirect-modal/index.tsx
@@ -92,7 +92,7 @@ export default function JetpackProRedirectModal( { redirectTo, productSourceFrom
 							const id = feature.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
 							return (
 								<li key={ id }>
-									<CheckIcon id={ id } />
+									<CheckIcon />
 									{ feature }
 								</li>
 							);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -413,7 +413,7 @@ export function CheckoutSummaryRefundWindows( {
 		<>
 			{ includeRefundIcon && <StyledIcon icon={ reusableBlock } size={ 24 } /> }
 			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon id="features-list-refund-text" />
+				<WPCheckoutCheckIcon />
 				{ highlight ? <strong>{ text }</strong> : text }
 			</CheckoutSummaryFeaturesListItem>
 		</>
@@ -491,7 +491,7 @@ export function CheckoutSummaryFeaturesList( props: {
 
 			{ hasNoAdsAddOn && (
 				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id="features-list-support-text" />
+					<WPCheckoutCheckIcon />
 					{ translate( 'Remove ads from your site with the No Ads add-on' ) }
 				</CheckoutSummaryFeaturesListItem>
 			) }
@@ -499,13 +499,13 @@ export function CheckoutSummaryFeaturesList( props: {
 			{ hasDomainTransferProduct && (
 				<>
 					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon id="features-list-support-another-year" />
+						<WPCheckoutCheckIcon />
 						{ hasFreeCouponTransfersOnly( responseCart )
 							? translate( "Transfer is free and we'll pay for an extra year of registration." )
 							: translate( '1-year extension on your domain' ) }
 					</CheckoutSummaryFeaturesListItem>
 					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon id="features-list-support-privacy" />
+						<WPCheckoutCheckIcon />
 						{ translate( 'Private domain registration and SSL certificate included for free' ) }
 					</CheckoutSummaryFeaturesListItem>
 				</>
@@ -513,7 +513,7 @@ export function CheckoutSummaryFeaturesList( props: {
 
 			{ ! hasPlanInCart && hasEmailInCart && (
 				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id="features-list-support-email" />
+					<WPCheckoutCheckIcon />
 					{ translate( 'Fast support' ) }
 				</CheckoutSummaryFeaturesListItem>
 			) }
@@ -566,7 +566,7 @@ function CheckoutSummaryFlowFeaturesList( {
 			{ planFeatures.map( ( feature ) => {
 				return (
 					<CheckoutSummaryFeaturesListItem key={ `feature-list-${ feature.getSlug() }` }>
-						<WPCheckoutCheckIcon id={ `feature-list-${ feature.getSlug() }-icon` } />
+						<WPCheckoutCheckIcon />
 						{ feature.isHighlightedFeature ? (
 							<strong>{ feature.getTitle() }</strong>
 						) : (
@@ -614,7 +614,7 @@ function CheckoutSummaryFeaturesListDomainItem( { domain }: { domain: ResponseCa
 	if ( domain.is_bundled ) {
 		return (
 			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon id={ `feature-list-domain-item-${ domain.meta }` } />
+				<WPCheckoutCheckIcon />
 				{ bundledDomainText }
 			</CheckoutSummaryFeaturesListItem>
 		);
@@ -622,7 +622,7 @@ function CheckoutSummaryFeaturesListDomainItem( { domain }: { domain: ResponseCa
 
 	return (
 		<CheckoutSummaryFeaturesListItem>
-			<WPCheckoutCheckIcon id={ `feature-list-domain-item-${ domain.meta }` } />
+			<WPCheckoutCheckIcon />
 			<strong>{ domain.meta }</strong>
 		</CheckoutSummaryFeaturesListItem>
 	);
@@ -637,7 +637,7 @@ function CheckoutSummaryJetpackProductFeatures( { product }: { product: Response
 			{ productFeatures.map( ( feature, index ) => {
 				return (
 					<CheckoutSummaryFeaturesListItem key={ `feature${ index }` }>
-						<WPCheckoutCheckIcon id={ `icon${ index }` } />
+						<WPCheckoutCheckIcon />
 						{ feature }
 					</CheckoutSummaryFeaturesListItem>
 				);
@@ -665,7 +665,7 @@ function CheckoutSummaryAkismetProductFeatures( { product }: { product: Response
 			{ productFeatures.map( ( feature ) => {
 				return (
 					<CheckoutSummaryFeaturesListItem key={ feature }>
-						<WPCheckoutCheckIcon id={ feature.replace( /[^\w]/g, '_' ) } />
+						<WPCheckoutCheckIcon />
 						{ feature }
 					</CheckoutSummaryFeaturesListItem>
 				);
@@ -673,7 +673,7 @@ function CheckoutSummaryAkismetProductFeatures( { product }: { product: Response
 
 			{ yearlySavingsPercentage > 0 && (
 				<CheckoutSummaryFeaturesListItem>
-					<WPCheckoutCheckIcon id="yearly_savings" />
+					<WPCheckoutCheckIcon />
 					{ translate( '%(yearlySavingsPercentage)s%% price reduction for yearly term', {
 						args: {
 							yearlySavingsPercentage,
@@ -723,11 +723,7 @@ function CheckoutSummaryPlanFeatures( props: {
 
 				return (
 					<CheckoutSummaryFeaturesListItem key={ String( feature ) } isSupported={ isSupported }>
-						{ isSupported ? (
-							<WPCheckoutCheckIcon id={ feature.replace( /[^\w]/g, '_' ) } />
-						) : (
-							<WPCheckoutCrossIcon />
-						) }
+						{ isSupported ? <WPCheckoutCheckIcon /> : <WPCheckoutCrossIcon /> }
 						{ feature }
 					</CheckoutSummaryFeaturesListItem>
 				);
@@ -764,7 +760,7 @@ function CheckoutSummarySupportIfAvailable( props: {
 	if ( hasEnTranslation( 'Fast support' ) && hasEnTranslation( 'Priority support 24/7' ) ) {
 		return (
 			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon id="annual-live-chat" />
+				<WPCheckoutCheckIcon />
 				{ isWpComPremiumPlan( currentPlanSlug )
 					? translate( 'Fast support' )
 					: translate( 'Priority support 24/7' ) }
@@ -773,7 +769,7 @@ function CheckoutSummarySupportIfAvailable( props: {
 	}
 	return (
 		<CheckoutSummaryFeaturesListItem>
-			<WPCheckoutCheckIcon id="annual-live-chat" />
+			<WPCheckoutCheckIcon />
 			{ translate( 'Live chat support' ) }
 		</CheckoutSummaryFeaturesListItem>
 	);
@@ -812,14 +808,14 @@ function CheckoutSummaryAnnualUpsell( props: {
 			<CheckoutSummaryFeaturesListWrapper>
 				{ shouldShowFreeDomainUpsell && (
 					<CheckoutSummaryFeaturesListItem isSupported={ false }>
-						<WPCheckoutCheckIcon id="annual-domain-credit" />
+						<WPCheckoutCheckIcon />
 						{ translate( 'Free domain for one year' ) }
 					</CheckoutSummaryFeaturesListItem>
 				) }
 				{ hasEnTranslation( 'Fast support' ) && hasEnTranslation( 'Priority support 24/7' )
 					? ! isWpComPersonalPlan( productSlug ) && (
 							<CheckoutSummaryFeaturesListItem isSupported={ false }>
-								<WPCheckoutCheckIcon id="annual-live-chat" />
+								<WPCheckoutCheckIcon />
 								{ isWpComPremiumPlan( productSlug )
 									? translate( 'Fast support' )
 									: translate( 'Priority support 24/7' ) }
@@ -827,7 +823,7 @@ function CheckoutSummaryAnnualUpsell( props: {
 					  )
 					: ! isWpComPersonalPlan( productSlug ) && (
 							<CheckoutSummaryFeaturesListItem isSupported={ false }>
-								<WPCheckoutCheckIcon id="annual-live-chat" />
+								<WPCheckoutCheckIcon />
 								{ translate( 'Live chat support' ) }
 							</CheckoutSummaryFeaturesListItem>
 					  ) }


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* `<CheckIcon>` no longer needs to be passed a unique ID
* Internally the component can use `useId()`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

An issue was discovered here https://github.com/Automattic/wp-calypso/pull/102513#discussion_r2036241842, where if the ID passed to `<CheckIcon>` wasn't truly unique, then the icon could break in non-obvious ways.

React has a `useId()` hook now. We don't need devs to come up with carefully crafted unique IDs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through checkout.
* There should be no visible changes.
* Tests should pass (i.e. there are no tests that were depending on element IDs)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
