### PR TITLE
Add additional instructions for Cursor client rules

### DIFF
--- a/.cursor/rules/calypso-client-rules.mdc
+++ b/.cursor/rules/calypso-client-rules.mdc
@@ -60,9 +60,10 @@ Before responding to any request, follow these steps:
 - Try to always use RTL specific styles. For example, instead of margin-left, use margin-inline-start.
 - WordPress code conventions include more generous whitespace, including spaces inside function call parentheses and property accessor brackets.
 
-## WordPress imports
+## Dependencies
 
 - Use imports from [wordpress-imports.mdc](mdc:.cursor/rules/wordpress-imports.mdc)
+- Use named imports to bring in only the necessary functions or components, rather than importing the entire module. 
 
 ## Documentation
 

--- a/.cursor/rules/calypso-client-rules.mdc
+++ b/.cursor/rules/calypso-client-rules.mdc
@@ -86,5 +86,6 @@ Remember: Always prioritize WordPress coding standards and best practices while 
 
 - Run tests for individual files using the command `yarn test-client filename`, substituting `filename` with the relative path to the file you want to test.
 - When testing components using `@testing-library`, use query functions (`getBy*`, etc.) from the return value of `render`, not from the `screen` import.
+- Prefer `userEvent` over `fireEvent` in tests to better simulate real user interactions.
 
 

--- a/.cursor/rules/calypso-client-rules.mdc
+++ b/.cursor/rules/calypso-client-rules.mdc
@@ -1,6 +1,6 @@
 ---
 description: Rules that applies for all Clients within repository
-globs: client
+globs: client/**
 alwaysApply: false
 ---
 You are an expert AI programming assistant that primarily focuses on producing clear, readable React and TypeScript code.
@@ -58,7 +58,7 @@ Before responding to any request, follow these steps:
 
 - Don't use `&--` & `&__` selectors and write full name when defining styles.
 - Try to always use RTL specific styles. For example, instead of margin-left, use margin-inline-start.
-
+- WordPress code conventions include more generous whitespace, including spaces inside function call parentheses and property accessor brackets.
 
 ## WordPress imports
 
@@ -68,14 +68,22 @@ Before responding to any request, follow these steps:
 
 ### Code Documentation
 
--   Follow WordPress documentation standards
--   Follow JSDoc conventions
+- Follow WordPress documentation standards
+- Follow JSDoc conventions
+- Code comments should explain why the code exists or behaves a certain way, not just what it does. It should be concise, relevant, and avoid restating the obvious. Focus on intent, assumptions, and non-obvious decisions.
+- Wrap code comments to new lines at 100 columns
 
 ### User Documentation
 
--   Follow WordPress documentation style
--   Provide clear usage instructions
--   Include troubleshooting guides
+- Follow WordPress documentation style
+- Provide clear usage instructions
+- Include troubleshooting guides
 
 Remember: Always prioritize WordPress coding standards and best practices while delivering the most appealing UI.
+
+## Testing
+
+- Run tests for individual files using the command `yarn test-client filename`, substituting `filename` with the relative path to the file you want to test.
+- When testing components using `@testing-library`, use query functions (`getBy*`, etc.) from the return value of `render`, not from the `screen` import.
+
 


### PR DESCRIPTION
## Proposed Changes

* Adds additional instructions to Cursor editor rules applying to the `client/` directory, based on observations I've made using Cursor over the past few days
* Fixes the `globs` pattern, which, for me at least, was showing as not matching any files (presumably it was previously trying to match a `client` file and not all files within the `client/` directory)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the effectiveness of Cursor AI generation and agent interactions

Specific notes:

* >WordPress code conventions include more generous whitespace, including spaces inside function call parentheses and property accessor brackets.
   * Added after noticing that the AI agent will often search for code assuming no whitespace inside parenthesis, since WordPress code style is unique in how it adds generous whitespace. 
   * Example: ![image](https://github.com/user-attachments/assets/53ddaaae-b11b-40fb-9e47-d7cbc1a8ac5d)
* >Code comments should explain why the code exists or behaves a certain way, not just what it does. It should be concise, relevant, and avoid restating the obvious. Focus on intent, assumptions, and non-obvious decisions.
   * Added after noticing that AI will often generate code comments that don't provide much value in redundantly describing something that's very obvious by looking at the code
   * Example: ![image](https://github.com/user-attachments/assets/81a07337-d1ce-4eb9-9d8b-768b5c70646d)
* >Wrap code comments to new lines at 100 columns
   * Added after noticing that code comments generated by AI will often wrap at 80 character columns (a common default in other projects) rather than [our 100 character print width](https://github.com/Automattic/wp-calypso/blob/cdc7810455fa58bd04aaaddbc1bdbfd924da2eac/.prettierrc#L3)
* >Run tests for individual files using the command `yarn test-client filename`, substituting `filename` with the relative path to the file you want to test.
   * Added after noticing that AI agent will often get confused about how to run tests for a file, using a number of variations like `npm run test-client` or `npm test`, needing to `cd` into a directory, etc. 
   * It's particularly relevant when using Agent mode to run tests for a file to confirm correct revisions.
   * This also improves compatibility with Cursor's auto-run allowlist
* >When testing components using `@testing-library`, use query functions (`getBy*`, etc.) from the return value of `render`, not from the `screen` import.
   * This is a bit more of a personal preference, but using return values from the `render` function ensures that we are only querying content rendered by a component, and avoids an extra import.

## Testing Instructions

To test, you could try prompting the AI with a request that you'd expect to be impacted by one of the additions, like asking it to run tests for a particular file.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
