### PR TITLE
Untangled Plans: add Tracks events to the 'Manage add-ons' and 'Need more storage' buttons

### DIFF
--- a/client/sites/components/add-ons/manage-add-ons-button/index.tsx
+++ b/client/sites/components/add-ons/manage-add-ons-button/index.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import AddOnsModal from '../add-ons-modal';
+
+type ManageAddOnsButtonProps = {
+	tracksEventName: string;
+};
+
+export default function ManageAddOnsButton( { tracksEventName }: ManageAddOnsButtonProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ isManageAddOnsModalOpen, setIsManageAddOnsModalOpen ] = useState( false );
+
+	const onClick = () => {
+		dispatch( recordTracksEvent( tracksEventName ) );
+		setIsManageAddOnsModalOpen( true );
+	};
+
+	return (
+		<>
+			<Button variant="tertiary" onClick={ onClick }>
+				{ translate( 'Manage add-ons' ) }
+			</Button>
+			<AddOnsModal
+				isOpen={ isManageAddOnsModalOpen }
+				onClose={ () => setIsManageAddOnsModalOpen( false ) }
+			/>
+		</>
+	);
+}

--- a/client/sites/components/plan-stats/index.tsx
+++ b/client/sites/components/plan-stats/index.tsx
@@ -17,10 +17,11 @@ import './style.scss';
 
 type NeedMoreStorageProps = {
 	noLink?: boolean;
+	tracksEventName: string;
 	onClick: ( e: React.MouseEvent< HTMLButtonElement > ) => void;
 };
 
-function NeedMoreStorage( { noLink = false, onClick }: NeedMoreStorageProps ) {
+function NeedMoreStorage( { noLink = false, onClick, tracksEventName }: NeedMoreStorageProps ) {
 	const translate = useTranslate();
 	const site = useSelector( getSelectedSite );
 	const dispatch = useDispatch();
@@ -40,7 +41,7 @@ function NeedMoreStorage( { noLink = false, onClick }: NeedMoreStorageProps ) {
 					e.preventDefault();
 					onClick( e );
 				}
-				dispatch( recordTracksEvent( 'calypso_hosting_overview_need_more_storage_click' ) );
+				dispatch( recordTracksEvent( tracksEventName ) );
 			} }
 		>
 			{ text }
@@ -48,7 +49,11 @@ function NeedMoreStorage( { noLink = false, onClick }: NeedMoreStorageProps ) {
 	);
 }
 
