### PR TITLE
Fixing the campaign details chart when all values are 0

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -134,10 +134,15 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 			},
 			scales: {
 				y: {
-					range: ( self: uPlot, min: number, max: number ): [ number, number ] => [
-						min,
-						max + ( max - min ) * 0.4, // Increase the scale by 40%, this allows extra space for the tooltip
-					],
+					range: ( self: uPlot, min: number, max: number ): [ number, number ] => {
+						if ( min === 0 && max === 0 ) {
+							// If all values are 0, set a default range
+							return [ 0, 1 ];
+						}
+						// Increase the scale by 40%, this allows extra space for the tooltip
+						const padding = ( max - min ) * 0.4;
+						return [ min, max + padding ];
+					},
 				},
 			},
 			series: [


### PR DESCRIPTION
Related to 2994-gh-tumblr/a8c-dsp

## Proposed Changes

We noticed that the stats graph in the campaign details page is not working properly when all values are 0

## Why are these changes being made?
minor fix

## Testing Instructions
the PR is pretty simple.. a CR is enough i think... 

having said that.. if you want to test please check the main ticket for instructions on how to test using local DSP and sandbox 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
