### PR TITLE
Stepper: Onboarding flow: Add missing reference query param

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -134,7 +134,7 @@ const onboarding: FlowV2 = {
 
 			if ( isMvpOnboarding ) {
 				return [
-					`/overview/${ providedDependencies.siteSlug }`,
+					addQueryArgs( `/overview/${ providedDependencies.siteSlug }`, { ref: flowName } ),
 					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
 						siteSlug: providedDependencies.siteSlug,
 					} ),


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/102717

## Proposed Changes

* Add `ref` query param for easier tracking from which flow the user ended up on the `/overview` page following the same approach we have for the `site-migration` flow

## Why are these changes being made?

* Add a missing reference

## Testing Instructions

* Make sure you have "treatment" variant for the `calypso-onboarding-mvp-20250414` experiment
* Go to `/setup/onboarding` flow
* Pass through the steps
* Once you reach the Overview page
* Check if there is a `ref` query param

<img width="622" alt="Screenshot 2025-04-22 at 15 40 02" src="https://github.com/user-attachments/assets/8d7d522b-ed85-4975-8d71-d1a4704dd94b" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
