### PR TITLE
Teamcity: Configure mobile pre-release e2e tests

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1071,14 +1071,8 @@ fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildT
 			param("env.VIEWPORT_NAME", targetDevice)
 			param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
 			param("env.ALLURE_RESULTS_PATH", "allure-results")
-			// Skip known failing tests for mobile
-			if (targetDevice == "mobile") {
-				param("env.TEST_EXCLUDE_PATTERN", """(
-					.*gutenberg-editor.*|
-					.*jetpack-connect.*|
-					.*media-editor.*
-				)""")
-			}
+			// TODO: After running all tests on mobile and identifying actual failures,
+			// add TEST_EXCLUDE_PATTERN here with proper documentation of why each test is excluded
 		},
 		buildFeatures = {
 			notifications {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1071,8 +1071,25 @@ fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildT
 			param("env.VIEWPORT_NAME", targetDevice)
 			param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
 			param("env.ALLURE_RESULTS_PATH", "allure-results")
-			// TODO: After running all tests on mobile and identifying actual failures,
-			// add TEST_EXCLUDE_PATTERN here with proper documentation of why each test is excluded
+			// Skip tests that fail specifically on mobile viewport due to UI/layout differences
+			if (targetDevice == "mobile") {
+				param("env.TEST_EXCLUDE_PATTERN", """
+					# Tests failing due to mobile-specific UI issues:
+					
+					# 1. Signup with theme from LOHP - elements not visible in mobile viewport
+					# Error: Element is not visible when trying to hover over theme
+					.*signup__with-theme-LOHP.*|
+					
+					# 2. LOHP to signup events - elements not visible/clickable in mobile layout
+					# Error: Timeout waiting for element to be visible and clickable
+					.*tracks__lohp-to-signup-events.*|
+					
+					# 3. Signup with premium theme & Lifecycle tests - sidebar navigation issues
+					# Error: Cannot click Purchases link in sidebar - element outside viewport
+					.*signup__with-theme-premium.*|
+					.*lifecycle__signup-onboarding-launch-cancel.*
+				""".trimIndent())
+			}
 		},
 		buildFeatures = {
 			notifications {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1062,9 +1062,45 @@ fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildT
 		buildUuid = buildUuid,
 		buildName = "Pre-Release E2E Tests ($targetDevice)",
 		buildDescription = "Runs a pre-release suite of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production. Will run on $targetDevice size.",
-		testGroup = "calypso-pr",
-		buildFeatures = {
+		testGroup = "calypso-release",
+		buildParams = {
+			param("env.NODE_CONFIG_ENV", "test")
+			param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
+			param("env.HEADLESS", "true")
+			param("env.LOCALE", "en")
+			param("env.VIEWPORT_NAME", targetDevice)
+			param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
+			param("env.ALLURE_RESULTS_PATH", "allure-results")
+			// Skip known failing tests for mobile
+			if (targetDevice == "mobile") {
+				param("env.TEST_EXCLUDE_PATTERN", """(
+					.*gutenberg-editor.*|
+					.*jetpack-connect.*|
+					.*media-editor.*
+				)""")
+			}
 		},
+		buildFeatures = {
+			notifications {
+				notifierSettings = slackNotifier {
+					connection = "PROJECT_EXT_11"
+					sendTo = "#e2eflowtesting-notif"
+					messageFormat = verboseMessageFormat {
+						addStatusText = true
+					}
+				}
+				branchFilter = "+:<default>"
+				buildFailedToStart = true
+				buildFailed = true
+				buildFinishedSuccessfully = false
+				buildProbablyHanging = true
+			}
+		},
+		buildDependencies = {
+			snapshot(PreReleaseE2ETests) {
+				onDependencyFailure = FailureAction.FAIL_TO_START
+			}
+		}
 	)
 }
 

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1073,22 +1073,11 @@ fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildT
 			param("env.ALLURE_RESULTS_PATH", "allure-results")
 			// Skip tests that fail specifically on mobile viewport due to UI/layout differences
 			if (targetDevice == "mobile") {
-				param("env.TEST_EXCLUDE_PATTERN", """
-					# Tests failing due to mobile-specific UI issues:
-					
-					# 1. Signup with theme from LOHP - elements not visible in mobile viewport
-					# Error: Element is not visible when trying to hover over theme
-					.*signup__with-theme-LOHP.*|
-					
-					# 2. LOHP to signup events - elements not visible/clickable in mobile layout
-					# Error: Timeout waiting for element to be visible and clickable
-					.*tracks__lohp-to-signup-events.*|
-					
-					# 3. Signup with premium theme & Lifecycle tests - sidebar navigation issues
-					# Error: Cannot click Purchases link in sidebar - element outside viewport
-					.*signup__with-theme-premium.*|
-					.*lifecycle__signup-onboarding-launch-cancel.*
-				""".trimIndent())
+				// These tests are skipped due to mobile-specific UI issues:
+				// 1. signup__with-theme-LOHP - Elements not visible in mobile viewport
+				// 2. tracks__lohp-to-signup-events - Elements not visible/clickable in mobile layout
+				// 3. signup__with-theme-premium & lifecycle__signup-onboarding-launch-cancel - Sidebar navigation issues
+				param("env.TEST_EXCLUDE_PATTERN", "signup__with-theme-LOHP|tracks__lohp-to-signup-events|signup__with-theme-premium|lifecycle__signup-onboarding-launch-cancel")
 			}
 		},
 		buildFeatures = {

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1071,14 +1071,6 @@ fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildT
 			param("env.VIEWPORT_NAME", targetDevice)
 			param("env.CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
 			param("env.ALLURE_RESULTS_PATH", "allure-results")
-			// Skip tests that fail specifically on mobile viewport due to UI/layout differences
-			if (targetDevice == "mobile") {
-				// These tests are skipped due to mobile-specific UI issues:
-				// 1. signup__with-theme-LOHP - Elements not visible in mobile viewport
-				// 2. tracks__lohp-to-signup-events - Elements not visible/clickable in mobile layout
-				// 3. signup__with-theme-premium & lifecycle__signup-onboarding-launch-cancel - Sidebar navigation issues
-				param("env.TEST_EXCLUDE_PATTERN", "signup__with-theme-LOHP|tracks__lohp-to-signup-events|signup__with-theme-premium|lifecycle__signup-onboarding-launch-cancel")
-			}
 		},
 		buildFeatures = {
 			notifications {
@@ -1089,7 +1081,8 @@ fun e2ePreReleaseBuildType( targetDevice: String, buildUuid: String ): E2EBuildT
 						addStatusText = true
 					}
 				}
-				branchFilter = "+:<default>"
+				// TODO: Temporarily targeting test branches - revert to '+:<default>' after testing
+				branchFilter = "+:add/mobile-pre-release-tests,+:add/mobile-e2e-prerelease"
 				buildFailedToStart = true
 				buildFailed = true
 				buildFinishedSuccessfully = false


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTCOM-10584/configure-mobile-pre-release-e2e-tests-in-the-new-structure-and-skip

## Proposed Changes

- Run automatically after the main pre-release tests are completed successfully
- Skip known problematic tests in the mobile viewport
- Report results and issues through Slack notifications
- Generate Allure reports for test results analysis

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
