### PR TITLE
Hosting Dashboard v2: add a8c site filter

### DIFF
--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -34,6 +34,23 @@ export const updateProfile = async ( data: Partial< Profile > ) => {
 	} );
 };
 
+const SITE_FIELDS = [
+	'ID',
+	'URL',
+	'name',
+	'icon',
+	'subscribers_count',
+	'plan',
+	'active_modules',
+	'is_deleted',
+	'is_coming_soon',
+	'is_private',
+	'launch_status',
+	'site_migration',
+	'options',
+	'site_owner',
+].join( ',' );
+
 export const fetchSites = async (): Promise< Site[] > => {
 	return (
 		await wpcom.req.get(
@@ -45,22 +62,7 @@ export const fetchSites = async (): Promise< Site[] > => {
 				site_visibility: 'all',
 				include_domain_only: 'true',
 				site_activity: 'active',
-				fields: [
-					'ID',
-					'URL',
-					'name',
-					'icon',
-					'subscribers_count',
-					'plan',
-					'active_modules',
-					'is_deleted',
-					'is_coming_soon',
-					'is_private',
-					'launch_status',
-					'site_migration',
-					'options',
-					'site_owner',
-				].join( ',' ),
+				fields: SITE_FIELDS,
 			}
 		)
 	).sites;
@@ -75,18 +77,7 @@ export const fetchSite = async ( id: string ): Promise< Site > => {
 			path: `/sites/${ id }?http_envelope=1`,
 			apiNamespace: 'rest/v1.1',
 		},
-		{
-			fields: [
-				'ID',
-				'URL',
-				'name',
-				'icon',
-				'subscribers_count',
-				'plan',
-				'active_modules',
-				'options',
-			].join( ',' ),
-		}
+		{ fields: SITE_FIELDS }
 	);
 };
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -59,6 +59,7 @@ export const fetchSites = async (): Promise< Site[] > => {
 					'launch_status',
 					'site_migration',
 					'options',
+					'site_owner',
 				].join( ',' ),
 			}
 		)

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -86,6 +86,7 @@ export interface Site {
 	site_migration: {
 		migration_status: string;
 	} | null;
+	site_owner: number;
 }
 
 export type EmailProvider = 'titan' | 'google-workspace' | 'forwarding';

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -48,7 +48,7 @@ export default function SiteCard( {
 								justifyContent: 'center',
 							} }
 						>
