### PR TITLE
Magic login: Don't show magic login when it's not allowed

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -37,7 +37,7 @@ class RequestLoginEmailForm extends Component {
 		isFetching: PropTypes.bool,
 		isJetpackMagicLinkSignUpEnabled: PropTypes.bool,
 		redirectTo: PropTypes.string,
-		requestError: PropTypes.string,
+		requestError: PropTypes.object,
 		showCheckYourEmail: PropTypes.bool,
 		userEmail: PropTypes.string,
 		flow: PropTypes.string,
@@ -213,8 +213,8 @@ class RequestLoginEmailForm extends Component {
 			! isSubmitButtonDisabled;
 
 		const errorText =
-			typeof requestError === 'string' && requestError.length
-				? requestError
+			typeof requestError?.message === 'string' && requestError?.message.length
+				? requestError?.message
 				: translate( 'Unable to complete request' );
 
 		const buttonLabel = translate( 'Send link' );

--- a/client/state/data-layer/wpcom/auth/send-login-email/index.js
+++ b/client/state/data-layer/wpcom/auth/send-login-email/index.js
@@ -118,7 +118,12 @@ export const onError = (
 	error
 ) => [
 	...( loginFormFlow || requestLoginEmailFormFlow
-		? [ { type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR, error: error.message } ]
+		? [
+				{
+					type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR,
+					error: { code: error.error, message: error.message },
+				},
+		  ]
 		: [] ),
 	...( requestLoginEmailFormFlow
 		? [


### PR DESCRIPTION
Fixes JETPACK-255

Currently, when coming from the new Jetpack onboarding, you are presented the default option of signing in via magic link. It works great, except when the user is not allowed to login via magic link, e.g. Automatticians.

<details>
<summary>Thus, such users see the error by default, which is not intuitive</summary>
<img width="823" alt="Screenshot 2025-04-02 at 19 23 28" src="https://github.com/user-attachments/assets/7d44c89b-d1e3-428c-8b9c-b694b99f6229" />
</details>

We can do a better job at not having the user end up here, if they can't use it.

So, I have created a wpcom patch (180527-ghe-Automattic/wpcom) to update the error code when the user can't login via the magic link and this PR makes use of that error code to appropriately handle such a case.

## Proposed Changes

* Update the magic email response error state to store both the `code` and the `message`
* Use the error `code` to decide if we should avoid showing magic login if the user can't use it, i.e. to switch to the default password login.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 180527-ghe-Automattic/wpcom to your sandbox
* Point `public-api.wordpress.com` to your sandbox
* Run this PR, via any of these two options
    - Run `yarn start` and use `http://calypso.localhost:3000`
    - Use the Calypso Live link below
* As an Automattician on wp.com, try to start the onboarding session for a site from the "My Jetpack" section
* Once you enter the email and land at the magic login step, you should see the error saying that you can't request a login link
* Replace `https://wordpress.com` with either `http://calypso.localhost:3000` or the Calypso Live link domain and hit enter
* Confirm that you don't see the error regarding magic link
* Confirm that you are presented with the default login method
* Goto `/log-in`
* Click on `Email me a login link` and continue with the email address associated with your Automattician wpcom account
* Confirm that you see the error saying, `You’re not allowed to request a login link for this account.`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

- This is where you land if you can't use the magic login
    <img width="958" alt="Screenshot 2025-04-14 at 11 50 29 AM" src="https://github.com/user-attachments/assets/4928a71f-b58b-4ddd-ae5e-acb2e3b87f12" />
- This is the default flow when the user explicitly clicks on `Email me a login link` from `/log-in`
    <img width="578" alt="Screenshot 2025-04-14 at 11 49 09 AM" src="https://github.com/user-attachments/assets/86e410cd-013f-49e7-973a-27b1c0699453" />

