### PR TITLE
SiteDetailsCapabilities: Make view_hosting optional

### DIFF
--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -214,7 +214,10 @@ export interface SiteDetailsCapabilities {
 	remove_users: boolean;
 	upload_files: boolean;
 	update_plugins: boolean;
-	view_hosting: boolean;
+	/**
+	 * @deprecated `view_hosting` is no longer used and will be removed in a future release.
+	 */
+	view_hosting?: boolean;
 	view_stats: boolean;
 }
 


### PR DESCRIPTION
Related to #

## Proposed Changes

* Mark view_hosting as optional for eventual removal.

## Why are these changes being made?

* View_hosting was introduced for `/hosting-config/`. However, we no longer use `/hosting-config/` and instead use `/hosting-features/` or `/sites/settings/server/`. Each of these has their own access control checking the status of the site independent from view_hosting.
  * On the backend, view_hosting does an expensive check, so let's remove it so we don't need to do these for casual browsing of calypso.

## Testing Instructions


* Visit calypso and make sure you can still view the "Hosting Settings" tab or "Server Settings" as before.

<img width="826" alt="Screenshot 2025-04-22 at 3 11 59 PM" src="https://github.com/user-attachments/assets/13400641-3e17-447b-859e-8f259a764953" />


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