-							{ __( 'Private Site' ) }
+							{ __( 'A8C Private Site' ) }
 						</div>
 					) }
 					{ ! iframeDisabled && (

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -9,6 +9,7 @@ import {
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import SitePreview from '../site-preview';
+import { isA8CSite } from '../utils/site-owner';
 import { getSiteStatusLabel } from '../utils/site-status';
 import type { Site, SiteDomain, Plan } from '../data/types';
 
@@ -28,12 +29,14 @@ export default function SiteCard( {
 } ) {
 	const { options, URL: url } = site;
 	const { software_version, blog_public } = options;
+	// If the site is a private A8C site, X-Frame-Options is set to same
+	// origin.
+	const iframeDisabled = isA8CSite( site ) && blog_public === -1;
 	return (
 		<Card>
 			<VStack spacing={ 6 }>
 				<div className="dashboard-site-overview__preview-image">
-					{ /* If the site is private, show the preview image, because X-Frame-Options is set to same origin. */ }
-					{ blog_public === -1 && (
+					{ iframeDisabled && (
 						<div
 							style={ {
 								width: '300px',
@@ -48,8 +51,7 @@ export default function SiteCard( {
 							{ __( 'Private Site' ) }
 						</div>
 					) }
-					{ /* If the site is public or coming soon, show the preview iframe. */ }
-					{ blog_public > -1 && (
+					{ ! iframeDisabled && (
 						<div
 							className="dashboard-site-overview__preview-iframe"
 							style={ { width: '300px', height: '200px' } }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -103,11 +103,12 @@ const DEFAULT_FIELDS = [
 			const [ resizeListener, { width } ] = useResizeObserver();
 			const { options, URL: url } = item;
 			const { blog_public } = options;
+			// If the site is a private A8C site, X-Frame-Options is set to same
+			// origin.
 			const iframeDisabled = isA8CSite( item ) && blog_public === -1;
 			return (
 				<>
 					{ resizeListener }
-					{ /* If the site is private, show the preview image, because X-Frame-Options is set to same origin. */ }
 					{ iframeDisabled && (
 						<div
 							style={ {
@@ -121,7 +122,6 @@ const DEFAULT_FIELDS = [
 							<SiteIcon site={ item } />
 						</div>
 					) }
-					{ /* If the site is public or coming soon, show the preview iframe. */ }
 					{ width && ! iframeDisabled && (
 						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
 					) }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -136,13 +136,13 @@ const DEFAULT_LAYOUTS = {
 		mediaField: 'icon.ico',
 		fields: [ 'subscribers_count', 'status', 'backups', 'protect' ],
 		titleField: 'name',
-		descriptionField: 'url',
+		descriptionField: 'URL',
 	},
 	grid: {
 		mediaField: 'preview',
 		fields: [],
 		titleField: 'name',
-		descriptionField: 'url',
+		descriptionField: 'URL',
 	},
 };
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -86,10 +86,10 @@ const DEFAULT_FIELDS = [
 	{
 		id: 'a8c_owned',
 		label: __( 'A8C Owned' ),
-		getValue: ( { item }: { item: Site } ) => isA8CSite( item ),
+		getValue: ( { item }: { item: Site } ) => isA8CSite( item ) || undefined,
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
-			{ value: false, label: __( 'No' ) },
+			{ value: undefined, label: __( 'No' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as Operator ],
@@ -166,7 +166,7 @@ export default function Sites() {
 						{
 							field: 'a8c_owned',
 							operator: 'is',
-							value: false,
+							value: undefined,
 						},
 					],
 			  }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -5,15 +5,16 @@ import { useResizeObserver } from '@wordpress/compose';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { sitesQuery } from '../app/queries';
 import DataViewsCard from '../dataviews-card';
 import PageLayout from '../page-layout';
 import SiteIcon from '../site-icon';
 import SitePreview from '../site-preview';
+import { isA8CSite } from '../utils/site-owner';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import type { Site } from '../data/types';
-import type { View } from '@wordpress/dataviews';
+import type { View, Operator } from '@wordpress/dataviews';
 
 const actions = [
 	{
@@ -28,8 +29,7 @@ const actions = [
 	},
 ];
 
-// Field definitions
-const fields = [
+const DEFAULT_FIELDS = [
 	{
 		id: 'name',
 		label: __( 'Site' ),
@@ -84,17 +84,31 @@ const fields = [
 		render: ( { item }: { item: Site } ) => getSiteStatusLabel( item ),
 	},
 	{
+		id: 'a8c_owned',
+		label: __( 'A8C Owned' ),
+		getValue: ( { item }: { item: Site } ) => isA8CSite( item ),
+		elements: [
+			{ value: true, label: __( 'Yes' ) },
+			{ value: false, label: __( 'No' ) },
+		],
+		filterBy: {
+			operators: [ 'is' as Operator ],
+		},
+		render: ( { item }: { item: Site } ) => ( isA8CSite( item ) ? __( 'Yes' ) : __( 'No' ) ),
+	},
+	{
 		id: 'preview',
 		label: __( 'Preview' ),
 		render: function PreviewRender( { item }: { item: Site } ) {
 			const [ resizeListener, { width } ] = useResizeObserver();
 			const { options, URL: url } = item;
 			const { blog_public } = options;
+			const iframeDisabled = isA8CSite( item ) && blog_public === -1;
 			return (
 				<>
 					{ resizeListener }
 					{ /* If the site is private, show the preview image, because X-Frame-Options is set to same origin. */ }
-					{ blog_public === -1 && (
+					{ iframeDisabled && (
 						<div
 							style={ {
 								fontSize: '24px',
@@ -108,7 +122,7 @@ const fields = [
 						</div>
 					) }
 					{ /* If the site is public or coming soon, show the preview iframe. */ }
-					{ width && blog_public > -1 && (
+					{ width && ! iframeDisabled && (
 						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
 					) }
 				</>
@@ -143,7 +157,26 @@ const DEFAULT_VIEW: View = {
 export default function Sites() {
 	const navigate = useNavigate();
 	const sites = useQuery( sitesQuery() ).data;
-	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const hasA8CSites = sites?.some( isA8CSite );
+	const [ view, setView ] = useState< View >(
+		hasA8CSites
+			? {
+					...DEFAULT_VIEW,
+					filters: [
+						{
+							field: 'a8c_owned',
+							operator: 'is',
+							value: false,
+						},
+					],
+			  }
+			: DEFAULT_VIEW
+	);
+	const fields = useMemo(
+		() =>
+			hasA8CSites ? DEFAULT_FIELDS : DEFAULT_FIELDS.filter( ( field ) => field.id !== 'a8c_owned' ),
+		[ hasA8CSites ]
+	);
 
 	if ( ! sites ) {
 		return;

--- a/client/dashboard/utils/site-owner.ts
+++ b/client/dashboard/utils/site-owner.ts
@@ -1,0 +1,5 @@
+import type { Site } from '../data/types';
+
+export function isA8CSite( site: Site ) {
+	return site.site_owner === 26957695;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes DOTCOM-10647

## Proposed Changes

* The new filter is only visible when there are a8c sites in the array, so normal users don't see this filter or have it enabled by default.
* It's difficult to test and demo as an actual user without being able to filter these out.
* We also need it to enable iframe-previews on _private_ sites. They actually work fine for normal sites, it only does not work for private a8c sites.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check for the filter.
* If you have a non-a8c private site, check that the preview works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
