### PR TITLE
Courses relaunch: Updated the course link to point to WordPress.com support docs

### DIFF
--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -57,7 +57,7 @@ export const HelpCenterMoreResources = () => {
 				<li className="help-center-more-resources__resource-item help-center-link__item">
 					<div className="help-center-more-resources__resource-cell help-center-link__cell">
 						<a
-							href={ localizeUrl( 'https://wordpress.com/courses/' ) }
+							href={ localizeUrl( 'https://wordpress.com/support/courses' ) }
 							rel="noreferrer"
 							target="_blank"
 							onClick={ () => trackLearnButtonClick( 'courses' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://linear.app/a8c/issue/DOTCOM-4163/update-courses-link-in-help-center

## Proposed Changes

* Updated where the `Courses` help center link points to
* Now we're linking to the support docs `wordpress.com/support/courses/`

![Screenshot 2025-04-10 at 12 00 16](https://github.com/user-attachments/assets/625a512d-71ce-412d-985e-cbafde879b26)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're going to relaunch courses and we need to make sure we're pointing the user to the correct documentation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso live link
* Open the Help Center from the hosting overview.
* Check that `Courses` takes you to the correct page.
* Open a site using the default interface.
* Open the help center, and click on the `Courses` link
* Make sure that it takes you to the correct page.
* Sandbox `widgets.wp.com`
* Apply these changes to your sandbox (upload the Help Center app)
* Open a site that uses wp-admin instead of the default interface.
* Open the help center and click on `Courses`
* Make sure you're taken to the correct page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
