### PR TITLE
Stats: add new navigation header component with slots

### DIFF
--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -16,7 +16,6 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-
 	}
 
 	&__left-section {

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -6,6 +6,7 @@
 	background-color: var(--wp-components-color-background, #fff);
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 	width: 100%;
+	padding: 24px 0;
 
 	&__head {
 		display: flex;

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -3,12 +3,21 @@
 @import "@wordpress/base-styles/variables";
 
 .calypso-navigation-header {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
 	background-color: var(--wp-components-color-background, #fff);
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 	width: 100%;
+
+	&__head {
+		display: flex;
+		align-items: center;
+	}
+
+	&__body {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+	}
 
 	&__left-section {
 		display: flex;
@@ -90,6 +99,7 @@
 	&.calypso-navigation-header__screen-options-tab {
 		padding-top: 38px; // 30 for screen options tab + 8 gap
 	}
+
 	@include break-small {
 		&.calypso-navigation-header__screen-options-tab {
 			// There are existing workarounds for desktop layouts, revert back to 16 here

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -58,43 +58,6 @@
 		align-items: center;
 	}
 
-	&__action-button {
-		padding: $grid-unit-10 $grid-unit-20;
-		background-color: var(--wp-components-color-accent, #2e7d32);
-		color: var(--wp-components-color-accent-inverted, #fff);
-		border: none;
-		border-radius: $grid-unit-05;
-		font-size: $default-font-size;
-		cursor: pointer;
-		transition: background-color 0.2s ease;
-
-		&:hover {
-			background-color: var(--wp-components-color-accent-darker-20, #1b5e20);
-		}
-
-		@media (max-width: $break-small) {
-			padding: $grid-unit-10 $grid-unit-15;
-			font-size: $mobile-text-min-font-size;
-		}
-	}
-
-	&__download-link {
-		display: flex;
-		align-items: center;
-		text-decoration: none;
-		color: var(--wp-components-color-accent, #2e7d32);
-		font-size: $default-font-size;
-		transition: color 0.2s ease;
-
-		svg {
-			margin-right: $grid-unit-10;
-		}
-
-		&:hover {
-			color: var(--wp-components-color-accent-darker-20, #1b5e20);
-		}
-	}
-
 	// Add extra space when there is a classic/non classic option tab at the top on mobile that collides with cta's
 	&.calypso-navigation-header__screen-options-tab {
 		padding-top: 38px; // 30 for screen options tab + 8 gap

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -1,0 +1,103 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.calypso-navigation-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	background-color: var(--wp-components-color-background, #fff);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+	width: 100%;
+
+	&__left-section {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-20;
+	}
+
+	&__back-link {
+		display: flex;
+		align-items: center;
+		text-decoration: none;
+		color: var(--wp-components-color-gray-600, #666);
+		font-size: $default-font-size;
+		transition: color 0.2s ease;
+
+		&:hover {
+			color: var(--wp-components-color-gray-900, #333);
+		}
+
+		svg {
+			margin-right: $grid-unit-10;
+		}
+	}
+
+	&__title {
+		margin: 0;
+		font-size: 24px;
+		font-weight: 500;
+		color: var(--wp-components-color-gray-900, #333);
+
+		@media (max-width: $break-small) {
+			font-size: 20px;
+		}
+	}
+
+	&__right-section {
+		display: flex;
+		align-items: center;
+	}
+
+	&__action-button {
+		padding: $grid-unit-10 $grid-unit-20;
+		background-color: var(--wp-components-color-accent, #2e7d32);
+		color: var(--wp-components-color-accent-inverted, #fff);
+		border: none;
+		border-radius: $grid-unit-05;
+		font-size: $default-font-size;
+		cursor: pointer;
+		transition: background-color 0.2s ease;
+
+		&:hover {
+			background-color: var(--wp-components-color-accent-darker-20, #1b5e20);
+		}
+
+		@media (max-width: $break-small) {
+			padding: $grid-unit-10 $grid-unit-15;
+			font-size: $mobile-text-min-font-size;
+		}
+	}
+
+	&__download-link {
+		display: flex;
+		align-items: center;
+		text-decoration: none;
+		color: var(--wp-components-color-accent, #2e7d32);
+		font-size: $default-font-size;
+		transition: color 0.2s ease;
+
+		svg {
+			margin-right: $grid-unit-10;
+		}
+
+		&:hover {
+			color: var(--wp-components-color-accent-darker-20, #1b5e20);
+		}
+	}
+
+	// Add extra space when there is a classic/non classic option tab at the top on mobile that collides with cta's
+	&.calypso-navigation-header__screen-options-tab {
+		padding-top: 38px; // 30 for screen options tab + 8 gap
+	}
+	@include break-small {
+		&.calypso-navigation-header__screen-options-tab {
+			// There are existing workarounds for desktop layouts, revert back to 16 here
+			padding-top: $grid-unit-20;
+		}
+	}
+}
+
+#primary header.calypso-navigation-header header.formatted-header {
+	margin: 0;
+}

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -70,7 +70,3 @@
 		}
 	}
 }
-
-#primary header.calypso-navigation-header header.formatted-header {
-	margin: 0;
-}

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -3,39 +3,15 @@ import { ReactNode } from 'react';
 import './navigation-header.scss';
 
 // Type definitions for the props
-interface ButtonProps extends React.ButtonHTMLAttributes< HTMLButtonElement > {
-	text?: string;
-	onClick?: ( e: React.MouseEvent< HTMLButtonElement > ) => void;
-}
-
-interface DownloadProps extends React.AnchorHTMLAttributes< HTMLAnchorElement > {
-	text?: string;
-	href?: string;
-	download?: boolean | string;
-}
-
 interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
 	title?: string;
 	backLink?: string;
 	backLinkText?: string;
-	rightElement?: ReactNode;
 	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
-	buttonProps?: ButtonProps;
-	downloadProps?: DownloadProps;
 	titleElement?: ReactNode;
 	children?: ReactNode;
 	hasScreenOptionsTab?: boolean;
 }
-
-// Download icon component
-const DownloadIcon: React.FC = () => (
-	<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<path
-			d="M14 8.3L13 7.2L9 11.2V0H7.5V11.3L3 7.2L2 8.3L8.2 14.1L14 8.3ZM14.5 12V15.5H1.5V12H0V17H16V12H14.5Z"
-			fill="#008710"
-		/>
-	</svg>
-);
 
 /**
  * Header component that can be used in various contexts
@@ -44,10 +20,7 @@ const DownloadIcon: React.FC = () => (
  * @param props.title - Header title text
  * @param props.backLink - URL for the back button
  * @param props.backLinkText - Text for the back button
- * @param props.rightElement - Custom element to display on the right side
  * @param props.onBackClick - Function to call when back button is clicked
- * @param props.buttonProps - Props for the action button if used
- * @param props.downloadProps - Props for the download link if used
  * @param props.titleElement - Custom element to override default title rendering
  * @param props.children - Child elements to render in the right section
  * @param props.hasScreenOptionsTab - Indicates whether the screen options tab should be added
@@ -57,45 +30,12 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 	title,
 	backLink,
 	backLinkText = translate( 'Back' ),
-	rightElement,
 	onBackClick,
 	titleElement = <h1 className="calypso-navigation-header__title">{ title }</h1>,
-	buttonProps,
-	downloadProps,
 	children,
 	hasScreenOptionsTab,
 	...rest
 } ) => {
-	// Determine what to render on the right side
-	const renderRightElement = (): ReactNode => {
-		if ( rightElement ) {
-			return rightElement;
-		} else if ( buttonProps ) {
-			return (
-				<button
-					className="calypso-navigation-header__action-button"
-					onClick={ buttonProps.onClick }
-					{ ...buttonProps }
-				>
-					{ buttonProps.text || 'View post' }
-				</button>
-			);
-		} else if ( downloadProps ) {
-			return (
-				<a
-					className="calypso-navigation-header__download-link"
-					href={ downloadProps.href || '#' }
-					download={ downloadProps.download }
-					{ ...downloadProps }
-				>
-					<DownloadIcon />
-					{ downloadProps.text || 'Download CSV' }
-				</a>
-			);
-		}
-		return null;
-	};
-
 	return (
 		<header
 			className={ `calypso-navigation-header${
@@ -121,10 +61,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 			</div>
 			<div className="calypso-navigation-header__body">
 				<div className="calypso-navigation-header__left-section">{ titleElement }</div>
-				<div className="calypso-navigation-header__right-section">
-					{ renderRightElement() }
-					{ children }
-				</div>
+				<div className="calypso-navigation-header__right-section">{ children }</div>
 			</div>
 		</header>
 	);

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -15,13 +15,14 @@ interface DownloadProps extends React.AnchorHTMLAttributes< HTMLAnchorElement > 
 }
 
 interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
-	title: string;
+	title?: string;
 	backLink?: string;
 	backLinkText?: string;
 	rightElement?: ReactNode;
 	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
 	buttonProps?: ButtonProps;
 	downloadProps?: DownloadProps;
+	titleElement?: ReactNode;
 	children?: ReactNode;
 }
 
@@ -76,6 +77,7 @@ const DownloadIcon: React.FC = () => (
  * @param props.onBackClick - Function to call when back button is clicked
  * @param props.buttonProps - Props for the action button if used
  * @param props.downloadProps - Props for the download link if used
+ * @param props.titleElement - Custom element to override default title rendering
  * @param props.children - Child elements to render in the right section
  * @returns The rendered NavigationHeader component
  */
@@ -85,6 +87,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 	backLinkText = translate( 'Back' ),
 	rightElement,
 	onBackClick,
+	titleElement = <h1 className="calypso-navigation-header__title">{ title }</h1>,
 	buttonProps,
 	downloadProps,
 	children,
@@ -122,7 +125,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 
 	return (
 		<header className="calypso-navigation-header" { ...rest }>
-			<div className="calypso-navigation-header__left-section">
+			<div className="calypso-navigation-header__head">
 				{ backLink && (
 					<a
 						className="calypso-navigation-header__back-link"
@@ -137,11 +140,13 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 						<ArrowLeftIcon /> { backLinkText }
 					</a>
 				) }
-				<h1 className="calypso-navigation-header__title">{ title }</h1>
 			</div>
-			<div className="calypso-navigation-header__right-section">
-				{ renderRightElement() }
-				{ children }
+			<div className="calypso-navigation-header__body">
+				<div className="calypso-navigation-header__left-section">{ titleElement }</div>
+				<div className="calypso-navigation-header__right-section">
+					{ renderRightElement() }
+					{ children }
+				</div>
 			</div>
 		</header>
 	);

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -3,13 +3,17 @@ import { ReactNode } from 'react';
 import './navigation-header.scss';
 
 // Type definitions for the props
-interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
-	title?: string;
+interface BackLinkProps {
 	backLink?: string;
 	backLinkText?: string;
 	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
+}
+
+interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
+	title?: string;
+	backLinkProps?: BackLinkProps;
 	titleElement?: ReactNode;
-	linkElement?: ReactNode;
+	headElement?: ReactNode;
 	children?: ReactNode;
 	hasScreenOptionsTab?: boolean;
 }
@@ -30,22 +34,20 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
  */
 const NavigationHeader: React.FC< HeaderProps > = ( {
 	title,
-	backLink,
-	backLinkText = translate( 'Back' ),
-	onBackClick,
+	backLinkProps,
 	titleElement = <h1 className="calypso-navigation-header__title">{ title }</h1>,
-	linkElement: backLinkElement = (
+	headElement: backLinkElement = (
 		<a
 			className="calypso-navigation-header__back-link"
-			href={ backLink }
+			href={ backLinkProps?.backLink }
 			onClick={ ( e ) => {
-				if ( onBackClick ) {
+				if ( backLinkProps?.onBackClick ) {
 					e.preventDefault();
-					onBackClick( e );
+					backLinkProps.onBackClick( e );
 				}
 			} }
 		>
-			← { backLinkText }
+			← { backLinkProps?.backLinkText ?? translate( 'Back' ) }
 		</a>
 	),
 	children,
@@ -59,7 +61,9 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 			}` }
 			{ ...rest }
 		>
-			<div className="calypso-navigation-header__head">{ backLink && backLinkElement }</div>
+			<div className="calypso-navigation-header__head">
+				{ backLinkProps?.backLink && backLinkElement }
+			</div>
 			<div className="calypso-navigation-header__body">
 				<div className="calypso-navigation-header__left-section">{ titleElement }</div>
 				<div className="calypso-navigation-header__right-section">{ children }</div>

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -23,11 +23,9 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
  *
  * @param props - Component props
  * @param props.title - Header title text
- * @param props.backLink - URL for the back button
- * @param props.backLinkText - Text for the back button
- * @param props.onBackClick - Function to call when back button is clicked
+ * @param props.backLinkProps - Object containing back link properties (backLink URL, backLinkText, and onBackClick handler)
  * @param props.titleElement - Custom element to override default title rendering
- * @param props.linkElement - Custom element to override default link rendering
+ * @param props.headElement - Custom element to override default head section rendering
  * @param props.children - Child elements to render in the right section
  * @param props.hasScreenOptionsTab - Indicates whether the screen options tab should be added
  * @returns The rendered NavigationHeader component
@@ -36,7 +34,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 	title,
 	backLinkProps,
 	titleElement = <h1 className="calypso-navigation-header__title">{ title }</h1>,
-	headElement: backLinkElement = (
+	headElement = (
 		<a
 			className="calypso-navigation-header__back-link"
 			href={ backLinkProps?.backLink }
@@ -61,9 +59,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 			}` }
 			{ ...rest }
 		>
-			<div className="calypso-navigation-header__head">
-				{ backLinkProps?.backLink && backLinkElement }
-			</div>
+			<div className="calypso-navigation-header__head">{ headElement }</div>
 			<div className="calypso-navigation-header__body">
 				<div className="calypso-navigation-header__left-section">{ titleElement }</div>
 				<div className="calypso-navigation-header__right-section">{ children }</div>

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -27,42 +27,12 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
 	hasScreenOptionsTab?: boolean;
 }
 
-// Arrow left icon component
-const ArrowLeftIcon: React.FC = () => (
-	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<path
-			d="M15 18L9 12L15 6"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-	</svg>
-);
-
 // Download icon component
 const DownloadIcon: React.FC = () => (
-	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<path
-			d="M21 15V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V15"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-		<path
-			d="M7 10L12 15L17 10"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		/>
-		<path
-			d="M12 15V3"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			d="M14 8.3L13 7.2L9 11.2V0H7.5V11.3L3 7.2L2 8.3L8.2 14.1L14 8.3ZM14.5 12V15.5H1.5V12H0V17H16V12H14.5Z"
+			fill="#008710"
 		/>
 	</svg>
 );
@@ -145,7 +115,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 							}
 						} }
 					>
-						<ArrowLeftIcon /> { backLinkText }
+						← { backLinkText }
 					</a>
 				) }
 			</div>

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -9,6 +9,7 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
 	backLinkText?: string;
 	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
 	titleElement?: ReactNode;
+	linkElement?: ReactNode;
 	children?: ReactNode;
 	hasScreenOptionsTab?: boolean;
 }
@@ -22,6 +23,7 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
  * @param props.backLinkText - Text for the back button
  * @param props.onBackClick - Function to call when back button is clicked
  * @param props.titleElement - Custom element to override default title rendering
+ * @param props.linkElement - Custom element to override default link rendering
  * @param props.children - Child elements to render in the right section
  * @param props.hasScreenOptionsTab - Indicates whether the screen options tab should be added
  * @returns The rendered NavigationHeader component
@@ -32,6 +34,20 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 	backLinkText = translate( 'Back' ),
 	onBackClick,
 	titleElement = <h1 className="calypso-navigation-header__title">{ title }</h1>,
+	linkElement: backLinkElement = (
+		<a
+			className="calypso-navigation-header__back-link"
+			href={ backLink }
+			onClick={ ( e ) => {
+				if ( onBackClick ) {
+					e.preventDefault();
+					onBackClick( e );
+				}
+			} }
+		>
+			← { backLinkText }
+		</a>
+	),
 	children,
 	hasScreenOptionsTab,
 	...rest
@@ -43,22 +59,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 			}` }
 			{ ...rest }
 		>
-			<div className="calypso-navigation-header__head">
-				{ backLink && (
-					<a
-						className="calypso-navigation-header__back-link"
-						href={ backLink }
-						onClick={ ( e ) => {
-							if ( onBackClick ) {
-								e.preventDefault();
-								onBackClick( e );
-							}
-						} }
-					>
-						← { backLinkText }
-					</a>
-				) }
-			</div>
+			<div className="calypso-navigation-header__head">{ backLink && backLinkElement }</div>
 			<div className="calypso-navigation-header__body">
 				<div className="calypso-navigation-header__left-section">{ titleElement }</div>
 				<div className="calypso-navigation-header__right-section">{ children }</div>
@@ -68,34 +69,3 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 };
 
 export default NavigationHeader;
-
-// Example usage:
-// For first image (Post with View post button):
-// <Header
-//   title="Post"
-//   buttonProps={{
-//     text: "View post",
-//     onClick: () => console.log("View post clicked")
-//   }}
-// />
-
-// For second image (Summary page with Download CSV link):
-// <Header
-//   title="Summary page"
-//   downloadProps={{
-//     href: "/data.csv",
-//     text: "Download CSV"
-//   }}
-// />
-
-// With custom element:
-// <Header
-//   title="Custom Header"
-//   rightElement={<YourCustomComponent />}
-// />
-
-// With screen options tab:
-// <Header
-//   title="With Options"
-//   hasScreenOptionsTab={true}
-// />

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -1,98 +1,29 @@
-import styled from '@emotion/styled';
 import { translate } from 'i18n-calypso';
 import { ReactNode } from 'react';
+import './navigation-header.scss';
 
-// Main container for the header
-const HeaderContainer = styled.header`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	background-color: white;
-	box-shadow: 0 1px 3px rgba( 0, 0, 0, 0.05 );
-	width: 100%;
-`;
+// Type definitions for the props
+interface ButtonProps extends React.ButtonHTMLAttributes< HTMLButtonElement > {
+	text?: string;
+	onClick?: ( e: React.MouseEvent< HTMLButtonElement > ) => void;
+}
 
-// Left section with back button and title
-const LeftSection = styled.div`
-	display: flex;
-	align-items: center;
-	gap: 16px;
-`;
+interface DownloadProps extends React.AnchorHTMLAttributes< HTMLAnchorElement > {
+	text?: string;
+	href?: string;
+	download?: boolean | string;
+}
 
-// Back button/link
-const BackLink = styled.a`
-	display: flex;
-	align-items: center;
-	text-decoration: none;
-	color: #666;
-	font-size: 16px;
-	transition: color 0.2s ease;
-
-	&:hover {
-		color: #333;
-	}
-
-	svg {
-		margin-right: 6px;
-	}
-`;
-
-// Title component that adjusts based on screen size
-const Title = styled.h1`
-	margin: 0;
-	font-size: 24px;
-	font-weight: 500;
-	color: #333;
-
-	@media ( max-width: 576px ) {
-		font-size: 20px;
-	}
-`;
-
-// Right section for buttons, links, or other elements
-const RightSection = styled.div`
-	display: flex;
-	align-items: center;
-`;
-
-// Button styling for the right section
-const ActionButton = styled.button`
-	padding: 8px 16px;
-	background-color: #2e7d32; /* Green color from the image */
-	color: white;
-	border: none;
-	border-radius: 4px;
-	font-size: 16px;
-	cursor: pointer;
-	transition: background-color 0.2s ease;
-
-	&:hover {
-		background-color: #1b5e20;
-	}
-
-	@media ( max-width: 576px ) {
-		padding: 6px 12px;
-		font-size: 14px;
-	}
-`;
-
-// Download link styling
-const DownloadLink = styled.a`
-	display: flex;
-	align-items: center;
-	text-decoration: none;
-	color: #2e7d32;
-	font-size: 16px;
-	transition: color 0.2s ease;
-
-	svg {
-		margin-right: 8px;
-	}
-
-	&:hover {
-		color: #1b5e20;
-	}
-`;
+interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
+	title: string;
+	backLink?: string;
+	backLinkText?: string;
+	rightElement?: ReactNode;
+	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
+	buttonProps?: ButtonProps;
+	downloadProps?: DownloadProps;
+	children?: ReactNode;
+}
 
 // Arrow left icon component
 const ArrowLeftIcon: React.FC = () => (
@@ -134,29 +65,6 @@ const DownloadIcon: React.FC = () => (
 	</svg>
 );
 
-// Type definitions for the props
-interface ButtonProps extends React.ButtonHTMLAttributes< HTMLButtonElement > {
-	text?: string;
-	onClick?: ( e: React.MouseEvent< HTMLButtonElement > ) => void;
-}
-
-interface DownloadProps extends React.AnchorHTMLAttributes< HTMLAnchorElement > {
-	text?: string;
-	href?: string;
-	download?: boolean | string;
-}
-
-interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
-	title: string;
-	backLink?: string;
-	backLinkText?: string;
-	rightElement?: ReactNode;
-	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
-	buttonProps?: ButtonProps;
-	downloadProps?: DownloadProps;
-	children?: ReactNode;
-}
-
 /**
  * Header component that can be used in various contexts
  *
@@ -188,48 +96,54 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 			return rightElement;
 		} else if ( buttonProps ) {
 			return (
-				<ActionButton onClick={ buttonProps.onClick } { ...buttonProps }>
+				<button
+					className="calypso-navigation-header__action-button"
+					onClick={ buttonProps.onClick }
+					{ ...buttonProps }
+				>
 					{ buttonProps.text || 'View post' }
-				</ActionButton>
+				</button>
 			);
 		} else if ( downloadProps ) {
 			return (
-				<DownloadLink
+				<a
+					className="calypso-navigation-header__download-link"
 					href={ downloadProps.href || '#' }
 					download={ downloadProps.download }
 					{ ...downloadProps }
 				>
 					<DownloadIcon />
 					{ downloadProps.text || 'Download CSV' }
-				</DownloadLink>
+				</a>
 			);
 		}
 		return null;
 	};
 
 	return (
-		<HeaderContainer { ...rest }>
-			{ backLink && (
-				<BackLink
-					href={ backLink }
-					onClick={ ( e ) => {
-						if ( onBackClick ) {
-							e.preventDefault();
-							onBackClick( e );
-						}
-					} }
-				>
-					<ArrowLeftIcon /> { backLinkText }
-				</BackLink>
-			) }
-			<LeftSection>
-				<Title>{ title }</Title>
-			</LeftSection>
-			<RightSection>
+		<header className="calypso-navigation-header" { ...rest }>
+			<div className="calypso-navigation-header__left-section">
+				{ backLink && (
+					<a
+						className="calypso-navigation-header__back-link"
+						href={ backLink }
+						onClick={ ( e ) => {
+							if ( onBackClick ) {
+								e.preventDefault();
+								onBackClick( e );
+							}
+						} }
+					>
+						<ArrowLeftIcon /> { backLinkText }
+					</a>
+				) }
+				<h1 className="calypso-navigation-header__title">{ title }</h1>
+			</div>
+			<div className="calypso-navigation-header__right-section">
 				{ renderRightElement() }
 				{ children }
-			</RightSection>
-		</HeaderContainer>
+			</div>
+		</header>
 	);
 };
 

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -4,8 +4,8 @@ import './navigation-header.scss';
 
 // Type definitions for the props
 interface BackLinkProps {
-	backLink?: string;
-	backLinkText?: string;
+	url?: string;
+	text?: string;
 	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
 }
 
@@ -34,10 +34,10 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 	title,
 	backLinkProps,
 	titleElement = <h1 className="calypso-navigation-header__title">{ title }</h1>,
-	headElement = (
+	headElement = backLinkProps?.url && (
 		<a
 			className="calypso-navigation-header__back-link"
-			href={ backLinkProps?.backLink }
+			href={ backLinkProps?.url }
 			onClick={ ( e ) => {
 				if ( backLinkProps?.onBackClick ) {
 					e.preventDefault();
@@ -45,7 +45,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 				}
 			} }
 		>
-			← { backLinkProps?.backLinkText ?? translate( 'Back' ) }
+			← { backLinkProps?.text ?? translate( 'Back' ) }
 		</a>
 	),
 	children,

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -1,0 +1,261 @@
+import styled from '@emotion/styled';
+import { translate } from 'i18n-calypso';
+import { ReactNode } from 'react';
+
+// Main container for the header
+const HeaderContainer = styled.header`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	background-color: white;
+	box-shadow: 0 1px 3px rgba( 0, 0, 0, 0.05 );
+	width: 100%;
+`;
+
+// Left section with back button and title
+const LeftSection = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 16px;
+`;
+
+// Back button/link
+const BackLink = styled.a`
+	display: flex;
+	align-items: center;
+	text-decoration: none;
+	color: #666;
+	font-size: 16px;
+	transition: color 0.2s ease;
+
+	&:hover {
+		color: #333;
+	}
+
+	svg {
+		margin-right: 6px;
+	}
+`;
+
+// Title component that adjusts based on screen size
+const Title = styled.h1`
+	margin: 0;
+	font-size: 24px;
+	font-weight: 500;
+	color: #333;
+
+	@media ( max-width: 576px ) {
+		font-size: 20px;
+	}
+`;
+
+// Right section for buttons, links, or other elements
+const RightSection = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+// Button styling for the right section
+const ActionButton = styled.button`
+	padding: 8px 16px;
+	background-color: #2e7d32; /* Green color from the image */
+	color: white;
+	border: none;
+	border-radius: 4px;
+	font-size: 16px;
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+
+	&:hover {
+		background-color: #1b5e20;
+	}
+
+	@media ( max-width: 576px ) {
+		padding: 6px 12px;
+		font-size: 14px;
+	}
+`;
+
+// Download link styling
+const DownloadLink = styled.a`
+	display: flex;
+	align-items: center;
+	text-decoration: none;
+	color: #2e7d32;
+	font-size: 16px;
+	transition: color 0.2s ease;
+
+	svg {
+		margin-right: 8px;
+	}
+
+	&:hover {
+		color: #1b5e20;
+	}
+`;
+
+// Arrow left icon component
+const ArrowLeftIcon: React.FC = () => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M15 18L9 12L15 6"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
+// Download icon component
+const DownloadIcon: React.FC = () => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M21 15V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V15"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<path
+			d="M7 10L12 15L17 10"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<path
+			d="M12 15V3"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
+// Type definitions for the props
+interface ButtonProps extends React.ButtonHTMLAttributes< HTMLButtonElement > {
+	text?: string;
+	onClick?: ( e: React.MouseEvent< HTMLButtonElement > ) => void;
+}
+
+interface DownloadProps extends React.AnchorHTMLAttributes< HTMLAnchorElement > {
+	text?: string;
+	href?: string;
+	download?: boolean | string;
+}
+
+interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
+	title: string;
+	backLink?: string;
+	backLinkText?: string;
+	rightElement?: ReactNode;
+	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
+	buttonProps?: ButtonProps;
+	downloadProps?: DownloadProps;
+	children?: ReactNode;
+}
+
+/**
+ * Header component that can be used in various contexts
+ *
+ * @param props - Component props
+ * @param props.title - Header title text
+ * @param props.backLink - URL for the back button
+ * @param props.backLinkText - Text for the back button
+ * @param props.rightElement - Custom element to display on the right side
+ * @param props.onBackClick - Function to call when back button is clicked
+ * @param props.buttonProps - Props for the action button if used
+ * @param props.downloadProps - Props for the download link if used
+ * @param props.children - Child elements to render in the right section
+ * @returns The rendered NavigationHeader component
+ */
+const NavigationHeader: React.FC< HeaderProps > = ( {
+	title,
+	backLink,
+	backLinkText = translate( 'Back' ),
+	rightElement,
+	onBackClick,
+	buttonProps,
+	downloadProps,
+	children,
+	...rest
+} ) => {
+	// Determine what to render on the right side
+	const renderRightElement = (): ReactNode => {
+		if ( rightElement ) {
+			return rightElement;
+		} else if ( buttonProps ) {
+			return (
+				<ActionButton onClick={ buttonProps.onClick } { ...buttonProps }>
+					{ buttonProps.text || 'View post' }
+				</ActionButton>
+			);
+		} else if ( downloadProps ) {
+			return (
+				<DownloadLink
+					href={ downloadProps.href || '#' }
+					download={ downloadProps.download }
+					{ ...downloadProps }
+				>
+					<DownloadIcon />
+					{ downloadProps.text || 'Download CSV' }
+				</DownloadLink>
+			);
+		}
+		return null;
+	};
+
+	return (
+		<HeaderContainer { ...rest }>
+			{ backLink && (
+				<BackLink
+					href={ backLink }
+					onClick={ ( e ) => {
+						if ( onBackClick ) {
+							e.preventDefault();
+							onBackClick( e );
+						}
+					} }
+				>
+					<ArrowLeftIcon /> { backLinkText }
+				</BackLink>
+			) }
+			<LeftSection>
+				<Title>{ title }</Title>
+			</LeftSection>
+			<RightSection>
+				{ renderRightElement() }
+				{ children }
+			</RightSection>
+		</HeaderContainer>
+	);
+};
+
+export default NavigationHeader;
+
+// Example usage:
+// For first image (Post with View post button):
+// <Header
+//   title="Post"
+//   buttonProps={{
+//     text: "View post",
+//     onClick: () => console.log("View post clicked")
+//   }}
+// />
+
+// For second image (Summary page with Download CSV link):
+// <Header
+//   title="Summary page"
+//   downloadProps={{
+//     href: "/data.csv",
+//     text: "Download CSV"
+//   }}
+// />
+
+// With custom element:
+// <Header
+//   title="Custom Header"
+//   rightElement={<YourCustomComponent />}
+// />

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -24,6 +24,7 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
 	downloadProps?: DownloadProps;
 	titleElement?: ReactNode;
 	children?: ReactNode;
+	hasScreenOptionsTab?: boolean;
 }
 
 // Arrow left icon component
@@ -79,6 +80,7 @@ const DownloadIcon: React.FC = () => (
  * @param props.downloadProps - Props for the download link if used
  * @param props.titleElement - Custom element to override default title rendering
  * @param props.children - Child elements to render in the right section
+ * @param props.hasScreenOptionsTab - Indicates whether the screen options tab should be added
  * @returns The rendered NavigationHeader component
  */
 const NavigationHeader: React.FC< HeaderProps > = ( {
@@ -91,6 +93,7 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 	buttonProps,
 	downloadProps,
 	children,
+	hasScreenOptionsTab,
 	...rest
 } ) => {
 	// Determine what to render on the right side
@@ -124,7 +127,12 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 	};
 
 	return (
-		<header className="calypso-navigation-header" { ...rest }>
+		<header
+			className={ `calypso-navigation-header${
+				hasScreenOptionsTab ? ' calypso-navigation-header__screen-options-tab' : ''
+			}` }
+			{ ...rest }
+		>
 			<div className="calypso-navigation-header__head">
 				{ backLink && (
 					<a
@@ -177,4 +185,10 @@ export default NavigationHeader;
 // <Header
 //   title="Custom Header"
 //   rightElement={<YourCustomComponent />}
+// />
+
+// With screen options tab:
+// <Header
+//   title="With Options"
+//   hasScreenOptionsTab={true}
 // />

--- a/client/components/navigation-header/stories/navigation-header.stories.tsx
+++ b/client/components/navigation-header/stories/navigation-header.stories.tsx
@@ -1,0 +1,95 @@
+import NavigationHeader from '../navigation-header';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof NavigationHeader > = {
+	title: 'Components/NavigationHeader',
+	component: NavigationHeader,
+	parameters: {
+		layout: 'fullscreen',
+	},
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+type Story = StoryObj< typeof NavigationHeader >;
+
+// Basic header with title only
+export const Basic: Story = {
+	args: {
+		title: 'Basic Header',
+	},
+};
+
+// Header with back button
+export const WithBackButton: Story = {
+	args: {
+		title: 'Header with Back',
+		backLink: '/previous-page',
+		backLinkText: 'Back to Dashboard',
+	},
+};
+
+// Header with action button
+export const WithActionButton: Story = {
+	args: {
+		title: 'Post Details',
+		buttonProps: {
+			text: 'View Post',
+			onClick: () => null,
+		},
+	},
+};
+
+// Header with download link
+export const WithDownloadLink: Story = {
+	args: {
+		title: 'Summary Page',
+		downloadProps: {
+			href: '/data.csv',
+			text: 'Download CSV',
+			download: true,
+		},
+	},
+};
+
+// Header with custom right element
+export const WithCustomRightElement: Story = {
+	args: {
+		title: 'Custom Header',
+		rightElement: (
+			<div style={ { display: 'flex', gap: '8px' } }>
+				<button>Custom Button 1</button>
+				<button>Custom Button 2</button>
+			</div>
+		),
+	},
+};
+
+// Header with back button and action button
+export const WithBackAndAction: Story = {
+	args: {
+		title: 'Complex Header',
+		backLink: '/previous-page',
+		backLinkText: 'Back',
+		buttonProps: {
+			text: 'Save Changes',
+			onClick: () => null,
+		},
+	},
+};
+
+// Mobile view example
+export const MobileView: Story = {
+	args: {
+		title: 'Mobile Header',
+		backLink: '/previous-page',
+		buttonProps: {
+			text: 'Action',
+		},
+	},
+	parameters: {
+		viewport: {
+			defaultViewport: 'mobile1',
+		},
+	},
+};

--- a/client/components/navigation-header/stories/navigation-header.stories.tsx
+++ b/client/components/navigation-header/stories/navigation-header.stories.tsx
@@ -41,10 +41,25 @@ export const Basic: Story = {
 	},
 };
 
+// Header with back link
+export const WithBackLink: Story = {
+	args: {
+		title: 'Header with Back Link',
+		backLinkProps: {
+			backLink: '/dashboard',
+			backLinkText: 'Back to Dashboard',
+		},
+	},
+};
+
 // Header with both download link and action button
 export const WithDownloadAndAction: Story = {
 	args: {
 		title: 'Report Summary',
+		backLinkProps: {
+			backLink: '/reports',
+			backLinkText: 'Back to Reports',
+		},
 		children: (
 			<div style={ { display: 'flex', gap: '16px', alignItems: 'center' } }>
 				<a href="/data.csv" download style={ downloadLinkStyle }>
@@ -67,15 +82,22 @@ export const WithDownloadAndAction: Story = {
 	},
 };
 
-// Header with multiple download options and action
-export const WithMultipleDownloads: Story = {
+// Header with screen options tab
+export const WithScreenOptions: Story = {
 	args: {
 		title: 'Analytics Dashboard',
-		backLink: '/dashboard',
-		backLinkText: 'Back to Dashboard',
+		hasScreenOptionsTab: true,
+		backLinkProps: {
+			backLink: '/dashboard',
+			backLinkText: 'Back to Dashboard',
+			onBackClick: ( e ) => {
+				e.preventDefault();
+				alert( 'Back button clicked!' );
+			},
+		},
 		children: (
 			<div style={ { display: 'flex', gap: '16px', alignItems: 'center' } }>
-				<button style={ actionButtonStyle } onClick={ () => null }>
+				<button style={ actionButtonStyle } onClick={ () => alert( 'Action clicked!' ) }>
 					Post
 				</button>
 			</div>

--- a/client/components/navigation-header/stories/navigation-header.stories.tsx
+++ b/client/components/navigation-header/stories/navigation-header.stories.tsx
@@ -2,7 +2,7 @@ import NavigationHeader from '../navigation-header';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta< typeof NavigationHeader > = {
-	title: 'Components/NavigationHeader',
+	title: 'client/components/NavigationHeader',
 	component: NavigationHeader,
 	parameters: {
 		layout: 'fullscreen',

--- a/client/components/navigation-header/stories/navigation-header.stories.tsx
+++ b/client/components/navigation-header/stories/navigation-header.stories.tsx
@@ -13,6 +13,27 @@ const meta: Meta< typeof NavigationHeader > = {
 export default meta;
 type Story = StoryObj< typeof NavigationHeader >;
 
+const actionButtonStyle = {
+	padding: '8px 16px',
+	backgroundColor: 'var(--wp-components-color-accent, #2e7d32)',
+	color: 'var(--wp-components-color-accent-inverted, #fff)',
+	border: 'none',
+	borderRadius: '4px',
+	fontSize: '14px',
+	cursor: 'pointer',
+	transition: 'background-color 0.2s ease',
+};
+
+const downloadLinkStyle = {
+	display: 'flex',
+	alignItems: 'center',
+	textDecoration: 'none',
+	color: 'var(--wp-components-color-accent, #2e7d32)',
+	fontSize: '14px',
+	transition: 'color 0.2s ease',
+	gap: '8px',
+};
+
 // Basic header with title only
 export const Basic: Story = {
 	args: {
@@ -20,76 +41,44 @@ export const Basic: Story = {
 	},
 };
 
-// Header with back button
-export const WithBackButton: Story = {
+// Header with both download link and action button
+export const WithDownloadAndAction: Story = {
 	args: {
-		title: 'Header with Back',
-		backLink: '/previous-page',
-		backLinkText: 'Back to Dashboard',
-	},
-};
-
-// Header with action button
-export const WithActionButton: Story = {
-	args: {
-		title: 'Post Details',
-		buttonProps: {
-			text: 'View Post',
-			onClick: () => null,
-		},
-	},
-};
-
-// Header with download link
-export const WithDownloadLink: Story = {
-	args: {
-		title: 'Summary Page',
-		downloadProps: {
-			href: '/data.csv',
-			text: 'Download CSV',
-			download: true,
-		},
-	},
-};
-
-// Header with custom right element
-export const WithCustomRightElement: Story = {
-	args: {
-		title: 'Custom Header',
-		rightElement: (
-			<div style={ { display: 'flex', gap: '8px' } }>
-				<button>Custom Button 1</button>
-				<button>Custom Button 2</button>
+		title: 'Report Summary',
+		children: (
+			<div style={ { display: 'flex', gap: '16px', alignItems: 'center' } }>
+				<a href="/data.csv" download style={ downloadLinkStyle }>
+					<svg
+						width="16"
+						height="17"
+						viewBox="0 0 16 17"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							d="M14 8.3L13 7.2L9 11.2V0H7.5V11.3L3 7.2L2 8.3L8.2 14.1L14 8.3ZM14.5 12V15.5H1.5V12H0V17H16V12H14.5Z"
+							fill="currentColor"
+						/>
+					</svg>
+					Download CSV
+				</a>
 			</div>
 		),
 	},
 };
 
-// Header with back button and action button
-export const WithBackAndAction: Story = {
+// Header with multiple download options and action
+export const WithMultipleDownloads: Story = {
 	args: {
-		title: 'Complex Header',
-		backLink: '/previous-page',
-		backLinkText: 'Back',
-		buttonProps: {
-			text: 'Save Changes',
-			onClick: () => null,
-		},
-	},
-};
-
-// Mobile view example
-export const MobileView: Story = {
-	args: {
-		title: 'Mobile Header',
-		backLink: '/previous-page',
-		buttonProps: {
-			text: 'Action',
-		},
-	},
-	parameters: {
-		viewport: {
-			defaultViewport: 'mobile1',
-		},
+		title: 'Analytics Dashboard',
+		backLink: '/dashboard',
+		backLinkText: 'Back to Dashboard',
+		children: (
+			<div style={ { display: 'flex', gap: '16px', alignItems: 'center' } }>
+				<button style={ actionButtonStyle } onClick={ () => null }>
+					Post
+				</button>
+			</div>
+		),
 	},
 };

--- a/client/components/navigation-header/stories/navigation-header.stories.tsx
+++ b/client/components/navigation-header/stories/navigation-header.stories.tsx
@@ -46,8 +46,8 @@ export const WithBackLink: Story = {
 	args: {
 		title: 'Header with Back Link',
 		backLinkProps: {
-			backLink: '/dashboard',
-			backLinkText: 'Back to Dashboard',
+			url: '/dashboard',
+			text: 'Back to Dashboard',
 		},
 	},
 };
@@ -57,8 +57,8 @@ export const WithDownloadAndAction: Story = {
 	args: {
 		title: 'Report Summary',
 		backLinkProps: {
-			backLink: '/reports',
-			backLinkText: 'Back to Reports',
+			url: '/reports',
+			text: 'Back to Reports',
 		},
 		children: (
 			<div style={ { display: 'flex', gap: '16px', alignItems: 'center' } }>
@@ -88,8 +88,8 @@ export const WithScreenOptions: Story = {
 		title: 'Analytics Dashboard',
 		hasScreenOptionsTab: true,
 		backLinkProps: {
-			backLink: '/dashboard',
-			backLinkText: 'Back to Dashboard',
+			url: '/dashboard',
+			text: 'Back to Dashboard',
 			onBackClick: ( e ) => {
 				e.preventDefault();
 				alert( 'Back button clicked!' );

--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -8,7 +8,7 @@ export const STATS_PERIOD = {
 
 // The product title. Do not translate.
 export const STATS_PRODUCT_NAME = 'Jetpack Stats';
-export const STATS_PRODUCT_NAME_NEW = 'Stats';
+export const STATS_PRODUCT_NAME_IMPR = 'Stats';
 
 // statTypes referred from
 // https://github.com/Automattic/wp-calypso/blob/trunk/packages/wpcom.js/src/lib/runtime/site.get.js

--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -8,6 +8,7 @@ export const STATS_PERIOD = {
 
 // The product title. Do not translate.
 export const STATS_PRODUCT_NAME = 'Jetpack Stats';
+export const STATS_PRODUCT_NAME_NEW = 'Stats';
 
 // statTypes referred from
 // https://github.com/Automattic/wp-calypso/blob/trunk/packages/wpcom.js/src/lib/runtime/site.get.js

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -23,6 +23,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
+import NavigationHeaderNew from 'calypso/components/navigation-header/navigation-header';
 import StickyPanel from 'calypso/components/sticky-panel';
 import memoizeLast from 'calypso/lib/memoize-last';
 import Main from 'calypso/my-sites/stats/components/stats-main';
@@ -32,6 +33,7 @@ import {
 	STATS_FEATURE_PAGE_TRAFFIC,
 	STATS_FEATURE_INTERVAL_DROPDOWN_WEEK,
 	STATS_PRODUCT_NAME,
+	STATS_PRODUCT_NAME_NEW,
 } from 'calypso/my-sites/stats/constants';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getChartRangeParams } from 'calypso/my-sites/stats/utils';
@@ -528,21 +530,25 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 					<JetpackBackupCredsBanner event="stats-backup-credentials" />
 				</div>
 			) }
-			{ isStatsNavigationImprovementEnabled && <div>The new Stats navigation is active.</div> }
-			<NavigationHeader
-				className="stats__section-header modernized-header"
-				title={ STATS_PRODUCT_NAME }
-				subtitle={ translate(
-					"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
-						},
-					}
-				) }
-				screenReader={ navItems.traffic?.label }
-				navigationItems={ [] }
-			></NavigationHeader>
+			{ isStatsNavigationImprovementEnabled ? (
+				<NavigationHeaderNew
+					className="stats__section-header modernized-header"
+					title={ STATS_PRODUCT_NAME_NEW }
+				/>
+			) : (
+				<NavigationHeader
+					subtitle={ translate(
+						"Gain insights into the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="stats" showIcon={ false } />,
+							},
+						}
+					) }
+					screenReader={ navItems.traffic?.label }
+					navigationItems={ [] }
+				/>
+			) }
 			<StatsNavigation selectedItem="traffic" interval={ period } siteId={ siteId } slug={ slug } />
 			<StatsNotices
 				siteId={ siteId }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -23,7 +23,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
-import NavigationHeaderNew from 'calypso/components/navigation-header/navigation-header';
+import NavigationHeaderImpr from 'calypso/components/navigation-header/navigation-header';
 import StickyPanel from 'calypso/components/sticky-panel';
 import memoizeLast from 'calypso/lib/memoize-last';
 import Main from 'calypso/my-sites/stats/components/stats-main';
@@ -33,7 +33,7 @@ import {
 	STATS_FEATURE_PAGE_TRAFFIC,
 	STATS_FEATURE_INTERVAL_DROPDOWN_WEEK,
 	STATS_PRODUCT_NAME,
-	STATS_PRODUCT_NAME_NEW,
+	STATS_PRODUCT_NAME_IMPR,
 } from 'calypso/my-sites/stats/constants';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
 import { getChartRangeParams } from 'calypso/my-sites/stats/utils';
@@ -531,9 +531,9 @@ function StatsBody( { siteId, chartTab = 'views', date, context, isInternal, ...
 				</div>
 			) }
 			{ isStatsNavigationImprovementEnabled ? (
-				<NavigationHeaderNew
+				<NavigationHeaderImpr
 					className="stats__section-header modernized-header"
-					title={ STATS_PRODUCT_NAME_NEW }
+					title={ STATS_PRODUCT_NAME_IMPR }
 				/>
 			) : (
 				<NavigationHeader

--- a/config/development.json
+++ b/config/development.json
@@ -193,7 +193,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/real-time-tab": true,
-		"stats/navigation-improvement": false,
+		"stats/navigation-improvement": true,
 		"subscriber-importer": true,
 		"subscribers-helper-library": true,
 		"themes/block-theme-previews-premium-and-woo": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to STATS-6

## Proposed Changes

* Introduces a new `NavigationHeader` that has three slots with predefined behaviors but could also be customized as well
* Added stories to demo the component
* Flips `stats/navigation-improvement` to true on development for easier testing

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve navigation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your local Calypso development evn
* Run `yarn storybook:start`
* Navigate to `CLIENT/components/NavigationHeader`
* Ensure the stories look good
* Open `http://calypso.localhost:3000/stats/day/{your-site}`
* Ensure the header looks like what's in the design

<img width="975" alt="image" src="https://github.com/user-attachments/assets/edbc7b54-8cc1-45e0-8e23-6239dc210586" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
