### PR TITLE
Calypso E2E: Fix the DonationsFormFlow test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
@@ -15,6 +15,9 @@ interface ValidationData {
 
 const blockParentSelector = 'div[aria-label="Block: Donations Form"]';
 
+const blockInsertedPopupConfirmButtonSelector =
+	'div.jetpack-donations-first-time-modal[role="dialog"] button:has-text("Got it")';
+
 /**
  * Represents the flow of using the Donations Form block.
  */
@@ -34,6 +37,7 @@ export class DonationsFormFlow implements BlockFlow {
 
 	blockSidebarName = 'Donations Form';
 	blockEditorSelector = blockParentSelector;
+	blockInsertedPopupConfirmButtonSelector = blockInsertedPopupConfirmButtonSelector;
 
 	/**
 	 * Configure the block in the editor with the configuration data from the constructor

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/types.ts
@@ -9,6 +9,7 @@ export interface BlockFlow {
 	blockTestName?: string;
 	blockTestFallBackName?: string;
 	blockEditorSelector: string;
+	blockInsertedPopupConfirmButtonSelector?: string;
 	noSearch?: boolean;
 	configure?( context: EditorContext ): Promise< void >;
 	validateAfterPublish?( context: PublishedPostContext ): Promise< void >;

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -291,13 +291,22 @@ export class EditorPage {
 	async addBlockFromSidebar(
 		blockName: string,
 		blockEditorSelector: string,
-		{ noSearch, blockFallBackName }: { noSearch?: boolean; blockFallBackName?: string } = {}
+		{
+			noSearch,
+			blockFallBackName,
+			blockInsertedPopupConfirmButtonSelector,
+		}: {
+			noSearch?: boolean;
+			blockFallBackName?: string;
+			blockInsertedPopupConfirmButtonSelector?: string;
+		} = {}
 	): Promise< ElementHandle > {
 		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent, {
 			noSearch: noSearch,
 			blockFallBackName: blockFallBackName,
+			blockInsertedPopupConfirmButtonSelector: blockInsertedPopupConfirmButtonSelector,
 		} );
 
 		const blockHandle =
@@ -366,12 +375,32 @@ export class EditorPage {
 	private async addBlockFromInserter(
 		blockName: string,
 		inserter: BlockInserter,
-		{ noSearch, blockFallBackName }: { noSearch?: boolean; blockFallBackName?: string } = {}
+		{
+			noSearch,
+			blockFallBackName,
+			blockInsertedPopupConfirmButtonSelector,
+		}: {
+			noSearch?: boolean;
+			blockFallBackName?: string;
+			blockInsertedPopupConfirmButtonSelector?: string;
+		} = {}
 	): Promise< void > {
 		if ( ! noSearch ) {
 			await inserter.searchBlockInserter( blockName );
 		}
 		await inserter.selectBlockInserterResult( blockName, { blockFallBackName } );
+
+		if ( blockInsertedPopupConfirmButtonSelector ) {
+			const editorParent = await this.editor.parent();
+			const blockInsertedPopupConfirmButtonLocator = editorParent.locator(
+				'div[role="dialog"] button:has-text("OK")'
+			);
+
+			const count = await blockInsertedPopupConfirmButtonLocator.count();
+			if ( count ) {
+				blockInsertedPopupConfirmButtonLocator.click();
+			}
+		}
 	}
 
 	/**

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -71,6 +71,8 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 						{
 							noSearch: blockFlow.noSearch === false ? false : true,
 							blockFallBackName: blockFlow.blockTestFallBackName,
+							blockInsertedPopupConfirmButtonSelector:
+								blockFlow.blockInsertedPopupConfirmButtonSelector,
 						}
 					);
 					const id = await blockHandle.getAttribute( 'id' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/42214

## Proposed Changes

* The https://github.com/Automattic/jetpack/pull/42214 introduced a modal that appears when the Donation Form block is inserted for the first time. This PR proposes a change to support a blockInsertedPopupConfirmButtonSelector parameter, allowing the modal to be programmatically closed if needed.

![image](https://github.com/user-attachments/assets/0d5e9a6a-70a6-4c5b-94a1-1c171a5dbad9)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix broken E2E

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the test passed on TeamCity

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
