### PR TITLE
Subscribers: Add a page param

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -226,6 +226,18 @@ const SubscriberDataViews = ( {
 	const shouldShowLaunchpad =
 		! isLoading && ! searchTerm && ( ! grandTotal || ( grandTotal === 1 && isOwnerSubscribed ) );
 
+	// Read page from URL when component mounts or URL changes
+	useEffect( () => {
+		const urlParams = new URLSearchParams( window.location.search );
+		const pageFromUrl = urlParams.get( 'page' );
+		if ( pageFromUrl && ! isNaN( parseInt( pageFromUrl, 10 ) ) ) {
+			setCurrentView( ( prev ) => ( {
+				...prev,
+				page: parseInt( pageFromUrl, 10 ),
+			} ) );
+		}
+	}, [] );
+
 	const handleSubscriberSelection = useCallback(
 		( input: Subscriber | string[] ) => {
 			if ( Array.isArray( input ) ) {
@@ -234,14 +246,20 @@ const SubscriberDataViews = ( {
 					page.show( `/subscribers/${ siteSlug }` );
 					return;
 				}
-				const subscriber = subscribers.find( ( s ) => getSubscriptionIdString( s ) === input[ 0 ] );
+				const subscriber = subscribersQueryResult?.subscribers.find(
+					( s ) => getSubscriptionIdString( s ) === input[ 0 ]
+				);
 				if ( subscriber ) {
 					recordSubscriberClicked( 'list', {
 						site_id: siteId,
 						subscription_id: getSubscriptionId( subscriber ),
 						user_id: subscriber.user_id,
 					} );
-					page.show( `/subscribers/${ siteSlug }/${ getSubscriptionIdString( subscriber ) }` );
+					page.show(
+						`/subscribers/${ siteSlug }/${ getSubscriptionIdString( subscriber ) }?page=${
+							currentView.page
+						}`
+					);
 				}
 			} else {
 				recordSubscriberClicked( 'row', {
@@ -249,11 +267,32 @@ const SubscriberDataViews = ( {
 					subscription_id: getSubscriptionId( input ),
 					user_id: input.user_id,
 				} );
-				page.show( `/subscribers/${ siteSlug }/${ getSubscriptionIdString( input ) }` );
+				page.show(
+					`/subscribers/${ siteSlug }/${ getSubscriptionIdString( input ) }?page=${
+						currentView.page
+					}`
+				);
 			}
 		},
-		[ subscribers, recordSubscriberClicked, siteId, siteSlug ]
+		[
+			subscribersQueryResult?.subscribers,
+			recordSubscriberClicked,
+			siteId,
+			siteSlug,
+			currentView.page,
+		]
 	);
+
+	// Modify the onClose handler in SubscriberDetails to preserve the page when going back to the list
+	const handleClose = useCallback( () => {
+		const urlParams = new URLSearchParams( window.location.search );
+		const pageParam = urlParams.get( 'page' );
+		if ( pageParam ) {
+			page.show( `/subscribers/${ siteSlug }?page=${ pageParam }` );
+		} else {
+			page.show( `/subscribers/${ siteSlug }` );
+		}
+	}, [ siteSlug ] );
 
 	const fields = useMemo(
 		() => [
@@ -567,9 +606,7 @@ const SubscriberDataViews = ( {
 							subscriber={ subscriberDetails }
 							siteId={ siteId }
 							subscriptionId={ getSubscriptionId( selectedSubscriber ) }
-							onClose={ () => {
-								page.show( `/subscribers/${ siteSlug }` );
-							} }
+							onClose={ handleClose }
 							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }
 							newsletterCategoriesEnabled={ subscribedNewsletterCategoriesData?.enabled }
 							newsletterCategories={ subscribedNewsletterCategoriesData?.newsletterCategories }

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -487,6 +487,14 @@ const SubscriberDataViews = ( {
 				} );
 			}
 
+			// Update URL when page changes
+			if ( newView.page !== currentView.page ) {
+				const currentPath = window.location.pathname;
+				const urlParams = new URLSearchParams( window.location.search );
+				urlParams.set( 'page', String( newView.page ) );
+				page.show( `${ currentPath }?${ urlParams.toString() }` );
+			}
+
 			setCurrentView( newView );
 		},
 		[

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -226,7 +226,13 @@ const SubscriberDataViews = ( {
 	const shouldShowLaunchpad =
 		! isLoading && ! searchTerm && ( ! grandTotal || ( grandTotal === 1 && isOwnerSubscribed ) );
 
-	// Read page from URL when component mounts or URL changes
+	/**
+	 * Read page from URL when component mounts or URL changes.
+	 *
+	 * URL Parameters:
+	 * - /subscribers/{siteSlug}/{subscriberId} - View specific subscriber
+	 * - ?page={number} - Navigate to specific page (preserved across views)
+	 */
 	useEffect( () => {
 		const urlParams = new URLSearchParams( window.location.search );
 		const pageFromUrl = urlParams.get( 'page' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add a page parameter to the URL, so that when you navigate to a specific subscriber via the URL, you also open the correct page.

https://github.com/user-attachments/assets/5189d2e9-138e-4b3d-8b29-de0ba82e4453


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Land the user on the correct page for the subscriber they've requested.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Navigate to a page that isn't 1.
* Click on a subscriber. You should see the subscriber id and page # in the URL.
* Refresh, or open the URL in a new tab. You should land on the correct page and subscriber.
* Close the subscriber. You should still see the page in the URL, and see it changes when you switch pages.
* Regression test that you can still get to a specific subscriber with just the subscriber id in the URL (no page). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
