### PR TITLE
Launch flow: Catch Big Sky free trials and redirect to Big Sky launch flow

### DIFF
--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -151,7 +151,9 @@ const LaunchSite = () => {
 		btnComponent = (
 			<Button
 				onClick={ () => {
-					dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId, 'general-settings' ) );
+					dispatch(
+						launchSiteOrRedirectToLaunchSignupFlow( siteId, 'general-settings', site.title, 'yes' )
+					);
 				} }
 			>
 				{ btnText }

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -22,6 +22,7 @@ import {
 	isSiteOnECommerceTrial as getIsSiteOnECommerceTrial,
 	isSiteOnMigrationTrial as getIsSiteOnMigrationTrial,
 } from 'calypso/state/sites/plans/selectors';
+import isSiteBigSkyTrial from 'calypso/state/sites/plans/selectors/is-site-big-sky-trial';
 import { isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
@@ -90,6 +91,7 @@ const LaunchSite = () => {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	const isPaidPlan = useSelector( ( state ) => isCurrentPlanPaid( state, siteId ) );
 	const isComingSoon = useSelector( ( state ) => isSiteComingSoon( state, siteId ) );
+	const isBigSkyTrial = useSelector( ( state ) => isSiteBigSkyTrial( state, siteId ) );
 	const hasSitePreviewLink = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS )
 	);
