### PR TITLE
capabilities.view_hosting: Remove from test fixtures

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/test/index.tsx
@@ -97,7 +97,6 @@ const DEFAULT_SITE_CAPABILITIES = {
 	remove_users: true,
 	update_plugins: true,
 	upload_files: true,
-	view_hosting: true,
 	view_stats: true,
 };
 

--- a/client/my-sites/plugins/plugin-management-v2/test/utils/constants.ts
+++ b/client/my-sites/plugins/plugin-management-v2/test/utils/constants.ts
@@ -36,7 +36,6 @@ const site: SiteDetails = {
 		delete_users: true,
 		remove_users: true,
 		own_site: true,
-		view_hosting: true,
 		view_stats: true,
 		activate_plugins: true,
 	},

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -382,7 +382,6 @@ describe( 'getSiteOptions', () => {
 			delete_users: true,
 			remove_users: true,
 			own_site: true,
-			view_hosting: true,
 			view_stats: true,
 			activate_plugins: true,
 		},

--- a/packages/launchpad/src/test/lib/fixtures.ts
+++ b/packages/launchpad/src/test/lib/fixtures.ts
@@ -30,7 +30,6 @@ export const defaultSiteDetails: SiteDetails = {
 		delete_users: false,
 		remove_users: true,
 		own_site: true,
-		view_hosting: true,
 		view_stats: true,
 		activate_plugins: true,
 	},


### PR DESCRIPTION
## Proposed Changes / Why are these changes being made?

* Removing deprecated code that serves the old /hosting-config page which has been replaced by /hosting-features.
* See also: 181320-ghe-Automattic/wpcom


## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
