### PR TITLE
Launchpad: Hide the focused launchpad for the treatment exp variant

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -3,6 +3,7 @@ import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import {
 	useIsPlaygroundEligible,
 	isPlaygroundEligible,
@@ -81,8 +82,10 @@ const onboarding: FlowV2 = {
 
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
+		const location = useLocation();
 		const isPlaygroundEligible = useIsPlaygroundEligible();
-		const [ , isMvpOnboarding ] = useMvpOnboardingExperiment();
+		const [ , isMvpOnboarding ] = useMvpOnboardingExperiment( location );
+
 		const {
 			setDomain,
 			setDomainCartItem,

--- a/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
+++ b/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
@@ -1,12 +1,12 @@
 import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 import { useIsPlaygroundEligible, isPlaygroundEligible } from './use-is-playground-eligible';
-import { useQuery } from './use-query';
 
 const MVP_ONBOARDING_EXPERIMENT_NAME = 'calypso_onboarding_mvp_20250414';
 
-export function useMvpOnboardingExperiment() {
+export function useMvpOnboardingExperiment( location: { search: string } ) {
 	const isPlaygroundEligible = useIsPlaygroundEligible();
-	const hasPlaygroundId = useQuery().has( 'playground' );
+	const params = new URLSearchParams( location.search );
+	const hasPlaygroundId = params.has( 'playground' );
 
 	const [ isLoading, assignment ] = useExperiment( MVP_ONBOARDING_EXPERIMENT_NAME, {
 		isEligible: ! isPlaygroundEligible || ! hasPlaygroundId,

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -17,6 +17,7 @@ import useDomainDiagnosticsQuery from 'calypso/data/domains/diagnostics/use-doma
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layout-query';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
+import { useMvpOnboardingExperiment } from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -71,6 +72,7 @@ const HomeContent = ( {
 	handleVerifyIcannEmail,
 	isAdmin,
 } ) => {
+	const [ , isMvpOnboarding ] = useMvpOnboardingExperiment( window.location );
 	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState( false );
 	const [ launchedSiteId, setLaunchedSiteId ] = useState( null );
 	const queryClient = useQueryClient();
@@ -154,7 +156,11 @@ const HomeContent = ( {
 		);
 	}
 
-	if ( layout?.view_name === 'VIEW_FOCUSED_LAUNCHPAD' && ! focusedLaunchpadDismissed ) {
+	if (
+		layout?.view_name === 'VIEW_FOCUSED_LAUNCHPAD' &&
+		! focusedLaunchpadDismissed &&
+		! isMvpOnboarding
+	) {
 		return (
 			<FullScreenLaunchpad
 				onClose={ async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/102578

## Proposed Changes

* Extend `useMvpOnboardingExperiment` hook to support usage outside of the `react-router-dom` context
* Hide the focused launchpad for the `treatment` variant

## Why are these changes being made?

https://linear.app/a8c/issue/DOTOBRD-103/mvp-hosting-onboarding-hide-focused-launchpad

## Testing Instructions

* Assign yourself to the `treatment` variant in the experiment
* Go to `/setup/onboarding`
* Press the "My Home" button
* Check if there is a focused launchpad (it should be hidden this time)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
