### PR TITLE
StepContainerV2 Onboarding: Stop relying on getSignupCompleteFlowName

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -9,13 +9,12 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
 import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
-import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
+import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { getRedirectFromPendingPage } from 'calypso/my-sites/checkout/src/lib/pending-page';
 import { sendMessageToOpener } from 'calypso/my-sites/checkout/src/lib/popup';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
@@ -94,7 +93,9 @@ function CheckoutPending( {
 		fromSiteSlug,
 	} );
 
-	const content = shouldUseStepContainerV2( getSignupCompleteFlowName() ) ? (
+	const isInStepContainerV2 = useInitialIsInStepContainerV2FlowContext();
+
+	const content = isInStepContainerV2 ? (
 		<Step.Loading title={ headingText } delay={ 2000 } />
 	) : (
 		<Main className="checkout-thank-you__pending">

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -38,7 +38,7 @@ import debugFactory from 'debug';
 import { formatCurrency, useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import Loading from 'calypso/components/loading';
-import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
+import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import {
 	hasGoogleApps,
@@ -64,7 +64,6 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import useOneDollarOfferTrack from 'calypso/my-sites/plans/hooks/use-onedollar-offer-track';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
-import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -498,7 +497,7 @@ export default function CheckoutMainContent( {
 
 	useOneDollarOfferTrack( siteId, 'checkout' );
 
-	const isStepContainerV2 = shouldUseStepContainerV2( getSignupCompleteFlowName() );
+	const isStepContainerV2 = useInitialIsInStepContainerV2FlowContext();
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
 	const { helpCenterButtonCopy, helpCenterButtonLink, toggleHelpCenter } = useCheckoutHelpCenter();

--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -2,8 +2,7 @@ import { Step } from '@automattic/onboarding';
 import { TranslateResult } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import Loading from 'calypso/components/loading';
-import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
-import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
+import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import './style.scss';
 
 const ACCELERATED_REFRESH_INTERVAL = 750;
@@ -85,7 +84,9 @@ export default function MarketplaceProgressBar( {
 		};
 	}, [ additionalSteps, currentStep ] );
 
-	if ( shouldUseStepContainerV2( getSignupCompleteFlowName() ) ) {
+	const isInStepContainerV2Context = useInitialIsInStepContainerV2FlowContext();
+
+	if ( isInStepContainerV2Context ) {
 		return <Step.Loading title={ stepValue } progress={ simulatedProgressPercentage } />;
 	}
 


### PR DESCRIPTION
## Proposed Changes

Title. We need to stop relying on it, as sessionStorage is not a reliable source for deciding whether or not to show StepContainerV2 at checkout or after checkout.

The state doesn't survive across tabs (let's say the user closes the tab and browses it again from history, or simply copies and sends it to a friend or opens it in a different tab). Also, we're using the URL as the source of truth for almost everything, so let's continue doing that.

On top of it, having a standard makes this easier to manage.

## Why are these changes being made?

During testing with @paulopmt1, we realized its unreliability. Arc in incognito opens several tabs for some reason. We noticed that the top bar was missing, rendering the old checkout.

## Testing Instructions

Verify that you see a consistent experience at checkout and post-checkout:
1. Buy a Personal plan in `/setup/onboading`; both screens should display StepContainerV2;
2. Buy a partner theme in `/setup/site-setup`; both screens should display StepContainerV2.