### PR TITLE
E2E: Fix page template selection

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -425,7 +425,9 @@ export class EditorPage {
 	 * @param {string} patternName Name of the pattern to insert.
 	 */
 	async addPatternFromSidebar( patternName: string ): Promise< Locator > {
-		await this.editorGutenbergComponent.resetSelectedBlock();
+		if ( ! ( envVariables.TEST_ON_ATOMIC && envVariables.VIEWPORT_NAME === 'mobile' ) ) {
+			await this.editorGutenbergComponent.resetSelectedBlock();
+		}
 		await this.editorToolbarComponent.openBlockInserter();
 		return await this.addPatternFromInserter(
 			patternName,

--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -36,9 +36,10 @@ export class PagesPage {
 	 */
 	async addNewPage(): Promise< void > {
 		const locator = this.page.locator( selectors.addNewPageButton );
-		await Promise.all( [
-			this.page.waitForNavigation( { url: /post-new.php\?post_type=page/, timeout: 20 * 1000 } ),
-			locator.click( { timeout: 20 * 1000 } ),
-		] );
+		await locator.click( { timeout: 20 * 1000 } );
+		await this.page.waitForURL( /post-new.php\?post_type=page/, {
+			timeout: 20 * 1000,
+			waitUntil: 'domcontentloaded',
+		} );
 	}
 }

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -63,7 +63,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Page Flow' ), function () 
 
 		const editorParent = await editorPage.getEditorParent();
 
-		const modalSelector = await editorParent.getByRole( 'listbox', { name: 'Block patterns' } );
+		const modalSelector = await editorParent.getByRole( 'listbox', {
+			name: /^(All|Block patterns)$/,
+		} );
 
 		// The PR, https://github.com/WordPress/gutenberg/pull/69081, restored the starter content modal for newly created pages.
 		// However, not all of themes have the page template. As a result, we have to check whether the modal is open.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See https://github.com/Automattic/wp-calypso/pull/102707#issuecomment-2821291306. The page template name can be either "All" or "Block patterns". This updates the selector to check for either variant.

Also, I was having issues with the navigation to a new page timing out. I updated the test to use `waitForURL` instead of the deprecated-and-discouraged `waitForNavigation` call, and set `waitUntil` to `domcontentloaded` (instead of the default `load`).

Finally, I fixed the tests for Atomic + mobile by skipping an unneeded `this.editorGutenbergComponent.resetSelectedBlock()` call in that scenario.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This should work on Atomic:
```
ATOMIC_VARIATION="php-old" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__page-basic-flow.ts"
ATOMIC_VARIATION="php-old" TEST_ON_ATOMIC="true" VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__page-basic-flow.ts"
```

And Simple:

```
VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__page-basic-flow.ts"
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__page-basic-flow.ts"
```

Or you can do a big long test:
```
yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="private" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="wp-previous" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="mobile" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="mobile" ATOMIC_VARIATION="private" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="mobile" ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="mobile" ATOMIC_VARIATION="wp-previous" TEST_ON_ATOMIC="true" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts && VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test test/e2e/specs/editor/editor__page-basic-flow.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?