### PR TITLE
Domains Management: Update add domain button URL

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -10,7 +10,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
-import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { composeAnalytics, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -32,17 +32,9 @@ class AddDomainButton extends Component {
 		super( props );
 	}
 
-	getAddNewDomainUrl = () => {
-		if ( ! this.props.selectedSiteSlug ) {
-			return '/start/domain';
-		}
-
-		return domainAddNew( this.props.selectedSiteSlug );
-	};
-
 	clickAddDomain = () => {
 		this.props.trackAddDomainClick();
-		page( this.getAddNewDomainUrl() );
+		page( '/start/domain' );
 	};
 
 	trackMenuClick = ( reactEvent ) => {
@@ -93,7 +85,7 @@ class AddDomainButton extends Component {
 				whiteSeparator={ ! this.props.sidebarMode }
 				label={ isBreakpointActive ? undefined : translate( 'Add new domain' ) }
 				toggleIcon={ isBreakpointActive ? 'plus' : undefined }
-				href={ this.getAddNewDomainUrl() }
+				href="/start/domain"
 				onClick={ this.trackAddDomainClick }
 			>
 				{ this.renderOptions() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/101976

## Proposed Changes

This PR updates both buttons "Add new domain" and "Register a new domain" to always land on /start/domain, and not /domains/add/:domain when a domain has been selected due to odd UI.

![Screenshot 2025-04-17 at 4 52 21 PM](https://github.com/user-attachments/assets/ca9d5cf8-d130-47a1-a663-7970854ca708)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /domains/manage
* Select a domain
* In the domains list, click on "Add new domain"
* Ensure you land on /start/domain which redirects to /start/domain/domain-only

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
