### PR TITLE
Stepper: Expose is_simplified_onboarding tracking param

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -9,6 +9,7 @@ import recordStepComplete, {
 } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-step-complete';
 import recordStepStart from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-step-start';
 import { useIntent } from 'calypso/landing/stepper/hooks/use-intent';
+import { useMvpOnboardingExperiment } from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import useSnakeCasedKeys from 'calypso/landing/stepper/utils/use-snake-cased-keys';
@@ -46,6 +47,7 @@ interface Props {
  */
 export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props ) => {
 	const intent = useIntent();
+	const [ , isMvpOnboarding ] = useMvpOnboardingExperiment();
 	const hasRequestedSelectedSite = useHasRequestedSelectedSite();
 	const stepCompleteEventPropsRef = useRef< RecordStepCompleteProps | null >( null );
 	const pathname = window.location.pathname;
@@ -127,6 +129,7 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		const pageTitle = `Setup > ${ flowName } > ${ stepSlug }`;
 		const params = {
 			flow: flowName,
+			is_simplified_onboarding: isMvpOnboarding,
 			...( skipStepRender && { skip_step_render: skipStepRender } ),
 			...reenteringStepAfterSignupCompleteProps,
 		};

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -152,6 +152,7 @@ describe( 'StepRoute', () => {
 
 			expect( recordPageView ).toHaveBeenCalledWith( '/', 'Setup > some-flow > some-step-slug', {
 				flow: 'some-flow',
+				is_simplified_onboarding: false,
 			} );
 		} );
 
@@ -214,6 +215,7 @@ describe( 'StepRoute', () => {
 			expect( recordPageView ).toHaveBeenCalledWith( '/', 'Setup > some-flow > some-step-slug', {
 				flow: 'some-flow',
 				skip_step_render: true,
+				is_simplified_onboarding: false,
 				signup_complete_flow_name: 'some-other-flow',
 				signup_complete_step_name: 'some-other-step-slug',
 			} );
@@ -246,6 +248,7 @@ describe( 'StepRoute', () => {
 			} );
 			expect( recordPageView ).toHaveBeenCalledWith( '/', 'Setup > some-flow > some-step-slug', {
 				flow: 'some-flow',
+				is_simplified_onboarding: false,
 				skip_step_render: true,
 				signup_complete_flow_name: 'some-other-flow',
 				signup_complete_step_name: 'some-other-step-slug',


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTOBRD-120/connect-the-experiment-with-exposure-events

## Proposed Changes

* Expose `is_simplified_onboarding` tracking param to `calypso_page_view` event

## Why are these changes being made?

https://linear.app/a8c/issue/DOTOBRD-120/connect-the-experiment-with-exposure-events

## Testing Instructions

- Assign yourself to treatment group in **calypso_signup_onboarding_simplified_hosting_flow** experiment 22238-explat-experiment
- Go to `/setup/onboarding`
- Check if there is a new `is_simplified_onboarding` param
<img width="613" alt="Screenshot 2025-04-24 at 15 58 12" src="https://github.com/user-attachments/assets/73c96df4-8ebe-4aec-8009-5ec5f10b8e60" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
