### PR TITLE
Stats - Apply the jetpack green color to page-module-popover in odyssey stats

### DIFF
--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -135,3 +135,8 @@
 .jitm-card.jitm-banner {
 	display: none;
 }
+
+// Apply jetpack green color to the module toggler.
+.page-modules-settings-popover {
+	--wp-components-color-accent: var(--studio-jetpack-green-50);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Set the Jetpack green color to the toggles from the page module toggler component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Set the Jetpack green color to the toggles from the page module toggler component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Option 2 or Option 3 for testing this branch in Jetpack site - PCYsg-Pp7-p2
* Open the popover for page modules toggle on Odyssey stats

![Arc -2025-04-25 at 15 36 06@2x](https://github.com/user-attachments/assets/c841a42e-6869-40b6-b8f5-0fe97f7baae5)

![Arc -2025-04-25 at 15 35 26@2x](https://github.com/user-attachments/assets/164b28a6-555d-4969-bbaf-7260d2e32963)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?