### PR TITLE
[DO NOT MERGE] Update/stats odyssey v2 upgrade banner

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -14,6 +14,7 @@ const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	// TODO: Check if the site needs to be upgraded to a higher tier on the back end.
 	tier_upgrade: true,
 	gdpr_cookie_consent: false,
+	jetpack_version_upgrade: true,
 	[ NOTICES_KEY_ABLE_TO_SUBMIT_FEEDBACK ]: true,
 	[ NOTICES_KEY_SHOW_FLOATING_USER_FEEDBACK_PANEL ]: true,
 };
@@ -37,6 +38,7 @@ const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
 		'gdpr_cookie_consent',
 		'client_paid_plan_purchase_success',
 		'client_free_plan_purchase_success',
+		'jetpack_version_upgrade',
 		'do_you_love_jetpack_stats',
 		'commercial_site_upgrade',
 		// TODO: Check if the current usage is over the tier limit inside the isVisibleFunc.

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -3,6 +3,7 @@ import CommercialSiteUpgradeNotice from './commercial-site-upgrade-notice';
 import DoYouLoveJetpackStatsNotice from './do-you-love-jetpack-stats-notice';
 import FreePlanPurchaseSuccessJetpackStatsNotice from './free-plan-purchase-success-notice';
 import GDPRCookieConsentNotice from './gdpr-cookie-consent-notice';
+import JetpackVersionUpgradeNotice from './jetpack-version-upgrade-notice';
 import PaidPlanPurchaseSuccessJetpackStatsNotice from './paid-plan-purchase-success-notice';
 import TierUpgradeNotice from './tier-upgrade-notice';
 import { StatsNoticeProps } from './types';
@@ -28,6 +29,13 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		noticeId: 'client_free_plan_purchase_success',
 		isVisibleFunc: ( { statsPurchaseSuccess }: StatsNoticeProps ) =>
 			statsPurchaseSuccess === 'free',
+		disabled: false,
+	},
+	{
+		// Force show the Jetpack version upgrade notice for testing
+		component: JetpackVersionUpgradeNotice as React.ComponentType< StatsNoticeProps >,
+		noticeId: 'jetpack_version_upgrade',
+		isVisibleFunc: () => true, // Always show for testing
 		disabled: false,
 	},
 	{

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -32,10 +32,14 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		disabled: false,
 	},
 	{
-		// Force show the Jetpack version upgrade notice for testing
 		component: JetpackVersionUpgradeNotice as React.ComponentType< StatsNoticeProps >,
 		noticeId: 'jetpack_version_upgrade',
-		isVisibleFunc: () => true, // Always show for testing
+		isVisibleFunc: ( { isOdysseyStats }: StatsNoticeProps ) => {
+			if ( ! isOdysseyStats ) {
+				return false;
+			}
+			return true;
+		},
 		disabled: false,
 	},
 	{

--- a/client/my-sites/stats/stats-notices/jetpack-version-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/jetpack-version-upgrade-notice.tsx
@@ -5,27 +5,18 @@ import versionCompare from 'calypso/lib/version-compare';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { StatsNoticeProps } from './types';
 
-const JetpackVersionUpgradeNotice: React.FC< StatsNoticeProps > = ( {
-	siteId,
-	isOdysseyStats,
-} ) => {
+const JetpackVersionUpgradeNotice: React.FC< StatsNoticeProps > = ( { siteId } ) => {
 	const translate = useTranslate();
 	const currentVersion = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'jetpack_version' )
 	);
 	const siteAdminUrl = useSelector( ( state ) => getSiteOption( state, siteId, 'admin_url' ) );
 
-	// Only show for Odyssey stats
-	if ( ! isOdysseyStats ) {
-		return null;
-	}
-
 	// Get latest version from WP.org API or Calypso state
-	const latestVersion = '12.9'; // This should be fetched from an API
+	const latestVersion = '15'; // This should be fetched from an API
 
-	const needsUpgrade = currentVersion && versionCompare( currentVersion, latestVersion, '<' );
-
-	if ( ! needsUpgrade ) {
+	// If we don't have version info yet or we're up to date, don't show anything
+	if ( ! currentVersion || ! versionCompare( currentVersion, latestVersion, '<' ) ) {
 		return null;
 	}
 

--- a/client/my-sites/stats/stats-notices/jetpack-version-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/jetpack-version-upgrade-notice.tsx
@@ -1,0 +1,60 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import Banner from 'calypso/components/banner';
+import versionCompare from 'calypso/lib/version-compare';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { StatsNoticeProps } from './types';
+
+const JetpackVersionUpgradeNotice: React.FC< StatsNoticeProps > = ( {
+	siteId,
+	isOdysseyStats,
+} ) => {
+	const translate = useTranslate();
+	const currentVersion = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'jetpack_version' )
+	);
+	const siteAdminUrl = useSelector( ( state ) => getSiteOption( state, siteId, 'admin_url' ) );
+
+	// Only show for Odyssey stats
+	if ( ! isOdysseyStats ) {
+		return null;
+	}
+
+	// Get latest version from WP.org API or Calypso state
+	const latestVersion = '12.9'; // This should be fetched from an API
+
+	const needsUpgrade = currentVersion && versionCompare( currentVersion, latestVersion, '<' );
+
+	if ( ! needsUpgrade ) {
+		return null;
+	}
+
+	const updateUrl = `${ siteAdminUrl }update-core.php`;
+
+	return (
+		<Banner
+			className="jetpack-version-upgrade-notice"
+			title={ translate( 'Jetpack Update Available' ) }
+			description={ translate(
+				'Update Jetpack from version %(currentVersion)s to %(latestVersion)s to access the latest Stats features and improvements.',
+				{
+					args: {
+						currentVersion: String( currentVersion ),
+						latestVersion,
+					},
+				}
+			) }
+			callToAction={ translate( 'Update Now' ) }
+			href={ updateUrl }
+			icon="plugins"
+			disableHref={ ! updateUrl }
+			horizontal
+			dismissPreferenceName="jetpack-version-upgrade-notice"
+			tracksImpressionName="calypso_jetpack_version_upgrade_view"
+			tracksClickName="calypso_jetpack_version_upgrade_click"
+			tracksDismissName="calypso_jetpack_version_upgrade_dismiss"
+		/>
+	);
+};
+
+export default JetpackVersionUpgradeNotice;

--- a/client/my-sites/stats/stats-notices/style.scss
+++ b/client/my-sites/stats/stats-notices/style.scss
@@ -60,3 +60,11 @@
 		}
 	}
 }
+
+.jetpack-version-upgrade-notice {
+	margin-bottom: 16px;
+	
+	&.is-dismissible {
+		padding-right: 48px;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
