### PR TITLE
Purchase Management: Remove unnecessary and mostly unused "Select a new plan" links from legacy Jetpack plans

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -437,20 +437,6 @@ class ManagePurchase extends Component<
 		);
 	}
 
-	renderSelectNewButton() {
-		const { translate, siteId, purchase } = this.props;
-
-		if ( purchase && this.isPendingDomainRegistration( purchase ) ) {
-			return null;
-		}
-
-		return (
-			<Button className="manage-purchase__renew-button" href={ `/plans/${ siteId }` } compact>
-				{ translate( 'Select a new plan' ) }
-			</Button>
-		);
-	}
-
 	renderRenewalNavItem( content: JSX.Element | string, onClick: () => void ) {
 		const { purchase } = this.props;
 		if ( ! purchase ) {
@@ -624,20 +610,6 @@ class ManagePurchase extends Component<
 			>
 				<Icon icon={ icon } className="card__icon" />
 				{ buttonText }
-			</CompactCard>
-		);
-	}
-
-	renderSelectNewNavItem() {
-		const { translate, siteId, purchase } = this.props;
-
-		if ( purchase && this.isPendingDomainRegistration( purchase ) ) {
-			return null;
-		}
-
-		return (
-			<CompactCard tagName="button" displayAsLink href={ `/plans/${ siteId }` }>
-				{ translate( 'Select a new plan' ) }
 			</CompactCard>
 		);
 	}
@@ -1335,7 +1307,7 @@ class ManagePurchase extends Component<
 		);
 	}
 
-	renderPurchaseDetail( preventRenewal: boolean, isJetpackLegacyPlan: boolean ) {
+	renderPurchaseDetail( preventRenewal: boolean ) {
 		if ( this.isDataLoading( this.props ) || this.isDomainsLoading( this.props ) ) {
 			return this.renderPlaceholder();
 		}
@@ -1410,7 +1382,6 @@ class ManagePurchase extends Component<
 						</div>
 						{ isProductOwner && ! purchase.isLocked && (
 							<div className="manage-purchase__renew-upgrade-buttons">
-								{ preventRenewal && isJetpackLegacyPlan && this.renderSelectNewButton() }
 								{ this.renderUpgradeButton( preventRenewal ) }
 								{ ! preventRenewal && this.renderRenewButton() }
 							</div>
@@ -1437,7 +1408,6 @@ class ManagePurchase extends Component<
 				) }
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
-						{ preventRenewal && isJetpackLegacyPlan && this.renderSelectNewNavItem() }
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&
@@ -1508,17 +1478,15 @@ class ManagePurchase extends Component<
 		}
 
 		let showExpiryNotice = false;
-		let preventRenewal = false;
-		let isJetpackLegacyPlan = false;
 
 		if (
 			purchase &&
 			( JETPACK_LEGACY_PLANS as ReadonlyArray< string > ).includes( purchase.productSlug )
 		) {
 			showExpiryNotice = isCloseToExpiration( purchase );
-			isJetpackLegacyPlan = true;
-			preventRenewal = ! isRenewable( purchase );
 		}
+
+		let preventRenewal = false;
 
 		if ( ! canExplicitRenew( purchase ) ) {
 			preventRenewal = true;
@@ -1570,7 +1538,7 @@ class ManagePurchase extends Component<
 					siteId={ this.props.siteId ?? 0 }
 					purchase={ purchase }
 				/>
-				{ this.renderPurchaseDetail( preventRenewal, isJetpackLegacyPlan ) }
+				{ this.renderPurchaseDetail( preventRenewal ) }
 				{ this.renderWordAdsEligibilityWarningDialog( purchase ) }
 				{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }
 			</Fragment>


### PR DESCRIPTION
Tracked in https://linear.app/a8c/issue/SHILL-689/purchase-management-remove-unnecessary-and-mostly-unused-select-a-new

## Proposed Changes

This is a followup to https://github.com/Automattic/wp-calypso/pull/102723 (which fixed strange-looking "Select a new plan" links that started appearing on some WordPress.com purchase management pages by accident).  That pull request restricted the links to legacy Jetpack plans only, as they were originally designed for.  This pull request removes them entirely.

The links appear to have been originally added based on the idea that we'd block legacy Jetpack plans from being renewed and force people to switch to a new plan instead.  You can see where https://github.com/Automattic/wp-calypso/pull/44947 references that type of logic being moved to server-side code.  But I can find no evidence that it exists (or ever existed) on the server, and in fact https://github.com/Automattic/wp-calypso/pull/45512 changed messages in Calypso so that it started encouraging customers with legacy plans to switch, rather than implying that they are required to do so.  So I think this feature was never launched.

Therefore, the "Select a new plan" links are mostly unusued -- and probably were completely unused until recently; the same issue that caused them to start appearing on WordPress.com plans (as noted above) still makes them appear on legacy Jetpack plans today.  This happens immediately after the plan has been renewed (which triggers a block on subsequent renewals based on https://github.com/Automattic/wp-calypso/pull/102461 and thereby triggers the conditions that make these links appear).  But since this behavior is unintentional, and the "Select a plan link" looks ugly (missing an icon) and also serves no real purpose (it takes you to the same place as the "Upgrade" link right next to it), we should just remove it in this case too.

Here are before/after screenshots for the one case where the "Select a new plan" link currently appears (immediately after a successful renewal) and is being removed by this pull request.

**Before:**
![before](https://github.com/user-attachments/assets/b7bfc1c9-6b8f-49da-9d6e-b1cef65f1e23)

**After:**
![after](https://github.com/user-attachments/assets/0dc09e7d-921f-4fd0-89e7-6282340e58b0)

## Testing Instructions

1. Add a legacy Jetpack plan (for example, Jetpack Personal) to a Jetpack-connected site via Store Admin.
2. Go to the purchase management page for that subscription (e.g. go to `/me/purchases` and click through to manage it there). Check that the page looks the same before and after this pull request.
3. Change the plan's expiration date in Store Admin so that it expires a few days from now.  Check that the purchase management page looks the same before and after this pull request (in both cases it should now also show a message encouraging you to switch to a different plan).
4. Renew the subscription. Check that the only difference between the purchase management page before and after this pull request is the removal of the "Select a new plan" links (see screenshots above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
