### PR TITLE
A4A > Layout: Fix all the Layout & LayoutBanner width issues

### DIFF
--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -14,7 +14,7 @@ import './style.scss';
 
 const AGENCY_APPROVAL_DISMISS_PREFERENCE = 'a4a-agency-approval-notice-dismissed';
 
-const A4AAgencyApprovalNotice = () => {
+const A4AAgencyApprovalNotice = ( { isFullWidth }: { isFullWidth?: boolean } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
@@ -81,9 +81,9 @@ const A4AAgencyApprovalNotice = () => {
 
 	return (
 		<LayoutBanner
+			isFullWidth={ isFullWidth }
 			level={ bannerDetails.level as 'warning' | 'success' | 'error' }
 			onClose={ dismissNotice }
-			className="a4a-agency-approval-notice"
 			hideCloseButton={ bannerDetails.hideCloseButton }
 		>
 			<div className="a4a-agency-approval-notice__text">{ bannerDetails.text }</div>

--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/style.scss
@@ -1,11 +1,3 @@
-.a4a-agency-approval-notice {
-	margin-block-end: 24px;
-}
-
-.sites-dashboard .a4a-agency-approval-notice {
-	padding: 0;
-}
-
 .a4a-agency-approval-notice__text {
 	max-width: 930px;
 }

--- a/client/a8c-for-agencies/components/layout/banner.tsx
+++ b/client/a8c-for-agencies/components/layout/banner.tsx
@@ -16,6 +16,7 @@ type Props = {
 	title?: string;
 	preferenceName?: string;
 	hideCloseButton?: boolean;
+	isFullWidth?: boolean;
 };
 
 export default function LayoutBanner( {
@@ -27,6 +28,7 @@ export default function LayoutBanner( {
 	level = 'success',
 	preferenceName,
 	hideCloseButton = false,
+	isFullWidth = false,
 }: Props ) {
 	const dispatch = useDispatch();
 
@@ -34,7 +36,9 @@ export default function LayoutBanner( {
 		preferenceName ? getPreference( state, preferenceName ) : false
 	);
 
-	const wrapperClass = clsx( className, 'a4a-layout__banner' );
+	const wrapperClass = clsx( className, 'a4a-layout__banner', {
+		'a4a-layout__banner--full-width': isFullWidth,
+	} );
 
 	const handleClose = () => {
 		if ( preferenceName ) {

--- a/client/a8c-for-agencies/components/layout/layout-with-payment-notification.tsx
+++ b/client/a8c-for-agencies/components/layout/layout-with-payment-notification.tsx
@@ -7,10 +7,11 @@ import './style.scss';
 export default function LayoutWithPaymentNotification( {
 	children,
 	withNavigation,
-}: ComponentProps< typeof LayoutTop > ) {
+	isFullWidth,
+}: ComponentProps< typeof LayoutTop > & { isFullWidth?: boolean } ) {
 	return (
 		<LayoutTop withNavigation={ withNavigation }>
-			<PendingPaymentNotification />
+			<PendingPaymentNotification isFullWidth={ isFullWidth } />
 			{ children }
 		</LayoutTop>
 	);

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -14,7 +14,7 @@
 	max-height: 100%;
 	margin-block: 24px;
 
-	> * {
+	&:not( .a4a-layout__banner--full-width ) > * {
 
 		@include breakpoint-deprecated( ">660px" ) {
 			max-width: 1500px;

--- a/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
+++ b/client/a8c-for-agencies/components/pending-payment-notification/index.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 // TODO: Uncomment this if we would want to dismiss the notification.
 // const PENDING_PAYMENT_NOTIFICATION_DISMISS_PREFERENCE = 'pending-payment-notification-dismissed';
 
-export default function PendingPaymentNotification() {
+export default function PendingPaymentNotification( { isFullWidth }: { isFullWidth?: boolean } ) {
 	const invoices = useFetchInvoices( { starting_after: '', ending_before: '' }, undefined, 'open' );
 
 	const translate = useTranslate();
@@ -78,6 +78,7 @@ export default function PendingPaymentNotification() {
 
 	return (
 		<LayoutBanner
+			isFullWidth={ isFullWidth }
 			className="pending-payment-notification"
 			level={ level }
 			title={ title }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -74,7 +74,7 @@ export default function MigrationsCommissions() {
 			title={ title }
 			wide
 		>
-			<LayoutTop>
+			<LayoutTop isFullWidth={ ! showEmptyState }>
 				<LayoutHeader>
 					<Breadcrumb
 						hideOnMobile

--- a/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/common/missing-payment-settings-notice/index.tsx
@@ -6,7 +6,7 @@ import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
 
 import './style.scss';
 
-export const MissingPaymentSettingsNotice = () => {
+export const MissingPaymentSettingsNotice = ( { isFullWidth }: { isFullWidth?: boolean } ) => {
 	const translate = useTranslate();
 
 	const { data: tipaltiData } = useGetTipaltiPayee();
@@ -22,6 +22,7 @@ export const MissingPaymentSettingsNotice = () => {
 
 	return (
 		<LayoutBanner
+			isFullWidth={ isFullWidth }
 			level="warning"
 			title={ translate( 'Add your payment information to get paid' ) }
 			className="missing-payment-settings-notice"

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/index.tsx
@@ -95,15 +95,16 @@ export default function ReferralsOverview( {
 			withBorder
 		>
 			<LayoutColumn wide className="referrals-layout__column">
-				<LayoutTop>
+				<LayoutTop isFullWidth={ hasReferrals }>
 					{ !! referralEmail && (
 						<NewReferralOrderNotification
 							email={ referralEmail }
 							onClose={ () => setReferralEmail( '' ) }
+							isFullWidth={ hasReferrals }
 						/>
 					) }
 
-					<MissingPaymentSettingsNotice />
+					<MissingPaymentSettingsNotice isFullWidth />
 
 					<LayoutHeader>
 						<Title>{ title } </Title>

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/new-referral-order-notification.tsx
@@ -5,9 +5,10 @@ import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 type Props = {
 	email: string;
 	onClose?: () => void;
+	isFullWidth?: boolean;
 };
 
-export default function NewReferralOrderNotification( { email, onClose }: Props ) {
+export default function NewReferralOrderNotification( { email, onClose, isFullWidth }: Props ) {
 	const [ showBanner, setShowBanner ] = useState( true );
 
 	const translate = useTranslate();
@@ -19,7 +20,7 @@ export default function NewReferralOrderNotification( { email, onClose }: Props 
 
 	return (
 		showBanner && (
-			<LayoutBanner level="success" onClose={ onCloseClick }>
+			<LayoutBanner isFullWidth={ isFullWidth } level="success" onClose={ onCloseClick }>
 				{ translate(
 					'Your referral order was emailed to %(referralEmail)s for payment.{{br/}}Once they pay you can assign the items that were purchased.',
 					{

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/index.tsx
@@ -170,7 +170,7 @@ export default function NeedSetup( { licenseKey }: Props ) {
 			title={ title }
 		>
 			<LayoutColumn className="sites-overview" wide>
-				<LayoutTop>
+				<LayoutTop isFullWidth>
 					<PurchaseConfirmationMessage />
 
 					<LayoutHeader>

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/purchase-confirmation-message.tsx
@@ -1,8 +1,8 @@
 import page from '@automattic/calypso-router';
-import NoticeBanner from '@automattic/components/src/notice-banner';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -34,16 +34,15 @@ export default function PurchaseConfirmationMessage() {
 	}, [ dispatch, wpcomHostingPurchased ] );
 
 	return successNotification ? (
-		<div className="sites-overview__banner">
-			<NoticeBanner
-				level="success"
-				title={ translate( 'Congratulations on your WordPress.com purchase!' ) }
-				onClose={ () => setSuccessNotification( false ) }
-			>
-				{ translate(
-					'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.'
-				) }
-			</NoticeBanner>
-		</div>
+		<LayoutBanner
+			isFullWidth
+			level="success"
+			title={ translate( 'Congratulations on your WordPress.com purchase!' ) }
+			onClose={ () => setSuccessNotification( false ) }
+		>
+			{ translate(
+				'Set up your sites as you need them, in the “Needs setup” tab within the sites dashboard. Once set up, you can access each site under the “All” tab.'
+			) }
+		</LayoutBanner>
 	) : null;
 }

--- a/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
+++ b/client/a8c-for-agencies/sections/sites/needs-setup-sites/style.scss
@@ -64,12 +64,6 @@
 	}
 }
 
-.sites-overview__banner {
-	margin-inline: auto !important;
-	margin-block-end: 24px;
-	padding-inline: 64px;
-}
-
 .sites-dashboard.is-without-filters {
 	.dataviews-view-table {
 		margin-block-start: 32px;

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/index.tsx
@@ -246,9 +246,9 @@ export default function SitesDashboard() {
 			title={ dataViewsState.selectedItem ? null : translate( 'Sites' ) }
 		>
 			<LayoutColumn className="sites-overview" wide>
-				<LayoutTop withNavigation={ navItems.length > 1 }>
+				<LayoutTop isFullWidth withNavigation={ navItems.length > 1 }>
 					<ProvisioningSiteNotification />
-					<A4AAgencyApprovalNotice />
+					<A4AAgencyApprovalNotice isFullWidth />
 
 					<LayoutHeader>
 						<Title>{ translate( 'Sites' ) }</Title>

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/provisioning-site-notification.tsx
@@ -1,10 +1,10 @@
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import {
 	A4A_SITES_LINK_DEVELOPMENT,
 	A4A_FEEDBACK_LINK,
@@ -85,7 +85,8 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 
 	return (
 		showBanner && (
-			<NoticeBanner
+			<LayoutBanner
+				isFullWidth
 				level={ isReady ? 'success' : 'warning' }
 				hideCloseButton={ ! isReady }
 				onClose={ onClose }
@@ -121,7 +122,7 @@ function Banner( { siteId, migration, development, onDismiss }: BannerProps ) {
 					: translate(
 							"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
 					  ) }
-			</NoticeBanner>
+			</LayoutBanner>
 		)
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -1090,5 +1090,4 @@
 
 .sites-dashboard.preview-hidden .notice-banner {
 	display: flex;
-	margin: 0 64px 24px !important;
 }

--- a/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/index.tsx
@@ -96,7 +96,7 @@ export default function TeamList( { currentTab }: Props ) {
 
 	return (
 		<Layout className="team-list full-width-layout-with-table" title={ title } wide>
-			<LayoutTop withNavigation>
+			<LayoutTop isFullWidth withNavigation>
 				<LayoutHeader>
 					<Title>{ title }</Title>
 					<Actions>

--- a/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/missing-payment-settings-notice/index.tsx
@@ -18,6 +18,7 @@ export const MissingPaymentSettingsNotice = () => {
 
 	return (
 		<LayoutBanner
+			isFullWidth
 			level="warning"
 			title={ translate( 'Add your payout information to get paid.' ) }
 			className="missing-payment-settings-notice"

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-dashboard/index.tsx
@@ -146,11 +146,13 @@ const WooPaymentsDashboard = () => {
 		return <WooPaymentsDashboardContent />;
 	}, [ isLoading, showEmptyState ] );
 
+	const isFullWidth = ! showEmptyState && isDesktop && ! isLoading;
+
 	return (
 		<Layout
 			className={ clsx( 'woopayments-dashboard', {
 				'is-empty': showEmptyState,
-				'full-width-layout-with-table': ! showEmptyState && isDesktop && ! isLoading,
+				'full-width-layout-with-table': isFullWidth,
 			} ) }
 			title={ title }
 			wide
@@ -162,7 +164,7 @@ const WooPaymentsDashboard = () => {
 					sitesWithPluginsStates: sitesWithPluginsStatesSorted,
 				} }
 			>
-				<LayoutTop>
+				<LayoutTop isFullWidth={ isFullWidth }>
 					{ !! sitesWithPluginsStates.length && <MissingPaymentSettingsNotice /> }
 					<LayoutHeader>
 						<Title>{ title }</Title>

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -600,6 +600,10 @@ html {
 		padding-inline: 0;
 	}
 
+	.hosting-dashboard-layout__top-wrapper > * {
+		max-width: none;
+	}
+
 	.redesigned-a8c-table .dataviews-view-table tr {
 
 		td:first-child,


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2088

## Proposed Changes

This PR fixes all the Layout & LayoutBanner width issues on A4A.

## Why are these changes being made?

* To make the UI consistent and look polished.

## Testing Instructions

* Switch to the branch locally for complete testing
* Go to Marketplace > Purchase a WP.com hosting > Once you are redirected to the Site > Needs setup page > Verify the banner looks good on mobile, large screen, and huge screen(>2560 px)

<img width="1657" alt="Screenshot 2025-04-25 at 1 48 01 PM" src="https://github.com/user-attachments/assets/8c1c122f-d0d1-49f2-b04f-a52af0e685a7" />

<img width="374" alt="Screenshot 2025-04-25 at 1 48 23 PM" src="https://github.com/user-attachments/assets/59d2650c-e294-4e21-939f-2decccda2d4a" />

*  Create a new WP.com license > Once it is created, verify the banner looks good on mobile, large screen, and huge screen(>2560 px)

<img width="375" alt="Screenshot 2025-04-25 at 1 47 13 PM" src="https://github.com/user-attachments/assets/6b8fb46c-89cc-43b0-8cab-1e52a96bbd47" />

<img width="1657" alt="Screenshot 2025-04-25 at 1 47 32 PM" src="https://github.com/user-attachments/assets/061989ac-2695-4ee0-b153-cd6e7885aa1f" />

* Manually alter the code to display the `A4AAgencyApprovalNotice` component: client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx > Refresh the page > Go to Sites > Verify it looks good on mobile, large screen, and huge screen(>2560 px). 

<img width="1879" alt="Screenshot 2025-04-25 at 2 46 42 PM" src="https://github.com/user-attachments/assets/0906d60f-6c51-4503-8677-8b3c844768a9" />

* Go to Overview and verify the same for the above scenario

* Manually alter the code to display the `MissingPaymentSettingsNotice` component: client/a8c-for-agencies/sections/referrals/common/missing-payment-setti…/index.tsx > Refresh the page > Go to Referrals: Dashboard > Verify it looks good on mobile, large screen, and huge screen(>2560 px). 

<img width="1879" alt="Screenshot 2025-04-25 at 2 11 53 PM" src="https://github.com/user-attachments/assets/3d9a3fe6-2d67-47e2-b2c8-1f2e2da788b7" />

* Go to Overview and verify the same for the above scenario

* Manually alter the code to display the `MissingPaymentSettingsNotice` component: client/a8c-for-agencies/sections/woopayments/missing-payment-settings…/index.tsx > Refresh the page > Go to Referrals: Dashboard > Verify it looks good on mobile, large screen, and huge screen(>2560 px). 

* Send out a referral > Verify the banner displayed looks good on the Referrals page. Please note you need to either skipor submit the feedback and send the referral again if a feedback form is shown

<img width="1879" alt="Screenshot 2025-04-25 at 2 16 26 PM" src="https://github.com/user-attachments/assets/0cb1496e-86e1-469f-b34f-e0dd6eb99b03" />

* Next, test all the pages and ensure the layout top aligns well with the content. There are some pages that take full width based on the data. For example, Migrations, Referrals Dashboard, and WooPayment Dashboard have full width where there is data. So, we need to test both scenarios. Compare the page with the production version and verify we have fixed a bunch of pages, especially the huge screens (>2560px), the rest should look the same.

<img width="1879" alt="Screenshot 2025-04-25 at 2 11 21 PM" src="https://github.com/user-attachments/assets/f65b6ec6-4594-44aa-9f16-3b6fdf92d2bc" />

<img width="1879" alt="Screenshot 2025-04-25 at 2 11 29 PM" src="https://github.com/user-attachments/assets/484feb9f-70d4-4174-9f8a-0a8ccd626185" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
