### PR TITLE
A4A: Fix new client checkout redirects.

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -143,6 +143,7 @@ function ClientCheckoutContent() {
 			<CheckoutMain
 				sitelessCheckoutType="a4a"
 				redirectTo={ window.location.origin + '/client/subscriptions' }
+				customizedPreviousPath="/client/subscriptions"
 				isInModal={ false }
 				siteSlug=""
 				siteId={ 0 }

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -144,6 +144,7 @@ export default function usePrepareProductsForCart( {
 			sitelessCheckoutType === 'jetpack' ||
 			sitelessCheckoutType === 'akismet' ||
 			sitelessCheckoutType === 'marketplace' ||
+			sitelessCheckoutType === 'a4a' ||
 			isGiftPurchase
 	);
 	useStripProductsFromUrl( siteSlug, doNotStripProducts );


### PR DESCRIPTION
This PR fixes two minor issues in the new Client checkout page.

## Proposed Changes

* The first issue concerns the page URL changing to `/checkout`. This occurred because the cart logic removed the URL's product query parameters. These query parameters do not apply to the A4A client use case, so we are adding an exception for the A4A siteless checkout. https://github.com/Automattic/wp-calypso/pull/102531/commits/683f5c43a9d82cd11b9dc24526f834e78269f8e5
* Removing items from the cart redirects the user to the `/client/subscription` page, but the URL retains parameters from the prior page. To achieve a clean URL in this case, we need to provide a `customPreviousPath`. https://github.com/Automattic/wp-calypso/pull/102531/commits/30728a500155ebdfa371088689b661bca81ded86

## Why are these changes being made?

* This is part of the Client referral BillingDragon project.

## Testing Instructions

# Issue 1
* Create a referral order and receive the magic link.
* Access the magic link and replace the domain to the A4A live link.
* Replace the `/client/checkout` in the URL to `/client/checkout/v2` to load the new checkout page.
* Confirm that when the page finishes loading. The URL retains to `/client/checkout/v2`.

# Issue 2
* Remove all items in the cart by clicking the 'Remove from cart' button.
* Confirm that when all items are removed, the page redirects to the `/client/subscription` page without any URL Query parameters.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
