### PR TITLE
Docker: Change base image frequency to 6h

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -211,7 +211,7 @@ object BuildBaseImages : BuildType({
 	triggers {
 		schedule {
 			schedulingPolicy = cron {
-				hours = "*/12"
+				hours = "*/6"
 			}
 			branchFilter = """
 				+:trunk


### PR DESCRIPTION
## Proposed Changes

Changing the base Docker image frequency from 12h to 6h.

## Why are these changes being made?

To be able to leverage the base image cache more frequently. Since the last few months, we've had more contributions to Calypso, so the base image cache has been invalidating more frequently, causing Docker image builds to be longer than usual more often. 

It might also help reduce the instances of unexpected yarn cache pollution, see p4TIVU-b34-p2

## Testing Instructions

Not needed. The base image should start running every 6h after this change.
