### PR TITLE
Delay mounting opfs dir on first boot

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -20,7 +20,7 @@ export async function initializeWordPressPlayground(
 	let isWordPressInstalled = false;
 
 	const url = new URL( window.location.href );
-	let playgroundId = url.searchParams.get( 'playground' );
+	let playgroundId: string | null = url.searchParams.get( 'playground' );
 	if ( ! playgroundId ) {
 		playgroundId = crypto.randomUUID();
 		// update url in browser history
@@ -43,7 +43,7 @@ export async function initializeWordPressPlayground(
 				path: `${ OPFS_PATH_PREFIX }/${ playgroundId }/`,
 			},
 			mountpoint: '/wordpress',
-			initialSyncDirection: 'opfs-to-memfs',
+			initialSyncDirection: isWordPressInstalled ? 'opfs-to-memfs' : 'memfs-to-opfs',
 		};
 
 		const client = await startPlaygroundWeb( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -51,8 +51,12 @@ export async function initializeWordPressPlayground(
 			remoteUrl: 'https://playground.wordpress.net/remote.html',
 			blueprint: await getBlueprint( isWordPressInstalled, recommendedPhpVersion ),
 			shouldInstallWordPress: ! isWordPressInstalled,
-			mounts: [ mountDescriptor ],
+			mounts: isWordPressInstalled ? [ mountDescriptor ] : [],
 		} );
+
+		if ( ! isWordPressInstalled ) {
+			await client.mountOpfs( mountDescriptor );
+		}
 
 		await client.isReady();
 		return client;


### PR DESCRIPTION
## Why are these changes being made?

* While installation of WordPress upon first bool, our journal has nothing to sync from memfs to opfs (as it does upon mounting), and then right after installation, it records and tries to sync all 3K+ files which hangs up the first request it does to `/scope:xxx` url by several seconds (9-12 secs) intermittently.
* While this is happening, a white screen is displayed which leaves the user confused.
* While we are currently discussing how to make journal faster, and there is a possibility we can get rid of journaling based on @brandonpayton's PR for making FS functions async, which could be used to support OPFS as a first-class filesystem without journaling. 

## Proposed Changes

* This PR delays mounting of OPFS when we need to install WordPress, so that first page is served quickly and then we handle the sync upon mounting, so essentially we don't wait on the sync to show user the first WP page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
