### PR TITLE
Revert PR: Undoes the change that put "StepContainerV2" into production

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
+++ b/client/landing/stepper/declarative-flow/helpers/should-use-step-container-v2.ts
@@ -4,7 +4,10 @@ import { SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW } from '@automatt
 const FLOWS_USING_STEP_CONTAINER_V2 = [ SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW ];
 
 export const shouldUseStepContainerV2 = ( flow: string ) => {
-	return FLOWS_USING_STEP_CONTAINER_V2.includes( flow );
+	return (
+		configApi.isEnabled( 'onboarding/step-container-v2' ) &&
+		FLOWS_USING_STEP_CONTAINER_V2.includes( flow )
+	);
 };
 
 export const shouldUseStepContainerV2MigrationFlow = ( flow: string ) => {

--- a/client/layout/test/utils.test.ts
+++ b/client/layout/test/utils.test.ts
@@ -1,8 +1,26 @@
+import configApi from '@automattic/calypso-config';
 import { SITE_SETUP_FLOW, ONBOARDING_FLOW, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
 import { isInStepContainerV2FlowContext } from '../utils';
 
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
 describe( 'layout/utils', () => {
 	describe( 'isInStepContainerV2FlowContext', () => {
+		beforeEach( () => {
+			// Reset all mocks before each test
+			jest.clearAllMocks();
+
+			// Default mock for configApi.isEnabled to return true for step-container-v2
+			( configApi.isEnabled as jest.Mock ).mockImplementation( ( feature ) => {
+				if ( feature === 'onboarding/step-container-v2' ) {
+					return true;
+				}
+				return false;
+			} );
+		} );
+
 		describe( 'setup path', () => {
 			it( 'should return false when path starts with /setup and flow is a not supported flow', () => {
 				const pathname = '/setup/random-flow';
@@ -21,6 +39,17 @@ describe( 'layout/utils', () => {
 					const result = isInStepContainerV2FlowContext( pathname, query );
 					expect( result ).toBe( true );
 				} );
+			} );
+
+			it( 'should return false when configApi.isEnabled returns false', () => {
+				const pathname = '/setup/' + SITE_SETUP_FLOW;
+				const query = 'step=step1';
+				( configApi.isEnabled as jest.Mock ).mockReturnValue( false );
+
+				const result = isInStepContainerV2FlowContext( pathname, query );
+
+				expect( configApi.isEnabled ).toHaveBeenCalledWith( 'onboarding/step-container-v2' );
+				expect( result ).toBe( false );
 			} );
 		} );
 

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,3 +1,4 @@
+import configApi from '@automattic/calypso-config';
 import { useRef } from 'react';
 import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { DEFAULT_FLOW, getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
@@ -188,6 +189,10 @@ const isMarketplaceThankYouRedirect = ( redirectTo: string ) => {
  * the StepContainerV2 loader or hide the masterbar.
  */
 export const isInStepContainerV2FlowContext = ( pathname: string, query: string ) => {
+	if ( ! configApi.isEnabled( 'onboarding/step-container-v2' ) ) {
+		return false;
+	}
+
 	if ( pathname.startsWith( '/setup' ) ) {
 		return shouldUseStepContainerV2( getFlowFromURL( pathname, query ) || DEFAULT_FLOW );
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -139,6 +139,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
+		"onboarding/step-container-v2": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/trail-map-feature-grid": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -114,6 +114,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
+		"onboarding/step-container-v2": true,
 		"onboarding/step-container-v2-import-flow": false,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -31,8 +31,6 @@ global.CSS = {
 	supports: jest.fn(),
 };
 
-global.ResizeObserver = require( 'resize-observer-polyfill' );
-
 global.fetch = jest.fn( () =>
 	Promise.resolve( {
 		json: () => Promise.resolve(),


### PR DESCRIPTION
Reverts Automattic/wp-calypso#102548

This is a just-in-case PR, so that we have a revert ready to go if necessary.