### PR TITLE
Hide wrong links in editor and wp-admin

### DIFF
--- a/packages/help-center/src/hooks/use-admin-results.ts
+++ b/packages/help-center/src/hooks/use-admin-results.ts
@@ -69,7 +69,11 @@ export function useAdminResults( searchTerm: string ) {
 	const siteSlug = useSiteSlug();
 	const customizerUrls = useCustomizerUrls();
 	const siteEditorUrls = useSiteEditorUrls();
-	const { googleMailServiceFamily, locale, onboardingUrl } = useHelpCenterContext();
+	const { googleMailServiceFamily, locale, onboardingUrl, sectionName } = useHelpCenterContext();
+
+	if ( [ 'wp-admin', 'gutenberg-editor' ].includes( sectionName ) ) {
+		return [];
+	}
 
 	if ( siteSlug ) {
 		const sections = generateAdminSections(
@@ -84,5 +88,6 @@ export function useAdminResults( searchTerm: string ) {
 
 		return filteredSections;
 	}
+
 	return [];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/102173
"Show me where" links in the help center were malformed.
This PR hides the links for wp-admin and gutenberg.

## Proposed Changes

* Hide links based on sectionName

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Avoid showing wrong links to users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* In /home/{site_slug} open the help center and type "Plugins". 
* Click on the "show me where" result. And verify that the link is correct.
* Now open the help center in wp-admin and gutenberg and verify that this section and link is hidden when you search "Plugins"
