### PR TITLE
A4A: Handle referrals with only free products as regular checkout.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -278,11 +278,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 						{ isAutomatedReferrals && onlyFreeItems && (
 							<LayoutBanner level="info" hideCloseButton>
 								{ translate(
-									"As the referral includes only free item, this checkout won't need a client and will be processed like a regular purchase.",
-									"As the referral includes only free items, this checkout won't need a client and will be processed like a regular purchase.",
-									{
-										count: checkoutItems.length,
-									}
+									'Because your referral includes only free products, you can assign them immediately after purchase — no client payment or approval required.'
 								) }
 							</LayoutBanner>
 						) }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/index.tsx
@@ -156,6 +156,8 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 
 	const title = isAutomatedReferrals ? translate( 'Referral checkout' ) : translate( 'Checkout' );
 
+	const onlyFreeItems = checkoutItems.every( ( item ) => item.price_per_unit === 0 );
+
 	const handleShowPopover = () => {
 		if ( ! canIssueLicenses ) {
 			setShowPopover( true );
@@ -211,7 +213,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 		</>
 	);
 
-	if ( isAutomatedReferrals ) {
+	if ( isAutomatedReferrals && ! onlyFreeItems ) {
 		actionContent = <RequestClientPayment checkoutItems={ checkoutItems } />;
 	}
 
@@ -273,6 +275,18 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 							</LayoutBanner>
 						) }
 
+						{ isAutomatedReferrals && onlyFreeItems && (
+							<LayoutBanner level="info" hideCloseButton>
+								{ translate(
+									"As the referral includes only free item, this checkout won't need a client and will be processed like a regular purchase.",
+									"As the referral includes only free items, this checkout won't need a client and will be processed like a regular purchase.",
+									{
+										count: checkoutItems.length,
+									}
+								) }
+							</LayoutBanner>
+						) }
+
 						<div className="checkout__main-list">
 							{ referralBlogId && isLoadingReferralDevSite ? (
 								<div className="product-info__placeholder"></div>
@@ -297,7 +311,7 @@ function Checkout( { isClient, referralBlogId }: Props ) {
 						<PricingSummary
 							items={ checkoutItems }
 							onRemoveItem={ siteId || isClient ? undefined : onRemoveItem }
-							isAutomatedReferrals={ isAutomatedReferrals }
+							isAutomatedReferrals={ isAutomatedReferrals && ! onlyFreeItems }
 							isClient={ isClient }
 						/>
 


### PR DESCRIPTION
For referrals consisting solely of free products, we do not need to request payment from the client. This PR modifies the checkout page to manage this process similarly to a standard purchase.

Closes https://linear.app/a8c/issue/A4A-747/referrals-payment-request-not-needed-for-free-products

## Proposed Changes

* Revise the checkout page to treat referrals of solely free products as standard agency purchases. Display a message to clarify the situation for the user.

<img width="1040" alt="Screenshot 2025-04-25 at 8 01 25 PM" src="https://github.com/user-attachments/assets/fd94c896-7e41-49a8-b42a-b3d1a20b01a1" />


## Why are these changes being made?

* This prevents a complicated process for agencies that don't provide real value.

## Testing Instructions

* Use the A4A live link and navigate to the `/marketplace/products` page.
* Toggle the referral mode and purchase only free products.
* Ensure that the checkout page does not require client email and processes the checkout as a standard purchase.
* Verify that a banner is shown to clarify the situation.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
