### PR TITLE
Notifications: Fix screen reader text and tabs z-index

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -255,6 +255,10 @@ $with-sidebar-min-page-width: 1114px;
 				flex-basis: auto;
 			}
 		}
+
+		.components-toggle-group-control-option-base {
+			z-index: initial;
+		}
 	}
 
 	.wpnc__note-list:not(.is-note-open) .wpnc__filter {

--- a/apps/notifications/src/panel/boot/stylesheets/note-common.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/note-common.scss
@@ -22,7 +22,7 @@ div.wpnc__note-actions {
 }
 
 // Taken from packages/components/src/screen-reader-text/style.scss
-.wpnc__note-list button.screen-reader-text {
+.wpnc__note-body button.screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;
 

--- a/apps/notifications/src/panel/boot/stylesheets/note-common.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/note-common.scss
@@ -22,6 +22,7 @@ div.wpnc__note-actions {
 }
 
 // Taken from packages/components/src/screen-reader-text/style.scss
+.wpnc__note-list button.screen-reader-text,
 .wpnc__note-body button.screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100357

## Proposed Changes

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/bf11f413-0f8a-4413-ba7d-bf25ea402a08) | ![image](https://github.com/user-attachments/assets/9326be91-3037-4057-b908-2afa14db1619) |
| ![image](https://github.com/user-attachments/assets/90e2dac2-518c-4252-8bbf-8eecaf61445e) | ![image](https://github.com/user-attachments/assets/b8533037-5ffc-45b9-b83a-0db24c990458) |


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix UI bugs introduced in https://github.com/Automattic/wp-calypso/pull/102562

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Verify Calypso:

* Go to `/reader`.
* Open notifications panel.
* Select any notification.
* Verification mobile view isn't distrubed i.e. tabs are visible.

### Verify Dotcom sites (non calypso) which are using iframe:

* In sandbox run `install-plugin.sh notifications calypso-100357/use-toggle-group-control-on-notifications-page`.
* Sandbox `wordpress.com` and `widgets.wp.com`.
* Go to `mehmoodak2.wordpress.com`
* Open notifications panel.
* Select any notification.
* Verify screen reader text isn't appearing now.
* Verification mobile view isn't distrubed i.e. tabs are visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
