### PR TITLE
Redirect Github properly in the AI onboarding flow

### DIFF
--- a/client/components/social-buttons/utils.ts
+++ b/client/components/social-buttons/utils.ts
@@ -39,13 +39,18 @@ export const getRedirectUri = (
 		return `https://${ host + login( { socialService } ) }`;
 	}
 
+	let flow = 'start';
+	// TODO: I am restricting this to certain flows for testing sake, but I think this should be the default behavior.
+	if ( flowName === 'ai-site-builder' && socialService === 'github' ) {
+		flow = `setup/${ flowName }`;
+	}
+
+	let protocol = 'https';
 	if ( typeof window !== 'undefined' && window.location.hostname === 'calypso.localhost' ) {
-		return isLogin
-			? `http://${ host + login( { socialService } ) }`
-			: `http://${ host }/start/user`;
+		protocol = 'http';
 	}
 
 	return isLogin
-		? `https://${ host + login( { socialService } ) }`
-		: `https://${ host }/start/user`;
+		? `${ protocol }://${ host + login( { socialService } ) }`
+		: `${ protocol }://${ host }/${ flow }/user`;
 };

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder/ai-site-builder.ts
@@ -54,11 +54,17 @@ const aiSiteBuilder: Flow = {
 	useSideEffect() {
 		const dispatch = useDispatch();
 		const siteId = useQuery().get( 'siteId' );
+		const prompt = useQuery().get( 'prompt' );
 		useEffect( () => {
 			if ( siteId ) {
 				dispatch( setSelectedSiteId( parseInt( siteId ) ) );
 			}
 		}, [ siteId ] );
+		useEffect( () => {
+			if ( prompt && prompt.length > 0 ) {
+				window.sessionStorage.setItem( 'stored_ai_prompt', prompt );
+			}
+		}, [ prompt ] );
 	},
 	initialize() {
 		// stepsWithRequiredLogin will take care of redirecting to the login step if the user is not logged in.
@@ -141,8 +147,12 @@ const aiSiteBuilder: Flow = {
 
 						if ( prompt ) {
 							promptParam = `&prompt=${ encodeURIComponent( prompt ) }`;
+						} else if ( window.sessionStorage.getItem( 'stored_ai_prompt' ) ) {
+							promptParam = `&prompt=${ encodeURIComponent(
+								window.sessionStorage.getItem( 'stored_ai_prompt' ) || ''
+							) }`;
+							window.sessionStorage.removeItem( 'stored_ai_prompt' );
 						}
-
 						window.location.replace(
 							`${ siteURL }/wp-admin/site-editor.php?canvas=edit&referrer=${ AI_SITE_BUILDER_FLOW }${ promptParam }`
 						);


### PR DESCRIPTION
Fixes BSKY-342

This fixes a problem when Github login drops out of Ai-site-builder flow

## Testing instructions

1. Sandbox properly social logins ( `yarn run start-mock-wordpress-com` )
2. Incognito
3. Start in http://wordpress.com/setup/ai-site-builder/?prompt=potato factory
4. Chose Github login option
5. Confirm log in
6. See being redirected to https://wordpress.com/setup/ai-site-builder/user?service=github&code=CODEHERE&start_ref=https%3A%2F%2Fgithub.com%2F
7. See the prompt being reinstated in query strin
8. See the prompt being carried over to big sky
