### PR TITLE
Fix the redirect on the hosted migration flow when the site is WordPress

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -189,7 +189,7 @@ const siteMigration: FlowV2 = {
 								);
 							}
 
-							if ( platformQueryParam && platformQueryParam !== 'wordpress' ) {
+							if ( platformQueryParam !== 'unknown' && platformQueryParam !== 'wordpress' ) {
 								if ( isPlatformImportable( platformQueryParam ) && fromQueryParam ) {
 									return exitFlow(
 										getFullImporterUrl( platformQueryParam, siteSlug, fromQueryParam )

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -189,7 +189,7 @@ const siteMigration: FlowV2 = {
 								);
 							}
 
-							if ( platformQueryParam !== 'wordpress' ) {
+							if ( platformQueryParam && platformQueryParam !== 'wordpress' ) {
 								if ( isPlatformImportable( platformQueryParam ) && fromQueryParam ) {
 									return exitFlow(
 										getFullImporterUrl( platformQueryParam, siteSlug, fromQueryParam )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1745379768819529-slack-C02G2HLNB1R

## Proposed Changes

* Fix the condition that was redirected an user that could migrate to the Import List step.
* With the fix, we should redirect the user to `Import or Migrate` step, which offers the possibility of migrating the site.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* While testing another change, I noticed that we're being redirected to the Import List step even when the site is a WordPress site and could be migrated directly. The Import List step displays various import tools, including WordPress, but in this case, we should encourage users to migrate instead of presenting the full list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link
* Navigate to [WordPress.com/move](https://wordpress.com/move/)
* Input a WordPress(outside WPCOM) site to migrate
* You should reach the Site Picker step, replace the WordPress.com domain to your calypso live domain
* Select any sites from the list.
* You should be redirected to the `Migrate or Import` step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?