### PR TITLE
Staging Site: Update Local State Unconditionally Based on Remote Response

### DIFF
--- a/client/state/jetpack-connection-health/actions.js
+++ b/client/state/jetpack-connection-health/actions.js
@@ -6,7 +6,6 @@ import {
 	JETPACK_CONNECTION_HEALTH_REQUEST,
 	JETPACK_CONNECTION_HEALTH_REQUEST_FAILURE,
 } from 'calypso/state/action-types';
-import isJetpackConnectionUnhealthy from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-unhealthy';
 
 import 'calypso/state/jetpack-connection-health/init';
 
@@ -64,10 +63,7 @@ export const setJetpackConnectionRequestFailure = ( siteId, error ) => ( {
  * @param {number} siteId The site id to which the status belongs
  * @returns {Function} Action thunk
  */
-export const requestJetpackConnectionHealthStatus = ( siteId ) => ( dispatch, getState ) => {
-	const currentState = getState();
-	const reduxIsUnhealthy = isJetpackConnectionUnhealthy( currentState, siteId );
-
+export const requestJetpackConnectionHealthStatus = ( siteId ) => ( dispatch ) => {
 	dispatch( {
 		type: JETPACK_CONNECTION_HEALTH_REQUEST,
 		siteId,
@@ -81,10 +77,9 @@ export const requestJetpackConnectionHealthStatus = ( siteId ) => ( dispatch, ge
 		} )
 		.then( ( response ) => {
 			const { is_healthy, error } = response;
-			if ( is_healthy && reduxIsUnhealthy ) {
+			if ( is_healthy ) {
 				dispatch( setJetpackConnectionHealthy( siteId ) );
-			}
-			if ( ! is_healthy && ! reduxIsUnhealthy ) {
+			} else {
 				dispatch( setJetpackConnectionUnhealthy( siteId, error ) );
 			}
 		} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

> [!CAUTION]
>  This PR would work just fine but would lose the performance benefit of avoiding unnecessary state updates.

Related to DOTCOM-10549

Slack: p1744866613342559-slack-C02FMH4G8

## Proposed Changes

* Remove the condition to always update the local Jetpack connection health state 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Jetpack connection state is not being updated in case the current state is incorrect. 

#### Problem
The Jetpack connection health state isn't updating correctly due to a mismatch between the state structure and selector expectations. Specifically, `isJetpackConnectionUnhealthy` requires both conditions to be true:
1. `siteConnectionHealth.jetpack_connection_problem === true`
2. `Boolean(siteConnectionHealth.error) === true`

However, when we set the connection as "maybe unhealthy" via [JETPACK_CONNECTION_MAYBE_UNHEALTHY](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/jetpack-connection-health/actions.js#L101), we only set `jetpack_connection_problem: true` without setting an error value. This causes [reduxIsUnhealthy](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/jetpack-connection-health/actions.js#L69) to always be `false` in [requestJetpackConnectionHealthStatus](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/jetpack-connection-health/actions.js#L66), preventing state updates when they should occur.

#### Root Cause
The issue stems from this optimization in `requestJetpackConnectionHealthStatus`:
```javascript
if ( is_healthy && reduxIsUnhealthy ) {
    dispatch( setJetpackConnectionHealthy( siteId ) );
}
if ( ! is_healthy && ! reduxIsUnhealthy ) {
    dispatch( setJetpackConnectionUnhealthy( siteId, error ) );
}
```

Since `reduxIsUnhealthy` is always `false` (due to missing error value), the state updates are skipped when they shouldn't be.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR
* Open the network tab in the inspection tool
* Also open application tab -> IndexedDB -> calypso
* Visit /staging-site/:site
* Make sure every time you visit this page, A request to the endpoint `wpcom/v2/sites/:site/jetpack-connection-health` is made. Which means, the component is refreshing the connection status. 
* Make sure calypso indexed db is updated after every page load. 
![CleanShot 2025-04-17 at 16 13 09@2x](https://github.com/user-attachments/assets/22028545-767f-4abe-83cb-11d316bc5b98)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?