### PR TITLE
Site Migration: Remove "Skip and create a new site" 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -1,4 +1,4 @@
-import { SITE_MIGRATION_FLOW, StepContainer } from '@automattic/onboarding';
+import { StepContainer } from '@automattic/onboarding';
 import {
 	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
 	GroupableSiteLaunchStatuses,
@@ -27,7 +27,7 @@ const SitePickerStep: Step< {
 		queryParams?: Partial< SitesDashboardQueryParams >;
 		site?: SiteExcerptData;
 	};
-} > = function SitePickerStep( { navigation, flow } ) {
+} > = function SitePickerStep( { navigation } ) {
 	const { __ } = useI18n();
 	const urlQueryParams = useQuery();
 	const page = Number( urlQueryParams.get( 'page' ) ) || 1;
@@ -108,8 +108,7 @@ const SitePickerStep: Step< {
 				stepName="site-picker"
 				hideBack
 				goBack={ navigation.goBack }
-				hideSkip={ SITE_MIGRATION_FLOW === flow }
-				skipLabelText={ __( 'Skip and create a new site' ) }
+				hideSkip
 				goNext={ createNewSite }
 				stepContent={
 					<SitePicker


### PR DESCRIPTION
Related to MIGRATE-20

## Proposed Changes
* Remove the "Skip and create a new site"  from the `setup/site-migration/sitePicker` step.

![CleanShot 2025-04-17 at 13 23 41@2x](https://github.com/user-attachments/assets/4bbf0fbe-43e8-4fdc-b06b-78980960ecc9)

## Why are these changes being made?
* As discussed here p1744892803187999-slack-C02G2HLNB1R, we want to remove the duplicated button

## Testing Instructions
* Go to /setup/hosted-site-migration
* Set any WordPress site
* Verify the step doesn't have the link "Skip and create a new site" 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?