### PR TITLE
Fix HB courses in non-EN locales

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -49,13 +49,20 @@ $signup_url      = localized_wpcom_url( 'https://wordpress.com/log-in?redirect_t
 		<?php if ( $site_type === 'support' ) : ?>
 			<div class="support-content-resource">
 				<h4 class="support-content-resource__title">
-					<?php esc_html_e( 'Watch a course', 'happy-blocks' ); ?>
+					<?php if ( get_locale() === 'en' ) : ?>
+						<?php esc_html_e( 'Watch a course', 'happy-blocks' ); ?>
+					<?php else : ?>
+						<?php esc_html_e( 'Watch a course (in English)', 'happy-blocks' ); ?>
+					<?php endif; ?>
 				</h4>
 				<p>
 					<?php esc_html_e( 'Learn how to create a website with our step-by-step video course.', 'happy-blocks' ); ?>
+					<?php if ( get_locale() !== 'en' ) : ?>
+						<br /> <br /><em><?php esc_html_e( 'Available in English only.', 'happy-blocks' ); ?></em>
+					<?php endif; ?>
 				</p>
 				<div class="resource-link">
-					<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/courses/create-your-website/' ) ); ?>">
+					<a href="<?php echo esc_url( '//wordpress.com/support/courses/create-your-website/' ); ?>">
 						<?php esc_html_e( 'Create your website', 'happy-blocks' ); ?>
 					</a>
 				</div>


### PR DESCRIPTION
Courses are only available in English so this is indicates that on the footer of /support.