### PR TITLE
Add email support option to help center and adjust styles

### DIFF
--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -63,3 +63,7 @@
 .help-center__container-chat .chatbox-messages .odie__transfer-chat {
 	width: calc(100% - 46px);
 }
+
+.help-center__email-support {
+	margin-top: 0.5em!important;
+}

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -14,6 +14,7 @@ interface GetSupportProps {
 	onClickAdditionalEvent?: ( destination: string ) => void;
 	isUserEligibleForPaidSupport?: boolean;
 	canConnectToZendesk?: boolean;
+	displayEmailSupport?: boolean;
 }
 
 interface ButtonConfig {
@@ -23,7 +24,9 @@ interface ButtonConfig {
 	hideButton?: boolean;
 }
 
-export const NewThirdPartyCookiesNotice: React.FC = () => {
+export const NewThirdPartyCookiesNotice: React.FC< { displayEmailSupport?: boolean } > = ( {
+	displayEmailSupport,
+} ) => {
 	return (
 		<div className="help-center__cookie-warning">
 			<p>
@@ -41,6 +44,19 @@ export const NewThirdPartyCookiesNotice: React.FC = () => {
 				>
 					{ __( 'Learn more.', __i18n_text_domain__ ) }
 				</a>
+				{ displayEmailSupport && (
+					<>
+						<br />
+						<p className="help-center__email-support">
+							{ __( 'You can also send an email to', __i18n_text_domain__ ) }&nbsp;
+							<a className="help-center__email-support-link" href="mailto:help@wordpress.com">
+								help@wordpress.com
+							</a>
+							&nbsp;
+							{ __( 'and we’ll help you further.', __i18n_text_domain__ ) }
+						</p>
+					</>
+				) }
 			</p>
 		</div>
 	);
@@ -50,6 +66,7 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 	onClickAdditionalEvent,
 	isUserEligibleForPaidSupport,
 	canConnectToZendesk = false,
+	displayEmailSupport = false,
 } ) => {
 	const navigate = useNavigate();
 	const newConversation = useCreateZendeskConversation();
@@ -78,7 +95,11 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		! ( canConnectToZendesk || contextCanConnectToZendesk ) &&
 		( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport )
 	) {
-		return <NewThirdPartyCookiesNotice />;
+		return (
+			<>
+				<NewThirdPartyCookiesNotice displayEmailSupport={ displayEmailSupport } />
+			</>
+		);
 	}
 
 	const getButtonConfig = (): ButtonConfig[] => {

--- a/packages/odie-client/src/components/message/message-content.tsx
+++ b/packages/odie-client/src/components/message/message-content.tsx
@@ -1,5 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
+import { useOdieAssistantContext } from '../../context';
 import { zendeskMessageConverter } from '../../utils';
 import ChatWithSupportLabel from '../chat-with-support';
 import ErrorMessage from './error-message';
@@ -31,6 +32,8 @@ export const MessageContent = ( {
 		message?.context?.flags?.show_ai_avatar === false && 'odie-chatbox-message-no-avatar'
 	);
 	const isFeedbackMessage = message.type === 'conversation-feedback' && message?.meta?.feedbackUrl;
+	const { canConnectToZendesk } = useOdieAssistantContext();
+	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
 
 	const containerClasses = clsx(
 		'odie-chatbox-message-sources-container',
@@ -63,7 +66,9 @@ export const MessageContent = ( {
 		<>
 			<div className={ containerClasses } data-is-message="true">
 				<div className={ messageClasses }>
-					{ message?.context?.flags?.show_ai_avatar !== false && messageHeader }
+					{ ! ( ! canConnectToZendesk && isRequestingHumanSupport ) &&
+						message?.context?.flags?.show_ai_avatar !== false &&
+						messageHeader }
 					{ message.type === 'error' && <ErrorMessage message={ message } /> }
 					{ ( [ 'message', 'image', 'image-placeholder', 'file', 'text' ].includes(
 						message.type

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -224,6 +224,10 @@ $blueberry-color: #3858e9;
 		}
 	}
 
+	.chat-feedback-wrapper-no-margin-left {
+		margin-left: 0;
+	}
+
 	.odie-feedback-component-container {
 		&.odie-question-collapse {
 			margin-top: 0;

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -23,7 +23,8 @@ export const UserMessage = ( {
 	message: Message;
 	isMessageWithoutEscalationOption?: boolean;
 } ) => {
-	const { isUserEligibleForPaidSupport, trackEvent, chat } = useOdieAssistantContext();
+	const { isUserEligibleForPaidSupport, trackEvent, chat, canConnectToZendesk } =
+		useOdieAssistantContext();
 
 	const hasCannedResponse = message.context?.flags?.canned_response;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
@@ -55,7 +56,7 @@ export const UserMessage = ( {
 	const renderExtraContactOptions = () => {
 		return (
 			chat.provider === 'odie' && (
-				<GetSupport onClickAdditionalEvent={ handleContactSupportClick } />
+				<GetSupport onClickAdditionalEvent={ handleContactSupportClick } displayEmailSupport />
 			)
 		);
 	};
@@ -95,22 +96,26 @@ export const UserMessage = ( {
 
 	return (
 		<>
-			<div className="odie-chatbox-message__content">
-				<Markdown
-					urlTransform={ uriTransformer }
-					components={ {
-						a: ( props: React.ComponentProps< 'a' > ) => (
-							<CustomALink { ...props } target="_blank" />
-						),
-					} }
-				>
-					{ isRequestingHumanSupport ? displayMessage : message.content }
-				</Markdown>
-			</div>
+			{ ( canConnectToZendesk || ! isRequestingHumanSupport ) && (
+				<div className="odie-chatbox-message__content">
+					<Markdown
+						urlTransform={ uriTransformer }
+						components={ {
+							a: ( props: React.ComponentProps< 'a' > ) => (
+								<CustomALink { ...props } target="_blank" />
+							),
+						} }
+					>
+						{ isRequestingHumanSupport ? displayMessage : message.content }
+					</Markdown>
+				</div>
+			) }
 			{ ! isMessageWithoutEscalationOption && isBot && (
 				<div
 					className={ clsx( 'chat-feedback-wrapper', {
 						'chat-feedback-wrapper-no-extra-contact': ! showExtraContactOptions,
+						'chat-feedback-wrapper-no-margin-left':
+							! canConnectToZendesk && isRequestingHumanSupport,
 					} ) }
 				>
 					<Sources message={ message } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1745411989129209/1744907358.012229-slack-C05FNGX7SKX

## Proposed Changes

When the user cannot reach user support via Zendesk, we are showing a Third Party Notice (which is most likely the thing that is happening to prevent the user escalation). We are adding an alternative way for those cases where the user can't escalate, the only minus is that the chat conversation is not sent via email, but HE's cant still look for the conversation manually.

![image](https://github.com/user-attachments/assets/bbefa0cb-1279-4829-a94c-923f998a40bc)

## Why are these changes being made?

We believe this would help the user when they are stuck, asking for human support within the Help Center through the AI Assistant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You should block the URL for getting the configuration to connect to Zendesk, You can use the ModResponse Chrome Extension and block the URL: 379f3-pb/

Once the URL is blocked:

**Test 1**

1. Start a new conversation
2. Trigger the human support
3. Assert that it happens the same as the previously provided screenshot
4. Restore the blocking URL and reload the site
5. Assert that you see a button to connect to Zendesk in your conversation

**Test 2** (Regression test)

1. Start a conversation and just chat normally, assert that the conversation has no rendering issues with the AI Assistant header
2. Trigger the human support, assert that everything flows normally (eg, when you ask for human support with no context, the AI asks for context, and if you have enough context, you should be transferred automatically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?