### PR TITLE
Help Center: Paginated search results

### DIFF
--- a/packages/help-center/src/components/help-center-more-resources.scss
+++ b/packages/help-center/src/components/help-center-more-resources.scss
@@ -5,6 +5,7 @@
 // More resources
 .help-center-more-resources {
 	@include help-center-link;
+	margin-top: 32px;
 
 	.help-center-link__item.help-center-more-resources__resource-item {
 		.help-center-link__cell.help-center-more-resources__resource-cell {

--- a/packages/help-center/src/components/help-center-more-resources.scss
+++ b/packages/help-center/src/components/help-center-more-resources.scss
@@ -5,7 +5,6 @@
 // More resources
 .help-center-more-resources {
 	@include help-center-link;
-	margin-top: 32px;
 
 	.help-center-link__item.help-center-more-resources__resource-item {
 		.help-center-link__cell.help-center-more-resources__resource-cell {

--- a/packages/help-center/src/components/help-center-search-results.scss
+++ b/packages/help-center/src/components/help-center-search-results.scss
@@ -18,7 +18,7 @@
 	}
 
 	li:last-child {
-		margin-bottom: 40px;
+		margin-bottom: 14px;
 	}
 
 	.help-center-search-results__title {

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -36,6 +36,8 @@ import type { SearchResult } from '../types';
 
 import './help-center-search-results.scss';
 
+const MAX_VISIBLE_RESULTS = 5;
+
 type HelpLinkProps = {
 	result: SearchResult;
 	type: string;
@@ -225,10 +227,10 @@ function HelpSearchResults( {
 	const searchResults = searchData ?? [];
 	const hasAPIResults = searchResults.length > 0;
 
-	const [ visibleResults, setVisibleResults ] = useState( 5 );
+	const [ visibleResults, setVisibleResults ] = useState( MAX_VISIBLE_RESULTS );
 
 	const handleShowMore = () => {
-		setVisibleResults( visibleResults + 5 );
+		setVisibleResults( visibleResults + MAX_VISIBLE_RESULTS );
 	};
 
 	useEffect( () => {
@@ -239,7 +241,7 @@ function HelpSearchResults( {
 
 		// If there's no query, then we don't need to announce anything.
 		if ( ! searchQuery ) {
-			setVisibleResults( 5 );
+			setVisibleResults( MAX_VISIBLE_RESULTS );
 			return;
 		}
 
@@ -248,7 +250,7 @@ function HelpSearchResults( {
 		} else if ( ! hasAPIResults ) {
 			errorSpeak();
 		} else if ( hasAPIResults ) {
-			setVisibleResults( 5 );
+			setVisibleResults( MAX_VISIBLE_RESULTS );
 			resultsSpeak();
 		}
 	}, [ isSearching, hasAPIResults, searchQuery ] );

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -247,6 +247,7 @@ function HelpSearchResults( {
 		} else if ( ! hasAPIResults ) {
 			errorSpeak();
 		} else if ( hasAPIResults ) {
+			setVisibleResults( 5 );
 			resultsSpeak();
 		}
 	}, [ isSearching, hasAPIResults, searchQuery ] );

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -239,6 +239,7 @@ function HelpSearchResults( {
 
 		// If there's no query, then we don't need to announce anything.
 		if ( ! searchQuery ) {
+			setVisibleResults( 5 );
 			return;
 		}
 

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -342,7 +342,9 @@ function HelpSearchResults( {
 	const sections = [
 		{
 			type: SUPPORT_TYPE_API_HELP,
-			title: __( 'Recommended Resources', __i18n_text_domain__ ),
+			title: searchQuery
+				? __( 'Search Results', __i18n_text_domain__ )
+				: __( 'Recommended Resources', __i18n_text_domain__ ),
 			results: searchResults,
 			condition: ! isSearching && searchResults.length > 0,
 		},

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -335,7 +335,7 @@ function HelpSearchResults( {
 				</ul>
 				{ results.length > visibleResults && (
 					<Button variant="secondary" onClick={ handleShowMore } className="show-more-button">
-						{ __( 'Show More', __i18n_text_domain__ ) }
+						{ __( 'Show more', __i18n_text_domain__ ) }
 					</Button>
 				) }
 			</Fragment>

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -11,6 +11,7 @@ import {
 } from '@automattic/data-stores';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { speak } from '@wordpress/a11y';
+import { Button } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import {
@@ -23,7 +24,7 @@ import {
 import { useRtl } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
-import { Fragment, useEffect, useMemo } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useHelpCenterContext } from '../contexts/HelpCenterContext';
 import { useAdminResults } from '../hooks/use-admin-results';
@@ -224,6 +225,12 @@ function HelpSearchResults( {
 	const searchResults = searchData ?? [];
 	const hasAPIResults = searchResults.length > 0;
 
+	const [ visibleResults, setVisibleResults ] = useState( 5 );
+
+	const handleShowMore = () => {
+		setVisibleResults( visibleResults + 5 );
+	};
+
 	useEffect( () => {
 		// Cancel all queued speak messages.
 		loadingSpeak.cancel();
@@ -311,7 +318,7 @@ function HelpSearchResults( {
 					className="help-center-search-results__list help-center-articles__list"
 					aria-labelledby={ title ? id : undefined }
 				>
-					{ results.map( ( result, index ) => (
+					{ results.slice( 0, visibleResults ).map( ( result, index ) => (
 						<HelpLink
 							key={ `${ id }-${ index }` }
 							result={ result }
@@ -322,6 +329,11 @@ function HelpSearchResults( {
 						/>
 					) ) }
 				</ul>
+				{ results.length > visibleResults && (
+					<Button onClick={ handleShowMore } className="show-more-button">
+						Show More
+					</Button>
+				) }
 			</Fragment>
 		) : null;
 	};
@@ -330,7 +342,7 @@ function HelpSearchResults( {
 		{
 			type: SUPPORT_TYPE_API_HELP,
 			title: __( 'Recommended Resources', __i18n_text_domain__ ),
-			results: searchResults.slice( 0, 5 ),
+			results: searchResults,
 			condition: ! isSearching && searchResults.length > 0,
 		},
 		{

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -330,8 +330,8 @@ function HelpSearchResults( {
 					) ) }
 				</ul>
 				{ results.length > visibleResults && (
-					<Button onClick={ handleShowMore } className="show-more-button">
-						Show More
+					<Button variant="secondary" onClick={ handleShowMore } className="show-more-button">
+						{ __( 'Show More', __i18n_text_domain__ ) }
 					</Button>
 				) }
 			</Fragment>

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -368,7 +368,7 @@ function HelpSearchResults( {
 
 	return (
 		<div className="help-center-search-results" aria-label={ resultsLabel }>
-			<HelpCenterRecentConversations />
+			{ ! searchQuery && <HelpCenterRecentConversations /> }
 			{ isSearching && ! searchResults.length && <PlaceholderLines lines={ placeholderLines } /> }
 			{ searchQuery && ! ( hasAPIResults || isSearching ) ? (
 				<p className="help-center-search-results__empty-results">

--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -39,7 +39,7 @@ const fetchArticlesAPI = async (
 		} as APIFetchOptions ) ) as SearchResult[];
 	}
 
-	return searchResultResponse.slice( 0, 5 );
+	return searchResultResponse;
 };
 
 export const useHelpSearchQuery = (

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -71,7 +71,7 @@
 		font-size: $font-body-small;
 		font-weight: 500;
 		color: var(--studio-gray-100);
-		margin: 1em 0;
+		margin: 32px 0 1em;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p2rHU0-2iW-p2#comment-4238

## Proposed Changes

![image](https://github.com/user-attachments/assets/5c3c1e33-56b4-44cb-9ab3-77e9d79ed74c)

- We have now a bigger number of results coming from the search API, we are showing them all, with a "Search More"
- We hide "Recent Conversation" when searching.
- Changed "Recommended Resources" to "Search Results" when searching.
- "Show More" button is resetted when going through searches or removing the search query.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Help Center in various pages.
* Try searching for things like "DNS" or "Menu"