### PR TITLE
Grid: Remove explicit grid positionning

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -9,6 +9,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Grid component for CSS Grid layouts
-- Support for precise and implicit positioning of child elements
 - Customizable columns, spacing, and row height
 - Support for automated responsive layout by specifying minimum column widths

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -1,6 +1,6 @@
 # Grid
 
-A flexible grid component for React applications. This component uses CSS Grid to create layouts with precise control over the positioning of elements.
+A flexible grid component for React applications. This component uses CSS Grid to create layouts with automatic positioning of elements.
 
 ## Installation
 
@@ -15,9 +15,9 @@ import { Grid } from '@automattic/grid';
 
 const MyLayout = () => {
 	const layout = [
-		{ key: 'a', x: 0, y: 0, width: 1 },
-		{ key: 'b', x: 1, y: 0, width: 3 },
-		{ key: 'c', x: 4, y: 0, width: 1 },
+		{ key: 'a', width: 1 },
+		{ key: 'b', width: 3 },
+		{ key: 'c', width: 1 },
 	];
 
 	return (
@@ -40,8 +40,6 @@ The main component exported by this package.
 
 - `layout` (required): An array of layout items with the following properties:
   - `key` (string): A unique identifier that matches the `key` prop of the corresponding child component
-  - `x` (number): The starting column (0-indexed)
-  - `y` (number): The starting row (0-indexed)
   - `width` (number): The number of columns this item spans
   - `height` (number, optional): The number of rows this item spans (defaults to 1)
   - `order` (number, optional): In responsive mode, determines the order of items (lower values displayed first)
@@ -52,20 +50,20 @@ The main component exported by this package.
 - `rowHeight` (optional): Height of each row (e.g., "50px", "auto")
 - `minColumnWidth` (optional): Minimum width in pixels for each column; when provided, enables responsive mode that automatically adjusts columns based on container width
 
-## Fixed vs. Responsive Mode
+## Standard vs. Responsive Mode
 
 The Grid component can operate in two modes:
 
-### Fixed Mode (Default)
+### Standard Mode (Default)
 
-In fixed mode, items are positioned exactly according to their `x` and `y` coordinates in the layout. This provides precise control over the grid layout.
+In standard mode, items are positioned automatically in a grid with the specified number of columns. Each item can span multiple columns and rows.
 
 ```jsx
-// Fixed layout with 6 columns
+// Standard layout with 6 columns
 <Grid
 	layout={ [
-		{ key: 'a', x: 0, y: 0, width: 2 },
-		{ key: 'b', x: 2, y: 0, width: 4 },
+		{ key: 'a', width: 2 },
+		{ key: 'b', width: 4 },
 	] }
 	columns={ 6 }
 >
@@ -79,7 +77,7 @@ In fixed mode, items are positioned exactly according to their `x` and `y` coord
 When `minColumnWidth` is provided, the Grid activates responsive mode, which automatically adjusts the number of columns based on the container width. In this mode:
 
 1. Items flow according to their `order` property (or original array order if not specified)
-2. The grid will collapse to fewer columns when the container width can't accommodate `columns` columns of `minColumnWidth` each
+2. The grid will use the available space to fit as many columns as possible, based on the `minColumnWidth`
 3. Items that can't fit on a row will wrap to the next row
 4. Items with `fullWidth` set to `true` will always span all available columns
 
@@ -91,7 +89,6 @@ When `minColumnWidth` is provided, the Grid activates responsive mode, which aut
 		{ key: 'b', width: 2, order: 2 },
 		{ key: 'c', width: 4, order: 3, fullWidth: true },
 	] }
-	columns={ 6 }
 	minColumnWidth={ 150 } // Each column should be at least 150px
 >
 	<div key="a">Item A</div>

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from 'react';
 
 export function Grid( {
 	layout,
-	columns = 1,
+	columns = 6,
 	children,
 	className,
 	spacing = 2,
@@ -51,17 +51,6 @@ export function Grid( {
 		} );
 	}, [ layout, minColumnWidth ] );
 
-	// Get the number of rows in the layout
-	const rows = useMemo( () => {
-		const activeLayout = responsiveLayout || layout;
-		let maxRow = 0;
-		activeLayout.forEach( ( item ) => {
-			const itemHeight = item.height || 1;
-			maxRow = Math.max( maxRow, ( item.y ?? 0 ) + itemHeight );
-		} );
-		return maxRow;
-	}, [ layout, responsiveLayout ] );
-
 	// Create a map of layout items for quick access
 	const activeLayoutMap = useMemo( () => {
 		const activeLayout = responsiveLayout || layout;
@@ -75,7 +64,7 @@ export function Grid( {
 	const gridStyle = {
 		display: 'grid',
 		gridTemplateColumns: `repeat(${ effectiveColumns }, 1fr)`,
-		gridTemplateRows: `repeat(${ rows }, ${ rowHeight })`,
+		gridAutoRows: rowHeight,
 		gap: gapPx,
 	};
 
@@ -92,11 +81,9 @@ export function Grid( {
 		const item: Omit< GridLayoutItem, 'key' > = key ? activeLayoutMap.get( key )! ?? {} : {};
 		const itemHeight = item.height || 1;
 
-		// Apply grid positioning
+		// Apply grid positioning - using only automatic positioning
 		const style = {
 			...element.props.style,
-			gridColumnStart: item.x !== undefined ? item.x + 1 : undefined,
-			gridRowStart: item.y !== undefined ? item.y + 1 : undefined,
 			gridColumnEnd: `span ${
 				item.fullWidth ? effectiveColumns : Math.min( item.width ?? 1, effectiveColumns )
 			}`,

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -47,38 +47,11 @@ function Card( {
 export const Default: StoryObj< typeof Grid > = {
 	args: {
 		layout: [
-			{ key: 'a', x: 0, y: 0, width: 1 },
-			{ key: 'b', x: 1, y: 0, width: 3 },
-			{ key: 'c', x: 4, y: 0, width: 1 },
-		],
-		columns: 6,
-		children: [
-			<Card key="a" color="#f44336">
-				A
-			</Card>,
-			<Card key="b" color="#2196f3">
-				B
-			</Card>,
-			<Card key="c" color="#4caf50">
-				C
-			</Card>,
-		],
-	},
-};
-
-/**
- * Basic usage example of the Grid component with implicit positions
- */
-export const Implicit: StoryObj< typeof Grid > = {
-	args: {
-		layout: [
 			{ key: 'a', width: 1 },
 			{ key: 'b', width: 3 },
 			{ key: 'c', width: 1 },
 		],
 		columns: 6,
-		spacing: 2,
-		rowHeight: '100px',
 		children: [
 			<Card key="a" color="#f44336">
 				A
@@ -88,44 +61,6 @@ export const Implicit: StoryObj< typeof Grid > = {
 			</Card>,
 			<Card key="c" color="#4caf50">
 				C
-			</Card>,
-		],
-	},
-};
-
-/**
- * Multi-row grid layout example
- */
-export const MultiRowLayout: StoryObj< typeof Grid > = {
-	args: {
-		layout: [
-			{ key: 'a', x: 0, y: 0, width: 2, height: 1 },
-			{ key: 'b', x: 2, y: 0, width: 3, height: 2 },
-			{ key: 'c', x: 5, y: 0, width: 1, height: 1 },
-			{ key: 'd', x: 0, y: 1, width: 2, height: 1 },
-			{ key: 'e', x: 5, y: 1, width: 1, height: 1 },
-		],
-		columns: 6,
-		spacing: 2,
-		rowHeight: '100px',
-		children: [
-			<Card key="a" color="#f44336">
-				A
-			</Card>,
-			<Card key="b" color="#2196f3">
-				B
-			</Card>,
-			<Card key="c" color="#4caf50">
-				C
-			</Card>,
-			<Card key="d" color="#ff9800">
-				D
-			</Card>,
-			<Card key="e" color="#9c27b0">
-				E
-			</Card>,
-			<Card key="f" color="black">
-				F
 			</Card>,
 		],
 	},
@@ -138,15 +73,15 @@ export const MultiRowLayout: StoryObj< typeof Grid > = {
 export const ResponsiveGrid: StoryObj< typeof Grid > = {
 	args: {
 		layout: [
-			{ key: 'a', width: 1, height: 1, order: 1 },
-			{ key: 'b', width: 3, height: 1, order: 2 },
-			{ key: 'c', width: 1, height: 1, order: 3 },
-			{ key: 'd', width: 3, height: 1, order: 4 },
-			{ key: 'e', width: 4, height: 1, order: 5 },
+			{ key: 'a', width: 2, height: 1, order: 1 },
+			{ key: 'b', width: 2, height: 1, order: 2 },
+			{ key: 'c', width: 2, height: 1, order: 3 },
+			{ key: 'd', width: 4, height: 1, order: 4 },
+			{ key: 'e', width: 2, height: 1, order: 5 },
 			{ key: 'f', height: 2, order: 6, fullWidth: true },
 		],
 		rowHeight: '100px',
-		minColumnWidth: 200,
+		minColumnWidth: 160,
 		children: [
 			<Card key="a" color="#f44336">
 				Card A

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -8,16 +8,6 @@ export interface GridLayoutItem {
 	key: string;
 
 	/**
-	 * Starting column (0-indexed).
-	 */
-	x?: number;
-
-	/**
-	 * Starting row (0-indexed).
-	 */
-	y?: number;
-
-	/**
 	 * Number of columns this item spans.
 	 */
 	width?: number;
@@ -41,17 +31,11 @@ export interface GridLayoutItem {
 /**
  * Props for the Grid component
  */
-export interface GridProps {
+interface BaseGridProps {
 	/**
 	 * Array of layout items.
 	 */
 	layout: GridLayoutItem[];
-
-	/**
-	 * Total number of columns in the grid.
-	 * @default 1
-	 */
-	columns: number;
 
 	/**
 	 * Grid children.
@@ -73,10 +57,26 @@ export interface GridProps {
 	 * Height of each row (e.g., "50px", "auto")
 	 */
 	rowHeight?: string;
+}
 
+interface StandardGridProps extends BaseGridProps {
+	/**
+	 * Total number of columns in the grid.
+	 * @default 6
+	 */
+	columns: number;
+
+	minColumnWidth?: never;
+}
+
+interface ResponsiveGridProps extends BaseGridProps {
 	/**
 	 * Minimum width in pixels for each column in responsive mode.
 	 * If provided, enables responsive mode which automatically adjusts columns based on container width.
 	 */
 	minColumnWidth?: number;
+
+	columns?: never;
 }
+
+export type GridProps = StandardGridProps | ResponsiveGridProps;


### PR DESCRIPTION
## Proposed Changes

After slack discussions, I'm going to optimize for the automatic positioning of items rather than explicit one. In this PR I'm removing support for x,y coordinates and making things a bit more simple in the Grid component. 

## Testing Instructions

- cd packages/grid
- yarn storybook:start
