### PR TITLE
Move `new-hosted-site` to FlowV2

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -17,6 +17,7 @@ import {
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
+import { getCurrentQueryParams } from '../../../utils/get-current-query-params';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import type { FlowV2, ProvidedDependencies, StepperStep } from '../../internals/types';
@@ -31,7 +32,7 @@ const hosting: FlowV2 = {
 
 		await resetOnboardStore();
 
-		const queryParams = new URLSearchParams( window.location.search );
+		const queryParams = getCurrentQueryParams();
 		const showDomainStep = queryParams.has( 'showDomainStep' );
 		const productSlug = queryParams.get( 'plan' );
 

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -1,6 +1,6 @@
 import { isFreeHostingTrial, isDotComPlan } from '@automattic/calypso-products';
 import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { useIsValidWooPartner } from 'calypso/landing/stepper/hooks/use-is-valid-woo-partner';
@@ -14,34 +14,70 @@ import {
 	setSignupCompleteSiteID,
 	getSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
-import { useDispatch as reduxUseDispatch, useSelector } from 'calypso/state';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
-import { Flow, ProvidedDependencies } from '../../internals/types';
-import type { OnboardSelect } from '@automattic/data-stores';
+import type { FlowV2, ProvidedDependencies, StepperStep } from '../../internals/types';
+import type { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 
-function useShowDomainStep(): boolean {
-	const query = useQuery();
-	return query.has( 'showDomainStep' );
-}
-
-const hosting: Flow = {
+const hosting: FlowV2 = {
 	name: NEW_HOSTED_SITE_FLOW,
 	__experimentalUseBuiltinAuth: true,
 	isSignupFlow: true,
-	useSteps() {
-		const showDomainStep = useShowDomainStep();
-		return stepsWithRequiredLogin( [
-			...( showDomainStep ? [ STEPS.UNIFIED_DOMAINS ] : [] ),
-			STEPS.UNIFIED_PLANS,
-			STEPS.TRIAL_ACKNOWLEDGE,
-			STEPS.SITE_CREATION_STEP,
-			STEPS.PROCESSING,
-		] );
+	async initialize( reduxStore ) {
+		const { resetOnboardStore, setPlanCartItem } = dispatch( ONBOARD_STORE ) as OnboardActions;
+
+		await resetOnboardStore();
+
+		// @ts-expect-error - This is a thunk. We need to type `reduxStore` better.
+		reduxStore.dispatch( setSelectedSiteId( null ) );
+
+		const queryParams = new URLSearchParams( window.location.search );
+		const showDomainStep = queryParams.has( 'showDomainStep' );
+		const productSlug = queryParams.get( 'plan' );
+
+		const eligibleForFreeHostingTrial = isUserEligibleForFreeHostingTrial( reduxStore.getState() );
+
+		const steps: StepperStep[] = [];
+
+		if ( showDomainStep ) {
+			steps.push( STEPS.UNIFIED_DOMAINS );
+		}
+
+		const utmSource = queryParams.get( 'utm_source' );
+
+		if ( ! productSlug || ! isDotComPlan( { product_slug: productSlug } ) ) {
+			steps.push( STEPS.UNIFIED_PLANS, STEPS.TRIAL_ACKNOWLEDGE );
+		} else if ( ! isFreeHostingTrial( productSlug ) ) {
+			await setPlanCartItem( {
+				product_slug: productSlug,
+				extra: {
+					...( utmSource && {
+						hideProductVariants: utmSource === 'wordcamp',
+					} ),
+				},
+			} );
+		} else if ( eligibleForFreeHostingTrial ) {
+			await setPlanCartItem( {
+				product_slug: productSlug,
+				extra: {
+					...( utmSource && {
+						hideProductVariants: utmSource === 'wordcamp',
+					} ),
+				},
+			} );
+
+			steps.push( STEPS.TRIAL_ACKNOWLEDGE, STEPS.UNIFIED_PLANS );
+		} else {
+			steps.push( STEPS.UNIFIED_PLANS );
+		}
+
+		steps.push( STEPS.SITE_CREATION_STEP, STEPS.PROCESSING );
+
+		return stepsWithRequiredLogin( steps );
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const {
@@ -63,10 +99,12 @@ const hosting: Flow = {
 		);
 
 		const query = useQuery();
-		const queryParams = Object.fromEntries( query );
-		const plan = queryParams.plan;
+
+		const utmSource = query.get( 'utm_source' );
+		const studioSiteId = query.get( 'studioSiteId' );
+
 		const flowName = this.name;
-		const showDomainStep = useShowDomainStep();
+		const showDomainStep = query.has( 'showDomainStep' );
 		const isWooPartner = useIsValidWooPartner();
 
 		const getGoBack = () => {
@@ -79,29 +117,39 @@ const hosting: Flow = {
 			}
 		};
 
+		const flowSteps = this.getSteps!();
+
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			if ( providedDependencies.siteId ) {
 				setSignupCompleteSiteID( providedDependencies.siteId );
 			}
 
 			switch ( _currentStepSlug ) {
-				case 'domains': {
+				case STEPS.UNIFIED_DOMAINS.slug: {
 					setSiteUrl( providedDependencies.siteUrl );
 					setDomain( providedDependencies.suggestion );
 					setDomainCartItem( providedDependencies.domainItem );
 					setDomainCartItems( providedDependencies.domainCart );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin );
 
-					// If the plan is already supplied as a query param, add it to cart, and skip plans step
-					if ( plan && isDotComPlan( { product_slug: plan } ) ) {
-						setPlanCartItem( {
-							product_slug: plan,
-						} );
-						return navigate( 'create-site' );
+					// Surely there's a better way to do this?
+					const currentStepIndex = flowSteps.findIndex(
+						( step ) => step.slug === STEPS.UNIFIED_DOMAINS.slug
+					);
+
+					if ( currentStepIndex === -1 ) {
+						throw new Error( 'Current step index not found' );
 					}
-					return navigate( 'plans' );
+
+					const nextStep = flowSteps[ currentStepIndex + 1 ];
+
+					if ( ! nextStep ) {
+						throw new Error( 'Next step not found' );
+					}
+
+					navigate( nextStep.slug );
 				}
-				case 'plans': {
+				case STEPS.UNIFIED_PLANS.slug: {
 					const cartItems = providedDependencies.cartItems as Array< typeof planCartItem >;
 					const productSlug = cartItems?.[ 0 ]?.product_slug;
 
@@ -112,37 +160,36 @@ const hosting: Flow = {
 					setPlanCartItem( {
 						product_slug: productSlug,
 						extra: {
-							...( queryParams?.utm_source && {
-								hideProductVariants: queryParams.utm_source === 'wordcamp',
+							...( utmSource && {
+								hideProductVariants: utmSource === 'wordcamp',
 							} ),
 						},
 					} );
 
 					if ( isFreeHostingTrial( productSlug ) ) {
-						return navigate( 'trialAcknowledge' );
+						return navigate( STEPS.TRIAL_ACKNOWLEDGE.slug );
 					}
 
 					setSignupCompleteFlowName( flowName );
-					return navigate( 'create-site' );
+					return navigate( STEPS.SITE_CREATION_STEP.slug );
 				}
 
-				case 'trialAcknowledge': {
-					return navigate( 'create-site' );
+				case STEPS.TRIAL_ACKNOWLEDGE.slug: {
+					return navigate( STEPS.SITE_CREATION_STEP.slug );
 				}
 
-				case 'create-site':
-					return navigate( 'processing' );
+				case STEPS.SITE_CREATION_STEP.slug:
+					return navigate( STEPS.PROCESSING.slug );
 
-				case 'processing': {
-					const hasStudioSyncSiteId = queryParams.studioSiteId;
+				case STEPS.PROCESSING.slug: {
 					const siteId = providedDependencies.siteId || getSignupCompleteSiteID();
 					const siteSlug = providedDependencies.siteSlug || getSignupCompleteSlug();
 					const destinationParams: Record< string, string > = {
 						siteId,
 					};
-					if ( hasStudioSyncSiteId ) {
+					if ( studioSiteId ) {
 						destinationParams[ 'redirect_to' ] = addQueryArgs( `/home/${ siteId }`, {
-							studioSiteId: queryParams.studioSiteId,
+							studioSiteId: studioSiteId,
 						} );
 					} else if ( isWooPartner ) {
 						// For partners, we'll redirect to the WooCommerce admin page
@@ -174,7 +221,7 @@ const hosting: Flow = {
 						);
 					}
 
-					return navigate( 'plans' );
+					return navigate( STEPS.UNIFIED_PLANS.slug );
 				}
 			}
 		};
@@ -184,44 +231,17 @@ const hosting: Flow = {
 			submit,
 		};
 	},
-	useSideEffect( currentStepSlug, navigate ) {
-		const dispatch = reduxUseDispatch();
-		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
-		const query = useQuery();
-		const isEligible = useSelector( isUserEligibleForFreeHostingTrial );
-		// Support for FlowV1 and V2, remove useSteps once FlowV1 is removed.
-		const steps = 'useSteps' in this ? this.useSteps() : this.getSteps?.();
-
-		const queryParams = Object.fromEntries( query );
+	useSideEffect( currentStepSlug ) {
+		const studioSiteId = useQuery().get( 'studioSiteId' );
 
 		useEffect( () => {
-			if ( currentStepSlug === 'trialAcknowledge' && ! isEligible && steps?.[ 0 ] ) {
-				// Go to the first step if the user is not eligible for a free hosting trial
-				navigate( steps[ 0 ].slug );
-			}
-		}, [ isEligible, currentStepSlug, navigate, steps ] );
-
-		useEffect( () => {
-			if ( queryParams.studioSiteId ) {
+			if ( studioSiteId ) {
 				recordTracksEvent( 'calypso_studio_sync_step', {
 					flow: NEW_HOSTED_SITE_FLOW,
 					step: currentStepSlug,
 				} );
 			}
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [ currentStepSlug ] );
-
-		useEffect(
-			() => {
-				if ( ! currentStepSlug ) {
-					resetOnboardStore();
-				}
-				dispatch( setSelectedSiteId( null ) );
-			},
-			// We only need to reset the store and/or check the `campaign` param when the flow is mounted.
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-			[]
-		);
+		}, [ currentStepSlug, studioSiteId ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -15,7 +15,6 @@ import {
 	getSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
@@ -31,9 +30,6 @@ const hosting: FlowV2 = {
 		const { resetOnboardStore, setPlanCartItem } = dispatch( ONBOARD_STORE ) as OnboardActions;
 
 		await resetOnboardStore();
-
-		// @ts-expect-error - This is a thunk. We need to type `reduxStore` better.
-		reduxStore.dispatch( setSelectedSiteId( null ) );
 
 		const queryParams = new URLSearchParams( window.location.search );
 		const showDomainStep = queryParams.has( 'showDomainStep' );

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -114,8 +114,6 @@ const hosting: FlowV2 = {
 			}
 		};
 
-		const flowSteps = this.getSteps!();
-
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			if ( providedDependencies.siteId ) {
 				setSignupCompleteSiteID( providedDependencies.siteId );
@@ -129,22 +127,11 @@ const hosting: FlowV2 = {
 					setDomainCartItems( providedDependencies.domainCart );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin );
 
-					// Surely there's a better way to do this?
-					const currentStepIndex = flowSteps.findIndex(
-						( step ) => step.slug === STEPS.UNIFIED_DOMAINS.slug
-					);
-
-					if ( currentStepIndex === -1 ) {
-						throw new Error( 'Current step index not found' );
+					if ( planCartItem ) {
+						return navigate( STEPS.SITE_CREATION_STEP.slug );
 					}
 
-					const nextStep = flowSteps[ currentStepIndex + 1 ];
-
-					if ( ! nextStep ) {
-						throw new Error( 'Next step not found' );
-					}
-
-					navigate( nextStep.slug );
+					return navigate( STEPS.UNIFIED_PLANS.slug );
 				}
 				case STEPS.UNIFIED_PLANS.slug: {
 					const cartItems = providedDependencies.cartItems as Array< typeof planCartItem >;

--- a/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/new-hosted-site-flow/new-hosted-site-flow.ts
@@ -185,7 +185,7 @@ const hosting: FlowV2 = {
 					};
 					if ( studioSiteId ) {
 						destinationParams[ 'redirect_to' ] = addQueryArgs( `/home/${ siteId }`, {
-							studioSiteId: studioSiteId,
+							studioSiteId,
 						} );
 					} else if ( isWooPartner ) {
 						// For partners, we'll redirect to the WooCommerce admin page

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -107,19 +107,6 @@ const PlansStepAdaptor: StepType< {
 
 	useQueryTheme( 'wpcom', selectedDesign?.slug );
 
-	// TODO: Remove this once we have a better way to handle the plan from the query param.
-	// This is a hack used by new-hosted-site flow.
-	const planFromQuery = useQuery().get( 'plan' );
-
-	if ( planFromQuery ) {
-		props.navigation.submit?.( {
-			...stepState,
-			cartItems: [ { product_slug: planFromQuery } ],
-		} );
-
-		return null;
-	}
-
 	/**
 	 * isWordCampPromo is temporary
 	 */

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -1,5 +1,6 @@
 import { StepperInternal } from '@automattic/data-stores';
 import React from 'react';
+import { Store } from 'redux';
 import { STEPPER_TRACKS_EVENTS } from '../../constants';
 
 /**
@@ -230,11 +231,9 @@ export type FlowV2 = {
 	 *
 	 * Returning false will kill the app.
 	 */
-	initialize():
-		| false
-		| Promise< false >
-		| Promise< readonly StepperStep[] >
-		| readonly StepperStep[];
+	initialize(
+		reduxStore: Store
+	): false | Promise< false > | Promise< readonly StepperStep[] > | readonly StepperStep[];
 	useStepNavigation: UseStepNavigationHook< StepperStep[] >;
 	/**
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..

--- a/client/landing/stepper/utils/get-current-query-params.ts
+++ b/client/landing/stepper/utils/get-current-query-params.ts
@@ -1,0 +1,4 @@
+/**
+ * Parses and returns the query parameters from the URL
+ */
+export const getCurrentQueryParams = () => new URLSearchParams( window.location.search );

--- a/client/landing/stepper/utils/get-query.ts
+++ b/client/landing/stepper/utils/get-query.ts
@@ -1,7 +1,0 @@
-/**
- * Parses and returns the query parameters from the URL
- * @returns An object with the query parameters
- */
-export const getQuery = () => {
-	return Object.fromEntries( new URLSearchParams( window.location.search ) );
-};

--- a/client/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs.ts
+++ b/client/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs.ts
@@ -11,8 +11,6 @@ export const useFreeTrialPlanSlugs: UseFreeTrialPlanSlugs = ( {
 
 		if ( intent === 'plans-new-hosted-site' && eligibleForFreeHostingTrial ) {
 			freeTrialSlugs[ TYPE_BUSINESS ] = PLAN_HOSTING_TRIAL_MONTHLY;
-			// Disable free hosting trials - see pMz3w-k4H-p2#comment-119368
-			delete freeTrialSlugs[ TYPE_BUSINESS ];
 		}
 
 		return freeTrialSlugs;

--- a/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
+++ b/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
@@ -1,17 +1,7 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { getCurrentUser } from '../current-user/selectors';
-import type { AppState } from '../../types';
+import { AppState } from '../../types';
 
-export const isUserEligibleForFreeHostingTrial = ( state: AppState ) => {
-	if ( ! isEnabled( 'plans/hosting-trial' ) ) {
-		return false;
-	}
-
-	const currentUser = getCurrentUser( state );
-
-	if ( ! currentUser ) {
-		return false;
-	}
-
-	return ! currentUser.had_hosting_trial;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const isUserEligibleForFreeHostingTrial = ( _state: AppState ) => {
+	// Disable free hosting trials - see pMz3w-k4H-p2#comment-119368
+	return false;
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102658.

## Proposed Changes

- Port flow from v1 to v2
- Pass Redux Store as a parameter of the `flow.initialize` function
- Moves flow initialization logic to the `initialize` function

## Why are these changes being made?

The flow is now much cleaner.

## Testing Instructions

Enter `/setup/new-hosted-site` directly, and you should see only the plans step. Then, you should land at checkout with it in the cart.

Enter `/setup/new-hosted-site?showDomainStep`, and you should see the domains step before the plans. You should land at checkout with a domain and a site in the cart.

Enter `/setup/new-hosted-site?plan=business-bundle`, and you should be redirected to the checkout directly with a plan in the cart.

Enter `/setup/new-hosted-site?showDomainStep&plan=business-bundle-monthly`, and you should see only the domains step. You should land at checkout with a domain and a site in the cart.

Enter `/setup/new-hosted-site?plan=wp_bundle_hosting_trial_monthly` as an eligible trial user (a user that hasn't had a trial before) and should be able to create a trial site, going through checkout. **To test this you must remove the guard within `isUserEligibleForFreeHostingTrial`.**

Enter `/setup/new-hosted-site?plan=wp_bundle_hosting_trial_monthly` as an INeligible trial user (a user that had a trial before) and you should be sent to the plans page.