### PR TITLE
A4A: Remove "Free domain for one year" feature from Pressable plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/common/hosting-features.tsx
@@ -5,9 +5,10 @@ import HostingFeaturesSectionV2 from '../../../common/hosting-features-section-v
 
 type Props = {
 	heading: string;
+	isPressable?: boolean;
 };
 
-export default function HostingFeatures( { heading }: Props ) {
+export default function HostingFeatures( { heading, isPressable }: Props ) {
 	const translate = useTranslate();
 
 	return (
@@ -70,7 +71,7 @@ export default function HostingFeatures( { heading }: Props ) {
 						translate( 'In-depth site analytics dashboard' ),
 						translate( 'Elastic-powered search' ),
 						translate( '4K, unbranded VideoPress player' ),
-						translate( 'Free domain for one year' ),
+						...( isPressable ? [] : [ translate( 'Free domain for one year' ) ] ),
 						translate( 'Smart redirects' ),
 					],
 				},

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview-v3/hosting-content/premier-agency-hosting/index.tsx
@@ -80,7 +80,7 @@ export default function PremierAgencyHosting( { onAddToCart }: Props ) {
 				isFetching={ isExistingPlanFetched }
 			/>
 
-			<HostingFeatures heading={ translate( 'Included with every Pressable site' ) } />
+			<HostingFeatures heading={ translate( 'Included with every Pressable site' ) } isPressable />
 
 			<HostingAdditionalFeaturesSection
 				icon={ <JetpackLogo size={ 16 } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to #

## Proposed Changes

* Modified `HostingFeatures` component to conditionally exclude "Free domain for one year" when `isPressable` is `true`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Pressable plans do not include a free domain.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the live link.
2. Navigate to `/marketplace/hosting/wpcom`.
3. Verify that **"Free domain for one year"** appears in the **"And More!"** column.
4. Then, go to `/marketplace/hosting/pressable`.
5. Confirm that **"Free domain for one year"** is **not** present in the **"And More!"** column.

<img width="375" alt="Screenshot 2025-04-10 at 13 39 07" src="https://github.com/user-attachments/assets/3df9ea6d-de8c-482f-9590-a8bc2aa86fa0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
