### PR TITLE
Hosting Dashboard v2: use createLink

### DIFF
--- a/client/dashboard/404/index.tsx
+++ b/client/dashboard/404/index.tsx
@@ -1,32 +1,16 @@
-import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import PageLayout from '../page-layout';
+import RouterLinkButton from '../router-link-button';
 
 function NotFound() {
-	const to = '/sites';
-	const navigate = useNavigate();
-	const router = useRouter();
-	const href = router.buildLocation( {
-		to,
-	} ).href;
-
 	return (
 		<PageLayout
 			title={ __( '404 Not Found' ) }
 			description={ __( 'The page you are looking for does not exist.' ) }
 			actions={
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					href={ href }
-					onClick={ ( event: React.MouseEvent ) => {
-						event.preventDefault();
-						navigate( { to } );
-					} }
-				>
+				<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
 					{ __( 'Go to Sites' ) }
-				</Button>
+				</RouterLinkButton>
 			}
 		/>
 	);

--- a/client/dashboard/500/index.tsx
+++ b/client/dashboard/500/index.tsx
@@ -1,32 +1,17 @@
-import { useNavigate, useRouter } from '@tanstack/react-router';
-import { Button, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import PageLayout from '../page-layout';
+import RouterLinkButton from '../router-link-button';
 
 function UnknownError( { error }: { error: Error } ) {
-	const to = '/sites';
-	const navigate = useNavigate();
-	const router = useRouter();
-	const href = router.buildLocation( {
-		to,
-	} ).href;
-
 	return (
 		<PageLayout
 			title={ __( '500 Error' ) }
 			description={ __( 'Something wrong happened.' ) }
 			actions={
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					href={ href }
-					onClick={ ( event: React.MouseEvent ) => {
-						event.preventDefault();
-						navigate( { to } );
-					} }
-				>
+				<RouterLinkButton to="/sites" variant="primary" __next40pxDefaultSize>
 					{ __( 'Go to Sites' ) }
-				</Button>
+				</RouterLinkButton>
 			}
 		>
 			<Notice status="error" isDismissible={ false }>

--- a/client/dashboard/billing/billing-card.tsx
+++ b/client/dashboard/billing/billing-card.tsx
@@ -1,14 +1,14 @@
-import { useNavigate, useRouter } from '@tanstack/react-router';
 import {
 	Card,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
-	Button,
 	Icon,
 } from '@wordpress/components';
 import { chevronRight } from '@wordpress/icons';
+import RouterLinkButton from '../router-link-button';
 import type { ReactElement, ReactNode } from 'react';
+
 import './style.scss';
 
 interface CardProps {
@@ -20,17 +20,8 @@ interface CardProps {
 }
 
 export default function BillingCard( { title, icon, description, to, children }: CardProps ) {
-	const navigate = useNavigate();
-	const router = useRouter();
-	const href = router.buildLocation( {
-		to,
-	} ).href;
-	const handleClick = ( e: React.MouseEvent ) => {
-		e.preventDefault();
-		navigate( { to } );
-	};
 	return (
-		<Button href={ href } onClick={ handleClick } className="billing-card-button">
+		<RouterLinkButton to={ to } className="billing-card-button">
 			<Card className="billing-card">
 				<HStack spacing={ 4 } justify="space-between" alignment="flex-start">
 					<HStack justify="flex-start" spacing={ 2 } alignment="flex-start">
@@ -44,6 +35,6 @@ export default function BillingCard( { title, icon, description, to, children }:
 					<Icon icon={ chevronRight } className="billing-card-icon" />
 				</HStack>
 			</Card>
-		</Button>
+		</RouterLinkButton>
 	);
 }

--- a/client/dashboard/menu/index.tsx
+++ b/client/dashboard/menu/index.tsx
@@ -1,17 +1,12 @@
-import { useMatchRoute } from '@tanstack/react-router';
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import clsx from 'clsx';
 import RouterLinkButton from '../router-link-button';
 
 import './style.scss';
 
 function MenuItem( { to, children }: { to: string; children: React.ReactNode } ) {
-	const matchRoute = useMatchRoute();
 	return (
 		<RouterLinkButton
-			className={ clsx( 'dashboard-menu__item', {
-				'is-active': matchRoute( { to } ),
-			} ) }
+			className="dashboard-menu__item"
 			variant="tertiary"
 			to={ to }
 			__next40pxDefaultSize

--- a/client/dashboard/menu/index.tsx
+++ b/client/dashboard/menu/index.tsx
@@ -1,33 +1,23 @@
-import { useNavigate, useMatchRoute, useRouter } from '@tanstack/react-router';
-import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import { useMatchRoute } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import clsx from 'clsx';
+import RouterLinkButton from '../router-link-button';
+
 import './style.scss';
 
 function MenuItem( { to, children }: { to: string; children: React.ReactNode } ) {
-	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
-	const isActive = matchRoute( { to } );
-	const router = useRouter();
-	const href = router.buildLocation( {
-		to,
-	} ).href;
-	const handleClick = ( e: React.MouseEvent ) => {
-		e.preventDefault();
-		navigate( { to } );
-	};
-
 	return (
-		<Button
+		<RouterLinkButton
 			className={ clsx( 'dashboard-menu__item', {
-				'is-active': isActive,
+				'is-active': matchRoute( { to } ),
 			} ) }
 			variant="tertiary"
-			href={ href }
-			onClick={ handleClick }
+			to={ to }
 			__next40pxDefaultSize
 		>
 			{ children }
-		</Button>
+		</RouterLinkButton>
 	);
 }
 

--- a/client/dashboard/menu/style.scss
+++ b/client/dashboard/menu/style.scss
@@ -1,7 +1,7 @@
 .dashboard-menu__item.dashboard-menu__item {
 	color: var( --dashboard-menu-item__color );
 
-	&.is-active {
+	&.active {
 		color: var( --dashboard-menu-item-active__color );
 	}
 }

--- a/client/dashboard/primary-menu-mobile/index.tsx
+++ b/client/dashboard/primary-menu-mobile/index.tsx
@@ -1,39 +1,8 @@
-import { useNavigate, useRouter } from '@tanstack/react-router';
-import { DropdownMenu, MenuItem } from '@wordpress/components';
+import { DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
 import { useAppContext } from '../app/context';
-
-function MobileMenuItem( {
-	to,
-	children,
-	onClose,
-}: {
-	to: string;
-	children: React.ReactNode;
-	onClose: () => void;
-} ) {
-	const navigate = useNavigate();
-	const router = useRouter();
-	const href = router.buildLocation( {
-		to,
-	} ).href;
-	const handleClick = ( e: React.MouseEvent ) => {
-		e.preventDefault();
-		navigate( { to } );
-		onClose();
-	};
-
-	return (
-		<MenuItem
-			onClick={ handleClick }
-			// @ts-expect-error -- href is supported by MenuItem, the types are not correct.
-			href={ href }
-		>
-			{ children }
-		</MenuItem>
-	);
-}
+import RouterLinkMenuItem from '../router-link-menu-item';
 
 function PrimaryMenuMobile() {
 	const { supports } = useAppContext();
@@ -49,24 +18,24 @@ function PrimaryMenuMobile() {
 			{ ( { onClose } ) => (
 				<>
 					{ supports.overview && (
-						<MobileMenuItem to="/overview" onClose={ onClose }>
+						<RouterLinkMenuItem to="/overview" onClick={ onClose }>
 							{ __( 'Overview' ) }
-						</MobileMenuItem>
+						</RouterLinkMenuItem>
 					) }
 					{ supports.sites && (
-						<MobileMenuItem to="/sites" onClose={ onClose }>
+						<RouterLinkMenuItem to="/sites" onClick={ onClose }>
 							{ __( 'Sites' ) }
-						</MobileMenuItem>
+						</RouterLinkMenuItem>
 					) }
 					{ supports.domains && (
-						<MobileMenuItem to="/domains" onClose={ onClose }>
+						<RouterLinkMenuItem to="/domains" onClick={ onClose }>
 							{ __( 'Domains' ) }
-						</MobileMenuItem>
+						</RouterLinkMenuItem>
 					) }
 					{ supports.emails && (
-						<MobileMenuItem to="/emails" onClose={ onClose }>
+						<RouterLinkMenuItem to="/emails" onClick={ onClose }>
 							{ __( 'Emails' ) }
-						</MobileMenuItem>
+						</RouterLinkMenuItem>
 					) }
 				</>
 			) }

--- a/client/dashboard/responsive-menu/index.tsx
+++ b/client/dashboard/responsive-menu/index.tsx
@@ -1,40 +1,9 @@
-import { useNavigate, useRouter } from '@tanstack/react-router';
-import { DropdownMenu, MenuItem } from '@wordpress/components';
+import { DropdownMenu } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { menu } from '@wordpress/icons';
 import React from 'react';
 import Menu from '../menu';
-
-function MobileMenuItem( {
-	to,
-	children,
-	onClose,
-}: {
-	to: string;
-	children: React.ReactNode;
-	onClose: () => void;
-} ) {
-	const navigate = useNavigate();
-	const router = useRouter();
-	const href = router.buildLocation( {
-		to,
-	} ).href;
-	const handleClick = ( e: React.MouseEvent ) => {
-		e.preventDefault();
-		navigate( { to } );
-		onClose();
-	};
-
-	return (
-		<MenuItem
-			onClick={ handleClick }
-			// @ts-expect-error -- href is supported by MenuItem, the types are not correct.
-			href={ href }
-		>
-			{ children }
-		</MenuItem>
-	);
-}
+import RouterLinkMenuItem from '../router-link-menu-item';
 
 type ResponsiveMenuProps = {
 	children: React.ReactNode;
@@ -78,9 +47,9 @@ function ResponsiveMenu( {
 						if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
 							const { to, children: itemChildren } = child.props;
 							return (
-								<MobileMenuItem to={ to } onClose={ onClose }>
+								<RouterLinkMenuItem to={ to } onClick={ onClose }>
 									{ itemChildren }
-								</MobileMenuItem>
+								</RouterLinkMenuItem>
 							);
 						}
 						return child;

--- a/client/dashboard/router-link-button/index.tsx
+++ b/client/dashboard/router-link-button/index.tsx
@@ -4,7 +4,7 @@ import { ButtonProps } from '@wordpress/components/build-types/button/types';
 import { forwardRef } from 'react';
 
 export default createLink(
-	forwardRef( ( props: ButtonProps, ref: React.Ref< HTMLButtonElement > ) => (
+	forwardRef( ( props: ButtonProps, ref: React.Ref< HTMLAnchorElement > ) => (
 		<Button ref={ ref } { ...props } />
 	) )
 );

--- a/client/dashboard/router-link-button/index.tsx
+++ b/client/dashboard/router-link-button/index.tsx
@@ -3,8 +3,8 @@ import { Button } from '@wordpress/components';
 import { ButtonProps } from '@wordpress/components/build-types/button/types';
 import { forwardRef } from 'react';
 
-export function RouterLinkButton( props: ButtonProps, ref: React.Ref< HTMLButtonElement > ) {
-	return <Button ref={ ref } { ...props } />;
-}
-
-export default createLink( forwardRef( RouterLinkButton ) );
+export default createLink(
+	forwardRef( ( props: ButtonProps, ref: React.Ref< HTMLButtonElement > ) => (
+		<Button ref={ ref } { ...props } />
+	) )
+);

--- a/client/dashboard/router-link-button/index.tsx
+++ b/client/dashboard/router-link-button/index.tsx
@@ -1,0 +1,10 @@
+import { createLink } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
+import { ButtonProps } from '@wordpress/components/build-types/button/types';
+import { forwardRef } from 'react';
+
+export function RouterLinkButton( props: ButtonProps, ref: React.Ref< HTMLButtonElement > ) {
+	return <Button ref={ ref } { ...props } />;
+}
+
+export default createLink( forwardRef( RouterLinkButton ) );

--- a/client/dashboard/router-link-menu-item/index.tsx
+++ b/client/dashboard/router-link-menu-item/index.tsx
@@ -8,6 +8,7 @@ export default createLink(
 	forwardRef(
 		(
 			props: WordPressComponentProps< MenuItemProps, 'button', false >,
+			// To do: Fix MenuItemProps so that it allows HTMLAnchorElement.
 			ref: React.Ref< HTMLButtonElement >
 		) => <MenuItem ref={ ref } { ...props } />
 	)

--- a/client/dashboard/router-link-menu-item/index.tsx
+++ b/client/dashboard/router-link-menu-item/index.tsx
@@ -4,11 +4,11 @@ import { WordPressComponentProps } from '@wordpress/components/build-types/conte
 import { MenuItemProps } from '@wordpress/components/build-types/menu-item/types';
 import { forwardRef } from 'react';
 
-export function RouterLinkMenuItem(
-	props: WordPressComponentProps< MenuItemProps, 'button', false >,
-	ref: React.Ref< HTMLButtonElement >
-) {
-	return <MenuItem ref={ ref } { ...props } />;
-}
-
-export default createLink( forwardRef( RouterLinkMenuItem ) );
+export default createLink(
+	forwardRef(
+		(
+			props: WordPressComponentProps< MenuItemProps, 'button', false >,
+			ref: React.Ref< HTMLButtonElement >
+		) => <MenuItem ref={ ref } { ...props } />
+	)
+);

--- a/client/dashboard/router-link-menu-item/index.tsx
+++ b/client/dashboard/router-link-menu-item/index.tsx
@@ -1,0 +1,14 @@
+import { createLink } from '@tanstack/react-router';
+import { MenuItem } from '@wordpress/components';
+import { WordPressComponentProps } from '@wordpress/components/build-types/context/wordpress-component';
+import { MenuItemProps } from '@wordpress/components/build-types/menu-item/types';
+import { forwardRef } from 'react';
+
+export function RouterLinkMenuItem(
+	props: WordPressComponentProps< MenuItemProps, 'button', false >,
+	ref: React.Ref< HTMLButtonElement >
+) {
+	return <MenuItem ref={ ref } { ...props } />;
+}
+
+export default createLink( forwardRef( RouterLinkMenuItem ) );

--- a/client/dashboard/secondary-menu/index.tsx
+++ b/client/dashboard/secondary-menu/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useRouter } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -15,28 +15,9 @@ import { useAppContext } from '../app/context';
 import { useAuth } from '../auth';
 import { useOpenCommandPalette } from '../command-palette/utils';
 import MenuDivider from '../menu-divider';
-import './style.scss';
+import RouterLinkMenuItem from '../router-link-menu-item';
 
-function NavMenuItem( { to, children }: { to: string; children: React.ReactNode } ) {
-	const navigate = useNavigate();
-	const router = useRouter();
-	const href = router.buildLocation( {
-		to,
-	} ).href;
-	return (
-		<MenuItem
-			// @ts-expect-error -- The MenuItem component types are not correct, href is a valid prop.
-			href={ href }
-			onClick={ ( e ) => {
-				e.preventDefault();
-				navigate( { to } );
-			} }
-			__next40pxDefaultSize
-		>
-			{ children }
-		</MenuItem>
-	);
-}
+import './style.scss';
 
 // User profile dropdown component
 function UserProfile() {
@@ -77,12 +58,14 @@ function UserProfile() {
 						<Text variant="muted">@{ user.username }</Text>
 					</VStack>
 					<MenuGroup>
-						<NavMenuItem to="/me/profile">{ __( 'Profile' ) }</NavMenuItem>
-						<NavMenuItem to="/me/billing">{ __( 'Billing' ) }</NavMenuItem>
-						<NavMenuItem to="/me/security">{ __( 'Security' ) }</NavMenuItem>
-						<NavMenuItem to="/me/privacy">{ __( 'Privacy' ) }</NavMenuItem>
+						<RouterLinkMenuItem to="/me/profile">{ __( 'Profile' ) }</RouterLinkMenuItem>
+						<RouterLinkMenuItem to="/me/billing">{ __( 'Billing' ) }</RouterLinkMenuItem>
+						<RouterLinkMenuItem to="/me/security">{ __( 'Security' ) }</RouterLinkMenuItem>
+						<RouterLinkMenuItem to="/me/privacy">{ __( 'Privacy' ) }</RouterLinkMenuItem>
 						{ supports.notifications && (
-							<NavMenuItem to="/me/notifications">{ __( 'Notifications' ) }</NavMenuItem>
+							<RouterLinkMenuItem to="/me/notifications">
+								{ __( 'Notifications' ) }
+							</RouterLinkMenuItem>
 						) }
 					</MenuGroup>
 					<MenuGroup>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fixes DOTCOM-10614.

#102760 but with using `createLink` instead. This fixes modifier key + click to open in new tab etc. too.

The only curious thing is that Tanstack Router decides to output relative links, so this may break if the app is not hosted at the root. In that case, I guess we could filter the `href` prop.

Overall this seems like a better approach than #102760.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
