### PR TITLE
Revert "Site migration: Track signup events regardless the flow name"

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
@@ -5,6 +5,7 @@ import siteMigration from '../site-migration-flow/site-migration-flow';
 const hostedSiteMigrationFlow: Flow = {
 	...siteMigration,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
+	isSignupFlow: true,
 };
 
 export default hostedSiteMigrationFlow;

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -58,14 +58,7 @@ const hasSite = ( siteId: number, siteSlug: string ) => {
 
 const siteMigration: FlowV2 = {
 	name: SITE_MIGRATION_FLOW,
-	get isSignupFlow() {
-		const searchParams = new URLSearchParams( window.location.search );
-		const hasDestinationSite = [
-			searchParams.has( 'siteSlug' ),
-			searchParams.has( 'siteId' ),
-		].some( Boolean );
-		return ! hasDestinationSite;
-	},
+	isSignupFlow: false,
 	__experimentalUseSessions: true,
 	__experimentalUseBuiltinAuth: true,
 

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -78,27 +78,6 @@ describe( 'Site Migration Flow', () => {
 		jest.restoreAllMocks();
 	} );
 
-	describe( 'isSignupFlow', () => {
-		afterEach( () => {
-			window.location.search = '';
-		} );
-
-		it( 'returns false when there is siteSlug on query params', () => {
-			window.location.search = '?siteSlug=123';
-			expect( siteMigrationFlow.isSignupFlow ).toBe( false );
-		} );
-
-		it( 'returns false when there is siteId on query params', () => {
-			window.location.search = '?siteId=123';
-			expect( siteMigrationFlow.isSignupFlow ).toBe( false );
-		} );
-
-		it( 'returns true when there is no siteSlug or siteId on query params', () => {
-			window.location.search = '';
-			expect( siteMigrationFlow.isSignupFlow ).toBe( true );
-		} );
-	} );
-
 	describe( 'useAssertConditions', () => {
 		it( 'redirects the user to the start page when the user is not a site admin', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -14,6 +14,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
+import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordSignupProcessingScreen } from 'calypso/lib/analytics/signup';
@@ -63,7 +64,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ hasEmptyActionRun, setHasEmptyActionRun ] = useState( false );
-	const [ destinationState, setDestinationState ] = useState< { siteCreated?: boolean } >( {} );
+	const [ destinationState, setDestinationState ] = useState( {} );
 
 	/**
 	 * There is a long-term bug here that the `submit` function will be called multiple times if we
@@ -164,9 +165,12 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	useEffect( () => {
 		if ( hasActionSuccessfullyRun && ! isSubmittedRef.current ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
-
-			if ( destinationState.siteCreated ) {
-				recordSignupComplete( { ...destinationState } );
+			if ( availableFlows[ flow ] ) {
+				availableFlows[ flow ]().then( ( flowExport ) => {
+					if ( flowExport.default.isSignupFlow ) {
+						recordSignupComplete( { ...destinationState } );
+					}
+				} );
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#102600

The reverting cause was we have flows which are sending any information to the processing step, so [the original idea of track](https://github.com/Automattic/wp-calypso/pull/102837/files#diff-b7ff3243075883b8ecc07a8d6f6e9c94a960ec6d179ac29676a74d6270a6fe1aL168) a calypso_signup_complete based on the `siteCreated` flag is not viable solution.  


Here is an example of flow sending `undefined` as destinationState. 
https://github.com/Automattic/wp-calypso/blob/a330f5c9fd1d15a22501f852809a6f4eb37fdacc/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts#L239-L240