### PR TITLE
Experiment: Update exp name for the simplified onboarding flow

### DIFF
--- a/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
+++ b/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
@@ -2,7 +2,7 @@ import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 import { useIsPlaygroundEligible, isPlaygroundEligible } from './use-is-playground-eligible';
 import { useQuery } from './use-query';
 
-const MVP_ONBOARDING_EXPERIMENT_NAME = 'calypso_onboarding_mvp_20250414';
+const MVP_ONBOARDING_EXPERIMENT_NAME = 'calypso_signup_onboarding_simplified_hosting_flow';
 
 export function useMvpOnboardingExperiment() {
 	const isPlaygroundEligible = useIsPlaygroundEligible();


### PR DESCRIPTION
Related to 22238-explat-experiment
Related to https://github.com/Automattic/wp-calypso/pull/102578

## Proposed Changes

* Update experiment name since we recently created an updated experiment

## Testing Instructions

- Assign yourself to treatment group in **calypso_signup_onboarding_simplified_hosting_flow** experiment 22238-explat-experiment
- Go to `/setup/onboarding`
- Check if it works the same as for the previous exp name

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?