### PR TITLE
Checkout: Clarify business card filter UI

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -361,11 +361,11 @@ export default function CheckoutMain( {
 		isForBusiness,
 	} );
 
-	// Stored cards are filtered by the shoppingCart's tax_location->is_for_business value
+	// If tax_location->is_for_business is set to true, then only business
+	// cards will show in Checkout. We should announce this filtering to the
+	// user which these variables will do.
 	const areStoredCardsFiltered = isForBusiness;
-
-	// If tax_location->is_for_business is set to true, then only business cards will show in Checkout
-	const isBusinessCardsFilterEmpty = isForBusiness && storedCards.length ? true : false;
+	const isBusinessCardsFilterEmpty = isForBusiness && storedCards.length ? false : true;
 
 	useActOnceOnStrings( [ storedCardsError ].filter( isValueTruthy ), ( messages ) => {
 		messages.forEach( ( message ) => {

--- a/client/my-sites/checkout/src/components/payment-methods-filter.tsx
+++ b/client/my-sites/checkout/src/components/payment-methods-filter.tsx
@@ -17,17 +17,14 @@ export const PaymentMethodFilterNotice = ( {
 }: {
 	isBusinessCardsFilterEmpty?: boolean;
 } ) => {
-	let noticeText;
-
-	if ( isBusinessCardsFilterEmpty ) {
-		noticeText = __( 'There are no stored business cards on your account. Please add one below.' );
-	} else {
-		noticeText = __( 'Payment methods filtered by Business Cards' );
-	}
-
 	return (
 		<Text color="var(--studio-gray-60)" size="14px">
-			{ noticeText }
+			{ __( 'Payment methods filtered to show only business cards.' ) }
+			{ isBusinessCardsFilterEmpty && (
+				<div>
+					{ __( 'There are no stored business cards on your account. Please add one below.' ) }
+				</div>
+			) }
 		</Text>
 	);
 };
@@ -57,7 +54,7 @@ export const PaymentMethodFilter = ( {
 		<Spacer marginTop="16px" marginBottom="16px">
 			<HStack alignment="center" justify="space-between">
 				<PaymentMethodFilterNotice isBusinessCardsFilterEmpty={ isBusinessCardsFilterEmpty } />
-				{ ! isBusinessCardsFilterEmpty && <PaymentMethodFilterButton /> }
+				<PaymentMethodFilterButton />
 			</HStack>
 		</Spacer>
 	) : null;

--- a/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
@@ -101,7 +101,7 @@ export function useStoredPaymentMethods( {
 		return isForBusiness
 			? data.filter( ( method ) => method?.tax_location?.is_for_business === isForBusiness )
 			: data;
-	}, [ isForBusiness, data ] );
+	}, [ isForBusiness, data, isDataValid ] );
 
 	const mutation = useMutation<
 		StoredPaymentMethod[ 'stored_details_id' ],


### PR DESCRIPTION
## Proposed Changes

This PR is a follow-up to https://github.com/Automattic/wp-calypso/pull/102716 which makes the following changes:

- Fixes isBusinessCardsFilterEmpty so it is true when the filter results in no available stored cards.
- Always shows the "Remove" button for the filter when the filter is active.
- Normalizes the casing of "business card" in the notices.
- Always shows the "Payment methods filtered..." message if filtering is enabled.

## Testing Instructions

See the testing instructions of https://github.com/Automattic/wp-calypso/pull/102716