### PR TITLE
Help Page: Remove webinars

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -137,7 +137,6 @@ class Help extends PureComponent {
 		<>
 			<h2 className="help__section-title">{ this.props.translate( 'More Resources' ) }</h2>
 			<div className="help__support-links">
-				{ this.getCoursesTeaser() }
 				<CompactCard
 					className="help__support-link"
 					href="https://www.youtube.com/@WordPressdotcom"
@@ -191,25 +190,6 @@ class Help extends PureComponent {
 			</div>
 		</>
 	);
-
-	getCoursesTeaser = () => {
-		return (
-			<CompactCard
-				className="help__support-link"
-				href={ localizeUrl( 'https://wordpress.com/webinars/' ) }
-				onClick={ this.trackCoursesButtonClick }
-				showLinkIcon={ false }
-			>
-				<Gridicon icon="chat" size={ 36 } />
-				<div className="help__support-link-section">
-					<h2 className="help__support-link-title">{ this.props.translate( 'Webinars' ) }</h2>
-					<p className="help__support-link-content">
-						{ this.props.translate( 'Make the most of your site with courses and webinars.' ) }
-					</p>
-				</div>
-			</CompactCard>
-		);
-	};
 
 	trackCoursesButtonClick = () => {
 		const { isBusinessOrEcomPlanUser } = this.props;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1745591442316699-slack-C07D72S1135

## Proposed Changes

*   Removes the "Webinars" card from the "More Resources" section in `/me/help`.
*   Removes the associated `getCoursesTeaser` method and `trackCoursesButtonClick` tracking call.
<img width="286" alt="image" src="https://github.com/user-attachments/assets/074a43b7-5b7d-41dc-93b6-be1859c68899" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Webinars do not exist anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1.  Navigate to `/me/help`.
2.  Scroll down to the "More Resources" section.
3.  Verify that the "Webinars" card (previously showing a `chat` icon) is no longer present.
4.  Verify that the "Video tutorials", "Courses", and "Guides" cards are still displayed correctly.
