### PR TITLE
Revert 102607 & 102617

### DIFF
--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -3,7 +3,6 @@ import { SITE_LAUNCH, SITE_LAUNCH_FAILURE, SITE_LAUNCH_SUCCESS } from 'calypso/s
 import 'calypso/state/data-layer/wpcom/sites/launch';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import isSiteBigSkyTrial from 'calypso/state/sites/plans/selectors/is-site-big-sky-trial';
 import { getSiteSlug, isCurrentPlanPaid, getSiteOption } from 'calypso/state/sites/selectors';
 import { isSiteOnHostingTrial } from '../plans/selectors';
 
@@ -33,7 +32,7 @@ export const launchSiteFailure = ( siteId ) => ( {
  * @param {string?} source
  */
 export const launchSiteOrRedirectToLaunchSignupFlow =
-	( siteId, source = null, siteTitle = null, search = null ) =>
+	( siteId, source = null ) =>
 	( dispatch, getState ) => {
 		if ( ! isUnlaunchedSite( getState(), siteId ) ) {
 			return;
@@ -51,17 +50,9 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 
 		const siteSlug = getSiteSlug( getState(), siteId );
 
-		if ( isSiteBigSkyTrial( getState(), siteId ) ) {
-			window.location.href = addQueryArgs(
-				{ siteId: siteId, source, redirect: 'site-launch', new: siteTitle, search },
-				'/setup/ai-site-builder/domains'
-			);
-			return;
-		}
-
 		// TODO: consider using the `page` library instead of calling using `location.href` here
 		window.location.href = addQueryArgs(
-			{ siteSlug, source, hide_initial_query: 'yes', new: siteTitle, search },
+			{ siteSlug, source, hide_initial_query: 'yes' },
 			'/start/launch-site'
 		);
 	};

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -32,7 +32,7 @@ export class SiteSettingsPage {
 	 * Start the site launch process.
 	 */
 	async launchSite(): Promise< void > {
-		const launchSite = this.page.getByRole( 'button', { name: 'Launch site' } );
+		const launchSite = this.page.getByRole( 'link', { name: 'Launch site' } );
 		await launchSite.click();
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Revert https://github.com/Automattic/wp-calypso/pull/102607 & https://github.com/Automattic/wp-calypso/pull/102617

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The changed caused an e2e break that we need to fix

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
