### PR TITLE
Gravatar: Fix sign-in UIs styles

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -614,6 +614,13 @@ $image-height: 47px;
 		}
 	}
 
+	.wp-login__main > .locale-suggestions > .locale-suggestions__notice.is-light {		
+		&,
+		.notice__icon-wrapper {
+			background-color: var(--studio-gray-0);
+		}
+	}
+
 	.login__form-gutenboarding-wordpress-logo {
 		display: none;
 	}
@@ -894,6 +901,11 @@ $image-height: 47px;
 
 	@include break-small {
 		background-color: #efefef;
+
+		.wp-login__main:not(:has(.locale-suggestions)) .login,
+		.grav-powered-magic-login:not(:has(.locale-suggestions)) .grav-powered-magic-login__content {
+			margin-top: 40px;
+		}
 
 		.login {
 			padding: 40px 56px;

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -614,7 +614,7 @@ $image-height: 47px;
 		}
 	}
 
-	.wp-login__main > .locale-suggestions > .locale-suggestions__notice.is-light {		
+	.wp-login__main .locale-suggestions .locale-suggestions__notice.is-light {		
 		&,
 		.notice__icon-wrapper {
 			background-color: var(--studio-gray-0);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 110221-gh-Automattic/gravatar

## Proposed Changes

* Fix the missed top margins
* Fix the wrong locale suggestion background color

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Related to 110221-gh-Automattic/gravatar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Set up Calypso](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started) and check out this PR
* Run `yarn start`
* Go to [this URL](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D02278bbbfb3ebed32633fc14259cf1e1901244ad7bbd203025ec5bb228a0c0b1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854), and the missed top margin has backed:

| Before | After |
| - | - |
| <img width="695" alt="截圖 2025-04-23 晚上7 32 54" src="https://github.com/user-attachments/assets/f1edea62-5cdd-4dad-b45a-7000b772290b" /> | <img width="695" alt="截圖 2025-04-23 晚上7 32 46" src="https://github.com/user-attachments/assets/7c41bacc-396f-4711-8d43-56d1f3dda98d" /> | 

* Go to [this URL](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D02278bbbfb3ebed32633fc14259cf1e1901244ad7bbd203025ec5bb228a0c0b1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854), and the missed top margin has backed:

| Before | After |
| - | - |
| <img width="695" alt="截圖 2025-04-23 晚上7 32 39" src="https://github.com/user-attachments/assets/b199e645-8d4b-4243-af8c-8d697380b98d" /> | <img width="695" alt="截圖 2025-04-23 晚上7 32 20" src="https://github.com/user-attachments/assets/4e6f5430-e62e-4144-a468-4a3cc32d3f67" /> |

* Go to [this URL](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D02278bbbfb3ebed32633fc14259cf1e1901244ad7bbd203025ec5bb228a0c0b1%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854), and use the browser's dev tool to check the locale suggestion in mobile view, the BG color of the suggestion has been changed to light gray:

| Before | After |
| - | - |
| <img width="390" alt="截圖 2025-04-23 晚上7 31 37" src="https://github.com/user-attachments/assets/58cd9665-f717-42b9-a325-6e67d3072763" /> | <img width="390" alt="截圖 2025-04-23 晚上7 31 09" src="https://github.com/user-attachments/assets/0ee4f2b5-a2ea-42d5-a320-6f6f2306b82e" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
