### PR TITLE
lib/wp: use Core i18n to read current locale

### DIFF
--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -1,4 +1,4 @@
-import i18n from 'i18n-calypso';
+import { getLocaleData } from '@wordpress/i18n';
 import { parse, stringify } from 'qs';
 
 /**
@@ -8,7 +8,8 @@ import { parse, stringify } from 'qs';
  * @returns {Object}        Revised parameters, if non-default locale
  */
 export function addLocaleQueryParam( params ) {
-	const locale = i18n.getLocaleVariant() || i18n.getLocaleSlug();
+	const localeData = getLocaleData();
+	const locale = localeData?.[ '' ]?.localeVariant || localeData?.[ '' ]?.localeSlug;
 
 	if ( ! locale || 'en' === locale ) {
 		return params;

--- a/client/lib/wp/localization/test/index.js
+++ b/client/lib/wp/localization/test/index.js
@@ -1,9 +1,9 @@
-import i18n from 'i18n-calypso';
+import { setLocaleData, resetLocaleData } from '@wordpress/i18n';
 import { addLocaleQueryParam, injectLocalization } from '../';
 
 describe( 'index', () => {
 	beforeEach( () => {
-		i18n.configure(); // ensure everything is reset
+		resetLocaleData(); // ensure everything is reset
 	} );
 
 	describe( '#addLocaleQueryParam()', () => {
@@ -19,19 +19,19 @@ describe( 'index', () => {
 		} );
 
 		test( 'should include the locale query parameter for a non-default locale', () => {
-			i18n.setLocale( { '': { localeSlug: 'fr' } } );
+			setLocaleData( { '': { localeSlug: 'fr' } } );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
 			expect( params ).toEqual( { query: 'locale=fr&search=foo' } );
 		} );
 
 		test( 'should include the locale query parameter for a locale variant', () => {
-			i18n.setLocale( { '': { localeSlug: 'de', localeVariant: 'de_formal' } } );
+			setLocaleData( { '': { localeSlug: 'de', localeVariant: 'de_formal' } } );
 			const params = addLocaleQueryParam( { query: 'search=foo' } );
 			expect( params ).toEqual( { query: 'locale=de_formal&search=foo' } );
 		} );
 
 		test( 'should prioritize the locale specified on the request', () => {
-			i18n.setLocale( { '': { localeSlug: 'fr' } } );
+			setLocaleData( { '': { localeSlug: 'fr' } } );
 			const params = addLocaleQueryParam( { query: 'locale=cs' } );
 			expect( params ).toEqual( { query: 'locale=cs' } );
 		} );
@@ -52,7 +52,7 @@ describe( 'index', () => {
 		} );
 
 		test( 'should modify params by default', async () => {
-			i18n.setLocale( { '': { localeSlug: 'fr' } } );
+			setLocaleData( { '': { localeSlug: 'fr' } } );
 			const wpcom = {
 				async request( params ) {
 					expect( params.query ).toBe( 'locale=fr&search=foo' );


### PR DESCRIPTION
We'd like to remove the `i18n-calypso` dependency from the `lib/wp` WP.com REST client and replace it with the Core `@wordpress/i18n`. Because we want to use `lib/wp` in projects that aim to use solely the Core i18n library--like the new Sites Dashboard.

This PR reads the current locale from the `@wordpress/i18n` singleton. The Calypso and Core libraries are synced [at this place](https://github.com/Automattic/wp-calypso/blob/59220fdfca304a09326ede1badb20fc7394795b4/client/components/calypso-i18n-provider/index.tsx#L15-L30), where the Calypso translations are copied to the `default` domain in the Core translations.

`localeVariant` and `localeSlug` are fields specific for WP.com translations. `@wordpress/i18n` doesn't have any special methods to read these custom fields, that's why we read them in a low-level way, accessing the `[ '' ]` field of the locale data.

## Testing instructions:
1. Switch your WP.com account to another locale like `de`.
2. Load development Calypso with this PR applied.
3. In the network panel verify that all REST requests have the `?locale=de` or `?_locale=de` param.