### PR TITLE
A4A > Feedback: Implement General Feedback Mechanism

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-provide-general-feedback.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-provide-general-feedback.ts
@@ -1,0 +1,181 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import useSubmitSupportFormMutation from 'calypso/a8c-for-agencies/data/support/use-submit-support-form-mutation';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import {
+	FeedbackType,
+	type FeedbackSurveyResponsesPayload,
+	type GeneralFeedbackParams,
+} from '../types';
+import useSaveFeedbackMutation from './use-save-feedback-mutation';
+import type { SubmitContactSupportParams } from 'calypso/a8c-for-agencies/data/support/types';
+
+export const useProvideGeneralFeedback = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const agencyId = useSelector( getActiveAgencyId );
+	const user = useSelector( getCurrentUser );
+
+	const [ createTicket, setCreateTicket ] = useState( false );
+
+	const getMessage = useCallback( ( type: FeedbackType ) => {
+		switch ( type ) {
+			case FeedbackType.BugReport:
+				return 'A4A Feedback - Bug Report';
+			case FeedbackType.SuggestAFeature:
+				return 'A4A Feedback - Suggest a Feature';
+		}
+	}, [] );
+
+	const {
+		mutate: saveFeedback,
+		isPending: isSavingFeedback,
+		isSuccess: isSuccessFeedback,
+		isError: isErrorFeedback,
+	} = useSaveFeedbackMutation();
+
+	const {
+		mutateAsync: submitSupportForm,
+		isPending: isSubmittingSupportForm,
+		isSuccess: isSuccessSupportForm,
+		isError: isErrorSupportForm,
+	} = useSubmitSupportFormMutation();
+
+	const isSuccess = useMemo(
+		() => ( createTicket ? isSuccessSupportForm && isSuccessFeedback : isSuccessFeedback ),
+		[ createTicket, isSuccessSupportForm, isSuccessFeedback ]
+	);
+
+	const isError = useMemo(
+		() => ( createTicket ? isErrorSupportForm || isErrorFeedback : isErrorFeedback ),
+		[ createTicket, isErrorSupportForm, isErrorFeedback ]
+	);
+
+	const handleError = useCallback( () => {
+		dispatch(
+			errorNotice(
+				translate( 'An error occurred while submitting your feedback. Please try again.' ),
+				{
+					id: 'a4a-feedback-error',
+					duration: 10000,
+				}
+			)
+		);
+		setCreateTicket( false );
+	}, [ dispatch, translate ] );
+
+	const handleSuccess = useCallback( () => {
+		dispatch(
+			successNotice(
+				translate(
+					'Thanks! Our team will use your feedback to help prioritize improvements to Automattic for Agencies.'
+				),
+				{
+					id: 'a4a-feedback-success',
+					duration: 10000,
+				}
+			)
+		);
+		setCreateTicket( false );
+	}, [ dispatch, translate ] );
+
+	useEffect( () => {
+		if ( isError ) {
+			handleError();
+		}
+		if ( isSuccess ) {
+			handleSuccess();
+		}
+	}, [ isError, isSuccess, handleError, handleSuccess, createTicket ] );
+
+	const handleSaveFeedback = useCallback(
+		( feedback: GeneralFeedbackParams ) => {
+			if ( ! agencyId || ! feedback.responses ) {
+				return;
+			}
+			const { responses, type, ticketId } = feedback;
+			// Convert the responses object to a format that can be sent so that we can send the correct data to MC Marketing Survey tool
+			const surveyResponses = Object.entries( responses ).reduce(
+				( acc, [ key, value ] ) => ( {
+					...acc,
+					[ key ]: { text: value },
+				} ),
+				{}
+			);
+			const params: FeedbackSurveyResponsesPayload = {
+				site_id: agencyId,
+				survey_id: type,
+				survey_responses: { ...surveyResponses, ...( ticketId ? { ticket_id: ticketId } : {} ) },
+			};
+			saveFeedback( { params } );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_provide_feedback_feedback_submitted', {
+					feedback_type: type,
+				} )
+			);
+		},
+		[ agencyId, dispatch, saveFeedback ]
+	);
+
+	const submitGeneralFeedback = useCallback(
+		async ( feedback: GeneralFeedbackParams ) => {
+			setCreateTicket( false );
+			if ( ! agencyId || ! feedback.responses ) {
+				return;
+			}
+			const { responses, type, screenshot } = feedback;
+			// Create a Zendesk ticket for bug reports and feature suggestions.
+			if ( [ FeedbackType.BugReport, FeedbackType.SuggestAFeature ].includes( type ) && user ) {
+				setCreateTicket( true );
+				const formData = new FormData();
+				const fields = {
+					...responses,
+					product: 'a4a',
+					message: getMessage( type ),
+					name: user.display_name,
+					email: user.email,
+					agency_id: agencyId,
+				};
+				Object.entries( fields ).forEach( ( [ key, value ] ) => {
+					if ( value ) {
+						formData.append( key, value as string );
+					}
+				} );
+				if ( screenshot ) {
+					formData.append( 'screenshot', screenshot );
+				}
+				try {
+					const response = await submitSupportForm(
+						formData as unknown as SubmitContactSupportParams
+					);
+					dispatch(
+						recordTracksEvent( 'calypso_a4a_provide_feedback_zendesk_ticket_submitted', {
+							feedback_type: type,
+						} )
+					);
+					const updatedFeedback = {
+						...feedback,
+						ticketId: response?.ticket_id,
+					};
+					handleSaveFeedback( updatedFeedback );
+				} catch {
+					// We are already handling the error
+				}
+			} else {
+				handleSaveFeedback( feedback );
+			}
+		},
+		[ agencyId, dispatch, getMessage, handleSaveFeedback, submitSupportForm, user ]
+	);
+
+	return {
+		submitGeneralFeedback,
+		isSubmitting: isSubmittingSupportForm || isSavingFeedback,
+		isSuccess,
+	};
+};

