### PR TITLE
Staging sites: Replace deprecated button component

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
+++ b/client/sites/staging-site/components/staging-site-card/card-content/new-staging-site-card-content.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
@@ -22,6 +22,10 @@ const WarningTitle = styled.p( {
 
 const WarningDescription = styled.p( {
 	marginBottom: '8px',
+} );
+
+const StyledButton = styled( Button )( {
+	fontSize: '14px',
 } );
 
 type CardContentProps = {
@@ -77,9 +81,13 @@ export const NewStagingSiteCardContent = ( {
 						{ disabledMessage }
 					</Notice>
 				) }
-				<Button primary disabled={ isButtonDisabled } onClick={ onAddClick }>
-					<span>{ translate( 'Add staging site' ) }</span>
-				</Button>
+				<StyledButton
+					variant="primary"
+					disabled={ isButtonDisabled }
+					onClick={ onAddClick }
+					__next40pxDefaultSize
+					text={ translate( 'Add staging site' ) }
+				></StyledButton>
 				{ showQuotaError && <ExceedQuotaErrorContent /> }
 			</>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTDEV-49

## Proposed Changes

While working on https://github.com/Automattic/wp-calypso/pull/102785, I noticed the warning related to the button component from automattic/components:

<img width="832" alt="Screenshot 2025-04-23 at 4 46 14 PM" src="https://github.com/user-attachments/assets/e26ebb40-bf53-4ab5-b638-da45ff1771f0" />

This PR replaces that button with the core Button component. Here is a side by side comparison of the two buttons:

<img width="1262" alt="Screenshot 2025-04-23 at 4 44 16 PM" src="https://github.com/user-attachments/assets/7111fb10-f575-4a00-a273-ba29393c4e49" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch or use Calypso live link
* Create a site with an e-Commerce plan
* Once that site is created, navigate to `/staging-site/testcommercesitekat.wpcomstaging.com?search={yourEcommerceSite}`
* Confirm that you can see the `Add staging site` button and that it looks identical to the one present on trunk

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
