### PR TITLE
Design Picker: Query the site's purchases and features

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -70,17 +70,6 @@ jest.mock( 'calypso/state/themes/selectors/get-theme-demo-url', () => ( {
 	},
 } ) );
 
-jest.mock( '../../../../../hooks/use-marketplace-theme-products', () => ( {
-	useMarketplaceThemeProducts: () => ( {
-		isLoading: false,
-		selectedMarketplaceProduct: '',
-		selectedMarketplaceProductCartItems: [],
-		isMarketplaceThemeSubscriptionNeeded: false,
-		isMarketplaceThemeSubscribed: false,
-		isExternallyManagedThemeAvailable: false,
-	} ),
-} ) );
-
 /**
  * Mock wpcom-proxy-request so that we could use wpcom-xhr-request to call the endpoint
  * and get the response from nock
@@ -102,6 +91,9 @@ const renderComponent = ( component, initialState = {} ) => {
 	const queryClient = new QueryClient();
 	const store = mockStore( {
 		purchases: {},
+		productsList: {
+			isFetching: false,
+		},
 		sites: {},
 		ui: { selectedSiteId: 'anySiteId' },
 		...initialState,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -10,6 +10,9 @@ import { StepContainer, ONBOARDING_FLOW, isSiteSetupFlow, Step } from '@automatt
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
+import { useQueryProductsList } from 'calypso/components/data/query-products-list';
+import { useQuerySiteFeatures } from 'calypso/components/data/query-site-features';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Loading from 'calypso/components/loading';
@@ -212,6 +215,17 @@ const UnifiedDesignPickerStep: StepType< {
 	useQueryThemes( 'wpcom', {
 		number: 1000,
 	} );
+
+	/**
+	 * Load data needed for the ThemeTierBadge.
+	 *
+	 * TODO: Move this within ThemeTierBadge as it's the consumer of the data.
+	 * We will need to dedupe requests because right now each ThemeTierBadge
+	 * instance will trigger a new request.
+	 */
+	useQueryProductsList();
+	useQuerySiteFeatures( [ site?.ID ] );
+	useQuerySitePurchases( site?.ID ?? -1 );
 
 	const getBadge = ( themeId: string, isLockedStyleVariation: boolean ) => (
 		<ThemeTierBadge


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102310.

## Proposed Changes

After splitting the design picker and the theme preview, we've stopped querying the current site's features and purchases, which broke the badge as the data fetching wasn't (and still isn't) done within the badge.

This PR restores the current behavior by querying the required data for the badge within the Design Picker.

But ideally, we should be doing this query right next to the place it's actually used, which is the theme badge component. Let's do it as a follow-up.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/user-attachments/assets/2d5bbf2b-bad1-4947-9f4a-9bebf59bb6fb) | ![image](https://github.com/user-attachments/assets/99eb4480-101f-48d1-8960-adba9b826e09) |

## Testing Instructions

Enter `/setup/site-setup?siteSlug=%s` and verify the badge:
- Displays `Included with plan` if the requirement plan for the theme matches the site's current plan;
- Displays `Available in X` if the site's on a lower plan;
- Displays `$ X` for partner themes on a site already on the business plan.