### PR TITLE
Hosting Dashboard v2: add site switcher

### DIFF
--- a/client/dashboard/header-bar/style.scss
+++ b/client/dashboard/header-bar/style.scss
@@ -8,6 +8,6 @@
 	color: var( --dashboard-header__color );
 }
 
-.dashboard-header-bar-title {
+.dashboard-header-bar-title > span {
   padding-inline: $grid-unit-15;
 }

--- a/client/dashboard/me/index.tsx
+++ b/client/dashboard/me/index.tsx
@@ -13,7 +13,9 @@ function Me() {
 		<>
 			<HeaderBar>
 				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 4 }>
-					<HeaderBar.Title>{ __( 'Account' ) }</HeaderBar.Title>
+					<HeaderBar.Title>
+						<span>{ __( 'Account' ) }</span>
+					</HeaderBar.Title>
 					{ isDesktop && <MenuDivider /> }
 					<MeMenu />
 				</HStack>

--- a/client/dashboard/site/index.tsx
+++ b/client/dashboard/site/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { Outlet } from '@tanstack/react-router';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import { __experimentalHStack as HStack, Dropdown, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { siteQuery } from '../app/queries';
 import { siteRoute } from '../app/router';
@@ -8,6 +8,7 @@ import HeaderBar from '../header-bar';
 import MenuDivider from '../menu-divider';
 import SiteIcon from '../site-icon';
 import SiteMenu from '../site-menu';
+import Switcher from './switcher';
 
 function Site() {
 	const isDesktop = useViewportMatch( 'medium' );
@@ -25,8 +26,17 @@ function Site() {
 			<HeaderBar>
 				<HStack justify={ isDesktop ? 'flex-start' : 'space-between' } spacing={ 4 }>
 					<HeaderBar.Title>
-						<SiteIcon site={ site } size={ 24 } />
-						<span>{ site.name }</span>
+						<Dropdown
+							renderToggle={ ( { onToggle } ) => (
+								<Button
+									onClick={ () => onToggle() }
+									icon={ <SiteIcon site={ site } size={ 24 } /> }
+								>
+									{ site.name }
+								</Button>
+							) }
+							renderContent={ ( { onClose } ) => <Switcher onClose={ onClose } /> }
+						/>
 					</HeaderBar.Title>
 					{ isDesktop && <MenuDivider /> }
 					<SiteMenu siteId={ site.id } />

--- a/client/dashboard/site/switcher.scss
+++ b/client/dashboard/site/switcher.scss
@@ -1,0 +1,23 @@
+.site-switcher {
+  // To do: data views uses the container property, which collapses the popover
+  // if no width is explicitly set.
+  width: 300px;
+
+  // To do: data views is too inflexible about list item sizes. It completely
+  // ignores the size set in the mediaField.
+  .dataviews-view-list {
+    .dataviews-view-list__media-wrapper {
+      width: 24px;
+      height: 24px;
+    }
+    .dataviews-view-list__field-wrapper {
+      min-height: 24px;
+    }
+
+    // Additionally, data views list doesn't have a "compact" layout option.
+    div[role="row"] .dataviews-view-list__item-wrapper {
+      padding-top: 8px;
+      padding-bottom: 8px;
+    }
+  }
+}

--- a/client/dashboard/site/switcher.tsx
+++ b/client/dashboard/site/switcher.tsx
@@ -8,6 +8,8 @@ import SiteIcon from '../site-icon';
 import type { Site } from '../data/types';
 import type { View } from '@wordpress/dataviews';
 
+import './switcher.scss';
+
 const fields = [
 	{
 		id: 'name',
@@ -22,7 +24,7 @@ const fields = [
 ];
 
 const DEFAULT_VIEW: View = {
-	type: 'table',
+	type: 'list',
 	page: 1,
 	perPage: 10,
 	sort: {
@@ -31,9 +33,6 @@ const DEFAULT_VIEW: View = {
 	},
 	titleField: 'name',
 	mediaField: 'media',
-	layout: {
-		density: 'compact',
-	},
 };
 
 export default function Switcher( { onClose }: { onClose: () => void } ) {
@@ -53,7 +52,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 	};
 
 	return (
-		<div style={ { width: '300px' } }>
+		<div className="site-switcher">
 			<DataViews
 				data={ filteredData }
 				fields={ fields }

--- a/client/dashboard/site/switcher.tsx
+++ b/client/dashboard/site/switcher.tsx
@@ -1,0 +1,69 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { sitesQuery } from '../app/queries';
+import SiteIcon from '../site-icon';
+import type { Site } from '../data/types';
+import type { View } from '@wordpress/dataviews';
+
+const fields = [
+	{
+		id: 'name',
+		label: __( 'Site' ),
+		enableGlobalSearch: true,
+	},
+	{
+		id: 'media',
+		label: __( 'Media' ),
+		render: ( { item }: { item: Site } ) => <SiteIcon site={ item } size={ 24 } />,
+	},
+];
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 10,
+	sort: {
+		field: 'name',
+		direction: 'asc',
+	},
+	titleField: 'name',
+	mediaField: 'media',
+	layout: {
+		density: 'compact',
+	},
+};
+
+export default function Switcher( { onClose }: { onClose: () => void } ) {
+	const navigate = useNavigate();
+	const sites = useQuery( sitesQuery() ).data;
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	if ( ! sites ) {
+		return __( 'Loading…' );
+	}
+
+	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
+
+	const onClickItem = async ( item: Site ) => {
+		await navigate( { to: `/sites/${ item.id }` } );
+		onClose();
+	};
+
+	return (
+		<div style={ { width: '300px' } }>
+			<DataViews
+				data={ filteredData }
+				fields={ fields }
+				// actions={ actions }
+				view={ view }
+				onChangeView={ setView }
+				onClickItem={ onClickItem }
+				defaultLayouts={ { table: {} } }
+				paginationInfo={ paginationInfo }
+			/>
+		</div>
+	);
+}

--- a/client/dashboard/site/switcher.tsx
+++ b/client/dashboard/site/switcher.tsx
@@ -46,8 +46,8 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
 
-	const onClickItem = async ( item: Site ) => {
-		await navigate( { to: `/sites/${ item.id }` } );
+	const onChangeSelection = async ( items: string[] ) => {
+		await navigate( { to: `/sites/${ items[ 0 ] }` } );
 		onClose();
 	};
 
@@ -56,10 +56,9 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 			<DataViews
 				data={ filteredData }
 				fields={ fields }
-				// actions={ actions }
 				view={ view }
 				onChangeView={ setView }
-				onClickItem={ onClickItem }
+				onChangeSelection={ onChangeSelection }
 				defaultLayouts={ { table: {} } }
 				paginationInfo={ paginationInfo }
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/fb3e5fbb-d837-417a-b97a-8064785c9930" />



Fixes DOTCOM-10585
Related to #102573

## Proposed Changes

* Adds the site switcher. The up/down icon on the right I left out because it's not normal for a button to have two icons.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a site overview and click the toggle.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
