### PR TITLE
Add debug to request-external-access package

### DIFF
--- a/packages/request-external-access/package.json
+++ b/packages/request-external-access/package.json
@@ -35,7 +35,8 @@
 	},
 	"dependencies": {
 		"@automattic/popup-monitor": "workspace:^",
-		"@babel/runtime": "^7.26.10"
+		"@babel/runtime": "^7.26.10",
+		"debug": "^4.4.0"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^"

--- a/packages/request-external-access/src/index.js
+++ b/packages/request-external-access/src/index.js
@@ -1,4 +1,7 @@
 import PopupMonitor from '@automattic/popup-monitor';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:request-external-access' );
 
 /**
  * The callback function of the requestExternalAccess utility.
@@ -31,6 +34,8 @@ const requestExternalAccess = ( url, cb ) => {
 			result.id_token = lastMessage.id_token;
 			result.user = lastMessage.user;
 		}
+
+		debug( 'popupMonitor.once close', lastMessage );
 		cb( result );
 	} );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,6 +1736,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/popup-monitor": "workspace:^"
     "@babel/runtime": "npm:^7.26.10"
+    debug: "npm:^4.4.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Ref DOTCOM-10575

## Proposed Changes

This PR adds debug message to track whether request-external-access is working as intended or not.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Debug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
