### PR TITLE
Stats: Introduce "clsx" to NavigationHeader component

### DIFF
--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import './navigation-header.scss';
@@ -20,8 +21,8 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
 
 /**
  * Header component that can be used in various contexts
- *
  * @param props - Component props
+ * @param props.className - Additional CSS class name for the component
  * @param props.title - Header title text
  * @param props.backLinkProps - Object containing back link properties (backLink URL, backLinkText, and onBackClick handler)
  * @param props.titleElement - Custom element to override default title rendering
@@ -31,6 +32,7 @@ interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
  * @returns The rendered NavigationHeader component
  */
 const NavigationHeader: React.FC< HeaderProps > = ( {
+	className,
 	title,
 	backLinkProps,
 	titleElement = <h1 className="calypso-navigation-header__title">{ title }</h1>,
@@ -54,9 +56,9 @@ const NavigationHeader: React.FC< HeaderProps > = ( {
 } ) => {
 	return (
 		<header
-			className={ `calypso-navigation-header${
-				hasScreenOptionsTab ? ' calypso-navigation-header__screen-options-tab' : ''
-			}` }
+			className={ clsx( 'calypso-navigation-header', className, {
+				'calypso-navigation-header__screen-options-tab': hasScreenOptionsTab,
+			} ) }
 			{ ...rest }
 		>
 			<div className="calypso-navigation-header__head">{ headElement }</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/102813/files#r2057579314 and https://github.com/Automattic/wp-calypso/pull/102813/files#r2057579314

## Proposed Changes

* Introduce `clsx` to component `NavigationHeader`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Refactor for component class name combination.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the local Calypso environment.
* Navigate to Stats > Traffic page.
* Ensure the class name `calypso-navigation-header` coexists with Stats dedicated class names.

<img width="658" alt="截圖 2025-04-24 下午1 51 34" src="https://github.com/user-attachments/assets/b9c9414e-e2fc-4b00-b0f7-bee3d1226ad3" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
