### PR TITLE
Apply transfer with Software on the Migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -110,12 +110,12 @@ const SiteMigrationInstructions: Step< {
 	// Site preparation.
 	const {
 		detailedStatus,
-		completed: preparationCompleted,
+		softwareTransferCompleted: preparationCompleted,
 		error: preparationError,
 		migrationKey,
 	} = usePrepareSiteForMigration( siteId, fromUrl, { retry: 10 } );
 
-	const migrationKeyStatus = detailedStatus.migrationKey;
+	const migrationKeyStatus = detailedStatus.migrationKeyStatus;
 
 	// Register events and logs.
 	usePreparationEventsAndLogs( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/index.tsx
@@ -16,7 +16,7 @@ interface ProvisionStatusProps {
 export const ProvisionStatus: FC< ProvisionStatusProps > = ( { status } ) => {
 	const { siteTransferStatus, migrationKeyStatus } = status;
 
-	const preparationCompleted = siteTransferStatus === 'success';
+	const preparationCompleted = siteTransferStatus === 'completed';
 
 	if ( preparationCompleted ) {
 		const text =

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/index.tsx
@@ -6,25 +6,17 @@ import { FC, ReactNode } from 'react';
 import { recordMigrationInstructionsLinkClick } from '../tracking';
 import './style.scss';
 
-export type Status = 'idle' | 'pending' | 'success' | 'error';
-
 interface ProvisionStatusProps {
 	status: {
-		siteTransfer: Status;
-		migrationKey: string;
-		pluginInstallation?: Status;
+		siteTransferStatus: string;
+		migrationKeyStatus: string;
 	};
 }
 
 export const ProvisionStatus: FC< ProvisionStatusProps > = ( { status } ) => {
-	const {
-		siteTransfer: siteTransferStatus,
-		migrationKey: migrationKeyStatus,
-		pluginInstallation: pluginInstallationStatus,
-	} = status;
+	const { siteTransferStatus, migrationKeyStatus } = status;
 
-	const preparationCompleted =
-		siteTransferStatus === 'success' && pluginInstallationStatus === 'success';
+	const preparationCompleted = siteTransferStatus === 'success';
 
 	if ( preparationCompleted ) {
 		const text =
@@ -49,7 +41,6 @@ export const ProvisionStatus: FC< ProvisionStatusProps > = ( { status } ) => {
 
 	const actions = [
 		{ status: siteTransferStatus, text: translate( 'Provisioning your new site' ) },
-		{ status: pluginInstallationStatus, text: translate( 'Installing the required plugins' ) },
 		{ status: migrationKeyStatus, text: translate( 'Getting the migration key' ) },
 	].filter( ( action ) => action.status );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/test/index.tsx
@@ -8,7 +8,7 @@ import { ProvisionStatus } from '..';
 describe( 'ProvisionStatus', () => {
 	it( 'shows the number of in-progress steps', () => {
 		const status = {
-			siteTransferStatus: 'completed',
+			siteTransferStatus: 'idle',
 			migrationKeyStatus: 'error',
 		};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/provision-status/test/index.tsx
@@ -6,35 +6,21 @@ import React from 'react';
 import { ProvisionStatus } from '..';
 
 describe( 'ProvisionStatus', () => {
-	it( 'renders "in progress" status', () => {
-		const status = {
-			siteTransfer: 'success',
-			pluginInstallation: 'pending',
-			migrationKey: 'error',
-		};
-
-		render( <ProvisionStatus status={ status } /> );
-
-		expect( screen.getByText( 'Installing the required plugins' ) ).toBeVisible();
-	} );
-
 	it( 'shows the number of in-progress steps', () => {
 		const status = {
-			siteTransfer: 'success',
-			pluginInstallation: 'pending',
-			migrationKey: 'error',
+			siteTransferStatus: 'completed',
+			migrationKeyStatus: 'error',
 		};
 
 		render( <ProvisionStatus status={ status } /> );
 
-		expect( screen.getByText( '2/3' ) ).toBeVisible();
+		expect( screen.getByText( '1/2' ) ).toBeVisible();
 	} );
 
 	it( 'should render success message when all actions are successul', () => {
 		const status = {
-			siteTransfer: 'success',
-			pluginInstallation: 'success',
-			migrationKey: 'success',
+			siteTransferStatus: 'completed',
+			migrationKeyStatus: 'success',
 		};
 
 		render( <ProvisionStatus status={ status } /> );
@@ -48,9 +34,8 @@ describe( 'ProvisionStatus', () => {
 
 	it( "shows instructions to the user get the key by itself when we can't get the key", () => {
 		const status = {
-			siteTransfer: 'success',
-			pluginInstallation: 'success',
-			migrationKey: 'error',
+			siteTransferStatus: 'completed',
+			migrationKeyStatus: 'error',
 		};
 
 		render( <ProvisionStatus status={ status } /> );
@@ -64,9 +49,8 @@ describe( 'ProvisionStatus', () => {
 
 	it( 'should render error message when one of ther first two action fails', () => {
 		const status = {
-			siteTransfer: 'success',
-			pluginInstallation: 'error',
-			migrationKey: 'idle',
+			siteTransferStatus: 'error',
+			migrationKeyStatus: 'idle',
 		};
 
 		render( <ProvisionStatus status={ status } /> );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -183,8 +183,8 @@ describe( 'SiteMigrationInstructions', () => {
 
 	it( 'should display a fallback in the last step when preparation completes and there is an error with the migration key', async () => {
 		( usePrepareSiteForMigration as jest.Mock ).mockReturnValue( {
-			detailedStatus: { migrationKey: 'error' },
-			completed: true,
+			detailedStatus: { migrationKeyStatus: 'error' },
+			softwareTransferCompleted: true,
 			migrationKey: '',
 			error: null,
 		} );

--- a/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
+++ b/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
@@ -4,183 +4,139 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
-import React from 'react';
 import { usePrepareSiteForMigration } from '../use-prepare-site-for-migration';
-import { replyWithError, replyWithSuccess } from './helpers/nock';
-
+// Mock dependencies
 jest.mock( '@automattic/calypso-config', () => {
 	const mock = () => '';
 	mock.isEnabled = jest.fn();
 	return mock;
 } );
 
-const TRANSFER_ACTIVE = ( siteId: number ) => ( {
-	atomic_transfer_id: '1253811',
-	blog_id: siteId,
-	status: 'active',
-} );
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn(),
+} ) );
 
-const TRANSFER_COMPLETED = ( siteId: number ) => ( {
-	atomic_transfer_id: '1254451',
-	blog_id: siteId,
-	status: 'completed',
-} );
+const SITE_ID = 123;
+const API_ROOT = 'https://public-api.wordpress.com';
 
-jest.mock( 'calypso/lib/analytics/tracks' );
-jest.mock( 'calypso/lib/logstash' );
+const Wrapper =
+	( queryClient: QueryClient ) =>
+	( { children } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
 
-const errorCaptureMigrationKey = replyWithError( {
-	error: 'anyError',
-} );
+const render = ( { siteId } ) => {
+	const queryClient = new QueryClient();
 
-describe( 'usePrepareSiteForMigrationWithMigrateGuru', () => {
-	beforeAll( () => nock.disableNetConnect() );
-	beforeEach( () => nock.cleanAll() );
+	const renderResult = renderHook( () => usePrepareSiteForMigration( siteId, 'test.com' ), {
+		wrapper: Wrapper( queryClient ),
+	} );
 
-	const Wrapper =
-		( queryClient: QueryClient ) =>
-		( { children } ) => (
-			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
-		);
-
-	const render = ( { siteId } ) => {
-		const queryClient = new QueryClient();
-
-		const renderResult = renderHook( () => usePrepareSiteForMigration( siteId ), {
-			wrapper: Wrapper( queryClient ),
-		} );
-
-		return {
-			...renderResult,
-			queryClient,
-		};
+	return {
+		...renderResult,
+		queryClient,
 	};
+};
 
-	it( 'returns idle states when site id is not available', () => {
+describe( 'usePrepareSiteForMigration', () => {
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
+
+	beforeEach( () => {
+		nock.cleanAll();
+	} );
+
+	it( 'should return "idle" when site id is not available', () => {
 		const { result } = render( { siteId: undefined } );
 
 		expect( result.current ).toEqual( {
-			completed: false,
-			error: null,
 			detailedStatus: {
-				migrationKey: 'idle',
-				pluginInstallation: 'idle',
-				siteTransfer: 'idle',
+				siteTransferStatus: 'idle',
+				migrationKeyStatus: 'idle',
 			},
+			softwareTransferCompleted: false,
+			error: null,
 			migrationKey: null,
 		} );
 	} );
 
-	it( 'returns siteTransfer status as "pending" when siteTransfer is still happening', () => {
-		const siteId = 123;
-		nock( 'https://public-api.wordpress.com:443' )
-			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
-			.once()
-			.reply( 200, TRANSFER_ACTIVE( siteId ) );
-
-		const { result } = render( { siteId: 123 } );
-
-		expect( result.current ).toEqual( {
-			completed: false,
-			error: null,
-			detailedStatus: {
-				migrationKey: 'idle',
-				pluginInstallation: 'idle',
-				siteTransfer: 'pending',
-			},
-			migrationKey: null,
-		} );
-	} );
-
-	it( 'gets the migration key after the plugin installation', async () => {
-		const siteId = 123;
-
-		nock( 'https://public-api.wordpress.com:443' )
-			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
-			.reply( 200, TRANSFER_COMPLETED( siteId ) )
-			.get( `/rest/v1.2/sites/${ siteId }/plugins?http_envelope=1` )
-			.reply( 200, { plugins: [] } )
-			.post( `/rest/v1.2/sites/${ siteId }/plugins/wpcom-migration/install?http_envelope=1` )
-			.reply( replyWithSuccess() )
-			.post( `/rest/v1.2/sites/${ siteId }/plugins/wpcom-migration%2Fwpcom_migration` )
-			.reply( replyWithSuccess() )
-			.get( `/wpcom/v2/sites/${ siteId }/atomic-migration-status/wpcom-migration-key` )
+	it( 'should handle successful migration preparation', async () => {
+		nock( API_ROOT )
+			.post( '/wpcom/v2/sites/123/atomic/transfer-with-software', {
+				plugin_slug: 'wpcom-migration',
+				settings: {
+					migration_source_site_domain: 'test.com',
+				},
+			} )
 			.query( { http_envelope: 1 } )
-			.reply( replyWithSuccess( { migration_key: 'some-migration-key' } ) );
+			.reply( 200, {
+				blog_id: SITE_ID,
+				transfer_id: 456,
+				transfer_status: 'pending',
+			} )
+			.get( `/wpcom/v2/sites/${ SITE_ID }/atomic/transfer-with-software/456` )
+			.query( { http_envelope: 1 } )
+			.reply( 200, {
+				blog_id: SITE_ID,
+				transfer_id: 456,
+				transfer_status: 'success',
+			} )
+			.get( `/wpcom/v2/sites/${ SITE_ID }/atomic-migration-status/wpcom-migration-key` )
+			.query( { http_envelope: 1 } )
+			.reply( 200, { migration_key: 'test-key-123' } );
 
-		const { result } = render( { siteId: 123 } );
+		const { result } = render( { siteId: SITE_ID } );
 
 		await waitFor(
 			() => {
 				expect( result.current ).toEqual( {
-					completed: true,
-					error: null,
 					detailedStatus: {
-						migrationKey: 'success',
-						pluginInstallation: 'success',
-						siteTransfer: 'success',
+						siteTransferStatus: 'success',
+						migrationKeyStatus: 'success',
 					},
-					migrationKey: 'some-migration-key',
+					softwareTransferCompleted: true,
+					error: null,
+					migrationKey: 'test-key-123',
 				} );
 			},
 			{ timeout: 3000 }
 		);
 	} );
 
-	it( 'returns error when is not possible to get the migration key', async () => {
-		const siteId = 123;
+	it( 'should handle transfer failure', async () => {
+		// Mock transfer initiation
+		nock( API_ROOT )
+			.post( `/wpcom/v2/sites/${ SITE_ID }/atomic/transfer-with-software?http_envelope=1` )
+			.reply( 200, {
+				blog_id: 0,
+				atomic_transfer_id: 0,
+				atomic_transfer_status: 'pending',
+			} );
 
-		nock( 'https://public-api.wordpress.com:443' )
-			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
-			.reply( 200, TRANSFER_COMPLETED( siteId ) )
-			.get( `/rest/v1.2/sites/${ siteId }/plugins?http_envelope=1` )
-			.reply( 200, { plugins: [] } )
-			.post( `/rest/v1.2/sites/${ siteId }/plugins/wpcom-migration/install?http_envelope=1` )
-			.reply( replyWithSuccess() )
-			.post( `/rest/v1.2/sites/${ siteId }/plugins/wpcom-migration%2Fwpcom_migration` )
-			.reply( 200 )
-			.get( `/wpcom/v2/sites/${ siteId }/atomic-migration-status/wpcom-migration-key` )
-			.reply( errorCaptureMigrationKey );
+		nock( API_ROOT )
+			.get( `/wpcom/v2/sites/${ SITE_ID }/atomic/transfer-with-software/?http_envelope=1` )
+			.reply( 200, {
+				blog_id: 0,
+				atomic_transfer_id: 0,
+				atomic_transfer_status: 'pending',
+			} );
 
-		const { result } = render( { siteId: 123 } );
+		const { result } = render( { siteId: SITE_ID } );
 
 		await waitFor(
 			() => {
 				expect( result.current ).toEqual( {
-					completed: true,
-					error: expect.any( Error ),
 					detailedStatus: {
-						migrationKey: 'error',
-						pluginInstallation: 'success',
-						siteTransfer: 'success',
+						siteTransferStatus: 'idle',
+						migrationKeyStatus: 'idle',
 					},
+					softwareTransferCompleted: false,
+					error: null,
 					migrationKey: null,
 				} );
 			},
 			{ timeout: 3000 }
 		);
-	} );
-
-	it( 'starts the plugin installation after the siteTransfer is completed', async () => {
-		const siteId = 123;
-		nock( 'https://public-api.wordpress.com:443' )
-			.get( `/wpcom/v2/sites/${ siteId }/atomic/transfers/latest` )
-			.once()
-			.reply( 200, TRANSFER_COMPLETED( siteId ) );
-
-		const { result } = render( { siteId: 123 } );
-
-		await waitFor( () => {
-			expect( result.current ).toEqual( {
-				completed: false,
-				error: null,
-				detailedStatus: {
-					migrationKey: 'idle',
-					pluginInstallation: 'pending',
-					siteTransfer: 'success',
-				},
-				migrationKey: null,
-			} );
-		} );
 	} );
 } );

--- a/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
+++ b/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
@@ -80,7 +80,7 @@ describe( 'usePrepareSiteForMigration', () => {
 			.reply( 200, {
 				blog_id: SITE_ID,
 				transfer_id: 456,
-				transfer_status: 'success',
+				transfer_status: 'completed',
 			} )
 			.get( `/wpcom/v2/sites/${ SITE_ID }/atomic-migration-status/wpcom-migration-key` )
 			.query( { http_envelope: 1 } )

--- a/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
+++ b/client/landing/stepper/hooks/test/use-prepare-site-for-migration.tsx
@@ -92,7 +92,7 @@ describe( 'usePrepareSiteForMigration', () => {
 			() => {
 				expect( result.current ).toEqual( {
 					detailedStatus: {
-						siteTransferStatus: 'success',
+						siteTransferStatus: 'completed',
 						migrationKeyStatus: 'success',
 					},
 					softwareTransferCompleted: true,

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -1,9 +1,11 @@
 import config from '@automattic/calypso-config';
+import { UseMutationResult } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { usePluginAutoInstallation } from './use-plugin-auto-installation';
+import { useRequestTransferWithSoftware } from 'calypso/sites/hooks/use-transfer-with-software-start-mutation';
+import { useTransferWithSoftwareStatus } from 'calypso/sites/hooks/use-transfer-with-software-status-query';
 import { useSiteMigrationKey } from './use-site-migration-key';
-import { useSiteTransfer } from './use-site-transfer';
+import type { TransferWithSoftwareResponse } from 'calypso/sites/hooks/use-transfer-with-software-start-mutation';
 
 type Status = 'idle' | 'pending' | 'success' | 'error';
 
@@ -69,45 +71,64 @@ type Options = {
  *  This hook manages the site transfer, plugin installation and migration key fetching.
  */
 export const usePrepareSiteForMigration = (
-	siteId?: number,
+	siteId: number,
 	from?: string,
 	options: Options = {}
 ) => {
-	const plugin = { name: 'wpcom-migration/wpcom_migration', slug: 'wpcom-migration' };
+	// Request the transfer with software
+	const transferMutation: UseMutationResult< TransferWithSoftwareResponse, Error, void > =
+		useRequestTransferWithSoftware( {
+			siteId,
+			apiSettings: {
+				migration_source_site_domain: from,
+			},
+			plugin_slug: 'wpcom-migration',
+		} );
 
-	const siteTransferState = useSiteTransfer( siteId, {
+	// Trigger the mutation when the hook is first used
+	useEffect( () => {
+		if ( siteId && from ) {
+			transferMutation.mutate();
+		}
+	}, [ siteId, from ] ); // Dependencies that should trigger a new transfer
+
+	const {
+		data: { transfer_status } = {},
+		error: softwareTransferError,
+		status: softwareTransferStatus,
+	} = useTransferWithSoftwareStatus( siteId, transferMutation.data?.transfer_id ?? undefined, {
 		retry: options.retry ?? 0,
-		from,
 	} );
 
-	const pluginInstallationState = usePluginAutoInstallation( plugin, siteId, {
-		enabled: Boolean( siteTransferState.completed ),
-	} );
+	const softwareTransferCompleted = 'success' === transfer_status;
 
 	const {
 		data: { migrationKey } = {},
 		error: migrationKeyError,
 		status: migrationKeyStatus,
 	} = useSiteMigrationKey( siteId, {
-		enabled: Boolean( pluginInstallationState.completed ),
+		enabled: Boolean( softwareTransferCompleted ),
 		retry: options.retry ?? 0,
 	} );
 
-	const completed = siteTransferState.completed && pluginInstallationState.completed;
-	const error = siteTransferState.error || pluginInstallationState.error || migrationKeyError;
-	const criticalError = siteTransferState.error || pluginInstallationState.error;
+	const error = softwareTransferError || migrationKeyError;
+	const criticalError = softwareTransferError;
 
 	const detailedStatus = {
-		siteTransfer: siteTransferState.status,
-		pluginInstallation: pluginInstallationState.status,
-		migrationKey: ! pluginInstallationState.completed ? 'idle' : migrationKeyStatus,
+		siteTransferStatus: transfer_status ?? 'idle',
+		migrationKeyStatus: ! softwareTransferCompleted ? 'idle' : migrationKeyStatus,
 	};
 
-	useLogMigration( completed, siteTransferState.status, criticalError, siteId );
+	useLogMigration(
+		softwareTransferCompleted,
+		softwareTransferStatus as Status,
+		criticalError,
+		siteId
+	);
 
 	return {
 		detailedStatus,
-		completed,
+		softwareTransferCompleted,
 		error,
 		migrationKey: migrationKey ?? null,
 	};

--- a/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
+++ b/client/landing/stepper/hooks/use-prepare-site-for-migration.ts
@@ -100,7 +100,7 @@ export const usePrepareSiteForMigration = (
 		retry: options.retry ?? 0,
 	} );
 
-	const softwareTransferCompleted = 'success' === transfer_status;
+	const softwareTransferCompleted = 'completed' === transfer_status;
 
 	const {
 		data: { migrationKey } = {},

--- a/client/sites/hooks/use-transfer-with-software-start-mutation.ts
+++ b/client/sites/hooks/use-transfer-with-software-start-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-type TransferWithSoftwareResponse = {
+export type TransferWithSoftwareResponse = {
 	blog_id: number;
 	transfer_id: number;
 	transfer_status: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Applies the Transfer with Software API on the "Do it yourself" migration flow. It simplifies the process of provisioning the Atomic and site and installing the `wpcom` plugin.
* Updates the test according to the new API.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We recently deployed the new Transfer with Software API(178867-ghe-Automattic/wpcom) that aims to simplify the provisioning of sites with software, reducing the responsibility of managing the provisioning process on the front-end.  This will make the provisioning process in the migration less error-prone and more reliable.
* Before, you could mess up the state of the provisioning if you refreshed the page. Now that should not happen anymore, as the new API is idempotent and can be called many times without affecting the result.

More context: paYKcK-61R-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Testing a Simple Site

* Use the Calypso live link below or apply this PR to your local environment
* Navigate to `/start`, pick a free domain, and then pick the free plan
* Go through the flow until you reach the `Let us migrate your site` step
* Click on `I'll do it myself` in the top right corner
* Now, ensure you can go through the migration process correctly

### Testing an Atomic Site

* Use the Calypso Live link below or apply this PR to your sandbox
* Navigate to `/move` and input one of your source sites
* Now, pick a site that is already Atomic and doesn't have the wpcom-migration plugin installed
* Go through the flow until you reach the `Let us migrate your site` step
* Click on `I'll do it myself` in the top right corner
* Now, ensure you can go through the migration process correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?