### PR TITLE
A4A: Error message for unverified accounts attempting to provision a dev site

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -109,6 +109,14 @@ export default function SiteConfigurationsModal( {
 						)
 					)
 				);
+			} else if ( error.code === 'email_unverified' ) {
+				dispatch(
+					errorNotice(
+						translate(
+							'Please verify your email address by clicking the link we sent to your inbox.'
+						)
+					)
+				);
 			} else {
 				dispatch( errorNotice( translate( 'Something went wrong. Please try again.' ) ) );
 			}


### PR DESCRIPTION
Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/2046

## Proposed Changes

* Adds a new error message for unverified accounts attempting to provision a dev site.

<img width="676" alt="Screenshot 2025-04-15 at 14 42 22" src="https://github.com/user-attachments/assets/ea0d7dcc-32a3-484d-a6a0-4270fa8fe038" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing instructions here: 180692-ghe-Automattic/wpcom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?