### PR TITLE
New hosted site: Remove ineligibility message from plans grid

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -170,7 +170,12 @@ describe( 'useGenerateActionHook', () => {
 		expect( action.primary.text ).toBe( 'Start with Free' );
 	} );
 
-	it( 'should handle signup actions for business plan with ineligible free hosting trial', () => {
+	/**
+	 * Disable free hosting trials - see pMz3w-k4H-p2#comment-119368
+	 * See https://github.com/Automattic/wp-calypso/pull/102861
+	 * for how to restore this test.
+	 */
+	it.skip( 'should handle signup actions for business plan with ineligible free hosting trial', () => {
 		( useSelector as jest.Mock ).mockImplementation( ( selector ) =>
 			selector( {
 				ui: {},

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -22,7 +22,10 @@ import { useState } from '@wordpress/element';
 import { type LocalizeProps, type TranslateResult, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
-import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
+import {
+	FREE_HOSTING_TRIAL_ENABLED,
+	isUserEligibleForFreeHostingTrial,
+} from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors/is-current-user-current-plan-owner';
 import isCurrentPlanPaid from 'calypso/state/sites/selectors/is-current-plan-paid';
 import { IAppState } from 'calypso/state/types';
@@ -320,7 +323,8 @@ function getSignupAction( {
 	if (
 		isBusinessPlan( planSlug ) &&
 		! eligibleForFreeHostingTrial &&
-		plansIntent === 'plans-new-hosted-site'
+		plansIntent === 'plans-new-hosted-site' &&
+		FREE_HOSTING_TRIAL_ENABLED
 	) {
 		return createSignupAction(
 			translate( 'Get %(plan)s', {

--- a/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
+++ b/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
@@ -1,7 +1,13 @@
 import { AppState } from '../../types';
 
+export const FREE_HOSTING_TRIAL_ENABLED = false;
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const isUserEligibleForFreeHostingTrial = ( _state: AppState ) => {
-	// Disable free hosting trials - see pMz3w-k4H-p2#comment-119368
-	return false;
+	/**
+	 * Disable free hosting trials - see pMz3w-k4H-p2#comment-119368
+	 * See https://github.com/Automattic/wp-calypso/pull/102659/files#diff-5bf70c26edb1f5ec4791ff1d23f8bcf214b047ee08c9462549865d1f59bf92c5
+	 * for how to restore the eligibility check.
+	 */
+	return FREE_HOSTING_TRIAL_ENABLED;
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102659.

## Proposed Changes

We were making the current user ineligible for the free hosting trial, and that was causing the non-eligibility message to show up in the plans grid in `/setup/new-hosted-site`. This PR fixes this wrong behavior.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/user-attachments/assets/c4d0a713-c5cd-4826-93eb-539239d70db3) | ![image](https://github.com/user-attachments/assets/e9e8c025-e7f4-405f-99aa-ffe34f5c04d9) |

## Testing Instructions

Enter `/setup/new-hosted-site` and verify you don't see the message above the add-on selector.