### PR TITLE
Fix some mobile E2E tests

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import envVariables from '../../../env-variables';
 
 const selectors = {
 	// Menu items
@@ -22,14 +23,20 @@ export class MeSidebarComponent {
 	}
 
 	/**
+	 * Opens the menu on mobile.
+	 */
+	async openMobileMenu() {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await this.page.getByTitle( 'Menu' ).click();
+		}
+	}
+
+	/**
 	 * Given a string, navigate to the menu on the sidebar.
 	 *
 	 * @param {string} menu Menu item label or href to navigate to.
 	 */
 	async navigate( menu: string ): Promise< void > {
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( selectors.menuItem( menu ) ),
-		] );
+		await this.page.click( selectors.menuItem( menu ) );
 	}
 }

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -217,6 +217,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			await mePage.visit();
 
 			const meSidebarComponent = new MeSidebarComponent( page );
+			await meSidebarComponent.openMobileMenu();
 			await meSidebarComponent.navigate( 'Purchases' );
 		} );
 

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -138,6 +138,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			await mePage.visit();
 
 			const meSidebarComponent = new MeSidebarComponent( page );
+			await meSidebarComponent.openMobileMenu();
 			await meSidebarComponent.navigate( 'Purchases' );
 		} );
 

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -33,15 +33,15 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 		expect( await didEventFirePromise ).toBe( true );
 	} );
 
-	it( 'Clicking link on LOHP fires wpcom_link_click', async function () {
+	it( 'Clicking link on LOHP fires wpcom_homepage_link_click', async function () {
 		// Navigate to LOHP
 		await tracksEventManager.navigateToUrl( lohpUrl );
 
-		// Set up listener for wpcom_link_click event
-		const didEventFirePromise = tracksEventManager.didEventFire( 'wpcom_link_click' );
+		// Set up listener for wpcom_homepage_link_click event
+		const didEventFirePromise = tracksEventManager.didEventFire( 'wpcom_homepage_link_click' );
 
 		// Click first signup link to go to signup page
-		await page.locator( 'a[href^="https://wordpress.com/setup/onboarding"]' ).first().click();
+		await page.getByRole( 'link', { name: 'Get started' } ).first().click();
 
 		// Expect the event to fire
 		expect( await didEventFirePromise ).toBe( true );
@@ -62,7 +62,8 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 		requestUrlPromise = tracksEventManager.getRequestUrlForEvent( 'calypso_page_view' );
 
 		// Click first signup link to go to signup page
-		await page.locator( 'a[href^="https://wordpress.com/setup/onboarding"]' ).first().click();
+		await page.getByRole( 'link', { name: 'Get started' } ).first().click();
+
 		requestUrl = await requestUrlPromise;
 
 		// Expect anon ids in wpcom and calypso page view events to match


### PR DESCRIPTION
Related to DOTCOM-10588.

## Proposed Changes

Fixes almost all tests from [this run](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release_mobile/14781779?buildTab=overview&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true):

- `lifecycle__signup-onboarding-launch-cancel.ts`
- `signup__with-theme-premium.ts`
- `tracks__lohp-to-signup-events.ts`

## Test instructions

- Run `yarn workspace @automattic/calypso-e2e build`.
- Run `yarn workspace wp-e2e-tests test:mobile -- %s`.