### PR TITLE
Reader: Fix linting error on DiscoverSSR by using DiscoverHeaderAndNavigation

### DIFF
--- a/client/components/scrollable-horizontal-navigation/index.tsx
+++ b/client/components/scrollable-horizontal-navigation/index.tsx
@@ -1,8 +1,7 @@
 import { Button, Gridicon, SegmentedControl } from '@automattic/components';
 import clsx from 'clsx';
 import { throttle } from 'lodash';
-import React, { useEffect, useRef } from 'react';
-import { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
+import { useEffect, useRef } from 'react';
 
 import './styles.scss';
 
@@ -23,7 +22,6 @@ interface Props< T extends object > {
 	selectedTab: string;
 	tabs: Tab< T >[];
 	titleField?: keyof Tab< T >;
-	width: number;
 }
 
 const ScrollableHorizontalNavigation = < T extends object >( {
@@ -32,7 +30,6 @@ const ScrollableHorizontalNavigation = < T extends object >( {
 	selectedTab,
 	tabs,
 	titleField = 'title',
-	width,
 }: Props< T > ) => {
 	const scrollRef = useRef< HTMLDivElement >( null );
 
@@ -83,11 +80,7 @@ const ScrollableHorizontalNavigation = < T extends object >( {
 	}, 50 );
 
 	return (
-		<div
-			className={ clsx( 'scrollable-horizontal-navigation', className, {
-				'reader-dual-column': width > WIDE_DISPLAY_CUTOFF,
-			} ) }
-		>
+		<div className={ clsx( 'scrollable-horizontal-navigation', className ) }>
 			<div
 				className={ clsx( 'scrollable-horizontal-navigation__left-button-wrapper', {
 					'display-none': shouldHideLeftScrollButton(),

--- a/client/components/scrollable-horizontal-navigation/styles.scss
+++ b/client/components/scrollable-horizontal-navigation/styles.scss
@@ -1,16 +1,12 @@
 .scrollable-horizontal-navigation {
 	position: relative;
 	margin: auto;
-	margin-bottom: -20px;
 	overflow: hidden;
+
 	@media only screen and (max-width: 600px) {
 		padding: 0 24px;
 	}
 
-	&.reader-dual-column {
-		max-width: 968px; // Max width of dual column reader stream.
-		margin-bottom: 0;
-	}
 	@media only screen and (max-width: 660px) {
 		margin: 0 16px -24px;
 	}

--- a/client/my-sites/plugins/search-categories/index.tsx
+++ b/client/my-sites/plugins/search-categories/index.tsx
@@ -8,7 +8,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import ScrollableHorizontalNavigation from 'calypso/components/scrollable-horizontal-navigation';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import scrollTo from 'calypso/lib/scroll-to';
-import withDimensions from 'calypso/lib/with-dimensions';
 import Categories from 'calypso/my-sites/plugins/categories';
 import {
 	ALLOWED_CATEGORIES,
@@ -90,8 +89,7 @@ const SearchCategories: FC< {
 	searchRef: MutableRefObject< ImperativeHandle >;
 	searchTerm: string;
 	searchTerms: string[];
-	width: number;
-} > = ( { category, isSearching, isSticky, searchRef, searchTerm, searchTerms, width } ) => {
+} > = ( { category, isSearching, isSticky, searchRef, searchTerm, searchTerms } ) => {
 	const dispatch = useDispatch();
 	const getCategoryUrl = useGetCategoryUrl();
 	const categoriesRef = useRef< HTMLDivElement >( null );
@@ -141,7 +139,6 @@ const SearchCategories: FC< {
 							selectedTab={ category ?? categories[ 0 ].slug }
 							tabs={ categories }
 							titleField="menu"
-							width={ width }
 						/>
 					</>
 				) : (
@@ -155,4 +152,4 @@ const SearchCategories: FC< {
 	);
 };
 
-export default withDimensions( SearchCategories );
+export default SearchCategories;

--- a/client/reader/discover/components/header-and-navigation/index.tsx
+++ b/client/reader/discover/components/header-and-navigation/index.tsx
@@ -1,4 +1,3 @@
-import './styles.scss';
 import page from '@automattic/calypso-router';
 import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils';
 import clsx from 'clsx';
@@ -8,20 +7,18 @@ import { addQueryArgs } from 'calypso/lib/url';
 import ReaderBackButton from 'calypso/reader/components/back-button';
 import DiscoverNavigation from 'calypso/reader/discover/components/navigation';
 import DiscoverTagsNavigation from 'calypso/reader/discover/components/tags-navigation';
-import { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
 import { getSelectedTabTitle, FIRST_POSTS_TAB, ADD_NEW_TAB, REDDIT_TAB } from '../../helper';
 
-interface DiscoverHeaderAndNavigationProps {
-	width: number;
+export interface DiscoverHeaderAndNavigationProps {
 	selectedTab: string;
 	effectiveTabSelection: string;
-	selectedTag: string;
+	selectedTag?: string;
 }
 
 export default function DiscoverHeaderAndNavigation(
 	props: DiscoverHeaderAndNavigationProps
 ): JSX.Element {
-	const { width, selectedTab, effectiveTabSelection, selectedTag } = props;
+	const { selectedTab, effectiveTabSelection, selectedTag } = props;
 	const currentLocale = useLocale();
 	const tabTitle = getSelectedTabTitle( effectiveTabSelection );
 	const translate = useTranslate();
@@ -58,18 +55,12 @@ export default function DiscoverHeaderAndNavigation(
 			<NavigationHeader
 				title={ translate( 'Discover' ) }
 				subtitle={ subHeaderText }
-				className={ clsx( 'discover-stream-header', {
-					'reader-dual-column': width > WIDE_DISPLAY_CUTOFF,
-				} ) }
+				className={ clsx( 'discover-stream-header' ) }
 			/>
 			<DiscoverNavigation selectedTab={ selectedTab } />
 
 			{ selectedTab === 'tags' && (
-				<DiscoverTagsNavigation
-					width={ width }
-					selectedTag={ selectedTag }
-					onTagSelect={ handleTagSelect }
-				/>
+				<DiscoverTagsNavigation selectedTag={ selectedTag } onTagSelect={ handleTagSelect } />
 			) }
 		</>
 	);

--- a/client/reader/discover/components/header-and-navigation/styles.scss
+++ b/client/reader/discover/components/header-and-navigation/styles.scss
@@ -1,7 +1,0 @@
-.is-section-reader {
-	.navigation-header.discover-stream-header {
-		&.reader-dual-column {
-			max-width: 968px; // Max width of dual column reader stream.
-		}
-	}
-}

--- a/client/reader/discover/components/tags-navigation/index.tsx
+++ b/client/reader/discover/components/tags-navigation/index.tsx
@@ -13,9 +13,8 @@ interface Tag {
 	slug: string;
 }
 
-interface Props {
+interface DiscoverTagsNavigationProps {
 	selectedTag?: string;
-	width: number;
 	onTagSelect: ( tag: string ) => void;
 }
 
@@ -46,7 +45,7 @@ export const useRecommendedTags = (): Tag[] => {
 	return interestTags;
 };
 
-const DiscoverTagsNavigation = ( { selectedTag, width, onTagSelect }: Props ) => {
+const DiscoverTagsNavigation = ( { selectedTag, onTagSelect }: DiscoverTagsNavigationProps ) => {
 	const recommendedTags = useRecommendedTags();
 	const dispatch = useDispatch();
 
@@ -67,7 +66,6 @@ const DiscoverTagsNavigation = ( { selectedTag, width, onTagSelect }: Props ) =>
 			onTabClick={ menuTabClick }
 			selectedTab={ selectedTag || '' }
 			tabs={ recommendedTags }
-			width={ width }
 		/>
 	);
 };

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import withDimensions from 'calypso/lib/with-dimensions';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import DiscoverAddNew from 'calypso/reader/discover/components/add-new';
 import DiscoverHeaderAndNavigation from 'calypso/reader/discover/components/header-and-navigation';
@@ -70,4 +69,4 @@ const DiscoverStream = ( props ) => {
 	);
 };
 
-export default withDimensions( DiscoverStream );
+export default DiscoverStream;

--- a/client/reader/discover/index.node.js
+++ b/client/reader/discover/index.node.js
@@ -3,10 +3,10 @@ import {
 	removeLocaleFromPathLocaleInFront,
 } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import DiscoverHeaderAndNavigation from 'calypso/reader/discover/components/header-and-navigation';
 import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
 import renderHeaderSection from '../lib/header-section';
 import { DiscoverDocumentHead } from './discover-document-head';
-import { DiscoverHeader } from './discover-stream';
 import { getSelectedTabTitle, DEFAULT_TAB } from './helper';
 
 const discoverSsr = ( context, next ) => {
@@ -26,7 +26,10 @@ const discoverSsr = ( context, next ) => {
 	context.primary = (
 		<>
 			<DiscoverDocumentHead tabTitle={ tabTitle } />
-			<DiscoverHeader selectedTab={ selectedTab } />
+			<DiscoverHeaderAndNavigation
+				selectedTab={ selectedTab }
+				effectiveTabSelection={ selectedTab }
+			/>
 			<PostPlaceholder />
 		</>
 	);

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -6,12 +6,11 @@ import { useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
-import withDimensions from 'calypso/lib/with-dimensions';
 import QuickPost from 'calypso/reader/components/quick-post';
 import { focusEditor } from 'calypso/reader/components/quick-post/utils';
 import ReaderOnboarding from 'calypso/reader/onboarding';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
-import ReaderStream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
+import ReaderStream from 'calypso/reader/stream';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
@@ -69,9 +68,7 @@ function FollowingStream( { ...props } ) {
 							newCopy: translate( 'Latest from your subscriptions.' ),
 							oldCopy: translate( 'Fresh content from blogs you follow.' ),
 						} ) }
-						className={ clsx( 'following-stream-header', {
-							'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
-						} ) }
+						className={ clsx( 'following-stream-header' ) }
 					>
 						<ViewToggle />
 					</NavigationHeader>
@@ -104,4 +101,4 @@ function FollowingStream( { ...props } ) {
 	);
 }
 
-export default SuggestionProvider( withDimensions( FollowingStream ) );
+export default SuggestionProvider( FollowingStream );

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,12 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
 
-.is-section-reader .navigation-header.following-stream-header {
-
-	&.reader-dual-column {
-		max-width: 968px; // Max width of dual column reader stream.
-	}
-}
-
 .following.main .section-nav {
 	margin-top: 0;
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102571#discussion_r2052216936

## Proposed Changes

- Updated `DiscoverHeader` usage in DiscoverSSR with the new `DiscoverHeaderAndNavigation` component.
- In some places we were using the `width` attribute to add `reader-dual-columns` but now those screens have single columns so removed the class and the extra attribute.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix linting errors.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/discover/tags`. Verify UI and responsiveness is working fine.
2. Go to `/plugins`. Verify UI and responsiveness is working fine.
3. Open private mode or log out.
4. Repeat 1 & 2.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
