### PR TITLE
Add Playground flow track event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -3,11 +3,14 @@ import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { PlaygroundClient } from '@wp-playground/client';
 import { useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useIsPlaygroundEligible } from '../../../../hooks/use-is-playground-eligible';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { PlaygroundIframe } from './components/playground-iframe';
+import { getBlueprintName } from './lib/blueprint';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -16,7 +19,7 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const playgroundClientRef = useRef< PlaygroundClient | null >( null );
 	const { __ } = useI18n();
-
+	const [ query ] = useSearchParams();
 	if ( ! isPlaygroundEligible ) {
 		window.location.assign( '/start' );
 
@@ -31,6 +34,15 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 		if ( ! submit ) {
 			return;
 		}
+
+		const blueprintName = getBlueprintName( query.get( 'blueprint' ) );
+
+		recordTracksEvent( 'calypso_playground_launch_site', {
+			flow,
+			step: 'playground',
+			blueprint: blueprintName ?? 'unknown',
+		} );
+
 		submit();
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -105,9 +105,17 @@ function getDefaultBlueprint( recommendedPhpVersion: string ): Blueprint {
 	};
 }
 
+export function getBlueprintName( name: string | null ): string | null {
+	if ( name && name in PREDEFINED_BLUEPRINTS ) {
+		return name;
+	}
+
+	return null;
+}
+
 async function getBlueprintFromUrl( recommendedPhpVersion: string ): Blueprint {
 	const url = new URL( window.location.href );
-	const predefinedBlueprintName = url.searchParams.get( 'blueprint' );
+	const predefinedBlueprintName = getBlueprintName( url.searchParams.get( 'blueprint' ) );
 
 	// If a predefined blueprint is specified and exists, use it
 	if ( predefinedBlueprintName && predefinedBlueprintName in PREDEFINED_BLUEPRINTS ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -118,7 +118,7 @@ async function getBlueprintFromUrl( recommendedPhpVersion: string ): Blueprint {
 	const predefinedBlueprintName = getBlueprintName( url.searchParams.get( 'blueprint' ) );
 
 	// If a predefined blueprint is specified and exists, use it
-	if ( predefinedBlueprintName && predefinedBlueprintName in PREDEFINED_BLUEPRINTS ) {
+	if ( predefinedBlueprintName ) {
 		const blueprint = PREDEFINED_BLUEPRINTS[ predefinedBlueprintName ];
 		return {
 			...blueprint,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DOTOBRD-107/conversion-rate-stats

## Proposed Changes

* Add track event on "Launch on WordPress.com" click

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Be sure to have Tracks Vigilante installed
* Visit http://calypso.localhost:3000/setup/onboarding/playground
* Visit http://calypso.localhost:3000/setup/onboarding/playground?blueprint=2023
* Launch the site with a blueprint and without

Be sure a `calypso_playground_launch_site` is spawn with these values:

```
{
  blueprint: unknown (or the name of the blueprint, see PREDEFINED_BLUEPRINTS)
  client: browser
  step: playground
  ...
}
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
