### PR TITLE
Hosting Dashboard v2: site options can be undefined

### DIFF
--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -78,7 +78,8 @@ export interface Site {
 	plan: SitePlan;
 	active_modules?: string[];
 	subscribers_count: number;
-	options: SiteOptions;
+	// Can be undefined for deleted sites.
+	options?: SiteOptions;
 	is_deleted: boolean;
 	is_coming_soon: boolean;
 	is_private: boolean;

--- a/client/dashboard/site-overview/index.tsx
+++ b/client/dashboard/site-overview/index.tsx
@@ -46,14 +46,16 @@ function SiteOverview() {
 			actions={
 				<>
 					<ExternalLink href={ site.URL }>{ __( 'Visit' ) }</ExternalLink>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						href={ site.options.admin_url }
-						icon={ wordpress }
-					>
-						{ __( 'WP Admin' ) }
-					</Button>
+					{ site.options?.admin_url && (
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							href={ site.options.admin_url }
+							icon={ wordpress }
+						>
+							{ __( 'WP Admin' ) }
+						</Button>
+					) }
 				</>
 			}
 		>

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -27,11 +27,10 @@ export default function SiteCard( {
 	primaryDomain?: SiteDomain;
 	currentPlan: Plan;
 } ) {
-	const { options, URL: url } = site;
-	const { software_version, blog_public } = options;
+	const { options, URL: url, is_private } = site;
 	// If the site is a private A8C site, X-Frame-Options is set to same
 	// origin.
-	const iframeDisabled = isA8CSite( site ) && blog_public === -1;
+	const iframeDisabled = isA8CSite( site ) && is_private;
 	return (
 		<Card>
 			<VStack spacing={ 6 }>
@@ -70,7 +69,9 @@ export default function SiteCard( {
 						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
 					</HStack>
 					<HStack justify="space-between">
-						<Field title={ __( 'WordPress' ) }>{ software_version }</Field>
+						{ options?.software_version && (
+							<Field title={ __( 'WordPress' ) }>{ options.software_version }</Field>
+						) }
 						{ phpVersion && <Field title={ __( 'PHP' ) }>{ phpVersion }</Field> }
 					</HStack>
 					<PlanDetails site={ site } currentPlan={ currentPlan } primaryDomain={ primaryDomain } />

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -23,9 +23,11 @@ const actions = [
 		label: __( 'WP Admin' ),
 		callback: ( sites: Site[] ) => {
 			const site = sites[ 0 ];
-			window.location.href = site.options?.admin_url ?? '';
+			if ( site.options?.admin_url ) {
+				window.location.href = site.options.admin_url;
+			}
 		},
-		isEligible: ( item: Site ) => ( item.is_deleted ? false : true ),
+		isEligible: ( item: Site ) => ( item.is_deleted || ! item.options?.admin_url ? false : true ),
 	},
 ];
 
@@ -107,11 +109,10 @@ const DEFAULT_FIELDS = [
 		label: __( 'Preview' ),
 		render: function PreviewRender( { item }: { item: Site } ) {
 			const [ resizeListener, { width } ] = useResizeObserver();
-			const { options, URL: url } = item;
-			const { blog_public } = options;
+			const { is_deleted, is_private, URL: url } = item;
 			// If the site is a private A8C site, X-Frame-Options is set to same
 			// origin.
-			const iframeDisabled = isA8CSite( item ) && blog_public === -1;
+			const iframeDisabled = is_deleted || ( isA8CSite( item ) && is_private );
 			return (
 				<>
 					{ resizeListener }

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -24,7 +24,7 @@ export function getSiteStatus( item: Site ) {
 		return 'deleted';
 	}
 
-	if ( item.options.is_redirect ) {
+	if ( item.options?.is_redirect ) {
 		return 'redirect';
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

It can be undefined for deleted sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
