### PR TITLE
Remove unused survey isOpen prop and context

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import surveyImage from 'calypso/assets/images/onboarding/migrations/survey/wordpress-half-logo.png';
-import { Survey, SurveyProps, SurveyTriggerAccept, SurveyTriggerSkip } from '../survey';
+import { Survey, SurveyTriggerAccept, SurveyTriggerSkip } from '../survey';
 import './style.scss';
 
 const linkByCountry = {
@@ -11,15 +11,15 @@ const linkByCountry = {
 
 type Countries = keyof typeof linkByCountry;
 
-type MigrationSurveyProps = Pick< SurveyProps, 'isOpen' > & {
+interface MigrationSurveyProps {
 	countryCode: string;
-};
+}
 
 const getLink = ( country: Countries ) => {
 	return linkByCountry[ country ];
 };
 
-const MigrationSurvey = ( { isOpen, countryCode }: MigrationSurveyProps ) => {
+const MigrationSurvey = ( { countryCode }: MigrationSurveyProps ) => {
 	const surveyLink = getLink( countryCode as Countries );
 
 	return (
@@ -27,7 +27,6 @@ const MigrationSurvey = ( { isOpen, countryCode }: MigrationSurveyProps ) => {
 			name="migration-survey"
 			className="migration-survey"
 			title={ translate( 'Migration Survey' ) }
-			isOpen={ isOpen }
 		>
 			<div className="migration-survey__popup-img">
 				<img src={ surveyImage } alt={ translate( 'Code editor' ) } width={ 436 } height={ 249 } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/migration-survey/index.tsx
@@ -11,9 +11,9 @@ const linkByCountry = {
 
 type Countries = keyof typeof linkByCountry;
 
-interface MigrationSurveyProps {
+type MigrationSurveyProps = {
 	countryCode: string;
-}
+};
 
 const getLink = ( country: Countries ) => {
 	return linkByCountry[ country ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/index.tsx
@@ -5,16 +5,9 @@ import cookie from 'cookie';
 import React, { cloneElement, useCallback, useContext, useMemo, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import {
-	type SurveyContextType,
-	type SurveyActionsContextType,
-	type TriggerProps,
-	type SurveyProps,
-} from './types';
+import { type SurveyActionsContextType, type TriggerProps, type SurveyProps } from './types';
 export * from './types';
 import './style.scss';
-
-const SurveyContext = React.createContext< SurveyContextType | undefined >( undefined );
 
 export const SurveyActionsContext = React.createContext< SurveyActionsContextType >( {
 	accept: () => {},
@@ -85,18 +78,10 @@ const ONE_DAY_IN_SECONDS = 1000 * 60 * 60 * 24;
  * </Survey>
  * ```
  */
-export const Survey = ( {
-	children,
-	name,
-	onAccept,
-	onSkip,
-	isOpen = true,
-	title,
-	className,
-}: SurveyProps ) => {
+export const Survey = ( { children, name, onAccept, onSkip, title, className }: SurveyProps ) => {
 	const cookieValue = cookie.parse( document.cookie );
 	const shouldShow = ! cookieValue[ name ];
-	const [ shouldShowSurvey, setShouldShowSurvey ] = useState( isOpen && shouldShow );
+	const [ shouldShowSurvey, setShouldShowSurvey ] = useState( shouldShow );
 	const element = bemElement( className );
 	const handleClose = useCallback(
 		( reason: 'skip' | 'accept' | 'skip_backdrop' ) => {
@@ -144,38 +129,33 @@ export const Survey = ( {
 	}
 
 	return (
-		<SurveyContext.Provider value={ { isOpen } }>
-			<SurveyActionsContext.Provider value={ actions }>
-				<div aria-label={ name } className={ clsx( 'survey-notice', className ) }>
-					<SurveyTriggerSkip asChild>
-						<button className={ clsx( 'survey-notice__backdrop', element( 'backdrop' ) ) } />
-					</SurveyTriggerSkip>
-					<div className={ clsx( 'survey-notice__popup', element( 'popup' ) ) }>
-						<div className={ clsx( 'survey-notice__popup-head', element( 'popup-head' ) ) }>
-							<div
+		<SurveyActionsContext.Provider value={ actions }>
+			<div aria-label={ name } className={ clsx( 'survey-notice', className ) }>
+				<SurveyTriggerSkip asChild>
+					<button className={ clsx( 'survey-notice__backdrop', element( 'backdrop' ) ) } />
+				</SurveyTriggerSkip>
+				<div className={ clsx( 'survey-notice__popup', element( 'popup' ) ) }>
+					<div className={ clsx( 'survey-notice__popup-head', element( 'popup-head' ) ) }>
+						<div
+							className={ clsx( 'survey-notice__popup-head-title', element( 'popup-head-title' ) ) }
+						>
+							{ title }
+						</div>
+						<SurveyTriggerSkip asChild>
+							<Button
 								className={ clsx(
-									'survey-notice__popup-head-title',
-									element( 'popup-head-title' )
+									'survey-notice__popup-head-close',
+									element( 'popup-head-close' )
 								) }
 							>
-								{ title }
-							</div>
-							<SurveyTriggerSkip asChild>
-								<Button
-									className={ clsx(
-										'survey-notice__popup-head-close',
-										element( 'popup-head-close' )
-									) }
-								>
-									<Gridicon icon="cross" size={ 16 } />
-								</Button>
-							</SurveyTriggerSkip>
-						</div>
-
-						<div>{ children }</div>
+								<Gridicon icon="cross" size={ 16 } />
+							</Button>
+						</SurveyTriggerSkip>
 					</div>
+
+					<div>{ children }</div>
 				</div>
-			</SurveyActionsContext.Provider>
-		</SurveyContext.Provider>
+			</div>
+		</SurveyActionsContext.Provider>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/test/index.tsx
@@ -110,16 +110,6 @@ describe( 'Survey', () => {
 		expect( screen.queryByText( 'Survey' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'does not render the survey when isOpen is false', () => {
-		render(
-			<Survey name={ SURVEY_NAME } isOpen={ false }>
-				<h1>Survey</h1>
-			</Survey>
-		);
-
-		expect( screen.queryByText( 'Survey' ) ).not.toBeInTheDocument();
-	} );
-
 	it( 'use trigger as child for accept', async () => {
 		const onAccept = jest.fn();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/survey/types.ts
@@ -1,8 +1,5 @@
 import React, { PropsWithChildren } from 'react';
 
-export interface SurveyContextType {
-	isOpen: boolean;
-}
 export interface SurveyActionsContextType {
 	accept: () => void;
 	skip: () => void;
@@ -12,7 +9,6 @@ export interface SurveyProps extends PropsWithChildren {
 	name: string;
 	onAccept?: () => void;
 	onSkip?: () => void;
-	isOpen?: boolean;
 	className?: string;
 	title?: string;
 }


### PR DESCRIPTION
Related to #102722 (specifically https://github.com/Automattic/wp-calypso/pull/102722#discussion_r2052948714 )

## Proposed Changes

Removes unused `isOpen` prop from the Stepper's `Survey` component. In doing so, it also removes the `SurveyContext` context, which previously included only the `isOpen` value as a context value (not used).

## Why are these changes being made?

Removing unused code improves clarity and size of the code.

## Testing Instructions

Repeat Testing Instructions from #102722.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
