### PR TITLE
E2E Tests: Fix the starter page modal may not be shown because the theme doesn't have starter patterns

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-inline-block-inserter-component.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page, Locator } from 'playwright';
 import { EditorComponent } from './editor-component';
 
 const popoverParentSelector = '.block-editor-inserter__quick-inserter';
@@ -41,8 +41,10 @@ export class EditorInlineBlockInserterComponent {
 	 * Where multiple matches exist (eg. due to partial matching), the first
 	 * result will be chosen.
 	 */
-	async selectBlockInserterResult( name: string ): Promise< void > {
+	async selectBlockInserterResult( name: string ): Promise< Locator > {
 		const editorParent = await this.editor.parent();
-		await editorParent.getByRole( 'option', { name, exact: true } ).first().click();
+		const locator = editorParent.getByRole( 'option', { name, exact: true } ).first();
+		await locator.click();
+		return locator;
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page, Locator } from 'playwright';
 import envVariables from '../../env-variables';
 import { EditorComponent } from './editor-component';
 
@@ -74,7 +74,7 @@ export class EditorSidebarBlockInserterComponent {
 			type = 'block',
 			blockFallBackName = '',
 		}: { type?: 'block' | 'pattern'; blockFallBackName?: string } = {}
-	): Promise< void > {
+	): Promise< Locator > {
 		const editorParent = await this.editor.parent();
 		let locator;
 
@@ -98,5 +98,7 @@ export class EditorSidebarBlockInserterComponent {
 
 		await Promise.all( [ locator.hover(), locator.focus() ] );
 		await locator.click();
+
+		return locator;
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -384,11 +384,12 @@ export class EditorPage {
 			blockFallBackName?: string;
 			blockInsertedPopupConfirmButtonSelector?: string;
 		} = {}
-	): Promise< void > {
+	): Promise< Locator > {
 		if ( ! noSearch ) {
 			await inserter.searchBlockInserter( blockName );
 		}
-		await inserter.selectBlockInserterResult( blockName, { blockFallBackName } );
+
+		const locator = await inserter.selectBlockInserterResult( blockName, { blockFallBackName } );
 
 		if ( blockInsertedPopupConfirmButtonSelector ) {
 			const editorParent = await this.editor.parent();
@@ -408,6 +409,8 @@ export class EditorPage {
 				await blockInsertedPopupConfirmButtonLocator.click();
 			}
 		}
+
+		return locator;
 	}
 
 	/**
@@ -421,10 +424,13 @@ export class EditorPage {
 	 *
 	 * @param {string} patternName Name of the pattern to insert.
 	 */
-	async addPatternFromSidebar( patternName: string ): Promise< void > {
+	async addPatternFromSidebar( patternName: string ): Promise< Locator > {
 		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
-		await this.addPatternFromInserter( patternName, this.editorSidebarBlockInserterComponent );
+		return await this.addPatternFromInserter(
+			patternName,
+			this.editorSidebarBlockInserterComponent
+		);
 	}
 
 	/**
@@ -442,11 +448,14 @@ export class EditorPage {
 	 * @param {string} patternName Name of the pattern to insert as it matches the label in the inserter.
 	 * @param {Locator} inserterLocator Locator to the element that will open the pattern/block inserter when clicked.
 	 */
-	async addPatternInline( patternName: string, inserterLocator: Locator ): Promise< void > {
+	async addPatternInline( patternName: string, inserterLocator: Locator ): Promise< Locator > {
 		// Perform a click action on the locator.
 		await inserterLocator.click();
 		// Add the specified pattern from the inserter.
-		await this.addPatternFromInserter( patternName, this.editorInlineBlockInserterComponent );
+		return await this.addPatternFromInserter(
+			patternName,
+			this.editorInlineBlockInserterComponent
+		);
 	}
 
 	/**
@@ -458,15 +467,16 @@ export class EditorPage {
 	private async addPatternFromInserter(
 		patternName: string,
 		inserter: BlockInserter
-	): Promise< void > {
+	): Promise< Locator > {
 		const editorParent = await this.editor.parent();
 
 		await inserter.searchBlockInserter( patternName );
-		await inserter.selectBlockInserterResult( patternName, { type: 'pattern' } );
+		const locator = await inserter.selectBlockInserterResult( patternName, { type: 'pattern' } );
 		const insertConfirmationToastLocator = editorParent.locator(
 			`.components-snackbar__content:text('Block pattern "${ patternName }" inserted.')`
 		);
 		await insertConfirmationToastLocator.waitFor();
+		return locator;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
+++ b/packages/calypso-e2e/src/lib/pages/shared-types/editor-types.ts
@@ -6,5 +6,5 @@ export interface BlockInserter {
 	selectBlockInserterResult(
 		name: string,
 		options?: { type?: 'block' | 'pattern'; blockFallBackName?: string }
-	): Promise< void >;
+	): Promise< Locator >;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/WordPress/gutenberg/pull/69081, https://github.com/Automattic/wp-calypso/pull/101265

## Proposed Changes

* The starter page modal was initially removed in [WordPress/gutenberg#66836](https://github.com/WordPress/gutenberg/pull/66836), but later restored by [WordPress/gutenberg#69081](https://github.com/WordPress/gutenberg/pull/69081). However, the registration of starter page patterns from Dotcom Patterns was removed in [Automattic/jetpack#41479](https://github.com/Automattic/jetpack/pull/41479). As a result, the starter page modal may not appear if the active theme (e.g., TT1) doesn't include any matching patterns.
* This PR proposes a fallback: if no starter patterns are available from the theme, the starter content will be inserted via the sidebar instead. **Perhaps we can consider removing this test case, as it now aligns with Core’s behavior.**

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix e2e tests for GB 20.6.0

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The `Select page template` test case should pass successfully

![image](https://github.com/user-attachments/assets/eeb01abf-10b4-44f6-89b4-bce3f08e54af)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
