### PR TITLE
Apply container v2 to `already-wpcom`  step 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
@@ -1,13 +1,12 @@
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { type FC } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import Form from './components/form';
-import type { StepProps } from '../../types';
-
+import type { Step as StepType } from '../../types';
 import './style.scss';
 
 const extractDomainFromUrl = ( url: string ) => {
@@ -19,7 +18,7 @@ const extractDomainFromUrl = ( url: string ) => {
 	}
 };
 
-const SiteMigrationAlreadyWPCOM: FC< StepProps > = ( { stepName, flow, navigation } ) => {
+const SiteMigrationAlreadyWPCOM: StepType = ( { stepName, flow, navigation } ) => {
 	const translate = useTranslate();
 	const [ query ] = useSearchParams();
 	const from = query.get( 'from' )!;
@@ -29,6 +28,7 @@ const SiteMigrationAlreadyWPCOM: FC< StepProps > = ( { stepName, flow, navigatio
 			break: <span style={ { display: 'block' } } />,
 		},
 	} );
+
 	const subHeaderText = translate(
 		"Let's figure out your next steps for {{strong}}%(from)s{{/strong}} together. Please complete the form below.",
 		{
@@ -44,6 +44,23 @@ const SiteMigrationAlreadyWPCOM: FC< StepProps > = ( { stepName, flow, navigatio
 	const onSubmit = () => {
 		navigation?.submit?.();
 	};
+
+	if ( shouldUseStepContainerV2MigrationFlow( flow ) ) {
+		return (
+			<>
+				<DocumentHead title={ translate( 'Your site is already on WordPress.com' ) } />
+				<Step.CenteredColumnLayout
+					columnWidth={ 5 }
+					topBar={
+						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
+					}
+					heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
+				>
+					<Form onComplete={ onSubmit } />
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
@@ -50,7 +50,7 @@ const SiteMigrationAlreadyWPCOM: StepType = ( { stepName, flow, navigation } ) =
 			<>
 				<DocumentHead title={ translate( 'Your site is already on WordPress.com' ) } />
 				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
+					columnWidth={ 8 }
 					topBar={
 						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-68

## Proposed Changes
Apply Container V2 to the `already-wpcom` step




| Before | After |
|--------|--------|
| ![CleanShot 2025-04-22 at 16 50 54@2x](https://github.com/user-attachments/assets/8ad642ae-e8f6-4ecc-8adc-a58f67b0da10) | ![CleanShot 2025-04-22 at 16 55 58@2x](https://github.com/user-attachments/assets/6796679e-2692-41f5-8e7a-6fd1ff329cff) 
| ![CleanShot 2025-04-22 at 16 57 11@2x](https://github.com/user-attachments/assets/68d17482-85e6-4ba2-9c35-a0132458cd26) | ![CleanShot 2025-04-22 at 16 56 40@2x](https://github.com/user-attachments/assets/29898292-9683-4cdb-9f70-da4a503ec1f6) | 



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To migrate to the new and improved stepper containers.

## Testing Instructions

Go to: `/setup/hosted-site-migration/already-wpcom?flags=step-container-v2-migration-flow`
* Compare with the screenshots above (after)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
