### PR TITLE
verbum-block-editor: build the package and types in prepare step

### DIFF
--- a/packages/verbum-block-editor/package.json
+++ b/packages/verbum-block-editor/package.json
@@ -27,9 +27,10 @@
 		"build": "NODE_ENV=production yarn dev",
 		"upload": "yarn build && yarn translate && rsync -ahz --delete --exclude='.*' dist/ wpcom-sandbox:/home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"build:app": "calypso-build",
+		"build:package": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/verbum-block-editor",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"prepare": "yarn build",
+		"prepare": "yarn build:package",
 		"translate": "node ./bin/build-languages.js"
 	},
 	"dependencies": {


### PR DESCRIPTION
I was running into errors when running `yarn typecheck`: imports of `@automattic/verbum-block-editor` fail because the `dist/types` directory declared in the `types` field in `package.json` doesn't exist. Turns out that `yarn build-packages` doesn't always build it, probably when other `dist` sub-directories (`dist/cjs` or `dist/esm`) already exist.

And the `yarn run prepare` command that runs inside `build-packages` also doesn't build it. And that's what I'm fixing in this PR. The `prepare` script is supposed to prepare the package for consumption, i.e., build the `dist/{cjs,esm,types}` directories that are referenced in `package.json` fields. But instead it was building the Verbum Block Editor app that is synced to a wpcom sandbox. But we don't need that in the `prepare` script. Instead, I'm now running `tsc` to do the "real" prepare.

As a possible follow-up, I'm curious about the `build:app` scripts that runs `calypso-build`. What does it do? Isn't it redundant? After all, the "build the package" and "build the app" steps are already covered by other scripts.

## Testing instructions:
Verify that `yarn build-packages` builds the `dist/esm` and `dist/types` directories in `packages/verbum-block-editor`.