--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-provide-general-feedback.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-provide-general-feedback.ts
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback } from 'react';
 import useSubmitSupportFormMutation from 'calypso/a8c-for-agencies/data/support/use-submit-support-form-mutation';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -21,8 +21,6 @@ export const useProvideGeneralFeedback = () => {
 	const agencyId = useSelector( getActiveAgencyId );
 	const user = useSelector( getCurrentUser );
 
-	const [ createTicket, setCreateTicket ] = useState( false );
-
 	const getMessage = useCallback( ( type: FeedbackType ) => {
 		switch ( type ) {
 			case FeedbackType.BugReport:
@@ -32,31 +30,7 @@ export const useProvideGeneralFeedback = () => {
 		}
 	}, [] );
 
-	const {
-		mutate: saveFeedback,
-		isPending: isSavingFeedback,
-		isSuccess: isSuccessFeedback,
-		isError: isErrorFeedback,
-	} = useSaveFeedbackMutation();
-
-	const {
-		mutateAsync: submitSupportForm,
-		isPending: isSubmittingSupportForm,
-		isSuccess: isSuccessSupportForm,
-		isError: isErrorSupportForm,
-	} = useSubmitSupportFormMutation();
-
-	const isSuccess = useMemo(
-		() => ( createTicket ? isSuccessSupportForm && isSuccessFeedback : isSuccessFeedback ),
-		[ createTicket, isSuccessSupportForm, isSuccessFeedback ]
-	);
-
-	const isError = useMemo(
-		() => ( createTicket ? isErrorSupportForm || isErrorFeedback : isErrorFeedback ),
-		[ createTicket, isErrorSupportForm, isErrorFeedback ]
-	);
-
-	const handleError = useCallback( () => {
+	const handleError = () => {
 		dispatch(
 			errorNotice(
 				translate( 'An error occurred while submitting your feedback. Please try again.' ),
@@ -66,10 +40,9 @@ export const useProvideGeneralFeedback = () => {
 				}
 			)
 		);
-		setCreateTicket( false );
-	}, [ dispatch, translate ] );
+	};
 
-	const handleSuccess = useCallback( () => {
+	const handleSuccess = () => {
 		dispatch(
 			successNotice(
 				translate(
@@ -81,17 +54,21 @@ export const useProvideGeneralFeedback = () => {
 				}
 			)
 		);
-		setCreateTicket( false );
-	}, [ dispatch, translate ] );
+	};
 
-	useEffect( () => {
-		if ( isError ) {
-			handleError();
-		}
-		if ( isSuccess ) {
-			handleSuccess();
-		}
-	}, [ isError, isSuccess, handleError, handleSuccess, createTicket ] );
+	const {
+		mutate: saveFeedback,
+		isPending: isSavingFeedback,
+		isSuccess: isSuccessFeedback,
+	} = useSaveFeedbackMutation( {
+		onSuccess: handleSuccess,
+		onError: handleError,
+	} );
+
+	const { mutateAsync: submitSupportForm, isPending: isSubmittingSupportForm } =
+		useSubmitSupportFormMutation( {
+			onError: handleError,
+		} );
 
 	const handleSaveFeedback = useCallback(
 		( feedback: GeneralFeedbackParams ) => {
@@ -124,14 +101,12 @@ export const useProvideGeneralFeedback = () => {
 
 	const submitGeneralFeedback = useCallback(
 		async ( feedback: GeneralFeedbackParams ) => {
-			setCreateTicket( false );
 			if ( ! agencyId || ! feedback.responses ) {
 				return;
 			}
 			const { responses, type, screenshot } = feedback;
 			// Create a Zendesk ticket for bug reports and feature suggestions.
 			if ( [ FeedbackType.BugReport, FeedbackType.SuggestAFeature ].includes( type ) && user ) {
-				setCreateTicket( true );
 				const formData = new FormData();
 				const fields = {
 					...responses,
@@ -176,6 +151,6 @@ export const useProvideGeneralFeedback = () => {
 	return {
 		submitGeneralFeedback,
 		isSubmitting: isSubmittingSupportForm || isSavingFeedback,
-		isSuccess,
+		isSuccess: isSuccessFeedback,
 	};
 };

--- a/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback.tsx
@@ -98,7 +98,7 @@ const useShowFeedback = ( type: FeedbackType ) => {
 					survey_id: params.survey_id,
 					rating: params.survey_responses.rating,
 					suggestions: params.survey_responses.suggestions?.text,
-					comment: params.survey_responses.comment.text,
+					comment: params.survey_responses.comment?.text,
 				} )
 			);
 			saveFeedback( { params } );

--- a/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/index.tsx
@@ -109,6 +109,7 @@ export default function ProvideFeedback() {
 	const [ feedbackType, setFeedbackType ] = useState< FeedbackType >( options[ 0 ].value );
 	const [ feedbackFields, setFeedbackFields ] = useState< Record< string, string > >( {} );
 	const [ screenshot, setScreenshot ] = useState< File | null >( null );
+	const [ screenshotError, setScreenshotError ] = useState< string | null >( null );
 
 	const handleFieldChange = useCallback( ( id: string, value: string ) => {
 		setFeedbackFields( ( prevFields ) => ( { ...prevFields, [ id ]: value } ) );
@@ -116,10 +117,17 @@ export default function ProvideFeedback() {
 
 	const handleScreenshotChange = useCallback(
 		( file: File | null ) => {
+			// If the file size is greater than 50MB, set the error message.
+			if ( file?.size && file.size > 50 * 1024 * 1024 ) {
+				setScreenshot( null );
+				setScreenshotError( translate( 'The image file size must be less than 50MB.' ) );
+				return;
+			}
+			setScreenshotError( null );
 			setScreenshot( file );
 			dispatch( recordTracksEvent( 'calypso_a4a_provide_feedback_screenshot_added' ) );
 		},
-		[ dispatch ]
+		[ dispatch, translate ]
 	);
 	const handleSetFeedbackType = useCallback(
 		( value?: FeedbackType ) => {
@@ -191,7 +199,7 @@ export default function ProvideFeedback() {
 			onClose={ onCloseProvideFeedbackForm }
 			title={ translate( 'Provide feedback' ) }
 			subtile={
-				<div className="a4a-provide-feedback__subtitle">
+				<>
 					{ translate(
 						'We want to hear from you! Use this form for general feedback to make the product better.'
 					) }
@@ -205,7 +213,7 @@ export default function ProvideFeedback() {
 							),
 						},
 					} ) }
-				</div>
+				</>
 			}
 			extraActions={
 				<Button
@@ -234,7 +242,7 @@ export default function ProvideFeedback() {
 					disabled={ isSubmitting }
 				></SelectControl>
 				{ currentFields.map( ( field ) => (
-					<FormFieldset key={ field.id }>
+					<FormFieldset key={ field.id } className="a4a-provide-feedback__form-fieldset">
 						<FormLabel className="a4a-provide-feedback__form-label" htmlFor={ field.id }>
 							{ field.label }
 						</FormLabel>
@@ -251,20 +259,36 @@ export default function ProvideFeedback() {
 								disabled={ isSubmitting }
 							/>
 						) }
+
 						{ field.type === 'file' && (
-							<FilePicker
-								accept="image/*,.pdf"
-								onPick={ ( files: FileList ) => handleScreenshotChange( files[ 0 ] ) }
-							>
+							<>
 								{ screenshot && (
 									<div className="a4a-provide-feedback__form-file-container">
 										<div className="a4a-provide-feedback__form-file-name">{ screenshot.name }</div>
+										<Button
+											size="small"
+											variant="tertiary"
+											onClick={ () => handleScreenshotChange( null ) }
+										>
+											{ translate( 'Remove' ) }
+										</Button>
 									</div>
 								) }
-								<Button variant="secondary" disabled={ isSubmitting }>
-									{ screenshot ? translate( 'Replace file' ) : translate( 'Select file' ) }
-								</Button>
-							</FilePicker>
+								{ screenshotError && (
+									<div className="a4a-provide-feedback__form-file-error">{ screenshotError }</div>
+								) }
+								<FilePicker
+									accept="image/*"
+									onPick={ ( files: FileList ) => handleScreenshotChange( files[ 0 ] ) }
+								>
+									<Button variant="secondary" disabled={ isSubmitting }>
+										{ screenshot ? translate( 'Replace image' ) : translate( 'Select image' ) }
+									</Button>
+								</FilePicker>
+								<div className="a4a-provide-feedback__form-file-instructions">
+									{ translate( 'Upload any image up to 50MB in size.' ) }
+								</div>
+							</>
 						) }
 					</FormFieldset>
 				) ) }

--- a/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/index.tsx
@@ -1,0 +1,274 @@
+import { FormLabel } from '@automattic/components';
+import { Button, SelectControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState, type ChangeEvent, useMemo, useEffect } from 'react';
+import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import A4AModal from 'calypso/a8c-for-agencies/components/a4a-modal';
+import FilePicker from 'calypso/components/file-picker';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useProvideGeneralFeedback } from '../hooks/use-provide-general-feedback';
+import { FeedbackType, type GeneralFeedbackTextAreaTypes } from '../types';
+
+import './style.scss';
+
+export const PROVIDE_FEEDBACK_URL_HASH_FRAGMENT = '#provide-feedback';
+
+export default function ProvideFeedback() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { submitGeneralFeedback, isSubmitting, isSuccess } = useProvideGeneralFeedback();
+
+	const provideFeedbackHash = window.location.hash === PROVIDE_FEEDBACK_URL_HASH_FRAGMENT;
+
+	const [ showProvideFeedbackForm, setShowProvideFeedbackForm ] = useState( provideFeedbackHash );
+
+	const options: {
+		label: string;
+		value: FeedbackType;
+		fields: {
+			id: GeneralFeedbackTextAreaTypes;
+			label: string;
+			placeholder?: string;
+			type: string;
+			optional?: boolean;
+		}[];
+	}[] = useMemo(
+		() => [
+			{
+				label: translate( 'General feedback' ),
+				value: FeedbackType.GeneralFeedback,
+				fields: [
+					{
+						id: 'improvements',
+						label: translate( 'What can we improve within Automattic for Agencies?' ),
+						placeholder: translate( 'Enter your thoughts' ),
+						type: 'textarea',
+					},
+				],
+			},
+			{
+				label: translate( 'Bug report' ),
+				value: FeedbackType.BugReport,
+				fields: [
+					{
+						id: 'issues',
+						label: translate( 'What problem(s) did you find?' ),
+						placeholder: translate( 'Enter the issues you encountered' ),
+						type: 'textarea',
+					},
+					{
+						id: 'location',
+						label: translate( 'Where did you find the problem(s)?' ),
+						placeholder: translate( 'Enter where you saw the problem' ),
+						type: 'textarea',
+					},
+					{
+						id: 'screenshot',
+						label: translate( 'Upload a screenshot (Optional)' ),
+						type: 'file',
+						optional: true,
+					},
+				],
+			},
+			{
+				label: translate( 'Suggest a feature' ),
+				value: FeedbackType.SuggestAFeature,
+				fields: [
+					{
+						id: 'feature',
+						label: translate(
+							'What would you like to see us improve within Automattic for Agencies?'
+						),
+						placeholder: translate( 'Enter the feature you want to see' ),
+						type: 'textarea',
+					},
+					{
+						id: 'inspiration',
+						label: translate( 'Have you seen this elsewhere? If so, where?' ),
+						placeholder: translate( 'Enter your inspiration' ),
+						type: 'textarea',
+					},
+					{
+						id: 'workflow',
+						label: translate(
+							'How important is this to you? Can you describe your ideal workflow?'
+						),
+						placeholder: translate( 'Enter your ideal workflow' ),
+						type: 'textarea',
+					},
+				],
+			},
+		],
+		[ translate ]
+	);
+
+	const [ feedbackType, setFeedbackType ] = useState< FeedbackType >( options[ 0 ].value );
+	const [ feedbackFields, setFeedbackFields ] = useState< Record< string, string > >( {} );
+	const [ screenshot, setScreenshot ] = useState< File | null >( null );
+
+	const handleFieldChange = useCallback( ( id: string, value: string ) => {
+		setFeedbackFields( ( prevFields ) => ( { ...prevFields, [ id ]: value } ) );
+	}, [] );
+
+	const handleScreenshotChange = useCallback(
+		( file: File | null ) => {
+			setScreenshot( file );
+			dispatch( recordTracksEvent( 'calypso_a4a_provide_feedback_screenshot_added' ) );
+		},
+		[ dispatch ]
+	);
+	const handleSetFeedbackType = useCallback(
+		( value?: FeedbackType ) => {
+			setFeedbackType( value ?? options[ 0 ].value );
+			setFeedbackFields( {} );
+			setScreenshot( null );
+			if ( value ) {
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_provide_feedback_type_selected', {
+						feedback_type: value,
+					} )
+				);
+			}
+		},
+		[ options, dispatch ]
+	);
+
+	const onCloseProvideFeedbackForm = useCallback( () => {
+		// Remove any hash from the URL.
+		history.pushState( null, '', window.location.pathname + window.location.search );
+		handleSetFeedbackType();
+		setShowProvideFeedbackForm( false );
+	}, [ handleSetFeedbackType ] );
+
+	// We need make sure to set this to true when we have the support form hash fragment.
+	if ( provideFeedbackHash && ! showProvideFeedbackForm ) {
+		setShowProvideFeedbackForm( true );
+	}
+
+	const currentFields = useMemo(
+		() => options.find( ( option ) => option.value === feedbackType )?.fields || [],
+		[ options, feedbackType ]
+	);
+
+	const handleSubmit = useCallback( () => {
+		submitGeneralFeedback( {
+			type: feedbackType as FeedbackType,
+			responses: currentFields.reduce(
+				( acc, field ) => ( {
+					...acc,
+					// Remove the screenshot from the responses if it exists.
+					...( field.id !== 'screenshot' ? { [ field.id ]: feedbackFields[ field.id ] } : {} ),
+				} ),
+				{} as Record< string, string >
+			),
+			screenshot: screenshot || undefined,
+		} );
+	}, [ feedbackFields, feedbackType, currentFields, submitGeneralFeedback, screenshot ] );
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			onCloseProvideFeedbackForm();
+		}
+	}, [ isSuccess, onCloseProvideFeedbackForm ] );
+
+	if ( ! showProvideFeedbackForm ) {
+		return null;
+	}
+
+	// Disable the submit button if any of the current textarea fields are empty and not optional.
+	const isDisabled = currentFields.some(
+		( field ) => ! field?.optional && ! feedbackFields[ field.id ]
+	);
+
+	return (
+		<A4AModal
+			className="a4a-provide-feedback__modal"
+			showCloseButton={ false }
+			onClose={ onCloseProvideFeedbackForm }
+			title={ translate( 'Provide feedback' ) }
+			subtile={
+				<div className="a4a-provide-feedback__subtitle">
+					{ translate(
+						'We want to hear from you! Use this form for general feedback to make the product better.'
+					) }
+					<br />
+					{ translate( 'Need a reply? {{a}}Reach out to your partner manager{{/a}}.', {
+						components: {
+							a: (
+								<a href={ CONTACT_URL_HASH_FRAGMENT }>
+									{ translate( 'Reach out to your partner manager.' ) }
+								</a>
+							),
+						},
+					} ) }
+				</div>
+			}
+			extraActions={
+				<Button
+					variant="primary"
+					onClick={ handleSubmit }
+					disabled={ isSubmitting || isDisabled }
+					isBusy={ isSubmitting }
+				>
+					{ translate( 'Submit' ) }
+				</Button>
+			}
+		>
+			<div className="a4a-provide-feedback__form">
+				<SelectControl
+					className="a4a-provide-feedback__form-select"
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ translate( 'What kind of feedback do you want to provide' ) }
+					labelPosition="top"
+					value={ feedbackType }
+					options={ options.map( ( option ) => ( {
+						label: option.label,
+						value: option.value,
+					} ) ) }
+					onChange={ handleSetFeedbackType }
+					disabled={ isSubmitting }
+				></SelectControl>
+				{ currentFields.map( ( field ) => (
+					<FormFieldset key={ field.id }>
+						<FormLabel className="a4a-provide-feedback__form-label" htmlFor={ field.id }>
+							{ field.label }
+						</FormLabel>
+						{ field.type === 'textarea' && (
+							<FormTextarea
+								className="a4a-provide-feedback__form-textarea"
+								name={ field.id }
+								id={ field.id }
+								value={ feedbackFields[ field.id ] }
+								placeholder={ field.placeholder }
+								onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+									handleFieldChange( field.id, event.target.value )
+								}
+								disabled={ isSubmitting }
+							/>
+						) }
+						{ field.type === 'file' && (
+							<FilePicker
+								accept="image/*,.pdf"
+								onPick={ ( files: FileList ) => handleScreenshotChange( files[ 0 ] ) }
+							>
+								{ screenshot && (
+									<div className="a4a-provide-feedback__form-file-container">
+										<div className="a4a-provide-feedback__form-file-name">{ screenshot.name }</div>
+									</div>
+								) }
+								<Button variant="secondary" disabled={ isSubmitting }>
+									{ screenshot ? translate( 'Replace file' ) : translate( 'Select file' ) }
+								</Button>
+							</FilePicker>
+						) }
+					</FormFieldset>
+				) ) }
+			</div>
+		</A4AModal>
+	);
+}

--- a/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
+++ b/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
@@ -1,13 +1,11 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-.a4a-provide-feedback__modal {
-	.a4a-modal__main {
-		height: auto;
+.a4a-provide-feedback__modal .a4a-modal__main {
+	height: auto;
 
-		.a4a-modal__title {
-			@include heading-x-large;
-		}
+	.a4a-modal__title {
+		@include heading-x-large;
 	}
 }
 
@@ -40,10 +38,8 @@
 	margin-block-end: 0;
 }
 
-.a4a-provide-feedback__form-select {
-	.components-input-control__container {
-		width: fit-content;
-	}
+.a4a-provide-feedback__form-select .components-input-control__container {
+	width: fit-content;
 }
 
 .a4a-provide-feedback__form-file-container {

--- a/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
+++ b/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
@@ -1,0 +1,52 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.a4a-provide-feedback__modal {
+	.a4a-modal__main {
+		height: 725px;
+	}
+}
+
+.a4a-provide-feedback__form {
+	padding-block: 16px 98px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	flex: 1 1 auto;
+
+	.form-fieldset {
+		margin-block-end: 0;
+	}
+
+	.file-picker {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+
+		button {
+			width: fit-content;
+		}
+	}
+}
+
+.form-label.a4a-provide-feedback__form-label {
+	@include heading-small;
+	padding-block-end: 8px;
+	text-transform: uppercase;
+	margin-block-end: 0;
+}
+
+.a4a-provide-feedback__form-select {
+	.components-input-control__container {
+		width: fit-content;
+	}
+}
+
+.a4a-provide-feedback__form-file-container {
+	width: 100%;
+	height: 100%;
+}
+
+.a4a-provide-feedback__form-file-name {
+	@include body-small;
+}

--- a/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
+++ b/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
@@ -33,7 +33,6 @@
 
 .form-label.a4a-provide-feedback__form-label {
 	@include heading-small;
-	padding-block-end: 8px;
 	text-transform: uppercase;
 	margin-block-end: 0;
 }
@@ -45,8 +44,31 @@
 .a4a-provide-feedback__form-file-container {
 	width: 100%;
 	height: 100%;
+	display: flex;
+	align-items: center;
+	gap: 16px;
 }
 
 .a4a-provide-feedback__form-file-name {
 	@include body-small;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 30vw;
+}
+
+.a4a-provide-feedback__form-file-instructions {
+	@include body-small;
+	color: var(--color-accent-50);
+}
+
+.a4a-provide-feedback__form-file-error {
+	@include body-small;
+	color: var(--color-scary-50);
+}
+
+.a4a-provide-feedback__form-fieldset {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }

--- a/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
+++ b/client/a8c-for-agencies/components/a4a-feedback/provide-feedback/style.scss
@@ -3,12 +3,16 @@
 
 .a4a-provide-feedback__modal {
 	.a4a-modal__main {
-		height: 725px;
+		height: auto;
+
+		.a4a-modal__title {
+			@include heading-x-large;
+		}
 	}
 }
 
 .a4a-provide-feedback__form {
-	padding-block: 16px 98px;
+	padding-block: 16px 68px;
 	display: flex;
 	flex-direction: column;
 	gap: 24px;

--- a/client/a8c-for-agencies/components/a4a-feedback/types.ts
+++ b/client/a8c-for-agencies/components/a4a-feedback/types.ts
@@ -5,6 +5,9 @@ export enum FeedbackType {
 	PurchaseCompleted = 'purchase-completed',
 	LicenseCancelProduct = 'license-cancel-product',
 	LicenseCancelHosting = 'license-cancel-hosting',
+	GeneralFeedback = 'general-feedback',
+	BugReport = 'bug-report',
+	SuggestAFeature = 'feature-request',
 }
 
 export type FeedbackQueryData = {
@@ -28,17 +31,20 @@ export type FeedbackProps = {
 	};
 };
 
-interface FeedbackSurveyResponses {
+type FeedbackSurveyResponses = {
+	[ key in GeneralFeedbackTextAreaTypes ]?: string;
+} & {
 	rating?: string;
-	comment: { text: string };
+	comment?: { text: string };
 	suggestions?: { text: string };
+	ticket_id?: number;
 	cta?: string;
 	meta?: {
 		product_name: string;
 		license_key: string;
 		license_type: string;
 	};
-}
+};
 export interface FeedbackSurveyResponsesPayload {
 	site_id: number;
 	survey_id: FeedbackType;
@@ -48,3 +54,19 @@ export interface FeedbackSurveyResponsesPayload {
 export interface MutationSaveFeedbackVariables {
 	params: FeedbackSurveyResponsesPayload;
 }
+
+export interface GeneralFeedbackParams {
+	type: FeedbackType;
+	responses: Record< GeneralFeedbackTextAreaTypes, string > | undefined;
+	screenshot?: File;
+	ticketId?: number;
+}
+
+export type GeneralFeedbackTextAreaTypes =
+	| 'improvements'
+	| 'issues'
+	| 'location'
+	| 'screenshot'
+	| 'feature'
+	| 'inspiration'
+	| 'workflow';

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -10,6 +10,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { CONTACT_URL_HASH_FRAGMENT } from '../../a4a-contact-support-widget';
+import { PROVIDE_FEEDBACK_URL_HASH_FRAGMENT } from '../../a4a-feedback/provide-feedback';
 import {
 	EXTERNAL_A4A_KNOWLEDGE_BASE,
 	EXTERNAL_A4A_CLIENT_KNOWLEDGE_BASE,
@@ -30,6 +31,12 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 		setMenuExpanded( false );
 		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_gethelp' ) );
 	}, [ dispatch, setMenuExpanded ] );
+
+	const onProvideFeedback = useCallback( () => {
+		setMenuExpanded( false );
+		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_provide_feedback' ) );
+	}, [ dispatch, setMenuExpanded ] );
+
 	const onSignOut = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_a4a_sidebar_signout' ) );
 		dispatch( redirectToLogout() );
@@ -42,11 +49,22 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 			{
 				// Show the "Contact support" button if the user is not a client
 				! isClient && (
-					<li className="a4a-sidebar__profile-dropdown-menu-item">
-						<Button borderless onClick={ onGetHelp } href={ CONTACT_URL_HASH_FRAGMENT }>
-							{ translate( 'Contact support' ) }
-						</Button>
-					</li>
+					<>
+						<li className="a4a-sidebar__profile-dropdown-menu-item">
+							<Button
+								borderless
+								onClick={ onProvideFeedback }
+								href={ PROVIDE_FEEDBACK_URL_HASH_FRAGMENT }
+							>
+								{ translate( 'Provide feedback' ) }
+							</Button>
+						</li>
+						<li className="a4a-sidebar__profile-dropdown-menu-item">
+							<Button borderless onClick={ onGetHelp } href={ CONTACT_URL_HASH_FRAGMENT }>
+								{ translate( 'Contact support' ) }
+							</Button>
+						</li>
+					</>
 				)
 			}
 			<li className="a4a-sidebar__profile-dropdown-menu-item">

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -15,6 +15,7 @@ import Sidebar, {
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import A4AContactSupportWidget, { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
+import ProvideFeedback from '../a4a-feedback/provide-feedback';
 import SidebarHeader from './header';
 import ProfileDropdown from './header/profile-dropdown';
 
@@ -132,6 +133,7 @@ const A4ASidebar = ( {
 			</SidebarFooter>
 
 			<A4AContactSupportWidget />
+			<ProvideFeedback />
 		</Sidebar>
 	);
 };

--- a/client/a8c-for-agencies/data/support/types.ts
+++ b/client/a8c-for-agencies/data/support/types.ts
@@ -16,4 +16,10 @@ export interface SubmitContactSupportParams {
 	contact_type?: string;
 	pressable_id?: number;
 	tags?: string[];
+	issues?: string;
+	location?: string;
+	screenshot?: File;
+	feature?: string;
+	inspiration?: string;
+	workflow?: string;
 }

--- a/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
+++ b/client/a8c-for-agencies/data/support/use-submit-support-form-mutation.ts
@@ -4,6 +4,7 @@ import type { APIError, SubmitContactSupportParams } from './types';
 
 interface APIResponse {
 	success: boolean;
+	ticket_id?: number;
 }
 
 function mutationSubmitSupportForm( params: SubmitContactSupportParams ): Promise< APIResponse > {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2015
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2016
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2018

## Proposed Changes

* Implement a General Feedback Mechanism that allows agency users to provide general feedback, report a bug, and suggest a feature.

Note: The Slack channel name can be found here: https://github.com/Automattic/automattic-for-agencies-dev/issues/2006).

## Why are these changes being made?

* To help bolster our retention and get relevant, in-context feedback from agencies.

## Testing Instructions

* Patch 180754-ghe-Automattic/wpcom to your sandbox
* Open the A4A live link
* Click the Profile dropdown > Verify you can see the `Provide feedback` button

<img width="263" alt="Screenshot 2025-04-16 at 11 23 49 AM" src="https://github.com/user-attachments/assets/10253034-9896-4b87-9925-fe37d2efa409" />

----

Click the `Provide feedback` button > Verify you can see the modal displayed as shown below. Verify that the submit button is disabled until you enter values in the textarea. Verify that clicking the `Reach out to your partner manager` opens the contact support modal. Submit the form as `General feedback` > Verify that the modal is closed, a success message is displayed, and a Slack message is published.

<img width="794" alt="Screenshot 2025-04-16 at 11 26 19 AM" src="https://github.com/user-attachments/assets/b2cbd0f7-d313-4299-bedd-36f31715a88c" />

<img width="331" alt="Screenshot 2025-04-16 at 12 37 59 PM" src="https://github.com/user-attachments/assets/afc9124f-aa17-49df-8fcd-3c88a5e0b201" />

<img width="794" alt="Screenshot 2025-04-16 at 12 32 20 PM" src="https://github.com/user-attachments/assets/4d4acf57-d7dd-46a4-8943-a8553b8f84d1" />

----

Click the `Provide feedback` button > Select `Bug report`. Verify that the submit button is disabled until you enter values in the textarea. Select a screenshot > Submit the form > Verify that the modal is closed, a success message is displayed, and a Slack message is published. Ensure the Zendesk ticket is also created along with the screeshot. You can find the ticket link on the Slack message. 

<img width="790" alt="Screenshot 2025-04-21 at 9 59 14 AM" src="https://github.com/user-attachments/assets/2d3c5f38-6ebf-4e08-99a3-b481801ca301" />

<img width="790" alt="Screenshot 2025-04-21 at 9 59 24 AM" src="https://github.com/user-attachments/assets/7256a97c-a737-4693-b6c0-014556826ec6" />

<img width="790" alt="Screenshot 2025-04-21 at 9 59 31 AM" src="https://github.com/user-attachments/assets/5fe6addf-61a6-4f93-89f3-c2c284fdae23" />


<img width="272" alt="Screenshot 2025-04-16 at 12 41 13 PM" src="https://github.com/user-attachments/assets/08f0983c-e697-45eb-b7d9-37b75a81e827" />

<img width="254" alt="Screenshot 2025-04-15 at 1 15 00 PM" src="https://github.com/user-attachments/assets/37401358-b26a-47ad-adf6-168c7066be0f" />

----

Click the `Provide feedback` button > Select `Suggest feature`. Verify that the submit button is disabled until you enter values in the textarea > Submit the form > Verify that the modal is closed, a success message is displayed, and a Slack message is published. Ensure the Zendesk ticket is also created. You can find the ticket link on the Slack message. 

<img width="794" alt="Screenshot 2025-04-16 at 12 34 12 PM" src="https://github.com/user-attachments/assets/ed345f2f-a5c6-4686-9f31-00650f464d6f" />

<img width="281" alt="Screenshot 2025-04-15 at 1 15 07 PM" src="https://github.com/user-attachments/assets/53d2013b-ff9c-4e71-b07a-2d2d2c01fb01" />

<img width="281" alt="Screenshot 2025-04-16 at 12 43 43 PM" src="https://github.com/user-attachments/assets/005c9d13-d4b1-4282-89da-759305efec30" />

----

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?