### PR TITLE
Untangled Plans: open the add-ons modal on add-ons-modal=true param

### DIFF
--- a/client/my-sites/add-ons/controller.tsx
+++ b/client/my-sites/add-ons/controller.tsx
@@ -1,5 +1,8 @@
 import page, { type Callback } from '@automattic/calypso-router';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { isPlansPageUntangled } from 'calypso/lib/plans/untangling-plans-experiment';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AddOnsMain from './main';
 
@@ -21,6 +24,17 @@ export const addOnsManagement: Callback = ( context, next ) => {
 
 	if ( ! selectedSite ) {
 		page.redirect( '/add-ons' );
+
+		return null;
+	}
+
+	if ( isPlansPageUntangled( state ) ) {
+		page.redirect(
+			addQueryArgs( `/plans/${ context.params.site }`, {
+				...getCurrentQueryArguments( state ),
+				'add-ons-modal': true,
+			} )
+		);
 
 		return null;
 	}

--- a/client/sites/components/add-ons/manage-add-ons-button/index.tsx
+++ b/client/sites/components/add-ons/manage-add-ons-button/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useRouteModal } from 'calypso/lib/route-modal';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AddOnsModal from '../add-ons-modal';
 
@@ -12,11 +13,18 @@ type ManageAddOnsButtonProps = {
 export default function ManageAddOnsButton( { tracksEventName }: ManageAddOnsButtonProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ isManageAddOnsModalOpen, setIsManageAddOnsModalOpen ] = useState( false );
+
+	const { isModalOpen, closeModal } = useRouteModal( 'add-ons-modal' );
+	const [ isManageAddOnsModalOpen, setIsManageAddOnsModalOpen ] = useState( isModalOpen );
 
 	const onClick = () => {
 		dispatch( recordTracksEvent( tracksEventName ) );
 		setIsManageAddOnsModalOpen( true );
+	};
+
+	const onCloseAddOnsModal = () => {
+		closeModal();
+		setIsManageAddOnsModalOpen( false );
 	};
 
 	return (
@@ -24,10 +32,7 @@ export default function ManageAddOnsButton( { tracksEventName }: ManageAddOnsBut
 			<Button variant="tertiary" onClick={ onClick }>
 				{ translate( 'Manage add-ons' ) }
 			</Button>
-			<AddOnsModal
-				isOpen={ isManageAddOnsModalOpen }
-				onClose={ () => setIsManageAddOnsModalOpen( false ) }
-			/>
+			<AddOnsModal isOpen={ isManageAddOnsModalOpen } onClose={ onCloseAddOnsModal } />
 		</>
 	);
 }

--- a/client/sites/plan/test/index.tsx
+++ b/client/sites/plan/test/index.tsx
@@ -67,8 +67,9 @@ describe( '/plans/:siteSlug', () => {
 		window.scrollTo = originalScrollTo;
 	} );
 
-	const renderPage = () => {
+	const renderPage = ( { initialPath } = {} ) => {
 		renderWithProvider( <PlansWrapper context={ { path: '/plans' } } />, {
+			initialPath,
 			initialState,
 			reducers: {
 				ui: uiReducer,
@@ -84,11 +85,11 @@ describe( '/plans/:siteSlug', () => {
 		( isEnabled as jest.Mock ).mockImplementation( configMock( { 'untangling/plans': true } ) );
 
 		( useCurrentPlan as jest.Mock ).mockReturnValue( mockPlan );
-
-		renderPage();
 	} );
 
 	describe( "'Manage add-ons' button", () => {
+		beforeEach( renderPage );
+
 		it( 'should be visible', () => {
 			expect( screen.getByRole( 'button', { name: 'Manage add-ons' } ) ).toBeInTheDocument();
 		} );
@@ -112,6 +113,20 @@ describe( '/plans/:siteSlug', () => {
 					'Boost your plan with add-ons'
 				);
 			} );
+		} );
+	} );
+
+	describe( "when the '?add-ons-modal=true' query param is present", () => {
+		beforeEach( () => {
+			renderPage( { initialPath: '?add-ons-modal=true' } );
+		} );
+
+		it( 'should show the add-ons modal initially', () => {
+			const dialog = screen.getByRole( 'dialog' );
+			expect( dialog ).toBeInTheDocument();
+			expect( within( dialog ).getByRole( 'heading' ) ).toHaveTextContent(
+				'Boost your plan with add-ons'
+			);
 		} );
 	} );
 } );

--- a/client/test-helpers/testing-library/index.js
+++ b/client/test-helpers/testing-library/index.js
@@ -5,10 +5,12 @@ import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import { thunk as thunkMiddleware } from 'redux-thunk';
 import initialReducer from 'calypso/state/reducer';
+import { setRoute } from 'calypso/state/route/actions';
+import routeReducer from 'calypso/state/route/reducer';
 
 export const renderWithProvider = (
 	ui,
-	{ initialState, store = null, reducers, ...renderOptions } = {}
+	{ initialPath, initialState, store = null, reducers, ...renderOptions } = {}
 ) => {
 	const queryClient = new QueryClient();
 
@@ -21,7 +23,18 @@ export const renderWithProvider = (
 			}
 		}
 
+		if ( initialPath ) {
+			reducer = reducer.addReducer( [ 'route' ], routeReducer );
+		}
+
 		store = createStore( reducer, initialState, applyMiddleware( thunkMiddleware ) );
+
+		if ( initialPath ) {
+			const { pathname, search } = new URL( window.location.href + initialPath );
+			const searchParams = new URLSearchParams( search );
+			const query = Object.fromEntries( searchParams.entries() );
+			store.dispatch( setRoute( pathname, query ) );
+		}
 	}
 
 	const Wrapper = ( { children } ) => (


### PR DESCRIPTION
Fixes DOTCOM-6407

## Proposed Changes

This PR routes the `/add-ons/:site` (Upgrades/Hosting -> Add-ons) menu to the newly untangled Plans page, with the add-ons modal shown by default.

<img width="438" alt="image" src="https://github.com/user-attachments/assets/17de3387-7728-4966-9b11-bf96ff9e739d" />


## Why are these changes being made?

pbxlJb-6Xi-p2

## Testing Instructions

1. Go to `/home/:site?flags=untangling/plans` of a Free site
2. Go to (Upgrades/Hosting) -> Add-ons
3. Verify that you land in the Plans page with the Add-ons modal shown.

## REGRESSION TESTING:
1. Go to `/home/:site` of that site (notice no flag)
2. Go to (Upgrades/Hosting) -> Add-ons
3. Verify that you land in the existing Add-ons page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?