### PR TITLE
HelpCenter-BigSky: Get user field flow name from APIs

### DIFF
--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -17,8 +17,10 @@ import './help-center-chat.scss';
 
 export function HelpCenterChat( {
 	isUserEligibleForPaidSupport,
+	userFieldFlowName,
 }: {
 	isUserEligibleForPaidSupport: boolean;
+	userFieldFlowName?: string;
 } ): JSX.Element {
 	const navigate = useNavigate();
 	const shouldUseWapuu = useShouldUseWapuu();
@@ -29,7 +31,6 @@ export function HelpCenterChat( {
 	const userFieldMessage = params.get( 'userFieldMessage' );
 	const siteUrl = params.get( 'siteUrl' );
 	const siteId = params.get( 'siteId' );
-	const userFieldFlowName = params.get( 'userFieldFlowName' );
 
 	useEffect( () => {
 		if ( preventOdieAccess ) {
@@ -48,7 +49,7 @@ export function HelpCenterChat( {
 			selectedSiteId={ Number( siteId ) || ( site?.ID as number ) }
 			selectedSiteURL={ siteUrl || ( site?.URL as string ) }
 			userFieldMessage={ userFieldMessage }
-			userFieldFlowName={ userFieldFlowName }
+			userFieldFlowName={ userFieldFlowName ?? params.get( 'userFieldFlowName' ) }
 			isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
 			extraContactOptions={
 				<ExtraContactOptions isUserEligible={ isUserEligibleForPaidSupport } />

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -70,6 +70,8 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const isUserEligibleForPaidSupport =
 		Boolean( data?.eligibility?.is_user_eligible ) || allowPremiumSupport;
 
+	const userFieldFlowName = data?.eligibility?.user_field_flow_name;
+
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
 			pathname: location.pathname,
@@ -131,7 +133,10 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 					<Route
 						path="/odie"
 						element={
-							<HelpCenterChat isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport } />
+							<HelpCenterChat
+								isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
+								userFieldFlowName={ userFieldFlowName }
+							/>
 						}
 					/>
 					<Route path="/chat-history" element={ <HelpCenterChatHistory /> } />

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -97,6 +97,7 @@ interface Eligibility {
 		| 'ecommerce'
 		| 'jetpack-paid'
 		| 'p2-plus';
+	user_field_flow_name: string;
 }
 
 export interface SupportStatus {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 180297-ghe-Automattic/wpcom

## Proposed Changes

Let's use the new `user_field_flow_name` value from the support status API, if it exists, to set the appropriate user field when starting a new chat with Zendesk.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

So in Zendesk we can know which chats are referring to Big Sky, helpful for Happiness engineers and to manage chats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 180297-ghe-Automattic/wpcom to sandbox.
* Sandbox APIs
* Open Help Center, the user_field_flow_name value returned from support-status should be null.
* Go through wordpress.com/AI until you have a Big Sky website
* When you reach the editor, open the Help Center and check support-status. You should see the `messaging_flow_dotcom_bigsky` value.