### PR TITLE
[ DO NOT MERGE ] Stats: Replace version checks for Odyssey Stats v2

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -118,9 +118,11 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	const geoMode = GEO_MODES[ selectedOption ];
 	const title = translate( 'Locations' );
 
-	const { supportsLocationsStats: supportsLocationsStatsFeature } = useSelector( ( state ) =>
+	const { isOldJetpack } = useSelector( ( state ) =>
 		getEnvStatsFeatureSupportChecks( state, siteId )
 	);
+
+	const supportsLocationsStatsFeature = ! isOldJetpack;
 
 	// Main location data query
 	const {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -193,13 +193,9 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 		[ hasVideoPress, moduleToggles ]
 	);
 
-	const {
-		supportsPlanUsage,
-		supportsUTMStats: supportsUTMStatsFeature,
-		supportsDevicesStats: supportsDevicesStatsFeature,
-		isOldJetpack,
-		supportUserFeedback,
-	} = useSelector( ( state ) => getEnvStatsFeatureSupportChecks( state, siteId ) );
+	const { supportsPlanUsage, isOldJetpack, supportUserFeedback } = useSelector( ( state ) =>
+		getEnvStatsFeatureSupportChecks( state, siteId )
+	);
 
 	// Find the applied shortcut with shortcut ID from the URL.
 	const shortcuts = useShortcuts( {
@@ -245,8 +241,8 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	);
 
 	const shouldShowUpsells = isOdysseyStats && ! isAtomic;
-	const supportsUTMStats = supportsUTMStatsFeature || isInternal;
-	const supportsDevicesStats = supportsDevicesStatsFeature || isInternal;
+	const supportsUTMStats = ! isOldJetpack || isInternal;
+	const supportsDevicesStats = ! isOldJetpack || isInternal;
 	const getAvailableLegend = () => {
 		const activeTab = getActiveTab( chartTab );
 		// TODO: remove this when we support hourly visitors.
@@ -640,7 +636,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 							) }
 
 							{ /* If UTM if supported display the module or update Jetpack plugin card */ }
-							{ supportsUTMStats && ! isOldJetpack && (
+							{ supportsUTMStats ? (
 								<StatsModuleUTM
 									siteId={ siteId }
 									period={ props.period }
@@ -649,9 +645,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 									summary={ false }
 									className={ halfWidthModuleClasses }
 								/>
-							) }
-
-							{ supportsUTMStats && isOldJetpack && (
+							) : (
 								<StatsModuleUTMOverlay
 									siteId={ siteId }
 									className={ halfWidthModuleClasses }
@@ -716,16 +710,14 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 								)
 							}
 
-							{ supportsDevicesStats && ! isOldJetpack && (
+							{ supportsDevicesStats ? (
 								<StatsModuleDevices
 									siteId={ siteId }
 									period={ props.period }
 									query={ query }
 									className={ halfWidthModuleClasses }
 								/>
-							) }
-
-							{ supportsDevicesStats && isOldJetpack && (
+							) : (
 								<StatsModuleUpgradeDevicesOverlay
 									className={ halfWidthModuleClasses }
 									siteId={ siteId }

--- a/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
@@ -4,14 +4,21 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'calypso/state';
-import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
 import { Props } from './';
 
 const StatsCardUpdateJetpackVersion: React.FC< Props > = ( { className, siteId, statType } ) => {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isSiteJetpackUpgradable = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } )
+	);
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+
+	if ( ! isSiteJetpackUpgradable ) {
+		return null;
+	}
 
 	const tracksEvent = 'update_jetpack_feature_card_clicked';
 

--- a/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
+++ b/client/my-sites/stats/stats-card-upsell/stats-card-update-jetpack-version.tsx
@@ -4,7 +4,6 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { useSelector } from 'calypso/state';
-import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import StatsCardUpsellOverlay from './stats-card-upsell-overlay';
 import { Props } from './';
@@ -14,13 +13,7 @@ const StatsCardUpdateJetpackVersion: React.FC< Props > = ( { className, siteId, 
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
-	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	const tracksEvent = 'update_jetpack_feature_card_clicked';
-
-	if ( isWPCOMSite ) {
-		// Don't show Jetpack update outside Jetpack.
-		return null;
-	}
 
 	const onClick = () => {
 		// publish an event

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -260,7 +260,7 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const isPreviewable = isSitePreviewable( state, siteId );
 	const isPostHomepage = postId === 0;
 	const countLikes = countPostLikes( state, siteId, postId ) || 0;
-	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
+	const { isOldJetpack } = getEnvStatsFeatureSupportChecks( state, siteId );
 
 	return {
 		post: getSitePost( state, siteId, postId ),
@@ -274,7 +274,7 @@ const connectComponent = connect( ( state, { postId } ) => {
 		showViewLink: ! isJetpack && ! isPostHomepage && isPreviewable,
 		previewUrl: getPostPreviewUrl( state, siteId, postId ),
 		siteId,
-		supportsUTMStats,
+		supportsUTMStats: ! isOldJetpack,
 	};
 } );
 

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -408,12 +408,12 @@ class StatsSummary extends Component {
 export default connect( ( state, { context, postId } ) => {
 	const siteId = getSelectedSiteId( state );
 
-	const { supportsUTMStats } = getEnvStatsFeatureSupportChecks( state, siteId );
+	const { isOldJetpack } = getEnvStatsFeatureSupportChecks( state, siteId );
 
 	return {
 		siteId: getSelectedSiteId( state ),
 		siteSlug: getSelectedSiteSlug( state, siteId ),
 		media: context.params.module === 'videodetails' ? getMediaItem( state, siteId, postId ) : false,
-		supportsUTMStats,
+		supportsUTMStats: ! isOldJetpack,
 	};
 } )( localize( StatsSummary ) );

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -4,6 +4,9 @@ import version_compare from 'calypso/lib/version-compare';
 import { getJetpackVersion } from 'calypso/state/sites/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 
+// TODO: Update the version check for the real number of Odyssey Stats v2.
+const ODYSSEY_STATS_V2_MIN_VERSION = '14.6';
+
 const version_greater_than_or_equal = (
 	version: string | null,
 	compareVersion: string,
@@ -69,8 +72,11 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			isOdysseyStats
 		),
 		supportsWpcomV3Jitm: version_greater_than_or_equal( jetpackVersion, '14.5', isOdysseyStats ),
-		// TODO: Update the version check for the real number of Odyssey Stats v2.
-		isOldJetpack: ! version_greater_than_or_equal( jetpackVersion, '14.6', isOdysseyStats ),
+		isOldJetpack: ! version_greater_than_or_equal(
+			jetpackVersion,
+			ODYSSEY_STATS_V2_MIN_VERSION,
+			isOdysseyStats
+		),
 	};
 }
 

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -43,9 +43,9 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.16.0-alpha',
 			isOdysseyStats
 		),
-		// Deprecating and is replaced with `isOldJetpack`.
+		// Deprecated: Use `isOldJetpack` instead.
 		supportsUTMStats: ! isOdysseyStats || !! statsAdminVersion,
-		// Deprecating and is replaced with `isOldJetpack`.
+		// Deprecated: Use `isOldJetpack` instead.
 		supportsDevicesStats: ! isOdysseyStats || !! statsAdminVersion,
 		supportsOnDemandCommercialClassification: version_greater_than_or_equal(
 			statsAdminVersion,
@@ -57,7 +57,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.22.0',
 			isOdysseyStats
 		),
-		// Deprecating and is replaced with `isOldJetpack`.
+		// Deprecated: Use `isOldJetpack` instead.
 		supportsLocationsStats: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.24.0',

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { createSelector } from '@automattic/state-utils';
 import version_compare from 'calypso/lib/version-compare';
-import { getJetpackVersion, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getJetpackVersion } from 'calypso/state/sites/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 
 const version_greater_than_or_equal = (
@@ -16,9 +16,6 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const statsAdminVersion = getJetpackStatsAdminVersion( state, siteId );
 	const jetpackVersion = getJetpackVersion( state, siteId );
-	const isSiteJetpackNotAtomic = isJetpackSite( state, siteId, {
-		treatAtomicAsJetpackSite: false,
-	} );
 
 	return {
 		supportsHighlightsSettings: version_greater_than_or_equal(
@@ -46,7 +43,9 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.16.0-alpha',
 			isOdysseyStats
 		),
+		// Deprecating and is replaced with `isOldJetpack`.
 		supportsUTMStats: ! isOdysseyStats || !! statsAdminVersion,
+		// Deprecating and is replaced with `isOldJetpack`.
 		supportsDevicesStats: ! isOdysseyStats || !! statsAdminVersion,
 		supportsOnDemandCommercialClassification: version_greater_than_or_equal(
 			statsAdminVersion,
@@ -69,10 +68,8 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			isOdysseyStats
 		),
 		supportsWpcomV3Jitm: version_greater_than_or_equal( jetpackVersion, '14.5', isOdysseyStats ),
-		isOldJetpack:
-			isSiteJetpackNotAtomic &&
-			!! statsAdminVersion &&
-			! version_greater_than_or_equal( statsAdminVersion, '0.19.0-alpha', isOdysseyStats ),
+		// TODO: Update the version check for the real number of Odyssey Stats v2.
+		isOldJetpack: ! version_greater_than_or_equal( jetpackVersion, '14.6', isOdysseyStats ),
 	};
 }
 
@@ -80,9 +77,6 @@ const getEnvStatsFeatureSupportChecksMemoized = createSelector(
 	getEnvStatsFeatureSupportChecks,
 	( state, siteId ) => [
 		getJetpackStatsAdminVersion( state, siteId ),
-		isJetpackSite( state, siteId, {
-			treatAtomicAsJetpackSite: false,
-		} ),
 		config.isEnabled( 'is_running_in_jetpack_site' ),
 		getJetpackVersion( state, siteId ),
 	]

--- a/client/state/sites/selectors/get-env-stats-feature-supports.ts
+++ b/client/state/sites/selectors/get-env-stats-feature-supports.ts
@@ -57,6 +57,7 @@ function getEnvStatsFeatureSupportChecks( state: object, siteId: number | null )
 			'0.22.0',
 			isOdysseyStats
 		),
+		// Deprecating and is replaced with `isOldJetpack`.
 		supportsLocationsStats: version_greater_than_or_equal(
 			statsAdminVersion,
 			'0.24.0',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
