### PR TITLE
Remove more goals-first experiment code from onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/build/build.ts
+++ b/client/landing/stepper/declarative-flow/flows/build/build.ts
@@ -7,8 +7,6 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { getStepFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
-import { useSelector } from 'calypso/state';
-import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import { shouldShowLaunchpadFirst } from 'calypso/state/selectors/should-show-launchpad-first';
 import { STEPPER_TRACKS_EVENT_SIGNUP_STEP_START } from '../../../constants';
 import { useExitFlow } from '../../../hooks/use-exit-flow';
@@ -18,10 +16,6 @@ import { ONBOARD_STORE } from '../../../stores';
 import { useLaunchpadDecider } from '../../internals/hooks/use-launchpad-decider';
 import { STEPS } from '../../internals/steps';
 import { Flow, ProvidedDependencies } from '../../internals/types';
-
-function useGoalsAtFrontExperimentQueryParam() {
-	return Boolean( useSelector( getInitialQueryArguments )?.[ 'goals-at-front-experiment' ] );
-}
 
 const steps = [ STEPS.LAUNCHPAD, STEPS.PROCESSING ];
 
@@ -35,7 +29,6 @@ const build: Flow = {
 		return steps;
 	},
 	useTracksEventProps() {
-		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
 		const goals = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
 			[]
@@ -51,16 +44,13 @@ const build: Flow = {
 			() => ( {
 				eventsProperties: {
 					[ STEPPER_TRACKS_EVENT_SIGNUP_STEP_START ]: {
-						...( isGoalsAtFrontExperiment && {
-							is_goals_first: 'true',
-						} ),
 						...( initialGoals.current.length && {
 							goals: initialGoals.current.join( ',' ),
 						} ),
 					},
 				},
 			} ),
-			[ isGoalsAtFrontExperiment, initialGoals ]
+			[ initialGoals ]
 		);
 
 		if ( site && shouldShowLaunchpadFirst( site ) && step === 'launchpad' ) {

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -22,7 +22,6 @@ import { useMarketplaceThemeProducts } from '../../../hooks/use-marketplace-them
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
-import { useRedirectDesignSetupOldSlug } from '../../helpers/use-redirect-design-setup-old-slug';
 import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { STEPS } from '../../internals/steps';
 import { Flow, ProvidedDependencies } from '../../internals/types';
@@ -126,7 +125,6 @@ const onboarding: Flow = {
 		};
 
 		clearUseMyDomainsQueryParams( currentStepSlug );
-		useRedirectDesignSetupOldSlug( currentStepSlug, navigate );
 
 		const submit = async ( providedDependencies: ProvidedDependencies = {} ) => {
 			switch ( currentStepSlug ) {

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -1,6 +1,5 @@
-import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
+import { Onboard } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
@@ -15,7 +14,6 @@ import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../../../constants';
-import { useActivateDesign } from '../../../hooks/use-activate-design';
 import { useIsPluginBundleEligible } from '../../../hooks/use-is-plugin-bundle-eligible';
 import { useSiteData } from '../../../hooks/use-site-data';
 import { useCanUserManageOptions } from '../../../hooks/use-user-can-manage-options';
@@ -669,76 +667,6 @@ const siteSetupFlow: Flow = {
 	},
 
 	useSideEffect() {
-		const { siteSlugOrId, siteId } = useSiteData();
-		const { setPendingAction } = useDispatch( ONBOARD_STORE );
-		const { selectedDesign, selectedStyleVariation, selectedGlobalStyles } = useSelect(
-			( select ) => {
-				const { getSelectedDesign, getSelectedStyleVariation, getSelectedGlobalStyles } = select(
-					ONBOARD_STORE
-				) as OnboardSelect;
-				return {
-					selectedDesign: getSelectedDesign(),
-					selectedStyleVariation: getSelectedStyleVariation(),
-					selectedGlobalStyles: getSelectedGlobalStyles(),
-				};
-			},
-			[]
-		);
-
-		const dispatch = reduxDispatch();
-
-		const skippedCheckout = useQuery().get( 'skippedCheckout' );
-		const activateDesign = useActivateDesign();
-		const isPendingActionSet = useRef( false );
-
-		useEffect( () => {
-			if ( ! siteSlugOrId || ! siteId ) {
-				return;
-			}
-
-			// Avoid the pending action to be triggered multiple times.
-			if ( isPendingActionSet.current ) {
-				return;
-			}
-
-			isPendingActionSet.current = true;
-			setPendingAction( async () => {
-				if ( ! selectedDesign ) {
-					return;
-				}
-				try {
-					await activateDesign( selectedDesign, {
-						styleVariation: selectedStyleVariation,
-						globalStyles: selectedGlobalStyles,
-					} );
-				} catch ( error: any ) {
-					// We attempt to set the design on the site anyway even when the checkout is skipped.
-					// That's because the user might have selected a free design, and there's no reason
-					// we shouldn't set that design on the site when the checkout is skipped.
-					// If the ThemeNotPurchasedError is thrown we know that they actually selected a
-					// paid theme and we're unable to apply it.
-					if ( error.name !== 'ThemeNotPurchasedError' || skippedCheckout !== '1' ) {
-						throw error;
-					}
-				}
-
-				const design_completed = selectedDesign?.default ? false : true;
-				await updateLaunchpadSettings( siteSlugOrId, {
-					checklist_statuses: { design_completed },
-				} );
-			} );
-		}, [
-			siteSlugOrId,
-			siteId,
-			activateDesign,
-			selectedDesign,
-			setPendingAction,
-			dispatch,
-			selectedStyleVariation,
-			selectedGlobalStyles,
-			skippedCheckout,
-		] );
-
 		const { get, set } = useFlowState();
 		const urlQueryParams = useQuery();
 		const ref = urlQueryParams.get( 'ref' );

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -11,7 +11,6 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { useDispatch as reduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getInitialQueryArguments } from 'calypso/state/selectors/get-initial-query-arguments';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
@@ -45,18 +44,12 @@ function isLaunchpadIntent( intent: string ) {
 	return intent === SiteIntent.Write || intent === SiteIntent.Build;
 }
 
-function useGoalsAtFrontExperimentQueryParam() {
-	return Boolean( useSelector( getInitialQueryArguments )?.[ 'goals-at-front-experiment' ] );
-}
-
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
 	isSignupFlow: false,
 	__experimentalUseSessions: true,
 
 	useSteps() {
-		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
-
 		const steps = [
 			STEPS.GOALS,
 			STEPS.INTENT,
@@ -85,15 +78,9 @@ const siteSetupFlow: Flow = {
 			STEPS.DIFM_STARTING_POINT,
 		];
 
-		if ( isGoalsAtFrontExperiment ) {
-			return [ STEPS.PROCESSING, STEPS.ERROR ];
-		}
-
 		return steps;
 	},
 	useStepNavigation( currentStep, navigate ) {
-		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
-
 		const intent = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 			[]
@@ -222,7 +209,6 @@ const siteSetupFlow: Flow = {
 						redirectionUrl = addQueryArgs(
 							{
 								showLaunchpad: true,
-								...( isGoalsAtFrontExperiment && { 'goals-at-front-experiment': true } ),
 								...( skippedCheckout && { skippedCheckout: 1 } ),
 							},
 							to
@@ -683,7 +669,6 @@ const siteSetupFlow: Flow = {
 	},
 
 	useSideEffect() {
-		const isGoalsAtFrontExperiment = useGoalsAtFrontExperimentQueryParam();
 		const { siteSlugOrId, siteId } = useSiteData();
 		const { setPendingAction } = useDispatch( ONBOARD_STORE );
 		const { selectedDesign, selectedStyleVariation, selectedGlobalStyles } = useSelect(
@@ -707,7 +692,7 @@ const siteSetupFlow: Flow = {
 		const isPendingActionSet = useRef( false );
 
 		useEffect( () => {
-			if ( ! isGoalsAtFrontExperiment || ! siteSlugOrId || ! siteId ) {
+			if ( ! siteSlugOrId || ! siteId ) {
 				return;
 			}
 
@@ -743,7 +728,6 @@ const siteSetupFlow: Flow = {
 				} );
 			} );
 		}, [
-			isGoalsAtFrontExperiment,
 			siteSlugOrId,
 			siteId,
 			activateDesign,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -340,8 +340,7 @@ const UnifiedDesignPickerStep: StepType< {
 
 	// Don't render until we've done fetching all the data needed for initial render.
 	const isSiteLoading = ! site;
-	const isDesignsLoading = isLoadingDesigns;
-	const isLoading = isSiteLoading || isDesignsLoading;
+	const isLoading = isSiteLoading || isLoadingDesigns;
 
 	if ( isLoading || isComingFromTheUpgradeScreen ) {
 		return isUsingStepContainerV2 ? <Step.Loading /> : <Loading />;

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -15,13 +15,11 @@ import {
 	NewSiteResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiDeleteSite, fixme_retry } from '../shared';
+import { apiDeleteSite } from '../shared';
 
 declare const browser: Browser;
 
-// wpcalypso is currently using the goals-first onboarding flow, so this is
-// skipped for now. Check out the "Plans: Create a WordPress.com/Business site with goals-first flow as existing user" test below.
-describe.skip(
+describe(
 	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com/Business site as exising user' ),
 	function () {
 		const planName = 'Business';
@@ -79,126 +77,6 @@ describe.skip(
 				await page.waitForURL( /setup\/site-setup\/goals/ );
 				const startSiteFlow = new StartSiteFlow( page );
 				await startSiteFlow.clickButton( 'Skip to dashboard' );
-			} );
-
-			it( 'See Home', async function () {
-				await page.waitForURL( /home/ );
-			} );
-		} );
-
-		describe( `Validate WordPress.com ${ planName } functionality`, function () {
-			let sidebarComponent: SidebarComponent;
-
-			it( `Sidebar states user is on WordPress.com ${ planName } plan`, async function () {
-				sidebarComponent = new SidebarComponent( page );
-				const currentPlan = await sidebarComponent.getCurrentPlanName();
-				expect( currentPlan ).toBe( planName );
-			} );
-		} );
-
-		afterAll( async function () {
-			if ( ! siteCreatedFlag ) {
-				return;
-			}
-
-			const restAPIClient = new RestAPIClient( {
-				username: testAccount.credentials.username,
-				password: testAccount.credentials.password,
-			} );
-
-			await apiDeleteSite( restAPIClient, {
-				url: newSiteDetails.blog_details.url,
-				id: newSiteDetails.blog_details.blogid,
-				name: newSiteDetails.blog_details.blogname,
-			} );
-		} );
-	}
-);
-
-// The steps in this test don't match what happens on production, because only wpcalypso
-// is using the goals-first onboarding flow. Check out the "Plans: Create a WordPress.com/Business site as exising user" test above
-// for the steps that work on production.
-describe(
-	DataHelper.createSuiteTitle(
-		'Plans: Create a WordPress.com/Business site with goals-first flow as exising user'
-	),
-	function () {
-		const planName = 'Business';
-
-		let testAccount: TestAccount;
-		let page: Page;
-		let siteCreatedFlag = false;
-		let newSiteDetails: NewSiteResponse;
-		let startSiteFlow: StartSiteFlow;
-
-		beforeAll( async function () {
-			page = await browser.newPage();
-
-			testAccount = new TestAccount( 'calypsoPreReleaseUser' );
-			await testAccount.authenticate( page );
-		} );
-
-		describe( 'Create new site', function () {
-			let cartCheckoutPage: CartCheckoutPage;
-
-			beforeAll( async function () {
-				await BrowserManager.setStoreCookie( page );
-			} );
-
-			it( 'Navigate to /start', async function () {
-				await page.goto( DataHelper.getCalypsoURL( 'start' ) );
-			} );
-
-			it( 'Skip goal selection', async function () {
-				await page.waitForURL( /setup\/onboarding\/goals/, { timeout: 30 * 1000 } );
-
-				startSiteFlow = new StartSiteFlow( page );
-				await startSiteFlow.clickButton( 'Skip' );
-			} );
-
-			it( 'Choose to proceed with theme', async function () {
-				await startSiteFlow.clickDesignChoice( 'theme' );
-			} );
-
-			it( 'Skip theme selection', async function () {
-				await startSiteFlow.clickButton( 'Skip setup' );
-			} );
-
-			it( 'Skip domain selection', async function () {
-				const signupDomainPage = new SignupDomainPage( page );
-				await signupDomainPage.searchForFooDomains();
-				await signupDomainPage.skipDomainSelection();
-			} );
-
-			it( `Select WordPress.com ${ planName } plan`, async function () {
-				const signupPickPlanPage = new SignupPickPlanPage( page );
-				newSiteDetails = await signupPickPlanPage.selectPlan( planName );
-
-				siteCreatedFlag = true;
-			} );
-
-			it( 'See secure checkout', async function () {
-				cartCheckoutPage = new CartCheckoutPage( page );
-				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-			} );
-
-			it( 'Enter payment details', async function () {
-				await cartCheckoutPage.selectSavedCard( 'End to End Testing' );
-			} );
-
-			it( 'Make purchase', async function () {
-				await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
-			} );
-
-			it( 'Skip the launchpad', async function () {
-				// dirty hack to wait for the launchpad to load.
-				// Stepper has a quirk where it redirects twice. Playwright hooks to the first one and thinks it was aborted.
-				await fixme_retry( () => page.waitForURL( /launchpad/ ) );
-
-				// Try to find the skip button with a more specific selector
-				const skipButton = page.getByRole( 'button', { name: /skip (for now|to dashboard)/i } );
-				await skipButton.waitFor( { state: 'visible', timeout: 10000 } );
-				await skipButton.click();
 			} );
 
 			it( 'See Home', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTOBRD-98
Related to DOTOBRD-36
Related to https://github.com/Automattic/wp-calypso/issues/101759

## Proposed Changes

* Removes remaining `useGoalsFirstExperiment()` code from the onboarding/site-setup flows.
* Remove the "big sky" state (i.e. `createWithBigSky`) from the onboarding store
  * This recorded the user's "design choice" step in the goals-first flow, it's not needed to record the user's big sky choice when big sky appears post-checkout.
* Remove deprecated goals-first related e2e test
* Removes logic for the goals and design choice step from the flow's `submit()` function
* Remove logic for showing custom goals-first related messages in the domains step upgrade modal

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- In DOTOBRD-98, we're adding a different A/B test to the onboarding flow https://github.com/Automattic/wp-calypso/pull/102578
- This will introduce async step loading (since we have to load experiment assignment before we can determine what steps the flow has), so ideally we would migrate the onboarding flow's `useSteps()` hook to the better `initialize()` function pdDR7T-22t-p2
- To migrate to `initialize()` we need to remove hooks (like `useGoalsFirstExperiment()`) from `useSteps()`
- To remove `useGoalsFirstExperiment()` I may as well remove all of the old goals-first code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should be no change to the onboarding flow since the goals first experiment was already hardcoded as `false`
* It'd be worth testing that the big sky flow is still working
  * `/setup/onboarding`
  * Choose premium plan
  * Complete checkout
  * Skip goals step
  * Choose AI website builder

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?