### PR TITLE
Remove redux-bridge usages from A4A code

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/index.tsx
@@ -18,8 +18,7 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import BudgetSelector from 'calypso/a8c-for-agencies/sections/partner-directory/components/budget-selector';
 import { AgencyDetails } from 'calypso/a8c-for-agencies/sections/partner-directory/types';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { setActiveAgency } from 'calypso/state/a8c-for-agencies/agency/actions';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
@@ -43,6 +42,7 @@ type Props = {
 
 const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const { validate, validationError, updateValidationError } = useDetailsFormValidation();
 
@@ -52,32 +52,31 @@ const AgencyDetailsForm = ( { initialFormData }: Props ) => {
 
 	const onSubmitSuccess = useCallback(
 		( response: Agency ) => {
-			response && reduxDispatch( setActiveAgency( { ...agency, ...response } ) );
+			if ( response ) {
+				dispatch( setActiveAgency( { ...agency, ...response } ) );
+			}
 
-			reduxDispatch(
+			dispatch(
 				successNotice( translate( 'Your agency profile was submitted!' ), {
 					displayOnNextPage: true,
 					duration: 6000,
 				} )
 			);
-			isFeedbackShown
-				? page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK )
-				: page(
-						addQueryArgs( A4A_FEEDBACK_LINK, {
-							type: FeedbackType.PDDetailsAdded,
-						} )
-				  );
+
+			if ( isFeedbackShown ) {
+				page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK );
+			} else {
+				page( addQueryArgs( A4A_FEEDBACK_LINK, { type: FeedbackType.PDDetailsAdded } ) );
+			}
 		},
-		[ agency, isFeedbackShown, translate ]
+		[ agency, isFeedbackShown, translate, dispatch ]
 	);
 
 	const onSubmitError = useCallback( () => {
-		reduxDispatch(
-			errorNotice( translate( 'Something went wrong submitting the profile!' ), {
-				duration: 6000,
-			} )
+		dispatch(
+			errorNotice( translate( 'Something went wrong submitting the profile!' ), { duration: 6000 } )
 		);
-	}, [ translate ] );
+	}, [ translate, dispatch ] );
 
 	const { formData, setFormData } = useDetailsForm( {
 		initialFormData,

--- a/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-expertise/index.tsx
@@ -15,8 +15,7 @@ import {
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_PARTNER_DIRECTORY_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { setActiveAgency } from 'calypso/state/a8c-for-agencies/agency/actions';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
@@ -89,18 +88,19 @@ type Props = {
 
 const AgencyExpertise = ( { initialFormData }: Props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const { validate, validationError, updateValidationError } = useExpertiseFormValidation();
-
 	const { availableDirectories } = useFormSelectors();
-
 	const agency = useSelector( getActiveAgency );
 
 	const onSubmitSuccess = useCallback(
 		( response: Agency ) => {
-			response && reduxDispatch( setActiveAgency( { ...agency, ...response } ) );
+			if ( response ) {
+				dispatch( setActiveAgency( { ...agency, ...response } ) );
+			}
 
-			reduxDispatch(
+			dispatch(
 				successNotice( translate( 'Your Partner Directory application was submitted!' ), {
 					displayOnNextPage: true,
 					duration: 6000,
@@ -108,16 +108,16 @@ const AgencyExpertise = ( { initialFormData }: Props ) => {
 			);
 			page( A4A_PARTNER_DIRECTORY_DASHBOARD_LINK );
 		},
-		[ agency, translate ]
+		[ agency, translate, dispatch ]
 	);
 
 	const onSubmitError = useCallback( () => {
-		reduxDispatch(
+		dispatch(
 			errorNotice( translate( 'Something went wrong submitting your application!' ), {
 				duration: 6000,
 			} )
 		);
-	}, [ translate ] );
+	}, [ translate, dispatch ] );
 
 	const {
 		formData,

--- a/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/dashboard/index.tsx
@@ -7,7 +7,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { A4A_PARTNER_DIRECTORY_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StepSection from 'calypso/a8c-for-agencies/components/step-section';
 import StepSectionItem from 'calypso/a8c-for-agencies/components/step-section-item';
-import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import { useDispatch, useSelector } from 'calypso/state';
 import { setActiveAgency } from 'calypso/state/a8c-for-agencies/agency/actions';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -99,15 +98,13 @@ const PartnerDirectoryDashboard = () => {
 	const onSubmitPublishProfileSuccess = useCallback(
 		( response: Agency ) => {
 			// Update the store with the new agency data
-			response && reduxDispatch( setActiveAgency( { ...agency, ...response } ) );
+			if ( response ) {
+				dispatch( setActiveAgency( { ...agency, ...response } ) );
+			}
 
-			reduxDispatch(
-				successNotice( translate( 'Your profile has been saved!' ), {
-					duration: 6000,
-				} )
-			);
+			dispatch( successNotice( translate( 'Your profile has been saved!' ), { duration: 6000 } ) );
 		},
-		[ agency, translate ]
+		[ agency, translate, dispatch ]
 	);
 
 	const { onSubmit: submitPublishProfile, isSubmitting: isSubmittingPublishProfile } =


### PR DESCRIPTION
I noticed that some A4A code is importing the `redux-bridge` module and calling the `reduxDispatch` from there, for no good reason. The standard way is to get the `dispatch` function from `useDispatch`, and there is nothing that prevents us from doing it this way here.

This PR refactors three offending files to `useDispatch`, adds necessary dependencies to `useCallback` hooks, and as a drive-by, refactors some conditions from `a && b` and `a ? b : c` to classic `if`/`else` statements. That's the Calypso standard.

The only usage of `redux-bridge` remains the `TwoStepAuthorization` singleton.

## Testing instructions:
- verify that the modified components are really always inside a React tree with a Redux provider.
- ensure that the modified code still works. It's a very straightforward refactoring, shouldn't break anything.