### PR TITLE
i18n: number-formatters – handle callback in `geolocateCurrencySymbol`

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -324,7 +324,9 @@ const boot = async ( currentUser, registerRoutes ) => {
 	onDisablePersistence( persistOnChange( reduxStore, currentUser?.ID ) );
 	onDisablePersistence( unsubscribePersister );
 	setupLocale( currentUser, reduxStore );
-	defaultCalypsoI18n.geolocateCurrencySymbol();
+
+	defaultCalypsoI18n.geolocateCurrencySymbol( setGeoLocation );
+
 	configureReduxStore( currentUser, reduxStore );
 	setupMiddlewares( currentUser, reduxStore, queryClient );
 	detectHistoryNavigation.start();

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { getLanguageSlugs } from '@automattic/i18n-utils';
+import { setGeoLocation } from '@automattic/number-formatters';
 import { getToken } from '@automattic/oauth-token';
 import { JETPACK_PRICING_PAGE } from '@automattic/urls';
 import debugFactory from 'debug';

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -4,6 +4,7 @@ import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
 import { UserActions, User as UserStore } from '@automattic/data-stores';
+import { setGeoLocation } from '@automattic/number-formatters';
 import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { dispatch } from '@wordpress/data';
@@ -164,7 +165,7 @@ async function main() {
 	}
 
 	// No need to await this, it's not critical to the boot process and will slow booting down.
-	defaultCalypsoI18n.geolocateCurrencySymbol();
+	defaultCalypsoI18n.geolocateCurrencySymbol( setGeoLocation );
 
 	const root = createRoot( document.getElementById( 'wpcom' ) as HTMLElement );
 

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -11,11 +11,12 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { CompactCard, Gridicon } from '@automattic/components';
+import { formatCurrency } from '@automattic/number-formatters';
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import { ExternalLink } from '@wordpress/components';
 import { Icon, warning as warningIcon } from '@wordpress/icons';
 import clsx from 'clsx';
-import { formatCurrency, localize, useTranslate } from 'i18n-calypso';
+import { localize, useTranslate } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -72,7 +72,7 @@ const translation4 = i18n.translate(
 		'from Marathon to Waterloo, in order categorical.'
 );
 
-const emoji = i18n.translate( 'Let us celebrate 🎉');
+const emoji = i18n.translate( 'Let us celebrate 🎉' );
 ```
 
 ### String Substitution
@@ -421,7 +421,7 @@ i18n.numberFormat( 2500.33, { decimals: 3 } ); // '2.500,330'
 
 ### geolocateCurrencySymbol()
 
-`geolocateCurrencySymbol(): Promise<void>`
+`geolocateCurrencySymbol( callback?: ( geoLocation: string ) => void ): Promise<void>`
 
 This will attempt to make an unauthenticated network request to `https://public-api.wordpress.com/geo/`. This is to determine the country code to provide better USD formatting. By default, the currency symbol for USD will be based on the locale (unlike other currency codes which use a hard-coded list of overrides); for `en-US`/`en` it will be `$` and for all other locales it will be `US$`. However, if the geolocation determines that the country is not inside the US, the USD symbol will be `US$` regardless of locale. This is to prevent confusion for users in non-US countries using an English locale.
 
@@ -438,11 +438,11 @@ Formatting currency amounts can be surprisingly complex. Most people assume that
 Technically this package just provides a wrapper for `Intl.NumberFormat`, but it handles a lot of things automatically to make things simple and provide consistency. Here's what the functions of this package provide:
 
 - A cached number formatter for performance, keyed by currency and locale as well as any other options which must be passed to the `Intl` formatter (whether to show non-zero decimals, and whether to display a `+` sign for positive amounts).
-- The locale is set from WordPress, if available, but also falls back to the browser’s locale, and can be set explicitly if WordPress is not available (eg: for a logged-out pricing page).
+- The locale is set from WordPress, if available, but also falls back to the browser's locale, and can be set explicitly if WordPress is not available (eg: for a logged-out pricing page).
 - This uses a forced latin character set to make sure we always display latin numbers for consistency.
 - We override currency codes with a hard-coded list. This is for consistency and so that some currencies seem less confusing when viewed in EN locales, since those are the default locales for many users (eg: always use `C$` for CAD instead of `CA$` or just `$` which are the CLDR standard depending on locale since `$` might imply CAD and it might imply USD).
-- We always show `US$` for USD when the user’s geolocation is not inside the US. This is important because other currencies use `$` for their currency and are surprised sometimes if they are actually charged in USD (which is the default for many users). We can’t safely display `US$` for everyone because we've found that US users are confused by that style and it decreases confidence in the product.
-- An option to format currency from the currency’s smallest unit (eg: cents in USD, yen in JPY). This is important because doing price math with floating point numbers in code produces unexpected rounding errors, so most currency amounts should be provided and manipulated as integers.
+- We always show `US$` for USD when the user's geolocation is not inside the US. This is important because other currencies use `$` for their currency and are surprised sometimes if they are actually charged in USD (which is the default for many users). We can't safely display `US$` for everyone because we've found that US users are confused by that style and it decreases confidence in the product.
+- An option to format currency from the currency's smallest unit (eg: cents in USD, yen in JPY). This is important because doing price math with floating point numbers in code produces unexpected rounding errors, so most currency amounts should be provided and manipulated as integers.
 - An optional API to return the formatted pieces of a price separately, so the consumer can decide how best to render them (eg: this is used to wrap different HTML tags around prices and currency symbols). JS already includes this feature as `Intl.NumberFormat.formatToParts()` but our API must also include the other features listed here and extra information like the position of the currency symbol (before or after the number).
 
 #### Usage

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -187,7 +187,7 @@ I18N.throwErrors = false;
  * As a result, those users will see a price with `$` and could be misled about what currency is being displayed.
  * `geolocateCurrencySymbol()` helps prevent that from happening by showing `US$` for those users.
  */
-I18N.prototype.geolocateCurrencySymbol = async function () {
+I18N.prototype.geolocateCurrencySymbol = async function ( callback ) {
 	const geoData = await globalThis
 		.fetch?.( GEO_LOCATION_ENDPOINT_URL )
 		.then( ( response ) => response.json() )
@@ -196,6 +196,7 @@ I18N.prototype.geolocateCurrencySymbol = async function () {
 		} );
 
 	this.geoLocation = 'string' === typeof geoData?.country_short ? geoData.country_short : '';
+	callback?.( this.geoLocation );
 };
 
 I18N.prototype.on = function ( ...args ) {

--- a/packages/i18n-calypso/src/test/index.js
+++ b/packages/i18n-calypso/src/test/index.js
@@ -313,6 +313,29 @@ describe( 'I18n', function () {
 		} );
 	} );
 
