### PR TITLE
Hosting Dashboard v2: fetch site once

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -26,22 +26,15 @@ export function siteQuery( siteId: string ) {
 	return {
 		queryKey: [ 'site', siteId ],
 		queryFn: async () => {
+			// Site usually takes the longest, so kick it off first.
 			const sitePromise = fetchSite( siteId );
+			// Kick off all independent promises in parallel.
 			const mediaStoragePromise = fetchSiteMediaStorage( siteId );
 			const currentPlanPromise = fetchCurrentPlan( siteId );
 			const primaryDomainPromise = fetchSitePrimaryDomain( siteId );
 			const engagementStatsPromise = fetchSiteEngagementStats( siteId );
-			const siteMonitorUptimePromise = sitePromise.then( ( site ) =>
-				site.jetpack && site.jetpack_modules.includes( 'monitor' )
-					? fetchSiteMonitorUptime( siteId )
-					: undefined
-			);
-			const phpVersionPromise = sitePromise.then( ( site ) =>
-				site.options.is_wpcom_atomic ? fetchPHPVersion( siteId ) : undefined
-			);
-
+			const site = await sitePromise;
 			const [
-				site,
 				mediaStorage,
 				currentPlan,
 				primaryDomain,
@@ -49,13 +42,15 @@ export function siteQuery( siteId: string ) {
 				siteMonitorUptime,
 				phpVersion,
 			] = await Promise.all( [
-				sitePromise,
 				mediaStoragePromise,
 				currentPlanPromise,
 				primaryDomainPromise,
 				engagementStatsPromise,
-				siteMonitorUptimePromise,
-				phpVersionPromise,
+				// Kick off dependent promises in parallel.
+				site.jetpack && site.jetpack_modules.includes( 'monitor' )
+					? fetchSiteMonitorUptime( siteId )
+					: undefined,
+				site.options.is_wpcom_atomic ? fetchPHPVersion( siteId ) : undefined,
 			] );
 			return {
 				site,

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -26,8 +26,8 @@ export function siteQuery( siteId: string ) {
 	return {
 		queryKey: [ 'site', siteId ],
 		queryFn: async () => {
+			const site = await fetchSite( siteId );
 			const [
-				site,
 				mediaStorage,
 				siteMonitorUptime,
 				phpVersion,
@@ -35,10 +35,9 @@ export function siteQuery( siteId: string ) {
 				primaryDomain,
 				engagementStats,
 			] = await Promise.all( [
-				fetchSite( siteId ),
 				fetchSiteMediaStorage( siteId ),
-				fetchSiteMonitorUptime( siteId ),
-				fetchPHPVersion( siteId ),
+				fetchSiteMonitorUptime( site ),
+				fetchPHPVersion( site ),
 				fetchCurrentPlan( siteId ),
 				fetchSitePrimaryDomain( siteId ),
 				fetchSiteEngagementStats( siteId ),

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -32,9 +32,13 @@ export function siteQuery( siteId: string ) {
 			const primaryDomainPromise = fetchSitePrimaryDomain( siteId );
 			const engagementStatsPromise = fetchSiteEngagementStats( siteId );
 			const siteMonitorUptimePromise = sitePromise.then( ( site ) =>
-				fetchSiteMonitorUptime( site )
+				site.jetpack && site.jetpack_modules.includes( 'monitor' )
+					? fetchSiteMonitorUptime( siteId )
+					: undefined
 			);
-			const phpVersionPromise = sitePromise.then( ( site ) => fetchPHPVersion( site ) );
+			const phpVersionPromise = sitePromise.then( ( site ) =>
+				site.options.is_wpcom_atomic ? fetchPHPVersion( siteId ) : undefined
+			);
 
 			const [
 				site,

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -26,21 +26,32 @@ export function siteQuery( siteId: string ) {
 	return {
 		queryKey: [ 'site', siteId ],
 		queryFn: async () => {
-			const site = await fetchSite( siteId );
+			const sitePromise = fetchSite( siteId );
+			const mediaStoragePromise = fetchSiteMediaStorage( siteId );
+			const currentPlanPromise = fetchCurrentPlan( siteId );
+			const primaryDomainPromise = fetchSitePrimaryDomain( siteId );
+			const engagementStatsPromise = fetchSiteEngagementStats( siteId );
+			const siteMonitorUptimePromise = sitePromise.then( ( site ) =>
+				fetchSiteMonitorUptime( site )
+			);
+			const phpVersionPromise = sitePromise.then( ( site ) => fetchPHPVersion( site ) );
+
 			const [
+				site,
 				mediaStorage,
-				siteMonitorUptime,
-				phpVersion,
 				currentPlan,
 				primaryDomain,
 				engagementStats,
+				siteMonitorUptime,
+				phpVersion,
 			] = await Promise.all( [
-				fetchSiteMediaStorage( siteId ),
-				fetchSiteMonitorUptime( site ),
-				fetchPHPVersion( site ),
-				fetchCurrentPlan( siteId ),
-				fetchSitePrimaryDomain( siteId ),
-				fetchSiteEngagementStats( siteId ),
+				sitePromise,
+				mediaStoragePromise,
+				currentPlanPromise,
+				primaryDomainPromise,
+				engagementStatsPromise,
+				siteMonitorUptimePromise,
+				phpVersionPromise,
 			] );
 			return {
 				site,

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -71,9 +71,6 @@ export const fetchSites = async (): Promise< Site[] > => {
 };
 
 export const fetchSite = async ( id: string ): Promise< Site > => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
-	}
 	return await wpcom.req.get(
 		{
 			path: `/sites/${ id }?http_envelope=1`,
@@ -84,9 +81,6 @@ export const fetchSite = async ( id: string ): Promise< Site > => {
 };
 
 export const fetchSiteMediaStorage = async ( id: string ): Promise< MediaStorage > => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
-	}
 	const mediaStorage = await wpcom.req.get( {
 		path: `/sites/${ id }/media-storage`,
 		apiVersion: '1.1',
@@ -101,9 +95,6 @@ export const fetchSiteMediaStorage = async ( id: string ): Promise< MediaStorage
 export const fetchSiteMonitorUptime = async (
 	id: string
 ): Promise< MonitorUptime | undefined > => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
-	}
 	return wpcom.req.get(
 		{
 			path: `/sites/${ id }/jetpack-monitor-uptime`,
@@ -114,9 +105,6 @@ export const fetchSiteMonitorUptime = async (
 };
 
 export const fetchPHPVersion = async ( id: string ): Promise< string | undefined > => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
-	}
 	// TODO: check request in different contexts.. Also do we show this only for atomic sites?
 	// TODO: find out what check is needed before this request to avoid 403 errors.
 	return wpcom.req.get( {
@@ -126,9 +114,6 @@ export const fetchPHPVersion = async ( id: string ): Promise< string | undefined
 };
 
 export const fetchCurrentPlan = async ( id: string ): Promise< Plan > => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
-	}
 	const plans: Record< string, Plan > = await wpcom.req.get( {
 		path: `/sites/${ id }/plans`,
 		apiVersion: '1.3',
@@ -141,10 +126,6 @@ export const fetchCurrentPlan = async ( id: string ): Promise< Plan > => {
 };
 
 export const fetchSiteEngagementStats = async ( id: string ) => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
-	}
-
 	const response = await wpcom.req.get(
 		{ path: `/sites/${ id }/stats/visits` },
 		{

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -99,34 +99,28 @@ export const fetchSiteMediaStorage = async ( id: string ): Promise< MediaStorage
 };
 
 export const fetchSiteMonitorUptime = async (
-	site: Site
+	id: string
 ): Promise< MonitorUptime | undefined > => {
-	if ( ! site ) {
-		return Promise.reject( new Error( 'Site is undefined' ) );
-	}
-	if ( ! site.jetpack || ! site.jetpack_modules?.includes( 'monitor' ) ) {
-		return;
+	if ( ! id ) {
+		return Promise.reject( new Error( 'Site ID is undefined' ) );
 	}
 	return wpcom.req.get(
 		{
-			path: `/sites/${ site.ID }/jetpack-monitor-uptime`,
+			path: `/sites/${ id }/jetpack-monitor-uptime`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{ period: '30 days' }
 	);
 };
 
-export const fetchPHPVersion = async ( site: Site ): Promise< string | undefined > => {
-	if ( ! site ) {
-		return Promise.reject( new Error( 'Site is undefined' ) );
-	}
-	if ( ! site.options.is_wpcom_atomic ) {
-		return;
+export const fetchPHPVersion = async ( id: string ): Promise< string | undefined > => {
+	if ( ! id ) {
+		return Promise.reject( new Error( 'Site ID is undefined' ) );
 	}
 	// TODO: check request in different contexts.. Also do we show this only for atomic sites?
 	// TODO: find out what check is needed before this request to avoid 403 errors.
 	return wpcom.req.get( {
-		path: `/sites/${ site.ID }/hosting/php-version`,
+		path: `/sites/${ id }/hosting/php-version`,
 		apiNamespace: 'wpcom/v2',
 	} );
 };

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -49,6 +49,8 @@ const SITE_FIELDS = [
 	'site_migration',
 	'options',
 	'site_owner',
+	'jetpack',
+	'jetpack_modules',
 ].join( ',' );
 
 export const fetchSites = async (): Promise< Site[] > => {
@@ -97,51 +99,34 @@ export const fetchSiteMediaStorage = async ( id: string ): Promise< MediaStorage
 };
 
 export const fetchSiteMonitorUptime = async (
-	id: string
+	site: Site
 ): Promise< MonitorUptime | undefined > => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
+	if ( ! site ) {
+		return Promise.reject( new Error( 'Site is undefined' ) );
 	}
-	// TODO: check this in different contexts..
-	// TODO: this and similar requests trigger multiple requests to the same endpoint
-	// with different fields. How can we avoid this?
-	const site = await wpcom.req.get(
-		{
-			path: `/sites/${ id }?http_envelope=1`,
-			apiNamespace: 'rest/v1.1',
-		},
-		{ fields: [ 'ID', 'jetpack', 'jetpack_modules' ].join( ',' ) }
-	);
-	if ( ! site?.jetpack || ! site?.jetpack_modules?.includes( 'monitor' ) ) {
+	if ( ! site.jetpack || ! site.jetpack_modules?.includes( 'monitor' ) ) {
 		return;
 	}
 	return wpcom.req.get(
 		{
-			path: `/sites/${ id }/jetpack-monitor-uptime`,
+			path: `/sites/${ site.ID }/jetpack-monitor-uptime`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{ period: '30 days' }
 	);
 };
 
-export const fetchPHPVersion = async ( id: string ): Promise< string | undefined > => {
-	if ( ! id ) {
-		return Promise.reject( new Error( 'Site ID is undefined' ) );
+export const fetchPHPVersion = async ( site: Site ): Promise< string | undefined > => {
+	if ( ! site ) {
+		return Promise.reject( new Error( 'Site is undefined' ) );
 	}
-	const site = await wpcom.req.get(
-		{
-			path: `/sites/${ id }?http_envelope=1`,
-			apiNamespace: 'rest/v1.1',
-		},
-		{ fields: [ 'ID', 'options' ].join( ',' ) }
-	);
-	if ( ! site.options?.is_wpcom_atomic ) {
+	if ( ! site.options.is_wpcom_atomic ) {
 		return;
 	}
 	// TODO: check request in different contexts.. Also do we show this only for atomic sites?
 	// TODO: find out what check is needed before this request to avoid 403 errors.
 	return wpcom.req.get( {
-		path: `/sites/${ id }/hosting/php-version`,
+		path: `/sites/${ site.ID }/hosting/php-version`,
 		apiNamespace: 'wpcom/v2',
 	} );
 };

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -186,10 +186,7 @@ export const fetchDomains = async (): Promise< Domain[] > => {
 	return (
 		await wpcom.req.get(
 			{ path: '/all-domains?http_envelope=1' },
-			{
-				no_wpcom: true,
-				resolve_status: true,
-			}
+			{ no_wpcom: true, resolve_status: true }
 		)
 	).domains;
 };

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -87,6 +87,8 @@ export interface Site {
 		migration_status: string;
 	} | null;
 	site_owner: number;
+	jetpack: boolean;
+	jetpack_modules: string[];
 }
 
 export type EmailProvider = 'titan' | 'google-workspace' | 'forwarding';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Was left as a to do: let's wait for the site for two of the promises instead of refetching it twice.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
