### PR TITLE
Hosting Overview: Record tracks event on browsers back

### DIFF
--- a/client/sites/overview/components/hosting-overview.tsx
+++ b/client/sites/overview/components/hosting-overview.tsx
@@ -1,8 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
+import { FC, useCallback, useEffect } from 'react';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isNotAtomicJetpack, isMigrationInProgress } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getCurrentRoutePattern from 'calypso/state/selectors/get-current-route-pattern';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ActiveDomainsCard from './active-domains-card';
 import MigrationOverview from './migration-overview';
@@ -16,7 +19,29 @@ import './style.scss';
 
 const HostingOverview: FC = () => {
 	const site = useSelector( getSelectedSite );
+	const currentRoute = useSelector( getCurrentRoute );
+	const currentRoutePattern = useSelector( getCurrentRoutePattern );
 	const translate = useTranslate();
+
+	const handleBrowsersBack = useCallback(
+		( ev: PopStateEvent ) => {
+			recordTracksEvent( 'calypso_hosting_overview_back_button', {
+				from_route: currentRoute,
+				from_route_path: currentRoutePattern,
+				to_route: ev.state?.path,
+			} );
+		},
+		[ currentRoute, currentRoutePattern ]
+	);
+
+	useEffect( () => {
+		window.addEventListener( 'popstate', handleBrowsersBack );
+		return () => {
+			setTimeout( () => {
+				window.removeEventListener( 'popstate', handleBrowsersBack );
+			}, 0 );
+		};
+	}, [ handleBrowsersBack ] );
 
 	if ( site ) {
 		if ( isMigrationInProgress( site ) ) {


### PR DESCRIPTION
Related to pdtkmj-3zG-p2#comment-6854

## Proposed Changes

* Site overview: Record tracks event on Browser's back

## Why are these changes being made?

* For the future analytics

## Testing Instructions

* Go to `/sites`
* Open a site
* Make sure you are on the Overview tab
* Open dev tool
* Press the browser's back button
* Check if there is `calypso:analytic` record with proper params
* Or go to `/setup/onboarding`
* Make sure you are assigned to treatment variant of the experiment
* Check if there is `calypso:analytic` record with proper params

<img width="492" alt="Screenshot 2025-04-23 at 23 32 52" src="https://github.com/user-attachments/assets/a41aa0c4-9276-4568-8771-749ed2e1e4e5" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?