+	describe( 'geolocateCurrencySymbol()', () => {
+		const originalFetch = globalThis.fetch;
+
+		afterEach( async () => {
+			globalThis.fetch = originalFetch;
+		} );
+
+		it( 'should call the callback with the correct value', async () => {
+			globalThis.fetch = jest.fn( ( url ) =>
+				Promise.resolve( {
+					json: () =>
+						url.includes( '/geo' )
+							? Promise.resolve( { country_short: 'en' } )
+							: Promise.resolve( 'invalid' ),
+				} )
+			);
+			const callback = jest.fn();
+
+			await i18n.geolocateCurrencySymbol( callback );
+			expect( callback ).toHaveBeenCalledWith( 'en' );
+		} );
+	} );
+
 	describe( 'formatCurrency', () => {
 		const originalFetch = globalThis.fetch;
 

--- a/packages/i18n-calypso/src/types/index.d.ts
+++ b/packages/i18n-calypso/src/types/index.d.ts
@@ -147,7 +147,7 @@ export interface I18N {
 	 * As a result, those users will see a price with `$` and could be misled about what currency is being displayed.
 	 * `geolocateCurrencySymbol()` helps prevent that from happening by showing `US$` for those users.
 	 */
-	geolocateCurrencySymbol(): Promise< void >;
+	geolocateCurrencySymbol( callback?: ( geoLocation: string ) => void ): Promise< void >;
 
 	getLocale(): LocaleData;
 	getLocaleSlug(): string | null; // TODO clk i18ncalypso this should be string. Default is 'en'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See PT: pxLjZ-9ME-p2
Part of addressing https://github.com/Automattic/i18n-issues/issues/942

## Proposed Changes

- Update `geolocateCurrencySymbol` in `i18n-calypso` to accept a callback. This is needed to set the geolocation in the `number-formatters` singleton used throughout the app. 
- Refactors purchases page to use `@automattic/number-formatters` for the billing description (as example use to confirm)

Alternatives:

1. Populate the singleton directly from `i18n-calypso`
2. Migrate `geolocateCurrencySymbol` out of `i18n-calypso`
3. Return a Promise
4. Reap it all out and use a Query hook (or existing hook)
5. More holistic refactor

For the moment, passing a callback should suffice. I am not sure about importing number-formatters in i18n-calypso right now.

## Media

Outside US:

<img width="1070" alt="Screenshot 2025-04-10 at 6 04 40 PM" src="https://github.com/user-attachments/assets/1e68a3d8-4440-43dd-94cf-35604c74625d" />

From US:

<img width="1074" alt="Screenshot 2025-04-10 at 6 29 01 PM" src="https://github.com/user-attachments/assets/c7e0bc4e-e649-410a-aa9e-8c4b9d2b5da6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Part of addressing https://github.com/Automattic/i18n-issues/issues/942
We need to ensure geo-location propagates to the number-formatters instance

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase any plan and go to `/purchases/subscriptions/:site`
* If outside the US, the price should render with `US` prefix, otherwise without (per media above)
  * Can switch location with AutoProxxy: PCYsg-qMt-p2 (use `atl` for a US server)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?