### PR TITLE
A4A > Referrals: Show button to refer products

### DIFF
--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -1,7 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import {
+	getActiveAgency,
+	hasApprovedAgencyStatus,
+} from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
@@ -24,13 +27,15 @@ const A4AAgencyApprovalNotice = () => {
 		getPreference( state, AGENCY_APPROVAL_DISMISS_PREFERENCE )
 	);
 
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
+
 	if ( isDismissed ) {
 		return null;
 	}
 
 	// If approved, only show banner for 1 week after signup
 	if (
-		agency?.approval_status === ApprovalStatus.APPROVED &&
+		isAgencyApproved &&
 		agency?.created_at &&
 		new Date( agency.created_at ) < new Date( Date.now() - 7 * 24 * 60 * 60 * 1000 ) // 7 days
 	) {

--- a/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/referral-toggle/index.tsx
@@ -4,8 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect } from 'react';
 import useReferralsGuide from 'calypso/a8c-for-agencies/components/guide-modal/guides/useReferralsGuide';
 import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { MarketplaceTypeContext } from '../../context';
@@ -22,11 +21,7 @@ const ReferralToggle = () => {
 
 	const guideModalSeen = useSelector( ( state ) => getPreference( state, PREFERENCE_NAME ) );
 
-	const agency = useSelector( getActiveAgency );
-
-	// Old agencies didn't had approval_status set, so we need to check for that
-	const isAgencyApproved =
-		agency?.approval_status === ApprovalStatus.APPROVED || agency?.approval_status === '';
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
 	useEffect( () => {
 		if ( marketplaceType === 'referral' && ! guideModalSeen ) {

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -25,8 +25,7 @@ import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
 import { useDispatch, useSelector } from 'calypso/state';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
-import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
+import { hasApprovedAgencyStatus } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MissingPaymentSettingsNotice from '../../common/missing-payment-settings-notice';
 import useFetchReferrals from '../../hooks/use-fetch-referrals';
@@ -45,9 +44,7 @@ export default function ReferralsOverview( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const agency = useSelector( getActiveAgency );
-
-	const isAgencyApproved = agency?.approval_status === ApprovalStatus.APPROVED;
+	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,

--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -1,9 +1,15 @@
 // Required for modular state.
 import 'calypso/state/a8c-for-agencies/init';
-import { A4AStore, APIError, Agency } from '../types';
+import { A4AStore, APIError, Agency, ApprovalStatus } from '../types';
 
 export function getActiveAgency( state: A4AStore ): Agency | null {
 	return state.a8cForAgencies.agencies.activeAgency;
+}
+
+export function hasApprovedAgencyStatus( state: A4AStore ): boolean {
+	const agency = getActiveAgency( state );
+	// Old agencies didn't have approval_status set, so we need to account for that
+	return agency?.approval_status === ApprovalStatus.APPROVED || agency?.approval_status === '';
 }
 
 export function getActiveAgencyId( state: A4AStore ): number | undefined {


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2083


## Proposed Changes

- Fix `New referral` button render issue when the agency is a legacy one
- Create a `hasApprovedAgencyStatus` selector that can be reused instead of manually checking everytime.

## Why are these changes being made?

* To show the `New referral` button when the agency is a legacy one

## Testing Instructions

* Ensure your agency is legacy by visiting https://agencies.automattic.com/referrals and the `New referral` button is not displayed.
* Open the A4A live link
* Go to Referrals > Verify the `New referral` button is now displayed
* Click the button > When redirected to the Marketplace, toggle the Refer products and verify it works as expected. 

<img width="1900" alt="Screenshot 2025-04-23 at 2 42 24 PM" src="https://github.com/user-attachments/assets/342db658-77ad-4807-a588-8e8aa33cec29" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
