### PR TITLE
Skip social e2e for private sites

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -14,6 +14,7 @@ import {
 	TestAccountName,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
+import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
@@ -76,212 +77,218 @@ if ( envVariables.JETPACK_TARGET === 'wpcom-deployment' ) {
  *
  * Keywords: Social, Jetpack, Publicize, Editor
  */
-describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () {
-	for ( const { plan, platform, testAccountName, features } of testCases ) {
-		const title = `For ${ platform } sites with ${ plan } plan`;
+skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
+	DataHelper.createSuiteTitle( 'Social: Editor features' ),
+	function () {
+		for ( const { plan, platform, testAccountName, features } of testCases ) {
+			const title = `For ${ platform } sites with ${ plan } plan`;
 
-		describe( DataHelper.createSuiteTitle( title ), function () {
-			let page: Page;
-			let editorPage: EditorPage;
-			let socialConnectionsManager: SocialConnectionsManager;
+			describe( DataHelper.createSuiteTitle( title ), function () {
+				let page: Page;
+				let editorPage: EditorPage;
+				let socialConnectionsManager: SocialConnectionsManager;
 
-			let siteSlug: string;
-			let siteId: number;
+				let siteSlug: string;
+				let siteId: number;
 
-			beforeAll( async () => {
-				page = await browser.newPage();
-				editorPage = new EditorPage( page );
+				beforeAll( async () => {
+					page = await browser.newPage();
+					editorPage = new EditorPage( page );
 
-				const testAccount = new TestAccount( testAccountName );
-				siteId = testAccount.credentials.testSites?.primary?.id || 0;
-				siteSlug = testAccount.getSiteURL( { protocol: false } );
-				socialConnectionsManager = new SocialConnectionsManager( page, siteId! );
-				await testAccount.authenticate( page );
-			} );
+					const testAccount = new TestAccount( testAccountName );
+					siteId = testAccount.credentials.testSites?.primary?.id || 0;
+					siteSlug = testAccount.getSiteURL( { protocol: false } );
+					socialConnectionsManager = new SocialConnectionsManager( page, siteId! );
+					await testAccount.authenticate( page );
+				} );
 
-			beforeEach( async () => {
-				await editorPage.visit( 'post', { siteSlug } );
-			} );
+				beforeEach( async () => {
+					await editorPage.visit( 'post', { siteSlug } );
+				} );
 
-			afterEach( async () => {
-				await socialConnectionsManager.clearIntercepts();
-			} );
+				afterEach( async () => {
+					await socialConnectionsManager.clearIntercepts();
+				} );
 
-			test( 'Should verify that auto-sharing is available for new posts', async function () {
-				await socialConnectionsManager.interceptRequests();
+				test( 'Should verify that auto-sharing is available for new posts', async function () {
+					await socialConnectionsManager.interceptRequests();
 
-				await Promise.all( [
+					await Promise.all( [
+						// Open the Jetpack sidebar.
+						editorPage.openSettings( 'Jetpack' ),
+						// Wait for the connection test results to finish
+						socialConnectionsManager.waitForConnectionTests(),
+					] );
+
+					// Expand the Publicize panel.
+					const section = await editorPage.expandSection( 'Share this post' );
+
+					// Verify that the toggle is enabled.
+					const toggle = section.getByLabel( 'Share when publishing' );
+					expect( await toggle.isChecked() ).toBe( true );
+
+					// Verify that the message box is editable.
+					const messageBox = section.getByRole( 'textbox', { name: 'Message' } );
+					expect( await messageBox.isEditable() ).toBe( true );
+
+					// Verify whether the media button is available.
+					const mediaButton = section.getByRole( 'button', { name: 'Choose Media' } );
+					expect( await mediaButton.isVisible() ).toBe( features.mediaSharing );
+				} );
+
+				test( `Should verify that resharing ${
+					features.resharing ? 'IS' : 'is NOT'
+				} available`, async function () {
+					let connectionTestPromise = Promise.resolve();
+					await socialConnectionsManager.interceptRequests();
+
+					connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+
 					// Open the Jetpack sidebar.
-					editorPage.openSettings( 'Jetpack' ),
-					// Wait for the connection test results to finish
-					socialConnectionsManager.waitForConnectionTests(),
-				] );
+					await editorPage.openSettings( 'Jetpack' );
 
-				// Expand the Publicize panel.
-				const section = await editorPage.expandSection( 'Share this post' );
+					await connectionTestPromise;
 
-				// Verify that the toggle is enabled.
-				const toggle = section.getByLabel( 'Share when publishing' );
-				expect( await toggle.isChecked() ).toBe( true );
+					// Expand the Publicize panel.
+					let section = await editorPage.expandSection( 'Share this post' );
 
-				// Verify that the message box is editable.
-				const messageBox = section.getByRole( 'textbox', { name: 'Message' } );
-				expect( await messageBox.isEditable() ).toBe( true );
-
-				// Verify whether the media button is available.
-				const mediaButton = section.getByRole( 'button', { name: 'Choose Media' } );
-				expect( await mediaButton.isVisible() ).toBe( features.mediaSharing );
-			} );
-
-			test( `Should verify that resharing ${
-				features.resharing ? 'IS' : 'is NOT'
-			} available`, async function () {
-				let connectionTestPromise = Promise.resolve();
-				await socialConnectionsManager.interceptRequests();
-
-				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
-
-				// Open the Jetpack sidebar.
-				await editorPage.openSettings( 'Jetpack' );
-
-				await connectionTestPromise;
-
-				// Expand the Publicize panel.
-				let section = await editorPage.expandSection( 'Share this post' );
-
-				// Verify that resharing button is not visible on new posts in the share modal
-				let sharePostModalButton = section.getByRole( 'button', {
-					name: 'Preview social posts',
-					exact: true,
-				} );
-				await sharePostModalButton.click();
-
-				const shareModal = ( await editorPage.getEditorParent() ).getByRole( 'dialog' ).filter( {
-					hasText: 'Social Preview',
-				} );
-
-				await shareModal.waitFor();
-				let reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
-
-				expect( await reshareButton.isVisible() ).toBe( false );
-
-				let closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
-				await closeButton.click();
-
-				// Set a title for the post
-				await editorPage.enterTitle( 'Resharing: ' + DataHelper.getRandomPhrase() );
-				// Publish the post.
-				await editorPage.publish();
-				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
-				await editorPage.closeAllPanels();
-
-				// Open the Jetpack sidebar.
-				await editorPage.openSettings( 'Jetpack' );
-
-				await connectionTestPromise;
-
-				// Expand the Publicize panel.
-				section = await editorPage.expandSection( 'Share this post' );
-
-				// Verify whether the auto-share toggle is no longer visible.
-				const toggle = section.getByLabel( 'Share when publishing' );
-				expect( await toggle.isVisible() ).toBe( false );
-
-				// Check if the Preview & Share button is visible based on resharing feature
-				sharePostModalButton = section.getByRole( 'button', {
-					name: 'Preview & Share',
-					exact: true,
-				} );
-
-				expect( await sharePostModalButton.isVisible() ).toBe( features.resharing );
-
-				let isReshareButtonVisible = false;
-
-				if ( features.resharing ) {
+					// Verify that resharing button is not visible on new posts in the share modal
+					let sharePostModalButton = section.getByRole( 'button', {
+						name: 'Preview social posts',
+						exact: true,
+					} );
 					await sharePostModalButton.click();
 
 					const shareModal = ( await editorPage.getEditorParent() ).getByRole( 'dialog' ).filter( {
-						hasText: 'Share Post',
+						hasText: 'Social Preview',
 					} );
+
 					await shareModal.waitFor();
+					let reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
 
-					// Look for the Share button within the modal dialog
-					reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
-					isReshareButtonVisible = await reshareButton.isVisible();
+					expect( await reshareButton.isVisible() ).toBe( false );
 
-					// Close the share post modal by clicking the Close button within the modal
-					closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
+					let closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
 					await closeButton.click();
-				}
-				expect( isReshareButtonVisible ).toBe( features.resharing );
 
-				// Verify whether the upgrade nudge/link is visible.
-				if ( ! features.resharing ) {
-					const upgradeLink = section.getByRole( 'link', { name: 'Upgrade now' } );
-					// The upgrade CTA is a button instead of a link until some API call finishes to get the checkout URL, which makes it a link.
-					// So, we need to wait for the link to appear.
-					await upgradeLink.waitFor();
-				}
+					// Set a title for the post
+					await editorPage.enterTitle( 'Resharing: ' + DataHelper.getRandomPhrase() );
+					// Publish the post.
+					await editorPage.publish();
+					connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+					await editorPage.closeAllPanels();
 
-				const content = await section.textContent();
+					// Open the Jetpack sidebar.
+					await editorPage.openSettings( 'Jetpack' );
 
-				const message = 'To re-share a post, you need to upgrade to the WordPress.com Premium plan';
+					await connectionTestPromise;
 
-				expect( content?.includes( message ) ).toBe( ! features.resharing );
-			} );
+					// Expand the Publicize panel.
+					section = await editorPage.expandSection( 'Share this post' );
 
-			test( `Should verify that manual sharing ${
-				features.manualSharing ? 'IS' : 'is NOT'
-			} available`, async function () {
-				// Open the Jetpack sidebar.
-				await editorPage.openSettings( 'Jetpack' );
+					// Verify whether the auto-share toggle is no longer visible.
+					const toggle = section.getByLabel( 'Share when publishing' );
+					expect( await toggle.isVisible() ).toBe( false );
 
-				// Expand the Publicize panel.
-				let section = await editorPage.expandSection( 'Share this post' );
+					// Check if the Preview & Share button is visible based on resharing feature
+					sharePostModalButton = section.getByRole( 'button', {
+						name: 'Preview & Share',
+						exact: true,
+					} );
 
-				// Verify that manual sharing is NOT available before publishing.
-				let manualSharing = section.getByRole( 'paragraph', { name: 'Manual sharing' } );
-				expect( await manualSharing.isVisible() ).toBe( false );
+					expect( await sharePostModalButton.isVisible() ).toBe( features.resharing );
 
-				// Set a title for the post
-				await editorPage.enterTitle( 'Manual sharing: ' + DataHelper.getRandomPhrase() );
-				// Publish the post.
-				await editorPage.publish();
+					let isReshareButtonVisible = false;
 
-				// Verify whether the manual sharing is available on post publish panel
-				manualSharing = ( await editorPage.getPublishPanelRoot() ).getByRole( 'button', {
-					name: 'Manual sharing',
+					if ( features.resharing ) {
+						await sharePostModalButton.click();
+
+						const shareModal = ( await editorPage.getEditorParent() )
+							.getByRole( 'dialog' )
+							.filter( {
+								hasText: 'Share Post',
+							} );
+						await shareModal.waitFor();
+
+						// Look for the Share button within the modal dialog
+						reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
+						isReshareButtonVisible = await reshareButton.isVisible();
+
+						// Close the share post modal by clicking the Close button within the modal
+						closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
+						await closeButton.click();
+					}
+					expect( isReshareButtonVisible ).toBe( features.resharing );
+
+					// Verify whether the upgrade nudge/link is visible.
+					if ( ! features.resharing ) {
+						const upgradeLink = section.getByRole( 'link', { name: 'Upgrade now' } );
+						// The upgrade CTA is a button instead of a link until some API call finishes to get the checkout URL, which makes it a link.
+						// So, we need to wait for the link to appear.
+						await upgradeLink.waitFor();
+					}
+
+					const content = await section.textContent();
+
+					const message =
+						'To re-share a post, you need to upgrade to the WordPress.com Premium plan';
+
+					expect( content?.includes( message ) ).toBe( ! features.resharing );
 				} );
 
-				if ( features.manualSharing ) {
-					await manualSharing.waitFor();
-				}
+				test( `Should verify that manual sharing ${
+					features.manualSharing ? 'IS' : 'is NOT'
+				} available`, async function () {
+					// Open the Jetpack sidebar.
+					await editorPage.openSettings( 'Jetpack' );
 
-				// Close the post publish panel.
-				await editorPage.closeAllPanels();
+					// Expand the Publicize panel.
+					let section = await editorPage.expandSection( 'Share this post' );
 
-				// Open the Jetpack sidebar.
-				await editorPage.openSettings( 'Jetpack' );
+					// Verify that manual sharing is NOT available before publishing.
+					let manualSharing = section.getByRole( 'paragraph', { name: 'Manual sharing' } );
+					expect( await manualSharing.isVisible() ).toBe( false );
 
-				// Expand the Publicize panel.
-				section = await editorPage.expandSection( 'Share this post' );
+					// Set a title for the post
+					await editorPage.enterTitle( 'Manual sharing: ' + DataHelper.getRandomPhrase() );
+					// Publish the post.
+					await editorPage.publish();
 
-				// Verify whether manual sharing is available in the Jetpack sidebar.
-				manualSharing = section.getByText( 'Manual sharing' );
-				expect( await manualSharing.isVisible() ).toBe( features.manualSharing );
+					// Verify whether the manual sharing is available on post publish panel
+					manualSharing = ( await editorPage.getPublishPanelRoot() ).getByRole( 'button', {
+						name: 'Manual sharing',
+					} );
+
+					if ( features.manualSharing ) {
+						await manualSharing.waitFor();
+					}
+
+					// Close the post publish panel.
+					await editorPage.closeAllPanels();
+
+					// Open the Jetpack sidebar.
+					await editorPage.openSettings( 'Jetpack' );
+
+					// Expand the Publicize panel.
+					section = await editorPage.expandSection( 'Share this post' );
+
+					// Verify whether manual sharing is available in the Jetpack sidebar.
+					manualSharing = section.getByText( 'Manual sharing' );
+					expect( await manualSharing.isVisible() ).toBe( features.manualSharing );
+				} );
+
+				test( `Should verify that Social Image Generator ${
+					features.socialImageGenerator ? 'IS' : 'is NOT'
+				} available`, async function () {
+					// Open the Jetpack sidebar.
+					await editorPage.openSettings( 'Jetpack' );
+
+					const section = await editorPage.getSettingsSection( 'Social Image Generator' );
+
+					// Verify whether the Social Image Generator panel exists.
+					expect( await section.isVisible() ).toBe( features.socialImageGenerator );
+				} );
 			} );
-
-			test( `Should verify that Social Image Generator ${
-				features.socialImageGenerator ? 'IS' : 'is NOT'
-			} available`, async function () {
-				// Open the Jetpack sidebar.
-				await editorPage.openSettings( 'Jetpack' );
-
-				const section = await editorPage.getSettingsSection( 'Social Image Generator' );
-
-				// Verify whether the Social Image Generator panel exists.
-				expect( await section.isVisible() ).toBe( features.socialImageGenerator );
-			} );
-		} );
+		}
 	}
-} );
+);

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -40,6 +40,7 @@ const testCases: Array< {
 		'resharing' | 'manualSharing' | 'mediaSharing' | 'socialImageGenerator',
 		boolean
 	>;
+	isPrivate?: boolean;
 } > = [];
 
 if ( envVariables.JETPACK_TARGET === 'wpcom-deployment' ) {
@@ -82,7 +83,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 	for ( const { plan, platform, testAccountName, features, isPrivate } of testCases ) {
 		const title = `For ${ platform } sites with ${ plan } plan`;
 
-		skipDescribeIf( isPrivate )( DataHelper.createSuiteTitle( title ), function () {
+		skipDescribeIf( isPrivate ?? false )( DataHelper.createSuiteTitle( title ), function () {
 			let page: Page;
 			let editorPage: EditorPage;
 			let socialConnectionsManager: SocialConnectionsManager;

--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -48,6 +48,7 @@ if ( envVariables.JETPACK_TARGET === 'wpcom-deployment' ) {
 		platform: envVariables.TEST_ON_ATOMIC ? 'Atomic' : 'Simple',
 		testAccountName: getTestAccountByFeature( envToFeatureKey( envVariables ) ),
 		features: features4BusinessPlan,
+		isPrivate: envVariables.TEST_ON_ATOMIC && envVariables.ATOMIC_VARIATION === 'private',
 	} );
 } else {
 	testCases.push(
@@ -77,218 +78,212 @@ if ( envVariables.JETPACK_TARGET === 'wpcom-deployment' ) {
  *
  * Keywords: Social, Jetpack, Publicize, Editor
  */
-skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
-	DataHelper.createSuiteTitle( 'Social: Editor features' ),
-	function () {
-		for ( const { plan, platform, testAccountName, features } of testCases ) {
-			const title = `For ${ platform } sites with ${ plan } plan`;
+describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () {
+	for ( const { plan, platform, testAccountName, features, isPrivate } of testCases ) {
+		const title = `For ${ platform } sites with ${ plan } plan`;
 
-			describe( DataHelper.createSuiteTitle( title ), function () {
-				let page: Page;
-				let editorPage: EditorPage;
-				let socialConnectionsManager: SocialConnectionsManager;
+		skipDescribeIf( isPrivate )( DataHelper.createSuiteTitle( title ), function () {
+			let page: Page;
+			let editorPage: EditorPage;
+			let socialConnectionsManager: SocialConnectionsManager;
 
-				let siteSlug: string;
-				let siteId: number;
+			let siteSlug: string;
+			let siteId: number;
 
-				beforeAll( async () => {
-					page = await browser.newPage();
-					editorPage = new EditorPage( page );
+			beforeAll( async () => {
+				page = await browser.newPage();
+				editorPage = new EditorPage( page );
 
-					const testAccount = new TestAccount( testAccountName );
-					siteId = testAccount.credentials.testSites?.primary?.id || 0;
-					siteSlug = testAccount.getSiteURL( { protocol: false } );
-					socialConnectionsManager = new SocialConnectionsManager( page, siteId! );
-					await testAccount.authenticate( page );
-				} );
+				const testAccount = new TestAccount( testAccountName );
+				siteId = testAccount.credentials.testSites?.primary?.id || 0;
+				siteSlug = testAccount.getSiteURL( { protocol: false } );
+				socialConnectionsManager = new SocialConnectionsManager( page, siteId! );
+				await testAccount.authenticate( page );
+			} );
 
-				beforeEach( async () => {
-					await editorPage.visit( 'post', { siteSlug } );
-				} );
+			beforeEach( async () => {
+				await editorPage.visit( 'post', { siteSlug } );
+			} );
 
-				afterEach( async () => {
-					await socialConnectionsManager.clearIntercepts();
-				} );
+			afterEach( async () => {
+				await socialConnectionsManager.clearIntercepts();
+			} );
 
-				test( 'Should verify that auto-sharing is available for new posts', async function () {
-					await socialConnectionsManager.interceptRequests();
+			test( 'Should verify that auto-sharing is available for new posts', async function () {
+				await socialConnectionsManager.interceptRequests();
 
-					await Promise.all( [
-						// Open the Jetpack sidebar.
-						editorPage.openSettings( 'Jetpack' ),
-						// Wait for the connection test results to finish
-						socialConnectionsManager.waitForConnectionTests(),
-					] );
-
-					// Expand the Publicize panel.
-					const section = await editorPage.expandSection( 'Share this post' );
-
-					// Verify that the toggle is enabled.
-					const toggle = section.getByLabel( 'Share when publishing' );
-					expect( await toggle.isChecked() ).toBe( true );
-
-					// Verify that the message box is editable.
-					const messageBox = section.getByRole( 'textbox', { name: 'Message' } );
-					expect( await messageBox.isEditable() ).toBe( true );
-
-					// Verify whether the media button is available.
-					const mediaButton = section.getByRole( 'button', { name: 'Choose Media' } );
-					expect( await mediaButton.isVisible() ).toBe( features.mediaSharing );
-				} );
-
-				test( `Should verify that resharing ${
-					features.resharing ? 'IS' : 'is NOT'
-				} available`, async function () {
-					let connectionTestPromise = Promise.resolve();
-					await socialConnectionsManager.interceptRequests();
-
-					connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
-
+				await Promise.all( [
 					// Open the Jetpack sidebar.
-					await editorPage.openSettings( 'Jetpack' );
+					editorPage.openSettings( 'Jetpack' ),
+					// Wait for the connection test results to finish
+					socialConnectionsManager.waitForConnectionTests(),
+				] );
 
-					await connectionTestPromise;
+				// Expand the Publicize panel.
+				const section = await editorPage.expandSection( 'Share this post' );
 
-					// Expand the Publicize panel.
-					let section = await editorPage.expandSection( 'Share this post' );
+				// Verify that the toggle is enabled.
+				const toggle = section.getByLabel( 'Share when publishing' );
+				expect( await toggle.isChecked() ).toBe( true );
 
-					// Verify that resharing button is not visible on new posts in the share modal
-					let sharePostModalButton = section.getByRole( 'button', {
-						name: 'Preview social posts',
-						exact: true,
-					} );
+				// Verify that the message box is editable.
+				const messageBox = section.getByRole( 'textbox', { name: 'Message' } );
+				expect( await messageBox.isEditable() ).toBe( true );
+
+				// Verify whether the media button is available.
+				const mediaButton = section.getByRole( 'button', { name: 'Choose Media' } );
+				expect( await mediaButton.isVisible() ).toBe( features.mediaSharing );
+			} );
+
+			test( `Should verify that resharing ${
+				features.resharing ? 'IS' : 'is NOT'
+			} available`, async function () {
+				let connectionTestPromise = Promise.resolve();
+				await socialConnectionsManager.interceptRequests();
+
+				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				await connectionTestPromise;
+
+				// Expand the Publicize panel.
+				let section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify that resharing button is not visible on new posts in the share modal
+				let sharePostModalButton = section.getByRole( 'button', {
+					name: 'Preview social posts',
+					exact: true,
+				} );
+				await sharePostModalButton.click();
+
+				const shareModal = ( await editorPage.getEditorParent() ).getByRole( 'dialog' ).filter( {
+					hasText: 'Social Preview',
+				} );
+
+				await shareModal.waitFor();
+				let reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
+
+				expect( await reshareButton.isVisible() ).toBe( false );
+
+				let closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
+				await closeButton.click();
+
+				// Set a title for the post
+				await editorPage.enterTitle( 'Resharing: ' + DataHelper.getRandomPhrase() );
+				// Publish the post.
+				await editorPage.publish();
+				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+				await editorPage.closeAllPanels();
+
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				await connectionTestPromise;
+
+				// Expand the Publicize panel.
+				section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify whether the auto-share toggle is no longer visible.
+				const toggle = section.getByLabel( 'Share when publishing' );
+				expect( await toggle.isVisible() ).toBe( false );
+
+				// Check if the Preview & Share button is visible based on resharing feature
+				sharePostModalButton = section.getByRole( 'button', {
+					name: 'Preview & Share',
+					exact: true,
+				} );
+
+				expect( await sharePostModalButton.isVisible() ).toBe( features.resharing );
+
+				let isReshareButtonVisible = false;
+
+				if ( features.resharing ) {
 					await sharePostModalButton.click();
 
 					const shareModal = ( await editorPage.getEditorParent() ).getByRole( 'dialog' ).filter( {
-						hasText: 'Social Preview',
+						hasText: 'Share Post',
 					} );
-
 					await shareModal.waitFor();
-					let reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
 
-					expect( await reshareButton.isVisible() ).toBe( false );
+					// Look for the Share button within the modal dialog
+					reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
+					isReshareButtonVisible = await reshareButton.isVisible();
 
-					let closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
+					// Close the share post modal by clicking the Close button within the modal
+					closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
 					await closeButton.click();
+				}
+				expect( isReshareButtonVisible ).toBe( features.resharing );
 
-					// Set a title for the post
-					await editorPage.enterTitle( 'Resharing: ' + DataHelper.getRandomPhrase() );
-					// Publish the post.
-					await editorPage.publish();
-					connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
-					await editorPage.closeAllPanels();
+				// Verify whether the upgrade nudge/link is visible.
+				if ( ! features.resharing ) {
+					const upgradeLink = section.getByRole( 'link', { name: 'Upgrade now' } );
+					// The upgrade CTA is a button instead of a link until some API call finishes to get the checkout URL, which makes it a link.
+					// So, we need to wait for the link to appear.
+					await upgradeLink.waitFor();
+				}
 
-					// Open the Jetpack sidebar.
-					await editorPage.openSettings( 'Jetpack' );
+				const content = await section.textContent();
 
-					await connectionTestPromise;
+				const message = 'To re-share a post, you need to upgrade to the WordPress.com Premium plan';
 
-					// Expand the Publicize panel.
-					section = await editorPage.expandSection( 'Share this post' );
-
-					// Verify whether the auto-share toggle is no longer visible.
-					const toggle = section.getByLabel( 'Share when publishing' );
-					expect( await toggle.isVisible() ).toBe( false );
-
-					// Check if the Preview & Share button is visible based on resharing feature
-					sharePostModalButton = section.getByRole( 'button', {
-						name: 'Preview & Share',
-						exact: true,
-					} );
-
-					expect( await sharePostModalButton.isVisible() ).toBe( features.resharing );
-
-					let isReshareButtonVisible = false;
-
-					if ( features.resharing ) {
-						await sharePostModalButton.click();
-
-						const shareModal = ( await editorPage.getEditorParent() )
-							.getByRole( 'dialog' )
-							.filter( {
-								hasText: 'Share Post',
-							} );
-						await shareModal.waitFor();
-
-						// Look for the Share button within the modal dialog
-						reshareButton = shareModal.getByRole( 'button', { name: 'Share', exact: true } );
-						isReshareButtonVisible = await reshareButton.isVisible();
-
-						// Close the share post modal by clicking the Close button within the modal
-						closeButton = shareModal.getByRole( 'button', { name: 'Close' } );
-						await closeButton.click();
-					}
-					expect( isReshareButtonVisible ).toBe( features.resharing );
-
-					// Verify whether the upgrade nudge/link is visible.
-					if ( ! features.resharing ) {
-						const upgradeLink = section.getByRole( 'link', { name: 'Upgrade now' } );
-						// The upgrade CTA is a button instead of a link until some API call finishes to get the checkout URL, which makes it a link.
-						// So, we need to wait for the link to appear.
-						await upgradeLink.waitFor();
-					}
-
-					const content = await section.textContent();
-
-					const message =
-						'To re-share a post, you need to upgrade to the WordPress.com Premium plan';
-
-					expect( content?.includes( message ) ).toBe( ! features.resharing );
-				} );
-
-				test( `Should verify that manual sharing ${
-					features.manualSharing ? 'IS' : 'is NOT'
-				} available`, async function () {
-					// Open the Jetpack sidebar.
-					await editorPage.openSettings( 'Jetpack' );
-
-					// Expand the Publicize panel.
-					let section = await editorPage.expandSection( 'Share this post' );
-
-					// Verify that manual sharing is NOT available before publishing.
-					let manualSharing = section.getByRole( 'paragraph', { name: 'Manual sharing' } );
-					expect( await manualSharing.isVisible() ).toBe( false );
-
-					// Set a title for the post
-					await editorPage.enterTitle( 'Manual sharing: ' + DataHelper.getRandomPhrase() );
-					// Publish the post.
-					await editorPage.publish();
-
-					// Verify whether the manual sharing is available on post publish panel
-					manualSharing = ( await editorPage.getPublishPanelRoot() ).getByRole( 'button', {
-						name: 'Manual sharing',
-					} );
-
-					if ( features.manualSharing ) {
-						await manualSharing.waitFor();
-					}
-
-					// Close the post publish panel.
-					await editorPage.closeAllPanels();
-
-					// Open the Jetpack sidebar.
-					await editorPage.openSettings( 'Jetpack' );
-
-					// Expand the Publicize panel.
-					section = await editorPage.expandSection( 'Share this post' );
-
-					// Verify whether manual sharing is available in the Jetpack sidebar.
-					manualSharing = section.getByText( 'Manual sharing' );
-					expect( await manualSharing.isVisible() ).toBe( features.manualSharing );
-				} );
-
-				test( `Should verify that Social Image Generator ${
-					features.socialImageGenerator ? 'IS' : 'is NOT'
-				} available`, async function () {
-					// Open the Jetpack sidebar.
-					await editorPage.openSettings( 'Jetpack' );
-
-					const section = await editorPage.getSettingsSection( 'Social Image Generator' );
-
-					// Verify whether the Social Image Generator panel exists.
-					expect( await section.isVisible() ).toBe( features.socialImageGenerator );
-				} );
+				expect( content?.includes( message ) ).toBe( ! features.resharing );
 			} );
-		}
+
+			test( `Should verify that manual sharing ${
+				features.manualSharing ? 'IS' : 'is NOT'
+			} available`, async function () {
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				// Expand the Publicize panel.
+				let section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify that manual sharing is NOT available before publishing.
+				let manualSharing = section.getByRole( 'paragraph', { name: 'Manual sharing' } );
+				expect( await manualSharing.isVisible() ).toBe( false );
+
+				// Set a title for the post
+				await editorPage.enterTitle( 'Manual sharing: ' + DataHelper.getRandomPhrase() );
+				// Publish the post.
+				await editorPage.publish();
+
+				// Verify whether the manual sharing is available on post publish panel
+				manualSharing = ( await editorPage.getPublishPanelRoot() ).getByRole( 'button', {
+					name: 'Manual sharing',
+				} );
+
+				if ( features.manualSharing ) {
+					await manualSharing.waitFor();
+				}
+
+				// Close the post publish panel.
+				await editorPage.closeAllPanels();
+
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				// Expand the Publicize panel.
+				section = await editorPage.expandSection( 'Share this post' );
+
+				// Verify whether manual sharing is available in the Jetpack sidebar.
+				manualSharing = section.getByText( 'Manual sharing' );
+				expect( await manualSharing.isVisible() ).toBe( features.manualSharing );
+			} );
+
+			test( `Should verify that Social Image Generator ${
+				features.socialImageGenerator ? 'IS' : 'is NOT'
+			} available`, async function () {
+				// Open the Jetpack sidebar.
+				await editorPage.openSettings( 'Jetpack' );
+
+				const section = await editorPage.getSettingsSection( 'Social Image Generator' );
+
+				// Verify whether the Social Image Generator panel exists.
+				expect( await section.isVisible() ).toBe( features.socialImageGenerator );
+			} );
+		} );
 	}
-);
+} );


### PR DESCRIPTION
Social is not supposed to be active on private sites and thus E2E tests should reflect the same.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
