### PR TITLE
Revert DOTCOM-796-fix-add-domain-button

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -10,7 +10,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
-import { domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
 import { composeAnalytics, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -32,9 +32,17 @@ class AddDomainButton extends Component {
 		super( props );
 	}
 
+	getAddNewDomainUrl = () => {
+		if ( ! this.props.selectedSiteSlug ) {
+			return '/start/domain';
+		}
+
+		return domainAddNew( this.props.selectedSiteSlug );
+	};
+
 	clickAddDomain = () => {
 		this.props.trackAddDomainClick();
-		page( '/start/domain' );
+		page( this.getAddNewDomainUrl() );
 	};
 
 	trackMenuClick = ( reactEvent ) => {
@@ -85,7 +93,7 @@ class AddDomainButton extends Component {
 				whiteSeparator={ ! this.props.sidebarMode }
 				label={ isBreakpointActive ? undefined : translate( 'Add new domain' ) }
 				toggleIcon={ isBreakpointActive ? 'plus' : undefined }
-				href="/start/domain"
+				href={ this.getAddNewDomainUrl() }
 				onClick={ this.trackAddDomainClick }
 			>
 				{ this.renderOptions() }


### PR DESCRIPTION
Related to #102665

## Proposed Changes

This PR reverts #102665.

## Why are these changes being made?

#102665. fixed the original issue in #101976 (adding domain from the domain overview page becomes a loop) but changed the behavior when adding a domain in a site context (see report at p1745489672035839-slack-C029GN3KD).

## Testing Instructions

- Open the live Calypso link or build this branch lcoally
- Go to a site and click on the "Add new domain" button
- Ensure you stay in the site context and aren't taken to the `/start/domain` domain-only flow

Expected behavior:

https://github.com/user-attachments/assets/02cb5bfc-a356-4eac-a5a7-ddc406cdaf1b

Previous behavior:

https://github.com/user-attachments/assets/4a7b47c0-a477-48ab-8d8a-0068b3b19d84

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
