### PR TITLE
StepContainerV2 Checkout: Fix sidebar layout shift

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -184,7 +184,7 @@ function ConditionalContactDetailsMessage( {
 
 function LoadingSidebarContent() {
 	return (
-		<LoadingSidebar>
+		<LoadingSidebar className="checkout-loading-sidebar">
 			<SideBarLoadingCopy />
 			<LoadingCheckoutSummaryFeaturesList />
 			<LoadingFooter>
@@ -1014,7 +1014,8 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 				max-width: 100%;
 			}
 
-			.checkout__summary-area {
+			.checkout__summary-area,
+			.checkout-loading-sidebar {
 				min-width: 300px;
 			}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102513.

## Proposed Changes

Now that the sidebar on desktop has 300px, we need to make the skeleton match its width.

| Before | After |
| ------- | ------ |
| <video src="https://github.com/user-attachments/assets/f98109e7-088e-4397-b828-cb6ca05d3e00" /> | <video src="https://github.com/user-attachments/assets/e3adeac8-f3de-40c3-9b10-f2ca5bf4054b" /> |

## Testing Instructions

Check that there's no layout shift on desktop checkout.
