### PR TITLE
Untangled plans: don't show underlines on navigational links

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -20,6 +20,11 @@ const StyledLi = styled.li`
 	font-size: 13px;
 	font-weight: 400;
 	--color-link: var( --studio-gray-50 );
+
+	a {
+		text-decoration: none;
+	}
+
 	& .info-popover {
 		align-self: flex-start;
 	}

--- a/client/sites/components/plan-stats/style.scss
+++ b/client/sites/components/plan-stats/style.scss
@@ -14,6 +14,10 @@ $blueberry-color: #3858e9;
 	line-height: 16px;
 	margin-top: 30px;
 
+	a {
+		text-decoration: none;
+	}
+
 	.plan-storage__bar {
 		width: 100%;
 		background: color-mix(in srgb, $blueberry-color 8%, transparent);


### PR DESCRIPTION
Fixes DOTCOM-1884

## Proposed Changes

This PR removes rogue underlines in the links in the Plans page, which was a "regression" from:

- https://github.com/Automattic/wp-calypso/pull/101358

The way I fix that uses similar approach as the above PR; i.e., adding `text-decoration: none` to specific components.

|Before|After|
|-|-|
|<img width="851" alt="image" src="https://github.com/user-attachments/assets/a70cd598-0d43-474e-afc9-4e8cafad3ee6" />|<img width="839" alt="image" src="https://github.com/user-attachments/assets/444beec5-0945-4249-b844-82a456c6ac20" />|

Reasoning:

> Links that are part of navigational components (sidebar menus, breadcrumbs, cards, etc.) should not be underlined.

From:

- https://github.com/Automattic/wp-calypso/issues/99254#issuecomment-2633369448

## Why are these changes being made?

Fixes a visual bug.

## Testing Instructions

1. Go to /plans/:site?flags=untangling/plans.
2. Verify that the links (see screenshot above) no longer have underlines.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
