### PR TITLE
Upgrade site migration fallback step to container v2

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -1,21 +1,23 @@
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { shouldUseStepContainerV2MigrationFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { CredentialsForm } from './components/credentials-form';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import './style.scss';
 
-const SiteMigrationFallbackCredentials: Step< {
+const SiteMigrationFallbackCredentials: StepType< {
 	submits: {
 		action: 'submit' | 'skip';
 		from?: string;
 	};
-} > = function ( { navigation } ) {
+} > = function ( { navigation, flow } ) {
 	const translate = useTranslate();
 	const siteURL = useQuery().get( 'from' ) || '';
+	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	// Removes "https://" or "http://" from URL
 	const cleanUrl = siteURL.replace( /^(https?:\/\/)?(.*?)(\/)?$/, '$2' );
@@ -31,9 +33,34 @@ const SiteMigrationFallbackCredentials: Step< {
 		} );
 	};
 
+	const title = translate( 'Tell us about your WordPress site' );
+	const headerText = translate( 'Securely share your credentials' );
+	const subHeaderText = translate(
+		'Enter your login details for a WordPress Admin so we can temporarily access {{b}}%s{{/b}} and start migrating it to WordPress.com.',
+		{ components: { b: <strong /> }, args: cleanUrl }
+	);
+	const content = <CredentialsForm onSubmit={ handleSubmit } onSkip={ handleSkip } />;
+
+	if ( isUsingStepContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ title } />
+				<Step.CenteredColumnLayout
+					columnWidth={ 5 }
+					topBar={
+						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
+					}
+					heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+				>
+					{ content }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
+
 	return (
 		<>
-			<DocumentHead title={ translate( 'Tell us about your WordPress site' ) } />
+			<DocumentHead title={ title } />
 			<StepContainer
 				stepName="site-migration-fallback-credentials"
 				flowName="site-migration"
@@ -44,15 +71,12 @@ const SiteMigrationFallbackCredentials: Step< {
 				formattedHeader={
 					<FormattedHeader
 						id="site-migration-credentials-header"
-						headerText={ translate( 'Securely share your credentials' ) }
-						subHeaderText={ translate(
-							'Enter your login details for a WordPress Admin so we can temporarily access {{b}}%s{{/b}} and start migrating it to WordPress.com.',
-							{ components: { b: <strong /> }, args: cleanUrl }
-						) }
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
 						align="center"
 					/>
 				}
-				stepContent={ <CredentialsForm onSubmit={ handleSubmit } onSkip={ handleSkip } /> }
+				stepContent={ content }
 				recordTracksEvent={ recordTracksEvent }
 			/>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-66

## Proposed Changes

| Before | After |
|--------|--------|
|<img width="469" alt="image" src="https://github.com/user-attachments/assets/c84e5b02-8e69-4e43-b1da-49380390b1ea" />|<img width="461" alt="image" src="https://github.com/user-attachments/assets/335f67e5-2092-4776-b5fe-7aff0a583f15" />|
|<img width="1420" alt="image" src="https://github.com/user-attachments/assets/ba6c7dc2-33ea-4285-88fa-6e4986aae000" />|<img width="1420" alt="image" src="https://github.com/user-attachments/assets/8ced21f5-0647-4ecc-914a-bb289dafbab0" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve overall flow consistency with the rest of onboarding.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to `/setup/site-migration/site-migration-fallback-credentials?flags=onboarding%2Fstep-container-v2-migration-flow&sessionId=CX&from=[SOME_SITE_URL]` with and without the flag and verify it corresponds with the screenshots.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
