### PR TITLE
My Home: Refetch site before handling redirect to Launchpad

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -3,12 +3,14 @@ import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { getSiteFragment } from 'calypso/lib/route';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { fetchModuleList } from 'calypso/state/jetpack/modules/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
+import { requestSite } from 'calypso/state/sites/actions';
 import { isSiteOnWooExpressEcommerceTrial } from 'calypso/state/sites/plans/selectors';
 import isSiteBigSkyTrial from 'calypso/state/sites/plans/selectors/is-site-big-sky-trial';
 import { canCurrentUserUseCustomerHome, getSiteUrl } from 'calypso/state/sites/selectors';
@@ -35,6 +37,9 @@ export default async function renderHome( context, next ) {
 }
 
 export async function maybeRedirect( context, next ) {
+	const siteFragment = context.params.site || getSiteFragment( context.path );
+	await context.store.dispatch( requestSite( siteFragment ) );
+
 	const state = context.store.getState();
 	const slug = getSelectedSiteSlug( state );
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { captureException } from '@automattic/calypso-sentry';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
@@ -38,7 +39,12 @@ export default async function renderHome( context, next ) {
 
 export async function maybeRedirect( context, next ) {
 	const siteFragment = context.params.site || getSiteFragment( context.path );
-	await context.store.dispatch( requestSite( siteFragment ) );
+	try {
+		await context.store.dispatch( requestSite( siteFragment ) );
+	} catch ( e ) {
+		// If the network returns an error we don't want the page to fail to load
+		captureException( e );
+	}
 
 	const state = context.store.getState();
 	const slug = getSelectedSiteSlug( state );


### PR DESCRIPTION
Fixes p1744392546817009-slack-C02FMH4G8.

## Proposed Changes

This fixes the redirect loop between `/home/%s` and `/setup/build/launchpad` by refetching the site data upon rendering `/home/%s` instead of relying on the persisted cache, which might be stale.

## Why are these changes being made?

[In the site-setup flow we're re-fetching the site and then redirecting to the desired `exitFlow` location](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts#L254-L255).

The problem is that it takes a while for the new site data to persist, even if we `await` the site fetching, so we have a race condition between Redux persistence and the redirection! By the time you get to `/home/%s`, the data may (it was persisted before redirecting) or may not (the redirection call won the race, and the persisted data is stale) be up to date.

Because we're saving the `site_intent` in that `exitFlow` call, the stale site data might have an empty `site_intent`, causing it to loop at least once until a new copy of the site is fetched from the remote, which doesn't happen in the `maybeRedirect` middleware from `/home/%s`.

## The actual fix

Refetching the site before continuing fixes the problem. Fetching the site on every `/home/%s` request is not ideal, but it's our most straightforward solution for now.

Ideally, we could wait for the persistence layer to update/flush before redirecting. @Automattic/team-calypso, is that possible?

## Testing Instructions

On `trunk`, modify [this line](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts#L255) to `window.open( redirectionUrl, '_blank' )` so it's easier to reproduce the behavior.

This will increase the likelihood that the new page doesn't have the updated persisted data after the `onboarding-customization` endpoint call succeeds.

Open `/setup/onboarding` and create a new free site. In the goals screen, click "Next" and pick any free design. You should see the `processing` step; a new tab will open right after that. If you're lucky, you'll see at least one redirect cycle between `/setup/build/launchpad` > `/home/%s` > `/setup/build/launchpad` > `/home/%s`.

Now, checkout this branch and do the same `window.open` change in the site-setup flow file. Create another site, but this time verify you're not thrown around by Calypso: it should render `/setup/build/launchpad` once, then send you to `/home/%s`.