### PR TITLE
Stepper: Make Navigate type smarter

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/plugin-bundle-flow/plugin-bundle-data.ts
+++ b/client/landing/stepper/declarative-flow/flows/plugin-bundle-flow/plugin-bundle-data.ts
@@ -29,7 +29,7 @@ interface BundleStepsSettings {
 		/** Custom steps for the bundle. Empty string if it has not custom steps. */
 		customSteps: StepperStep[];
 		/** Customize back function only for custom steps of the flow. The default steps have their logic separately. It returns `false` if nothing should be done here. */
-		goBack?: ( currentStep: string, navigate: Navigate< StepperStep[] > ) => boolean | void;
+		goBack?: ( currentStep: string, navigate: Navigate ) => boolean | void;
 		/** Custom end of flow. Notice that it can end earlier depending on the current state. It returns `false` if nothing should be done here. */
 		endFlow?: ( {
 			intent,

--- a/client/landing/stepper/declarative-flow/flows/readymade-template/readymade-template.tsx
+++ b/client/landing/stepper/declarative-flow/flows/readymade-template/readymade-template.tsx
@@ -25,7 +25,6 @@ import {
 	Flow,
 	Navigate,
 	ProvidedDependencies,
-	StepperStep,
 } from '../../internals/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import type { AnyAction } from 'redux';
@@ -221,7 +220,7 @@ function enableAssemblerThemeAndConfigureTemplates(
 	siteId: number,
 	siteSlug: string,
 	readymadeTemplate: ReadymadeTemplate & { globalStyles: GlobalStylesObject },
-	navigate: Navigate< StepperStep[] >,
+	navigate: Navigate,
 	assembleSite: (
 		arg0: any,
 		arg1: string,

--- a/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
+++ b/client/landing/stepper/declarative-flow/helpers/use-redirect-design-setup-old-slug.ts
@@ -1,13 +1,10 @@
 import { useEffect } from 'react';
 import { getStepOldSlug } from './get-step-old-slug';
-import type { StepperStep, Navigate } from '../internals/types';
+import type { Navigate } from '../internals/types';
 
 const DESIGN_SETUP_SLUG = 'design-setup';
 
-export function useRedirectDesignSetupOldSlug(
-	currentStep: string,
-	navigate: Navigate< StepperStep[] >
-) {
+export function useRedirectDesignSetupOldSlug( currentStep: string, navigate: Navigate ) {
 	const oldSlug = getStepOldSlug( DESIGN_SETUP_SLUG );
 	useEffect( () => {
 		if ( currentStep === oldSlug ) {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -18,7 +18,7 @@ type StepRouteProps = {
 	step: StepperStep;
 	flow: Flow;
 	renderStep: ( step: StepperStep ) => JSX.Element | null;
-	navigate: Navigate< StepperStep[] >;
+	navigate: Navigate;
 };
 
 // TODO: Check we can move RenderStep function to here and remove the renderStep prop

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-flow-navigation/index.tsx
@@ -10,7 +10,7 @@ import { ONBOARD_STORE, STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/s
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { PRIVATE_STEPS } from '../../steps';
-import type { Flow, Navigate, StepperStep } from '../../types';
+import type { Flow, Navigate } from '../../types';
 
 const useOnboardingIntent = () => {
 	const intent = useSelect(
@@ -21,7 +21,7 @@ const useOnboardingIntent = () => {
 };
 
 interface FlowNavigation {
-	navigate: Navigate< StepperStep[] >;
+	navigate: Navigate;
 	params: {
 		flow: string | null;
 		step: string | null;
@@ -46,7 +46,7 @@ export const useFlowNavigation = ( flow: Flow ): FlowNavigation => {
 	const locale = useFlowLocale();
 	const { siteId, siteSlug } = useSiteData();
 
-	const customNavigate = useCallback< Navigate< StepperStep[] > >(
+	const customNavigate = useCallback< Navigate >(
 		( nextStep: string, extraData = {}, replace = false ) => {
 			// If the user is not logged in, and the next step requires a logged in user, redirect to the login step.
 			if (

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider/index.tsx
@@ -1,13 +1,13 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { addQueryArgs } from '@wordpress/url';
 import { getSessionId } from 'calypso/landing/stepper/utils/use-session-id';
-import type { Navigate, StepperStep } from '../../types';
+import type { Navigate } from '../../types';
 
 export const LAUNCHPAD_EXPERIMENT_NAME = 'calypso_onboarding_launchpad_removal_test_2024_08';
 
 interface Props {
 	exitFlow: ( path: string ) => void;
-	navigate: Navigate< StepperStep[] >;
+	navigate: Navigate;
 }
 
 interface PostFlowUrlProps {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -89,7 +89,7 @@ export type StepperStep = AsyncStepperStep | AsyncUserStep;
  * @param extraData - Extra data to pass to the step.
  * @param replace - If true, the current step will be replaced in the history stack.
  */
-export type Navigate< FlowSteps extends readonly StepperStep[] > = (
+export type Navigate< FlowSteps extends readonly StepperStep[] = StepperStep[] > = (
 	stepName: FlowSteps[ number ][ 'slug' ] | `${ FlowSteps[ number ][ 'slug' ] }?${ string }`,
 	extraData?: any,
 	/**

--- a/client/landing/stepper/hooks/use-exit-flow.ts
+++ b/client/landing/stepper/hooks/use-exit-flow.ts
@@ -1,10 +1,10 @@
 import { useDispatch } from '@wordpress/data';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import type { Navigate, StepperStep } from '../declarative-flow/internals/types';
+import type { Navigate } from '../declarative-flow/internals/types';
 
 type UseExitFlowParams =
-	| { processing: true; navigate: Navigate< StepperStep[] > }
-	| { processing?: false; navigate?: Navigate< StepperStep[] > }
+	| { processing: true; navigate: Navigate }
+	| { processing?: false; navigate?: Navigate }
 	| undefined;
 
 /**


### PR DESCRIPTION
This makes `Navigate` type not require the steps param. Since it doesn't add any meaning.

My motivation behind this PR is to make https://github.com/Automattic/wp-calypso/pull/102103 smaller.