@@ -150,13 +152,11 @@ const LaunchSite = () => {
 		);
 		querySiteDomainsComponent = '';
 	} else {
-		btnComponent = (
-			<Button
-				href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&new=${ site.title }&search=yes` }
-			>
-				{ btnText }
-			</Button>
-		);
+		let href = `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&new=${ site.title }&search=yes`;
+		if ( isBigSkyTrial ) {
+			href = `/setup/ai-site-builder/domains?siteId=${ siteId }&source=general-settings&redirect=site-launch`;
+		}
+		btnComponent = <Button href={ href }>{ btnText }</Button>;
 		querySiteDomainsComponent = '';
 	}
 

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -16,7 +16,10 @@ import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { launchSite } from 'calypso/state/sites/launch/actions';
+import {
+	launchSite,
+	launchSiteOrRedirectToLaunchSignupFlow,
+} from 'calypso/state/sites/launch/actions';
 import { getIsSiteLaunchInProgress } from 'calypso/state/sites/launch/selectors';
 import {
 	isSiteOnECommerceTrial as getIsSiteOnECommerceTrial,
@@ -152,11 +155,15 @@ const LaunchSite = () => {
 		);
 		querySiteDomainsComponent = '';
 	} else {
-		let href = `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&new=${ site.title }&search=yes`;
-		if ( isBigSkyTrial ) {
-			href = `/setup/ai-site-builder/domains?siteId=${ siteId }&source=general-settings&redirect=site-launch`;
-		}
-		btnComponent = <Button href={ href }>{ btnText }</Button>;
+		btnComponent = (
+			<Button
+				onClick={ () => {
+					dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId, 'general-settings' ) );
+				} }
+			>
+				{ btnText }
+			</Button>
+		);
 		querySiteDomainsComponent = '';
 	}
 

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -25,13 +25,8 @@ import {
 	isSiteOnECommerceTrial as getIsSiteOnECommerceTrial,
 	isSiteOnMigrationTrial as getIsSiteOnMigrationTrial,
 } from 'calypso/state/sites/plans/selectors';
-import isSiteBigSkyTrial from 'calypso/state/sites/plans/selectors/is-site-big-sky-trial';
 import { isCurrentPlanPaid } from 'calypso/state/sites/selectors';
-import {
-	getSelectedSite,
-	getSelectedSiteId,
-	getSelectedSiteSlug,
-} from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { LaunchConfirmationModal } from './launch-confirmation-modal';
 import { LaunchSiteTrialUpsellNotice } from './launch-site-trial-notice';
 
@@ -91,10 +86,8 @@ const LaunchSite = () => {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSettings = useSelector( ( state ) => getSiteSettings( state, siteId ) );
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	const isPaidPlan = useSelector( ( state ) => isCurrentPlanPaid( state, siteId ) );
 	const isComingSoon = useSelector( ( state ) => isSiteComingSoon( state, siteId ) );
-	const isBigSkyTrial = useSelector( ( state ) => isSiteBigSkyTrial( state, siteId ) );
 	const hasSitePreviewLink = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS )
 	);

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -127,7 +127,9 @@ const LaunchSite = () => {
 		if ( isDevelopmentSite && ! siteReferralActive ) {
 			openLaunchConfirmationModal();
 		} else {
-			dispatchSiteLaunch();
+			dispatch(
+				launchSiteOrRedirectToLaunchSignupFlow( siteId, 'general-settings', site.title, 'yes' )
+			);
 		}
 	};
 
@@ -136,25 +138,15 @@ const LaunchSite = () => {
 	if ( 0 === siteDomains.length ) {
 		querySiteDomainsComponent = <QuerySiteDomains siteId={ siteId } />;
 		btnComponent = <Button>{ btnText }</Button>;
-	} else if ( isPaidPlan && siteDomains.length > 1 ) {
+	} else {
 		btnComponent = (
 			<Button
 				onClick={ handleLaunchSiteClick }
 				busy={ isLaunchInProgress }
-				disabled={ ! isLaunchable || ( isDevelopmentSite && agencyLoading ) }
-			>
-				{ btnText }
-			</Button>
-		);
-		querySiteDomainsComponent = '';
-	} else {
-		btnComponent = (
-			<Button
-				onClick={ () => {
-					dispatch(
-						launchSiteOrRedirectToLaunchSignupFlow( siteId, 'general-settings', site.title, 'yes' )
-					);
-				} }
+				disabled={
+					( isPaidPlan && siteDomains.length > 1 && ! isLaunchable ) ||
+					( isDevelopmentSite && agencyLoading )
+				}
 			>
 				{ btnText }
 			</Button>

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -33,7 +33,7 @@ export const launchSiteFailure = ( siteId ) => ( {
  * @param {string?} source
  */
 export const launchSiteOrRedirectToLaunchSignupFlow =
-	( siteId, source = null ) =>
+	( siteId, source = null, siteTitle = null, search = null ) =>
 	( dispatch, getState ) => {
 		if ( ! isUnlaunchedSite( getState(), siteId ) ) {
 			return;
@@ -53,7 +53,7 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 
 		if ( isSiteBigSkyTrial( getState(), siteId ) ) {
 			window.location.href = addQueryArgs(
-				{ siteId: siteId, source, redirect: 'site-launch' },
+				{ siteId: siteId, source, redirect: 'site-launch', new: siteTitle, search },
 				'/setup/ai-site-builder/domains'
 			);
 			return;
@@ -61,7 +61,7 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 
 		// TODO: consider using the `page` library instead of calling using `location.href` here
 		window.location.href = addQueryArgs(
-			{ siteSlug, source, hide_initial_query: 'yes' },
+			{ siteSlug, source, hide_initial_query: 'yes', new: siteTitle, search },
 			'/start/launch-site'
 		);
 	};

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -3,6 +3,7 @@ import { SITE_LAUNCH, SITE_LAUNCH_FAILURE, SITE_LAUNCH_SUCCESS } from 'calypso/s
 import 'calypso/state/data-layer/wpcom/sites/launch';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import isSiteBigSkyTrial from 'calypso/state/sites/plans/selectors/is-site-big-sky-trial';
 import { getSiteSlug, isCurrentPlanPaid, getSiteOption } from 'calypso/state/sites/selectors';
 import { isSiteOnHostingTrial } from '../plans/selectors';
 
@@ -49,6 +50,14 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 		}
 
 		const siteSlug = getSiteSlug( getState(), siteId );
+
+		if ( isSiteBigSkyTrial( getState(), siteId ) ) {
+			window.location.href = addQueryArgs(
+				{ siteId: siteId, source, redirect: 'site-launch' },
+				'/setup/ai-site-builder/domains'
+			);
+			return;
+		}
 
 		// TODO: consider using the `page` library instead of calling using `location.href` here
 		window.location.href = addQueryArgs(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1744641114045159-slack-C06121P56QZ

Fixes BSKY-350

## Proposed Changes

This change catches free trial sites that otherwise would be heading to `/start/launch-site`, and redirects to the Big Sky launch flow instead. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Because launching a free trial site is kind of a broken experience. When viewing your sites on wordpress.com/sites, there are multiple buttons and UIs that drop users into the regular launch flow, which offers plans that Big Sky does not support. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- http://calypso.localhost:3000/sites
- Launch via the admin toolbar, and all other UIs that allow it. 
- You should be taken to `/setup/ai-site-builder/domains` with the correct site info
- You should be able to check out properly and be redirected back to the site properly

- Make sure this does not impact non-big sky free trial flows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?