### PR TITLE
Design Preview: Pass valid value to onboarding query parameter when redirecting to checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker-preview.tsx
@@ -298,8 +298,9 @@ const UnifiedDesignPickerPreview = ( {
 		// When the user is done with checkout, send them back to the current url
 		// If the theme is externally managed, send them to the marketplace thank you page
 		const destination = selectedDesign?.is_externally_managed
-			? addQueryArgs( `/marketplace/thank-you/${ wpcomSiteSlug ?? siteSlug }?onboarding`, {
+			? addQueryArgs( `/marketplace/thank-you/${ wpcomSiteSlug ?? siteSlug }`, {
 					themes: selectedDesign?.slug,
+					onboarding: true,
 			  } )
 			: addQueryArgs( window.location.href.replace( window.location.origin, '' ), {
 					continue: 1,

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -179,7 +179,7 @@ const isRedirectingToStepContainerV2Flow = ( redirectTo: string ) => {
 const isMarketplaceThankYouRedirect = ( redirectTo: string ) => {
 	const { pathname, searchParams } = new URL( redirectTo, 'http://example.com' );
 
-	return pathname.startsWith( '/marketplace' ) && searchParams.has( 'onboarding' );
+	return pathname.startsWith( '/marketplace' ) && searchParams.get( 'onboarding' ) === 'true';
 };
 
 /**
@@ -216,7 +216,7 @@ export const isInStepContainerV2FlowContext = ( pathname: string, query: string 
 	if ( pathname.startsWith( '/marketplace' ) ) {
 		const params = new URLSearchParams( query );
 
-		if ( params.has( 'onboarding' ) ) {
+		if ( params.get( 'onboarding' ) === 'true' ) {
 			return true;
 		}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -137,7 +137,7 @@ function getWithThemeDestination( {
 	const style = styleVariation ? `&styleVariation=${ styleVariation }` : '';
 
 	if ( [ MARKETPLACE_THEME, PREMIUM_THEME, BUNDLED_THEME ].includes( themeType ) ) {
-		return `/marketplace/thank-you/${ siteSlug }?onboarding=&themes=${ themeParameter }${ style }`;
+		return `/marketplace/thank-you/${ siteSlug }?onboarding=true&themes=${ themeParameter }${ style }`;
 	}
 
 	return `/setup/site-setup/design-setup?siteSlug=${ siteSlug }&theme=${ themeParameter }${ style }`;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102550.

## Proposed Changes

In the original PR, I [said](https://github.com/Automattic/wp-calypso/pull/102550#discussion_r2038366904):

>I don't know where we're setting onboarding= in the URL, but I'd love it if we could set it to onboarding=true instead.

Well, now I know! Let's set `onboarding=true` instead of just the query parameter key.

## Why are these changes being made?

Code quality.

## Testing Instructions

You should see no changes compared to the original PR. Follow the instructions from there.
