### PR TITLE
Checkout: List all refund policies in sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -12,12 +12,12 @@ import {
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, REFUNDS } from '@automattic/urls';
-import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
+import { isWpComProductRenewal as isRenewal, isValueTruthy } from '@automattic/wpcom-checkout';
 import { formatCurrency, useTranslate } from 'i18n-calypso';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { has100YearPlan, has100YearDomain } from 'calypso/lib/cart-values/cart-items';
 import CheckoutTermsItem from './checkout-terms-item';
-import type { ResponseCart } from '@automattic/shopping-cart';
+import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 
 export enum RefundPolicy {
 	DomainNameRegistration = 1,
@@ -46,126 +46,132 @@ export enum RefundPolicy {
 	DomainNameTransfer,
 }
 
-export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
+export function getRefundPolicyForCartItem(
+	cart: ResponseCart,
+	product: ResponseCartProduct
+): RefundPolicy | undefined {
 	const isGiftPurchase = cart.is_gift_purchase;
-
-	const refundPolicies: Array< RefundPolicy | undefined > = cart.products.map( ( product ) => {
-		if ( isGiftPurchase ) {
-			if ( isDomainRegistration( product ) ) {
-				return RefundPolicy.GiftDomainPurchase;
-			}
-
-			if ( isMonthlyProduct( product ) ) {
-				return RefundPolicy.GiftMonthlyPurchase;
-			}
-
-			if ( isYearly( product ) ) {
-				return RefundPolicy.GiftYearlyPurchase;
-			}
-
-			if ( isBiennially( product ) ) {
-				return RefundPolicy.GiftBiennialPurchase;
-			}
-		}
-
-		if ( isGoogleWorkspaceExtraLicence( product ) ) {
-			return RefundPolicy.NonRefundable;
-		}
-
-		if ( ! product.item_subtotal_integer ) {
-			return undefined;
-		}
-
+	if ( isGiftPurchase ) {
 		if ( isDomainRegistration( product ) ) {
-			if ( has100YearDomain( cart ) ) {
-				return RefundPolicy.GenericCentennial;
-			}
-
-			if ( isRenewal( product ) ) {
-				return RefundPolicy.DomainNameRenewal;
-			}
-			return RefundPolicy.DomainNameRegistration;
-		}
-
-		if ( isDomainTransfer( product ) ) {
-			if ( has100YearDomain( cart ) ) {
-				return RefundPolicy.GenericCentennial;
-			}
-
-			return RefundPolicy.DomainNameTransfer;
-		}
-
-		if ( product.product_slug === 'premium_theme' ) {
-			return RefundPolicy.PremiumTheme;
-		}
-
-		if ( isPlan( product ) ) {
-			// Monthly plans can have an associated "bundled" domain, even if the domain price
-			// ultimately isn't free (i.e. it's not a real bundle). For that reason, we look at
-			// `product.extra.domain_to_bundle` here instead of `cart.bundled_domain`.
-			if ( product.extra?.domain_to_bundle ) {
-				if ( isMonthlyProduct( product ) ) {
-					return RefundPolicy.PlanMonthlyBundle;
-				}
-
-				if ( isYearly( product ) ) {
-					return RefundPolicy.PlanYearlyBundle;
-				}
-
-				if ( isBiennially( product ) ) {
-					return RefundPolicy.PlanBiennialBundle;
-				}
-
-				if ( isTriennially( product ) ) {
-					return RefundPolicy.PlanTriennialBundle;
-				}
-
-				if ( isCentennially( product ) ) {
-					return RefundPolicy.PlanCentennialBundle;
-				}
-			}
-
-			if ( isRenewal( product ) ) {
-				if ( isMonthlyProduct( product ) ) {
-					return RefundPolicy.PlanMonthlyRenewal;
-				}
-
-				if ( isYearly( product ) ) {
-					return RefundPolicy.PlanYearlyRenewal;
-				}
-
-				if ( isBiennially( product ) ) {
-					return RefundPolicy.PlanBiennialRenewal;
-				}
-
-				if ( isTriennially( product ) ) {
-					return RefundPolicy.PlanTriennialRenewal;
-				}
-			}
+			return RefundPolicy.GiftDomainPurchase;
 		}
 
 		if ( isMonthlyProduct( product ) ) {
-			return RefundPolicy.GenericMonthly;
+			return RefundPolicy.GiftMonthlyPurchase;
 		}
 
 		if ( isYearly( product ) ) {
-			return RefundPolicy.GenericYearly;
+			return RefundPolicy.GiftYearlyPurchase;
 		}
 
 		if ( isBiennially( product ) ) {
-			return RefundPolicy.GenericBiennial;
+			return RefundPolicy.GiftBiennialPurchase;
 		}
+	}
 
-		if ( isTriennially( product ) ) {
-			return RefundPolicy.GenericTriennial;
-		}
+	if ( isGoogleWorkspaceExtraLicence( product ) ) {
+		return RefundPolicy.NonRefundable;
+	}
 
-		if ( isCentennially( product ) ) {
+	if ( ! product.item_subtotal_integer ) {
+		return undefined;
+	}
+
+	if ( isDomainRegistration( product ) ) {
+		if ( has100YearDomain( cart ) ) {
 			return RefundPolicy.GenericCentennial;
 		}
 
-		return RefundPolicy.NonRefundable;
-	} );
+		if ( isRenewal( product ) ) {
+			return RefundPolicy.DomainNameRenewal;
+		}
+		return RefundPolicy.DomainNameRegistration;
+	}
+
+	if ( isDomainTransfer( product ) ) {
+		if ( has100YearDomain( cart ) ) {
+			return RefundPolicy.GenericCentennial;
+		}
+
+		return RefundPolicy.DomainNameTransfer;
+	}
+
+	if ( product.product_slug === 'premium_theme' ) {
+		return RefundPolicy.PremiumTheme;
+	}
+
+	if ( isPlan( product ) ) {
+		// Monthly plans can have an associated "bundled" domain, even if the domain price
+		// ultimately isn't free (i.e. it's not a real bundle). For that reason, we look at
+		// `product.extra.domain_to_bundle` here instead of `cart.bundled_domain`.
+		if ( product.extra?.domain_to_bundle ) {
+			if ( isMonthlyProduct( product ) ) {
+				return RefundPolicy.PlanMonthlyBundle;
+			}
+
+			if ( isYearly( product ) ) {
+				return RefundPolicy.PlanYearlyBundle;
+			}
+
+			if ( isBiennially( product ) ) {
+				return RefundPolicy.PlanBiennialBundle;
+			}
+
+			if ( isTriennially( product ) ) {
+				return RefundPolicy.PlanTriennialBundle;
+			}
+
+			if ( isCentennially( product ) ) {
+				return RefundPolicy.PlanCentennialBundle;
+			}
+		}
+
+		if ( isRenewal( product ) ) {
+			if ( isMonthlyProduct( product ) ) {
+				return RefundPolicy.PlanMonthlyRenewal;
+			}
+
+			if ( isYearly( product ) ) {
+				return RefundPolicy.PlanYearlyRenewal;
+			}
+
+			if ( isBiennially( product ) ) {
+				return RefundPolicy.PlanBiennialRenewal;
+			}
+
+			if ( isTriennially( product ) ) {
+				return RefundPolicy.PlanTriennialRenewal;
+			}
+		}
+	}
+
+	if ( isMonthlyProduct( product ) ) {
+		return RefundPolicy.GenericMonthly;
+	}
+
+	if ( isYearly( product ) ) {
+		return RefundPolicy.GenericYearly;
+	}
+
+	if ( isBiennially( product ) ) {
+		return RefundPolicy.GenericBiennial;
+	}
+
+	if ( isTriennially( product ) ) {
+		return RefundPolicy.GenericTriennial;
+	}
+
+	if ( isCentennially( product ) ) {
+		return RefundPolicy.GenericCentennial;
+	}
+
+	return RefundPolicy.NonRefundable;
+}
+
+export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
+	const refundPolicies = cart.products.map( ( product ) =>
+		getRefundPolicyForCartItem( cart, product )
+	);
 
 	const cartHasPlanBundlePolicy = refundPolicies.some(
 		( refundPolicy ) =>
@@ -191,45 +197,45 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 	);
 }
 
-type RefundWindow = 4 | 7 | 14 | 120;
+export type RefundWindow = 4 | 7 | 14 | 120;
+
+export function getRefundWindowForPolicy( refundPolicy: RefundPolicy ): RefundWindow | undefined {
+	switch ( refundPolicy ) {
+		case RefundPolicy.DomainNameTransfer:
+			return undefined;
+
+		case RefundPolicy.DomainNameRegistration:
+		case RefundPolicy.DomainNameRegistrationBundled:
+		case RefundPolicy.DomainNameRenewal:
+			return 4;
+
+		case RefundPolicy.GenericMonthly:
+		case RefundPolicy.PlanMonthlyBundle:
+			return 7;
+
+		case RefundPolicy.PlanBiennialBundle:
+		case RefundPolicy.PlanTriennialBundle:
+		case RefundPolicy.PlanYearlyBundle:
+		case RefundPolicy.PlanBiennialRenewal:
+		case RefundPolicy.PlanTriennialRenewal:
+		case RefundPolicy.PlanYearlyRenewal:
+		case RefundPolicy.GenericBiennial:
+		case RefundPolicy.GenericTriennial:
+		case RefundPolicy.GenericYearly:
+		case RefundPolicy.PremiumTheme:
+			return 14;
+
+		case RefundPolicy.GenericCentennial:
+		case RefundPolicy.PlanCentennialBundle:
+			return 120;
+	}
+	return undefined;
+}
 
 // Get the refund windows in days for the items in the cart
 export function getRefundWindows( refundPolicies: RefundPolicy[] ): RefundWindow[] {
-	const refundWindows = refundPolicies.map( ( refundPolicy ) => {
-		switch ( refundPolicy ) {
-			case RefundPolicy.DomainNameTransfer:
-				return 0;
-
-			case RefundPolicy.DomainNameRegistration:
-			case RefundPolicy.DomainNameRegistrationBundled:
-			case RefundPolicy.DomainNameRenewal:
-				return 4;
-
-			case RefundPolicy.GenericMonthly:
-			case RefundPolicy.PlanMonthlyBundle:
-				return 7;
-
-			case RefundPolicy.PlanBiennialBundle:
-			case RefundPolicy.PlanTriennialBundle:
-			case RefundPolicy.PlanYearlyBundle:
-			case RefundPolicy.PlanBiennialRenewal:
-			case RefundPolicy.PlanTriennialRenewal:
-			case RefundPolicy.PlanYearlyRenewal:
-			case RefundPolicy.GenericBiennial:
-			case RefundPolicy.GenericTriennial:
-			case RefundPolicy.GenericYearly:
-			case RefundPolicy.PremiumTheme:
-				return 14;
-
-			case RefundPolicy.GenericCentennial:
-			case RefundPolicy.PlanCentennialBundle:
-				return 120;
-		}
-	} );
-
-	return Array.from( new Set( refundWindows ) ).filter(
-		( refundWindow ): refundWindow is RefundWindow => refundWindow !== undefined
-	);
+	const refundWindows = refundPolicies.map( getRefundWindowForPolicy );
+	return Array.from( new Set( refundWindows ) ).filter( isValueTruthy );
 }
 
 function RefundPolicyItem( {

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -192,9 +192,7 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 		refundPolicies.push( RefundPolicy.DomainNameRegistrationBundled );
 	}
 
-	return Array.from( new Set( refundPolicies ) ).filter(
-		( refundPolicy ): refundPolicy is RefundPolicy => refundPolicy !== undefined
-	);
+	return Array.from( new Set( refundPolicies ) ).filter( isValueTruthy );
 }
 
 export type RefundWindow = 4 | 7 | 14 | 120;

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -200,6 +200,12 @@ export type RefundWindow = 4 | 7 | 14 | 120;
 export function getRefundWindowForPolicy( refundPolicy: RefundPolicy ): RefundWindow | undefined {
 	switch ( refundPolicy ) {
 		case RefundPolicy.DomainNameTransfer:
+			// Domain transfers have a complicated refund window. They can be
+			// fully refunded any time until the domain transfer process
+			// completes, at which point they (and the domain registration
+			// itself) are non-refundable. This is explained via a notice in
+			// the checkout footer but cannot be simply represented here, so we
+			// display nothing instead.
 			return undefined;
 
 		case RefundPolicy.DomainNameRegistration:

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -39,7 +39,6 @@ import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { formatCurrency, useTranslate } from 'i18n-calypso';
-import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -315,18 +314,20 @@ function CheckoutSummaryGiftFeaturesList( { siteSlug }: { siteSlug: string } ) {
 }
 
 function CheckoutSummaryRefundWindow( {
-	cart,
-	product,
+	products,
+	policy,
 	highlight,
 	includeRefundIcon,
 }: {
-	cart: ResponseCart;
-	product: ResponseCartProduct;
+	products: ResponseCartProduct[];
+	policy: RefundPolicy;
 	highlight?: boolean;
 	includeRefundIcon?: boolean;
 } ) {
 	const translate = useTranslate();
-	const policy = getRefundPolicyForCartItem( cart, product );
+	if ( products.length < 1 ) {
+		return null;
+	}
 	// FIXME: add the RefundPolicy.DomainNameRegistrationBundled policy if the
 	// cart has no bundle policy currently (eg: RefundPolicy.PlanYearlyBundle)
 	// and currently contains a plan + bundled domain, and the plan is not a
@@ -345,8 +346,7 @@ function CheckoutSummaryRefundWindow( {
 			count: refundWindow,
 			args: {
 				days: refundWindow,
-				// FIXME: list all products affected by this refund window, not only one
-				product: product?.product_name ?? '',
+				product: products.map( getProductNameForRefundWindow ).join( ', ' ),
 			},
 		}
 	);
@@ -361,9 +361,16 @@ function CheckoutSummaryRefundWindow( {
 	);
 }
 
+function getProductNameForRefundWindow( product: ResponseCartProduct ): string {
+	if ( product.meta ) {
+		return `${ product.product_name }: ${ product.meta }`;
+	}
+	return product.product_name;
+}
+
 export function CheckoutSummaryRefundWindows( {
 	cart,
-	highlight = false,
+	highlight,
 	includeRefundIcon,
 }: {
 	cart: ResponseCart;
@@ -376,21 +383,27 @@ export function CheckoutSummaryRefundWindows( {
 			return grouped;
 		}
 		if ( ! grouped.has( policy ) ) {
-			grouped.set( policy, product );
+			grouped.set( policy, [ product ] );
+			return grouped;
+		}
+		if ( grouped.has( policy ) ) {
+			const products = grouped.get( policy ) ?? [];
+			grouped.set( policy, [ ...products, product ] );
 		}
 		return grouped;
-	}, new Map< RefundPolicy, ResponseCartProduct >() );
-	return cartItemsGroupedByRefundPolicy
-		.values()
-		.map( ( product ) => (
+	}, new Map< RefundPolicy, ResponseCartProduct[] >() );
+	const cartItemGroups = [ ...cartItemsGroupedByRefundPolicy.entries() ];
+	return cartItemGroups.map( ( [ policy, products ] ) => {
+		return (
 			<CheckoutSummaryRefundWindow
-				key={ product.uuid }
-				cart={ cart }
-				product={ product }
+				key={ products[ 0 ].uuid }
+				products={ products }
+				policy={ policy }
 				highlight={ highlight }
 				includeRefundIcon={ includeRefundIcon }
 			/>
-		) );
+		);
+	} );
 }
 
 export function CheckoutSummaryFeaturesList( props: {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -328,10 +328,6 @@ function CheckoutSummaryRefundWindow( {
 	if ( products.length < 1 ) {
 		return null;
 	}
-	// FIXME: add the RefundPolicy.DomainNameRegistrationBundled policy if the
-	// cart has no bundle policy currently (eg: RefundPolicy.PlanYearlyBundle)
-	// and currently contains a plan + bundled domain, and the plan is not a
-	// 100-year plan.
 	if ( ! policy ) {
 		return null;
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -52,9 +52,12 @@ import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
 import { CheckIcon } from './check-icon';
 import { ProductsAndCostOverridesList } from './cost-overrides-list';
-import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
+import {
+	getRefundPolicyForCartItem,
+	getRefundWindowForPolicy,
+	RefundPolicy,
+} from './refund-policies';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
-import type { TranslateResult } from 'i18n-calypso';
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -311,104 +314,42 @@ function CheckoutSummaryGiftFeaturesList( { siteSlug }: { siteSlug: string } ) {
 	);
 }
 
-export function CheckoutSummaryRefundWindows( {
+function CheckoutSummaryRefundWindow( {
 	cart,
-	highlight = false,
+	product,
+	highlight,
 	includeRefundIcon,
 }: {
 	cart: ResponseCart;
+	product: ResponseCartProduct;
 	highlight?: boolean;
 	includeRefundIcon?: boolean;
 } ) {
 	const translate = useTranslate();
-
-	const refundPolicies = getRefundPolicies( cart );
-	const refundWindows = getRefundWindows( refundPolicies );
-
-	if ( ! refundWindows.length || refundPolicies.includes( RefundPolicy.NonRefundable ) ) {
+	const policy = getRefundPolicyForCartItem( cart, product );
+	// FIXME: add the RefundPolicy.DomainNameRegistrationBundled policy if the
+	// cart has no bundle policy currently (eg: RefundPolicy.PlanYearlyBundle)
+	// and currently contains a plan + bundled domain, and the plan is not a
+	// 100-year plan.
+	if ( ! policy ) {
 		return null;
 	}
-
-	const allCartItemsAreDomains = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.DomainNameRegistrationBundled ||
-			refundPolicy === RefundPolicy.DomainNameRenewal
-	);
-
-	if ( allCartItemsAreDomains ) {
+	const refundWindow = getRefundWindowForPolicy( policy );
+	if ( ! refundWindow ) {
 		return null;
 	}
-
-	const allCartItemsAreMonthlyPlanBundle = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRegistration ||
-			refundPolicy === RefundPolicy.PlanMonthlyBundle
-	);
-
-	const allCartItemsArePlanOrDomainRenewals = refundPolicies.every(
-		( refundPolicy ) =>
-			refundPolicy === RefundPolicy.DomainNameRenewal ||
-			refundPolicy === RefundPolicy.PlanMonthlyRenewal ||
-			refundPolicy === RefundPolicy.PlanYearlyRenewal ||
-			refundPolicy === RefundPolicy.PlanBiennialRenewal
-	);
-
-	let text: TranslateResult;
-
-	if ( refundWindows.length === 1 ) {
-		const refundWindow = refundWindows[ 0 ];
-		const planBundleRefundPolicy = refundPolicies.find(
-			( refundPolicy ) =>
-				refundPolicy === RefundPolicy.PlanBiennialBundle ||
-				refundPolicy === RefundPolicy.PlanYearlyBundle
-		);
-		const planProduct = cart.products.find( isPlan );
-
-		if ( planBundleRefundPolicy ) {
-			// Using plural translation because some languages have multiple plural forms and no plural-agnostic.
-			text = translate(
-				'%(days)d-day money back guarantee for %(product)s',
-				'%(days)d-day money back guarantee for %(product)s',
-				{
-					count: refundWindow,
-					args: {
-						days: refundWindow,
-						product: planProduct?.product_name ?? '',
-					},
-				}
-			);
-		} else {
-			text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
-				count: refundWindow,
-				args: { days: refundWindow },
-			} );
+	const text = translate(
+		'%(days)d-day money back guarantee for %(product)s',
+		'%(days)d-day money back guarantee for %(product)s',
+		{
+			count: refundWindow,
+			args: {
+				days: refundWindow,
+				// FIXME: list all products affected by this refund window, not only one
+				product: product?.product_name ?? '',
+			},
 		}
-	} else if ( allCartItemsAreMonthlyPlanBundle || allCartItemsArePlanOrDomainRenewals ) {
-		const refundWindow = Math.max( ...refundWindows );
-		const planProduct = cart.products.find( isPlan );
-
-		text = translate(
-			'%(days)d-day money back guarantee for %(product)s',
-			'%(days)d-day money back guarantee for %(product)s',
-			{
-				count: refundWindow,
-				args: {
-					days: refundWindow,
-					product: planProduct?.product_name ?? '',
-				},
-			}
-		);
-	} else {
-		const shortestRefundWindow = Math.min( ...refundWindows );
-
-		text = translate( '%(days)d-day money back guarantee', '%(days)d-day money back guarantee', {
-			count: shortestRefundWindow,
-			args: { days: shortestRefundWindow },
-			comment: 'The number of days until the shortest refund window in the cart expires.',
-		} );
-	}
-
+	);
 	return (
 		<>
 			{ includeRefundIcon && <StyledIcon icon={ reusableBlock } size={ 24 } /> }
@@ -418,6 +359,38 @@ export function CheckoutSummaryRefundWindows( {
 			</CheckoutSummaryFeaturesListItem>
 		</>
 	);
+}
+
+export function CheckoutSummaryRefundWindows( {
+	cart,
+	highlight = false,
+	includeRefundIcon,
+}: {
+	cart: ResponseCart;
+	highlight?: boolean;
+	includeRefundIcon?: boolean;
+} ) {
+	const cartItemsGroupedByRefundPolicy = cart.products.reduce( ( grouped, product ) => {
+		const policy = getRefundPolicyForCartItem( cart, product );
+		if ( ! policy ) {
+			return grouped;
+		}
+		if ( ! grouped.has( policy ) ) {
+			grouped.set( policy, product );
+		}
+		return grouped;
+	}, new Map< RefundPolicy, ResponseCartProduct >() );
+	return cartItemsGroupedByRefundPolicy
+		.values()
+		.map( ( product ) => (
+			<CheckoutSummaryRefundWindow
+				key={ product.uuid }
+				cart={ cart }
+				product={ product }
+				highlight={ highlight }
+				includeRefundIcon={ includeRefundIcon }
+			/>
+		) );
 }
 
 export function CheckoutSummaryFeaturesList( props: {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -708,7 +708,10 @@ function CheckoutSummaryPlanFeatures( props: {
 				}
 
 				return (
-					<CheckoutSummaryFeaturesListItem key={ String( feature ) } isSupported={ isSupported }>
+					<CheckoutSummaryFeaturesListItem
+						key={ String( feature ) }
+						isNotSupported={ ! isSupported }
+					>
 						{ isSupported ? <WPCheckoutCheckIcon /> : <WPCheckoutCrossIcon /> }
 						{ feature }
 					</CheckoutSummaryFeaturesListItem>
@@ -793,14 +796,14 @@ function CheckoutSummaryAnnualUpsell( props: {
 			</CheckoutSummaryFeaturesTitle>
 			<CheckoutSummaryFeaturesListWrapper>
 				{ shouldShowFreeDomainUpsell && (
-					<CheckoutSummaryFeaturesListItem isSupported={ false }>
+					<CheckoutSummaryFeaturesListItem isNotSupported>
 						<WPCheckoutCheckIcon />
 						{ translate( 'Free domain for one year' ) }
 					</CheckoutSummaryFeaturesListItem>
 				) }
 				{ hasEnTranslation( 'Fast support' ) && hasEnTranslation( 'Priority support 24/7' )
 					? ! isWpComPersonalPlan( productSlug ) && (
-							<CheckoutSummaryFeaturesListItem isSupported={ false }>
+							<CheckoutSummaryFeaturesListItem isNotSupported>
 								<WPCheckoutCheckIcon />
 								{ isWpComPremiumPlan( productSlug )
 									? translate( 'Fast support' )
@@ -808,7 +811,7 @@ function CheckoutSummaryAnnualUpsell( props: {
 							</CheckoutSummaryFeaturesListItem>
 					  )
 					: ! isWpComPersonalPlan( productSlug ) && (
-							<CheckoutSummaryFeaturesListItem isSupported={ false }>
+							<CheckoutSummaryFeaturesListItem isNotSupported>
 								<WPCheckoutCheckIcon />
 								{ translate( 'Live chat support' ) }
 							</CheckoutSummaryFeaturesListItem>
@@ -906,21 +909,18 @@ const StyledGridicon = styled( Gridicon )`
 
 const WPCheckoutCrossIcon = () => <StyledGridicon icon="cross" size={ 20 } />;
 
-const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean } >`
+const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isNotSupported?: boolean } >`
 	margin-bottom: 4px;
 	padding-left: 24px;
 	position: relative;
 	overflow-wrap: break-word;
-	color: ${ ( props ) => ( props.isSupported ? 'inherit' : props.theme.colors.textColorLight ) };
+	color: ${ ( props ) => ( props.isNotSupported ? props.theme.colors.textColorLight : 'inherit' ) };
 
 	.rtl & {
 		padding-right: 24px;
 		padding-left: 0;
 	}
 `;
-CheckoutSummaryFeaturesListItem.defaultProps = {
-	isSupported: true,
-};
 
 const CheckoutSubtotalSection = styled.div`
 	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };


### PR DESCRIPTION
## Proposed Changes

This PR modifies the `CheckoutSummaryRefundWindows` component used by checkout to show the refund policy in the feature list (shown in the sidebar at wide widths and collapsed at the top at small widths). Previously, the component would try to pick the most reasonable refund window text to display for all of them (mainly it will try to pick the shortest refund window). However, given the complexity of the products we sell, this can be difficult to do correctly.

Notably, Domain Transfer products can only be refunded before the domain transfer completes, at which point they become non-refundable. This is difficult to display in a small space so it's explained in the checkout footer (see https://github.com/Automattic/wp-calypso/pull/85468). Unfortunately, the way this was implemented means that any cart with a domain transfer will render "0-day money back guarantee".

In this PR, we refactor the component to instead display a list of every refund window for the items in the cart. Each line will display one refund window text string followed by a list of all the products in the cart to which that refund window applies.

Fixes https://linear.app/a8c/issue/SHILL-232/checkout-various-refund-window-bugs

## Screenshots

### Plan + Domain + Domain Transfer

Before             |  After
:-------------------------:|:-------------------------:
<img width="328" alt="before-102758-2" src="https://github.com/user-attachments/assets/31b4f96e-d446-44f8-a751-2a1500809aec" /> | <img width="328" alt="after-102758-2" src="https://github.com/user-attachments/assets/ac9730d5-a476-4575-a421-05c7a22459bb" />

## Testing Instructions

There are many scenarios that can be tested, but here's some notable ones. 

For domains with an annual plan, you'll need to actually have _two_ domains because the first will be required to take up the bundled domain credit (which is free and therefore has no refund period).

- A monthly plan and a (not bundled) domain transfer (7 days for the plan, nothing for the domain transfer).
- An annual plan in cart and a (not bundled) domain registration (14 days for the plan, 4 days for the domain).
- Monthly plan and (not bundled) annual domain registration (7 days for the plan, 4 days for the domain).
- Akismet intro offer (14 days).
- Akismet monthly (7 days).
