### PR TITLE
[Site Admin]: Introduce `<Page />` component

### DIFF
--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -42,4 +42,6 @@ Initial release of the site-admin package providing a framework for building mod
 
 ## Next
 
-- Add a Storybook story that demonstrates full usage of the package.
+### Components
+
+- `Page`: component wrapper for the page content.

--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -29,6 +29,7 @@ Initial release of the site-admin package providing a framework for building mod
 - Set `SiteNavigationItem`’s `as` prop automatically based on to or onClick.
 
 ### Components
+
 - `SiteHub`: Site navigation and context switcher
 - `Link`: Router component providing declarative navigation
 
@@ -40,3 +41,5 @@ Initial release of the site-admin package providing a framework for building mod
 - Expose the `SiteHub` component publicly
 
 ## Next
+
+- Add a Storybook story that demonstrates full usage of the package.

--- a/packages/site-admin/src/components/page/header.tsx
+++ b/packages/site-admin/src/components/page/header.tsx
@@ -11,7 +11,8 @@ import {
 /**
  * Types
  */
-import type { PageProps } from '.';
+import type { PageProps } from './types';
+
 type HeaderProps = Omit< PageProps, 'className' | 'hideTitleFromUI' | 'children' >;
 
 export default function Header( { title, subTitle, actions }: HeaderProps ) {

--- a/packages/site-admin/src/components/page/header.tsx
+++ b/packages/site-admin/src/components/page/header.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import {
+	FlexItem,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+/**
+ * Types
+ */
+import type { PageProps } from '.';
+type HeaderProps = Omit< PageProps, 'className' | 'hideTitleFromUI' | 'children' >;
+
+export default function Header( { title, subTitle, actions }: HeaderProps ) {
+	return (
+		<VStack className="edit-site-page-header" as="header" spacing={ 0 }>
+			<HStack className="edit-site-page-header__page-title">
+				<Heading
+					as="h2"
+					level={ 3 }
+					weight={ 500 }
+					className="edit-site-page-header__title"
+					truncate
+				>
+					{ title }
+				</Heading>
+				<FlexItem className="edit-site-page-header__actions">{ actions }</FlexItem>
+			</HStack>
+			{ subTitle && (
+				<Text variant="muted" as="p" className="edit-site-page-header__sub-title">
+					{ subTitle }
+				</Text>
+			) }
+		</VStack>
+	);
+}

--- a/packages/site-admin/src/components/page/header.tsx
+++ b/packages/site-admin/src/components/page/header.tsx
@@ -18,7 +18,7 @@ type HeaderProps = Pick< PageProps, 'title' | 'subTitle' | 'actions' >;
 export default function Header( { title, subTitle, actions }: HeaderProps ) {
 	return (
 		<VStack className="a8c-site-admin-page-header" as="header" spacing={ 0 }>
-			<HStack className="a8c-site-admin-page-header__page-title">
+			<HStack className="a8c-site-admin-page-header__title-container">
 				<Heading
 					as="h2"
 					level={ 3 }

--- a/packages/site-admin/src/components/page/header.tsx
+++ b/packages/site-admin/src/components/page/header.tsx
@@ -16,21 +16,21 @@ type HeaderProps = Omit< PageProps, 'className' | 'hideTitleFromUI' | 'children'
 
 export default function Header( { title, subTitle, actions }: HeaderProps ) {
 	return (
-		<VStack className="edit-site-page-header" as="header" spacing={ 0 }>
-			<HStack className="edit-site-page-header__page-title">
+		<VStack className="a8c-site-admin-page-header" as="header" spacing={ 0 }>
+			<HStack className="a8c-site-admin-page-header__page-title">
 				<Heading
 					as="h2"
 					level={ 3 }
 					weight={ 500 }
-					className="edit-site-page-header__title"
+					className="a8c-site-admin-page-header__title"
 					truncate
 				>
 					{ title }
 				</Heading>
-				<FlexItem className="edit-site-page-header__actions">{ actions }</FlexItem>
+				<FlexItem className="a8c-site-admin-page-header__actions">{ actions }</FlexItem>
 			</HStack>
 			{ subTitle && (
-				<Text variant="muted" as="p" className="edit-site-page-header__sub-title">
+				<Text variant="muted" as="p" className="a8c-site-admin-page-header__sub-title">
 					{ subTitle }
 				</Text>
 			) }

--- a/packages/site-admin/src/components/page/header.tsx
+++ b/packages/site-admin/src/components/page/header.tsx
@@ -13,7 +13,7 @@ import {
  */
 import type { PageProps } from './types';
 
-type HeaderProps = Omit< PageProps, 'className' | 'hideTitleFromUI' | 'children' >;
+type HeaderProps = Pick< PageProps, 'title' | 'subTitle' | 'actions' >;
 
 export default function Header( { title, subTitle, actions }: HeaderProps ) {
 	return (

--- a/packages/site-admin/src/components/page/index.tsx
+++ b/packages/site-admin/src/components/page/index.tsx
@@ -7,8 +7,12 @@ import { NavigableRegion } from '../../interface';
  * Internal dependencies
  */
 import Header from './header';
-import type { PageProps } from './types';
 import './style.scss';
+/**
+ * Types
+ */
+import type { PageProps } from './types';
+import type { PropsWithChildren } from 'react';
 
 export function Page( {
 	title,
@@ -17,7 +21,7 @@ export function Page( {
 	children,
 	className,
 	hideTitleFromUI = false,
-}: PageProps ) {
+}: PropsWithChildren< PageProps > ) {
 	const classes = clsx( 'a8c-site-admin-page', className );
 
 	return (

--- a/packages/site-admin/src/components/page/index.tsx
+++ b/packages/site-admin/src/components/page/index.tsx
@@ -26,11 +26,11 @@ export function Page( {
 	className,
 	hideTitleFromUI = false,
 }: PageProps ) {
-	const classes = clsx( 'edit-site-page', className );
+	const classes = clsx( 'a8c-site-admin-page', className );
 
 	return (
 		<NavigableRegion className={ classes } ariaLabel={ title }>
-			<div className="edit-site-page-content">
+			<div className="a8c-site-admin-page-content">
 				{ ! hideTitleFromUI && title && (
 					<Header title={ title } subTitle={ subTitle } actions={ actions } />
 				) }

--- a/packages/site-admin/src/components/page/index.tsx
+++ b/packages/site-admin/src/components/page/index.tsx
@@ -7,16 +7,8 @@ import { NavigableRegion } from '../../interface';
  * Internal dependencies
  */
 import Header from './header';
+import type { PageProps } from './types';
 import './style.scss';
-
-export type PageProps = {
-	title: string;
-	subTitle?: string;
-	actions?: React.ReactNode;
-	children: React.ReactNode;
-	className?: string;
-	hideTitleFromUI?: boolean;
-};
 
 export function Page( {
 	title,

--- a/packages/site-admin/src/components/page/index.tsx
+++ b/packages/site-admin/src/components/page/index.tsx
@@ -9,7 +9,7 @@ import { NavigableRegion } from '../../interface';
 import Header from './header';
 import './style.scss';
 
-type PageProps = {
+export type PageProps = {
 	title: string;
 	subTitle?: string;
 	actions?: React.ReactNode;

--- a/packages/site-admin/src/components/page/index.tsx
+++ b/packages/site-admin/src/components/page/index.tsx
@@ -26,7 +26,7 @@ export function Page( {
 
 	return (
 		<NavigableRegion className={ classes } ariaLabel={ title }>
-			<div className="a8c-site-admin-page-content">
+			<div className="a8c-site-admin-page__content">
 				{ ! hideTitleFromUI && title && (
 					<Header title={ title } subTitle={ subTitle } actions={ actions } />
 				) }

--- a/packages/site-admin/src/components/page/index.tsx
+++ b/packages/site-admin/src/components/page/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+import { NavigableRegion } from '../../interface';
+/**
+ * Internal dependencies
+ */
+import Header from './header';
+import './style.scss';
+
+type PageProps = {
+	title: string;
+	subTitle?: string;
+	actions?: React.ReactNode;
+	children: React.ReactNode;
+	className?: string;
+	hideTitleFromUI?: boolean;
+};
+
+export default function Page( {
+	title,
+	subTitle,
+	actions,
+	children,
+	className,
+	hideTitleFromUI = false,
+}: PageProps ) {
+	const classes = clsx( 'edit-site-page', className );
+
+	return (
+		<NavigableRegion className={ classes } ariaLabel={ title }>
+			<div className="edit-site-page-content">
+				{ ! hideTitleFromUI && title && (
+					<Header title={ title } subTitle={ subTitle } actions={ actions } />
+				) }
+				{ children }
+			</div>
+		</NavigableRegion>
+	);
+}

--- a/packages/site-admin/src/components/page/index.tsx
+++ b/packages/site-admin/src/components/page/index.tsx
@@ -18,7 +18,7 @@ type PageProps = {
 	hideTitleFromUI?: boolean;
 };
 
-export default function Page( {
+export function Page( {
 	title,
 	subTitle,
 	actions,

--- a/packages/site-admin/src/components/page/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/page/stories/index.stories.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { settings } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import { Page } from '../';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof Page > = {
+	title: 'Components/Page',
+	component: Page,
+};
+
+export default meta;
+
+type Story = StoryObj< typeof Page >;
+
+export const Default: Story = {
+	args: {
+		title: __( 'Blog posts', 'site-admin' ),
+		subTitle: __( 'Manage your blog posts', 'site-admin' ),
+		actions: (
+			<HStack>
+				<Button variant="primary">{ __( 'New post', 'site-admin' ) }</Button>,
+				<Button icon={ settings } />
+			</HStack>
+		),
+		children: (
+			<div>
+				<h2>{ __( 'Blog posts content', 'site-admin' ) }</h2>
+				<p>{ __( 'This is the content of the blog posts page.', 'site-admin' ) }</p>
+			</div>
+		),
+	},
+};

--- a/packages/site-admin/src/components/page/stories/index.stories.tsx
+++ b/packages/site-admin/src/components/page/stories/index.stories.tsx
@@ -8,6 +8,9 @@ import { settings } from '@wordpress/icons';
  * Internal dependencies
  */
 import { Page } from '../';
+/**
+ * Types
+ */
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta< typeof Page > = {

--- a/packages/site-admin/src/components/page/style.scss
+++ b/packages/site-admin/src/components/page/style.scss
@@ -1,0 +1,64 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/z-index";
+
+.edit-site-page {
+	color: $gray-800;
+	background: $white;
+	height: calc(100% - #{$header-height});
+	container: edit-site-page / inline-size;
+
+	@media not (prefers-reduced-motion) {
+		transition: width ease-out 0.2s;
+	}
+
+	@include break-medium() {
+		height: 100%;
+	}
+}
+
+.edit-site-page-header {
+	padding: $grid-unit-20 $grid-unit-60;
+	border-bottom: 1px solid $gray-100;
+	background: $white;
+	position: sticky;
+	top: 0;
+	z-index: z-index(".edit-site-page-header");
+
+	@media not (prefers-reduced-motion) {
+		transition: padding ease-out 0.1s;
+	}
+
+	.components-heading {
+		color: $gray-900;
+	}
+
+	.edit-site-page-header__page-title {
+		min-height: $grid-unit-50;
+
+		.components-heading {
+			flex-grow: 1;
+			flex-basis: 0;
+			white-space: nowrap;
+		}
+	}
+
+	.edit-site-page-header__sub-title {
+		margin-bottom: $grid-unit-10;
+	}
+}
+
+@container (max-width: 430px) {
+	.edit-site-page-header {
+		padding: $grid-unit-20 $grid-unit-30;
+	}
+}
+
+.edit-site-page-content {
+	height: 100%;
+	display: flex;
+	flex-flow: column;
+	position: relative;
+	z-index: z-index(".edit-site-page-content");
+}

--- a/packages/site-admin/src/components/page/style.scss
+++ b/packages/site-admin/src/components/page/style.scss
@@ -8,10 +8,6 @@
 	background: $white;
 	container: a8c-site-admin-page / inline-size;
 
-	@media not (prefers-reduced-motion) {
-		transition: width ease-out 0.2s;
-	}
-
 	@include break-medium() {
 		height: 100%;
 	}

--- a/packages/site-admin/src/components/page/style.scss
+++ b/packages/site-admin/src/components/page/style.scss
@@ -6,7 +6,6 @@
 .a8c-site-admin-page {
 	color: $gray-800;
 	background: $white;
-	height: calc(100% - #{$header-height});
 	container: a8c-site-admin-page / inline-size;
 
 	@media not (prefers-reduced-motion) {
@@ -30,14 +29,12 @@
 		transition: padding ease-out 0.1s;
 	}
 
-	.components-heading {
-		color: $gray-900;
-	}
-
-	.a8c-site-admin-page-header__page-title {
+	
+	&__title-container {
 		min-height: $grid-unit-50;
 
-		.components-heading {
+		.a8c-site-admin-page-header__title {
+			color: $gray-900;
 			flex-grow: 1;
 			flex-basis: 0;
 			white-space: nowrap;

--- a/packages/site-admin/src/components/page/style.scss
+++ b/packages/site-admin/src/components/page/style.scss
@@ -44,7 +44,7 @@
 		}
 	}
 
-	.a8c-site-admin-page-header__sub-title {
+	&__sub-title {
 		margin-bottom: $grid-unit-10;
 	}
 }

--- a/packages/site-admin/src/components/page/style.scss
+++ b/packages/site-admin/src/components/page/style.scss
@@ -25,11 +25,6 @@
 	top: 0;
 	z-index: 2; // hardcoded for now ARC-95
 
-	@media not (prefers-reduced-motion) {
-		transition: padding ease-out 0.1s;
-	}
-
-	
 	&__title-container {
 		min-height: $grid-unit-50;
 

--- a/packages/site-admin/src/components/page/style.scss
+++ b/packages/site-admin/src/components/page/style.scss
@@ -55,7 +55,7 @@
 	}
 }
 
-.a8c-site-admin-page-content {
+.a8c-site-admin-page__content {
 	height: 100%;
 	display: flex;
 	flex-flow: column;

--- a/packages/site-admin/src/components/page/style.scss
+++ b/packages/site-admin/src/components/page/style.scss
@@ -3,11 +3,11 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/z-index";
 
-.edit-site-page {
+.a8c-site-admin-page {
 	color: $gray-800;
 	background: $white;
 	height: calc(100% - #{$header-height});
-	container: edit-site-page / inline-size;
+	container: a8c-site-admin-page / inline-size;
 
 	@media not (prefers-reduced-motion) {
 		transition: width ease-out 0.2s;
@@ -18,13 +18,13 @@
 	}
 }
 
-.edit-site-page-header {
+.a8c-site-admin-page-header {
 	padding: $grid-unit-20 $grid-unit-60;
 	border-bottom: 1px solid $gray-100;
 	background: $white;
 	position: sticky;
 	top: 0;
-	z-index: z-index(".edit-site-page-header");
+	z-index: 2; // hardcoded for now ARC-95
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;
@@ -34,7 +34,7 @@
 		color: $gray-900;
 	}
 
-	.edit-site-page-header__page-title {
+	.a8c-site-admin-page-header__page-title {
 		min-height: $grid-unit-50;
 
 		.components-heading {
@@ -44,21 +44,21 @@
 		}
 	}
 
-	.edit-site-page-header__sub-title {
+	.a8c-site-admin-page-header__sub-title {
 		margin-bottom: $grid-unit-10;
 	}
 }
 
 @container (max-width: 430px) {
-	.edit-site-page-header {
+	.a8c-site-admin-page-header {
 		padding: $grid-unit-20 $grid-unit-30;
 	}
 }
 
-.edit-site-page-content {
+.a8c-site-admin-page-content {
 	height: 100%;
 	display: flex;
 	flex-flow: column;
 	position: relative;
-	z-index: z-index(".edit-site-page-content");
+	z-index: 1; // hardcoded for now ARC-95
 }

--- a/packages/site-admin/src/components/page/types.ts
+++ b/packages/site-admin/src/components/page/types.ts
@@ -1,0 +1,7 @@
+export type PageProps = {
+	title: string;
+	subTitle?: string;
+	actions?: React.ReactNode;
+	className?: string;
+	hideTitleFromUI?: boolean;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR introduces the Page component for site-admin package:

- Add `<Page />` component with header and content sections
- Include `<NavigableRegion />` for keyboard accessibility
- Support for `title`, `subtitle` and `action`.
- Add story examples demonstrating usage

The Page component provides a standardized layout structure for admin pages with proper accessibility support and responsive design.

Related to #
Closes ARC-25

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1) Run Storybook app
```bash
yarn workspace @automattic/site-admin run storybook:start
```

2) Go to the Page component stories under "Components/Page"

3) Test core functionality:
   - Verify title, subtitle, and content sections render correctly
   - Check that action buttons appear in header
   - Test keyboard navigation with Tab key
   - Use viewport controls to verify responsive layout

4) Test with a Long content story to verify scrolling behavior


https://github.com/user-attachments/assets/fb9017b1-e70a-4ad7-a7e0-6d345d5c6f8c


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
