### PR TITLE
Apply container v2 to `other-platform-detected` step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
@@ -92,12 +92,11 @@ const SiteMigrationOtherPlatform: StepType< {
 			<>
 				<DocumentHead title={ title } />
 				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
+					columnWidth={ 8 }
 					topBar={
 						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
 					}
 					heading={ <Step.Heading text={ title } subText={ description } /> }
-					className="site-migration-upgrade-plan-v2"
 				>
 					{ isAnalyzingUrl ? (
 						<Scanning />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -7,9 +7,10 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
+import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ImporterPlatform } from 'calypso/lib/importer/types';
-import { Step } from '../../types';
+import { Step as StepType } from '../../types';
 import { ImportPlatformForwarder } from './components/importer-forwarding-details';
 import './style.scss';
 
@@ -21,12 +22,12 @@ export const Scanning = () => {
 	);
 };
 
-const SiteMigrationOtherPlatform: Step< {
+const SiteMigrationOtherPlatform: StepType< {
 	submits: {
 		action: 'import' | 'skip';
 		platform?: ImporterPlatform | null;
 	};
-} > = function ( { navigation } ) {
+} > = function ( { navigation, flow } ) {
 	const translate = useTranslate();
 	const [ query ] = useSearchParams();
 	const from = query.get( 'from' ) as string;
@@ -81,7 +82,36 @@ const SiteMigrationOtherPlatform: Step< {
 	const descriptionWithoutPlatform = translate(
 		'Our migration service is for WordPress sites. We don’t currently support importing from this platform.'
 	);
+
 	const title = translate( "Looks like there's been a mix-up" );
+	const description =
+		platformName === 'Unknown' ? descriptionWithoutPlatform : descriptionWithPlatform;
+
+	if ( shouldUseStepContainerV2MigrationFlow( flow ) ) {
+		return (
+			<>
+				<DocumentHead title={ title } />
+				<Step.CenteredColumnLayout
+					columnWidth={ 5 }
+					topBar={
+						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
+					}
+					heading={ <Step.Heading text={ title } subText={ description } /> }
+					className="site-migration-upgrade-plan-v2"
+				>
+					{ isAnalyzingUrl ? (
+						<Scanning />
+					) : (
+						<ImportPlatformForwarder
+							platformName={ platformName }
+							onSubmit={ handleSubmit }
+							onHelp={ handleHelp }
+						/>
+					) }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
 
 	return (
 		<>
@@ -99,9 +129,7 @@ const SiteMigrationOtherPlatform: Step< {
 						<FormattedHeader
 							id="site-migration-credentials-header"
 							headerText={ title }
-							subHeaderText={
-								platformName === 'Unknown' ? descriptionWithoutPlatform : descriptionWithPlatform
-							}
+							subHeaderText={ description }
 							align="center"
 						/>
 					)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-69

## Proposed Changes
Apply Container V2 to the `other-platform-detected`




| Before | After |
|--------|--------|
| ![CleanShot 2025-04-22 at 17 14 12@2x](https://github.com/user-attachments/assets/82f6492a-201b-4822-ac37-1b337729455d) | ![CleanShot 2025-04-22 at 17 13 42@2x](https://github.com/user-attachments/assets/8315c120-bb3c-4aa5-af22-8aad33bb2af6)
| ![CleanShot 2025-04-22 at 17 08 20@2x](https://github.com/user-attachments/assets/3d7b3d13-bcdd-42df-a1b0-64a0c6edbead)| ![CleanShot 2025-04-22 at 17 12 39@2x](https://github.com/user-attachments/assets/e243378a-6813-49fb-aca1-326b78756a4f)
| 



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To migrate to the new and improved stepper containers.

## Testing Instructions

Go to: `/setup/hosted-site-migration/other-platform-detected?flags=onboarding/step-container-v2-migration-flow`
* Compare with the screenshots above (after)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
