### PR TITLE
Design Picker: Implement event tracking for the Show All button

### DIFF
--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -215,6 +215,13 @@ const DesignCardGroup = ( {
 		return [ ...boosted, ...remaining ];
 	}, [ isCollapsed, designs, category, shuffleSeed ] );
 
+	const handleShowAllClick = () => {
+		setIsCollapsed( false );
+		recordTracksEvent( 'calypso_design_picker_category_show_all_click', {
+			category: category,
+		} );
+	};
+
 	const content = (
 		<div className="design-picker__grid">
 			{ visibleDesigns.map( ( design, index ) => {
@@ -255,7 +262,7 @@ const DesignCardGroup = ( {
 			{ content }
 			{ isCollapsed && designs.length > COLLAPSED_DESIGNS_VISIBLE_COUNT && (
 				<div className="design-picker__design-card-group-footer">
-					<Button onClick={ () => setIsCollapsed( false ) }>
+					<Button onClick={ handleShowAllClick }>
 						{ translate( 'Show all %s themes', {
 							args: categoryName,
 							comment: '%s will be a name of the theme category. e.g. Blog.',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/102486

## Proposed Changes

This PR introduces the Tracks event `calypso_design_picker_category_show_all_click` with prop `category`.
![Screenshot 2025-04-10 at 4 52 59 PM](https://github.com/user-attachments/assets/e7a4380c-4052-4177-a8c5-46e1b044de96)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Tracking.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Design Picker.
* Click on the "Show all" button and ensure that the event fires as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
