### PR TITLE
Update text-wrap styles across multiple screens

### DIFF
--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,18 +1,6 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/calypso-color-schemes";
 
-// This block can be removed once support for `text-wrap: pretty` is stable in Safari.
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-caption,
-figcaption {
-	text-wrap: balance;
-}
-
 h1,
 h2,
 h3,

--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,6 +1,22 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/calypso-color-schemes";
 
+// Add base text-wrap styles.
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	text-wrap: balance;
+}
+p,
+ul,
+ol,
+blockquote {
+	text-wrap: pretty;
+}
+
 .help-center.entry-point-button {
 	&.is-active {
 		background: #1e1e1e;

--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,15 +1,26 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/calypso-color-schemes";
 
-// Add base text-wrap styles.
+// This block can be removed once support for `text-wrap: pretty` is stable in Safari.
 h1,
 h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+caption,
+figcaption {
 	text-wrap: balance;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+caption,
+figcaption,
 p,
 ul,
 ol,

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -146,10 +146,12 @@ h5,
 h6 {
 	clear: both;
 	text-wrap: balance;
+	text-wrap: pretty;
 }
 caption,
 figcaption {
 	text-wrap: balance;
+	text-wrap: pretty;
 }
 hr {
 	background: var(--color-neutral-10);

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -145,7 +145,7 @@ h4,
 h5,
 h6 {
 	clear: both;
-	text-wrap: balance;
+	text-wrap: balance; // TODO: remove this fallback once `pretty` is globally supported.
 	text-wrap: pretty;
 }
 caption,

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -307,9 +307,9 @@ export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, transl
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
 									</div>
-									<div className="eligibility-warnings__message-description">
+									<p className="eligibility-warnings__message-description">
 										{ holdMessages[ hold ].description }
-									</div>
+									</p>
 								</div>
 								{ holdMessages[ hold ].supportUrl && (
 									<div className="eligibility-warnings__hold-action">

--- a/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
+++ b/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
@@ -25,7 +25,7 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
         />
       </svg>
     </span>
-    <span
+    <p
       class="calypso-notice__content"
     >
       <span
@@ -33,7 +33,7 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
       >
         This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
       </span>
-    </span>
+    </p>
     <button
       aria-label="Dismiss"
       class="calypso-notice__dismiss"

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -226,10 +226,10 @@ export class Banner extends Component {
 		}
 		if ( typeof description === 'string' ) {
 			return (
-				<div
+				<p
 					className="banner__description"
 					dangerouslySetInnerHTML={ { __html: this.sanitize( description ) } } // eslint-disable-line react/no-danger
-				></div>
+				></p>
 			);
 		}
 		return <div className="banner__description">{ description }</div>;
@@ -274,7 +274,7 @@ export class Banner extends Component {
 					/>
 				) }
 				<div className="banner__info">
-					<div className="banner__title">{ title }</div>
+					<p className="banner__title">{ title }</p>
 					{ this.renderDescription( description ) }
 					{ size( list ) > 0 && (
 						<ul className="banner__list">

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -150,7 +150,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index, menu } ) => 
 					>
 						<Gridicon icon={ backIcon } size={ 18 } />
 					</Button>
-					<div className="blogging-prompt__prompt-text">{ getPrompt()?.text }</div>
+					<p className="blogging-prompt__prompt-text">{ getPrompt()?.text }</p>
 					<Button
 						aria-label={ translate( 'Show next prompt' ) }
 						borderless={ false }

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -41,7 +41,7 @@
 			font-size: $font-title-small;
 			font-weight: 500;
 			line-height: 26px;
-			text-wrap: pretty;
+			margin-bottom: 0;
 		}
 		button.navigation-link {
 			border-radius: 50%;

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -26,7 +26,7 @@ exports[`<GlobalNotices /> should render notices with the expected structure 1`]
           />
         </svg>
       </span>
-      <span
+      <p
         class="calypso-notice__content"
       >
         <span
@@ -34,7 +34,7 @@ exports[`<GlobalNotices /> should render notices with the expected structure 1`]
         >
           A test notice
         </span>
-      </span>
+      </p>
       <button
         aria-label="Dismiss"
         class="calypso-notice__dismiss"

--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -120,9 +120,9 @@ export default function Notice( {
 				{ iconNeedsDrop && <span className="calypso-notice__icon-wrapper-drop" /> }
 				{ renderedIcon }
 			</span>
-			<span className="calypso-notice__content">
-				<span className="calypso-notice__text">{ text ? text : children }</span>
-			</span>
+			<p className="calypso-notice__content">
+				<span className="notice__text">{ text ? text : children }</span>
+			</p>
 			{ text ? children : null }
 			{ showDismiss && (
 				<button

--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -121,7 +121,7 @@ export default function Notice( {
 				{ renderedIcon }
 			</span>
 			<p className="calypso-notice__content">
-				<span className="notice__text">{ text ? text : children }</span>
+				<span className="calypso-notice__text">{ text ? text : children }</span>
 			</p>
 			{ text ? children : null }
 			{ showDismiss && (

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -144,7 +144,7 @@ export default function ThemeCollection( {
 			<div className="theme-collection__meta">
 				<div className="theme-collection__headings">
 					<h2 className="theme-collection__title">{ title }</h2>
-					<div className="theme-collection__description">{ preventWidows( description ) }</div>
+					<p className="theme-collection__description">{ preventWidows( description ) }</p>
 				</div>
 				<div className="theme-collection__carousel-controls">
 					<Button className="theme-collection__see-all" onClick={ onSeeAllAction }>

--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -28,7 +28,7 @@ exports[`JetpackConnectNotices Should render non-terminal notice if callback sup
           />
         </svg>
       </span>
-      <span
+      <p
         class="calypso-notice__content"
       >
         <span
@@ -36,7 +36,7 @@ exports[`JetpackConnectNotices Should render non-terminal notice if callback sup
         >
           In some cases, authorization can take a few attempts. Please try again.
         </span>
-      </span>
+      </p>
     </div>
   </div>
 </div>
@@ -70,7 +70,7 @@ exports[`JetpackConnectNotices Should render notice 1`] = `
           />
         </svg>
       </span>
-      <span
+      <p
         class="calypso-notice__content"
       >
         <span
@@ -78,7 +78,7 @@ exports[`JetpackConnectNotices Should render notice 1`] = `
         >
           This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.
         </span>
-      </span>
+      </p>
     </div>
   </div>
 </div>

--- a/client/my-sites/add-ons/components/storage-add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/storage-add-ons-card.tsx
@@ -238,7 +238,9 @@ export default function StorageAddOnCard( { siteId, actionPrimary }: Props ) {
 					</div>
 				</CardHeader>
 				<CardBody className="storage-add-ons-card__body">
-					{ translate( 'Make more space for high-quality photos, videos, and other media.' ) }
+					<p>
+						{ translate( 'Make more space for high-quality photos, videos, and other media.' ) }
+					</p>
 					{ selectControlOptions.length ? (
 						<div className="storage-add-ons-card__storage-dropdown">
 							<CustomSelectControl

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -68,7 +68,6 @@ $plan-features-header-banner-height: 20px;
 .calypso-notice.plan-features-main__notice {
 	margin: 0 20px 24px;
 	width: unset;
-	text-wrap: pretty;
 
 	@include plans-section-custom-mobile-breakpoint {
 		margin: 0 0 24px;

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -33,7 +33,7 @@ export default function PluginsResultsHeader( {
 			{ ( title || subtitle ) && (
 				<div className="plugins-results-header__titles">
 					{ title && <TitleTag className="plugins-results-header__title">{ title }</TitleTag> }
-					{ subtitle && <div className="plugins-results-header__subtitle">{ subtitle }</div> }
+					{ subtitle && <p className="plugins-results-header__subtitle">{ subtitle }</p> }
 				</div>
 			) }
 			{ ( browseAllLink || resultCount ) && (

--- a/client/sites/components/add-ons/add-ons-card/index.tsx
+++ b/client/sites/components/add-ons/add-ons-card/index.tsx
@@ -144,7 +144,9 @@ const AddOnCard = ( { addOnMeta, actionPrimary, actionSecondary, highlightFeatur
 						<div className="add-ons-card__billing">{ addOnMeta.displayCost }</div>
 					</div>
 				</CardHeader>
-				<CardBody className="add-ons-card__body">{ addOnMeta.description }</CardBody>
+				<CardBody as="p" className="add-ons-card__body">
+					{ addOnMeta.description }
+				</CardBody>
 				<CardFooter isBorderless className="add-ons-card__footer">
 					{ shouldRenderLoadingState && (
 						<Spinner size={ 24 } className="spinner-button__spinner" />

--- a/client/sites/components/plan-pricing/index.tsx
+++ b/client/sites/components/plan-pricing/index.tsx
@@ -88,9 +88,9 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 					height="16px"
 				/>
 			) : (
-				<div className="plan-price-info">
+				<p className="plan-price-info">
 					{ price } { getBillingDetails() }
-				</div>
+				</p>
 			);
 		}
 
@@ -106,7 +106,7 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 						} ) }
 					</span>
 				</div>
-				<div className="plan-price-info">{ getBillingDetails() }</div>
+				<p className="plan-price-info">{ getBillingDetails() }</p>
 			</>
 		);
 	};

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -342,22 +342,22 @@ const FeaturesGrid = ( {
 				<div className="plan-features-2023-grid__content">
 					<div>
 						{ 'large' === gridSize && (
-							<div className="plan-features-2023-grid__desktop-view">
+							<p className="plan-features-2023-grid__desktop-view">
 								<Table { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-							</div>
+							</p>
 						) }
 						{ 'medium' === gridSize && (
-							<div className="plan-features-2023-grid__tablet-view">
+							<p className="plan-features-2023-grid__tablet-view">
 								<TabletView { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-							</div>
+							</p>
 						) }
 						{ 'small' === gridSize && (
-							<div className="plan-features-2023-grid__mobile-view">
+							<p className="plan-features-2023-grid__mobile-view">
 								<MobileView
 									{ ...planFeaturesProps }
 									enableShowAllFeaturesButton={ enableShowAllFeaturesButton }
 								/>
-							</div>
+							</p>
 						) }
 					</div>
 				</div>

--- a/packages/plans-grid-next/src/components/features-grid/plan-tagline.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-tagline.tsx
@@ -16,7 +16,7 @@ const PlanTagline = ( { options, renderedGridPlans }: PlanTaglineProps ) => {
 				className="plan-features-2023-grid__table-item"
 				isTableCell={ options?.isTableCell }
 			>
-				<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
+				<p className="plan-features-2023-grid__header-tagline">{ tagline }</p>
 			</PlanDivOrTdContainer>
 		);
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Starts addressing #100475

## Proposed Changes

* Adds the base text-wrap styles to the help center app. This has the unexpected side effect of making those styles available across wp-admin screens that contain the help widget.
* Changes `div` elements containing paragraphs of text to `p` elements, across several components.
* Removes custom `text-wrap` rules in places they are no longer needed after the conversion of `div`s to `p`s.

There are still a few instances of custom `text-wrap` rules across the codebase that I haven't removed, mostly because I can't find where they're being rendered. Those aren't really affecting product quality though, so perhaps they can be addressed sometime in the future.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For the help center inside the block editor/wp-admin screens, you may need to use a wpcom sandbox according to these instructions: PCYsg-OT6-p2
* For everything else, the calypso live link should work. The changes span many calypso screens, so best check everything looks as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?