### PR TITLE
Backup: fix text color override on usage warning action button

### DIFF
--- a/client/components/backup-storage-space/usage-warning/style.scss
+++ b/client/components/backup-storage-space/usage-warning/style.scss
@@ -4,7 +4,7 @@
 	margin-bottom: 16px;
 }
 
-.usage-warning__action-button {
+.usage-warning__action-button.components-button {
 	width: 100%;
 	height: 100%;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1744305471449339/1744266753.526739-slack-CS8UYNPEE

## Proposed Changes

* Increase the CSS selector specificity for `.usage-warning__action-button` by including the `.components-button` class. This ensures the intended text color is applied consistently.

| Before | After |
|---|---|
| ![CleanShot 2025-04-10 at 12 24 33@2x](https://github.com/user-attachments/assets/8c29467e-6129-4d86-a7c1-9373fecb8d4b) | ![CleanShot 2025-04-10 at 12 24 46@2x](https://github.com/user-attachments/assets/430e6104-3c28-49dd-8576-502ce4c356e5) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `.usage-warning__action-button` element also uses the `.components-button` class, which has conflicting styles loaded asynchronously. Due to stylesheet load order, the text color was sometimes overridden and appeared green instead of black. Increasing specificity ensures our style wins without using `!important`.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a Jetpack Cloud Live Branch.
2. Pick a site with a Jetpack VaultPress Backup plan and storage usage above 65%.
3. Visit the backup interface and validate that the warning button's text is **black**, not green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?