### PR TITLE
Purchase Management: Switch placeholder alert for silent return

### DIFF
--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -23,7 +23,7 @@ export function PurchasesDataViews( props: {
 } ) {
 	const { purchases } = props;
 	const onChangeView = () => {
-		alert( 'You clicked something!!' );
+		return;
 	};
 
 	const getItemId = ( item: Purchases.Purchase ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/102630#discussion_r2050881488

## Proposed Changes

* This removes the alert "You clicked something" from showing in Localhost and Developer environments where the feature flag "purchases/purchase-list-dataview" is set to `true`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While `onChangeView` is [a required parameter for the DataViews component](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#usage), it was [brought up](https://github.com/Automattic/wp-calypso/pull/102630#discussion_r2050881488) that having the `You clicked something` placeholder was not ideal in production code. This keeps the `onChangeView` function by changing the functionality to simply return silently. This means that clicking on elements within the DataView component won't actually trigger any action. 
* The project is still WIP, so the `onChangeView` function will get updated as part of the next steps: https://github.com/Automattic/wp-calypso/issues/86616#issuecomment-2812443900

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR and load `me/purchases` in the developer configuration, or localhost, 
* As the DataView table is loaded, you shouldn't see the 'You clicked something' alert
* If you click on any of the links in the DataView table, nothing should happen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
