### PR TITLE
Fix the y-axis of uplot graph in campaign details page

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-stats-line-chart/index.tsx/campaign-stats-line-chart.tsx
@@ -118,6 +118,7 @@ const CampaignStatsLineChart = ( { data, source, resolution }: GraphProps ) => {
 						show: false,
 					},
 					gap: 16,
+					size: 60,
 				},
 			],
 			cursor: {


### PR DESCRIPTION

Related to #
this is a hot fix (no ticket attached)

## Proposed Changes
I noticed that in campaign details page when the graph has a lot of data the y-axis of the graph we show has an issue with number not fitting in the space

<img width="705" alt="Screenshot 2025-04-25 at 11 05 22" src="https://github.com/user-attachments/assets/89f1a489-be07-4c60-ab28-1201051c75e2" />
this is a one liner fix to address that

now even with a lot of data (and large numbers) the number fit nicely

<img width="719" alt="Screenshot 2025-04-25 at 11 36 04" src="https://github.com/user-attachments/assets/e2694970-85c7-4181-bc52-07741260c491" />


## Testing Instructions

I think just CR is enough

to actually test it.., checkout the branch (or check the preview link) and open a campaign that has data (preferably with lot of data)

check the graph 

you re it 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
