### PR TITLE
Update Studio links to the latest build 1.4.0 on /me/get-apps page

### DIFF
--- a/client/blocks/get-apps/apps-config.tsx
+++ b/client/blocks/get-apps/apps-config.tsx
@@ -160,17 +160,17 @@ export const createWordPressStudioConfig = (
 			[ PlatformType.MacIntel ]: {
 				...platformConfigs[ PlatformType.MacIntel ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.3.9.dmg',
+				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.4.0.dmg',
 			},
 			[ PlatformType.MacSilicon ]: {
 				...platformConfigs[ PlatformType.MacSilicon ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_mac_silicon_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.3.9.dmg',
+				link: 'https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.4.0.dmg',
 			},
 			[ PlatformType.Windows ]: {
 				...platformConfigs[ PlatformType.Windows ],
 				onClick: () => recordTracksEvent( 'calypso_studio_download_windows_click' ),
-				link: 'https://cdn.a8c-ci.services/studio/studio-win32-v1.3.9.exe',
+				link: 'https://cdn.a8c-ci.services/studio/studio-win32-v1.4.0.exe',
 			},
 		},
 	};


### PR DESCRIPTION
Updating Studio download links to 1.4.0, according to Studio release P2 - pfHvTO-tH-p2

Visual review should suffice