### PR TITLE
Make the monochrome prop required to get the monochrome jetpack logo of size 24

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/index.tsx
@@ -139,7 +139,7 @@ export default function CommissionOverview() {
 							header={
 								<>
 									<div className="a4a-overview-hosting__logo-container">
-										<JetpackLogo className="jetpack-logo" size={ 24 } />
+										<JetpackLogo className="jetpack-logo" size={ 24 } monochrome />
 										<img width={ 45 } src={ WooLogoColor } alt="WooCommerce" />
 									</div>
 

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -134,7 +134,7 @@ export default function LayoutBodyContent( {
 				</div>
 			) }
 			<div className="referrals-overview__section-icons">
-				<JetpackLogo className="jetpack-logo" size={ 24 } />
+				<JetpackLogo className="jetpack-logo" size={ 24 } monochrome />
 				<img width={ 45 } src={ WooLogoColor } alt="WooCommerce" />
 				<img className="pressable-icon" src={ pressableIcon } alt="Pressable" />
 				<WordPressLogo className="a4a-overview-hosting__wp-logo" size={ 24 } />

--- a/client/components/jetpack-logo/docs/example.js
+++ b/client/components/jetpack-logo/docs/example.js
@@ -6,8 +6,8 @@ export default function JetpackLogoExample() {
 			<pre>{ '<JetpackLogo />' }</pre>
 			<JetpackLogo />
 			<hr />
-			<pre>{ '<JetpackLogo size={ 24 } />' }</pre>
-			<JetpackLogo size={ 24 } />
+			<pre>{ '<JetpackLogo size={ 24 } monochrome />' }</pre>
+			<JetpackLogo size={ 24 } monochrome />
 			<hr />
 			<pre>{ '<JetpackLogo full size={ 64 } />' }</pre>
 			<JetpackLogo full size={ 64 } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/migration-plan-feature-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/migration-plan-feature-list.tsx
@@ -120,7 +120,7 @@ export const MigrationPlanFeatureList = ( {
 				)
 			) }
 			<li className="import__upgrade-plan-feature logo">
-				<JetpackLogo size={ 24 } />
+				<JetpackLogo size={ 24 } monochrome />
 			</li>
 			{ migrationPlanFeatures[ 'jetpackFeatures' ].map( ( feature: ReactNode, index: number ) => (
 				<li key={ index } className="import__upgrade-plan-feature">

--- a/packages/components/src/logos/jetpack-logo/index.tsx
+++ b/packages/components/src/logos/jetpack-logo/index.tsx
@@ -86,7 +86,7 @@ export const JetpackLogo = ( {
 		);
 	}
 
-	if ( 24 === size ) {
+	if ( 24 === size && monochrome ) {
 		return (
 			<svg className={ classes } height="24" width="24" viewBox="0 0 24 24" { ...props }>
 				<path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M11,14H6l5-10V14z M13,20V10h5L13,20z" />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to STATS-30

## Proposed Changes

* Make the `monochrome` prop be set to true when returning the monochrome logo of size 24

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* If you set `size=24` in for the JetpackLogo component, it returns a custom logo, which is by default monochrome.
* Which does not work when you want a logo of size 24 but in color, so making the condition require `monochrome` prop to be true when returning this logo

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Cross-check if there are any other places where the <JetpackLogo> is called with size 24
* Test the logo does not change in places where the change is made
* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