-export default function PlanStats() {
+type PlanStatsProps = {
+	needMoreStorageTracksEventName: string;
+};
+
+export default function PlanStats( { needMoreStorageTracksEventName }: PlanStatsProps ) {
 	const site = useSelector( getSelectedSite );
 	const planDetails = site?.plan;
 	const planData = useSelector( ( state ) => getCurrentPlan( state, site?.ID ) );
@@ -80,6 +85,7 @@ export default function PlanStats() {
 						<div className="plan-storage-footer">
 							<NeedMoreStorage
 								noLink={ footerWrapperIsLink }
+								tracksEventName={ needMoreStorageTracksEventName }
 								onClick={ () => setIsStorageAddOnsModalOpen( true ) }
 							/>
 							{ isUntangled && (

--- a/client/sites/overview/components/plan-card.tsx
+++ b/client/sites/overview/components/plan-card.tsx
@@ -1,5 +1,4 @@
 import { LoadingPlaceholder, Badge } from '@automattic/components';
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -16,7 +15,7 @@ import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-p
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
-import AddOnsModal from '../../components/add-ons/add-ons-modal';
+import ManageAddOnsButton from '../../components/add-ons/manage-add-ons-button';
 import PlanPricing from '../../components/plan-pricing';
 import PlanStats from '../../components/plan-stats';
 import { LaunchIcon, ShareLinkIcon } from './icons';
@@ -86,11 +85,6 @@ const PlanCard = () => {
 
 	const plansPageIsUntangled = useSelector( isPlansPageUntangled );
 
-	const [ isManageAddOnsModalOpen, setIsManageAddOnsModalOpen ] = useState( false );
-	const onManageAddOnsButtonClick = () => {
-		setIsManageAddOnsModalOpen( true );
-	};
-
 	const renderManageButton = () => {
 		if ( isJetpack || ! site || isStaging || isAgencyPurchase || isDevelopmentSite ) {
 			return false;
@@ -98,15 +92,7 @@ const PlanCard = () => {
 		if ( isFreePlan ) {
 			if ( plansPageIsUntangled ) {
 				return (
-					<>
-						<Button variant="tertiary" onClick={ onManageAddOnsButtonClick }>
-							{ translate( 'Manage add-ons' ) }
-						</Button>
-						<AddOnsModal
-							isOpen={ isManageAddOnsModalOpen }
-							onClose={ () => setIsManageAddOnsModalOpen( false ) }
-						/>
-					</>
+					<ManageAddOnsButton tracksEventName="calypso_hosting_overview_manage_add_ons_button_click" />
 				);
 			}
 			return (
@@ -177,7 +163,7 @@ const PlanCard = () => {
 					</>
 				) }
 				{ ! isAgencyPurchase && ! isStaging && <PlanPricing /> }
-				<PlanStats />
+				<PlanStats needMoreStorageTracksEventName="calypso_hosting_overview_need_more_storage_click" />
 			</HostingCard>
 		</>
 	);

--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -2,18 +2,17 @@ import { is100Year } from '@automattic/calypso-products';
 import { LoadingPlaceholder } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import CoreBadge from 'calypso/components/core/badge';
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
 import { getMyPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
-import AddOnsModal from 'calypso/sites/components/add-ons/add-ons-modal';
-import PlanPricing from 'calypso/sites/components/plan-pricing';
-import PlanStats from 'calypso/sites/components/plan-stats';
 import { isA4AUser } from 'calypso/state/partner-portal/partner/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { getSelectedPurchase, getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
+import ManageAddOnsButton from '../../../components/add-ons/manage-add-ons-button';
+import PlanPricing from '../../../components/plan-pricing';
+import PlanStats from '../../../components/plan-stats';
 
 import './style.scss';
 
@@ -59,26 +58,11 @@ export default function CurrentPlanPanel() {
 		return <PlanPricing inline />;
 	};
 
-	const [ isManageAddOnsModalOpen, setIsManageAddOnsModalOpen ] = useState( false );
-	const onManageAddOnsButtonClick = () => {
-		setIsManageAddOnsModalOpen( true );
-	};
-
 	const renderManageAddOnsButton = () => {
 		if ( isA4APlan || is100YearPlan ) {
 			return null;
 		}
-		return (
-			<>
-				<Button variant="tertiary" onClick={ onManageAddOnsButtonClick }>
-					{ translate( 'Manage add-ons' ) }
-				</Button>
-				<AddOnsModal
-					isOpen={ isManageAddOnsModalOpen }
-					onClose={ () => setIsManageAddOnsModalOpen( false ) }
-				/>
-			</>
-		);
+		return <ManageAddOnsButton tracksEventName="calypso_plans_manage_add_ons_button_click" />;
 	};
 
 	const renderManageBillingButton = () => {
@@ -120,7 +104,7 @@ export default function CurrentPlanPanel() {
 				</div>
 			</div>
 
-			<PlanStats />
+			<PlanStats needMoreStorageTracksEventName="calypso_plans_need_more_storage_click" />
 			{ ! isA4APlan && ! is100YearPlan && <hr /> }
 		</div>
 	);


### PR DESCRIPTION
Fixes DOTCOM-6406

## Proposed Changes

This PR adds Tracks events to the following "buttons" in the following pages:

#### `/plans/:siteSlug?flags=untangling/plans`

<img width="930" alt="image" src="https://github.com/user-attachments/assets/40b0c588-edc1-4fa1-b607-8aadad3efb36" />


#### `/overview/:siteSlug?flags=untangling/plans`

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/25973963-c2db-4800-b86f-8e1d67dbf021" />


## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

1. Prepare a Free site.
2. Go to `/plans/:siteSlug?flags=untangling/plans`; verify the two Tracks events as shown above.
2. Go to `/overview/:siteSlug?flags=untangling/plans`; verify the two Tracks events as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?