### PR TITLE
Hosting Dashboard v2: sites: use 'is' filter for boolean fields

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -12,7 +12,7 @@ import PageLayout from '../page-layout';
 import SiteIcon from '../site-icon';
 import SitePreview from '../site-preview';
 import type { Site } from '../data/types';
-import type { View } from '@wordpress/dataviews';
+import type { View, Operator } from '@wordpress/dataviews';
 
 const actions = [
 	{
@@ -55,25 +55,31 @@ const fields = [
 		id: 'backups',
 		label: __( 'Backups' ),
 		getValue: ( { item }: { item: Site } ) =>
-			item.plan.features.active.includes( 'backups' ) ? 'enabled' : 'disabled',
+			item.plan.features.active.includes( 'backups' ) || undefined,
 		elements: [
-			{ value: 'enabled', label: __( 'Enabled' ) },
-			{ value: 'disabled', label: __( 'Disabled' ) },
+			{ value: true, label: __( 'Enabled' ) },
+			{ value: undefined, label: __( 'Disabled' ) },
 		],
 		render: ( { item }: { item: Site } ) =>
 			item.plan.features.active.includes( 'backups' ) ? <Icon icon={ check } /> : __( 'Disabled' ),
+		filterBy: {
+			operators: [ 'is' as Operator ],
+		},
 	},
 	{
 		id: 'protect',
 		label: __( 'Protect' ),
 		getValue: ( { item }: { item: Site } ) =>
-			item.active_modules?.includes( 'protect' ) ? 'enabled' : 'disabled',
+			item.active_modules?.includes( 'protect' ) || undefined,
 		render: ( { item }: { item: Site } ) =>
 			item.active_modules?.includes( 'protect' ) ? <Icon icon={ check } /> : __( 'Disabled' ),
 		elements: [
-			{ value: 'enabled', label: __( 'Enabled' ) },
-			{ value: 'disabled', label: __( 'Disabled' ) },
+			{ value: true, label: __( 'Enabled' ) },
+			{ value: undefined, label: __( 'Disabled' ) },
 		],
+		filterBy: {
+			operators: [ 'is' as Operator ],
+		},
 	},
 	{
 		id: 'preview',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Simplifies the filtering for boolean fields (remove isAny/isNone and immediately filter).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
