### PR TITLE
Invalidate sites query when staging site is removed

### DIFF
--- a/client/sites/staging-site/components/staging-site-card/index.js
+++ b/client/sites/staging-site/components/staging-site-card/index.js
@@ -230,11 +230,13 @@ export const StagingSiteCard = ( {
 		// If we are done with the transfer, and we have not errored we want to set the action to NONE, and display a success notice.
 		if ( stagingSiteStatus === StagingSiteStatus.REVERTED ) {
 			dispatch( setStagingSiteStatus( siteId, StagingSiteStatus.NONE ) );
+			// Refetch the sites to remove the deleted staging site from the list
+			queryClient.invalidateQueries( [ USE_SITE_EXCERPTS_QUERY_KEY ] );
 			dispatch(
 				successNotice( __( 'Staging site deleted.' ), { id: stagingSiteDeleteSuccessNoticeId } )
 			);
 		}
-	}, [ __, dispatch, siteId, stagingSiteStatus ] );
+	}, [ __, dispatch, queryClient, siteId, stagingSiteStatus ] );
 
 	const handleNullTransferStatus = useCallback( () => {
 		// When a revert is finished, the status after deletion becomes null, as the API doesn't return any value ( returns an error ) due to the staging site's deletion.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes [DOTDEV-63](https://linear.app/a8c/issue/DOTDEV-63/remove-staging-site-from-the-sidebar-after-its-deleted)

## Proposed Changes
- Invalidate the sites query when a staging site is deleted

## Testing Instructions
- Check out this branch or use the Calypso live link
- Go to a site that has a staging site
- Open the staging site management card
- Delete the staging site
- Verify that after the deletion is complete and the success notice appears, the staging site is removed from the sites list in the sidebar
- Verify that refreshing the page does not bring back the deleted staging site in the sidebar

https://github.com/user-attachments/assets/34b4ad91-c87e-4207-b90d-b6913830e860