### PR TITLE
Removes the `onboarding/playground flag`, which is true on all platforms

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-setup/index.tsx
@@ -5,7 +5,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import StepWrapper from 'calypso/signup/step-wrapper';
-import { useIsPlaygroundEligible } from '../../../../../../hooks/use-is-playground-eligible';
 import { importPlaygroundSite } from '../../lib/import-playground';
 import { PlaygroundIframe } from '../playground-iframe';
 import type { Step } from '../../../../types';
@@ -18,16 +17,9 @@ export const PlaygroundSetupStep: Step< {
 	};
 } > = ( props ) => {
 	const { submit } = props.navigation;
-	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const { __ } = useI18n();
 	const playgroundClientRef = useRef< PlaygroundClient | null >( null );
 	const { siteId, siteSlug } = useSiteData();
-
-	if ( ! isPlaygroundEligible ) {
-		window.location.assign( '/start' );
-
-		return;
-	}
 
 	const startImport = async ( client: PlaygroundClient ) => {
 		if ( ! client ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -5,7 +5,6 @@ import { useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useIsPlaygroundEligible } from '../../../../hooks/use-is-playground-eligible';
 import { PlaygroundIframe } from './components/playground-iframe';
 import { getBlueprintLabelForTracking } from './lib/blueprint';
 import type { Step as StepType } from '../../types';
@@ -13,15 +12,9 @@ import './style.scss';
 
 export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 	const { submit } = navigation;
-	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const playgroundClientRef = useRef< PlaygroundClient | null >( null );
 	const { __ } = useI18n();
 	const [ query ] = useSearchParams();
-	if ( ! isPlaygroundEligible ) {
-		window.location.assign( '/start' );
-
-		return;
-	}
 
 	const setPlaygroundClient = ( client: PlaygroundClient ) => {
 		playgroundClientRef.current = client;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
@@ -10,11 +10,6 @@ import { StepProps } from '../../../types';
 import { renderStep, mockStepProps, RenderStepOptions } from '../../test/helpers';
 import { initializeWordPressPlayground } from '../lib/initialize-playground';
 
-// Be sure to mock this hook to return true so that the step is rendered.
-jest.mock( 'calypso/landing/stepper/hooks/use-is-playground-eligible', () => ( {
-	useIsPlaygroundEligible: () => true,
-} ) );
-
 // Mock the initializeWordPressPlayground function to cause an error
 jest.mock( '../lib/initialize-playground' );
 

--- a/client/landing/stepper/hooks/use-is-playground-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-playground-eligible.ts
@@ -1,9 +1,0 @@
-import config from '@automattic/calypso-config';
-
-export function useIsPlaygroundEligible() {
-	return isPlaygroundEligible();
-}
-
-export function isPlaygroundEligible() {
-	return config.isEnabled( 'onboarding/playground' );
-}

--- a/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
+++ b/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
@@ -1,28 +1,24 @@
 import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
-import { useIsPlaygroundEligible, isPlaygroundEligible } from './use-is-playground-eligible';
 import { useQuery } from './use-query';
 
 const HOSTING_ONBOARDING_EXPERIMENT_NAME = 'calypso_signup_onboarding_simplified_hosting_flow_v3';
 
 export function useMvpOnboardingExperiment() {
-	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const hasPlaygroundId = useQuery().has( 'playground' );
 
 	const [ isLoading, assignment ] = useExperiment( HOSTING_ONBOARDING_EXPERIMENT_NAME, {
-		isEligible: ! isPlaygroundEligible || ! hasPlaygroundId,
+		isEligible: ! hasPlaygroundId,
 	} );
 
 	return [ isLoading, assignment?.variationName === 'treatment' ];
 }
 
 export async function isMvpOnboardingExperiment() {
-	if ( isPlaygroundEligible() ) {
-		const params = new URLSearchParams( window.location.search );
-		const hasPlaygroundId = params.has( 'playground' );
+	const params = new URLSearchParams( window.location.search );
+	const hasPlaygroundId = params.has( 'playground' );
 
-		if ( hasPlaygroundId ) {
-			return false;
-		}
+	if ( hasPlaygroundId ) {
+		return false;
 	}
 
 	const assignment = await loadExperimentAssignment( HOSTING_ONBOARDING_EXPERIMENT_NAME );

--- a/config/development.json
+++ b/config/development.json
@@ -138,7 +138,6 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light": false,
 		"onboarding/interval-dropdown": true,
-		"onboarding/playground": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/trail-map-feature-grid": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -87,7 +87,6 @@
 		"migration-flow/introductory-offer": true,
 		"migration-flow/cancel-difm": true,
 		"onboarding/create-course": false,
-		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
 		"onboarding/step-container-v2-migration-flow": true,
 		"p2-enabled": false,

--- a/config/production.json
+++ b/config/production.json
@@ -111,7 +111,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -108,7 +108,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid": false,

--- a/config/test.json
+++ b/config/test.json
@@ -88,7 +88,6 @@
 		"onboarding/import-from-squarespace": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
-		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"p2-enabled": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,7 +112,6 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light": false,
 		"onboarding/interval-dropdown": true,
-		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid-copy": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/102578

## Proposed Changes

* Removes the `onboarding/playground` feature flag
* Remove all code that was referring to it. It's `true` everywhere.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

As discussed here https://github.com/Automattic/wp-calypso/pull/102578#issuecomment-2800723723 this feature flag is no longer used. 💣 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'm not entirely sure on how to test the playground step. But I know that if I navigate to `http://calypso.localhost:3000/setup/onboarding/playground` then it will automatically add a `?playground=` id to the URL and will load a WP playground in the page. And it still appears to be working correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
