### PR TITLE
Standardise on using Odie assistant for transfer and upgrade help

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -211,10 +211,7 @@ export const EligibilityWarnings = ( {
 
 			<CompactCard>
 				<div className="eligibility-warnings__confirm-buttons">
-					<SupportLink
-						shouldUseHelpAssistant={ context === 'plugin-details' }
-						onShowHelpAssistant={ onDismiss }
-					/>
+					<SupportLink onShowHelpAssistant={ onDismiss } />
 					<Button
 						variant="primary"
 						__next40pxDefaultSize

--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -43,7 +43,7 @@ interface ExternalProps {
 	siteId?: number | null;
 	isEligible?: boolean;
 	backUrl?: string;
-	onDismiss?: () => void;
+	onDismiss?: () => void; // If rendered in a modal this is required. Used to dismiss the modal when accessing the help assistant.
 	onProceed: ( options: { geo_affinity?: string } ) => void;
 	standaloneProceed: boolean;
 	className?: string;

--- a/client/blocks/eligibility-warnings/support-link.tsx
+++ b/client/blocks/eligibility-warnings/support-link.tsx
@@ -10,7 +10,6 @@ import {
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import ActionPanelLink from 'calypso/components/action-panel/link';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import type { HelpCenterSelect } from '@automattic/data-stores';
 
@@ -19,10 +18,8 @@ const HELP_CENTER_STORE = HelpCenter.register();
 const SupportLink = ( {
 	onShowHelpAssistant = () => {},
 	translate,
-	shouldUseHelpAssistant = false,
 }: {
 	onShowHelpAssistant?: () => void;
-	shouldUseHelpAssistant?: boolean;
 } & LocalizeProps ) => {
 	const sectionName = useSelector( getSectionName );
 	const { show, isMinimized } = useDateStoreSelect( ( select ) => {
@@ -74,22 +71,11 @@ const SupportLink = ( {
 
 	return (
 		<div className="support-block">
-			{ shouldUseHelpAssistant ? (
-				translate( '{{button}}Need help?{{/button}}', {
-					components: {
-						button: <Button variant="link" onClick={ handleShowHelpAssistant } />,
-					},
-				} )
-			) : (
-				<>
-					<span>{ translate( 'Need help?' ) }</span>
-					{ translate( '{{a}}Contact support{{/a}}', {
-						components: {
-							a: <ActionPanelLink href="/help/contact" />,
-						},
-					} ) }
-				</>
-			) }
+			{ translate( '{{button}}Need help?{{/button}}', {
+				components: {
+					button: <Button variant="link" onClick={ handleShowHelpAssistant } />,
+				},
+			} ) }
 		</div>
 	);
 };

--- a/client/blocks/eligibility-warnings/test/index.tsx
+++ b/client/blocks/eligibility-warnings/test/index.tsx
@@ -212,31 +212,16 @@ describe( '<EligibilityWarnings>', () => {
 		expect( handleProceed ).not.toHaveBeenCalled();
 	} );
 
-	it( 'renders a help center button if the context is plugin-details', async () => {
-		const state = createState( {} );
-
-		const { getByText, queryByText } = renderWithStore(
-			<EligibilityWarnings backUrl="" onProceed={ noop } currentContext="plugin-details" />,
-			state
-		);
-
-		expect( queryByText( 'Contact support' ) ).toBeNull();
-		const helpCenterButton = getByText( 'Need help?' );
-		expect( helpCenterButton ).toBeVisible();
-		expect( helpCenterButton ).toBeInstanceOf( HTMLButtonElement );
-	} );
-
-	it( 'renders a contact support link if the context is not plugin-details', async () => {
+	it( 'renders a help button', async () => {
 		const state = createState( {} );
 
 		const { getByText } = renderWithStore(
-			<EligibilityWarnings backUrl="" onProceed={ noop } currentContext="foo" />,
+			<EligibilityWarnings backUrl="" onProceed={ noop } />,
 			state
 		);
 
-		expect( getByText( 'Need help?' ) ).toBeVisible();
-		const contactSupportLink = getByText( 'Contact support' );
-		expect( contactSupportLink ).toBeVisible();
-		expect( contactSupportLink ).toBeInstanceOf( HTMLAnchorElement );
+		const helpCenterButton = getByText( 'Need help?' );
+		expect( helpCenterButton ).toBeVisible();
+		expect( helpCenterButton ).toBeInstanceOf( HTMLButtonElement );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/eligibility-warnings-modal.tsx
@@ -28,6 +28,7 @@ export const EligibilityWarningsModal = ( {
 				standaloneProceed
 				isOnboarding
 				isMarketplace={ isMarketplace }
+				onDismiss={ handleClose }
 				onProceed={ handleContinue }
 			/>
 		</Dialog>

--- a/client/sites/hosting/components/hosting-activation-button.tsx
+++ b/client/sites/hosting/components/hosting-activation-button.tsx
@@ -56,6 +56,7 @@ export default function HostingActivationButton( { redirectUrl }: HostingActivat
 				>
 					<EligibilityWarnings
 						className="hosting__activating-warnings"
+						onDismiss={ () => setShowEligibility( false ) }
 						onProceed={ handleTransfer }
 						backUrl={ redirectUrl }
 						showDataCenterPicker


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #102583

## Proposed Changes

Consistently open a new Odie chat for all help flows regarding eligibility warnings, eg. for transfers to atomic, making the site public, etc.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Chat is a more useful and engaging experience than being redirected to the support page with no context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Activate hosting

1. Test on a site with a business plan that hasn't been transferred to atomic yet (the site URL should be [sitename].wordpress.com)
2. Go to the Hosting Overview screen and, under "Hosting Features", click "Activate now" to show the modal
3. Click the 'Need help?' link
4. The modal should close and the help center should open with a new Odie chat started

![calypso localhost_3000_sites(Desktop) (4)](https://github.com/user-attachments/assets/12fc99ba-ac21-42ae-9b25-b49adf8967c0)

#### Activate performance

1. Test on a private atomic site (the site URL should be [sitename].wpcomstaging.com)
2. Open http://calypso.localhost:3000/settings/performance/[sitename].wpcomstaging.com and the eligibility warnings info should be displayed inline within the page
3. Click the 'Need help?' link
4. The help center should open with a new Odie chat started

![calypso localhost_3000_settings_performance_pixelantics66 wpcomstaging com(Desktop)](https://github.com/user-attachments/assets/7dcef967-57a4-4963-bcd9-e9051f58f474)

#### Select external theme

1. Start adding a new site
2. Choose a free domain name and the free plan
3. Step through until you reach the theme picker step (http://calypso.localhost:3000/setup/site-setup/design-setup?...)
4. Search for SolarOne (an externally managed theme), select it, click 'Unlock theme', then 'Continue' in the next modal, which should open the eligibility warnings modal
5. Click the 'Need help?' link
6. The modal should close and the help center should open with a new Odie chat started

![calypso localhost_3000_setup_site-setup_design-setup_siteSlug=fhtrhdy wordpress com sessionId=5O categories=business theme=the-shore style_variation=pristine-white(Desktop)](https://github.com/user-attachments/assets/f8b1b20d-f08d-4c1a-b2a1-823cc6147b44)

#### Upload theme

1. Test on a site with a business plan that hasn't been transferred to atomic yet (the site URL should be [sitename].wordpress.com)
2. In the Themes Marketplace, click 'Upload new theme' and the eligibility warnings info should be displayed inline within the page
3. Click the 'Need help?' link
4. The help center should open with a new Odie chat started

![calypso localhost_3000_sites(Desktop)](https://github.com/user-attachments/assets/4b714986-533b-4717-8e65-b900aad5c636)

#### Activate theme

1. Test on a site with a business plan that hasn't been transferred to atomic yet (the site URL should be [sitename].wordpress.com)
2. In the Themes Marketplace, search for and select "Kiosko". Click "Activate" to show the modal
3. Click the 'Need help?' link
4. The modal should close and the help center should open with a new Odie chat started

![calypso localhost_3000_sites(Desktop) (3)](https://github.com/user-attachments/assets/35be772a-2559-4b28-8107-5c50eddf59a9)

#### Upload plugin

1. Test on any simple site (the site URL should be [sitename].wordpress.com)
2. In the plugins marketplace click the 'Upload' button and the eligibility warnings info should be displayed inline within the page
3. Click the 'Need help?' link
4. The help center should open with a new Odie chat started

![calypso localhost_3000_sites(Desktop) (2)](https://github.com/user-attachments/assets/3cebabd1-9633-42a8-8844-ba1a2a3d5199)

#### Activate plugin

1. Navigate to a plugin details page, eg. [http://calypso.localhost:3000/plugins/elementor/{your-domain}.wordpress.com](http://calypso.localhost:3000/plugins/elementor/%7Byour-domain%7D.wordpress.com)
2. Click the 'Upgrade and activate' button and observe the eligibility modal opening
3. Click the 'Need help?' link
4. The modal should close and the help center should open with a new Odie chat started

![calypso localhost_3000_sites(Desktop) (1)](https://github.com/user-attachments/assets/7e776a51-92a5-4457-b358-ca16025c854d)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
