### PR TITLE
Jetpack Benefits: remove Google Analytics

### DIFF
--- a/client/blocks/jetpack-benefits/general-benefits.tsx
+++ b/client/blocks/jetpack-benefits/general-benefits.tsx
@@ -1,6 +1,5 @@
 import {
 	planHasFeature,
-	FEATURE_GOOGLE_ANALYTICS,
 	FEATURE_JETPACK_VIDEOPRESS,
 	FEATURE_PREMIUM_SUPPORT,
 	FEATURE_SIMPLE_PAYMENTS,
@@ -58,19 +57,6 @@ const JetpackGeneralBenefits: React.FC< Props > = ( { productSlug } ) => {
 		benefits.push(
 			<React.Fragment>
 				{ translate( 'The {{strong}}Ad program{{/strong}} for WordPress.', {
-					components: {
-						strong: <strong />,
-					},
-				} ) }
-			</React.Fragment>
-		);
-	}
-
-	// Google Analytics
-	if ( planHasFeature( productSlug, FEATURE_GOOGLE_ANALYTICS ) ) {
-		benefits.push(
-			<React.Fragment>
-				{ translate( 'The {{strong}}Google Analytics{{/strong}} integration.', {
 					components: {
 						strong: <strong />,
 					},


### PR DESCRIPTION
## Proposed Changes

When one cancels their Jetpack plan, we list a series of benefits they will be losing by deleting their plan. Google Analytics should not be on that list.

## Why are these changes being made?

Google Analytics is no longer included in Jetpack.

See https://github.com/Automattic/jetpack/issues/36920

## Testing Instructions

* Start with a Jetpack site using a Complete plan.
* Go to https://wordpress.com/me/purchases
* Search for your site.
* Cancel your plan.
* You'll be redirected back to the purchases page after cancellation.
* Search for your site again.
* This time, delete your plan.
    * Ensure that Google Analytics is not listed among the benefits.
  
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
