### PR TITLE
Hosting Dashboard v2: sites grid

### DIFF
--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -26,6 +26,10 @@ body {
 	line-height: $font-line-height-small;
 }
 
+a {
+	color: var( --dashboard__link-color );
+}
+
 #wpcom {
 	font-size: $font-size-medium;
 }

--- a/client/dashboard/site-icon/index.tsx
+++ b/client/dashboard/site-icon/index.tsx
@@ -18,7 +18,16 @@ export default function SiteIcon( { site, size = 48 }: { site: Site; size?: numb
 	}, [ site.media ] );
 
 	if ( site.media ) {
-		return <img className="site-icon" src={ src } alt={ site.name } { ...dims } loading="lazy" />;
+		return (
+			<img
+				className="site-icon"
+				src={ src }
+				alt={ site.name }
+				{ ...dims }
+				loading="lazy"
+				style={ { width: size, height: size } }
+			/>
+		);
 	}
 
 	return (

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
+import SitePreview from '../site-preview';
 import type { Site, SiteDomain, Plan } from '../data/types';
 
 /**
@@ -52,20 +53,7 @@ export default function SiteCard( {
 							className="dashboard-site-overview__preview-iframe"
 							style={ { width: '300px', height: '200px' } }
 						>
-							<iframe
-								loading="lazy"
-								title="Site Preview"
-								// See mu-plugins/theme-preview.php
-								src={ `${ url }/?theme&hide_banners=true&preview_overlay=true` }
-								style={ {
-									display: 'block',
-									border: 'none',
-									transform: 'scale(0.25)',
-									transformOrigin: 'top left',
-								} }
-								width={ 1200 }
-								height={ 800 }
-							></iframe>
+							<SitePreview url={ url } scale={ 0.25 } />
 						</div>
 					) }
 				</div>

--- a/client/dashboard/site-preview/index.tsx
+++ b/client/dashboard/site-preview/index.tsx
@@ -1,0 +1,30 @@
+export default function SitePreview( {
+	url,
+	scale = 1,
+	width = 1200,
+	height = 800,
+}: {
+	url: string;
+	scale?: number;
+	width?: number;
+	height?: number;
+} ) {
+	return (
+		<iframe
+			loading="lazy"
+			// @ts-expect-error For some reason there's no inert type.
+			inert="true"
+			title="Site Preview"
+			// See mu-plugins/theme-preview.php + preview hides cookie banners + iframe hides admin bar for atomic sites.
+			src={ `${ url }/?theme&hide_banners=true&preview_overlay=true&preview=true&iframe=true` }
+			style={ {
+				display: 'block',
+				border: 'none',
+				transform: `scale(${ scale })`,
+				transformOrigin: 'top left',
+			} }
+			width={ width }
+			height={ height }
+		/>
+	);
+}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -38,7 +38,9 @@ const fields = [
 		id: 'url',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
-		render: ( { item }: { item: Site } ) => new URL( item.url ).hostname,
+		render: ( { item }: { item: Site } ) => (
+			<ExternalLink href={ item.url }>{ new URL( item.url ).hostname }</ExternalLink>
+		),
 	},
 	{
 		id: 'media',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
@@ -9,6 +10,7 @@ import { sitesQuery } from '../app/queries';
 import DataViewsCard from '../dataviews-card';
 import PageLayout from '../page-layout';
 import SiteIcon from '../site-icon';
+import SitePreview from '../site-preview';
 import type { Site } from '../data/types';
 import type { View } from '@wordpress/dataviews';
 
@@ -77,7 +79,50 @@ const fields = [
 			{ value: 'disabled', label: __( 'Disabled' ) },
 		],
 	},
+	{
+		id: 'preview',
+		label: __( 'Preview' ),
+		render: function PreviewRender( { item }: { item: Site } ) {
+			const [ resizeListener, { width } ] = useResizeObserver();
+			const { options, url } = item;
+			const { blog_public } = options;
+			return (
+				<>
+					{ resizeListener }
+					{ /* If the site is private, show the preview image, because X-Frame-Options is set to same origin. */ }
+					{ blog_public === -1 && (
+						<div
+							style={ {
+								fontSize: '24px',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								height: '100%',
+							} }
+						>
+							<SiteIcon site={ item } />
+						</div>
+					) }
+					{ /* If the site is public or coming soon, show the preview iframe. */ }
+					{ width && blog_public > -1 && (
+						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
+					) }
+				</>
+			);
+		},
+	},
 ];
+
+const DEFAULT_LAYOUTS = {
+	table: {
+		mediaField: 'media',
+		fields: [ 'subscribers', 'backups', 'protect' ],
+	},
+	grid: {
+		mediaField: 'preview',
+		fields: [],
+	},
+};
 
 export default function Sites() {
 	const navigate = useNavigate();
@@ -126,7 +171,7 @@ export default function Sites() {
 						view={ view }
 						onChangeView={ setView }
 						onClickItem={ onClickItem }
-						defaultLayouts={ { table: {} } }
+						defaultLayouts={ DEFAULT_LAYOUTS }
 						paginationInfo={ paginationInfo }
 					/>
 				</DataViewsCard>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![image](https://github.com/user-attachments/assets/7956f42e-9c85-4300-a9e3-60ef4086f4be)

Fixes DOTCOM-10627

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
