### PR TITLE
/woocommerce-installation: Add clientRender

### DIFF
--- a/client/my-sites/woocommerce/index.js
+++ b/client/my-sites/woocommerce/index.js
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { createElement } from 'react';
-import { makeLayout } from 'calypso/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getSiteFragment } from 'calypso/lib/route';
 import { siteSelection, navigation, sites } from 'calypso/my-sites/controller';
 import {
@@ -13,8 +13,15 @@ import Main from './main';
 import './style.scss';
 
 export default function ( router ) {
-	router( '/woocommerce-installation', siteSelection, sites, makeLayout );
-	router( '/woocommerce-installation/:site', siteSelection, navigation, setup, makeLayout );
+	router( '/woocommerce-installation', siteSelection, sites, makeLayout, clientRender );
+	router(
+		'/woocommerce-installation/:site',
+		siteSelection,
+		navigation,
+		setup,
+		makeLayout,
+		clientRender
+	);
 }
 
 function setup( context, next ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/102575

## Proposed Changes

There is a layout issue in /woocommerce-installation/:domain when accessed directly. Unfortunately, this is only reproducible on production, so let's see if this PR fixes it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit  /woocommerce-installation and  /woocommerce-installation/:domain to ensure that there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
