### PR TITLE
Plugin Management: Minor UI improvements and fixes.

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/style.scss
@@ -5,9 +5,6 @@
 .dataviews-pagination {
 	flex-shrink: 0;
 	background: #fff;
-	border-top: 1px solid #f1f1f1;
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
 	bottom: 0;
 	color: var(--Gray-Gray-40, #787c82);
 	@include body-small;

--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -1,7 +1,9 @@
 .is-section-a8c-for-agencies-plugins {
 	.wpcom-site {
 		.main.hosting-dashboard-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
-			.hosting-dashboard-layout-column__container {
+			.hosting-dashboard-layout-column__container.hosting-dashboard-layout-column__container.hosting-dashboard-layout-column__container {
+				height: calc(100vh - 40px - var(--masterbar-height));
+
 				.hosting-dashboard-layout__top-wrapper {
 					display: block;
 				}

--- a/client/components/dataviews/style.scss
+++ b/client/components/dataviews/style.scss
@@ -5,6 +5,11 @@
 .dataviews-wrapper {
 	// Maybe move upstream to the gutenberg repository
 	width: 100%;
+	padding-block-end: 40px;
+
+	@include break-mobile {
+		padding-block-end: 0;
+	}
 
 	tr.dataviews-view-table__row {
 		background: var( --studio-white );

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -137,7 +137,7 @@ export default function PluginsListDataViews( {
 						dispatch( recordTracksEvent( 'calypso_plugins_list_pending_update_filter_click' ) );
 					} }
 				>
-					{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }
+					{ translate( 'Update available (%s)', { args: [ pluginUpdateCount ] } ) }
 				</Button>
 			) }
 		</>

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -47,6 +47,7 @@ export default function PluginsListDataViews( {
 	bulkActionDialog,
 }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const isDesktopView = isDesktop();
 	const shouldUseListView = pluginSlug !== undefined || ! isDesktopView;
 	const pluginUpdateCount = currentPlugins.filter(
@@ -133,7 +134,7 @@ export default function PluginsListDataViews( {
 							} );
 						}
 						setIsFilteringUpdates( ! isFilteringUpdates );
-						recordTracksEvent( 'calypso_plugins_list_pending_update_filter_click' );
+						dispatch( recordTracksEvent( 'calypso_plugins_list_pending_update_filter_click' ) );
 					} }
 				>
 					{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }
@@ -180,7 +181,6 @@ export default function PluginsListDataViews( {
 		[ dataViewsState.type ]
 	);
 
-	const dispatch = useDispatch();
 	const trackPluginNameClick = useCallback(
 		( item: Plugin ) => {
 			dispatch(

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -133,6 +133,7 @@ export default function PluginsListDataViews( {
 							} );
 						}
 						setIsFilteringUpdates( ! isFilteringUpdates );
+						recordTracksEvent( 'calypso_plugins_list_pending_update_filter_click' );
 					} }
 				>
 					{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -1,6 +1,5 @@
 import pagejs from '@automattic/calypso-router';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
-import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -14,7 +13,6 @@ import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
 import { DataViews } from 'calypso/components/dataviews';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { useActions } from './use-actions';
 import { useFields } from './use-fields';
@@ -49,9 +47,6 @@ export default function PluginsListDataViews( {
 	const translate = useTranslate();
 	const isDesktopView = isDesktop();
 	const shouldUseListView = pluginSlug !== undefined || ! isDesktopView;
-	const pluginUpdateCount = currentPlugins.filter(
-		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
-	).length;
 
 	const fields = useFields( bulkActionDialog, openPluginSitesPane, shouldUseListView );
 	const actions = useActions( bulkActionDialog );
@@ -85,8 +80,6 @@ export default function PluginsListDataViews( {
 		};
 	} );
 
-	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
-
 	useEffect( () => {
 		// Sets the correct fields when route changes or viewport changes
 		setDataViewsState( {
@@ -107,57 +100,11 @@ export default function PluginsListDataViews( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ pluginSlug ] );
 
-	const header = (
-		<>
-			{ pluginUpdateCount > 0 && (
-				<Button
-					isPressed={ isFilteringUpdates }
-					onClick={ () => {
-						if ( isFilteringUpdates ) {
-							setDataViewsState( {
-								...dataViewsState,
-								filters: [],
-								page: 1,
-							} );
-						} else {
-							setDataViewsState( {
-								...dataViewsState,
-								filters: [
-									{
-										field: 'status',
-										operator: 'isAny',
-										value: [ PLUGINS_STATUS.UPDATE ],
-									},
-								],
-								page: 1,
-							} );
-						}
-						setIsFilteringUpdates( ! isFilteringUpdates );
-					} }
-				>
-					{ translate( 'Update available (%s)', { args: [ pluginUpdateCount ] } ) }
-				</Button>
-			) }
-		</>
-	);
-
 	useEffect( () => {
 		if ( dataViewsState.search !== initialSearch ) {
 			onSearch && onSearch( dataViewsState.search || '' );
 		}
 	}, [ dataViewsState.search, onSearch, initialSearch ] );
-
-	useEffect( () => {
-		if (
-			dataViewsState.filters?.length === 1 &&
-			dataViewsState.filters[ 0 ].field === 'status' &&
-			dataViewsState.filters[ 0 ].value?.includes( PLUGINS_STATUS.UPDATE )
-		) {
-			setIsFilteringUpdates( true );
-		} else {
-			setIsFilteringUpdates( false );
-		}
-	}, [ dataViewsState.filters ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		const result = filterSortAndPaginate( currentPlugins, dataViewsState, fields );
@@ -215,7 +162,6 @@ export default function PluginsListDataViews( {
 				isLoading={ isLoading }
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ defaultLayouts }
-				header={ header }
 			/>
 		</>
 	);

--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -1,5 +1,6 @@
 import pagejs from '@automattic/calypso-router';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
+import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -13,6 +14,7 @@ import QueryDotorgPlugins from 'calypso/components/data/query-dotorg-plugins';
 import { DataViews } from 'calypso/components/dataviews';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { PLUGINS_STATUS } from 'calypso/state/plugins/installed/status/constants';
 import { Plugin } from 'calypso/state/plugins/installed/types';
 import { useActions } from './use-actions';
 import { useFields } from './use-fields';
@@ -47,6 +49,9 @@ export default function PluginsListDataViews( {
 	const translate = useTranslate();
 	const isDesktopView = isDesktop();
 	const shouldUseListView = pluginSlug !== undefined || ! isDesktopView;
+	const pluginUpdateCount = currentPlugins.filter(
+		( plugin ) => plugin.status?.includes( PLUGINS_STATUS.UPDATE )
+	).length;
 
 	const fields = useFields( bulkActionDialog, openPluginSitesPane, shouldUseListView );
 	const actions = useActions( bulkActionDialog );
@@ -80,6 +85,8 @@ export default function PluginsListDataViews( {
 		};
 	} );
 
+	const [ isFilteringUpdates, setIsFilteringUpdates ] = useState( false );
+
 	useEffect( () => {
 		// Sets the correct fields when route changes or viewport changes
 		setDataViewsState( {
@@ -100,11 +107,57 @@ export default function PluginsListDataViews( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ pluginSlug ] );
 
+	const header = (
+		<>
+			{ pluginUpdateCount > 0 && (
+				<Button
+					isPressed={ isFilteringUpdates }
+					onClick={ () => {
+						if ( isFilteringUpdates ) {
+							setDataViewsState( {
+								...dataViewsState,
+								filters: [],
+								page: 1,
+							} );
+						} else {
+							setDataViewsState( {
+								...dataViewsState,
+								filters: [
+									{
+										field: 'status',
+										operator: 'isAny',
+										value: [ PLUGINS_STATUS.UPDATE ],
+									},
+								],
+								page: 1,
+							} );
+						}
+						setIsFilteringUpdates( ! isFilteringUpdates );
+					} }
+				>
+					{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }
+				</Button>
+			) }
+		</>
+	);
+
 	useEffect( () => {
 		if ( dataViewsState.search !== initialSearch ) {
 			onSearch && onSearch( dataViewsState.search || '' );
 		}
 	}, [ dataViewsState.search, onSearch, initialSearch ] );
+
+	useEffect( () => {
+		if (
+			dataViewsState.filters?.length === 1 &&
+			dataViewsState.filters[ 0 ].field === 'status' &&
+			dataViewsState.filters[ 0 ].value?.includes( PLUGINS_STATUS.UPDATE )
+		) {
+			setIsFilteringUpdates( true );
+		} else {
+			setIsFilteringUpdates( false );
+		}
+	}, [ dataViewsState.filters ] );
 
 	const { data, paginationInfo } = useMemo( () => {
 		const result = filterSortAndPaginate( currentPlugins, dataViewsState, fields );
@@ -162,6 +215,7 @@ export default function PluginsListDataViews( {
 				isLoading={ isLoading }
 				paginationInfo={ paginationInfo }
 				defaultLayouts={ defaultLayouts }
+				header={ header }
 			/>
 		</>
 	);

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -154,3 +154,8 @@ body.is-section-plugins .plugin-management-wrapper,
 	color: inherit;
 	cursor: pointer;
 }
+
+.plugin-name-container {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -75,7 +75,7 @@ export function useFields(
 
 					return (
 						<>
-							{ item.name }
+							<div className="plugin-name-container">{ item.name }</div>
 							{ pluginActionStatus }
 						</>
 					);

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -121,7 +121,11 @@ export function useFields(
 				},
 				enableHiding: false,
 				render: ( { item }: { item: Plugin } ) => {
-					if ( item.status?.includes( PLUGINS_STATUS.UPDATE ) && item?.update?.new_version ) {
+					if (
+						item.status?.includes( PLUGINS_STATUS.UPDATE ) &&
+						item?.update?.new_version &&
+						! isListView
+					) {
 						return (
 							<Button
 								variant="secondary"


### PR DESCRIPTION
This PR fixes a couple of UI issues related to the Plugin management components. 

Closes https://linear.app/a8c/issue/A4A-777/plugin-management-panel-view-ui-problems

## Proposed Changes

| Issue | Before | After |
|--------|--------|--------|
| If the Plugin name is excessively long, it may overlap when on list view, resulting in a horizontal scrollbar. | <img width="420" alt="Screenshot 2025-04-21 at 10 28 44 PM" src="https://github.com/user-attachments/assets/c1abd244-9afd-4b38-af4f-5e0e435a5854" /> | <img width="416" alt="Screenshot 2025-04-21 at 10 29 13 PM" src="https://github.com/user-attachments/assets/9cecd614-b174-400a-b565-c6c3a8a6faea" /> |
| Update CTAs near each plugin in sidebar should removed. The information density of this area is too much, and I'd be willing to bet that most folks aren't going to mass update plugins across all sites from this area. It's not visually aligned or the right size. They'll want to know details and update, which they can do once they click on the plugin title. It doesn't represent how many instances need that update. IE: It says Woo is installed on "11 sites "update to version 9.8.1" but actually only one of those sites needs an update. Let's leave the update action to the right panel. See screenshot. | <img width="410" alt="Screenshot 2025-04-21 at 10 32 32 PM" src="https://github.com/user-attachments/assets/0ced9f9d-7d26-456a-aeb9-19e318e0ff3c" /> | <img width="411" alt="Screenshot 2025-04-21 at 10 32 39 PM" src="https://github.com/user-attachments/assets/8f585a90-6946-49a9-a8a5-680fc0d58d41" /> |
| **A4A only:** The double border on the pagination shows here as well. | <img width="280" alt="Screenshot 2025-04-21 at 10 35 13 PM" src="https://github.com/user-attachments/assets/788a9766-a23a-4646-87e2-c8c251545a70" /> | <img width="232" alt="Screenshot 2025-04-21 at 10 35 21 PM" src="https://github.com/user-attachments/assets/2bd3ab79-691d-46cc-a10e-fe3203b7598c" /> | 

## Why are these changes being made?

* This enhances our UI, providing a more refined and enjoyable user experience.

## Testing Instructions

* Access the A4A live link and proceed to `/plugins`.
* Verify all elaborated issues are fixed.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
