### PR TITLE
upgrade error step to container v2

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,25 +1,28 @@
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useSiteDomains } from '../../../../hooks/use-site-domains';
 import { useSiteSetupError } from '../../../../hooks/use-site-setup-error';
 import SupportCard from '../store-address/support-card';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import './style.scss';
 
 const WarningsOrHoldsSection = styled.div`
 	margin-top: 40px;
 `;
 
-const ErrorStep: Step = function ErrorStep( { navigation, flow, variantSlug } ) {
+const ErrorStep: StepType = function ErrorStep( { navigation, flow, variantSlug } ) {
 	const { goBack, goNext } = navigation;
 	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
 	const { error, message } = useSiteSetupError();
+	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	let domain = '';
 
@@ -56,6 +59,27 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow, variantSlug } ) 
 		);
 	};
 
+	const headerText = __( "We've hit a snag" );
+	const subHeaderText = __(
+		'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
+	);
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ headerText } />
+				<Step.CenteredColumnLayout
+					columnWidth={ 5 }
+					topBar={ <Step.TopBar /> }
+					heading={ <Step.Heading text={ headerText } /> }
+				>
+					{ subHeaderText }
+					{ getContent() }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
+
 	return (
 		<StepContainer
 			stepName="error-step"
@@ -64,16 +88,8 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow, variantSlug } ) 
 			isHorizontalLayout={ false }
 			formattedHeader={
 				<>
-					<FormattedHeader
-						id="step-error-header"
-						headerText={ __( "We've hit a snag" ) }
-						align="left"
-					/>
-					<p>
-						{ __(
-							'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
-						) }
-					</p>
+					<FormattedHeader id="step-error-header" headerText={ headerText } align="left" />
+					<p>{ subHeaderText }</p>
 				</>
 			}
 			stepContent={ getContent() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -69,7 +69,7 @@ const ErrorStep: StepType = function ErrorStep( { navigation, flow, variantSlug 
 			<>
 				<DocumentHead title={ headerText } />
 				<Step.CenteredColumnLayout
-					columnWidth={ 5 }
+					columnWidth={ 8 }
 					topBar={ <Step.TopBar /> }
 					heading={ <Step.Heading text={ headerText } /> }
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-65

## Proposed Changes

Upgrades error-step to container v2
| Before | After |
|--------|--------|
|<img width="1421" alt="image" src="https://github.com/user-attachments/assets/736f3e26-e85f-4b48-bd5a-fbcb21965eea" />|<img width="1421" alt="image" src="https://github.com/user-attachments/assets/554a8dd7-aeb9-42ac-b735-ee360034644d" />|
|<img width="463" alt="image" src="https://github.com/user-attachments/assets/0cf6617c-03b9-4aa7-b3d6-1ff2991fc2fc" />|<img width="459" alt="image" src="https://github.com/user-attachments/assets/95f30b14-51f6-4c0d-a5f0-64022516b97f" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

to unify the experience across onboarding

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to `setup/site-migration/error?flags=onboarding%2Fstep-container-v2-migration-flow` and verify the step looks like the screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
