### PR TITLE
A4A: Make Payment methods and Invoices an external link for new clients.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
@@ -2,7 +2,7 @@ import { category, payment, receipt } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'calypso/state';
-import { getClientBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_CLIENT_SUBSCRIPTIONS_LINK,
 	A4A_CLIENT_PAYMENT_METHODS_LINK,
@@ -13,11 +13,11 @@ import { createItem } from '../lib/utils';
 const useClientMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
-	const clientBillingType = useSelector( getClientBillingType );
+	const userBillingType = useSelector( getUserBillingType );
 
-	// If the client billing type is BillingDragon, this mean we are reusing WPCOM billing and
-	// we need to redirect to the WPCOM billing page for this particular clients.
-	const isBillingTypeBD = clientBillingType === 'billingdragon';
+	// If the user billing type is 'billingdragon', this mean we are reusing WPCOM billing and
+	// we need to redirect to the WPCOM billing page for this particular users.
+	const isBillingTypeBD = userBillingType === 'billingdragon';
 
 	const menuItems = useMemo( () => {
 		return [

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
@@ -17,8 +17,7 @@ const useClientMenuItems = ( path: string ) => {
 
 	// If the client billing type is BillingDragon, this mean we are reusing WPCOM billing and
 	// we need to redirect to the WPCOM billing page for this particular clients.
-
-	const isBillingTypeBD = clientBillingType === 'BD';
+	const isBillingTypeBD = clientBillingType === 'billingdragon';
 
 	const menuItems = useMemo( () => {
 		return [

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
@@ -11,6 +11,8 @@ import { createItem } from '../lib/utils';
 const useClientMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
+	const isNewClient = true;
+
 	const menuItems = useMemo( () => {
 		return [
 			{
@@ -25,8 +27,11 @@ const useClientMenuItems = ( path: string ) => {
 			{
 				icon: payment,
 				path: '/',
-				link: A4A_CLIENT_PAYMENT_METHODS_LINK,
+				link: isNewClient
+					? 'https://wordpress.com/me/purchases/payment-methods'
+					: A4A_CLIENT_PAYMENT_METHODS_LINK,
 				title: translate( 'Payment methods' ),
+				isExternalLink: isNewClient,
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Client > Payment methods',
 				},
@@ -34,14 +39,15 @@ const useClientMenuItems = ( path: string ) => {
 			{
 				icon: receipt,
 				path: '/',
-				link: A4A_CLIENT_INVOICES_LINK,
+				link: isNewClient ? 'https://wordpress.com/me/purchases/billing' : A4A_CLIENT_INVOICES_LINK,
 				title: translate( 'Invoices' ),
+				isExternalLink: isNewClient,
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Client > Invoices',
 				},
 			},
 		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate ] );
+	}, [ isNewClient, path, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-client-menu-items.ts
@@ -1,6 +1,8 @@
 import { category, payment, receipt } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useSelector } from 'calypso/state';
+import { getClientBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_CLIENT_SUBSCRIPTIONS_LINK,
 	A4A_CLIENT_PAYMENT_METHODS_LINK,
@@ -11,7 +13,12 @@ import { createItem } from '../lib/utils';
 const useClientMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
-	const isNewClient = true;
+	const clientBillingType = useSelector( getClientBillingType );
+
+	// If the client billing type is BillingDragon, this mean we are reusing WPCOM billing and
+	// we need to redirect to the WPCOM billing page for this particular clients.
+
+	const isBillingTypeBD = clientBillingType === 'BD';
 
 	const menuItems = useMemo( () => {
 		return [
@@ -27,11 +34,11 @@ const useClientMenuItems = ( path: string ) => {
 			{
 				icon: payment,
 				path: '/',
-				link: isNewClient
+				link: isBillingTypeBD
 					? 'https://wordpress.com/me/purchases/payment-methods'
 					: A4A_CLIENT_PAYMENT_METHODS_LINK,
 				title: translate( 'Payment methods' ),
-				isExternalLink: isNewClient,
+				isExternalLink: isBillingTypeBD,
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Client > Payment methods',
 				},
@@ -39,15 +46,17 @@ const useClientMenuItems = ( path: string ) => {
 			{
 				icon: receipt,
 				path: '/',
-				link: isNewClient ? 'https://wordpress.com/me/purchases/billing' : A4A_CLIENT_INVOICES_LINK,
+				link: isBillingTypeBD
+					? 'https://wordpress.com/me/purchases/billing'
+					: A4A_CLIENT_INVOICES_LINK,
 				title: translate( 'Invoices' ),
-				isExternalLink: isNewClient,
+				isExternalLink: isBillingTypeBD,
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Client > Invoices',
 				},
 			},
 		].map( ( item ) => createItem( item, path ) );
-	}, [ isNewClient, path, translate ] );
+	}, [ isBillingTypeBD, path, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -4,7 +4,7 @@ import { getQueryArgs, addQueryArgs } from '@wordpress/url';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import {
 	getActiveAgency,
-	getClientBillingType,
+	getUserBillingType,
 	hasAgency,
 	hasFetchedAgency,
 } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -74,14 +74,14 @@ export const requireClientAccessContext: Callback = ( context, next ) => {
 
 export const requireLegacyClientBillingContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
-	const clientBillingType = getClientBillingType( state );
+	const userBillingType = getUserBillingType( state );
 
-	if ( clientBillingType === 'legacy' ) {
-		next();
+	if ( userBillingType !== 'legacy' ) {
+		page.redirect( A4A_CLIENT_SUBSCRIPTIONS_LINK );
 		return;
 	}
 
-	page.redirect( A4A_CLIENT_SUBSCRIPTIONS_LINK );
+	next();
 };
 
 export const requireTierAccessContext: Callback = ( context, next ) => {

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -4,11 +4,13 @@ import { getQueryArgs, addQueryArgs } from '@wordpress/url';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import {
 	getActiveAgency,
+	getClientBillingType,
 	hasAgency,
 	hasFetchedAgency,
 } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_CLIENT_LANDING_LINK,
+	A4A_CLIENT_SUBSCRIPTIONS_LINK,
 	A4A_LANDING_LINK,
 	A4A_OVERVIEW_LINK,
 } from './components/sidebar-menu/lib/constants';
@@ -68,6 +70,18 @@ export const requireClientAccessContext: Callback = ( context, next ) => {
 	page.redirect(
 		addQueryArgs( A4A_CLIENT_LANDING_LINK, { ...args, return: pathname + search + hash } )
 	);
+};
+
+export const requireLegacyClientBillingContext: Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const clientBillingType = getClientBillingType( state );
+
+	if ( clientBillingType === 'legacy' ) {
+		next();
+		return;
+	}
+
+	page.redirect( A4A_CLIENT_SUBSCRIPTIONS_LINK );
 };
 
 export const requireTierAccessContext: Callback = ( context, next ) => {

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -8,7 +8,10 @@ import {
 	A4A_CLIENT_INVOICES_LINK,
 	A4A_CLIENT_CHECKOUT,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { requireClientAccessContext } from 'calypso/a8c-for-agencies/controller';
+import {
+	requireClientAccessContext,
+	requireLegacyClientBillingContext,
+} from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
@@ -24,6 +27,7 @@ export default function () {
 	page(
 		A4A_CLIENT_PAYMENT_METHODS_LINK,
 		requireClientAccessContext,
+		requireLegacyClientBillingContext,
 		controller.clientPaymentMethodsContext,
 		makeLayout,
 		clientRender
@@ -31,6 +35,7 @@ export default function () {
 	page(
 		A4A_CLIENT_PAYMENT_METHODS_ADD_LINK,
 		requireClientAccessContext,
+		requireLegacyClientBillingContext,
 		controller.clientPaymentMethodsAddContext,
 		makeLayout,
 		clientRender
@@ -38,6 +43,7 @@ export default function () {
 	page(
 		A4A_CLIENT_INVOICES_LINK,
 		requireClientAccessContext,
+		requireLegacyClientBillingContext,
 		controller.clientInvoicesContext,
 		makeLayout,
 		clientRender
@@ -45,6 +51,7 @@ export default function () {
 	page(
 		A4A_CLIENT_CHECKOUT,
 		requireClientAccessContext,
+		requireLegacyClientBillingContext,
 		controller.clientCheckoutContext,
 		makeLayout,
 		clientRender

--- a/client/a8c-for-agencies/sections/client/index.tsx
+++ b/client/a8c-for-agencies/sections/client/index.tsx
@@ -51,7 +51,6 @@ export default function () {
 	page(
 		A4A_CLIENT_CHECKOUT,
 		requireClientAccessContext,
-		requireLegacyClientBillingContext,
 		controller.clientCheckoutContext,
 		makeLayout,
 		clientRender

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -4,7 +4,7 @@ import { translate } from 'i18n-calypso';
 import 'calypso/state/a8c-for-agencies/init';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { NoticeActionOptions } from 'calypso/state/notices/types';
-import { APIError, Agency, AgencyThunkAction } from '../types';
+import { APIError, Agency, AgencyThunkAction, ClientBillingType } from '../types';
 import {
 	JETPACK_GET_AGENCIES_ERROR,
 	JETPACK_GET_AGENCIES_REQUEST,
@@ -64,11 +64,18 @@ export function receiveAgencies( agencies: Agency[] ): AgencyThunkAction {
 	};
 }
 
-export function setAgencyClientUser( isClientUser: boolean ): AgencyThunkAction {
+export function setAgencyClientUser( {
+	isClientUser,
+	billingType,
+}: {
+	isClientUser: boolean;
+	billingType: ClientBillingType;
+} ): AgencyThunkAction {
 	return ( dispatch ) => {
 		dispatch( {
 			type: JETPACK_SET_AGENCY_CLIENT_USER,
 			isClientUser,
+			billingType,
 		} );
 	};
 }

--- a/client/state/a8c-for-agencies/agency/actions.ts
+++ b/client/state/a8c-for-agencies/agency/actions.ts
@@ -4,7 +4,7 @@ import { translate } from 'i18n-calypso';
 import 'calypso/state/a8c-for-agencies/init';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { NoticeActionOptions } from 'calypso/state/notices/types';
-import { APIError, Agency, AgencyThunkAction, ClientBillingType } from '../types';
+import { APIError, Agency, AgencyThunkAction, UserBillingType } from '../types';
 import {
 	JETPACK_GET_AGENCIES_ERROR,
 	JETPACK_GET_AGENCIES_REQUEST,
@@ -69,7 +69,7 @@ export function setAgencyClientUser( {
 	billingType,
 }: {
 	isClientUser: boolean;
-	billingType: ClientBillingType;
+	billingType: UserBillingType;
 } ): AgencyThunkAction {
 	return ( dispatch ) => {
 		dispatch( {

--- a/client/state/a8c-for-agencies/agency/handlers.ts
+++ b/client/state/a8c-for-agencies/agency/handlers.ts
@@ -2,7 +2,7 @@ import { AnyAction } from 'redux';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { APIError, Agency, ClientBillingType } from '../types';
+import { APIError, Agency, UserBillingType } from '../types';
 import { JETPACK_GET_AGENCIES_REQUEST } from './action-types';
 import { receiveAgencies, receiveAgenciesError, setAgencyClientUser } from './actions';
 
@@ -27,12 +27,12 @@ function fetchAgenciesHandler( action: AnyAction ): AnyAction {
 
 function receiveAgenciesHandler(
 	_action: AnyAction,
-	data: Agency[] | { is_client_user: boolean; billing_type: ClientBillingType }
+	data: Agency[] | { is_client_user: boolean; billing_type: UserBillingType }
 ) {
 	if ( 'is_client_user' in data ) {
 		return setAgencyClientUser( {
 			isClientUser: data.is_client_user,
-			billingType: data.billing_type ?? 'legacy',
+			billingType: data.billing_type || 'legacy',
 		} );
 	}
 	return receiveAgencies( data );

--- a/client/state/a8c-for-agencies/agency/handlers.ts
+++ b/client/state/a8c-for-agencies/agency/handlers.ts
@@ -32,7 +32,9 @@ function receiveAgenciesHandler(
 	if ( 'is_client_user' in data ) {
 		return setAgencyClientUser( {
 			isClientUser: data.is_client_user,
-			billingType: data.billing_type || 'legacy',
+			billingType: [ 'legacy', 'billingdragon' ].includes( data.billing_type )
+				? data.billing_type
+				: 'legacy',
 		} );
 	}
 	return receiveAgencies( data );

--- a/client/state/a8c-for-agencies/agency/handlers.ts
+++ b/client/state/a8c-for-agencies/agency/handlers.ts
@@ -32,7 +32,7 @@ function receiveAgenciesHandler(
 	if ( 'is_client_user' in data ) {
 		return setAgencyClientUser( {
 			isClientUser: data.is_client_user,
-			billingType: data.billing_type,
+			billingType: data.billing_type ?? 'legacy',
 		} );
 	}
 	return receiveAgencies( data );

--- a/client/state/a8c-for-agencies/agency/handlers.ts
+++ b/client/state/a8c-for-agencies/agency/handlers.ts
@@ -2,7 +2,7 @@ import { AnyAction } from 'redux';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { noRetry } from 'calypso/state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
-import { APIError, Agency } from '../types';
+import { APIError, Agency, ClientBillingType } from '../types';
 import { JETPACK_GET_AGENCIES_REQUEST } from './action-types';
 import { receiveAgencies, receiveAgenciesError, setAgencyClientUser } from './actions';
 
@@ -27,10 +27,13 @@ function fetchAgenciesHandler( action: AnyAction ): AnyAction {
 
 function receiveAgenciesHandler(
 	_action: AnyAction,
-	data: Agency[] | { is_client_user: boolean }
+	data: Agency[] | { is_client_user: boolean; billing_type: ClientBillingType }
 ) {
 	if ( 'is_client_user' in data ) {
-		return setAgencyClientUser( data.is_client_user );
+		return setAgencyClientUser( {
+			isClientUser: data.is_client_user,
+			billingType: data.billing_type,
+		} );
 	}
 	return receiveAgencies( data );
 }

--- a/client/state/a8c-for-agencies/agency/reducer.ts
+++ b/client/state/a8c-for-agencies/agency/reducer.ts
@@ -45,7 +45,7 @@ export const isAgencyClientUser = ( state = initialState.isFetching, action: Any
 	return state;
 };
 
-export const clientBillingType = ( state = initialState.isFetching, action: AnyAction ) => {
+export const userBillingType = ( state = initialState.isFetching, action: AnyAction ) => {
 	switch ( action.type ) {
 		case JETPACK_SET_AGENCY_CLIENT_USER: {
 			return action.billingType;
@@ -94,5 +94,5 @@ export default combineReducers( {
 	agencies,
 	error,
 	isAgencyClientUser,
-	clientBillingType,
+	userBillingType,
 } );

--- a/client/state/a8c-for-agencies/agency/reducer.ts
+++ b/client/state/a8c-for-agencies/agency/reducer.ts
@@ -45,6 +45,16 @@ export const isAgencyClientUser = ( state = initialState.isFetching, action: Any
 	return state;
 };
 
+export const clientBillingType = ( state = initialState.isFetching, action: AnyAction ) => {
+	switch ( action.type ) {
+		case JETPACK_SET_AGENCY_CLIENT_USER: {
+			return action.billingType;
+		}
+	}
+
+	return state;
+};
+
 export const isFetching = ( state = initialState.isFetching, action: AnyAction ) => {
 	switch ( action.type ) {
 		case JETPACK_GET_AGENCIES_REQUEST:
@@ -84,4 +94,5 @@ export default combineReducers( {
 	agencies,
 	error,
 	isAgencyClientUser,
+	clientBillingType,
 } );

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -1,6 +1,6 @@
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
-import { A4AStore, APIError, Agency, ApprovalStatus } from '../types';
+import { A4AStore, APIError, Agency, ClientBillingType } from '../types';
 
 export function getActiveAgency( state: A4AStore ): Agency | null {
 	return state.a8cForAgencies.agencies.activeAgency;
@@ -43,6 +43,10 @@ export function isAgencyOwner( state: A4AStore ): boolean {
 
 export function isAgencyClientUser( state: A4AStore ): boolean {
 	return state.a8cForAgencies.agencies.isAgencyClientUser;
+}
+
+export function getClientBillingType( state: A4AStore ): ClientBillingType {
+	return state.a8cForAgencies.agencies.clientBillingType;
 }
 
 export function hasAgencyCapability( state: A4AStore, capability: string ): boolean {

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -1,6 +1,6 @@
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
-import { A4AStore, APIError, Agency, ClientBillingType } from '../types';
+import { A4AStore, APIError, Agency, UserBillingType } from '../types';
 
 export function getActiveAgency( state: A4AStore ): Agency | null {
 	return state.a8cForAgencies.agencies.activeAgency;
@@ -45,8 +45,8 @@ export function isAgencyClientUser( state: A4AStore ): boolean {
 	return state.a8cForAgencies.agencies.isAgencyClientUser;
 }
 
-export function getClientBillingType( state: A4AStore ): ClientBillingType {
-	return state.a8cForAgencies.agencies.clientBillingType;
+export function getUserBillingType( state: A4AStore ): UserBillingType {
+	return state.a8cForAgencies.agencies.userBillingType;
 }
 
 export function hasAgencyCapability( state: A4AStore, capability: string ): boolean {

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -1,6 +1,6 @@
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
-import { A4AStore, APIError, Agency, UserBillingType } from '../types';
+import { A4AStore, APIError, Agency, ApprovalStatus, UserBillingType } from '../types';
 
 export function getActiveAgency( state: A4AStore ): Agency | null {
 	return state.a8cForAgencies.agencies.activeAgency;

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -101,7 +101,7 @@ export interface Agency {
 	created_at: string;
 }
 
-export type ClientBillingType = 'legacy' | 'BD';
+export type ClientBillingType = 'legacy' | 'billingdragon';
 
 export interface AgencyStore {
 	hasFetched: boolean;

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -101,6 +101,8 @@ export interface Agency {
 	created_at: string;
 }
 
+export type ClientBillingType = 'legacy' | 'BD';
+
 export interface AgencyStore {
 	hasFetched: boolean;
 	isFetching: boolean;
@@ -108,6 +110,7 @@ export interface AgencyStore {
 	agencies: Agency[] | [];
 	error: APIError | null;
 	isAgencyClientUser: boolean;
+	clientBillingType: ClientBillingType;
 }
 
 export type AgencyThunkAction< A extends Action = AnyAction, R = unknown > = ThunkAction<

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -101,7 +101,7 @@ export interface Agency {
 	created_at: string;
 }
 
-export type ClientBillingType = 'legacy' | 'billingdragon';
+export type UserBillingType = 'legacy' | 'billingdragon';
 
 export interface AgencyStore {
 	hasFetched: boolean;
@@ -110,7 +110,7 @@ export interface AgencyStore {
 	agencies: Agency[] | [];
 	error: APIError | null;
 	isAgencyClientUser: boolean;
-	clientBillingType: ClientBillingType;
+	userBillingType: UserBillingType;
 }
 
 export type AgencyThunkAction< A extends Action = AnyAction, R = unknown > = ThunkAction<


### PR DESCRIPTION
**NOTE: This needs to be tested with 180397-ghe-Automattic/wpcom**

<img width="604" alt="Screenshot 2025-04-10 at 7 33 10 PM" src="https://github.com/user-attachments/assets/f5b4c27a-559e-47fc-ab75-5ae7e926ef02" />

## Proposed Changes

* This PR updates the Agency store to acknowledge the new `client_billing_type` information from the Agency endpoint. This field is essential for identifying whether the current user employs the new checkout v2, which relies on WPCOM billing.
* If the current user uses 'BD' billing, we render the sidebar so that both the Payment Methods and Invoice pages goes to the WPCOM section. 
* We also added a new route middleware to check the current billing type. If the billing type is 'BD', access to `/client/payment-methods`, `/client/invoices`, and `/client/checkout` is restricted.

## Why are these changes being made?

* This is part of the Referrals move to BillingDragon project.

## Testing Instructions

* Follow instructions in 180397-ghe-Automattic/wpcom to set the client to 'BD billing'.
* Login as client and use the A4A live link and navigate to the `/client/subscription`.
* Verify that the **"Payment methods"** and **"Invoice"** menu is an external link that goes to WPCOM.
* Verify that if you access `/client/payment-methods`, `/client/invoices` and `/client/checkout`, you get redirected to `/client/subscription`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?