### PR TITLE
Jetpack Onboarding: Hide site only connection on login

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -823,8 +823,6 @@ export function redirectLostPassword( context, next ) {
 export function redirectJetpackDirectAuthError( context, next, newQuery = {} ) {
 	const queryParams = new URLSearchParams( Object.assign( {}, context.query, newQuery ) );
 
-	queryParams.set( 'allow_site_connection', '1' );
-
 	const fallbackUrl = `/log-in/jetpack/?${ queryParams.toString() }`;
 	window.history.replaceState( null, '', fallbackUrl );
 


### PR DESCRIPTION
#102027 seems to have introduced a minor regression where the site only connection option is shown on wpcom connect screen.

Fixes ONBOARD-86

## Proposed Changes

* Hide the option to "Continue without user account" on Jetpack connect screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To ensure that the user account is always created instead of a site-only connection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Fire up this PR using the Calypso Live link below or use the local `yarn start`
* On your site add this to a mu-plugin like `tools/docker/mu-plugins/0-snippets.php`
```php
add_filter(
	'jetpack_build_authorize_url',
	function ( $url ) {
		// Replace the calypso URL with the correct one
		$url = str_replace( 'https://wordpress.com', 'http://calypso.localhost:3000', $url );

		return $url;
	}
);
```
* On the Jetpack JT site, run `jetpack docker wp jetpack disconnect blog` to remove the site connection
* Goto My Jetpack to start onboarding and click on Google
* Confirm that you end up at the connection screen with no option to "Continue without user account"

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/64f4740e-7657-4e7e-8b9f-aad8f07f4c30

</td>
            <td>

https://github.com/user-attachments/assets/acd1c41d-396f-4bdb-9cde-6557f6d3b6b5

</td>
        </tr>
    </tbody>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
