### PR TITLE
Update copy for default landing page setting

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -3,7 +3,7 @@ import { Button, Card, Dialog, FormInputValidation, FormLabel } from '@automatti
 import { canBeTranslated, getLanguage, isLocaleVariant } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
 import debugFactory from 'debug';
-import { localize } from 'i18n-calypso';
+import { fixMe, localize } from 'i18n-calypso';
 import { debounce, flowRight as compose, get, map, size } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -963,9 +963,15 @@ class Account extends Component {
 							</FormLabel>
 							<ToggleLandingPageSettings />
 							<FormSettingExplanation>
-								{ translate(
-									'When you type https://www.wordpress.com in your browser, this is the page you land on.'
-								) }
+								{ fixMe( {
+									text: "Select what you'll see by default when visiting WordPress.com",
+									newCopy: translate(
+										"Select what you'll see by default when visiting WordPress.com"
+									),
+									oldCopy: translate(
+										'When you type https://www.wordpress.com in your browser, this is the page you land on.'
+									),
+								} ) }
 							</FormSettingExplanation>
 						</FormFieldset>
 

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -1,5 +1,5 @@
 import { RadioControl } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -66,14 +66,20 @@ function ToggleLandingPageSettings() {
 		}
 	}
 
+	const primarySiteLabel = fixMe( {
+		text: 'Primary site dashboard',
+		newCopy: translate( 'Primary site dashboard' ),
+		oldCopy: translate( 'My primary site' ),
+	} ) as string;
+
 	return (
 		<div>
 			<RadioControl
 				selected={ selectedOption }
 				options={ [
-					{ label: translate( 'My primary site' ), value: 'default' },
-					{ label: translate( 'All my sites' ), value: 'my-sites' },
-					{ label: translate( 'The Reader' ), value: 'reader' },
+					{ label: primarySiteLabel, value: 'default' },
+					{ label: translate( 'Sites' ), value: 'my-sites' },
+					{ label: translate( 'Reader' ), value: 'reader' },
 				] }
 				onChange={ handlePreferenceChange }
 				disabled={ isSaving }


### PR DESCRIPTION
The updated copy should make this setting easier to understand.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100336

## Proposed Changes

Change the copy on some labels, see diff.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To make the setting easier to understand.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the calypso live link
2. Go to /me/account
3. Note the text has changed for the Default Landing Page

Text we don't yet have a translation for will use the old translations still.

[Reader](https://translate.wordpress.com/projects/wpcom/-all-translations/33307/) and [Sites](https://translate.wordpress.com/projects/wpcom/-all-translations/11187/) are already translated in mag-16 languages.

Before | After
-------|------
<img width="773" alt="Screenshot 2025-04-22 at 18 12 24" src="https://github.com/user-attachments/assets/6f6d79e5-4a28-4107-b531-db3bce39de23" /> | <img width="773" alt="Screenshot 2025-04-22 at 18 12 49" src="https://github.com/user-attachments/assets/1d9f04bc-0337-4aed-97c4-005a0567514a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
