### PR TITLE
i18n: Fix translation loading for Jetpack stats interval dropdown

### DIFF
--- a/client/my-sites/stats/hooks/test/use-intervals.test.tsx
+++ b/client/my-sites/stats/hooks/test/use-intervals.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { STATS_PERIOD } from 'calypso/my-sites/stats/constants';
+import { useSelector } from 'calypso/state';
+import useIntervals from '../use-intervals';
+
+// Mock dependencies
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+const mockShouldGateStats = jest.fn( () => false );
+jest.mock( '../use-should-gate-stats', () => ( {
+	shouldGateStats: () => mockShouldGateStats(),
+} ) );
+
+describe( 'useIntervals', () => {
+	beforeEach( () => {
+		( useSelector as jest.Mock ).mockImplementation( ( selector ) => selector( {}, 123 ) );
+		mockShouldGateStats.mockReturnValue( false );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return memoized intervals when nothing changes', () => {
+		const { result, rerender } = renderHook( () => useIntervals( 123 ) );
+		const firstResult = result.current;
+
+		// Rerender the hook
+		rerender();
+		const secondResult = result.current;
+
+		// The results should be referentially equal
+		expect( secondResult ).toBe( firstResult );
+	} );
+
+	it( 'should return different references when siteId changes', () => {
+		const { result, rerender } = renderHook( ( props ) => useIntervals( props ), {
+			initialProps: 123,
+		} );
+		const firstResult = result.current;
+
+		// Rerender with different siteId
+		rerender( 456 );
+		const secondResult = result.current;
+
+		// The results should be different references
+		expect( secondResult ).not.toBe( firstResult );
+	} );
+
+	it( 'should return different references when gating status changes', () => {
+		const { result, rerender } = renderHook( () => useIntervals( 123 ) );
+		const firstResult = result.current;
+
+		// Change the gating status
+		mockShouldGateStats.mockReturnValue( true );
+		rerender();
+		const secondResult = result.current;
+
+		// The results should be different references
+		expect( secondResult ).not.toBe( firstResult );
+	} );
+
+	it( 'should include all interval periods with correct structure', () => {
+		const { result } = renderHook( () => useIntervals( 123 ) );
+
+		const periods = [ STATS_PERIOD.DAY, STATS_PERIOD.WEEK, STATS_PERIOD.MONTH, STATS_PERIOD.YEAR ];
+
+		// Check all periods exist
+		expect( Object.keys( result.current ) ).toEqual( periods );
+
+		// Check structure of each period
+		periods.forEach( ( period ) => {
+			expect( result.current[ period ] ).toEqual( {
+				id: period,
+				label: expect.any( String ),
+				statType: expect.any( String ),
+				isGated: false,
+			} );
+		} );
+	} );
+} );

--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -10,6 +10,7 @@ import {
 } from 'calypso/my-sites/stats/constants';
 import { useSelector } from 'calypso/state';
 import { shouldGateStats } from './use-should-gate-stats';
+import type { AppState } from 'calypso/types';
 
 type IntervalType = {
 	id: string;
@@ -51,7 +52,7 @@ function useStaticIntervals() {
 	);
 }
 
