### PR TITLE
calypso-e2e: remove unwanted yargs import

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/media-page.ts
@@ -1,5 +1,4 @@
 import { ElementHandle, Page } from 'playwright';
-import { number } from 'yargs';
 import { getCalypsoURL } from '../../data-helper';
 import { waitForElementEnabled, clickNavTab } from '../../element-helper';
 
@@ -105,7 +104,7 @@ export class MediaPage {
 	 * @throws {Error} If requested item could not be located in the gallery, or if the click action failed to select the gallery item.
 	 */
 	async selectItem( { index, name }: { index?: number; name?: string } = {} ): Promise< void > {
-		if ( ! name && ! number ) {
+		if ( ! index && ! name ) {
 			throw new Error( 'Specify either index or name.' );
 		}
 


### PR DESCRIPTION
This PR fixes a typo in the `media-page.ts` util for e2e tests. The module shouldn't import `number` from `yargs` and `selectIndex` should check the `index` param (1-indexed, so `0` is also an invalid value). The existing code looks like a bad autocomplete from VSCode.

I noticed this when tinkering with TypeScript configuration (for #102475), when suddenly typechecking the `yargs` import started failing for me.