### PR TITLE
Reader: properly show tags that contains utf-8 characters

### DIFF
--- a/client/blocks/reader-post-card/tag-link.jsx
+++ b/client/blocks/reader-post-card/tag-link.jsx
@@ -31,8 +31,8 @@ class TagLink extends Component {
 
 	render() {
 		const { tag } = this.props;
+		const path = addLocaleToPathLocaleInFront( `/tag/${ tag.slug }` );
 		const decodedSlug = decodeURIComponent( tag.slug ); // Other languages may contain non-ASCII characters so we need to decode it.
-		const path = addLocaleToPathLocaleInFront( `/tag/${ decodedSlug }` );
 
 		return (
 			<span className="reader-post-card__tag">

--- a/client/blocks/reader-post-card/tag-link.jsx
+++ b/client/blocks/reader-post-card/tag-link.jsx
@@ -31,7 +31,8 @@ class TagLink extends Component {
 
 	render() {
 		const { tag } = this.props;
-		const path = addLocaleToPathLocaleInFront( `/tag/${ encodeURIComponent( tag.slug ) }` );
+		const decodedSlug = decodeURIComponent( tag.slug ); // Other languages may contain non-ASCII characters so we need to decode it.
+		const path = addLocaleToPathLocaleInFront( `/tag/${ decodedSlug }` );
 
 		return (
 			<span className="reader-post-card__tag">
@@ -40,7 +41,7 @@ class TagLink extends Component {
 					className="reader-post-card__tag-link ignore-click"
 					onClick={ this.recordSingleTagClick }
 				>
-					{ tag.name || tag.slug }
+					{ tag.name || decodedSlug }
 				</a>
 			</span>
 		);

--- a/client/blocks/reader-post-card/tag-link.jsx
+++ b/client/blocks/reader-post-card/tag-link.jsx
@@ -31,7 +31,7 @@ class TagLink extends Component {
 
 	render() {
 		const { tag } = this.props;
-		const path = addLocaleToPathLocaleInFront( `/tag/${ tag.slug }` );
+		const path = addLocaleToPathLocaleInFront( `/tag/${ encodeURIComponent( tag.slug ) }` );
 		const decodedSlug = decodeURIComponent( tag.slug ); // Other languages may contain non-ASCII characters so we need to decode it.
 
 		return (

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -34,7 +34,7 @@ export function getSelectedTabTitle( selectedTab ) {
 	if ( selectedTab === FIRST_POSTS_TAB ) {
 		return 'fresh';
 	}
-	return selectedTab;
+	return decodeURIComponent( selectedTab );
 }
 
 /**

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -20,10 +20,9 @@ const analyticsPageTitle = 'Reader';
 export const tagListing = ( context, next ) => {
 	const basePath = '/tag/:slug';
 	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag;
-	const tagSlug = trim( context.params.tag )
-		.toLowerCase()
-		.replace( /\s+/g, '-' )
-		.replace( /-{2,}/g, '-' );
+	const tagSlug = decodeURIComponent(
+		trim( context.params.tag ).toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' )
+	);
 	const tagTitle = titlecase( trim( context.params.tag ) ).replace( /[-_]/g, ' ' );
 	const state = context.store.getState();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/616

## Proposed Changes

Add decode of utf-8 tags.

| Before | After |
| -------|------| 
| ![Screenshot 2025-04-18 at 12 24 59 AM](https://github.com/user-attachments/assets/01dcfcd1-f27a-43eb-ad9b-9c79300f62db) | ![image](https://github.com/user-attachments/assets/60bcb950-412a-457c-bd5d-1a5f5f7f6a56) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To properly show tags that contains utf-8 characters.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to any utf-8 tag ([example](https://wordpress.com/tag/%d0%ba%d0%bd%d0%b8%d0%b3%d0%b8)). Verify sidebar contains encoded tag.
- Go to same tag (`/tag/%d0%ba%d0%bd%d0%b8%d0%b3%d0%b8`) on calypso live. Verify sidebar is now showing the characters properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
