### PR TITLE
A4A: Fix the banner overlap issue on Mobile devices

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -12,16 +12,18 @@
 .a4a-layout__banner {
 	margin-inline: 0;
 	max-height: 100%;
-	margin-block-end: 24px;
+	margin-block: 24px;
 
 	> * {
-		padding-inline: 16px;
 
 		@include breakpoint-deprecated( ">660px" ) {
 			max-width: 1500px;
 			margin-inline: auto !important;
-			padding-inline: 64px;
 		}
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		margin-block-start: 0;
 	}
 }
 

--- a/client/layout/hosting-dashboard/style.scss
+++ b/client/layout/hosting-dashboard/style.scss
@@ -79,7 +79,6 @@
 	}
 
 	.notice-banner {
-		padding: 24px;
 
 		&.is-info {
 			border-left-color: var(--color-primary);


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1314

## Proposed Changes

This PR fixes the overlapping issues with the NoticeBanner component on A4A.

## Why are these changes being made?

* To fix the overlapping issues with the NoticeBanner component on A4A.

## Testing Instructions

* Open the A4A live link
* Verify the Layout banner is displayed perfectly, and doesn't overlap on mobile devices.
* Verify it looks good on large screen as well. You can go ahead and create a WP.com site if you don't have any existing notice.

<img width="377" alt="Screenshot 2025-04-24 at 1 56 16 PM" src="https://github.com/user-attachments/assets/9d9fa3f2-8c60-4660-b163-c5c48e23c65f" />

<img width="575" alt="Screenshot 2025-04-24 at 1 58 39 PM" src="https://github.com/user-attachments/assets/b32a9fc5-da58-42de-9526-cd5ad09e181d" />

<img width="720" alt="Screenshot 2025-04-24 at 1 59 28 PM" src="https://github.com/user-attachments/assets/9b5d6f94-13fa-48f0-b479-e481d37e62a3" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
