### PR TITLE
Update DIFM CTA buttons

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -117,7 +117,7 @@ const DIFMStartingPoint: StepType< {
 						onPrimarySubmit={ () =>
 							showNewOrExistingSiteChoice ? onSubmit( 'new-site' ) : onSubmit( 'existing-site' )
 						}
-						onSecondarySubmit={ () => onSubmit( 'new-site' ) }
+						onSecondarySubmit={ () => onSubmit( 'existing-site' ) }
 						showNewOrExistingSiteChoice={ showNewOrExistingSiteChoice }
 						siteId={ siteId }
 						isStoreFlow={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -115,7 +115,7 @@ const DIFMStartingPoint: StepType< {
 				stepContent={
 					<DIFMLanding
 						onPrimarySubmit={ () =>
-							showNewOrExistingSiteChoice ? onSubmit( 'existing-site' ) : onSubmit( 'new-site' )
+							showNewOrExistingSiteChoice ? onSubmit( 'new-site' ) : onSubmit( 'existing-site' )
 						}
 						onSecondarySubmit={ () => onSubmit( 'new-site' ) }
 						showNewOrExistingSiteChoice={ showNewOrExistingSiteChoice }

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -110,8 +110,8 @@ export default function DIFMLanding( {
 
 	const ctas = showNewOrExistingSiteChoice ? (
 		<>
-			<NextButton onClick={ onSecondarySubmit }>{ translate( 'Start a new site' ) }</NextButton>
-			<NextButton onClick={ onPrimarySubmit } variant="secondary">
+			<NextButton onClick={ onPrimarySubmit }>{ translate( 'Start a new site' ) }</NextButton>
+			<NextButton onClick={ onSecondarySubmit } variant="secondary">
 				{ translate( 'Use an existing site' ) }
 			</NextButton>
 		</>

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -56,7 +56,7 @@ const CTASectionWrapper = styled.div`
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
-	gap: 18px;
+	gap: 16px;
 	margin: 2rem 0;
 	.components-button.is-primary {
 		border-radius: 4px;
@@ -110,10 +110,9 @@ export default function DIFMLanding( {
 
 	const ctas = showNewOrExistingSiteChoice ? (
 		<>
-			<NextButton onClick={ onPrimarySubmit }>{ translate( 'Use an existing site' ) }</NextButton>
-			<span>{ translate( 'or' ) }</span>
-			<NextButton onClick={ onSecondarySubmit } variant="secondary">
-				{ translate( 'Start a new site' ) }
+			<NextButton onClick={ onSecondarySubmit }>{ translate( 'Start a new site' ) }</NextButton>
+			<NextButton onClick={ onPrimarySubmit } variant="secondary">
+				{ translate( 'Use an existing site' ) }
 			</NextButton>
 		</>
 	) : (

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -66,7 +66,7 @@ export default function NewOrExistingSiteStep( props: Props ) {
 							? newOrExistingSiteSelected( 'new-site' )
 							: newOrExistingSiteSelected( 'existing-site' )
 					}
-					onSecondarySubmit={ () => newOrExistingSiteSelected( 'new-site' ) }
+					onSecondarySubmit={ () => newOrExistingSiteSelected( 'existing-site' ) }
 					showNewOrExistingSiteChoice={ showNewOrExistingSiteChoice }
 					isStoreFlow={ 'do-it-for-me-store' === flowName }
 				/>

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -63,8 +63,8 @@ export default function NewOrExistingSiteStep( props: Props ) {
 				<DIFMLanding
 					onPrimarySubmit={ () =>
 						showNewOrExistingSiteChoice
-							? newOrExistingSiteSelected( 'existing-site' )
-							: newOrExistingSiteSelected( 'new-site' )
+							? newOrExistingSiteSelected( 'new-site' )
+							: newOrExistingSiteSelected( 'existing-site' )
 					}
 					onSecondarySubmit={ () => newOrExistingSiteSelected( 'new-site' ) }
 					showNewOrExistingSiteChoice={ showNewOrExistingSiteChoice }


### PR DESCRIPTION
Ref DOTCOM-851

## Proposed Changes

This PR updates the CTA buttons in the DIFM as follows:

- Adjusted the gap between buttons from 18px to 16px for better visual consistency
- Reordered CTA buttons to prioritize "Start a new site":
  - Made "Start a new site" the primary action (first position)
  - Changed "Use an existing site" to secondary styling
- Removed the "or" text separator between buttons for a cleaner look

| Before | After |
| --- | --- |
| ![Screenshot 2025-04-18 at 3 22 49 PM](https://github.com/user-attachments/assets/829117dd-e616-433b-8e7d-753702f0e273) | ![Screenshot 2025-04-18 at 3 22 54 PM](https://github.com/user-attachments/assets/89a7f583-ebb9-4788-9a07-2fd8a4f818c2) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WP.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /start/do-it-for-me/new-or-existing-site
* Ensure the CTA buttons are updated as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
