### PR TITLE
Grid: Add responsive mode

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 0.1.0 - Initial Release
 
 ### Added
+
 - Grid component for CSS Grid layouts
 - Support for precise and implicit positioning of child elements
 - Customizable columns, spacing, and row height
+- Support for automated responsive layout by specifying minimum column widths

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -44,7 +44,58 @@ The main component exported by this package.
   - `y` (number): The starting row (0-indexed)
   - `width` (number): The number of columns this item spans
   - `height` (number, optional): The number of rows this item spans (defaults to 1)
+  - `order` (number, optional): In responsive mode, determines the order of items (lower values displayed first)
+  - `fullWidth` (boolean, optional): In responsive mode, forces an item to always span all available columns
 - `columns` (required): Total number of columns in the grid
 - `className` (optional): Additional CSS class to apply to the grid container
 - `spacing` (optional): Grid gap multiplier size, defaults to 2 (e.g. A spacing of 2 results in a gap of 8px, it's multiplied by 4)
 - `rowHeight` (optional): Height of each row (e.g., "50px", "auto")
+- `minColumnWidth` (optional): Minimum width in pixels for each column; when provided, enables responsive mode that automatically adjusts columns based on container width
+
+## Fixed vs. Responsive Mode
+
+The Grid component can operate in two modes:
+
+### Fixed Mode (Default)
+
+In fixed mode, items are positioned exactly according to their `x` and `y` coordinates in the layout. This provides precise control over the grid layout.
+
+```jsx
+// Fixed layout with 6 columns
+<Grid
+	layout={ [
+		{ key: 'a', x: 0, y: 0, width: 2 },
+		{ key: 'b', x: 2, y: 0, width: 4 },
+	] }
+	columns={ 6 }
+>
+	<div key="a">Item A</div>
+	<div key="b">Item B</div>
+</Grid>
+```
+
+### Responsive Mode
+
+When `minColumnWidth` is provided, the Grid activates responsive mode, which automatically adjusts the number of columns based on the container width. In this mode:
+
+1. Items flow according to their `order` property (or original array order if not specified)
+2. The grid will collapse to fewer columns when the container width can't accommodate `columns` columns of `minColumnWidth` each
+3. Items that can't fit on a row will wrap to the next row
+4. Items with `fullWidth` set to `true` will always span all available columns
+
+```jsx
+// Responsive layout that adapts to container width
+<Grid
+	layout={ [
+		{ key: 'a', width: 2, order: 1 },
+		{ key: 'b', width: 2, order: 2 },
+		{ key: 'c', width: 4, order: 3, fullWidth: true },
+	] }
+	columns={ 6 }
+	minColumnWidth={ 150 } // Each column should be at least 150px
+>
+	<div key="a">Item A</div>
+	<div key="b">Item B</div>
+	<div key="c">Item C (always full width)</div>
+</Grid>
+```

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -45,5 +45,8 @@
 	"peerDependencies": {
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
+	},
+	"dependencies": {
+		"@wordpress/compose": "^7.22.0"
 	}
 }

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,4 +1,5 @@
-import { useMemo, Children, isValidElement } from 'react';
+import { useResizeObserver } from '@wordpress/compose';
+import { useMemo, Children, isValidElement, useState } from 'react';
 import type { GridProps, GridLayoutItem } from './types';
 import type { ReactElement } from 'react';
 
