### PR TITLE
Remove the toast from specific upload plugin errors.

### DIFF
--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -32,11 +32,9 @@ export const uploadPlugin = ( action ) => {
 
 const showErrorNotice = ( error ) => {
 	const knownErrors = {
-		exists: translate( 'This plugin is already installed on your site.' ),
 		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
 		incompatible: translate( 'The uploaded file is not a compatible plugin.' ),
 		unsupported_mime_type: translate( 'The uploaded file is not a valid zip.' ),
-		plugin_malicious: translate( 'The uploaded file is identified as malicious.' ),
 	};
 	const errorString = `${ error.error }${ error.message }`.toLowerCase();
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
@@ -79,14 +77,23 @@ export const uploadComplete =
 		} );
 	};
 
-export const receiveError = ( { siteId }, error ) => [
-	recordTracksEvent( 'calypso_plugin_upload_error', {
-		error_code: error.error,
-		error_message: error.message,
-	} ),
-	showErrorNotice( error ),
-	pluginUploadError( siteId, error ),
-];
+export const receiveError = ( { siteId }, error ) => {
+	const actions = [
+		recordTracksEvent( 'calypso_plugin_upload_error', {
+			error_code: error.error,
+			error_message: error.message,
+		} ),
+		pluginUploadError( siteId, error ),
+	];
+
+	// Mute error messages that are duplicated with content.
+	const errorsToMute = [ 'folder_exists', 'plugin_malicious' ];
+	if ( ! errorsToMute.includes( error.error ) ) {
+		actions.push( showErrorNotice( error ) );
+	}
+
+	return actions;
+};
 
 export const updateUploadProgress = ( { siteId }, { loaded, total } ) => {
 	const progress = total ? ( loaded / total ) * 100 : total;

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -86,7 +86,7 @@ export const receiveError = ( { siteId }, error ) => {
 		pluginUploadError( siteId, error ),
 	];
 
-	// Mute error messages that are duplicated with content.
+	// We don't need to display error notices. The front end components will alert the user.
 	const errorsToMute = [ 'folder_exists', 'plugin_malicious' ];
 	if ( ! errorsToMute.includes( error.error ) ) {
 		actions.push( showErrorNotice( error ) );


### PR DESCRIPTION
Related to #93610

Fixes: DOTSIMA-5

## Proposed Changes

This PR mutes the toast notice when the view already has leading information for the user. In those scenarios the toast is a distraction.

We can't remove it entirely because it also displays generic, unhandled messages that come from the server.

| Context | Before | After |
|--------|--------|--------|
| `plugin_malicious` | <img width="1017" alt="Screenshot 2025-04-16 at 11 21 14 AM" src="https://github.com/user-attachments/assets/05f7717b-f3dd-4e71-96c7-e4f19bf608f6" /> | <img width="1020" alt="Screenshot 2025-04-16 at 11 33 37 AM" src="https://github.com/user-attachments/assets/ef2eb8d0-8583-461c-8955-e446be217f30" /> |
| `folder_exists` | <img width="1242" alt="Screenshot 2025-04-16 at 10 55 22 AM" src="https://github.com/user-attachments/assets/2247b584-8402-46e0-8d4a-3634e12f1a7f" /> | <img width="1235" alt="Screenshot 2025-04-16 at 11 10 16 AM" src="https://github.com/user-attachments/assets/64330983-05b8-4ea5-b53c-f00958d5cff2" /> |
| `incompatible` (no change) | <img width="510" alt="Screenshot 2025-04-16 at 11 34 51 AM" src="https://github.com/user-attachments/assets/d164f67d-4d49-4b51-b1cd-4bbdd9daa86e" /> | <img width="510" alt="Screenshot 2025-04-16 at 11 30 29 AM" src="https://github.com/user-attachments/assets/c3557e29-70e5-4974-9498-207de154134c" /> | 





## Why are these changes being made?

The notice is redundant and distracting.

## Testing Instructions

**Test duplicate plugin.**
* Upload plugin
* Upload plugin again
* Expect to see relevant content, and no error toast.

**Test malicious plugin.**
 - Add early return to `upload_files``return new WP_Error( "plugin_malicious", "The uploaded file is identified as malicious." );`
- Upload a plugin
- Expect to see relevant content, and no error toast.


**Test incompatible plugins.**
- Add early return to `upload_files` `return new WP_Error( "incompatible", "Your plugin is incompatible" );`
- Upload a plugin
- Expect to see content and error message.


**Test random error.**
- Add early return to `upload_files` `return new WP_Error( "not_handle_error", "This did not work as expected." );`
- Upload a plugin
- Expect to see content and error message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
