### PR TITLE
 SitesDropdown: Add disabled state

### DIFF
--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -23,6 +23,7 @@ export class SitesDropdown extends PureComponent {
 		filter: PropTypes.func,
 		isPlaceholder: PropTypes.bool,
 		hasMultipleSites: PropTypes.bool,
+		disabled: PropTypes.bool,
 
 		// connected props
 		selectedSite: PropTypes.object,
@@ -34,6 +35,7 @@ export class SitesDropdown extends PureComponent {
 		onSiteSelect: noop,
 		isPlaceholder: false,
 		hasMultipleSites: false,
+		disabled: false,
 	};
 
 	constructor( props ) {
@@ -94,6 +96,7 @@ export class SitesDropdown extends PureComponent {
 				className={ clsx(
 					'sites-dropdown',
 					{ 'is-open': this.state.open },
+					{ 'is-disabled': this.props.disabled },
 					{ 'has-multiple-sites': this.props.hasMultipleSites }
 				) }
 			>
@@ -111,7 +114,9 @@ export class SitesDropdown extends PureComponent {
 						) : (
 							<Site siteId={ this.state.selectedSiteId } indicator={ false } />
 						) }
-						{ this.props.hasMultipleSites && <Gridicon icon="chevron-down" /> }
+						{ this.props.hasMultipleSites && (
+							<Gridicon icon="chevron-down" height={ 16 } width={ 16 } />
+						) }
 					</div>
 					{ this.props.hasMultipleSites && this.state.open && (
 						<SiteSelector

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -9,12 +9,29 @@
 		}
 	}
 
+	&.is-disabled {
+		.sites-dropdown__wrapper {
+			background-color: var(--color-neutral-0);
+			border-color: var(--color-neutral-0);
+			pointer-events: none;
+
+			.site__title,
+			.site__domain {
+				color: var(--color-neutral-20);
+
+				&::after {
+					content: none;
+				}
+			}
+		}
+	}
+
 	.gridicons-chevron-down {
 		align-self: center;
 		color: var(--color-neutral-20);
 		flex-grow: 0;
 		flex-shrink: 0;
-		margin-right: 16px;
+		margin-right: 12px;
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
 }

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -498,6 +498,7 @@ class Account extends Component {
 				isPlaceholder={ ! primarySiteId || requestingMissingSites }
 				selectedSiteId={ primarySiteId }
 				onSiteSelect={ this.onSiteSelect }
+				disabled={ this.state.submittingForm }
 			/>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100332

## Proposed Changes

This PR implements a disabled state for the SitesDropdown component as per mockup:

![image](https://github.com/user-attachments/assets/0cd4b4d2-54aa-4a56-8d18-3f008bb9a278)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WP.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /me/account
* Change your primary site
* Ensure that the site dropdown is disabled as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
