### PR TITLE
hosted-site-migration: Remove custom login code

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
@@ -1,5 +1,4 @@
 import { HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
-import { useSearchParams } from 'react-router-dom';
 import { type Flow } from '../../internals/types';
 import siteMigration from '../site-migration-flow/site-migration-flow';
 
@@ -7,16 +6,6 @@ const hostedSiteMigrationFlow: Flow = {
 	...siteMigration,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
 	isSignupFlow: true,
-	useLoginParams() {
-		const [ searchParams ] = useSearchParams();
-		const backTo = searchParams.get( 'back_to' );
-
-		return {
-			extraQueryParams: {
-				...( backTo ? { back_to: backTo } : {} ),
-			},
-		};
-	},
 };
 
 export default hostedSiteMigrationFlow;


### PR DESCRIPTION
Related to MIGRATE-20

## Proposed Changes
Remove the custom login params `useLoginParams` from the hosted-site-migration flow.

## Why are these changes being made?
* As part the project to unify the hosted-site-migration and the site-migration flows, this PR aims to remove custom login code related only to hosted-site-migration to reduce the divergence between the flow before deprecated and remove.
* The code is also not more in use because nowadays stepper already have its own mechanism to handle login page and redirect back to the flow. 

## Testing Instructions
* Visual inspection should be enough. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
