### PR TITLE
Untangled Plans: Add stylings to the storage add-ons modal

### DIFF
--- a/client/sites/components/storage-add-ons/storage-indicator/style.scss
+++ b/client/sites/components/storage-add-ons/storage-indicator/style.scss
@@ -6,15 +6,15 @@
 	flex-direction: column;
 	gap: $grid-unit-15;
 
-	&__usage {
+	.storage-indicator__usage {
 		display: flex;
 		gap: 2px;
 
-		&--capacity {
+		.storage-indicator__usage--capacity {
 			font-size: rem(15px);
 		}
 
-		&--used {
+		.storage-indicator__usage--used {
 			align-self: center;
 			margin-left: auto;
 			color: $gray-700;
@@ -23,30 +23,31 @@
 		}
 	}
 
-	&__bar {
+	.storage-indicator__bar {
 		display: flex;
 
 		> div {
 			height: 1.5px;
 		}
 
-		&--existing {
+		.storage-indicator__bar--existing {
 			background-color: #3858E9;
 		}
 
-		&--add-on {
+		.storage-indicator__bar--add-on {
 			background-color: var(--studio-green-50);
 		}
 	}
 
-	&__quota {
+	.storage-indicator__quota {
 		display: flex;
 		gap: $grid-unit-15;
 		color: $gray-700;
 		font-size: rem(12px);
 		line-height: rem(16px);
 
-		&--plan, &--add-on {
+		.storage-indicator__quota--plan,
+		.storage-indicator__quota--add-on {
 			position: relative;
 			padding-left: 10px;
 
@@ -62,11 +63,11 @@
 			}
 		}
 
-		&--plan::before {
+		.storage-indicator__quota--plan::before {
 			background-color: #3858E9;
 		}
 
-		&--add-on::before {
+		.storage-indicator__quota--add-on::before {
 			background-color: var(--studio-green-50);
 		}
 	}


### PR DESCRIPTION
Fixes DOTCOM-1883

## Proposed Changes

This PR updates the stylings of the new add-ons modal as per Figma kyrhgvUpBQak3Qww1560PK-fi-357_110450

<img width="917" alt="image" src="https://github.com/user-attachments/assets/783680db-84ef-4781-8e74-1b70dea69d1e" />

## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

1. Go to `/plans/:siteSlug?flags=untangling/plans`
2. Click the `Need more storage?` link
3. Verify you can see the modal
4. Verify you can buy storage add-on
5. Repeat similarly in `/overview/:siteSlug?flags=untangling/plans` (the link is in the overview card panel)

## Regression testing instructions

- Verify that you can see and buy storage add-ons on the untangled page: `/add-ons/:siteSlug`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?