### PR TITLE
TeamCity: Configure Desktop Pre-release E2E tests in the new structure

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -84,6 +84,7 @@ open class E2EBuildType(
 			logs => logs.tgz
 			screenshots => screenshots
 			trace => trace
+			allure-results => allure-results.tgz
 		""".trimIndent()
 
 		vcs {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DOTCOM-10583/configure-desktop-pre-release-e2e-tests-in-the-new-structure

## Proposed Changes

This PR is updating the TeamCity config to make the [Pre-Release E2E Tests (desktop)](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release_desktop?mode=builds#all-projects) job run the exact same way as the [Pre-Release E2E Tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release?mode=builds#all-projects) job.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of: pet6gk-29i-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [TeamCity](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release_desktop?branch=update%2Fteamcity-pre-release-e2e-tests&buildTypeTab=overview&mode=builds#all-projects) and run the job. Make sure you are targeting this branch.
* Make sure the job is successful and runs the same way as the [Pre-Release E2E Tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release?mode=builds#all-projects) job. It should be running the same tests as well.
* Make sure the code logic is the same as the [Pre-Release E2E Tests](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release?mode=builds#all-projects) job (PreReleaseE2ETests).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?