### PR TITLE
Staging Sites: Refresh jetpack connection health status on component load

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -15,6 +15,7 @@ import {
 	transferRevertingInProgress,
 } from 'calypso/state/automated-transfer/constants';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { requestJetpackConnectionHealthStatus } from 'calypso/state/jetpack-connection-health/actions';
 import isJetpackConnectionProblem from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
@@ -501,6 +502,13 @@ export const StagingSiteCard = ( {
 	} else if ( ! hasCompletedInitialLoading ) {
 		stagingSiteCardContent = <LoadingPlaceholder />;
 	}
+
+	// Get the fresh jetpack connection health status
+	useEffect( () => {
+		if ( isJetpack && siteId ) {
+			dispatch( requestJetpackConnectionHealthStatus( siteId ) );
+		}
+	}, [ dispatch, isJetpack, siteId ] );
 
 	return (
 		<CardContentWrapper>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

> [!NOTE]
> I have managed to receive the message on a couple of sites, but it disappeared shortly after refreshing the page. Based on my understanding, I have created this [PR](https://github.com/Automattic/wp-calypso/pull/102664), but I can’t test it since I do not have any sites where I receive that message. Hence, I can’t say the PR will actually fix the issue. 

Related to DOTCOM-10549

## Proposed Changes

* Refresh Jetpack connection health status on component load

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users are getting the a following error message when trying to create new site.
```
Unable to create a new test site. There is a problem connecting to the site. If the problem persists, please contact support.
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Open the network tab in the inspection tool
* Visit /staging-site/:site
* Make sure every time you visit this page, A request to the endpoint `wpcom/v2/sites/:site/jetpack-connection-health` is made. Which means, the component is refreshing the connection status. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
