### PR TITLE
Site migration: Track signup events regardless the flow name

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/hosted-site-migration-flow/hosted-site-migration-flow.ts
@@ -5,7 +5,6 @@ import siteMigration from '../site-migration-flow/site-migration-flow';
 const hostedSiteMigrationFlow: Flow = {
 	...siteMigration,
 	variantSlug: HOSTED_SITE_MIGRATION_FLOW,
-	isSignupFlow: true,
 };
 
 export default hostedSiteMigrationFlow;

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -58,7 +58,14 @@ const hasSite = ( siteId: number, siteSlug: string ) => {
 
 const siteMigration: FlowV2 = {
 	name: SITE_MIGRATION_FLOW,
-	isSignupFlow: false,
+	get isSignupFlow() {
+		const searchParams = new URLSearchParams( window.location.search );
+		const hasDestinationSite = [
+			searchParams.has( 'siteSlug' ),
+			searchParams.has( 'siteId' ),
+		].some( Boolean );
+		return ! hasDestinationSite;
+	},
 	__experimentalUseSessions: true,
 	__experimentalUseBuiltinAuth: true,
 

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/site-migration-flow.ts
@@ -17,6 +17,7 @@ import { AssertConditionState } from 'calypso/landing/stepper/declarative-flow/i
 import { goToImporter } from 'calypso/landing/stepper/declarative-flow/migration/helpers';
 import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { useSiteData } from 'calypso/landing/stepper/hooks/use-site-data';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
@@ -119,6 +120,8 @@ const siteMigration: FlowV2 = {
 		const exitFlow = ( to: string ) => {
 			return window.location.assign( addQueryArgs( { sessionId }, to ) );
 		};
+
+		const recordSignupComplete = useRecordSignupComplete( flowName );
 
 		// Call triggerGuidesForStep for the current step
 		useEffect( () => {
@@ -245,6 +248,8 @@ const siteMigration: FlowV2 = {
 							message: 'Site not created',
 						} );
 					}
+
+					recordSignupComplete( { siteId } );
 
 					//NOTE: There are links pointing to this step with the action=migrate query param, so we need to ignore the platform
 					if ( actionQueryParam === 'migrate' ) {

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -78,6 +78,27 @@ describe( 'Site Migration Flow', () => {
 		jest.restoreAllMocks();
 	} );
 
+	describe( 'isSignupFlow', () => {
+		afterEach( () => {
+			window.location.search = '';
+		} );
+
+		it( 'returns false when there is siteSlug on query params', () => {
+			window.location.search = '?siteSlug=123';
+			expect( siteMigrationFlow.isSignupFlow ).toBe( false );
+		} );
+
+		it( 'returns false when there is siteId on query params', () => {
+			window.location.search = '?siteId=123';
+			expect( siteMigrationFlow.isSignupFlow ).toBe( false );
+		} );
+
+		it( 'returns true when there is no siteSlug or siteId on query params', () => {
+			window.location.search = '';
+			expect( siteMigrationFlow.isSignupFlow ).toBe( true );
+		} );
+	} );
+
 	describe( 'useAssertConditions', () => {
 		it( 'redirects the user to the start page when the user is not a site admin', () => {
 			const { runUseAssertionCondition } = renderFlow( siteMigrationFlow );

--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -18,6 +18,7 @@ import { useIsSiteAdmin } from 'calypso/landing/stepper/hooks/use-is-site-admin'
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
+import { useRecordSignupComplete } from '../../../../hooks/use-record-signup-complete';
 import siteMigrationFlow from '../site-migration-flow';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
@@ -39,6 +40,9 @@ jest.mock( 'calypso/landing/stepper/declarative-flow/internals/state-manager/sto
 } ) );
 
 jest.mock( 'calypso/state/sites/selectors/get-site-option' );
+jest.mock( 'calypso/landing/stepper/hooks/use-record-signup-complete', () => ( {
+	useRecordSignupComplete: jest.fn().mockReturnValue( jest.fn() ),
+} ) );
 
 const runNavigation = ( options: Parameters< typeof runFlowNavigation >[ 1 ] ) =>
 	runFlowNavigation( siteMigrationFlow, options, 'forward' );
@@ -255,6 +259,18 @@ describe( 'Site Migration Flow', () => {
 						sessionId: '123',
 					},
 				} );
+			} );
+
+			it( 'records signup complete when the site is created', () => {
+				const recordSignupComplete = jest.fn();
+				jest.mocked( useRecordSignupComplete ).mockReturnValue( recordSignupComplete );
+
+				runNavigation( {
+					from: STEPS.PROCESSING,
+					dependencies: { siteId: 123, siteCreated: true },
+				} );
+
+				expect( recordSignupComplete ).toHaveBeenCalledWith( { siteId: 123 } );
 			} );
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -14,7 +14,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
-import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordSignupProcessingScreen } from 'calypso/lib/analytics/signup';
@@ -64,7 +63,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ hasEmptyActionRun, setHasEmptyActionRun ] = useState( false );
-	const [ destinationState, setDestinationState ] = useState( {} );
+	const [ destinationState, setDestinationState ] = useState< { siteCreated?: boolean } >( {} );
 
 	/**
 	 * There is a long-term bug here that the `submit` function will be called multiple times if we
@@ -165,12 +164,9 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	useEffect( () => {
 		if ( hasActionSuccessfullyRun && ! isSubmittedRef.current ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
-			if ( availableFlows[ flow ] ) {
-				availableFlows[ flow ]().then( ( flowExport ) => {
-					if ( flowExport.default.isSignupFlow ) {
-						recordSignupComplete( { ...destinationState } );
-					}
-				} );
+
+			if ( destinationState.siteCreated ) {
+				recordSignupComplete( { ...destinationState } );
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -14,6 +14,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Loading from 'calypso/components/loading';
+import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordSignupProcessingScreen } from 'calypso/lib/analytics/signup';
@@ -63,7 +64,9 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 	const [ hasActionSuccessfullyRun, setHasActionSuccessfullyRun ] = useState( false );
 	const [ hasEmptyActionRun, setHasEmptyActionRun ] = useState( false );
-	const [ destinationState, setDestinationState ] = useState< { siteCreated?: boolean } >( {} );
+	const [ destinationState, setDestinationState ] = useState<
+		{ siteCreated?: boolean } | undefined
+	>( {} );
 
 	/**
 	 * There is a long-term bug here that the `submit` function will be called multiple times if we
@@ -165,8 +168,12 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		if ( hasActionSuccessfullyRun && ! isSubmittedRef.current ) {
 			// We should only trigger signup completion for signup flows, so check if we have one.
 
-			if ( destinationState.siteCreated ) {
-				recordSignupComplete( { ...destinationState } );
+			if ( availableFlows[ flow ] && ! isNewSiteMigrationFlow( flow ) ) {
+				availableFlows[ flow ]().then( ( flowExport ) => {
+					if ( flowExport.default.isSignupFlow ) {
+						recordSignupComplete( { ...destinationState } );
+					}
+				} );
 			}
 
 			if ( isNewSiteMigrationFlow( flow ) ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#102837