### PR TITLE
Move geolocation survey logic closer to survey component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -1,70 +1,28 @@
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
-import { Suspense } from 'react';
-import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
+import { type ComponentType, Suspense } from 'react';
 import AsyncMigrationSurvey from '../../steps-repository/components/migration-survey/async';
 import { Flow } from '../../types';
 import { DeferredRender } from '../deferred-render';
 
-const migrationFlows = [ SITE_MIGRATION_FLOW ];
-const availableCountries = [ 'US', 'IN' ];
-
-const isMigrationSurveyAvailable = ( {
-	country,
-	flow,
-	isEnglish,
-}: {
-	country?: string;
-	flow?: string;
-	isEnglish?: boolean;
-} ) => {
-	if ( ! country || ! flow || ! isEnglish ) {
-		return false;
-	}
-
-	if ( ! migrationFlows.includes( flow ) ) {
-		return false;
-	}
-
-	if ( ! availableCountries.includes( country ) ) {
-		return false;
-	}
-
-	return true;
-};
-
-const surveyList = [
-	{
-		Component: AsyncMigrationSurvey,
-		isAvailable: isMigrationSurveyAvailable,
-	},
-] as const;
+const FLOW_SURVEYS = new Map< string, ComponentType >( [
+	[ SITE_MIGRATION_FLOW, AsyncMigrationSurvey ],
+] );
 
 const SurveyManager = ( { disabled = false, flow }: { disabled?: boolean; flow?: Flow } ) => {
-	const isEnLocale = useIsEnglishLocale();
-	const { data } = useGeoLocationQuery();
-	const countryCode = data?.country_short;
-
-	if ( ! flow || disabled || ! countryCode ) {
+	if ( disabled || ! flow ) {
 		return null;
 	}
 
-	const survey = surveyList.find( ( { isAvailable } ) =>
-		isAvailable( {
-			flow: flow?.variantSlug || flow?.name,
-			country: countryCode,
-			isEnglish: isEnLocale,
-		} )
-	);
+	const SurveyComponent = FLOW_SURVEYS.get( flow.name );
 
-	if ( ! survey ) {
+	if ( ! SurveyComponent ) {
 		return null;
 	}
 
 	return (
 		<DeferredRender timeMs={ 2000 }>
 			<Suspense>
-				<survey.Component countryCode={ countryCode } />
+				<SurveyComponent />
 			</Suspense>
 		</DeferredRender>
 	);

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -1,28 +1,20 @@
 import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
-import { type ComponentType, Suspense } from 'react';
+import { Suspense } from 'react';
 import AsyncMigrationSurvey from '../../steps-repository/components/migration-survey/async';
 import { Flow } from '../../types';
 import { DeferredRender } from '../deferred-render';
 
-const FLOW_SURVEYS = new Map< string, ComponentType >( [
-	[ SITE_MIGRATION_FLOW, AsyncMigrationSurvey ],
-] );
+const MIGRATION_FLOWS = new Set< string >( [ SITE_MIGRATION_FLOW ] );
 
 const SurveyManager = ( { disabled = false, flow }: { disabled?: boolean; flow?: Flow } ) => {
-	if ( disabled || ! flow ) {
-		return null;
-	}
-
-	const SurveyComponent = FLOW_SURVEYS.get( flow.name );
-
-	if ( ! SurveyComponent ) {
+	if ( disabled || ! flow || ! MIGRATION_FLOWS.has( flow.name ) ) {
 		return null;
 	}
 
 	return (
 		<DeferredRender timeMs={ 2000 }>
 			<Suspense>
-				<SurveyComponent />
+				<AsyncMigrationSurvey />
 			</Suspense>
 		</DeferredRender>
 	);

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/index.tsx
@@ -1,13 +1,11 @@
-import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { isNewSiteMigrationFlow } from '@automattic/onboarding';
 import { Suspense } from 'react';
 import AsyncMigrationSurvey from '../../steps-repository/components/migration-survey/async';
 import { Flow } from '../../types';
 import { DeferredRender } from '../deferred-render';
 
-const MIGRATION_FLOWS = new Set< string >( [ SITE_MIGRATION_FLOW ] );
-
 const SurveyManager = ( { disabled = false, flow }: { disabled?: boolean; flow?: Flow } ) => {
-	if ( disabled || ! flow || ! MIGRATION_FLOWS.has( flow.name ) ) {
+	if ( disabled || ! flow || ! isNewSiteMigrationFlow( flow.name ) ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
@@ -2,27 +2,14 @@
  * @jest-environment jsdom
  */
 
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import { SITE_MIGRATION_FLOW, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
-import { render, screen } from '@testing-library/react';
+import { SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { render } from '@testing-library/react';
 import React from 'react';
-import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import SurveyManager from '../';
 import { type Flow } from '../../../types';
 
-// Mock the dependencies
-jest.mock( '@automattic/i18n-utils', () => ( {
-	useIsEnglishLocale: jest.fn(),
-} ) );
-
-jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
-	useGeoLocationQuery: jest.fn(),
-} ) );
-
 jest.mock( '../../../steps-repository/components/migration-survey/async', () => {
-	const AsyncMigrationSurvey = ( { countryCode }: { countryCode: string } ) => (
-		<div data-testid="mock-survey">Mock Survey for { countryCode }</div>
-	);
+	const AsyncMigrationSurvey = () => 'Mock Survey';
 
 	return AsyncMigrationSurvey;
 } );
@@ -34,74 +21,49 @@ jest.mock( '../../deferred-render', () => {
 	return { DeferredRender };
 } );
 
-// Mock flow type for testing
-const mockFlow: Flow = {
-	name: SITE_MIGRATION_FLOW,
-	isSignupFlow: true,
-	initialize: jest.fn(),
-	useStepNavigation: jest.fn(),
-};
-
 describe( 'SurveyManager', () => {
-	beforeEach( () => {
-		jest.clearAllMocks();
-		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
-		( useGeoLocationQuery as jest.Mock ).mockReturnValue( {
-			data: { country_short: 'US' },
-		} );
-	} );
-
 	it( 'should render null when disabled prop is true', () => {
-		const { container } = render( <SurveyManager disabled flow={ mockFlow } /> );
+		const flow: Flow = {
+			name: SITE_MIGRATION_FLOW,
+			isSignupFlow: true,
+			initialize: jest.fn(),
+			useStepNavigation: jest.fn(),
+		};
+
+		const { container } = render( <SurveyManager disabled flow={ flow } /> );
+
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should render null when no flow is provided', () => {
 		const { container } = render( <SurveyManager /> );
+
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'should render null when no country code is available', () => {
-		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: null } );
-		const { container } = render( <SurveyManager flow={ mockFlow } /> );
-		expect( container ).toBeEmptyDOMElement();
-	} );
-
-	it( 'should render null for non-migration flows', () => {
+	it( 'should render null for flows not associated with a survey', () => {
 		const nonMigrationFlow: Flow = {
-			...mockFlow,
 			name: 'other-flow',
+			isSignupFlow: true,
+			initialize: jest.fn(),
+			useStepNavigation: jest.fn(),
 		};
+
 		const { container } = render( <SurveyManager flow={ nonMigrationFlow } /> );
+
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'should render null for non-supported countries', () => {
-		( useGeoLocationQuery as jest.Mock ).mockReturnValue( {
-			data: { country_short: 'FR' },
-		} );
-		const { container } = render( <SurveyManager flow={ mockFlow } /> );
-		expect( container ).toBeEmptyDOMElement();
-	} );
+	it( 'should render survey for a flow with an associated survey', () => {
+		const testFlow: Flow = {
+			name: SITE_MIGRATION_FLOW,
+			isSignupFlow: true,
+			initialize: jest.fn(),
+			useStepNavigation: jest.fn(),
+		};
 
-	it( 'should render null for non-English locales', () => {
-		( useIsEnglishLocale as jest.Mock ).mockReturnValue( false );
-		const { container } = render( <SurveyManager flow={ mockFlow } /> );
-		expect( container ).toBeEmptyDOMElement();
-	} );
+		const { getByText } = render( <SurveyManager flow={ testFlow } /> );
 
-	describe.each( [ SITE_MIGRATION_FLOW, HOSTED_SITE_MIGRATION_FLOW ] )(
-		'Flow: %s',
-		( flowName ) => {
-			it( 'should render survey when all conditions are met', () => {
-				const testFlow: Flow = {
-					...mockFlow,
-					name: flowName,
-				};
-				render( <SurveyManager flow={ testFlow } /> );
-				expect( screen.getByTestId( 'mock-survey' ) ).toBeInTheDocument();
-				expect( screen.getByText( 'Mock Survey for US' ) ).toBeInTheDocument();
-			} );
-		}
-	);
+		expect( getByText( 'Mock Survey' ) ).toBeInTheDocument();
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
@@ -54,7 +54,7 @@ describe( 'SurveyManager', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'should render survey for a flow with an associated survey', () => {
+	it( 'should render survey for site migration flow', () => {
 		const testFlow: Flow = {
 			name: SITE_MIGRATION_FLOW,
 			isSignupFlow: true,

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { SITE_MIGRATION_FLOW, HOSTED_SITE_MIGRATION_FLOW } from '@automattic/onboarding';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
+import SurveyManager from '../';
+import { type Flow } from '../../../types';
+
+// Mock the dependencies
+jest.mock( '@automattic/i18n-utils', () => ( {
+	useIsEnglishLocale: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
+	useGeoLocationQuery: jest.fn(),
+} ) );
+
+jest.mock( '../../../steps-repository/components/migration-survey/async', () => {
+	const AsyncMigrationSurvey = ( { countryCode }: { countryCode: string } ) => (
+		<div data-testid="mock-survey">Mock Survey for { countryCode }</div>
+	);
+
+	return AsyncMigrationSurvey;
+} );
+
+jest.mock( '../../deferred-render', () => {
+	const DeferredRender = ( { children }: { children: React.ReactNode; timeMs?: number } ) =>
+		children;
+
+	return { DeferredRender };
+} );
+
+// Mock flow type for testing
+const mockFlow: Flow = {
+	name: SITE_MIGRATION_FLOW,
+	isSignupFlow: true,
+	initialize: jest.fn(),
+	useStepNavigation: jest.fn(),
+};
+
+describe( 'SurveyManager', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( {
+			data: { country_short: 'US' },
+		} );
+	} );
+
+	it( 'should render null when disabled prop is true', () => {
+		const { container } = render( <SurveyManager disabled flow={ mockFlow } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render null when no flow is provided', () => {
+		const { container } = render( <SurveyManager /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render null when no country code is available', () => {
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: null } );
+		const { container } = render( <SurveyManager flow={ mockFlow } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render null for non-migration flows', () => {
+		const nonMigrationFlow: Flow = {
+			...mockFlow,
+			name: 'other-flow',
+		};
+		const { container } = render( <SurveyManager flow={ nonMigrationFlow } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render null for non-supported countries', () => {
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( {
+			data: { country_short: 'FR' },
+		} );
+		const { container } = render( <SurveyManager flow={ mockFlow } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render null for non-English locales', () => {
+		( useIsEnglishLocale as jest.Mock ).mockReturnValue( false );
+		const { container } = render( <SurveyManager flow={ mockFlow } /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	describe.each( [ SITE_MIGRATION_FLOW, HOSTED_SITE_MIGRATION_FLOW ] )(
+		'Flow: %s',
+		( flowName ) => {
+			it( 'should render survey when all conditions are met', () => {
+				const testFlow: Flow = {
+					...mockFlow,
+					name: flowName,
+				};
+				render( <SurveyManager flow={ testFlow } /> );
+				expect( screen.getByTestId( 'mock-survey' ) ).toBeInTheDocument();
+				expect( screen.getByText( 'Mock Survey for US' ) ).toBeInTheDocument();
+			} );
+		}
+	);
+} );

--- a/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/survery-manager/test/index.test.tsx
@@ -64,6 +64,6 @@ describe( 'SurveyManager', () => {
 
 		const { getByText } = render( <SurveyManager flow={ testFlow } /> );
 
-		expect( getByText( 'Mock Survey' ) ).toBeInTheDocument();
+		expect( getByText( 'Mock Survey' ) ).toBeVisible();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
@@ -1,6 +1,8 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import surveyImage from 'calypso/assets/images/onboarding/migrations/survey/wordpress-half-logo.png';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { Survey, SurveyTriggerAccept, SurveyTriggerSkip } from '../survey';
 import './style.scss';
 
@@ -11,16 +13,19 @@ const linkByCountry = {
 
 type Countries = keyof typeof linkByCountry;
 
-type MigrationSurveyProps = {
-	countryCode: string;
-};
-
 const getLink = ( country: Countries ) => {
 	return linkByCountry[ country ];
 };
 
-const MigrationSurvey = ( { countryCode }: MigrationSurveyProps ) => {
+const MigrationSurvey = () => {
+	const isEnLocale = useIsEnglishLocale();
+	const { data } = useGeoLocationQuery();
+	const countryCode = data?.country_short;
 	const surveyLink = getLink( countryCode as Countries );
+
+	if ( ! isEnLocale || ! surveyLink ) {
+		return null;
+	}
 
 	return (
 		<Survey

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
@@ -6,22 +6,19 @@ import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { Survey, SurveyTriggerAccept, SurveyTriggerSkip } from '../survey';
 import './style.scss';
 
-const linkByCountry = {
+const linkByCountry: Record< string, string > = {
 	IN: 'https://automattic.survey.fm/wp-com-migration-survey-wtp-india-focused',
 	US: 'https://automattic.survey.fm/wp-com-migration-survey-wtp-us-focused',
 };
 
-type Countries = keyof typeof linkByCountry;
-
-const getLink = ( country: Countries ) => {
-	return linkByCountry[ country ];
-};
+const getLink = ( country?: string ): string | null =>
+	country && linkByCountry.hasOwnProperty( country ) ? linkByCountry[ country ] : null;
 
 const MigrationSurvey = () => {
 	const isEnLocale = useIsEnglishLocale();
 	const { data } = useGeoLocationQuery();
 	const countryCode = data?.country_short;
-	const surveyLink = getLink( countryCode as Countries );
+	const surveyLink = getLink( countryCode );
 
 	if ( ! isEnLocale || ! surveyLink ) {
 		return null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/test/index.test.tsx
@@ -26,7 +26,7 @@ describe( 'MigrationSurvey', () => {
 		( useIsEnglishLocale as jest.Mock ).mockReturnValue( false );
 		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'US' } } );
 
-		const { container } = render( <MigrationSurvey isOpen /> );
+		const { container } = render( <MigrationSurvey /> );
 
 		expect( container ).toBeEmptyDOMElement();
 	} );
@@ -35,7 +35,7 @@ describe( 'MigrationSurvey', () => {
 		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
 		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'FR' } } );
 
-		const { container } = render( <MigrationSurvey isOpen /> );
+		const { container } = render( <MigrationSurvey /> );
 
 		expect( container ).toBeEmptyDOMElement();
 	} );
@@ -44,7 +44,7 @@ describe( 'MigrationSurvey', () => {
 		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
 		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: undefined } );
 
-		const { container } = render( <MigrationSurvey isOpen /> );
+		const { container } = render( <MigrationSurvey /> );
 
 		expect( container ).toBeEmptyDOMElement();
 	} );
@@ -53,7 +53,7 @@ describe( 'MigrationSurvey', () => {
 		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
 		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'US' } } );
 
-		const { getByRole } = render( <MigrationSurvey isOpen /> );
+		const { getByRole } = render( <MigrationSurvey /> );
 
 		expect( getByRole( 'link', { name: 'Take survey' } ) ).toHaveAttribute(
 			'href',
@@ -65,7 +65,7 @@ describe( 'MigrationSurvey', () => {
 		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
 		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'IN' } } );
 
-		const { getByRole } = render( <MigrationSurvey isOpen /> );
+		const { getByRole } = render( <MigrationSurvey /> );
 
 		expect( getByRole( 'link', { name: 'Take survey' } ) ).toHaveAttribute(
 			'href',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/test/index.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
+import MigrationSurvey from '../';
+
+// Mock dependencies
+jest.mock( '@automattic/i18n-utils', () => ( {
+	useIsEnglishLocale: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/data/geo/use-geolocation-query', () => ( {
+	useGeoLocationQuery: jest.fn(),
+} ) );
+
+describe( 'MigrationSurvey', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should render null when not in English locale', () => {
+		( useIsEnglishLocale as jest.Mock ).mockReturnValue( false );
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'US' } } );
+
+		const { container } = render( <MigrationSurvey isOpen /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render null when country is not supported', () => {
+		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'FR' } } );
+
+		const { container } = render( <MigrationSurvey isOpen /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render null when country is not initialized', () => {
+		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: undefined } );
+
+		const { container } = render( <MigrationSurvey isOpen /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render survey for US users in English locale', () => {
+		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'US' } } );
+
+		const { getByRole } = render( <MigrationSurvey isOpen /> );
+
+		expect( getByRole( 'link', { name: 'Take survey' } ) ).toHaveAttribute(
+			'href',
+			'https://automattic.survey.fm/wp-com-migration-survey-wtp-us-focused'
+		);
+	} );
+
+	it( 'should render survey for India users in English locale', () => {
+		( useIsEnglishLocale as jest.Mock ).mockReturnValue( true );
+		( useGeoLocationQuery as jest.Mock ).mockReturnValue( { data: { country_short: 'IN' } } );
+
+		const { getByRole } = render( <MigrationSurvey isOpen /> );
+
+		expect( getByRole( 'link', { name: 'Take survey' } ) ).toHaveAttribute(
+			'href',
+			'https://automattic.survey.fm/wp-com-migration-survey-wtp-india-focused'
+		);
+	} );
+} );


### PR DESCRIPTION
Related to p58i-kIo-p2#comment-67529

## Proposed Changes

Updates `SurveyManager` to avoid considering locale and geolocation, instead limiting its purpose to mapping flows to surveys and deferring additional conditional considerations to the survey component

## Why are these changes being made?

As described in P2 context above, all stepper flows will currently trigger network requests for geolocation, even in flows where that geolocation data is not being used. By moving these considerations to the survey component itself, it does the following:

- Avoids network requests for geolocation unless needed for the specific flow
- Keeps logic relevant for the survey self-contained to the component itself, rather than splitting consideration between the survey component and `SurveyManager`

## Testing Instructions

Verify no excess network requests to `/geo` in flows other than those using the information:

1. Go to http://calypso.localhost:3000/setup/onboarding/user
2. Open Chrome DevTools Network tab
3. Refresh page
4. Observe a single `geo/` request (this request doesn't come from the affected components)
5. Optional: Compare to [the live flow](https://wordpress.com/setup/onboarding/user), where multiple requests are made to `geo/`

Verify that the survey still shows under expected conditions:

1. Optional: Change your geolocation or locale. The survey should only show in English locales, in US or India geolocated regions
2. Go to http://calypso.localhost:3000/setup/hosted-site-migration/site-migration-identify
3. Observe that a "Migration Survey" appears after a few seconds if you are in an English locale and in US or India geolocated region. (It may not show if you've previously dismissed, in which case clear all site data under the "Application" tab in DevTools)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?