### PR TITLE
Remove `useGoalsFirstExperiment` from unified design picker step (second round)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -6,7 +6,7 @@ import {
 	useDesignPickerFilters,
 } from '@automattic/design-picker';
 import { useLocale, useHasEnTranslation } from '@automattic/i18n-utils';
-import { StepContainer, ONBOARDING_FLOW, isSiteSetupFlow, Step } from '@automattic/onboarding';
+import { StepContainer, isSiteSetupFlow, Step } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback } from 'react';
@@ -27,7 +27,6 @@ import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
-import { useGoalsFirstExperiment } from '../../../helpers/use-goals-first-experiment';
 import {
 	getDesignEventProps,
 	recordPreviewedDesign,
@@ -67,9 +66,6 @@ const UnifiedDesignPickerStep: StepType< {
 	);
 	const variantName = experimentAssignment?.variationName;
 	const oldHighResImageLoading = ! isLoadingExperiment && variantName === 'treatment';
-
-	const [ isGoalsAtFrontExperimentLoading, isGoalsAtFrontExperiment ] = useGoalsFirstExperiment();
-	const isSiteRequired = flow !== ONBOARDING_FLOW || ! isGoalsAtFrontExperiment;
 
 	const isUpdatedBadgeDesign = useIsUpdatedBadgeDesign();
 
@@ -304,14 +300,6 @@ const UnifiedDesignPickerStep: StepType< {
 					},
 					optionalProps
 				);
-			} else if ( ! isSiteRequired && ! siteSlugOrId && _selectedDesign ) {
-				handleSubmit(
-					{
-						selectedDesign: _selectedDesign,
-						selectedSiteCategory: categorization.selections?.join( ',' ),
-					},
-					optionalProps
-				);
 			}
 		},
 		[
@@ -321,7 +309,6 @@ const UnifiedDesignPickerStep: StepType< {
 			designs,
 			globalStyles,
 			handleSubmit,
-			isSiteRequired,
 			reduxDispatch,
 			selectedDesign,
 			selectedStyleVariation,
@@ -362,8 +349,8 @@ const UnifiedDesignPickerStep: StepType< {
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	const isSiteLoading = ! site && isSiteRequired;
-	const isDesignsLoading = isLoadingDesigns || isGoalsAtFrontExperimentLoading;
+	const isSiteLoading = ! site;
+	const isDesignsLoading = isLoadingDesigns;
 	const isLoading = isSiteLoading || isDesignsLoading;
 
 	if ( isLoading || isComingFromTheUpgradeScreen ) {
@@ -455,7 +442,7 @@ const UnifiedDesignPickerStep: StepType< {
 	};
 
 	const backButton = getGoBackHandler();
-	const hideSkip = ! isGoalsAtFrontExperiment && ! isComingFromSuccessfulImport;
+	const hideSkip = ! isComingFromSuccessfulImport;
 	const skipLabelText = isComingFromSuccessfulImport
 		? translate( 'Skip to dashboard' )
 		: translate( 'Skip setup' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -21,7 +21,6 @@ import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query'
 import { useIsBigSkyEligible } from 'calypso/landing/stepper/hooks/use-is-site-big-sky-eligible';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
-import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { useActivateDesign } from '../../../../hooks/use-activate-design';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
@@ -60,7 +59,6 @@ const UnifiedDesignPickerStep: StepType< {
 		};
 	};
 } > = ( { navigation, flow, stepName } ) => {
-	// imageOptimizationExperimentAssignment, exerimentAssignment
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
 		'calypso_design_picker_image_optimization_202406'
 	);
@@ -73,8 +71,6 @@ const UnifiedDesignPickerStep: StepType< {
 
 	const queryParams = useQuery();
 	const { goBack, submit, exitFlow } = navigation;
-
-	const reduxDispatch = useReduxDispatch();
 
 	const translate = useTranslate();
 	const locale = useLocale();
@@ -106,7 +102,6 @@ const UnifiedDesignPickerStep: StepType< {
 		)
 	);
 
-	const { setDesignOnSite, assembleSite } = useDispatch( SITE_STORE );
 	const activateDesign = useActivateDesign();
 
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
@@ -304,18 +299,13 @@ const UnifiedDesignPickerStep: StepType< {
 		},
 		[
 			activateDesign,
-			assembleSite,
-			categorization.selections,
 			designs,
 			globalStyles,
 			handleSubmit,
-			reduxDispatch,
 			selectedDesign,
 			selectedStyleVariation,
-			setDesignOnSite,
 			setPendingAction,
 			setSelectedDesign,
-			site?.ID,
 			siteSlugOrId,
 		]
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #101759 
Related to DOTOBRD-36
Extracted from #101921

## Proposed Changes

Remove the use of the `useGoalsFirstExperiment ` hook from the `design-setup` Stepper step

(follow-up to https://github.com/Automattic/wp-calypso/pull/102425)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're cleaning up unused code related to the concluded goals-first experiment.

The return value of `useGoalsFirstExperiment` is hardcoded to `[false, false]` — meaning that we can actually remove it, update the logic in the code accordingly, and perform any extra cleanup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke-test Stepper flows that include the `design-setup` step (like `/setup/site-setup` and `/setup/update-design`) and make sure that there is no difference with `trunk`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
