### PR TITLE
A4A: Update migration commission status display based on tags

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -15,11 +15,20 @@ export const MigratedOnColumn = ( { migratedOn }: { migratedOn: number } ) => {
 	return <FormattedDate date={ date } format={ DETAILS_DATE_FORMAT_SHORT } />;
 };
 
-export const ReviewStatusColumn = ( { reviewStatus }: { reviewStatus: string } ) => {
+export const ReviewStatusColumn = ( {
+	reviewStatus,
+}: {
+	reviewStatus: 'pending' | 'confirmed' | 'rejected' | 'paid';
+} ) => {
 	const translate = useTranslate();
 
 	const getStatusProps = () => {
 		switch ( reviewStatus ) {
+			case 'paid':
+				return {
+					statusText: translate( 'Paid' ),
+					statusType: 'success',
+				};
 			case 'confirmed':
 				return {
 					statusText: translate( 'Confirmed' ),

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-list-actions.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { A4AConfirmationDialog } from 'calypso/a8c-for-agencies/components/a4a-confirmation-dialog';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -9,6 +9,7 @@ import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import useUpdateSiteTagsMutation from '../../sites/site-preview-pane/hooks/use-update-site-tags-mutation';
 import { A4A_MIGRATED_SITE_TAG } from '../lib/constants';
+import { getSiteReviewStatus } from '../lib/utils';
 import { TaggedSite } from '../types';
 
 type Props = {
@@ -24,6 +25,11 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ showRemoveSiteDialog, setShowRemoveSiteDialog ] = useState( false );
 	const { mutate, isPending } = useUpdateSiteTagsMutation();
+
+	const isPendingReview = useMemo( () => {
+		const tags = site.tags.map( ( tag ) => tag.name );
+		return getSiteReviewStatus( tags ) === 'pending';
+	}, [ site.tags ] );
 
 	const showActions = useCallback( () => {
 		setIsOpen( true );
@@ -70,6 +76,11 @@ const CommissionListActions = ( { fetchMigratedSites, site }: Props ) => {
 		dispatch,
 		translate,
 	] );
+
+	// Only render actions if the site is pending review
+	if ( ! isPendingReview ) {
+		return null;
+	}
 
 	return (
 		<div>

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -4,6 +4,7 @@ import { useMemo, ReactNode, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { getSiteReviewStatus } from '../lib/utils';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
 import CommissionListActions from './commission-list-actions';
 import MigrationsCommissionsListMobileView from './mobile-view';
@@ -55,7 +56,11 @@ export default function MigrationsCommissionsList( {
 				id: 'reviewStatus',
 				label: translate( 'Review status' ).toUpperCase(),
 				getValue: () => '-',
-				render: ( { item } ): ReactNode => <ReviewStatusColumn reviewStatus={ item.state } />,
+				render: ( { item }: { item: TaggedSite } ): ReactNode => {
+					const tags = item.tags.map( ( tag ) => tag.name );
+					const status = getSiteReviewStatus( tags );
+					return <ReviewStatusColumn reviewStatus={ status } />;
+				},
 				enableHiding: false,
 				enableSorting: false,
 			},

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
@@ -4,6 +4,7 @@ import {
 	ListItemCard,
 	ListItemCardContent,
 } from 'calypso/a8c-for-agencies/components/list-item-cards';
+import { getSiteReviewStatus } from '../lib/utils';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
 import type { TaggedSite } from '../types';
 
@@ -19,27 +20,32 @@ export default function MigrationsCommissionsListMobileView( {
 	return (
 		<div className="migrations-commissions-list-mobile-view">
 			<ListItemCards>
-				{ commissions.map( ( commission ) => (
-					<ListItemCard key={ commission.id }>
-						<ListItemCardContent title={ translate( 'Site' ) }>
-							<div className="migrations-commissions-list-mobile-view__column">
-								<SiteColumn site={ commission.url } />
-							</div>
-						</ListItemCardContent>
-						{
-							// FIXME: This should be "Migrated on" instead of "Date Added"
-							// We will change this when the MC tool is implemented and we have the migration date
-							<ListItemCardContent title={ translate( 'Date Added' ) }>
+				{ commissions.map( ( commission ) => {
+					const tags = commission.tags.map( ( tag ) => tag.name );
+					const status = getSiteReviewStatus( tags );
+
+					return (
+						<ListItemCard key={ commission.id }>
+							<ListItemCardContent title={ translate( 'Site' ) }>
 								<div className="migrations-commissions-list-mobile-view__column">
-									<MigratedOnColumn migratedOn={ commission.created_at } />
+									<SiteColumn site={ commission.url } />
 								</div>
 							</ListItemCardContent>
-						}
-						<ListItemCardContent title={ translate( 'Review status' ) }>
-							<ReviewStatusColumn reviewStatus={ commission.state } />
-						</ListItemCardContent>
-					</ListItemCard>
-				) ) }
+							{
+								// FIXME: This should be "Migrated on" instead of "Date Added"
+								// We will change this when the MC tool is implemented and we have the migration date
+								<ListItemCardContent title={ translate( 'Date Added' ) }>
+									<div className="migrations-commissions-list-mobile-view__column">
+										<MigratedOnColumn migratedOn={ commission.created_at } />
+									</div>
+								</ListItemCardContent>
+							}
+							<ListItemCardContent title={ translate( 'Review status' ) }>
+								<ReviewStatusColumn reviewStatus={ status } />
+							</ListItemCardContent>
+						</ListItemCard>
+					);
+				} ) }
 			</ListItemCards>
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/migrations/consolidated-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/consolidated-commissions/index.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { getSiteReviewStatus } from '../lib/utils';
 import type { TaggedSite } from '../types';
 
 import './style.scss';
@@ -13,13 +14,19 @@ export default function MigrationsConsolidatedCommissions( { items }: { items: T
 	const translate = useTranslate();
 
 	const migrationCommissions =
-		items.filter(
-			( item ) =>
-				// Consider only confirmed migrations for the current quarter
-				item.state === 'confirmed' && getQuarter( new Date( item.created_at ) ) === getQuarter()
-		).length * 100; // FIXME: Consider the maximum commission value when the MC tool is implemented
+		items.filter( ( item ) => {
+			const tags = item.tags.map( ( tag ) => tag.name );
+			// Consider only confirmed migrations for the current quarter
+			return (
+				getSiteReviewStatus( tags ) === 'confirmed' &&
+				getQuarter( new Date( item.created_at ) ) === getQuarter()
+			);
+		} ).length * 100; // FIXME: Consider the maximum commission value when the MC tool is implemented
 
-	const sitesPendingReview = items.filter( ( item ) => item.state !== 'confirmed' ).length;
+	const sitesPendingReview = items.filter( ( item ) => {
+		const tags = item.tags.map( ( tag ) => tag.name );
+		return getSiteReviewStatus( tags ) === 'pending';
+	} ).length;
 
 	const currentQuarter = getQuarter();
 

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
@@ -2,7 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { A4A_MIGRATED_SITE_TAG } from '../lib/constants';
+import {
+	A4A_MIGRATED_SITE_TAG,
+	A4A_MIGRATED_SITE_VERIFIED,
+	A4A_MIGRATED_SITE_REJECTED,
+	A4A_MIGRATED_TYPE_WPE,
+	A4A_MIGRATED_TYPE_STANDARD,
+	A4A_MIGRATED_STATUS_PAID,
+	A4A_MIGRATED_STATUS_UNPAID,
+} from '../lib/constants';
 
 export default function useFetchTaggedSitesForMigration() {
 	const agencyId = useSelector( getActiveAgencyId );
@@ -16,7 +24,18 @@ export default function useFetchTaggedSitesForMigration() {
 					path: `/agency/${ agencyId }/sites`,
 				},
 				{
-					filters: { tags: A4A_MIGRATED_SITE_TAG },
+					filters: {
+						tags: [
+							A4A_MIGRATED_SITE_TAG,
+							A4A_MIGRATED_SITE_VERIFIED,
+							A4A_MIGRATED_SITE_REJECTED,
+							A4A_MIGRATED_TYPE_WPE,
+							A4A_MIGRATED_TYPE_STANDARD,
+							A4A_MIGRATED_STATUS_PAID,
+							A4A_MIGRATED_STATUS_UNPAID,
+						],
+						tags_relation: 'OR',
+					},
 				}
 			),
 		refetchOnWindowFocus: false,

--- a/client/a8c-for-agencies/sections/migrations/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/migrations/lib/constants.ts
@@ -1,1 +1,7 @@
 export const A4A_MIGRATED_SITE_TAG = 'a4a_self_migrated_site';
+export const A4A_MIGRATED_SITE_VERIFIED = 'a4a_self_migrated_site_verified';
+export const A4A_MIGRATED_SITE_REJECTED = 'a4a_self_migrated_site_rejected';
+export const A4A_MIGRATED_TYPE_WPE = 'a4a_self_migrated_type_wpe';
+export const A4A_MIGRATED_TYPE_STANDARD = 'a4a_self_migrated_type_standard';
+export const A4A_MIGRATED_STATUS_PAID = 'a4a_self_migrated_status_paid';
+export const A4A_MIGRATED_STATUS_UNPAID = 'a4a_self_migrated_status_unpaid';

--- a/client/a8c-for-agencies/sections/migrations/lib/utils.ts
+++ b/client/a8c-for-agencies/sections/migrations/lib/utils.ts
@@ -1,0 +1,29 @@
+import {
+	A4A_MIGRATED_SITE_REJECTED,
+	A4A_MIGRATED_SITE_VERIFIED,
+	A4A_MIGRATED_STATUS_PAID,
+} from './constants';
+
+/**
+ * Determines the review status of a migrated site based on its tags.
+ *
+ * @param tags - An array of tag names associated with the site.
+ * @returns The review status: 'paid', 'confirmed', 'rejected', or 'pending'.
+ */
+export const getSiteReviewStatus = (
+	tags: string[]
+): 'pending' | 'confirmed' | 'rejected' | 'paid' => {
+	// Check for paid status first
+	if ( tags.includes( A4A_MIGRATED_STATUS_PAID ) ) {
+		return 'paid';
+	}
+	if ( tags.includes( A4A_MIGRATED_SITE_VERIFIED ) ) {
+		return 'confirmed';
+	}
+	if ( tags.includes( A4A_MIGRATED_SITE_REJECTED ) ) {
+		return 'rejected';
+	}
+	// If none of the above tags are present, assume pending.
+	// The presence of A4A_MIGRATED_SITE_TAG is implicitly assumed for sites passed to this function.
+	return 'pending';
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/1679

‼️ Apply this patch to your sandbox: 180462-ghe-Automattic/wpcom

<img width="988" alt="Screenshot 2025-04-11 at 16 06 52" src="https://github.com/user-attachments/assets/bafa0ce3-687b-48d4-b34e-9ce1801eef81" />

## Proposed Changes

*   Create constants for various migration-related tags (`a4a_self_migrated_site_verified`, `a4a_self_migrated_site_rejected`, etc.).
*   Refactor logic to determine migration review status ('pending', 'confirmed', 'rejected', 'paid') based on site tags instead of the `state` property.
*   Extract the status logic into a reusable utility function `getSiteReviewStatus`.
*   Update desktop and mobile commission lists (`index.tsx`, `mobile-view.tsx`) to use the new utility function for displaying status.
*   Update commission list actions (`commission-list-actions.tsx`) to only be available for sites in 'pending' status, using the utility function.
*   Update consolidated commission calculations (`consolidated-commissions/index.tsx`) for "Sites pending review" and "Migration commissions expected" to use the utility function.
*   Add handling and display logic for the 'paid' status in the `ReviewStatusColumn`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To reflect migration incentive payout status on the frontend;
* As a bonus, it will also display any migration reviews initiated by us, since it includes sites with confirmed, rejected, or paid status — which is actually something we want.

## Testing Instructions

1. Using a test agency with test sites (you can use `a4ademo` account)
2. Tag sites on the Commissions page (`/migrations/commissions`) 
3. Use the Bulk Tag Migration Incentives tool (`MC_URL/agencies/bulk-tools/migration-incentives.php`) to update incentive eligibility status on sites.
4.  Navigate to the Migrations -> Commissions page (`/migrations/commissions`).
5.  **Consolidated View:**
    *   Verify the "Sites pending review" count accurately reflects sites that have the `a4a_self_migrated_site` tag but *not* the `verified`, `rejected`, or `paid` tags.
    *   Verify the "Migration commissions expected" value is calculated based on sites tagged as `verified` or `paid` within the current quarter.
6.  **Commissions List (Desktop & Mobile):**
    *   Check the "Review status" column/section for different sites:
        *   Sites tagged only with `a4a_self_migrated_site` (and potentially type/unpaid) should show "Pending" (Warning badge).
        *   Sites tagged with `a4a_self_migrated_site_verified` should show "Confirmed" (Success badge).
        *   Sites tagged with `a4a_self_migrated_site_rejected` should show "Rejected" (Error badge).
        *   Sites tagged with `a4a_self_migrated_status_paid` should show "Paid" (Success badge, same as Confirmed).
7.  **Actions:**
    *   Verify the actions ellipsis (...) only appears in the list for sites with a "Pending" status.
    *   Confirm that the actions menu is *not* present for sites with "Confirmed", "Rejected", or "Paid" status.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?