### PR TITLE
Stepper: migrate entrepreneur flow to use built in authentication

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
@@ -1,22 +1,21 @@
 import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import { ENTREPRENEUR_FLOW, SITE_MIGRATION_FLOW } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import { anonIdCache, useCachedAnswers } from 'calypso/data/segmentaton-survey';
 import { useEntrepreneurAdminDestination } from 'calypso/landing/stepper/hooks/use-entrepreneur-admin-destination';
-import { useFlowLocale } from 'calypso/landing/stepper/hooks/use-flow-locale';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
-import { getLoginUrl } from 'calypso/landing/stepper/utils/path';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
-import { USER_STORE, ONBOARD_STORE } from '../../../stores';
+import { ONBOARD_STORE } from '../../../stores';
+import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { ENTREPRENEUR_TRIAL_SURVEY_KEY } from '../../internals/steps-repository/segmentation-survey';
 import type { Flow, ProvidedDependencies, StepperStep } from '../../internals/types';
-import type { UserSelect } from '@automattic/data-stores';
+
 const SEGMENTATION_SURVEY_SLUG = 'start';
 
 const entrepreneurFlow: Flow = {
@@ -25,34 +24,32 @@ const entrepreneurFlow: Flow = {
 	isSignupFlow: true,
 
 	useSteps() {
-		return [
-			// Replacing the `segmentation-survey` slug with `start` as having the
-			// word `survey` in the address bar might discourage users from continuing.
-			{
-				...STEPS.SEGMENTATION_SURVEY,
-				...{ slug: SEGMENTATION_SURVEY_SLUG as StepperStep[ 'slug' ] },
-			},
-			STEPS.TRIAL_ACKNOWLEDGE,
-			STEPS.SITE_CREATION_STEP,
-			STEPS.PROCESSING,
-			STEPS.WAIT_FOR_ATOMIC,
-			STEPS.WAIT_FOR_PLUGIN_INSTALL,
-			STEPS.ERROR,
-		] as const;
+		// Replacing the `segmentation-survey` slug with `start` as having the
+		// word `survey` in the address bar might discourage users from continuing.
+		const surveyStep = {
+			...STEPS.SEGMENTATION_SURVEY,
+			...{ slug: SEGMENTATION_SURVEY_SLUG as StepperStep[ 'slug' ] },
+		};
+
+		const steps: StepperStep[] = [
+			surveyStep,
+			...stepsWithRequiredLogin( [
+				STEPS.TRIAL_ACKNOWLEDGE,
+				STEPS.SITE_CREATION_STEP,
+				STEPS.PROCESSING,
+				STEPS.WAIT_FOR_ATOMIC,
+				STEPS.WAIT_FOR_PLUGIN_INSTALL,
+				STEPS.ERROR,
+			] ),
+		];
+
+		return steps;
 	},
 
 	useStepNavigation( currentStep, navigate ) {
-		const flowName = this.name;
-
 		const { setPluginsToVerify } = useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
 
-		const userIsLoggedIn = useSelect(
-			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
-			[]
-		);
-
-		const locale = useFlowLocale();
 		const [ isMigrationFlow, setIsMigrationFlow ] = useState( false );
 		const [ lastQuestionPath, setlastQuestionPath ] = useState( '#1' );
 		const { clearAnswers } = useCachedAnswers( ENTREPRENEUR_TRIAL_SURVEY_KEY );
@@ -61,19 +58,6 @@ const entrepreneurFlow: Flow = {
 
 		const entrepreneurAdminDestination = useEntrepreneurAdminDestination();
 		const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-
-		const getEntrepreneurLoginUrl = () => {
-			const redirectTo = `${ window.location.protocol }//${ window.location.host }/setup/entrepreneur/trialAcknowledge${ window.location.search }`;
-
-			const loginUrl = getLoginUrl( {
-				variationName: flowName,
-				redirectTo,
-				locale,
-				customLoginPath: '/start/entrepreneur/user-social',
-			} );
-
-			return loginUrl;
-		};
 
 		const goBack = () => {
 			if ( currentStep === STEPS.TRIAL_ACKNOWLEDGE.slug ) {
@@ -99,13 +83,7 @@ const entrepreneurFlow: Flow = {
 						setlastQuestionPath( providedDependencies.lastQuestionPath as string );
 					}
 
-					if ( userIsLoggedIn ) {
-						return navigate( STEPS.TRIAL_ACKNOWLEDGE.slug );
-					}
-
-					// Redirect user to the sign-in/sign-up page before site creation.
-					const entrepreneurLoginUrl = getEntrepreneurLoginUrl();
-					return window.location.replace( entrepreneurLoginUrl );
+					return navigate( STEPS.TRIAL_ACKNOWLEDGE.slug );
 				}
 
 				case STEPS.TRIAL_ACKNOWLEDGE.slug: {

--- a/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/entrepreneur-flow/entrepreneur-flow.ts
@@ -20,7 +20,7 @@ const SEGMENTATION_SURVEY_SLUG = 'start';
 
 const entrepreneurFlow: Flow = {
 	name: ENTREPRENEUR_FLOW,
-
+	__experimentalUseBuiltinAuth: true,
 	isSignupFlow: true,
 
 	useSteps() {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -25,7 +25,6 @@ export function generateFlows( {
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
 	getHostingFlowDestination = noop,
-	getEntrepreneurFlowDestination = noop,
 } = {} ) {
 	const userSocialStep = getUserSocialStepOrFallback();
 
@@ -552,17 +551,6 @@ export function generateFlows( {
 			hideProgressIndicator: true,
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
-		},
-		{
-			name: 'entrepreneur',
-			steps: [ userSocialStep ],
-			destination: getEntrepreneurFlowDestination,
-			description: 'Entrepreneur Trial signup flow that goes through the trialAcknowledge step',
-			lastModified: '2024-05-29',
-			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'toStepper', 'redirect_to' ],
-			optionalDependenciesInQuery: [ 'toStepper', 'redirect_to' ],
-			hideProgressIndicator: true,
 		},
 		{
 			name: 'onboarding-affiliate',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -193,10 +193,6 @@ function getHostingFlowDestination( { stepperHostingFlow } ) {
 	return `/setup/${ stepperHostingFlow }`;
 }
 
-function getEntrepreneurFlowDestination( { redirect_to } ) {
-	return redirect_to || '/setup/entrepreneur/trialAcknowledge';
-}
-
 const flows = generateFlows( {
 	getRedirectDestination,
 	getSignupDestination,
@@ -210,7 +206,6 @@ const flows = generateFlows( {
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
 	getHostingFlowDestination,
-	getEntrepreneurFlowDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {


### PR DESCRIPTION
## Proposed Changes

The `/start/entrepreneur` Start flow is just an account creation step wrapper that isn't needed anymore now that we have the logged-in user protection mechanism builtin in Stepper.

@dsas I looked for Tracks funnels that were relying on the `/start/entrepreneur` step but didn't find any. Just a heads-up!

## Why are these changes being made?

Code quality. This Start flow corresponds to around 5% of the traffic in that framework.

## Testing Instructions

Verify you can enter `/setup/entrepreneur/start` and see the survey as a guest. Upon skipping the survey, you'll be asked to login before visiting the `trialAcknowledge` step.

Visiting `trialAcknowledge` directly should fail - you should se sent to login.
