### PR TITLE
AVALON-33 CRM: Add Jetpack CRM Extensions to A4A's Dashboard

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/controller.tsx
+++ b/client/a8c-for-agencies/sections/purchases/controller.tsx
@@ -13,6 +13,7 @@ import {
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import BillingDashboard from './billing/billing-dashboard';
+import CrmDownloads from './crm-downloads';
 import InvoicesOverview from './invoices/invoices-overview';
 import LicensesOverview from './licenses/licenses-overview';
 import PaymentMethodAdd from './payment-methods/payment-method-add';
@@ -95,6 +96,18 @@ export const paymentMethodsAddContext: Callback = ( context, next ) => {
 		<>
 			<PageViewTracker title="Purchases > Payment Methods > Add" path={ context.path } />
 			<PaymentMethodAdd />
+		</>
+	);
+
+	next();
+};
+
+export const crmDownloadsContext: Callback = ( context, next ) => {
+	context.secondary = <PurchasesSidebar path={ context.path } />;
+	context.primary = (
+		<>
+			<PageViewTracker title="Purchases > Site > CRM Downloads" path={ context.path } />
+			<CrmDownloads licenseKey={ context.params.licenseKey || '' } />
 		</>
 	);
 

--- a/client/a8c-for-agencies/sections/purchases/crm-downloads/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/crm-downloads/index.tsx
@@ -1,0 +1,26 @@
+import { useTranslate } from 'i18n-calypso';
+import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import { CrmDownloadsContent } from 'calypso/components/crm-downloads/crm-downloads';
+import LayoutBody from 'calypso/layout/hosting-dashboard/body';
+import LayoutHeader, { LayoutHeaderTitle as Title } from 'calypso/layout/hosting-dashboard/header';
+import './style.scss';
+
+export function CrmDownloads( { licenseKey }: { licenseKey: string } ) {
+	const translate = useTranslate();
+
+	return (
+		<Layout className="crm-downloads" wide title={ translate( 'CRM Downloads' ) }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ translate( 'CRM Downloads' ) }</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<CrmDownloadsContent licenseKey={ licenseKey } />
+			</LayoutBody>
+		</Layout>
+	);
+}
+
+export default CrmDownloads;

