### PR TITLE
Jetpack Cloud: Fix site selector when having access to Jetpack Manage

### DIFF
--- a/client/jetpack-cloud/components/sidebar/site-selector.tsx
+++ b/client/jetpack-cloud/components/sidebar/site-selector.tsx
@@ -54,7 +54,12 @@ const SiteSelector = () => {
 			/* eslint-disable-next-line jsx-a11y/no-autofocus */
 			autoFocus={ isVisible }
 			isJetpackAgencyDashboard={ canAccessJetpackManage }
-			keepCurrentSection
+			/**
+			 * The site selector breaks to a blank page if you're on a Jetpack Manage section.
+			 * So only preserve the current section when switching sites if
+			 * the user can't access Jetpack Manage.
+			 */
+			keepCurrentSection={ ! canAccessJetpackManage }
 			allSitesPath="/dashboard"
 			siteBasePath="/landing"
 		/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* When having access to Jetpack Manage, if you change sites using the sidebar site selector, you land on a broken blank page. This happens because the site selector component tries to preserve the section when navigating to different sites, but when navigating inside manage, the sections from the Jetpack Manage experience do not support the site parameter that the site selector passes along, rendering a blank page. This fixes the behavior by not preserving the section when changing sites for user that have access to Jetpack Manage.

![image](https://github.com/user-attachments/assets/bb591aa0-5c99-489e-bf87-8fc33af9d3be)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This fixes bugs on the Jetpack Cloud experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You will need a Jetpack Partner account of type Agency. If you don't have one, ask Team Avalon to give you access.
* Go to https://jetpack.cloud.localhost:3000/overview
* Use the sidebar site selector and select any site ( it should be on the "All sites" option )
* You will land on a blank page
* Apply this patch and repeat the steps above, you should get to the site options on Jetpack Cloud

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
