### PR TITLE
Help Center: Add tracking to show more

### DIFF
--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -230,6 +230,12 @@ function HelpSearchResults( {
 	const [ visibleResults, setVisibleResults ] = useState( MAX_VISIBLE_RESULTS );
 
 	const handleShowMore = () => {
+		recordTracksEvent( 'calypso_help_center_search_results_show_more', {
+			search_term: searchQuery,
+			location,
+			section: sectionName,
+			visible_results: visibleResults,
+		} );
 		setVisibleResults( visibleResults + MAX_VISIBLE_RESULTS );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://href.li/?https://github.com/Automattic/wp-calypso/pull/102561

## Proposed Changes

* Add tracking ( `calypso_help_center_search_results_show_more` ) to the "Show more" in the Help Center. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help Center and search "menu"
* Click show more
* Be sure that the event is triggered (maybe use Tracks Vigilante)
