### PR TITLE
A4A: Display the nested sidebar preview on narrow screens

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -1,8 +1,9 @@
 import page from '@automattic/calypso-router';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import JetpackIcons from 'calypso/components/jetpack/jetpack-icons';
 import Sidebar, {
@@ -14,6 +15,7 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import A4AContactSupportWidget, { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
 import ProvideFeedback from '../a4a-feedback/provide-feedback';
 import SidebarHeader from './header';
@@ -61,6 +63,7 @@ const A4ASidebar = ( {
 	const dispatch = useDispatch();
 
 	const isClient = isClientView();
+	const isNarrowView = useBreakpoint( '<660px' );
 
 	const onShowUserSupportForm = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_share_product_feedback_click' ) );
@@ -69,6 +72,15 @@ const A4ASidebar = ( {
 	const contactUsText = isClient
 		? translate( 'Contact support' )
 		: translate( 'Contact sales & support' );
+
+	// When the sidebar is not displayed (narrow view), we need to set the layout focus to the preview.
+	// This is because, on a narrow view, we want to display the sidebar to navigate to all available pages
+	// rather than showing the default page of the nested sidebar directly.
+	useEffect( () => {
+		if ( path && isNarrowView ) {
+			dispatch( setLayoutFocus( 'preview' ) );
+		}
+	}, [ dispatch, path, isNarrowView ] );
 
 	return (
 		<Sidebar className={ clsx( 'a4a-sidebar', className ) }>


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1605

## Proposed Changes

This PR updates the `A4ASidebar` component to set the layout focus to "preview" when a nested menu is opened on narrow devices. The sidebar is hidden on narrow devices(<660px). This is because, on a narrow view, we want to display the sidebar to navigate to all available pages rather than showing the default page of the nested sidebar directly.

## Why are these changes being made?

* On a narrow view, we want to display the sidebar to navigate to all available pages rather than showing the default page of the nested sidebar directly.

## Testing Instructions

* Open the A4A live link
* Visit all the pages: Overview, Sites, Marketplace and the rest > Verify everything works as expected including the nested menu items 
* Switch to any view < 660px using the dev tool > Verify the non-nested menu is loading the page directly(Overview, Team etc) and nested menu displays the sidebar 

<img width="420" alt="Screenshot 2025-04-25 at 12 17 31 PM" src="https://github.com/user-attachments/assets/e1228226-0969-4b68-8824-36cedd6fb916" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
