### PR TITLE
A4A: Update text on revoking a license part of a bundle.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/index.tsx
@@ -137,17 +137,32 @@ export default function RevokeLicenseDialog( {
 			return (
 				<p>
 					{ translate(
-						'This license will be revoked from {{b}}%(siteUrl)s{{/b}}, and a new {{b}}%(product)s{{/b}} license will be created and added to the bundle.',
+						"You're revoking a single license from within your bundled purchase. This license is in use on {{b}}%(siteUrl)s{{/b}}. When you revoke this license, we will add an unassigned replacement license to the bundle which can be assigned to a new site when you're ready.{{br/}}{{br/}}" +
+							'If you wish to cancel the entire bundle, you can follow the steps {{kbLink}}here↗{{/kbLink}}.',
 						{
 							args: {
-								product,
 								siteUrl,
 							},
 							components: {
 								b: <b />,
+								br: <br />,
+								kbLink: (
+									<a
+										className="revoke-license-dialog__external-link"
+										href="https://agencieshelp.automattic.com/knowledge-base/purchases/#canceling-purchases"
+										target="_blank"
+										rel="noreferrer noopener"
+										onClick={ () => {
+											dispatch(
+												recordTracksEvent(
+													'calypso_a4a_license_list_revoke_dialog_cancel_kb_clicked'
+												)
+											);
+										} }
+									/>
+								),
 							},
-							comment:
-								'The %(siteUrl)s and %(product)s placeholders are replaced with the site URL and product name, respectively.',
+							comment: 'The %(siteUrl)s  placeholders are replaced with the site URL.',
 						}
 					) }
 				</p>

--- a/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/revoke-license-dialog/style.scss
@@ -111,3 +111,11 @@
 		}
 	}
 }
+
+a.revoke-license-dialog__external-link {
+	&,
+	&:visited {
+		text-decoration: underline;
+		color: var(--color-text);
+	}
+}


### PR DESCRIPTION
Our existing communication regarding the revocation of a license included in a bundle is unclear and causing confusion among some agencies. This PR aims to clarify this by providing additional context for the messaging.

| Before | After |
|--------|--------|
| <img width="716" alt="Screenshot 2025-04-15 at 8 59 04 PM" src="https://github.com/user-attachments/assets/2126dd42-94e5-45ad-8d18-0d0f7d0641b0" /> | <img width="711" alt="Screenshot 2025-04-15 at 8 58 14 PM" src="https://github.com/user-attachments/assets/bd2a7c89-2cc1-490c-a3e9-6090910eba01" /> | 


Context: https://linear.app/a8c/issue/A4A-670/add-clarity-to-revoking-licenses-in-a-bundle-and-how-to-revoke-a-whole

## Proposed Changes

* Revise the text regarding license revocation in the bundle. The updated text also includes a link to our knowledge base article about canceling a license.

## Why are these changes being made?

* This ensure that our agencies are not confused with our revocation process.

## Testing Instructions

* Use the A4A live link to navigate to `/marketplace/products`.
* Purchase some product bundles.
* Go to the `/licenses` page.
* Assign one of the licenses from the bundle you just purchased.
* Then revoke that license.
* Confirm that the text in the confirmation dialog matches the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
