### PR TITLE
Stats: Improved navigation create a new feature flag

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -182,6 +182,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 	const isWPAdmin = config.isEnabled( 'is_odyssey' );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isSitePrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
+	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 	const slug = useSelector( getSelectedSiteSlug );
 	const moduleToggles = useSelector( ( state ) => getModuleToggles( state, siteId, 'traffic' ) );
 	const momentSiteZone = useSelector( ( state ) => getMomentSiteZone( state, siteId ) );
@@ -527,6 +528,7 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 					<JetpackBackupCredsBanner event="stats-backup-credentials" />
 				</div>
 			) }
+			{ isStatsNavigationImprovementEnabled && <div>The new Stats navigation is active.</div> }
 			<NavigationHeader
 				className="stats__section-header modernized-header"
 				title={ STATS_PRODUCT_NAME }

--- a/config/development.json
+++ b/config/development.json
@@ -193,6 +193,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
+		"stats/navigation-improvement": false,
 		"subscriber-importer": true,
 		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -126,6 +126,7 @@
 		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/real-time-tab": false,
+		"stats/navigation-improvement": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,

--- a/config/production.json
+++ b/config/production.json
@@ -163,6 +163,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
+		"stats/navigation-improvement": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -158,6 +158,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
+		"stats/navigation-improvement": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,

--- a/config/test.json
+++ b/config/test.json
@@ -117,6 +117,7 @@
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/empty-module-v2": true,
+		"stats/navigation-improvement": false,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,6 +163,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": false,
+		"stats/navigation-improvement": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR adds a new feature flag `stats/navigation-improvement`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the [stats improve navigation project](https://linear.app/a8c/project/stats-improve-navigation-26f1f0cd5616/overview)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit calypso live branch and ensure everything looks as expected / normal
* Append the flag  `stats/navigation-improvement` 
* Check you can see the notice

![image](https://github.com/user-attachments/assets/69b44295-af87-4b1f-bde1-d247d8359826)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
