### PR TITLE
E2E README: Show use of CALYPSO_BASE_URL for testing on calypso.localhost

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -103,6 +103,12 @@ yarn workspace wp-e2e-tests build --watch
 yarn workspace wp-e2e-tests test -- <test_path>
 ```
 
+To run on calypso.localhost, don't forget the environment variable:
+
+```bash
+CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- <test_path>
+```
+
 ## Advanced setup
 
 Please refer to the [Advanced Setup](docs/setup.md) page.


### PR DESCRIPTION
## Proposed Changes

In the docs for E2E testing (``), alongside the instructions to run a test, add an example drawing attention to the necessary environment variable for testing on `calypso.localhost:3000`:

> To run on calypso.localhost, don't forget the environment variable:
> 
> ```bash
> CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- <test_path>
> 

## Why are these changes being made?
This was one of several gotchas I ran into when trying to run E2E tests on Calypso for the first time in many years.

## Pre-merge Checklist

_(Deleted, since there is no code in these changes and none of the checklist items apply.)_