### PR TITLE
Onboarding Experiment: Skeleton of minimal flow experiment

### DIFF
--- a/client/landing/stepper/hooks/use-is-playground-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-playground-eligible.ts
@@ -1,5 +1,9 @@
 import config from '@automattic/calypso-config';
 
 export function useIsPlaygroundEligible() {
+	return isPlaygroundEligible();
+}
+
+export function isPlaygroundEligible() {
 	return config.isEnabled( 'onboarding/playground' );
 }

--- a/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
+++ b/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
@@ -1,0 +1,30 @@
+import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
+import { useIsPlaygroundEligible, isPlaygroundEligible } from './use-is-playground-eligible';
+import { useQuery } from './use-query';
+
+const MVP_ONBOARDING_EXPERIMENT_NAME = 'calypso_onboarding_mvp_20250414';
+
+export function useMvpOnboardingExperiment() {
+	const isPlaygroundEligible = useIsPlaygroundEligible();
+	const hasPlaygroundId = useQuery().has( 'playground' );
+
+	const [ isLoading, assignment ] = useExperiment( MVP_ONBOARDING_EXPERIMENT_NAME, {
+		isEligible: ! isPlaygroundEligible || ! hasPlaygroundId,
+	} );
+
+	return [ isLoading, assignment?.variationName === 'treatment' ];
+}
+
+export async function isMvpOnboardingExperiment() {
+	if ( isPlaygroundEligible() ) {
+		const params = new URLSearchParams( window.location.search );
+		const hasPlaygroundId = params.has( 'playground' );
+
+		if ( hasPlaygroundId ) {
+			return false;
+		}
+	}
+
+	const assignment = await loadExperimentAssignment( MVP_ONBOARDING_EXPERIMENT_NAME );
+	return assignment.variationName === 'treatment';
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-98

## Proposed Changes

* Switch `onboarding` flow from `FlowV1` to `FlowV2`
  * Having async code in `useSteps` is problematic. Use the new and improved `initialize` function for defining a flow's steps asynchronously
* Add code for detecting `calypso_onboarding_mvp_20250414` experiment 22236-explat-experiment
* If experiment is active
  * only show the plans step during onboarding
  * new users land in the `/overview` page
* Add a vanilla `isPlaygroundEligible()` function, which is like the `useIsPlaygroundEligible()` hook except it can be used outside of hook-ish locations.
* Users using the playground flow are ineligible for the onboarding MVP experiment

**Free**

https://github.com/user-attachments/assets/09071fa6-0b3f-40ea-9357-da084c19d235

**Paid Plan**


https://github.com/user-attachments/assets/86bbadd3-c0f1-4f58-9a61-bed0a23b8d18




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to treatment group in `calypso_onboarding_mvp_20250414` experiment 22236-explat-experiment
* Go through free onboarding
* Go through paid plan onboarding
	* Complete checkout
	* Back out of checkout
* Hard code the `useMvpOnboardingExperiment` and `isMvpOnboardingExperiment` functions to return `true`
* Test as logged out user

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?