### PR TITLE
Hosting Dashboard v2: Fix site options type

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -50,7 +50,7 @@ export function siteQuery( siteId: string ) {
 				site.jetpack && site.jetpack_modules.includes( 'monitor' )
 					? fetchSiteMonitorUptime( siteId )
 					: undefined,
-				site.options.is_wpcom_atomic ? fetchPHPVersion( siteId ) : undefined,
+				site.options?.is_wpcom_atomic ? fetchPHPVersion( siteId ) : undefined,
 			] );
 			return {
 				site,


### PR DESCRIPTION
## Proposed Changes

Making the site options field optional in the `siteQuery`.

## Why are these changes being made?

To resolve this type error that's currently on trunk:

![Screenshot 2025-04-25 at 12 24 42](https://github.com/user-attachments/assets/a8965b1c-36c6-42be-8cf8-65d57b298205)

## Testing Instructions

Type checks should pass.