### PR TITLE
Update layout and copy for plugin error views.

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -456,7 +456,7 @@ const MarketplaceProductInstall = ( {
 					}
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
-					action={ translate( 'Continue' ) }
+					action={ translate( 'Re-upload plugin' ) }
 					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
 				/>
 			);

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -435,7 +435,7 @@ const MarketplaceProductInstall = ( {
 					) }
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ `/plugins/upload/${ selectedSiteSlug }` }
-					action={ translate( 'Continue' ) }
+					action={ translate( 'Re-upload plugin' ) }
 					actionURL={ `https://${ selectedSiteSlug }/wp-admin/plugin-install.php?tab=upload` }
 				/>
 			);

--- a/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
@@ -29,6 +29,14 @@ body.is-section-marketplace {
 		width: 100%;
 		height: 100vh;
 	}
+
+	.marketplace-plugin-install__root .empty-content {
+		margin-top: 0;
+	}
+
+	.marketplace-plugin-install__root .empty-content__action {
+		margin: 8px;
+	}
 }
 
 .marketplace-plugin-install__direct-install-container {


### PR DESCRIPTION
Related to #93610

Fixes: DOTSIMA-4

## Proposed Changes

This PR includes three changes:
- Update the space between the buttons.
- Move up the empty content container to be more centered.
- Update the copy to explain the next user action.
  - This aligns better with other button copy states and is a better lead for the customer. 

| Before | After |
|--------|--------|
| <img width="1190" alt="Screenshot 2025-04-16 at 10 18 38 AM" src="https://github.com/user-attachments/assets/cc7ba27a-4228-4b40-8c44-c18cff1c7765" /> |  <img width="1189" alt="Screenshot 2025-04-16 at 10 19 28 AM" src="https://github.com/user-attachments/assets/4ee4ad6a-7ed3-4e60-9646-aae16cdcba4c" /> | 
| <img width="733" alt="Screenshot 2025-04-16 at 10 49 29 AM" src="https://github.com/user-attachments/assets/0ac11ee2-de29-4e95-8f88-b7ab658db719" /> | <img width="669" alt="Screenshot 2025-04-16 at 10 49 13 AM" src="https://github.com/user-attachments/assets/a31b1dad-9601-4732-975d-7a7ac46b547d" /> |
| <img width="796" alt="Screenshot 2025-04-16 at 10 47 31 AM" src="https://github.com/user-attachments/assets/502f780d-2d80-4b2f-90a0-b494a523045b" /> | <img width="740" alt="Screenshot 2025-04-16 at 10 47 20 AM" src="https://github.com/user-attachments/assets/82138ddb-2a6c-43c0-8ce3-90eb8f99223f" /> |


> [!NOTE]
> For some reason the button spacing works in dev mode and not in production. I assume it's related to how CSS is bundled?

## Testing Instructions

With a business plan..
* Upload a plugin
* Upload the same plugin again
* Click on the "Re-upload button"
  * Expect to land on `wp-admin/plugin-install.php?tab=upload`
* Click on the "Back" button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
