### PR TITLE
Update the highlight label for the Business plan in onboarding-affiliate signup flow

### DIFF
--- a/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-highlight-labels.ts
@@ -70,6 +70,8 @@ const useHighlightLabels = ( {
 				if ( isPremiumPlan( planSlug ) ) {
 					label = translate( 'Best for Blog' );
 				}
+			} else if ( 'plans-affiliate' === intent && isBusinessPlan( planSlug ) ) {
+				label = translate( 'Popular' );
 			} else if ( isBusinessPlan( planSlug ) && ! selectedPlan ) {
 				label = translate( 'Best for devs' );
 			} else if ( isPopularPlan( planSlug ) && ! selectedPlan ) {


### PR DESCRIPTION
It's requested in pau2Xa-6Rd-p2 by @teafolk to change the highlight label from 'Best for devs' to 'Popular' in the
start/onboarding-affiliate flow

Related to #

## Proposed Changes

* Add an if so that the label changes. I considered merging it with the default at the bottom but this chain of ifs is ordered and defaulting to no label. I feel this is cleaner despite the minor duplication.

## Why are these changes being made?

* It's requested in pau2Xa-6Rd-p2 by @teafolk for the affiliate marketing

## Testing Instructions

* Go to /start/onboarding-affilaite
* You should see Popular instead of Best for devs

<img width="747" alt="Screenshot 2025-04-11 at 9 27 01" src="https://github.com/user-attachments/assets/9cfb1990-3039-4c30-9c56-94226ef1433f" />

* Go to /start/onboarding
* No change or console errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
