### PR TITLE
Site Migration: Add test case covering the non identified platform

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx
@@ -569,7 +569,7 @@ describe( 'Site Migration Flow', () => {
 		} );
 
 		describe( 'PICK_SITE', () => {
-			it( 'redirects to IMPORT_OR_MIGRATE if a site is selected', () => {
+			it( 'redirects to IMPORT_OR_MIGRATE when a site is selected', () => {
 				const destination = runNavigation( {
 					from: STEPS.PICK_SITE,
 					dependencies: {
@@ -581,6 +581,27 @@ describe( 'Site Migration Flow', () => {
 					},
 					query: {
 						platform: 'wordpress',
+					},
+				} );
+
+				expect( destination ).toMatchDestination( {
+					step: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
+					query: {
+						siteSlug: 'example.wordpress.com',
+						siteId: 123,
+					},
+				} );
+			} );
+
+			it( 'redirects to IMPORT_OR_MIGRATE when a site is selected and the platform is not identified', () => {
+				const destination = runNavigation( {
+					from: STEPS.PICK_SITE,
+					dependencies: {
+						action: 'select-site',
+						site: {
+							ID: 123,
+							slug: 'example.wordpress.com',
+						},
 					},
 				} );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102780

## Proposed Changes
* Add automated tasks to make sure we can evolve it more easily. 



## Testing Instructions
* Visual inspection
* Yarn test-client -- /Users/gabriel/Projects/wp-calypso/client/landing/stepper/declarative-flow/flows/site-migration-flow/test/site-migration-flow.tsx


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
