### PR TITLE
Command Palette: Add 'Import site' command

### DIFF
--- a/client/sites/overview/components/quick-actions-card.tsx
+++ b/client/sites/overview/components/quick-actions-card.tsx
@@ -8,11 +8,11 @@ import { HostingCard, HostingCardDescription } from 'calypso/components/hosting-
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import { WriteIcon } from 'calypso/layout/masterbar/write-icon';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
+import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
-import getPluginInstallUrl from 'calypso/state/selectors/get-plugin-install-url';
 import getStatsUrl from 'calypso/state/selectors/get-stats-url';
 import getThemeInstallUrl from 'calypso/state/selectors/get-theme-install-url';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
@@ -68,7 +68,6 @@ const QuickActionsCard: FC = () => {
 		site?.ID ? getEditorUrl( state, site?.ID ) : '#'
 	);
 	const themeInstallUrl = useSelector( ( state ) => getThemeInstallUrl( state, site?.ID ) ?? '' );
-	const pluginInstallUrl = useSelector( ( state ) => getPluginInstallUrl( state, site?.ID ) ?? '' );
 	const statsUrl = useSelector( ( state ) => getStatsUrl( state, site?.ID ) ?? '' );
 	const siteEditorUrl = useSelector( ( state ) =>
 		site?.ID && activeThemeData
@@ -80,6 +79,7 @@ const QuickActionsCard: FC = () => {
 			  )
 			: ''
 	);
+	const importSiteUrl = addQueryArgs( { siteSlug: site?.slug }, '/setup/site-migration' );
 
 	const { adminLabel, adminUrl } = useSiteAdminInterfaceData( site?.ID );
 
@@ -135,16 +135,16 @@ const QuickActionsCard: FC = () => {
 					commandName="installTheme"
 				/>
 				<Action
-					icon={ <SidebarCustomIcon icon="dashicons-admin-plugins hosting-overview__dashicon" /> }
-					href={ pluginInstallUrl }
-					text={ translate( 'Install plugins' ) }
-					commandName="installPlugin"
-				/>
-				<Action
 					icon={ <SidebarCustomIcon icon="dashicons-chart-bar hosting-overview__dashicon" /> }
 					href={ statsUrl }
 					text={ translate( 'See Jetpack Stats' ) }
 					commandName="openJetpackStats"
+				/>
+				<Action
+					icon={ <SidebarCustomIcon icon="dashicons-admin-plugins hosting-overview__dashicon" /> }
+					href={ importSiteUrl }
+					text={ translate( 'Import site to WordPress.com' ) }
+					commandName="importSite"
 				/>
 			</ul>
 		</HostingCard>

--- a/client/sites/overview/components/quick-actions-card.tsx
+++ b/client/sites/overview/components/quick-actions-card.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { chevronRightSmall, Icon } from '@wordpress/icons';
+import { Icon, chevronRightSmall, download } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode } from 'react';
 import { useSelector } from 'react-redux';
@@ -141,7 +141,7 @@ const QuickActionsCard: FC = () => {
 					commandName="openJetpackStats"
 				/>
 				<Action
-					icon={ <SidebarCustomIcon icon="dashicons-admin-plugins hosting-overview__dashicon" /> }
+					icon={ <Icon className="hosting-overview__dashicon" icon={ download } /> }
 					href={ importSiteUrl }
 					text={ translate( 'Import site to WordPress.com' ) }
 					commandName="importSite"

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -75,6 +75,10 @@ $blueberry-color: #3858e9;
 					color: var(--studio-gray-30);
 					margin-right: 8px;
 				}
+
+				svg {
+					fill: var(--studio-gray-30);
+				}
 			}
 
 			&:last-child {


### PR DESCRIPTION
Related to pdtkmj-3zG-p2#comment-6834

## Proposed Changes

* Add the "Import site to WordPress.com" command to the palette instead of "Install plugins"

## Why are these changes being made?

More info here: pdtkmj-3zG-p2#comment-6834

## Testing Instructions

- Go to `/sites`
- Select a site
- Check the command palette
- Click on "Import site to WordPress.com"
- Check if you reached the site-migration flow

<img width="499" alt="Screenshot 2025-04-23 at 14 13 13" src="https://github.com/user-attachments/assets/ef0b7a86-78c1-4491-b5c5-0ca6719b4b11" />

<img width="1728" alt="Screenshot 2025-04-22 at 17 49 54" src="https://github.com/user-attachments/assets/befad9b0-0196-4510-bc14-e1ce03a78df2" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?