### PR TITLE
Site migration: Track signup events regardless the flow name

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
@@ -5,7 +5,6 @@ import siteMigration from '../site-migration-flow/site-migration-flow';
 const hostedSiteMigrationFlow: Flow = {
 	...siteMigration,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
-	isSignupFlow: true,
 };
 
 export default hostedSiteMigrationFlow;

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -58,7 +58,14 @@ const hasSite = ( siteId: number, siteSlug: string ) => {
 
 const siteMigration: FlowV2 = {
 	name: SITE_MIGRATION_FLOW,
-	isSignupFlow: false,
+	get isSignupFlow() {
+		const searchParams = new URLSearchParams( window.location.search );
+		const hasDestinationSite = [
+			searchParams.has( 'siteSlug' ),
+			searchParams.has( 'siteId' ),
+		].some( Boolean );
+		return ! hasDestinationSite;
+	},
 	__experimentalUseSessions: true,
 	__experimentalUseBuiltinAuth: true,
 

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -78,6 +78,27 @@ describe( 'Site Migration Flow', () => {
 		jest.restoreAllMocks();
 	} );
 
+	describe( 'isSignupFlow', () => {
+		afterEach( () => {
+			window.location.search = '';
+		} );
+
+		it( 'returns false when there is siteSlug on query params', () => {
+			window.location.search = '?siteSlug=123';
+			expect( siteMigrationFlow.isSignupFlow ).toBe( false );
+		} );
+
+		it( 'returns false when there is siteId on query params', () => {
+			window.location.search = '?siteId=123';
+			expect( siteMigrationFlow.isSignupFlow ).toBe( false );
+		} );
+
+		it( 'returns true when there is no siteSlug or siteId on query params', () => {
+			window.location.search = '';
+			expect( siteMigrationFlow.isSignupFlow ).toBe( true );
+		} );
+	} );
+
 	describe( 'useAssertConditions', () => {
 		it( 'redirects the user to the start page when the user is not a site admin', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -63,7 +63,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ hasEmptyActionRun, setHasEmptyActionRun ] = useState( false );
-	const [ destinationState, setDestinationState ] = useState( {} );
+	const [ destinationState, setDestinationState ] = useState< { siteCreated?: boolean } >( {} );
 
 	/**
 	 * There is a long-term bug here that the `submit` function will be called multiple times if we
@@ -165,11 +165,8 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		if ( hasActionSuccessfullyRun && ! isSubmittedRef.current ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
 
-			if ( 'siteCreated' in destinationState ) {
-				const { siteCreated } = destinationState;
-				if ( siteCreated ) {
-					recordSignupComplete( { ...destinationState } );
-				}
+			if ( destinationState.siteCreated ) {
+				recordSignupComplete( { ...destinationState } );
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -14,7 +14,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
-import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordSignupProcessingScreen } from 'calypso/lib/analytics/signup';
@@ -165,12 +164,12 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	useEffect( () => {
 		if ( hasActionSuccessfullyRun && ! isSubmittedRef.current ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
-			if ( availableFlows[ flow ] ) {
-				availableFlows[ flow ]().then( ( flowExport ) => {
-					if ( flowExport.default.isSignupFlow ) {
-						recordSignupComplete( { ...destinationState } );
-					}
-				} );
+
+			if ( 'siteCreated' in destinationState ) {
+				const { siteCreated } = destinationState;
+				if ( siteCreated ) {
+					recordSignupComplete( { ...destinationState } );
+				}
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {


### PR DESCRIPTION
Related to DOTOBRD-99

## Proposed Changes
* Dynamically define the isSignupFlow flag based on the presence of siteId/siteSlug
* Trigger the `calypso_signup_complete` always a site is created. 


## Why are these changes being made?
It is part of the effort to unify the site-migration and hosted-site-migration flows.
We need to proper identify when the flow is used with sign-up purposes to better understand our tracking. A sign-in flow is a flow which lead the user to create a new site.

## Testing Instructions
### Sign-up Flow
* Go to /setup/hosted-site-migration
* Click on "pick your current platform from a list" 
* Click on "create a new one" 
* After the site creation, check if `calypso_signup_start` and  `calypso_signup_complete` were triggered 


### Sign-up Flows
NonSign-up Flow
* Create a free site
* Go to /setup/hosted-site-migration?siteSlug={YOUR_SITE_SLIG}
* Set any non-WPCOM WordPress site  (E.g wordpress.org)
* Follow the steps until the  the "What do you want to do?" step
* Check if `calypso_signup_start` and  `calypso_signup_complete` were  NOT triggered


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?