### PR TITLE
Email Upsell Navigation: Add missing tracking event

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/provider-cards/email-upsell-navigation.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/provider-cards/email-upsell-navigation.tsx
@@ -1,6 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { recordEmailUpsellTracksEvent } from 'calypso/my-sites/email/email-management/home/utils';
 
 import './email-upsell-navigation.scss';
 
@@ -12,19 +13,27 @@ type Props = {
 const EmailUpsellNavigation = ( { backUrl, skipUrl }: Props ) => {
 	const translate = useTranslate();
 
+	const handleBackClick = () => {
+		recordEmailUpsellTracksEvent( 'email', 'navigation_back' );
+	};
+
+	const handleSkipClick = () => {
+		recordEmailUpsellTracksEvent( 'email', 'navigation_skip' );
+	};
+
 	return (
 		<div
 			className={ clsx( 'email-upsell-navigation', {
 				'is-hiding-skip': ! skipUrl,
 			} ) }
 		>
-			<Button borderless href={ backUrl }>
+			<Button borderless href={ backUrl } onClick={ handleBackClick }>
 				<Gridicon icon="arrow-left" size={ 18 } />
 				{ translate( 'Back' ) }
 			</Button>
 
 			{ skipUrl && (
-				<Button borderless href={ skipUrl }>
+				<Button borderless href={ skipUrl } onClick={ handleSkipClick }>
 					{ translate( 'Skip' ) }
 					<Gridicon icon="arrow-right" size={ 18 } />
 				</Button>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/102718

## Proposed Changes

* Add missing tracking events

## Why are these changes being made?

* Missing tracking events

## Testing Instructions

* Select a blog with a paid plan
* Go to "Upgrade / Email"
* Press "Add Domain" button
* Select a domain
* Open dev tools
* Click on navigation "Back" or "Skip"
* Check if recording event is triggered

<img width="1728" alt="Screenshot 2025-04-22 at 12 40 42" src="https://github.com/user-attachments/assets/d8374664-291b-4a9d-89d1-35055cfa588b" />

<img width="905" alt="Screenshot 2025-04-22 at 12 44 33" src="https://github.com/user-attachments/assets/bf521164-e56e-41ac-9e13-77fd9d3f5587" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
