### PR TITLE
Update plugin-compatibility.js - remove wp-staging

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -126,8 +126,7 @@ const incompatiblePlugins = new Set( [
 
 	// cloning/staging
 	'flo-launch',
-	'wp-staging',
-
+	
 	// misc
 	'adult-mass-photos-downloader',
 	'adult-mass-videos-embedder',

--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -126,7 +126,7 @@ const incompatiblePlugins = new Set( [
 
 	// cloning/staging
 	'flo-launch',
-	
+
 	// misc
 	'adult-mass-photos-downloader',
 	'adult-mass-videos-embedder',


### PR DESCRIPTION
Remove `wp-staging` from list of incompatible plugins.

Related to https://github.com/Automattic/jetpack/pull/43170

## Proposed Changes

- This PR remove `wp-staging` from list of incompatible plugins.

## Why are these changes being made?

- WP-Staging (`wp-staging`) now detects if the plugin is being used on a WordPress.com site and if it is, it disables the staging feature. It also displays a message indicating this to the user. Some Fusion members have tested this plugin and confirm the changes have been made.

## Testing Instructions

* Checkout branch
* Test trying to install "WP Staging".  Note: this PR is for the free base version of the plugin, the paid version (WP STAGING PRO) requires the free version to be installed as well. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
