### PR TITLE
Plugins and Themes should not be a list anymore

### DIFF
--- a/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
@@ -86,7 +86,7 @@ describe( 'useRequestTransferWithSoftware', () => {
 		);
 	} );
 
-	it( 'should return an error if plugin_slug or theme_slug are not provided', async () => {
+	it( 'should return an error if both plugin_slug and theme_slug are not provided', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/sites/' + SITE_ID + '/atomic/transfer-with-software', {
 				plugin_slug: null,

--- a/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
@@ -8,10 +8,6 @@ import nock from 'nock';
 import React from 'react';
 import { useRequestTransferWithSoftware } from '../use-transfer-with-software-start-mutation';
 
-const replyErrorWithEnvelope =
-	( status: number, defaultBody: Record< string, string | number > = {} ) =>
-	( body = {} ) =>
-	() => [ 200, { code: status, body: { ...defaultBody, ...body } } ];
 const SITE_ID = 123;
 const API_SETTINGS = { migration_source_site_domain: 'example.com' };
 
@@ -89,12 +85,13 @@ describe( 'useRequestTransferWithSoftware', () => {
 	it( 'should return an error if both plugin_slug and theme_slug are not provided', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/sites/' + SITE_ID + '/atomic/transfer-with-software', {
-				plugin_slug: null,
-				theme_slug: null,
+				plugin_slug: undefined,
+				theme_slug: undefined,
 				settings: API_SETTINGS,
 			} )
 			.query( { http_envelope: 1 } )
-			.reply( replyErrorWithEnvelope( 400, { error: 'plugin_slug and theme_slug are required' } ) );
+			.reply( 400, { message: 'plugin_slug and theme_slug are required' } );
+
 		const { result } = render();
 
 		result.current.mutate();
@@ -102,6 +99,7 @@ describe( 'useRequestTransferWithSoftware', () => {
 		await waitFor(
 			() => {
 				expect( result.current.isError ).toBe( true );
+				expect( result.current.error?.message ).toBe( 'plugin_slug and theme_slug are required' );
 			},
 			{ timeout: 3000 }
 		);

--- a/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
@@ -30,8 +30,8 @@ const render = ( options = { retry: 0 } ) => {
 				{
 					siteId: SITE_ID,
 					apiSettings: API_SETTINGS,
-					plugins: [ 'plugin-1', 'install' ],
-					themes: [ 'theme-1', 'activate' ],
+					plugin_slug: 'plugin-1',
+					theme_slug: 'theme-1',
 				},
 				options
 			),
@@ -56,8 +56,8 @@ describe( 'useRequestTransferWithSoftware', () => {
 	it( 'should successfully request transfer with software and return the transfer_id', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/sites/' + SITE_ID + '/atomic/transfer-with-software', {
-				plugins: [ 'plugin-1', 'install' ],
-				themes: [ 'theme-1', 'activate' ],
+				plugin_slug: 'plugin-1',
+				theme_slug: 'theme-1',
 				settings: API_SETTINGS,
 			} )
 			.query( {
@@ -86,15 +86,15 @@ describe( 'useRequestTransferWithSoftware', () => {
 		);
 	} );
 
-	it( 'should return an error if plugins or themes are not provided', async () => {
+	it( 'should return an error if plugin_slug or theme_slug are not provided', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/sites/' + SITE_ID + '/atomic/transfer-with-software', {
-				plugins: null,
-				themes: null,
+				plugin_slug: null,
+				theme_slug: null,
 				settings: API_SETTINGS,
 			} )
 			.query( { http_envelope: 1 } )
-			.reply( replyErrorWithEnvelope( 400, { error: 'plugins and themes are required' } ) );
+			.reply( replyErrorWithEnvelope( 400, { error: 'plugin_slug and theme_slug are required' } ) );
 		const { result } = render();
 
 		result.current.mutate();

--- a/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
+++ b/client/sites/hooks/test/use-transfer-with-software-start-mutation.tsx
@@ -21,7 +21,7 @@ const Wrapper =
 		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 	);
 
-const render = ( options = { retry: 0 } ) => {
+const render = ( plugin_slug?: string, theme_slug?: string ) => {
 	const queryClient = new QueryClient();
 
 	const renderResult = renderHook(
@@ -30,10 +30,10 @@ const render = ( options = { retry: 0 } ) => {
 				{
 					siteId: SITE_ID,
 					apiSettings: API_SETTINGS,
-					plugin_slug: 'plugin-1',
-					theme_slug: 'theme-1',
+					plugin_slug: plugin_slug,
+					theme_slug: theme_slug,
 				},
-				options
+				{ retry: 0 }
 			),
 		{
 			wrapper: Wrapper( queryClient ),
@@ -69,7 +69,7 @@ describe( 'useRequestTransferWithSoftware', () => {
 				transfer_status: 'pending',
 			} );
 
-		const { result } = render();
+		const { result } = render( 'plugin-1', 'theme-1' );
 
 		result.current.mutate();
 
@@ -102,6 +102,66 @@ describe( 'useRequestTransferWithSoftware', () => {
 		await waitFor(
 			() => {
 				expect( result.current.isError ).toBe( true );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'should successfully request the transfer with a plugin slug', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/sites/' + SITE_ID + '/atomic/transfer-with-software', {
+				plugin_slug: 'plugin-1',
+				settings: API_SETTINGS,
+			} )
+			.query( { http_envelope: 1 } )
+			.reply( 200, {
+				transfer_id: 456,
+				blog_id: SITE_ID,
+				transfer_status: 'pending',
+			} );
+
+		const { result } = render( 'plugin-1' );
+
+		result.current.mutate();
+
+		await waitFor(
+			() => {
+				expect( result.current.isSuccess ).toBe( true );
+				expect( result.current.data ).toEqual( {
+					transfer_id: 456,
+					blog_id: SITE_ID,
+					transfer_status: 'pending',
+				} );
+			},
+			{ timeout: 3000 }
+		);
+	} );
+
+	it( 'should successfully request the transfer with a theme slug', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/sites/' + SITE_ID + '/atomic/transfer-with-software', {
+				theme_slug: 'theme-1',
+				settings: API_SETTINGS,
+			} )
+			.query( { http_envelope: 1 } )
+			.reply( 200, {
+				transfer_id: 456,
+				blog_id: SITE_ID,
+				transfer_status: 'pending',
+			} );
+
+		const { result } = render( undefined, 'theme-1' );
+
+		result.current.mutate();
+
+		await waitFor(
+			() => {
+				expect( result.current.isSuccess ).toBe( true );
+				expect( result.current.data ).toEqual( {
+					transfer_id: 456,
+					blog_id: SITE_ID,
+					transfer_status: 'pending',
+				} );
 			},
 			{ timeout: 3000 }
 		);

--- a/client/sites/hooks/use-transfer-with-software-start-mutation.ts
+++ b/client/sites/hooks/use-transfer-with-software-start-mutation.ts
@@ -8,15 +8,13 @@ type TransferWithSoftwareResponse = {
 };
 
 type SoftwareSlug = string;
-type SoftwareStatus = 'install' | 'activate';
-type Software = [ SoftwareSlug, SoftwareStatus ];
 type ApiSettings = Record< string, unknown >;
 
 type TransferOptions = {
 	siteId: number;
 	apiSettings?: ApiSettings;
-	plugins?: Software;
-	themes?: Software;
+	plugin_slug?: SoftwareSlug;
+	theme_slug?: SoftwareSlug;
 };
 
 const requestTransferWithSoftware: (
@@ -24,15 +22,15 @@ const requestTransferWithSoftware: (
 ) => Promise< TransferWithSoftwareResponse > = async ( {
 	siteId,
 	apiSettings,
-	plugins,
-	themes,
+	plugin_slug,
+	theme_slug,
 } ) => {
 	const response = await wpcom.req.post( {
 		path: `/sites/${ siteId }/atomic/transfer-with-software?http_envelope=1`,
 		apiNamespace: 'wpcom/v2',
 		body: {
-			plugins: plugins,
-			themes: themes,
+			plugin_slug: plugin_slug,
+			theme_slug: theme_slug,
 			settings: { ...apiSettings },
 		},
 	} );
@@ -57,8 +55,8 @@ export const useRequestTransferWithSoftware = (
 			'transfer-with-software',
 			transferOptions.siteId,
 			transferOptions.apiSettings,
-			transferOptions.plugins,
-			transferOptions.themes,
+			transferOptions.plugin_slug,
+			transferOptions.theme_slug,
 		],
 		mutationFn: async () => {
 			if ( ! transferOptions.siteId ) {
@@ -67,8 +65,8 @@ export const useRequestTransferWithSoftware = (
 			return requestTransferWithSoftware( {
 				siteId: transferOptions.siteId,
 				apiSettings: transferOptions.apiSettings,
-				plugins: transferOptions.plugins,
-				themes: transferOptions.themes,
+				plugin_slug: transferOptions.plugin_slug,
+				theme_slug: transferOptions.theme_slug,
 			} );
 		},
 		retry: queryOptions?.retry ?? 3, // Default retry 3 times

--- a/client/sites/hooks/use-transfer-with-software-start-mutation.ts
+++ b/client/sites/hooks/use-transfer-with-software-start-mutation.ts
@@ -7,14 +7,13 @@ type TransferWithSoftwareResponse = {
 	transfer_status: string;
 };
 
-type SoftwareSlug = string;
 type ApiSettings = Record< string, unknown >;
 
 type TransferOptions = {
 	siteId: number;
 	apiSettings?: ApiSettings;
-	plugin_slug?: SoftwareSlug;
-	theme_slug?: SoftwareSlug;
+	plugin_slug?: string;
+	theme_slug?: string;
 };
 
 const requestTransferWithSoftware: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 178867-ghe-Automattic/wpcom

## Proposed Changes

* The mutation should submit the plugin and theme as strings and not as an array of strings. The endpoint now only supports installing one theme and/or one plugin.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  As highlighted on 178867-ghe-Automattic/wpcom we don't support installing multiple plugins and themes, and since all use cases we have now are only for a single plugin/theme we changed the API to accept the plugin and theme as string and not array anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection should be enough

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?