### PR TITLE
Plugin Management: Fix inconsistent Plugin management update language.

### DIFF
--- a/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
+++ b/client/my-sites/plugins/plugins-list/plugins-list-dataviews.tsx
@@ -135,7 +135,7 @@ export default function PluginsListDataViews( {
 						setIsFilteringUpdates( ! isFilteringUpdates );
 					} }
 				>
-					{ translate( 'Pending update (%s)', { args: [ pluginUpdateCount ] } ) }
+					{ translate( 'Update available (%s)', { args: [ pluginUpdateCount ] } ) }
 				</Button>
 			) }
 		</>

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -37,7 +37,7 @@ export function useFields(
 					},
 					{
 						value: PLUGINS_STATUS.UPDATE,
-						label: translate( 'Needs update' ),
+						label: translate( 'Update available' ),
 					},
 				],
 				filterBy: {


### PR DESCRIPTION
This PR addresses the inconsistency in our update language within Plugin management.

Closes https://linear.app/a8c/issue/A4A-774/plugin-management-ui-inconsistent-update-language

## Proposed Changes

* We use three distinct phrases in three different locations to describe the same thing.
* The term "Pending update" is misleading, as it suggests that those plugins are currently in an update queue.
* All three locations should uniformly state "Update available" to ensure consistency.

| Before | After |
|--------|--------|
| <img width="1388" alt="Screenshot 2025-04-25 at 8 38 55 PM" src="https://github.com/user-attachments/assets/bc0fe829-012a-4d97-a77c-b2b02514613c" /> | <img width="1397" alt="Screenshot 2025-04-25 at 8 38 32 PM" src="https://github.com/user-attachments/assets/dbb3e484-6efc-4237-a11d-3e5cf8adc184" /> | 

## Why are these changes being made?

This enhances consistency in our language and clarifies our UI.

## Testing Instructions

* Use the Calypso live link and navigate to `/plugins`.
* Test that the 3 locations use the word 'Update available'.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
