### PR TITLE
Hosting Dashboard v2: main logo should be a link + fix misalignment

### DIFF
--- a/client/dashboard/header/index.tsx
+++ b/client/dashboard/header/index.tsx
@@ -1,18 +1,14 @@
-import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useAppContext } from '../app/context';
 import HeaderBar from '../header-bar';
 import PrimaryMenu from '../primary-menu';
 import PrimaryMenuMobile from '../primary-menu-mobile';
+import RouterLinkButton from '../router-link-button';
 import SecondaryMenu from '../secondary-menu';
 
 function Header() {
 	const { Logo } = useAppContext();
 	const isDesktop = useViewportMatch( 'medium' );
-	const navigate = useNavigate();
-	const router = useRouter();
-	const href = router.buildLocation( { to: '/' } ).href;
 
 	return (
 		<HeaderBar as="header">
@@ -24,14 +20,7 @@ function Header() {
 
 			{ Logo && (
 				<div style={ { display: 'flex', alignItems: 'center' } }>
-					<Button
-						icon={ <Logo /> }
-						href={ href }
-						onClick={ ( event: React.MouseEvent ) => {
-							event.preventDefault();
-							navigate( { to: '/' } );
-						} }
-					/>
+					<RouterLinkButton icon={ <Logo /> } to="/" />
 				</div>
 			) }
 

--- a/client/dashboard/header/index.tsx
+++ b/client/dashboard/header/index.tsx
@@ -1,3 +1,5 @@
+import { useNavigate, useRouter } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useAppContext } from '../app/context';
 import HeaderBar from '../header-bar';
@@ -8,6 +10,9 @@ import SecondaryMenu from '../secondary-menu';
 function Header() {
 	const { Logo } = useAppContext();
 	const isDesktop = useViewportMatch( 'medium' );
+	const navigate = useNavigate();
+	const router = useRouter();
+	const href = router.buildLocation( { to: '/' } ).href;
 
 	return (
 		<HeaderBar as="header">
@@ -19,7 +24,14 @@ function Header() {
 
 			{ Logo && (
 				<div style={ { display: 'flex', alignItems: 'center' } }>
-					<Logo />
+					<Button
+						icon={ <Logo /> }
+						href={ href }
+						onClick={ ( event: React.MouseEvent ) => {
+							event.preventDefault();
+							navigate( { to: '/' } );
+						} }
+					/>
 				</div>
 			) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Two things:

It annoys me when you can't click the main logo to go back to the main page (whatever is the main page by app config).

Secondly, since the main logo was not a icon button, it was missing a padding (compare the distance between the edges and logo vs profile picture):

| Before  | After |
| ------------- | ------------- |
| <img width="1464" alt="image" src="https://github.com/user-attachments/assets/d2c4d2d3-efc7-4492-a02c-1dba40a001e7" />  | <img width="1464" alt="image" src="https://github.com/user-attachments/assets/bd2c0b88-7a22-4f7c-8218-1eefbf7817d7" />  |

Also check the misalignment with the secondary header:

| Before  | After |
| ------------- | ------------- |
| <img width="1464" alt="image" src="https://github.com/user-attachments/assets/a8ac3d2f-a6a8-4fdb-90fa-d3cd596a4b38" />  | <img width="1464" alt="image" src="https://github.com/user-attachments/assets/a45fda42-1020-4e48-ad2c-5d5de1d55725" />  |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the logo.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
