### PR TITLE
Remove Playground V1 onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -11,7 +11,7 @@ import { getBlueprintName } from './lib/blueprint';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
-export const PlaygroundStep: StepType = ( { navigation } ) => {
+export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 	const { submit } = navigation;
 	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const playgroundClientRef = useRef< PlaygroundClient | null >( null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -1,20 +1,17 @@
 import { Step } from '@automattic/onboarding';
-import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { PlaygroundClient } from '@wp-playground/client';
 import { useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import StepWrapper from 'calypso/signup/step-wrapper';
 import { useIsPlaygroundEligible } from '../../../../hooks/use-is-playground-eligible';
-import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import { PlaygroundIframe } from './components/playground-iframe';
 import { getBlueprintName } from './lib/blueprint';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
-export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
+export const PlaygroundStep: StepType = ( { navigation } ) => {
 	const { submit } = navigation;
 	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const playgroundClientRef = useRef< PlaygroundClient | null >( null );
@@ -46,58 +43,27 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 		submit();
 	};
 
-	if ( shouldUseStepContainerV2( flow ) ) {
-		return (
-			<>
-				<DocumentHead title={ __( 'Playground' ) } />
-				<Step.PlaygroundLayout
-					className="playground-v2"
-					topBar={
-						<Step.TopBar
-							rightElement={
-								<Step.PrimaryButton onClick={ launchSite }>
-									{ __( 'Launch on WordPress.com' ) }
-								</Step.PrimaryButton>
-							}
-						/>
-					}
-				>
-					<PlaygroundIframe
-						className="playground__onboarding-iframe"
-						playgroundClient={ playgroundClientRef.current }
-						setPlaygroundClient={ setPlaygroundClient }
-					/>
-				</Step.PlaygroundLayout>
-			</>
-		);
-	}
-
 	return (
 		<>
 			<DocumentHead title={ __( 'Playground' ) } />
-			<StepWrapper
-				hideBack
-				hideSkip
-				hideFormattedHeader
-				customizedActionButtons={
-					<Button
-						variant="primary"
-						className="step-wrapper__navigation-link forward"
-						onClick={ launchSite }
-					>
-						{ __( 'Launch on WordPress.com' ) }
-					</Button>
+			<Step.PlaygroundLayout
+				className="playground"
+				topBar={
+					<Step.TopBar
+						rightElement={
+							<Step.PrimaryButton onClick={ launchSite }>
+								{ __( 'Launch on WordPress.com' ) }
+							</Step.PrimaryButton>
+						}
+					/>
 				}
-				stepContent={
-					<div className="playground__onboarding-page">
-						<PlaygroundIframe
-							className="playground__onboarding-iframe"
-							playgroundClient={ playgroundClientRef.current }
-							setPlaygroundClient={ setPlaygroundClient }
-						/>
-					</div>
-				}
-			/>
+			>
+				<PlaygroundIframe
+					className="playground__onboarding-iframe"
+					playgroundClient={ playgroundClientRef.current }
+					setPlaygroundClient={ setPlaygroundClient }
+				/>
+			</Step.PlaygroundLayout>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/style.scss
@@ -1,16 +1,5 @@
-.playground-v2 {
+.playground {
 	width: 100%;
-
-	.playground__onboarding-iframe {
-		width: 100%;
-		height: 100%;
-	}
-}
-
-// v1
-.playground__onboarding-page {
-	margin-top: 17px;
-	height: 100vh;
 
 	.playground__onboarding-iframe {
 		width: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DOTOBRD-115/remove-v1-onboarding-flow

## Proposed Changes

* Remove onboarding flow V1

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