-const getGatedIntervals = createSelector( ( state, siteId, intervals ) => {
+const getGatedIntervals = createSelector( ( state: AppState, siteId, intervals ) => {
 	return Object.keys( intervals ).reduce( ( acc, key ) => {
 		const interval = intervals[ key ];
 

--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -24,22 +24,30 @@ type IntervalsType = {
 const intervals = {
 	[ STATS_PERIOD.DAY ]: {
 		id: STATS_PERIOD.DAY,
-		label: translate( 'Days' ),
+		get label() {
+			return translate( 'Days' );
+		},
 		statType: STATS_FEATURE_INTERVAL_DROPDOWN_DAY,
 	},
 	[ STATS_PERIOD.WEEK ]: {
 		id: STATS_PERIOD.WEEK,
-		label: translate( 'Weeks' ),
+		get label() {
+			return translate( 'Weeks' );
+		},
 		statType: STATS_FEATURE_INTERVAL_DROPDOWN_WEEK,
 	},
 	[ STATS_PERIOD.MONTH ]: {
 		id: STATS_PERIOD.MONTH,
-		label: translate( 'Months' ),
+		get label() {
+			return translate( 'Months' );
+		},
 		statType: STATS_FEATURE_INTERVAL_DROPDOWN_MONTH,
 	},
 	[ STATS_PERIOD.YEAR ]: {
 		id: STATS_PERIOD.YEAR,
-		label: translate( 'Years' ),
+		get label() {
+			return translate( 'Years' );
+		},
 		statType: STATS_FEATURE_INTERVAL_DROPDOWN_YEAR,
 	},
 };
@@ -58,11 +66,16 @@ const getGatedIntervals = createSelector(
 			};
 		}, {} );
 	},
-	Object.values( intervals ).map(
-		( { statType } ) =>
-			( state: object, siteId ) =>
-				shouldGateStats( state, siteId, statType )
-	)
+	[
+		...Object.values( intervals ).map(
+			( { statType } ) =>
+				( state: object, siteId ) =>
+					shouldGateStats( state, siteId, statType )
+		),
+		() => {
+			return translate( 'Days' );
+		},
+	]
 );
 
 function useIntervals( siteId: number | null ): IntervalsType {

--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -1,5 +1,6 @@
 import { createSelector } from '@automattic/state-utils';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import {
 	STATS_FEATURE_INTERVAL_DROPDOWN_DAY,
 	STATS_FEATURE_INTERVAL_DROPDOWN_MONTH,
@@ -21,39 +22,37 @@ type IntervalsType = {
 	[ key: string ]: IntervalType;
 };
 
-const intervals = {
-	[ STATS_PERIOD.DAY ]: {
-		id: STATS_PERIOD.DAY,
-		get label() {
-			return translate( 'Days' );
-		},
-		statType: STATS_FEATURE_INTERVAL_DROPDOWN_DAY,
-	},
-	[ STATS_PERIOD.WEEK ]: {
-		id: STATS_PERIOD.WEEK,
-		get label() {
-			return translate( 'Weeks' );
-		},
-		statType: STATS_FEATURE_INTERVAL_DROPDOWN_WEEK,
-	},
-	[ STATS_PERIOD.MONTH ]: {
-		id: STATS_PERIOD.MONTH,
-		get label() {
-			return translate( 'Months' );
-		},
-		statType: STATS_FEATURE_INTERVAL_DROPDOWN_MONTH,
-	},
-	[ STATS_PERIOD.YEAR ]: {
-		id: STATS_PERIOD.YEAR,
-		get label() {
-			return translate( 'Years' );
-		},
-		statType: STATS_FEATURE_INTERVAL_DROPDOWN_YEAR,
-	},
-};
+function useStaticIntervals() {
+	const translate = useTranslate();
+	return useMemo(
+		() => ( {
+			[ STATS_PERIOD.DAY ]: {
+				id: STATS_PERIOD.DAY,
+				label: translate( 'Days' ),
+				statType: STATS_FEATURE_INTERVAL_DROPDOWN_DAY,
+			},
+			[ STATS_PERIOD.WEEK ]: {
+				id: STATS_PERIOD.WEEK,
+				label: translate( 'Weeks' ),
+				statType: STATS_FEATURE_INTERVAL_DROPDOWN_WEEK,
+			},
+			[ STATS_PERIOD.MONTH ]: {
+				id: STATS_PERIOD.MONTH,
+				label: translate( 'Months' ),
+				statType: STATS_FEATURE_INTERVAL_DROPDOWN_MONTH,
+			},
+			[ STATS_PERIOD.YEAR ]: {
+				id: STATS_PERIOD.YEAR,
+				label: translate( 'Years' ),
+				statType: STATS_FEATURE_INTERVAL_DROPDOWN_YEAR,
+			},
+		} ),
+		[ translate ]
+	);
+}
 
 const getGatedIntervals = createSelector(
-	( state, siteId ) => {
+	( state, siteId, intervals ) => {
 		return Object.keys( intervals ).reduce( ( acc, key ) => {
 			const interval = intervals[ key ];
 
@@ -66,20 +65,18 @@ const getGatedIntervals = createSelector(
 			};
 		}, {} );
 	},
-	[
-		...Object.values( intervals ).map(
+	( state, siteId, intervals ) => {
+		return Object.values( intervals ).map(
 			( { statType } ) =>
 				( state: object, siteId ) =>
 					shouldGateStats( state, siteId, statType )
-		),
-		() => {
-			return translate( 'Days' );
-		},
-	]
+		);
+	}
 );
 
 function useIntervals( siteId: number | null ): IntervalsType {
-	return useSelector( ( state ) => getGatedIntervals( state, siteId ) );
+	const staticIntervals = useStaticIntervals();
+	return useSelector( ( state ) => getGatedIntervals( state, siteId, staticIntervals ) );
 }
 
 export default useIntervals;

--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -15,7 +15,7 @@ import type { AppState } from 'calypso/types';
 type IntervalType = {
 	id: string;
 	label: string;
-	isGated: number;
+	isGated: boolean;
 	statType: string;
 };
 
@@ -23,9 +23,35 @@ type IntervalsType = {
 	[ key: string ]: IntervalType;
 };
 
-function useStaticIntervals() {
+const getGatedIntervals = createSelector(
+	(
+		state: AppState,
+		siteId: number | null,
+		intervals: Record< string, Omit< IntervalType, 'isGated' > >
+	) => {
+		return Object.fromEntries(
+			Object.entries( intervals ).map( ( [ key, interval ] ) => [
+				key,
+				{
+					...interval,
+					isGated: shouldGateStats( state, siteId, interval.statType ),
+				},
+			] )
+		) as IntervalsType;
+	},
+	( state, siteId, intervals: Record< string, Omit< IntervalType, 'isGated' > > ) => {
+		return [
+			...Object.values( intervals ).map( ( { statType } ) =>
+				shouldGateStats( state, siteId, statType )
+			),
+			intervals,
+		];
+	}
+);
+
+function useIntervals( siteId: number | null ): IntervalsType {
 	const translate = useTranslate();
-	return useMemo(
+	const intervals = useMemo(
 		() => ( {
 			[ STATS_PERIOD.DAY ]: {
 				id: STATS_PERIOD.DAY,
@@ -50,35 +76,8 @@ function useStaticIntervals() {
 		} ),
 		[ translate ]
 	);
-}
 
-const getGatedIntervals = createSelector(
-	( state: AppState, siteId, intervals ) => {
-		return Object.keys( intervals ).reduce( ( acc, key ) => {
-			const interval = intervals[ key ];
-
-			return {
-				...acc,
-				[ key ]: {
-					...interval,
-					isGated: shouldGateStats( state, siteId, interval.statType ),
-				},
-			};
-		}, {} );
-	},
-	( state, siteId, intervals: IntervalsType ) => {
-		return [
-			...Object.values( intervals ).map( ( { statType } ) =>
-				shouldGateStats( state, siteId, statType )
-			),
-			intervals,
-		];
-	}
-);
-
-function useIntervals( siteId: number | null ): IntervalsType {
-	const staticIntervals = useStaticIntervals();
-	return useSelector( ( state ) => getGatedIntervals( state, siteId, staticIntervals ) );
+	return useSelector( ( state ) => getGatedIntervals( state, siteId, intervals ) );
 }
 
 export default useIntervals;

--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -66,11 +66,12 @@ const getGatedIntervals = createSelector(
 		}, {} );
 	},
 	( state, siteId, intervals ) => {
-		return Object.values( intervals ).map(
-			( { statType } ) =>
-				( state: object, siteId ) =>
-					shouldGateStats( state, siteId, statType )
-		);
+		return [
+			...Object.values( intervals ).map( ( { statType } ) =>
+				shouldGateStats( state, siteId, statType )
+			),
+			intervals,
+		];
 	}
 );
 

--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -52,19 +52,29 @@ function useStaticIntervals() {
 	);
 }
 
-const getGatedIntervals = createSelector( ( state: AppState, siteId, intervals ) => {
-	return Object.keys( intervals ).reduce( ( acc, key ) => {
-		const interval = intervals[ key ];
+const getGatedIntervals = createSelector(
+	( state: AppState, siteId, intervals ) => {
+		return Object.keys( intervals ).reduce( ( acc, key ) => {
+			const interval = intervals[ key ];
 
-		return {
-			...acc,
-			[ key ]: {
-				...interval,
-				isGated: shouldGateStats( state, siteId, interval.statType ),
-			},
-		};
-	}, {} );
-} );
+			return {
+				...acc,
+				[ key ]: {
+					...interval,
+					isGated: shouldGateStats( state, siteId, interval.statType ),
+				},
+			};
+		}, {} );
+	},
+	( state, siteId, intervals: IntervalsType ) => {
+		return [
+			...Object.values( intervals ).map( ( { statType } ) =>
+				shouldGateStats( state, siteId, statType )
+			),
+			intervals,
+		];
+	}
+);
 
 function useIntervals( siteId: number | null ): IntervalsType {
 	const staticIntervals = useStaticIntervals();

--- a/client/my-sites/stats/hooks/use-intervals.tsx
+++ b/client/my-sites/stats/hooks/use-intervals.tsx
@@ -51,29 +51,19 @@ function useStaticIntervals() {
 	);
 }
 
-const getGatedIntervals = createSelector(
-	( state, siteId, intervals ) => {
-		return Object.keys( intervals ).reduce( ( acc, key ) => {
-			const interval = intervals[ key ];
+const getGatedIntervals = createSelector( ( state, siteId, intervals ) => {
+	return Object.keys( intervals ).reduce( ( acc, key ) => {
+		const interval = intervals[ key ];
 
-			return {
-				...acc,
-				[ key ]: {
-					...interval,
-					isGated: shouldGateStats( state, siteId, interval.statType ),
-				},
-			};
-		}, {} );
-	},
-	( state, siteId, intervals ) => {
-		return [
-			...Object.values( intervals ).map( ( { statType } ) =>
-				shouldGateStats( state, siteId, statType )
-			),
-			intervals,
-		];
-	}
-);
+		return {
+			...acc,
+			[ key ]: {
+				...interval,
+				isGated: shouldGateStats( state, siteId, interval.statType ),
+			},
+		};
+	}, {} );
+} );
 
 function useIntervals( siteId: number | null ): IntervalsType {
 	const staticIntervals = useStaticIntervals();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to I18N-193

## Proposed Changes

* Fix the translations of Days/Weeks/Months/Years in Jetpack stats dropdown

Before:
<img width="1348" alt="Screenshot 2025-04-14 at 11 28 39" src="https://github.com/user-attachments/assets/60a707fb-40fa-4264-972b-a50cf68d4899" />
After:
<img width="1348" alt="Screenshot 2025-04-14 at 11 31 53" src="https://github.com/user-attachments/assets/7b587ddb-af05-4a5f-97cb-2587105c6568" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* 1. Since the translatable strings are defined as constants, they're often being set to English before the translations are loaded. 2. `useSelector` call caches the data, so even if the translations get updated the output of `useIntervals` returns the cached English translations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce the issue, switch your wordpress.com locale to a Mag-16 language, start a local Calypso instance and navigate to `/stats/day/{your site}`.
* Refresh a few times until you'd see that the `Days` dropdown is not translated.
* Checkout the PR and confirm that the issue is fixed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
