### PR TITLE
Purchases: Hide "Select a new plan" except for Jetpack legacy

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1335,7 +1335,7 @@ class ManagePurchase extends Component<
 		);
 	}
 
-	renderPurchaseDetail( preventRenewal: boolean ) {
+	renderPurchaseDetail( preventRenewal: boolean, isJetpackLegacyPlan: boolean ) {
 		if ( this.isDataLoading( this.props ) || this.isDomainsLoading( this.props ) ) {
 			return this.renderPlaceholder();
 		}
@@ -1410,7 +1410,7 @@ class ManagePurchase extends Component<
 						</div>
 						{ isProductOwner && ! purchase.isLocked && (
 							<div className="manage-purchase__renew-upgrade-buttons">
-								{ preventRenewal && this.renderSelectNewButton() }
+								{ preventRenewal && isJetpackLegacyPlan && this.renderSelectNewButton() }
 								{ this.renderUpgradeButton( preventRenewal ) }
 								{ ! preventRenewal && this.renderRenewButton() }
 							</div>
@@ -1437,7 +1437,7 @@ class ManagePurchase extends Component<
 				) }
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
-						{ preventRenewal && this.renderSelectNewNavItem() }
+						{ preventRenewal && isJetpackLegacyPlan && this.renderSelectNewNavItem() }
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&
@@ -1509,12 +1509,14 @@ class ManagePurchase extends Component<
 
 		let showExpiryNotice = false;
 		let preventRenewal = false;
+		let isJetpackLegacyPlan = false;
 
 		if (
 			purchase &&
 			( JETPACK_LEGACY_PLANS as ReadonlyArray< string > ).includes( purchase.productSlug )
 		) {
 			showExpiryNotice = isCloseToExpiration( purchase );
+			isJetpackLegacyPlan = true;
 			preventRenewal = ! isRenewable( purchase );
 		}
 
@@ -1568,7 +1570,7 @@ class ManagePurchase extends Component<
 					siteId={ this.props.siteId ?? 0 }
 					purchase={ purchase }
 				/>
-				{ this.renderPurchaseDetail( preventRenewal ) }
+				{ this.renderPurchaseDetail( preventRenewal, isJetpackLegacyPlan ) }
 				{ this.renderWordAdsEligibilityWarningDialog( purchase ) }
 				{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }
 			</Fragment>


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/44949 added a new button to the purchase management page, "Select a new plan", which appears to have been designed for Jetpack legacy plans; however, it relied on setting a variable called `preventRenewal` to decide if it should show the button or not. As a result, when https://github.com/Automattic/wp-calypso/pull/102461 set `preventRenewal` for another reason, it also caused that button to be displayed.

In this PR we add an explicit `isJetpackLegacyPlan` variable and use it to determine if we should show the "Select a new plan" buttons. 

Tracked by https://linear.app/a8c/issue/CHE-13/purchases-hide-select-a-new-plan-except-for-jetpack-legacy

## Testing Instructions

- Purchase a renewing subscription.
- Visit the purchase management page in calypso for that subscription.
- Verify that you don't see any "Renew now" buttons (note that there are usually at least two: a small one in the header and a large one below the subscription information).
- Verify that you don't see a "Select a new plan" button either.
