### PR TITLE
Theme Showcase: Re-implement the event calypso_themeshowcase_last_page_scroll

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -135,11 +135,16 @@ class ThemesSelection extends Component {
 	};
 
 	fetchNextPage = ( options ) => {
-		if ( this.props.isRequesting || this.props.isLastPage ) {
+		if ( this.props.isRequesting ) {
 			return;
 		}
 
 		if ( options.triggeredByScroll ) {
+			if ( this.props.isLastPage ) {
+				this.trackLastPage();
+				return;
+			}
+
 			this.trackScrollPage();
 		}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/12462

## Proposed Changes

This PR reintroduced the event calypso_themeshowcase_last_page_scroll which was removed in https://github.com/Automattic/wp-calypso/pull/10019.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Event tracking.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /themes
* Scroll to the bottom and ensure that the event calypso_themeshowcase_last_page_scroll is triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
