### PR TITLE
E2E: Skip Social smoke test on private Atomic site

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-smoke.ts
+++ b/test/e2e/specs/jetpack/social__editor-smoke.ts
@@ -12,43 +12,48 @@ import {
 	TestAccount,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
+import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
+const isPrivateSite = envVariables.TEST_ON_ATOMIC && envVariables.ATOMIC_VARIATION === 'private';
 /**
  * Tests features offered by Jetpack Social.
  *
  * Keywords: Social, Jetpack, Publicize
  */
-describe( DataHelper.createSuiteTitle( 'Social: Editor Smoke test' ), function () {
-	let page: Page;
-	let editorPage: EditorPage;
+skipDescribeIf( isPrivateSite )(
+	DataHelper.createSuiteTitle( 'Social: Editor Smoke test' ),
+	function () {
+		let page: Page;
+		let editorPage: EditorPage;
 
-	let siteSlug: string;
+		let siteSlug: string;
 
-	beforeAll( async () => {
-		page = await browser.newPage();
-		editorPage = new EditorPage( page );
+		beforeAll( async () => {
+			page = await browser.newPage();
+			editorPage = new EditorPage( page );
 
-		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
-		const testAccount = new TestAccount( accountName );
-		siteSlug = testAccount.getSiteURL( { protocol: false } );
-		await testAccount.authenticate( page );
-	} );
+			const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+			const testAccount = new TestAccount( accountName );
+			siteSlug = testAccount.getSiteURL( { protocol: false } );
+			await testAccount.authenticate( page );
+		} );
 
-	it( 'Verify that Social UI is visible', async function () {
-		await editorPage.visit( 'post', { siteSlug } );
+		it( 'Verify that Social UI is visible', async function () {
+			await editorPage.visit( 'post', { siteSlug } );
 
-		// Open the Jetpack sidebar.
-		await editorPage.openSettings( 'Jetpack' );
+			// Open the Jetpack sidebar.
+			await editorPage.openSettings( 'Jetpack' );
 
-		// Expand the Publicize panel.
-		await editorPage.expandSection( 'Share this post' );
+			// Expand the Publicize panel.
+			await editorPage.expandSection( 'Share this post' );
 
-		const editorParent = await editorPage.getEditorParent();
+			const editorParent = await editorPage.getEditorParent();
 
-		const toggle = editorParent.getByLabel( 'Share when publishing' );
+			const toggle = editorParent.getByLabel( 'Share when publishing' );
 
-		await toggle.waitFor();
-	} );
-} );
+			await toggle.waitFor();
+		} );
+	}
+);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

p1744345086843399-slack-C034JEXD1RD

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Still works on normal Atomic site:
```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/jetpack/social__editor-smoke.ts"
```

Skips on private Atomic site:
```
yarn workspace wp-e2e-tests build && ATOMIC_VARIATION="private" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/jetpack/social__editor-smoke.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?