### PR TITLE
Reader: Show login prompts on all logged out reader streams

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -105,7 +105,6 @@ const DiscoverStream = ( props ) => {
 		showBack: false, // We will instead add this through the header section, since not all discover tabs have a stream to render the back button.
 		sidebarTabTitle: isDefaultTab ? translate( 'Sites' ) : translate( 'Related' ),
 		selectedStreamName: selectedTab,
-		disableInfiniteScroll: ! isLoggedIn,
 	};
 
 	const HeaderAndNavigation = () => {

--- a/client/reader/reader.const.ts
+++ b/client/reader/reader.const.ts
@@ -1,0 +1,1 @@
+export const MAX_POSTS_FOR_LOGGED_OUT_USERS: number = 10;

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -45,11 +45,6 @@ class SearchStream extends React.Component {
 	static propTypes = {
 		query: PropTypes.string,
 		streamKey: PropTypes.string,
-		disableInfiniteScroll: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		disableInfiniteScroll: false,
 	};
 
 	state = {
@@ -230,7 +225,6 @@ class SearchStream extends React.Component {
 									query={ query }
 									sort={ pickSort( sortOrder ) }
 									onReceiveSearchResults={ this.setSearchFeeds }
-									disableInfiniteScroll={ this.props.disableInfiniteScroll }
 								/>
 							) }
 							{ ! query && (
@@ -252,7 +246,6 @@ class SearchStream extends React.Component {
 									query={ query }
 									sort={ pickSort( sortOrder ) }
 									onReceiveSearchResults={ this.setSearchFeeds }
-									disableInfiniteScroll={ this.props.disableInfiniteScroll }
 								/>
 							) ) || (
 								<ReaderPopularSitesSidebar

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -88,7 +88,6 @@ const exported = {
 							onSortChange={ reportSortChange }
 							searchType={ show }
 							trendingTags={ context.params.trendingTags }
-							disableInfiniteScroll={ ! context.store.getState().currentUser.user }
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/101923

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/101923 we have added the functionality to show Login Prompt on selected reader streams, now we are updating this logic to show the login prompt on all reader streams which includes.

- /discover
- /search
- /tag/:tag_name
- All future pages that uses ReaderStream component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To cover all logged out screens.
- To improve resuability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- In logged out state go to following screens and verify login prompt is appearing after few scrolls:
     - /discover
     - /search (also write something on search box)
     - /tag/:tag_name
- In logged in state go to above mentioned screens and verify they are not affected by this change.
- Test other random screens to verify that there is no regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
