### PR TITLE
Hosting Dashboard v2: layout design: add domains new button + update user dropdown

### DIFF
--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
@@ -98,7 +99,14 @@ function Domains() {
 	}
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( domains, view, fields );
 	return (
-		<PageLayout title={ __( 'Domains' ) }>
+		<PageLayout
+			title={ __( 'Domains' ) }
+			actions={
+				<Button variant="primary" __next40pxDefaultSize>
+					{ __( 'Add New Domain' ) }
+				</Button>
+			}
+		>
 			<DataViewsCard>
 				<DataViews
 					data={ filteredData || [] }

--- a/client/dashboard/profile/index.tsx
+++ b/client/dashboard/profile/index.tsx
@@ -192,11 +192,6 @@ export default function Profile() {
 									</Text>
 								</div>
 							</HStack>
-						</CardBody>
-					</Card>
-
-					<Card>
-						<CardBody>
 							<VStack spacing={ 4 } alignment="left">
 								<DataForm< ProfileType >
 									data={ data }

--- a/client/dashboard/profile/index.tsx
+++ b/client/dashboard/profile/index.tsx
@@ -192,6 +192,11 @@ export default function Profile() {
 									</Text>
 								</div>
 							</HStack>
+						</CardBody>
+					</Card>
+
+					<Card>
+						<CardBody>
 							<VStack spacing={ 4 } alignment="left">
 								<DataForm< ProfileType >
 									data={ data }

--- a/client/dashboard/secondary-menu/index.tsx
+++ b/client/dashboard/secondary-menu/index.tsx
@@ -22,7 +22,6 @@ import './style.scss';
 // User profile dropdown component
 function UserProfile() {
 	const { user } = useAuth();
-	const { supports } = useAppContext();
 	const openCommandPalette = useOpenCommandPalette();
 
 	return (
@@ -58,15 +57,7 @@ function UserProfile() {
 						<Text variant="muted">@{ user.username }</Text>
 					</VStack>
 					<MenuGroup>
-						<RouterLinkMenuItem to="/me/profile">{ __( 'Profile' ) }</RouterLinkMenuItem>
-						<RouterLinkMenuItem to="/me/billing">{ __( 'Billing' ) }</RouterLinkMenuItem>
-						<RouterLinkMenuItem to="/me/security">{ __( 'Security' ) }</RouterLinkMenuItem>
-						<RouterLinkMenuItem to="/me/privacy">{ __( 'Privacy' ) }</RouterLinkMenuItem>
-						{ supports.notifications && (
-							<RouterLinkMenuItem to="/me/notifications">
-								{ __( 'Notifications' ) }
-							</RouterLinkMenuItem>
-						) }
+						<RouterLinkMenuItem to="/me/profile">{ __( 'Account' ) }</RouterLinkMenuItem>
 					</MenuGroup>
 					<MenuGroup>
 						<MenuItem


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The domains button is missing and the user dropdown has been redesigned.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See the Figma designs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
