### PR TITLE
Hosting Dashboard v2: use iframes instead of mshot

### DIFF
--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -48,6 +48,7 @@ const siteRequestObjectToSiteObject = ( site: WPCOMRESTAPISite ): Site => ( {
 		software_version: site.options?.software_version,
 		admin_url: site.options?.admin_url,
 		is_wpcom_atomic: site.options?.is_wpcom_atomic,
+		blog_public: site.options?.blog_public,
 	},
 	is_deleted: site.is_deleted,
 } );

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -64,6 +64,7 @@ export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
 	is_wpcom_atomic?: boolean;
+	blog_public: number;
 }
 
 export interface Site {

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -25,18 +25,49 @@ export default function SiteCard( {
 	currentPlan: Plan;
 } ) {
 	const { options, url } = site;
-	const { software_version } = options;
+	const { software_version, blog_public } = options;
 	return (
 		<Card>
 			<VStack spacing={ 6 }>
 				<div className="dashboard-site-overview__preview-image">
-					<img
-						src={ `https://s0.wp.com/mshots/v1/${ encodeURIComponent( url ) }?w=600&h=400` }
-						alt={ __( 'Site preview' ) }
-						width={ 300 }
-						height={ 200 }
-						style={ { display: 'block' } }
-					/>
+					{ /* If the site is private, show the preview image, because X-Frame-Options is set to same origin. */ }
+					{ blog_public === -1 && (
+						<div
+							style={ {
+								width: '300px',
+								height: '200px',
+								fontSize: '24px',
+								background: 'var(--dashboard__background-color)',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+							} }
+						>
+							{ __( 'Private Site' ) }
+						</div>
+					) }
+					{ /* If the site is public or coming soon, show the preview iframe. */ }
+					{ blog_public > -1 && (
+						<div
+							className="dashboard-site-overview__preview-iframe"
+							style={ { width: '300px', height: '200px' } }
+						>
+							<iframe
+								loading="lazy"
+								title="Site Preview"
+								// See mu-plugins/theme-preview.php
+								src={ `${ url }/?theme&hide_banners=true&preview_overlay=true` }
+								style={ {
+									display: 'block',
+									border: 'none',
+									transform: 'scale(0.25)',
+									transformOrigin: 'top left',
+								} }
+								width={ 1200 }
+								height={ 800 }
+							></iframe>
+						</div>
+					) }
 				</div>
 				<VStack spacing={ 6 } className="site-card-contents">
 					{ primaryDomain && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

|Before|After|
|-|-|
|<img width="1464" alt="image" src="https://github.com/user-attachments/assets/bbfcfde0-215c-43e0-bfee-09cba3710396" />|<img width="1464" alt="image" src="https://github.com/user-attachments/assets/02b7804c-c67a-4a18-a95c-b44b3eb8be16" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* mshot does not work for "coming soon" sites
* if mshot is loading the site for the first time, the "generating" default image will be shown until you manually reload the screen. We'd have to keep retrying to make it work properly
* It's important that we have something good for the grid layout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
