### PR TITLE
DIFM: Fix the behavior of the back button

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -274,7 +274,12 @@ export default connect( ( state, ownProps ) => {
 	const backToParam = getCurrentQueryArguments( state )?.back_to?.toString();
 	const backTo = backToParam?.startsWith( '/' ) ? backToParam : undefined;
 
-	const backUrl = ownProps.backUrl ?? backTo;
+	let backUrl = ownProps.backUrl;
+
+	// Fallback to back_to from the query string only if the current step is the first step.
+	if ( ! backUrl && ownProps.positionInFlow === 0 ) {
+		backUrl = backTo;
+	}
 
 	return {
 		backUrl,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/102654

## Proposed Changes

* The `backUrl` prop was introduced in [#97722](https://github.com/Automattic/wp-calypso/pull/97722) and [#97749](https://github.com/Automattic/wp-calypso/pull/97749) to enable navigation back to the Goals screen. However, this change introduced a regression where the Back button prioritized the `backUrl` prop over the expected navigation flow. As a result, clicking Back on any step would incorrectly return users to the Goals screen, instead of the previous step.
* This PR proposes a fix by limiting the fallback to the `back_to` value from the query string only when the current step is the first step in the flow. This ensures that intermediate steps correctly navigate to their immediate previous step, restoring the intended back navigation behavior.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve DIFM experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Select `Let us build a custom site for you` on the Goals screen
* Continue
* Ensure the rest of the steps can go back to the previous step instead of the Goals screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
