### PR TITLE
Hosting Dashboard v2: fix a4a colors

### DIFF
--- a/client/dashboard/app-a4a/style.scss
+++ b/client/dashboard/app-a4a/style.scss
@@ -6,12 +6,12 @@
 
 :root {
 	// Theme
-	--wp-admin-theme-color: #3858e9;
-	--wp-admin-theme-color--rgb: 56, 88, 233;
-	--wp-admin-theme-color-darker-10: #2145e6;
-	--wp-admin-theme-color-darker-10--rgb: 33, 69, 230;
-	--wp-admin-theme-color-darker-20: #183ad6;
-	--wp-admin-theme-color-darker-20--rgb: 24, 58, 214;
+	--wp-admin-theme-color: #007cba;
+	--wp-admin-theme-color--rgb: 0, 124, 186;
+	--wp-admin-theme-color-darker-10: #006ba1;
+	--wp-admin-theme-color-darker-10--rgb: 0, 107, 161;
+	--wp-admin-theme-color-darker-20: #005a87;
+	--wp-admin-theme-color-darker-20--rgb: 0, 90, 135;
 	--wp-admin-border-width-focus: 2px;
 
 	// Layout
@@ -19,14 +19,14 @@
 	--dashboard__text-color: #{$gray-900};
 
 	// Header bar
-	--dashboard-header__background-color: #{$black};
-	--dashboard-header__color: #{$white};
-	--dashboard-header__border-color: #{$gray-800};
+	--dashboard-header__background-color: #021A23;
+	--dashboard-header__color: #FFF;
+	--dashboard-header__border-color: #05374A;
 
 	// Menu
-	--dashboard-menu-item__color: #{$gray-700};
-	--dashboard-menu-item-active__color: #{$white};
+	--dashboard-menu-item__color: #949494;
+	--dashboard-menu-item-active__color: #FFF;
 
 	// Secondary menu
-	--dashboard-secondary-menu-item__color: #{$gray-700};
+	--dashboard-secondary-menu-item__color: #FFF;
 }

--- a/client/dashboard/menu-divider/style.scss
+++ b/client/dashboard/menu-divider/style.scss
@@ -2,5 +2,5 @@
 
 .dashboard-menu-divider {
 	height: $grid-unit-40;
-	border-left: $border-width solid $gray-100;
+	border-left: $border-width solid var( --dashboard-header__border-color );
 }

--- a/client/dashboard/site/index.tsx
+++ b/client/dashboard/site/index.tsx
@@ -29,6 +29,7 @@ function Site() {
 						<Dropdown
 							renderToggle={ ( { onToggle } ) => (
 								<Button
+									className="dashboard-menu__item active"
 									onClick={ () => onToggle() }
 									icon={ <SiteIcon site={ site } size={ 24 } /> }
 								>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes DOTCOM-10591

## Proposed Changes

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/07929ba1-ab0c-422e-9d72-2d889dba2bc4" />


*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
