### PR TITLE
Hosting Dashboard v2: sites: add status field

### DIFF
--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -54,6 +54,10 @@ export const fetchSites = async (): Promise< Site[] > => {
 					'plan',
 					'active_modules',
 					'is_deleted',
+					'is_coming_soon',
+					'is_private',
+					'launch_status',
+					'site_migration',
 					'options',
 				].join( ',' ),
 			}

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -65,6 +65,7 @@ export interface SiteOptions {
 	admin_url: string;
 	is_wpcom_atomic?: boolean;
 	blog_public: number;
+	is_redirect?: boolean;
 }
 
 export interface Site {
@@ -79,6 +80,12 @@ export interface Site {
 	subscribers_count: number;
 	options: SiteOptions;
 	is_deleted: boolean;
+	is_coming_soon: boolean;
+	is_private: boolean;
+	launch_status: string | boolean;
+	site_migration: {
+		migration_status: string;
+	} | null;
 }
 
 export type EmailProvider = 'titan' | 'google-workspace' | 'forwarding';

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -9,6 +9,7 @@ import {
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import SitePreview from '../site-preview';
+import { getSiteStatusLabel } from '../utils/site-status';
 import type { Site, SiteDomain, Plan } from '../data/types';
 
 /**
@@ -64,7 +65,7 @@ export default function SiteCard( {
 						</Field>
 					) }
 					<HStack justify="space-between">
-						<Field title={ __( 'Status' ) }>status here...</Field>
+						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
 					</HStack>
 					<HStack justify="space-between">
 						<Field title={ __( 'WordPress' ) }>{ software_version }</Field>

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -114,12 +114,12 @@ const fields = [
 		],
 	},
 	{
-		id: 'visibility',
-		label: __( 'Visibility' ),
+		id: 'status',
+		label: __( 'Status' ),
 		getValue: getStatus,
-		elements: Object.keys( STATUS_LABELS ).map( ( key ) => ( {
-			value: key,
-			label: STATUS_LABELS[ key ],
+		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( {
+			value,
+			label,
 		} ) ),
 		render: ( { item }: { item: Site } ) => {
 			return STATUS_LABELS[ getStatus( { item } ) ];
@@ -162,7 +162,7 @@ const fields = [
 const DEFAULT_LAYOUTS = {
 	table: {
 		mediaField: 'icon.ico',
-		fields: [ 'subscribers_count', 'backups', 'protect' ],
+		fields: [ 'subscribers_count', 'status', 'backups', 'protect' ],
 		titleField: 'name',
 		descriptionField: 'url',
 	},

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -11,6 +11,7 @@ import DataViewsCard from '../dataviews-card';
 import PageLayout from '../page-layout';
 import SiteIcon from '../site-icon';
 import SitePreview from '../site-preview';
+import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import type { Site } from '../data/types';
 import type { View } from '@wordpress/dataviews';
 
@@ -26,44 +27,6 @@ const actions = [
 		isEligible: ( item: Site ) => ( item.is_deleted ? false : true ),
 	},
 ];
-
-function getStatus( { item }: { item: Site } ) {
-	if ( item.site_migration?.migration_status.startsWith( 'migration-pending' ) ) {
-		return 'migration_pending';
-	}
-
-	if ( item.site_migration?.migration_status.startsWith( 'migration-started' ) ) {
-		return 'migration_started';
-	}
-
-	if ( item.is_deleted ) {
-		return 'deleted';
-	}
-
-	if ( item.options.is_redirect ) {
-		return 'redirect';
-	}
-
-	if ( item.is_coming_soon || ( item.is_private && item.launch_status === 'unlaunched' ) ) {
-		return 'coming_soon';
-	}
-
-	if ( item.is_private ) {
-		return 'private';
-	}
-
-	return 'public';
-}
-
-const STATUS_LABELS = {
-	public: __( 'Public' ),
-	private: __( 'Private' ),
-	coming_soon: __( 'Coming Soon' ),
-	deleted: __( 'Deleted' ),
-	redirect: __( 'Redirect' ),
-	migration_pending: __( 'Migration Pending' ),
-	migration_started: __( 'Migration Started' ),
-};
 
 // Field definitions
 const fields = [
@@ -116,14 +79,9 @@ const fields = [
 	{
 		id: 'status',
 		label: __( 'Status' ),
-		getValue: getStatus,
-		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( {
-			value,
-			label,
-		} ) ),
-		render: ( { item }: { item: Site } ) => {
-			return STATUS_LABELS[ getStatus( { item } ) ];
-		},
+		getValue: ( { item }: { item: Site } ) => getSiteStatus( item ),
+		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
+		render: ( { item }: { item: Site } ) => getSiteStatusLabel( item ),
 	},
 	{
 		id: 'preview',

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -27,6 +27,44 @@ const actions = [
 	},
 ];
 
+function getStatus( { item }: { item: Site } ) {
+	if ( item.site_migration?.migration_status.startsWith( 'migration-pending' ) ) {
+		return 'migration_pending';
+	}
+
+	if ( item.site_migration?.migration_status.startsWith( 'migration-started' ) ) {
+		return 'migration_started';
+	}
+
+	if ( item.is_deleted ) {
+		return 'deleted';
+	}
+
+	if ( item.options.is_redirect ) {
+		return 'redirect';
+	}
+
+	if ( item.is_coming_soon || ( item.is_private && item.launch_status === 'unlaunched' ) ) {
+		return 'coming_soon';
+	}
+
+	if ( item.is_private ) {
+		return 'private';
+	}
+
+	return 'public';
+}
+
+const STATUS_LABELS = {
+	public: __( 'Public' ),
+	private: __( 'Private' ),
+	coming_soon: __( 'Coming Soon' ),
+	deleted: __( 'Deleted' ),
+	redirect: __( 'Redirect' ),
+	migration_pending: __( 'Migration Pending' ),
+	migration_started: __( 'Migration Started' ),
+};
+
 // Field definitions
 const fields = [
 	{
@@ -74,6 +112,18 @@ const fields = [
 			{ value: 'enabled', label: __( 'Enabled' ) },
 			{ value: 'disabled', label: __( 'Disabled' ) },
 		],
+	},
+	{
+		id: 'visibility',
+		label: __( 'Visibility' ),
+		getValue: getStatus,
+		elements: Object.keys( STATUS_LABELS ).map( ( key ) => ( {
+			value: key,
+			label: STATUS_LABELS[ key ],
+		} ) ),
+		render: ( { item }: { item: Site } ) => {
+			return STATUS_LABELS[ getStatus( { item } ) ];
+		},
 	},
 	{
 		id: 'preview',

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+import type { Site } from '../data/types';
+
+export const STATUS_LABELS = {
+	public: __( 'Public' ),
+	private: __( 'Private' ),
+	coming_soon: __( 'Coming Soon' ),
+	deleted: __( 'Deleted' ),
+	redirect: __( 'Redirect' ),
+	migration_pending: __( 'Migration Pending' ),
+	migration_started: __( 'Migration Started' ),
+};
+
+export function getSiteStatus( item: Site ) {
+	if ( item.site_migration?.migration_status.startsWith( 'migration-pending' ) ) {
+		return 'migration_pending';
+	}
+
+	if ( item.site_migration?.migration_status.startsWith( 'migration-started' ) ) {
+		return 'migration_started';
+	}
+
+	if ( item.is_deleted ) {
+		return 'deleted';
+	}
+
+	if ( item.options.is_redirect ) {
+		return 'redirect';
+	}
+
+	if ( item.is_coming_soon || ( item.is_private && item.launch_status === 'unlaunched' ) ) {
+		return 'coming_soon';
+	}
+
+	if ( item.is_private ) {
+		return 'private';
+	}
+
+	return 'public';
+}
+
+export function getSiteStatusLabel( item: Site ) {
+	return STATUS_LABELS[ getSiteStatus( item ) ];
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fixes DOTCOM-10646

Allows you to filter out private sites.

<img width="537" alt="image" src="https://github.com/user-attachments/assets/ed82747d-f3f1-4863-bba8-cdb3018ac193" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
