### PR TITLE
Domains: Fix loop when adding domain from the all domains overview page

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -33,7 +33,7 @@ class AddDomainButton extends Component {
 	}
 
 	getAddNewDomainUrl = () => {
-		if ( ! this.props.selectedSiteSlug ) {
+		if ( this.props.sidebarMode || ! this.props.selectedSiteSlug ) {
 			return '/start/domain';
 		}
 


### PR DESCRIPTION
Related to #101976

## Proposed Changes

This PR fixes #101976 by sending users to the `/start/domain` domain-only flow when they click on "Add new domain" from the all domains overview page and a domain is already selected. It doesn't change the behavior of the button when in a site context.

## Why are these changes being made?

#101976 shows that when users try to add a new domain via the all domains overview page and a domain is already selected, they enter a loop and can't actually purchase a domain there. #102665 fixes that but changed the behavior for the button when in a site context (see report at p1745489672035839-slack-C029GN3KD).

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Please test 3 places where the button appears:

- All domains overview page: `/domains/manage`

<img width="1920" alt="Screenshot 2025-04-24 at 12 58 54" src="https://github.com/user-attachments/assets/5f5ed192-f1f5-4696-9af5-7190b16677bd" />

- All domains overview page with a domain selected:

<img width="1920" alt="Screenshot 2025-04-24 at 12 59 24" src="https://github.com/user-attachments/assets/cc5132d5-07d5-4ca7-9c98-2cdd2dd58b4c" />

- Adding a new domain when in a site context:

<img width="1920" alt="Screenshot 2025-04-24 at 13 00 08" src="https://github.com/user-attachments/assets/41f4dd9a-268f-4969-9f67-930fc05e0248" />

The first two should take you to the `/start/domain` domain-only flow, while the last one should take you to the domain search page like so:

<img width="1920" alt="Screenshot 2025-04-24 at 13 03 09" src="https://github.com/user-attachments/assets/44c9516f-b853-44f8-b9fb-b353ca0ebccd" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