--- a/client/a8c-for-agencies/sections/purchases/crm-downloads/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/crm-downloads/style.scss
@@ -1,0 +1,112 @@
+// Import the base component styles
+@import '~calypso/components/crm-downloads/style';
+
+// Error state styling
+.crm-downloads-error {
+	padding: 32px 24px;
+	background-color: var( --studio-white );
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 );
+	text-align: center;
+	max-width: 600px;
+	margin: 0 auto;
+
+	h2 {
+		font-size: 1.5rem;
+		margin: 16px 0;
+	}
+
+	p {
+		color: var( --studio-gray-60 );
+		margin-bottom: 24px;
+	}
+
+	.gridicon {
+		color: var( --studio-orange-40 );
+	}
+
+	button {
+		margin-top: 8px;
+	}
+
+	&__product-info {
+		background-color: var( --studio-gray-0 );
+		padding: 8px 16px;
+		border-radius: 4px;
+		font-family: monospace;
+		display: inline-block;
+	}
+}
+
+// Extensions table styling
+.extensions-table {
+	margin-top: 24px;
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+
+		th {
+			text-align: left;
+			padding: 12px;
+			border-bottom: 1px solid var( --studio-gray-5 );
+			font-weight: 600;
+		}
+
+		td {
+			padding: 16px 12px;
+			border-bottom: 1px solid var( --studio-gray-5 );
+			vertical-align: middle;
+
+			&:last-child {
+				width: 120px;
+				text-align: right;
+			}
+		}
+
+		tr:last-child td {
+			border-bottom: none;
+		}
+	}
+
+	.extensions-table__version {
+		color: var( --studio-gray-40 );
+		font-size: 0.75rem;
+		margin-top: 4px;
+	}
+
+	.extensions-table__description {
+		margin-top: 8px;
+		color: var( --studio-gray-60 );
+		font-size: 0.875rem;
+	}
+
+	.extensions-table__learn-more {
+		display: inline-block;
+		margin-top: 8px;
+		font-size: 0.875rem;
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+// Error state for extensions table
+.extensions-table__error {
+	padding: 24px;
+	text-align: center;
+	background-color: var( --studio-gray-0 );
+	border-radius: 2px;
+
+	.gridicon {
+		color: var( --studio-orange-40 );
+		margin-bottom: 16px;
+	}
+
+	p {
+		margin-bottom: 16px;
+		color: var( --studio-gray-80 );
+	}
+}

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -8,6 +8,7 @@ import {
 	invoicesContext,
 	paymentMethodsContext,
 	paymentMethodsAddContext,
+	crmDownloadsContext,
 } from './controller';
 
 export default function () {
@@ -46,4 +47,13 @@ export default function () {
 
 	// Invoices
 	page( '/purchases/invoices', requireAccessContext, invoicesContext, makeLayout, clientRender );
+
+	// CRM Downloads
+	page(
+		'/purchases/crm-downloads/:licenseKey',
+		// requireAccessContext,
+		crmDownloadsContext,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -13,6 +14,7 @@ import {
 	isPressableHostingProduct,
 	isWPCOMHostingProduct,
 } from 'calypso/a8c-for-agencies/sections/marketplace/lib/hosting';
+import isJetpackCrmProduct from 'calypso/components/crm-downloads/is-jetpack-crm-product';
 import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -105,11 +107,13 @@ export default function LicenseDetailsActions( {
 					</Button>
 				) }
 
-			{ licenseState === LicenseState.Attached && (
-				<Button compact href="/purchases/site/crm-downloads">
-					{ translate( 'Download Jetpack CRM Extensions' ) }
-				</Button>
-			) }
+			{ config.isEnabled( 'jetpack/crm-downloads' ) &&
+				licenseState === LicenseState.Attached &&
+				isJetpackCrmProduct( licenseKey ) && (
+					<Button compact href={ `/purchases/crm-downloads/${ licenseKey }` }>
+						{ translate( 'Download Jetpack CRM Extensions' ) }
+					</Button>
+				) }
 
 			{ ! isPressableLicense && licenseState === LicenseState.Attached && siteUrl && (
 				<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/actions.tsx
@@ -105,6 +105,12 @@ export default function LicenseDetailsActions( {
 					</Button>
 				) }
 
+			{ licenseState === LicenseState.Attached && (
+				<Button compact href="/purchases/site/crm-downloads">
+					{ translate( 'Download Jetpack CRM Extensions' ) }
+				</Button>
+			) }
+
 			{ ! isPressableLicense && licenseState === LicenseState.Attached && siteUrl && (
 				<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">
 					{ translate( 'View site' ) }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -65,7 +65,8 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true
+		"a8c-for-agencies-woopayments": true,
+		"jetpack/crm-downloads": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -58,7 +58,8 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true
+		"a8c-for-agencies-woopayments": true,
+		"jetpack/crm-downloads": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -60,7 +60,8 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true
+		"a8c-for-agencies-woopayments": true,
+		"jetpack/crm-downloads": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This is a continuation of https://github.com/Automattic/wp-calypso/pull/101997

## Add Jetpack CRM Downloads Component to Multiple Calypso Sections

This PR adds the Jetpack CRM downloads to:

1. **Agencies for Agencies (A4A)**: In the licenses section

### Integration Points
- **A4A**: Integrated into the licenses section for agency users

### Prerequisites
- You need a Jetpack Complete purchase for one of your sites or, if you are an agency partner, have issued a Jetpack Complete license. 

### A4A Testing
1. Log in as an agency user
2. Navigate to the licenses section
3. Find a license with Jetpack Complete
4. Verify that:
   - The CRM section appears with the proper heading
   - The license key is displayed correctly
   - The extensions table shows available extensions
   - The extensions download OK

### Error Handling Testing
1. Test with an invalid or expired license key
2. Verify that appropriate error messages are displayed

## Screenshots

<img width="1439" alt="crm_a4a" src="https://github.com/user-attachments/assets/84a17ca8-f082-4667-8b84-41df7fac88e3" />

## Why are these changes being made?
These changes make it easier for people who purchase Jetpack Complete to download their extensions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
