### PR TITLE
Use ExternalLink for external links on /me/account

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { Button, Card, Dialog, FormInputValidation, FormLabel } from '@automattic/components';
 import { canBeTranslated, getLanguage, isLocaleVariant } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
+import { ExternalLink } from '@wordpress/components';
 import debugFactory from 'debug';
 import { fixMe, localize } from 'i18n-calypso';
 import { debounce, flowRight as compose, get, map, size } from 'lodash';
@@ -305,20 +306,29 @@ class Account extends Component {
 		const { translate } = this.props;
 		const url = 'https://translate.wordpress.com/translators/?contributor_locale=' + locale;
 
-		return (
-			<FormSettingExplanation>
-				{ ' ' }
-				{ translate(
-					'Thanks to {{a}}all our community members who helped translate to {{language/}}{{/a}}!',
-					{
-						components: {
-							a: <a target="_blank" rel="noopener noreferrer" href={ url } />,
-							language: <span>{ language.name }</span>,
-						},
-					}
-				) }
-			</FormSettingExplanation>
-		);
+		const thanksLabel = fixMe( {
+			text: 'Thanks to {{a}}all our community members who helped translate to {{language/}}{{/a}}',
+			newCopy: translate(
+				'Thanks to {{a}}all our community members who helped translate to {{language/}}{{/a}}',
+				{
+					components: {
+						a: <ExternalLink children={ null } href={ url } />,
+						language: <span>{ language.name }</span>,
+					},
+				}
+			),
+			oldCopy: translate(
+				'Thanks to {{a}}all our community members who helped translate to {{language/}}{{/a}}!',
+				{
+					components: {
+						a: <ExternalLink children={ null } href={ url } />,
+						language: <span>{ language.name }</span>,
+					},
+				}
+			),
+		} );
+
+		return <FormSettingExplanation> { thanksLabel }</FormSettingExplanation>;
 	}
 
 	handleRadioChange = ( event ) => {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -312,7 +312,7 @@ class Account extends Component {
 				'Thanks to {{a}}all our community members who helped translate to {{language/}}{{/a}}',
 				{
 					components: {
-						a: <ExternalLink href={ url } />,
+						a: <ExternalLink children={ null } href={ url } />,
 						language: <span>{ language.name }</span>,
 					},
 				}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -312,7 +312,7 @@ class Account extends Component {
 				'Thanks to {{a}}all our community members who helped translate to {{language/}}{{/a}}',
 				{
 					components: {
-						a: <ExternalLink children={ null } href={ url } />,
+						a: <ExternalLink href={ url } />,
 						language: <span>{ language.name }</span>,
 					},
 				}

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -32,10 +32,6 @@ fieldset.account__settings-admin-home {
 		color: inherit;
 		font-style: inherit;
 	}
-
-	a.components-external-link {
-		text-decoration: none;
-	}
 }
 
 .account__link-destination {

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -32,6 +32,10 @@ fieldset.account__settings-admin-home {
 		color: inherit;
 		font-style: inherit;
 	}
+
+	a.components-external-link {
+		text-decoration: none;
+	}
 }
 
 .account__link-destination {

--- a/client/me/account/toggle-use-community-translator.tsx
+++ b/client/me/account/toggle-use-community-translator.tsx
@@ -1,4 +1,4 @@
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl, ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -33,11 +33,10 @@ function ToggleUseCommunityTranslator() {
 				label={ translate( 'Enable the in-page translator where available. {{a}}Learn more{{/a}}', {
 					components: {
 						a: (
-							<a
-								target="_blank"
-								rel="noopener noreferrer"
+							<ExternalLink
 								href="https://translate.wordpress.com/community-translator/"
 								onClick={ handleLearnMoreClick }
+								children={ null }
 							/>
 						),
 					},

--- a/client/me/account/toggle-use-community-translator.tsx
+++ b/client/me/account/toggle-use-community-translator.tsx
@@ -36,6 +36,7 @@ function ToggleUseCommunityTranslator() {
 							<ExternalLink
 								href="https://translate.wordpress.com/community-translator/"
 								onClick={ handleLearnMoreClick }
+								children={ null }
 							/>
 						),
 					},

--- a/client/me/account/toggle-use-community-translator.tsx
+++ b/client/me/account/toggle-use-community-translator.tsx
@@ -36,7 +36,6 @@ function ToggleUseCommunityTranslator() {
 							<ExternalLink
 								href="https://translate.wordpress.com/community-translator/"
 								onClick={ handleLearnMoreClick }
-								children={ null }
 							/>
 						),
 					},


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #100334

## Proposed Changes

Use ExternalIcon on external links on /me/account

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Some of the external links on /me/account weren't using the ExternalLink component and so weren't showing the appropriate icon. This is inconsistent with other links. This change uses the ExternalLink component, it also removes some punctuation, as it looked weird being the only thing that followed the icon.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use the calypso live branch
 2. Go to /me/account
 3. Notice the ExternalLink icon is used for "Enable the in-page translator where available. Learn more" and "This is the language of the interface you see across WordPress.com as a whole. Thanks to all our community members who helped translate to English (UK)!"

Before | After
-------|------
<img width="773" alt="Screenshot 2025-04-23 at 18 23 01" src="https://github.com/user-attachments/assets/8d488e8b-18f6-4579-9415-541348c004ca" /> |<img width="783" alt="Screenshot 2025-04-28 at 15 39 32" src="https://github.com/user-attachments/assets/a02c12ef-7e60-45d0-aacc-1aba44206eb4" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
