### PR TITLE
Site Migration: Improve the' Identify' step's back button logic to remove reference from hosted-site-migration. 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -1,10 +1,4 @@
-import {
-	StepContainer,
-	Title,
-	SubTitle,
-	HOSTED_SITE_MIGRATION_FLOW,
-	Step,
-} from '@automattic/onboarding';
+import { StepContainer, Title, SubTitle, Step } from '@automattic/onboarding';
 import { Icon, next, published, shield } from '@wordpress/icons';
 import { numberFormat, TranslateResult, useTranslate } from 'i18n-calypso';
 import { type FC, ReactElement, useEffect, useState, useCallback } from 'react';
@@ -16,6 +10,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
+//TODO: Move it to a more generic folder
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
 import type { Step as StepType } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
@@ -150,7 +145,7 @@ const SiteMigrationIdentify: StepType< {
 		platform?: string;
 		from?: string;
 	};
-} > = function ( { navigation, variantSlug, flow } ) {
+} > = function ( { navigation, flow } ) {
 	const siteSlug = useSiteSlug();
 	const translate = useTranslate();
 	const { createScreenshots } = useSitePreviewMShotImageHandler();
@@ -172,12 +167,10 @@ const SiteMigrationIdentify: StepType< {
 
 	const urlQueryParams = useQuery();
 
-	const shouldHideBackButton = () => {
-		const ref = urlQueryParams.get( 'ref' ) || '';
-		const shouldHideBasedOnRef = [ 'entrepreneur-signup', 'calypso-importer' ].includes( ref );
-		const shouldHideBasedOnVariant = [ HOSTED_SITE_MIGRATION_FLOW ].includes( variantSlug || '' );
-		const shouldNotHideIfBackToIsSet = Boolean( urlQueryParams.get( 'back_to' ) );
-		return ( shouldHideBasedOnRef || shouldHideBasedOnVariant ) && ! shouldNotHideIfBackToIsSet;
+	const shouldShowBackButton = () => {
+		const ref = urlQueryParams.get( 'ref' );
+		const isFromGoals = ref === 'goals';
+		return isFromGoals || urlQueryParams.has( 'back_to' );
 	};
 
 	const [ isVisible, setIsVisible ] = useState( false );
@@ -206,9 +199,7 @@ const SiteMigrationIdentify: StepType< {
 					topBar={
 						<Step.TopBar
 							leftElement={
-								shouldHideBackButton() ? undefined : (
-									<Step.BackButton onClick={ navigation.goBack } />
-								)
+								shouldShowBackButton() ? <Step.BackButton onClick={ navigation.goBack } /> : null
 							}
 						/>
 					}
@@ -234,7 +225,7 @@ const SiteMigrationIdentify: StepType< {
 				stepName="site-migration-identify"
 				flowName="site-migration"
 				className="import__onboarding-page"
-				hideBack={ shouldHideBackButton() }
+				hideBack={ ! shouldShowBackButton() }
 				backUrl={ urlQueryParams.get( 'back_to' ) || undefined }
 				hideSkip
 				hideFormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -169,8 +169,9 @@ const SiteMigrationIdentify: StepType< {
 
 	const shouldShowBackButton = () => {
 		const ref = urlQueryParams.get( 'ref' );
-		const isFromGoals = ref === 'goals';
-		return isFromGoals || urlQueryParams.has( 'back_to' );
+
+		const isBackButtonSupported = ref && [ 'goals', 'wp-admin-importers-list' ].includes( ref );
+		return isBackButtonSupported || urlQueryParams.has( 'back_to' );
 	};
 
 	const [ isVisible, setIsVisible ] = useState( false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -11,6 +11,7 @@ import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
 //TODO: Move it to a more generic folder
+import { useFlowState } from '../../state-manager/store';
 import { useSitePreviewMShotImageHandler } from '../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler';
 import type { Step as StepType } from '../../types';
 import type { UrlData } from 'calypso/blocks/import/types';
@@ -166,9 +167,10 @@ const SiteMigrationIdentify: StepType< {
 	);
 
 	const urlQueryParams = useQuery();
+	const { get } = useFlowState();
 
 	const shouldShowBackButton = () => {
-		const ref = urlQueryParams.get( 'ref' );
+		const ref = get( 'flow' )?.entryPoint;
 
 		const isBackButtonSupported = ref && [ 'goals', 'wp-admin-importers-list' ].includes( ref );
 		return isBackButtonSupported || urlQueryParams.has( 'back_to' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -6,12 +6,18 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
+import { useFlowState } from 'calypso/landing/stepper/declarative-flow/internals/state-manager/store';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import SiteMigrationIdentify from '..';
 import { UrlData } from '../../../../../../../blocks/import/types';
 import { StepProps } from '../../../types';
 import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
 
+jest.mock( 'calypso/landing/stepper/declarative-flow/internals/state-manager/store', () => ( {
+	useFlowState: jest.fn( () => ( {
+		get: jest.fn().mockReturnValue( { entryPoint: 'goals' } ),
+	} ) ),
+} ) );
 jest.mock( 'calypso/landing/stepper/hooks/use-site-slug' );
 jest.mock(
 	'../../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler',
@@ -62,6 +68,9 @@ const restoreIsMigrationExperimentEnabled = () => {
 
 describe( 'SiteMigrationIdentify', () => {
 	beforeAll( () => nock.disableNetConnect() );
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
 	afterEach( () => {
 		restoreIsMigrationExperimentEnabled();
 	} );
@@ -186,7 +195,12 @@ describe( 'SiteMigrationIdentify', () => {
 		).toBeVisible();
 	} );
 
-	it( 'shows the back link when the "ref" param is as "goals"', () => {
+	it( 'shows the back link when the entrypoint is "goals"', () => {
+		jest.mocked( useFlowState ).mockReturnValue( {
+			get: jest.fn().mockReturnValue( { entryPoint: 'goals' } ),
+			set: jest.fn(),
+			sessionId: null,
+		} );
 		render(
 			{
 				navigation: {
@@ -200,7 +214,7 @@ describe( 'SiteMigrationIdentify', () => {
 		expect( screen.getByRole( 'button', { name: /Back/ } ) ).toBeVisible();
 	} );
 
-	it( 'shows the back button when the "back_to" param defined', () => {
+	it( 'shows the back button when the "back_to" param is defined', () => {
 		render(
 			{
 				navigation: {
@@ -214,7 +228,12 @@ describe( 'SiteMigrationIdentify', () => {
 		expect( screen.getByRole( 'link', { name: /Back/ } ) ).toBeVisible();
 	} );
 
-	it( 'shows the back button when the "ref=wp-admin-importers-list"', () => {
+	it( 'shows the back button when the entrypoint is "wp-admin-importers-list"', () => {
+		jest.mocked( useFlowState ).mockReturnValue( {
+			get: jest.fn().mockReturnValue( { entryPoint: 'wp-admin-importers-list' } ),
+			set: jest.fn(),
+			sessionId: null,
+		} );
 		render(
 			{
 				navigation: {
@@ -229,6 +248,11 @@ describe( 'SiteMigrationIdentify', () => {
 	} );
 
 	it( 'hides the back button and link by default', async () => {
+		jest.mocked( useFlowState ).mockReturnValue( {
+			get: jest.fn().mockReturnValue( {} ),
+			set: jest.fn(),
+			sessionId: null,
+		} );
 		render(
 			{
 				navigation: {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -13,6 +13,14 @@ import { StepProps } from '../../../types';
 import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
 
 jest.mock( 'calypso/landing/stepper/hooks/use-site-slug' );
+jest.mock(
+	'../../site-migration-instructions/site-preview/hooks/use-site-preview-mshot-image-handler',
+	() => ( {
+		useSitePreviewMShotImageHandler: () => ( {
+			createScreenshots: jest.fn(),
+		} ),
+	} )
+);
 
 const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
 
@@ -176,5 +184,48 @@ describe( 'SiteMigrationIdentify', () => {
 		expect(
 			screen.getByText( /Round-the-clock security monitoring and DDoS protection./ )
 		).toBeVisible();
+	} );
+
+	it( 'shows the back link when the "ref" param is as "goals"', () => {
+		render(
+			{
+				navigation: {
+					goBack: jest.fn(),
+					submit: jest.fn(),
+				},
+			},
+			{ initialEntry: '/some-path?ref=goals' }
+		);
+
+		expect( screen.getByRole( 'button', { name: /Back/ } ) ).toBeVisible();
+	} );
+
+	it( 'shows the back button when the "back_to" param defined', () => {
+		render(
+			{
+				navigation: {
+					goBack: jest.fn(),
+					submit: jest.fn(),
+				},
+			},
+			{ initialEntry: '/some-path?back_to=https://example.com' }
+		);
+
+		expect( screen.getByRole( 'link', { name: /Back/ } ) ).toBeVisible();
+	} );
+
+	it( 'hides the back button and link by default', async () => {
+		render(
+			{
+				navigation: {
+					goBack: jest.fn(),
+					submit: jest.fn(),
+				},
+			},
+			{ initialEntry: '/some-path' }
+		);
+
+		expect( screen.queryByRole( 'button', { name: /Back/ } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /Back/ } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -214,6 +214,20 @@ describe( 'SiteMigrationIdentify', () => {
 		expect( screen.getByRole( 'link', { name: /Back/ } ) ).toBeVisible();
 	} );
 
+	it( 'shows the back button when the "ref=wp-admin-importers-list"', () => {
+		render(
+			{
+				navigation: {
+					goBack: jest.fn(),
+					submit: jest.fn(),
+				},
+			},
+			{ initialEntry: '/some-path?ref=wp-admin-importers-list' }
+		);
+
+		expect( screen.getByRole( 'button', { name: /Back/ } ) ).toBeVisible();
+	} );
+
 	it( 'hides the back button and link by default', async () => {
 		render(
 			{


### PR DESCRIPTION
Related to MIGRATE-4

## Proposed Changes
* Update back button logic to only show the UI back button in the presence of "ref=goals", ref="wp-admin-importers-list" or the back_to query param. 

## Why are these changes being made?
* Previously, we assumed the default behaviour was to show the back button in most cases and hide it in others.  I inverted the logic to only show the button when we are supporting the back button. Nowadays, we only support goals and the 'wp-admin-importers-list'. 


## Testing Instructions
Scenario: Regular Flow
* /setup/hosted-site-migration (or /setup/site-migration)
* Check if the identify step doesn't show the back button

Scenario: Coming from site-setup (ref=goals)
* Go to /start
* Select any plan
* On the goals step, click on Import or migrate an existing site
* Verify if there is a back button on the identification step
* Click the back button and check if you are on the goals step again. 

Scenario: Coming from WP ADMIN import list (ref=wp-admin-importers-list)
* Create a free site
* Go to {YOUR_SITE}/wp-admin/import.php
* Click `Get started`
* Verify if there is a back button on the identification step
* Click the back button and check if you are on the original location.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
