### PR TITLE
Hide Jetpack's progress bar for WooPayments flows

### DIFF
--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -41,6 +41,13 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 		shouldShowNoThanks = false;
 	}
 
+	// Check for the existence of the flow=nox query argument
+	const isWooNOX = getQueryArg( redirectToOriginal || '', 'flow' ) === 'nox';
+
+	if ( isWooNOX ) {
+		shouldShowProgressBar = false;
+	}
+
 	return (
 		<Fragment>
 			{ shouldShowProgressBar && <ProgressBar className="masterbar__progress-bar" value={ 95 } /> }

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'calypso/state';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { isWooCommercePaymentsOnboardingFlow } from 'calypso/state/selectors/is-woo-jpc-flow';
 
 // Masterbar for WooCommerce Core Profiler Jetpack step
 const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) => string } ) => {
@@ -41,10 +42,10 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 		shouldShowNoThanks = false;
 	}
 
-	// Check for the existence of the flow=nox query argument
-	const isWooNOX = getQueryArg( redirectToOriginal || '', 'flow' ) === 'nox';
+	const state = useSelector( ( state ) => state );
+	const isWooPaymentsFlow = isWooCommercePaymentsOnboardingFlow( state );
 
-	if ( isWooNOX ) {
+	if ( isWooPaymentsFlow ) {
 		shouldShowProgressBar = false;
 	}
 

--- a/client/state/selectors/is-woo-jpc-flow.ts
+++ b/client/state/selectors/is-woo-jpc-flow.ts
@@ -14,6 +14,8 @@ const isLegacyJetpackWooOnboardingFlow = ( state: AppState ) => {
 export const isWooCommercePaymentsOnboardingFlow = ( state: AppState ) => {
 	const from =
 		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
+		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
+		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-onboarding' ||
 		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-onboarding';
 
 	const redirectTo =

--- a/client/state/selectors/is-woo-jpc-flow.ts
+++ b/client/state/selectors/is-woo-jpc-flow.ts
@@ -14,7 +14,7 @@ const isLegacyJetpackWooOnboardingFlow = ( state: AppState ) => {
 const isWooCommercePaymentsOnboardingFlow = ( state: AppState ) => {
 	const from =
 		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
-		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-payments';
+		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-onboarding';
 
 	const redirectTo =
 		get( getInitialQueryArguments( state ), 'redirect_to' ) ||

--- a/client/state/selectors/is-woo-jpc-flow.ts
+++ b/client/state/selectors/is-woo-jpc-flow.ts
@@ -11,7 +11,7 @@ const isLegacyJetpackWooOnboardingFlow = ( state: AppState ) => {
 	return 'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
 };
 
-const isWooCommercePaymentsOnboardingFlow = ( state: AppState ) => {
+export const isWooCommercePaymentsOnboardingFlow = ( state: AppState ) => {
 	const from =
 		get( getInitialQueryArguments( state ), 'from' ) === 'woocommerce-payments' ||
 		get( getCurrentQueryArguments( state ), 'from' ) === 'woocommerce-onboarding';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to WOOPLUG-3957

## Proposed Changes

* This PR hides the progress bar in the Jetpack connection screen for WooPayments flows

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of our work to introduce a new onboarding experience for WooPayments in WooCommerce.
* We already have some onboarding steps that make this progress bar redundant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check this PR locally
2. Build and start Calypso locally, refer to [this checklist](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started). Calypso should be running on `http://calypso.localhost:3000/`
3. Create a new JN site with the WooCommerce's `add/onboarding-modal` branch, then skip the Woo profiler and select US
5. Install WooPayments using this zip p1743788537437949/1743788500.790389-slack-C0800LPNCET
6. Go to `WooCommerce > Settings > Payments > WooPayments > Complete Setup`
7. Click Continue on the first step, and click Connect on the WP.com connection step
8. A Jetpack page will open with a progress loading bar at the top
9. Replace wordpress.com with your local calypso link (ie `http://calypso.localhost:3000/`)
10. Double-check that the progress bar is not showing anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
