### PR TITLE
Plugin Management: Fix the alignment of view details and visual issues.

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -8,4 +8,20 @@
 			}
 		}
 	}
+
+	.plugin-manage-sites-pane {
+		.hosting-dashboard-layout-column__container {
+			.hosting-dashboard-layout__top-wrapper {
+				display: flex;
+			}
+
+			.hosting-dashboard-layout__viewport {
+				box-sizing: border-box;
+
+				> div {
+					width: 100%;
+				}
+			}
+		}
+	}
 }

--- a/client/my-sites/plugins/manage-site-plugins-dialog/style.scss
+++ b/client/my-sites/plugins/manage-site-plugins-dialog/style.scss
@@ -21,9 +21,9 @@
 	.plugin-details-v2__title {
 		color: var(--studio-gray-100);
 		font-size: $font-title-small;
-		padding: 16px 16px;
+		padding: 16px 48px;
 	}
-	
+
 	.dataviews-wrapper {
 		/* stylelint-disable-next-line scales/radii */
 		border-radius: 8px;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-table/style.scss
@@ -43,10 +43,7 @@
 		border-collapse: collapse;
 		vertical-align: middle;
 		@include break-xlarge() {
-			padding: 0 8px;
-		}
-		@include break-wide() {
-			padding: 0 16px;
+			padding: 0 48px;
 		}
 	}
 	.partner-portal-text-placeholder {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/style.scss
@@ -139,6 +139,7 @@
 	border: 1px solid var( --studio-gray-10 );
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 8px;
+	padding-block-end: 8px;
 
 	&.separators-top-bottom {
 		margin-top: 16px;

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -58,7 +58,11 @@
 		.plugin-details-v2__title {
 			color: var( --studio-gray-100 );
 			font-size: 1.25rem;
-			padding: 16px 16px;
+			padding: 16px 24px;
+
+			@include break-medium {
+				padding-inline: 48px;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR addresses various alignment and visual issues in the Plugin management details view.

Closes  https://linear.app/a8c/issue/A4A-776/plugin-management-detail-view-alignment-and-visual-issues-3


## Proposed Changes

| Description | Before | After |
|--------|--------|--------|
| (A4A only) The top header action button should align to the right | <img width="1058" alt="Screenshot 2025-04-25 at 9 58 50 PM" src="https://github.com/user-attachments/assets/526216cb-19eb-42ac-a296-665cf4617932" /> | <img width="1048" alt="Screenshot 2025-04-25 at 9 58 59 PM" src="https://github.com/user-attachments/assets/4326bce2-769c-4d02-8a2f-16a1f0da53b4" /> |
| The table padding should all align properly. | <img width="1593" alt="Screenshot 2025-04-25 at 10 01 04 PM" src="https://github.com/user-attachments/assets/e1127883-e1dd-412a-8585-a8d933ee75ad" /> | <img width="1555" alt="Screenshot 2025-04-25 at 10 02 24 PM" src="https://github.com/user-attachments/assets/277c8f84-5926-4e44-9f9a-9461ef212ae7" /> |
| Fix the cutoff at the bottom of the table by adding padding. | <img width="373" alt="Screenshot 2025-04-25 at 10 03 20 PM" src="https://github.com/user-attachments/assets/b16d8fc9-b89e-4be5-bd6f-a3b677152658" /> | <img width="456" alt="Screenshot 2025-04-25 at 10 03 26 PM" src="https://github.com/user-attachments/assets/172f4908-b639-4acd-abd4-a37b3ae19ee5" /> | 

## Why are these changes being made?

* Makes our UI more polished and improved user experience.

## Testing Instructions

* Use the A4A live link and navigate to `/plugins` page.
* Select some plugins
* Test the changes above. See screenshots

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
