### PR TITLE
A4A: Make A4A Siteless checkout items non-removable from cart.

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -884,7 +884,7 @@ export interface ResponseCartProductExtra {
 	isJetpackCheckout?: boolean;
 	isAkismetSitelessCheckout?: boolean;
 	isMarketplaceSitelessCheckout?: boolean;
-	isA4aSitelessCheckout?: boolean;
+	isA4ASitelessCheckout?: boolean;
 	referral_id?: number;
 	agency_id?: number;
 

--- a/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
+++ b/packages/wpcom-checkout/src/can-item-be-removed-from-cart.ts
@@ -41,5 +41,10 @@ export function canItemBeRemovedFromCart(
 		return false;
 	}
 
+	// If the item is an A4A siteless checkout, it cannot be removed from the cart
+	if ( item.extra?.isA4ASitelessCheckout ) {
+		return false;
+	}
+
 	return true;
 }


### PR DESCRIPTION

A4A's siteless checkout retains all items in the cart, utilizing our A4A-specific client shopping cart. This approach helps prevent potential referral order issues for our clients. 

**NOTE: If the A4A checkout process, including Agency checkout, transitions to BillingDragon, we may need to reassess this guard here later.**

| Before | After |
|--------|--------|
| <img width="814" alt="Screenshot 2025-04-14 at 9 03 05 PM" src="https://github.com/user-attachments/assets/f8c69c9a-a332-4a1a-8e2f-715bb76eadbd" /> | <img width="726" alt="Screenshot 2025-04-14 at 9 03 14 PM" src="https://github.com/user-attachments/assets/32755862-bc74-440f-ae2e-5fbe69e0e88e" /> | 

## Proposed Changes

* Update the `canItemBeRemovedFromCart` helper function to account for the additional field `isA4ASitelessCheckout`. If this exists, it indicates that this is an A4A-specific checkout item and should not be removable.

## Why are these changes being made?

This is part of the Referrals move to BillingDragon project.

## Testing Instructions

* Create a referral order from `agencies.automattic.com/marketplace`
* Access the magic link from your email.
* Once you are on the checkout page. Change the domain `agencies.automattic.com` and use the live link. Update the path to `/client/checkout/v2` so that you access the new checkout page.
* Confirm that the checkout page do not show the **'Remove from cart'** button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
