### PR TITLE
Close the atomic transfer dialog when accessing theme activation help

### DIFF
--- a/client/my-sites/themes/atomic-transfer-dialog.tsx
+++ b/client/my-sites/themes/atomic-transfer-dialog.tsx
@@ -202,6 +202,7 @@ class AtomicTransferDialog extends Component< AtomicTransferDialogProps > {
 					currentContext="plugin-details"
 					isMarketplace={ isMarketplaceProduct }
 					standaloneProceed
+					onDismiss={ () => this.handleDismiss() }
 					onProceed={ () => this.handleAccept() }
 					backUrl="#"
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100457

Discovered while testing https://github.com/Automattic/wp-calypso/pull/102439

## Proposed Changes

* My initial [PR](https://github.com/Automattic/wp-calypso/pull/101925) for improving this help flow missed the theme activation scenario. This PR fixes that flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The atomic transfer dialog stays open when accessing Odie help, when it should be closed.

![Screenshot 2025-04-11 at 2 32 07 PM](https://github.com/user-attachments/assets/bfd0185f-fa82-421e-87ad-2d7fcb4400c8)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on a site with a business plan that hasn't been transferred to atomic yet (the site URL should be [sitename].wordpress.com)
* In the Themes Marketplace, search for and select "Kiosko". Click "Activate" to show the modal
* Click the 'Need help?' link
* The modal should close and the help center should open with a new Odie chat started

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
