### PR TITLE
filterSites: deprecated /hosting-config/ no longer checks view_hosting capability

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -77,11 +77,8 @@ class Sites extends Component {
 		}
 
 		if ( /^\/hosting-config/.test( path ) ) {
-			if ( ! site.capabilities.view_hosting ) {
-				return false;
-			}
-
 			// allow both Atomic sites and Simple sites, so they can be exposed to upgrade notices.
+			// Note: This is a deprecated path, superceded by /hosting-features/ or /sites/settings/server/ as of 2025 April.
 			return true;
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Remove the check for "capabilities.view_hosting". This is no longer used, as /hosting-config/ has been replaced by /hosting-features/ or /sites/settings/server/. Each has their own set of robust checks when to display or not display.

Note that /hosting-config/ always redirects you and can no longer be visited:

- https://github.com/Automattic/wp-calypso/blob/d089005fe9240b4e68580809c6f17d6a148cde62/client/sites/hosting/index.tsx#L42
- https://github.com/Automattic/wp-calypso/blob/d089005fe9240b4e68580809c6f17d6a148cde62/client/hosting/overview/controller.tsx#L38-L40

"/hosting-config" is technically visitable, but nothing links there, and making every page load on calypso checking capabilities also compute "Can this site be transferred right now?" doesn't make sense in order to limit the sites shown on the unlinked page "/hosting-config".

## Why are these changes being made?

* To avoid calculating a server variable that isn't needed.

## Testing Instructions


* Visit calypso and make sure you can still view the "Hosting Settings" tab or "Server Settings" as before.

<img width="826" alt="Screenshot 2025-04-22 at 3 11 59 PM" src="https://github.com/user-attachments/assets/13400641-3e17-447b-859e-8f259a764953" />


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
