### PR TITLE
WIP: Plugin restriction for lower tier plans

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -13,6 +13,7 @@ export const PREINSTALLED_PLUGINS = [
 	'full-site-editing',
 	'layout-grid',
 	'page-optimize',
+	'classic-editor',
 ]; // These plugins auto update but shouldn't be deactivated.
 
 export const PREINSTALLED_PREMIUM_PLUGINS = {

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -39,6 +39,7 @@ import {
 } from 'calypso/state/plugins/installed/selectors';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import canUserInstallPluginsOnSite from 'calypso/state/selectors/can-user-install-plugins-on-site';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
@@ -411,6 +412,9 @@ function PrimaryButton( {
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isDisabledForWpcomStaging = isWpcomStaging && isMarketplaceProduct;
 	const isIncompatibleForAtomic = isAtomic && 'vaultpress' === plugin.slug;
+	const canInstallPlugins = useSelector( ( state ) =>
+		canUserInstallPluginsOnSite( state, selectedSite?.ID )
+	);
 
 	const onClick = useCallback( () => {
 		dispatch(
@@ -459,7 +463,8 @@ function PrimaryButton( {
 				incompatiblePlugin ||
 				userCantManageTheSite ||
 				isDisabledForWpcomStaging ||
-				isIncompatibleForAtomic
+				isIncompatibleForAtomic ||
+				! canInstallPlugins
 			}
 		/>
 	);

--- a/client/state/selectors/can-user-install-plugins-on-site.ts
+++ b/client/state/selectors/can-user-install-plugins-on-site.ts
@@ -3,6 +3,7 @@ import {
 	FEATURE_PLUGINS_ALLOW_ONE,
 	FEATURE_PLUGINS_ALLOW_THREE,
 } from '@automattic/calypso-products';
+import { PREINSTALLED_PLUGINS } from 'calypso/my-sites/plugins/constants';
 import { getPlugins } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -30,9 +31,11 @@ export default function canUserInstallPluginsOnSite(
 		return false;
 	}
 
-	// Get currently installed and active plugins count
+	// Get currently installed and active plugins count, excluding preinstalled plugins
 	const plugins = getPlugins( state, [ siteId ], 'active' ) as Plugin[];
-	const activePluginsCount = plugins.length;
+	const activePluginsCount = plugins.filter(
+		( plugin ) => ! PREINSTALLED_PLUGINS.includes( plugin.slug )
+	).length;
 
 	// Check plugin count limits based on features
 	if ( siteHasFeature( state, siteId, FEATURE_PLUGINS_ALLOW_ONE ) && activePluginsCount >= 1 ) {

--- a/client/state/selectors/can-user-install-plugins-on-site.ts
+++ b/client/state/selectors/can-user-install-plugins-on-site.ts
@@ -1,0 +1,47 @@
+import {
+	FEATURE_INSTALL_PLUGINS,
+	FEATURE_PLUGINS_ALLOW_ONE,
+	FEATURE_PLUGINS_ALLOW_THREE,
+} from '@automattic/calypso-products';
+import { getPlugins } from 'calypso/state/plugins/installed/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import type { Plugin } from 'calypso/state/plugins/installed/types';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns whether the user can install plugins on a specific site.
+ * This takes into account both user permissions and site features.
+ * @param {Object} state Global state tree
+ * @param {number} siteId The site ID
+ * @returns {boolean} Whether the user can install plugins on the site
+ */
+export default function canUserInstallPluginsOnSite(
+	state: AppState,
+	siteId: number | null | undefined
+): boolean {
+	// First check if user has permission to manage plugins
+	if ( ! canCurrentUser( state, siteId, 'manage_options' ) ) {
+		return false;
+	}
+
+	// Check if site has the basic plugin installation feature
+	if ( ! siteHasFeature( state, siteId, FEATURE_INSTALL_PLUGINS ) ) {
+		return false;
+	}
+
+	// Get currently installed and active plugins count
+	const plugins = getPlugins( state, [ siteId ], 'active' ) as Plugin[];
+	const activePluginsCount = plugins.length;
+
+	// Check plugin count limits based on features
+	if ( siteHasFeature( state, siteId, FEATURE_PLUGINS_ALLOW_ONE ) && activePluginsCount >= 1 ) {
+		return false;
+	}
+
+	if ( siteHasFeature( state, siteId, FEATURE_PLUGINS_ALLOW_THREE ) && activePluginsCount >= 3 ) {
+		return false;
+	}
+
+	return true;
+}

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -508,3 +508,5 @@ export const FEATURE_CONNECT_ANALYTICS = 'feature-connect-analytics';
 export const FEATURE_LIMITED_SITE_ACTIVITY_LOG = 'feature-limited-site-activity-log';
 export const FEATURE_BIG_SKY_WEBSITE_BUILDER = 'feature-big-sky-website-builder';
 export const FEATURE_BIG_SKY_WEBSITE_BUILDER_CHECKOUT = 'feature-big-sky-website-builder-checkout';
+export const FEATURE_PLUGINS_ALLOW_ONE = 'plugins-allow-one';
+export const FEATURE_PLUGINS_ALLOW_THREE = 'plugins-allow-three';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR introduces a restriction for plans that support a limited number of features

It's work in progress, mostly sharing as a PR for showing the direction. The final result will not have this button disabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
