### PR TITLE
Reader notifications - make panel full content width if not wide enough to flyout.

### DIFF
--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -223,7 +223,9 @@ div.reader-notifications__panel {
 		&-internal {
 			display: none;
 			bottom: 0;
+			padding: 0 30px;
 			right: var(--default-notes-panel-width);
+
 
 			@media only screen and (min-width: $breakpoint-flyout) {
 				display: flex;

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -1,6 +1,7 @@
 /**
  * Notifications
  */
+ @import "@wordpress/base-styles/breakpoints";
 
 #wpnc-panel {
 	position: fixed;
@@ -166,9 +167,13 @@ html.touch #wpnc-panel {
 div.reader-notifications__panel {
 	position: relative;
 
+	// This flyout breakpoint is based off the notifications panel having enough width for its
+	// default 'flyout' functionality for the nested level. Using a more general breakpoint would
+	// prevent us from applying this functionality for another ~166px of screen width (based off of
+	// using the $break-wide which is the closest larger breakpoint).
 	$breakpoint-flyout: 1114px;
-	$breakpoint-mobile: 601px;
 
+	--default-notes-panel-width: 400px;
 	--3pc-notice-external-height: 50px;
 	@media only screen and (min-width: $breakpoint-flyout) {
 		--3pc-notice-external-height: 0px; /* stylelint-disable-line length-zero-no-unit */
@@ -183,7 +188,7 @@ div.reader-notifications__panel {
 
 		&.wpnt-open {
 			position: absolute;
-			@media only screen and (min-width: $breakpoint-mobile) {
+			@media only screen and (min-width: $break-small) {
 				border-radius: 8px; /* stylelint-disable-line scales/radii */
 				width: 100%;
 				.wpnc__single-view,
@@ -195,11 +200,11 @@ div.reader-notifications__panel {
 				width: calc(100vw - var(--sidebar-width-max) - 16px); // 16px for content frame padding.
 
 				.wpnc__single-view {
-					width: 400px; // Standard notes panel width.
+					width: var(--default-notes-panel-width);
 					z-index: z-index( ".reader-notifications", ".wpnc__single-view" ); // This ensures the single view flies out above the 3PC notice.
 				}
 				.wpnc__note-list {
-					width: 400px; // Standard notes panel width.
+					width: var(--default-notes-panel-width);
 					z-index: z-index( ".reader-notifications", ".wpnc__note-list" ); // This ensures the single view does not rise above the note list while animating outwards.
 				}
 			}
@@ -218,7 +223,7 @@ div.reader-notifications__panel {
 		&-internal {
 			display: none;
 			bottom: 0;
-			right: 400px; //width of main notifs panel
+			right: var(--default-notes-panel-width);
 
 			@media only screen and (min-width: $breakpoint-flyout) {
 				display: flex;

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -226,7 +226,6 @@ div.reader-notifications__panel {
 			padding: 0 30px;
 			right: var(--default-notes-panel-width);
 
-
 			@media only screen and (min-width: $breakpoint-flyout) {
 				display: flex;
 			}

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -175,7 +175,6 @@ div.reader-notifications__panel {
 	}
 
 	#wpnc-panel.wpnc__main {
-		// top: calc(var(--masterbar-height) + var(--content-padding-top) + var(--3pc-notice-external-height));
 		top: var(--3pc-notice-external-height);
 		height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom) - var(--3pc-notice-external-height));
 		box-shadow: -3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -167,7 +167,6 @@ div.reader-notifications__panel {
 	position: relative;
 
 	$breakpoint-flyout: 1114px;
-	$breakpoint-nested: 783px;
 	$breakpoint-mobile: 601px;
 
 	--3pc-notice-external-height: 50px;
@@ -176,29 +175,33 @@ div.reader-notifications__panel {
 	}
 
 	#wpnc-panel.wpnc__main {
-		top: calc(var(--masterbar-height) + var(--content-padding-top) + var(--3pc-notice-external-height));
+		// top: calc(var(--masterbar-height) + var(--content-padding-top) + var(--3pc-notice-external-height));
+		top: var(--3pc-notice-external-height);
 		height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom) - var(--3pc-notice-external-height));
 		box-shadow: -3px 1px 10px -2px color-mix(in srgb, var(--color-neutral-70) 7.5%, transparent);
 		border-top: 1px solid var(--color-neutral-0);
 		box-sizing: border-box;
 
 		&.wpnt-open {
+			position: absolute;
 			@media only screen and (min-width: $breakpoint-mobile) {
-				right: 24px; // align with content frame padding.
 				border-radius: 8px; /* stylelint-disable-line scales/radii */
-			}
-			@media only screen and (min-width: $breakpoint-nested) {
-				right: 16px; // align with content frame padding.
+				width: 100%;
+				.wpnc__single-view,
+				.wpnc__note-list {
+					width: 100%;
+				}
 			}
 			@media only screen and (min-width: $breakpoint-flyout) {
 				width: calc(100vw - var(--sidebar-width-max) - 16px); // 16px for content frame padding.
-				// This ensures the single view flies out above the 3PC notice.
+
 				.wpnc__single-view {
-					z-index: z-index( ".reader-notifications", ".wpnc__single-view" );
+					width: 400px; // Standard notes panel width.
+					z-index: z-index( ".reader-notifications", ".wpnc__single-view" ); // This ensures the single view flies out above the 3PC notice.
 				}
-				// This ensures the single view does not rise above the note list while animating outwards.
 				.wpnc__note-list {
-					z-index: z-index( ".reader-notifications", ".wpnc__note-list" );
+					width: 400px; // Standard notes panel width.
+					z-index: z-index( ".reader-notifications", ".wpnc__note-list" ); // This ensures the single view does not rise above the note list while animating outwards.
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/547

## Proposed Changes

Updates the notifications page in calypso to have full content width panels once the screen is no longer wide enough to support the default fly-out functionality.
* Uses position absolute (instead of fixed) for the panel, and to easily apply 100% width from the content frame. Note the parent anchor has already been relative position.
* Sets the width to 100% for breakpoints above the mobile cutoff for the main panel and the nested list panels.
* Sets the width back to 400px (notification panel natural width) once above the flyout breakpoint.
* Removes some unnecessary styles as a result of these changes.

BEFORE (full width and mobile should be unaffected)
<img width="1061" alt="Screenshot 2025-04-14 at 12 31 04 PM" src="https://github.com/user-attachments/assets/0d220e68-fe6f-493f-8679-b27c8727b208" />
<img width="635" alt="Screenshot 2025-04-14 at 12 31 59 PM" src="https://github.com/user-attachments/assets/dbebe7b9-06bc-4f73-affb-18023744b545" />

AFTER (full width and mobile should be unaffected)
<img width="1064" alt="Screenshot 2025-04-14 at 12 30 13 PM" src="https://github.com/user-attachments/assets/4785c404-3532-4ebd-85e7-5595a032eea8" />
<img width="632" alt="Screenshot 2025-04-14 at 12 31 33 PM" src="https://github.com/user-attachments/assets/f1a5fb91-b894-4034-896f-0f543ba65165" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Once the panel can no longer fly-out for nested levels, it makes sense to allow them to fill the content frame.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /reader/notifications
* Test between 601px <= screen width <= 783px, and 783px <= screen width <= 1114px.
* Verify the panel now fills the content frame in the above widths.
* Click into nested levels and ensure they work as expected.
* Smoke test other screen widths, they should be unaffected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
