### PR TITLE
Reader: Use ToggleGroupControl on notifications panel (Take 2)

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -30,6 +30,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
+		"@wordpress/components": "^29.7.0",
 		"@wordpress/data": "^10.21.0",
 		"@wordpress/i18n": "^5.21.0",
 		"autoprefixer": "^10.2.5",

--- a/apps/notifications/src/panel/boot/stylesheets/actions.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/actions.scss
@@ -60,7 +60,7 @@
 	}
 }
 
-.wpnc__main .wpnc__action-link {
+.wpnc__main button.wpnc__action-link {
 	background-color: transparent;
 	border: none;
 	box-sizing: border-box;
@@ -132,4 +132,3 @@
 		overflow: hidden;
 	}
 }
-

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -97,7 +97,7 @@ $with-sidebar-min-page-width: 1114px;
 		color: var(--color-primary);
 	}
 
-	button {
+	button:not(.components-toggle-group-control-option-base) {
 		background-color: transparent;
 		border: none;
 		color: var(--color-primary);
@@ -242,72 +242,23 @@ $with-sidebar-min-page-width: 1114px;
 		box-sizing: border-box;
 		direction: ltr;
 		display: table; //fallback for browsers not supporting flexbox
+
+		.components-base-control {
+			padding: 6px 8px;
+		}
+	
+		.components-toggle-group-control {
+			border: 1px solid var(--wp-components-color-gray-600, #949494);
+			padding: 3px;
+
+			> div {
+				flex-basis: auto;
+			}
+		}
 	}
 
 	.wpnc__note-list:not(.is-note-open) .wpnc__filter {
 		border-left: 1px solid var(--color-neutral-0);
-	}
-
-	.wpnc__filter--segmented-control {
-		display: flex;
-		padding: 6px 8px;
-
-		&:focus {
-			box-shadow: 0 0 0 2px var(--color-primary-light);
-		}
-	}
-
-	.wpnc__filter--segmented-control-item {
-		background: var(--color-surface);
-		border: 1px solid var(--color-neutral-light);
-		border-right: none;
-		font-size: 13px;
-		height: 26px;
-		cursor: pointer;
-		user-select: none; // Makes text unselectable
-		box-sizing: border-box;
-		vertical-align: middle;
-
-		// Flexbox
-		display: flex;
-		align-items: center; // Vertically center text
-		justify-content: center; // Horizontally center text
-		flex: auto; // Fill horizontal space
-
-		&:hover {
-			color: var(--color-neutral-70);
-		}
-
-		&:focus {
-			outline: var(--color-primary-light) solid 2px;
-			outline-offset: -2px;
-		}
-
-		&:first-of-type {
-			border-top-left-radius: 4px;
-			border-bottom-left-radius: 4px;
-		}
-
-		&:last-of-type {
-			border-right: 1px solid var(--color-neutral-light);
-			border-top-right-radius: 4px;
-			border-bottom-right-radius: 4px;
-
-
-			&.selected {
-				border-right-color: var(--color-primary);
-			}
-		}
-
-		&.selected {
-			background: var(--color-primary);
-			border-color: var(--color-primary);
-			color: var(--color-text-inverted);
-
-			+ .segmented-control-item {
-				border-left-color: var(--color-primary); // Color left border on adjacent item to match active filter
-			}
-		}
 	}
 
 	.wpnc__list-view .wpnc__notes,

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -546,7 +546,7 @@ $with-sidebar-min-page-width: 1114px;
 		}
 	}
 
-	.wpnc__close-link {
+	button.wpnc__close-link {
 		color: var(--color-text-inverted);
 		margin-left: auto;
 		padding: 0 10px;

--- a/apps/notifications/src/panel/boot/stylesheets/note-common.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/note-common.scss
@@ -22,7 +22,7 @@ div.wpnc__note-actions {
 }
 
 // Taken from packages/components/src/screen-reader-text/style.scss
-.screen-reader-text {
+.wpnc__note-list button.screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;
 

--- a/apps/notifications/src/panel/boot/stylesheets/overlay-bars.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/overlay-bars.scss
@@ -26,7 +26,7 @@
 		margin: 15px 5px;
 	}
 
-	.wpnc__close-link {
+	button.wpnc__close-link {
 		position: relative;
 	}
 }

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -1,4 +1,7 @@
-import clsx from 'clsx';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -51,23 +54,13 @@ export class FilterBar extends Component {
 		}
 
 		const selectedFilter = this.filterListRef.current?.querySelector(
-			'.wpnc__filter--segmented-control-item[aria-selected="true"]'
+			'.components-toggle-group-control-option-base[aria-checked="true"]'
 		);
 		if ( selectedFilter ) {
 			// It might be focused immediately when the panel is opening because of the pointer-events is none.
 			this.timerId = window.setTimeout( () => selectedFilter.focus(), 300 );
 		}
 	}
-
-	selectFilter = ( event ) => {
-		if ( event ) {
-			event.stopPropagation();
-			event.preventDefault();
-		}
-
-		const filterName = event.target.dataset.filterName;
-		this.props.controller.selectFilter( filterName );
-	};
 
 	handleKeydown = ( event ) => {
 		let direction;
@@ -92,39 +85,23 @@ export class FilterBar extends Component {
 		const filterItems = this.getFilterItems();
 
 		return (
-			<div className="wpnc__filter">
-				<ul
-					className="wpnc__filter--segmented-control"
-					role="tablist"
-					aria-label={ translate( 'Filter notifications' ) }
-					ref={ this.filterListRef }
+			<div className="wpnc__filter" ref={ this.filterListRef }>
+				<ToggleGroupControl
+					hideLabelFromVision
+					isBlock
+					label={ translate( 'Filter Notifications' ) }
+					value={ filterName }
+					onChange={ ( selectedFilter ) => this.props.controller.selectFilter( selectedFilter ) }
 					onKeyDown={ this.handleKeydown }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				>
 					{ filterItems.map( ( { label, name } ) => {
-						const isSelected = name === filterName;
 						return (
-							<li
-								key={ name }
-								data-filter-name={ name }
-								className={ clsx( 'wpnc__filter--segmented-control-item', {
-									selected: isSelected,
-								} ) }
-								onClick={ this.selectFilter }
-								onKeyDown={ ( e ) => {
-									if ( e.key === 'Enter' ) {
-										this.selectFilter( e );
-									}
-								} }
-								role="tab"
-								aria-selected={ isSelected }
-								aria-controls="wpnc__note-list"
-								tabIndex={ isSelected ? 0 : -1 }
-							>
-								{ label( translate ) }
-							</li>
+							<ToggleGroupControlOption key={ name } label={ label( translate ) } value={ name } />
 						);
 					} ) }
-				</ul>
+				</ToggleGroupControl>
 			</div>
 		);
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,6 +1430,7 @@ __metadata:
     "@automattic/languages": "workspace:^"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
+    "@wordpress/components": "npm:^29.7.0"
     "@wordpress/data": "npm:^10.21.0"
     "@wordpress/i18n": "npm:^5.21.0"
     autoprefixer: "npm:^10.2.5"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100357

I had previously completed this work in #102533, but due to a bug, I had to revert it in #102559. The root cause of the bug was style specificity issues, which have now been fixed in ed068b1.

For more info view description of https://github.com/Automattic/wp-calypso/pull/102533