@@ -9,29 +10,59 @@ export function Grid( {
 	className,
 	spacing = 2,
 	rowHeight = 'auto',
+	minColumnWidth,
 }: GridProps ) {
-	// Create a map of layout items by key for quick lookup
-	const layoutMap = useMemo( () => {
-		const map = new Map< string, GridLayoutItem >();
-		layout.forEach( ( item ) => {
-			map.set( item.key, item );
+	const [ containerWidth, setContainerWidth ] = useState( 0 );
+	const responsiveColumns = Math.max( 1, Math.floor( containerWidth / ( minColumnWidth || 1 ) ) );
+	const effectiveColumns = minColumnWidth ? responsiveColumns : columns;
+	const resizeObserverRef = useResizeObserver( ( [ { contentRect } ] ) => {
+		setContainerWidth( contentRect.width );
+	} );
+
+	// In responsive mode, sort items by order property (or use original order if not specified)
+	const responsiveLayout = useMemo( () => {
+		if ( ! minColumnWidth ) {
+			return null;
+		}
+
+		return [ ...layout ].sort( ( a, b ) => {
+			if ( a.order !== undefined && b.order !== undefined ) {
+				return a.order - b.order;
+			}
+			if ( a.order !== undefined ) {
+				return -1;
+			}
+			if ( b.order !== undefined ) {
+				return 1;
+			}
+			return 0;
 		} );
-		return map;
-	}, [ layout ] );
+	}, [ layout, minColumnWidth ] );
 
 	// Get the number of rows in the layout
 	const rows = useMemo( () => {
+		const activeLayout = responsiveLayout || layout;
 		let maxRow = 0;
-		layout.forEach( ( item ) => {
+		activeLayout.forEach( ( item ) => {
 			const itemHeight = item.height || 1;
 			maxRow = Math.max( maxRow, ( item.y ?? 0 ) + itemHeight );
 		} );
 		return maxRow;
-	}, [ layout ] );
+	}, [ layout, responsiveLayout ] );
+
+	// Create a map of layout items for quick access
+	const activeLayoutMap = useMemo( () => {
+		const activeLayout = responsiveLayout || layout;
+		const map = new Map< string, GridLayoutItem >();
+		activeLayout.forEach( ( item ) => {
+			map.set( item.key, item );
+		} );
+		return map;
+	}, [ layout, responsiveLayout ] );
 
 	const gridStyle = {
 		display: 'grid',
-		gridTemplateColumns: `repeat(${ columns }, 1fr)`,
+		gridTemplateColumns: `repeat(${ effectiveColumns }, 1fr)`,
 		gridTemplateRows: `repeat(${ rows }, ${ rowHeight })`,
 		gap: spacing * 4,
 	};
@@ -46,7 +77,7 @@ export function Grid( {
 		const element = child as ReactElement;
 		const key = element.key?.toString();
 
-		const item: Omit< GridLayoutItem, 'key' > = key ? layoutMap.get( key )! ?? {} : {};
+		const item: Omit< GridLayoutItem, 'key' > = key ? activeLayoutMap.get( key )! ?? {} : {};
 		const itemHeight = item.height || 1;
 
 		// Apply grid positioning
@@ -54,7 +85,9 @@ export function Grid( {
 			...element.props.style,
 			gridColumnStart: item.x !== undefined ? item.x + 1 : undefined,
 			gridRowStart: item.y !== undefined ? item.y + 1 : undefined,
-			gridColumnEnd: `span ${ item.width }`,
+			gridColumnEnd: `span ${
+				item.fullWidth ? effectiveColumns : Math.min( item.width ?? 1, effectiveColumns )
+			}`,
 			gridRowEnd: `span ${ itemHeight }`,
 		};
 
@@ -69,7 +102,7 @@ export function Grid( {
 	} );
 
 	return (
-		<div className={ className } style={ gridStyle }>
+		<div ref={ resizeObserverRef } className={ className } style={ gridStyle }>
 			{ gridItems }
 		</div>
 	);

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -13,11 +13,25 @@ export function Grid( {
 	minColumnWidth,
 }: GridProps ) {
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
-	const responsiveColumns = Math.max( 1, Math.floor( containerWidth / ( minColumnWidth || 1 ) ) );
-	const effectiveColumns = minColumnWidth ? responsiveColumns : columns;
 	const resizeObserverRef = useResizeObserver( ( [ { contentRect } ] ) => {
 		setContainerWidth( contentRect.width );
 	} );
+
+	const gapPx = spacing * 4;
+
+	const responsiveColumns = useMemo( () => {
+		if ( ! minColumnWidth ) {
+			return columns;
+		}
+
+		// Calculate the total width per column including the gap
+		const totalWidthPerColumn = minColumnWidth + gapPx;
+		const maxColumns = Math.floor( ( containerWidth + gapPx ) / totalWidthPerColumn );
+
+		return Math.max( 1, maxColumns );
+	}, [ minColumnWidth, gapPx, containerWidth, columns ] );
+
+	const effectiveColumns = responsiveColumns;
 
 	// In responsive mode, sort items by order property (or use original order if not specified)
 	const responsiveLayout = useMemo( () => {
@@ -64,7 +78,7 @@ export function Grid( {
 		display: 'grid',
 		gridTemplateColumns: `repeat(${ effectiveColumns }, 1fr)`,
 		gridTemplateRows: `repeat(${ rows }, ${ rowHeight })`,
-		gap: spacing * 4,
+		gap: gapPx,
 	};
 
 	// Process children and apply grid positioning based on layout

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -19,7 +19,7 @@ export function Grid( {
 
 	const gapPx = spacing * 4;
 
-	const responsiveColumns = useMemo( () => {
+	const effectiveColumns = useMemo( () => {
 		if ( ! minColumnWidth ) {
 			return columns;
 		}
@@ -30,8 +30,6 @@ export function Grid( {
 
 		return Math.max( 1, maxColumns );
 	}, [ minColumnWidth, gapPx, containerWidth, columns ] );
-
-	const effectiveColumns = responsiveColumns;
 
 	// In responsive mode, sort items by order property (or use original order if not specified)
 	const responsiveLayout = useMemo( () => {

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -130,3 +130,51 @@ export const MultiRowLayout: StoryObj< typeof Grid > = {
 		],
 	},
 };
+
+/**
+ * Responsive grid that reflows based on container width.
+ * Resize the storybook window to see it in action.
+ */
+export const ResponsiveGrid: StoryObj< typeof Grid > = {
+	args: {
+		layout: [
+			{ key: 'a', width: 1, height: 1, order: 1 },
+			{ key: 'b', width: 3, height: 1, order: 2 },
+			{ key: 'c', width: 1, height: 1, order: 3 },
+			{ key: 'd', width: 3, height: 1, order: 4 },
+			{ key: 'e', width: 4, height: 1, order: 5 },
+			{ key: 'f', height: 2, order: 6, fullWidth: true },
+		],
+		rowHeight: '100px',
+		minColumnWidth: 200,
+		children: [
+			<Card key="a" color="#f44336">
+				Card A
+			</Card>,
+			<Card key="b" color="#2196f3">
+				Card B
+			</Card>,
+			<Card key="c" color="#4caf50">
+				Card C
+			</Card>,
+			<Card key="d" color="#ff9800">
+				Card D
+			</Card>,
+			<Card key="e" color="#9c27b0">
+				Card E
+			</Card>,
+			<Card key="f" color="#607d8b">
+				Full Width Card F
+			</Card>,
+		],
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'This example demonstrates the responsive behavior of the Grid component. The grid will automatically adjust the number of columns based on the container width. Resize the browser window to see it in action.',
+			},
+		},
+		layout: '',
+	},
+};

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -26,6 +26,16 @@ export interface GridLayoutItem {
 	 * Number of rows this item spans.
 	 */
 	height?: number;
+
+	/**
+	 * Optional order value for responsive mode (lower values displayed first)
+	 */
+	order?: number;
+
+	/**
+	 * Whether this item should always span all available columns in responsive mode
+	 */
+	fullWidth?: boolean;
 }
 
 /**
@@ -63,4 +73,10 @@ export interface GridProps {
 	 * Height of each row (e.g., "50px", "auto")
 	 */
 	rowHeight?: string;
+
+	/**
+	 * Minimum width in pixels for each column in responsive mode.
+	 * If provided, enables responsive mode which automatically adjusts columns based on container width.
+	 */
+	minColumnWidth?: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,6 +1127,7 @@ __metadata:
     "@storybook/addon-controls": "npm:^8.6.9"
     "@storybook/addon-docs": "npm:^8.6.9"
     "@storybook/react-webpack5": "npm:^8.6.9"
+    "@wordpress/compose": "npm:^7.22.0"
     postcss: "npm:^8.5.3"
     storybook: "npm:^8.6.9"
     typescript: "npm:^5.8.2"


### PR DESCRIPTION
Fixes ARC-121
Builds on top of #102706

## Proposed Changes

This PR adds an automatic responsive mode to the Grid component. Instead of defining a "columns" count, the user can define a minColumnWidth prop and the grid will figure out exactly how many columns fit within the container width and do its best to lay down the cards in the available space.

## Testing Instructions

- Check the responsive story in storybook and play with it a bit.
- cd packages/grid && yarn storybook:start
