### PR TITLE
Upgrade WoA Sites to PHP 8.3: Show recommended version on Calypso to 50% of sites

### DIFF
--- a/client/data/php-versions/use-php-versions.jsx
+++ b/client/data/php-versions/use-php-versions.jsx
@@ -5,9 +5,9 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export const usePhpVersions = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
-	// 10% of sites will have a recommended PHP version of 8.3. These sites are transferring to 8.3 by default.
+	// 50% of sites will have a recommended PHP version of 8.3. These sites are transferring to 8.3 by default.
 	// 243386763 is the first site of the list.
-	const isPhp83Default = siteId >= 243386763 && siteId % 10 === 0;
+	const isPhp83Default = siteId >= 243386763 && siteId % 2 === 0;
 	const recommendedValue = isPhp83Default ? '8.3' : '8.2';
 	const recommendedLabel = translate( '%s (recommended)', {
 		args: isPhp83Default ? '8.3' : '8.2',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://linear.app/a8c/issue/DOTCOM-6444/move-50percent-of-new-woa-transfers-to-php83
- 180803-ghe-Automattic/wpcom

## Proposed Changes

* We now show PHP 8.3 as the recommended version for 50 percent of sites.
* The sites that show PHP 8.3 as recommended are the same that get transferred to PHP 8.3 by default.

![Screenshot 2025-04-09 at 16 11 12](https://github.com/user-attachments/assets/947c9f5f-3d29-446b-8107-d80a3dff3465)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We need to upgrade PHP to 8.3 on our sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link.
* Go to {container}/sites/settings/server/{siteId}
* You should see PHP 8.3 as the recommended version if your site is in the 10% partition.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?