### PR TITLE
Hosting Dashboard v2: improve perf cards loading state

### DIFF
--- a/client/dashboard/overview-card/index.tsx
+++ b/client/dashboard/overview-card/index.tsx
@@ -68,6 +68,6 @@ export default function OverviewCard( {
 	);
 }
 
-export function OverviewCardProgressBar( { value }: { value: number } ) {
+export function OverviewCardProgressBar( { value }: { value: number | undefined } ) {
 	return <ProgressBar className="dashboard-overview-card__progress-bar" value={ value } />;
 }

--- a/client/dashboard/site-overview/performance-cards.tsx
+++ b/client/dashboard/site-overview/performance-cards.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { Spinner, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { desktop, mobile } from '@wordpress/icons';
 import CoreBadge from 'calypso/components/core/badge';
@@ -9,9 +8,12 @@ import type { Site, UrlPerformanceInsights } from '../data/types';
 
 type BadgeIntent = 'default' | 'info' | 'success' | 'warning' | 'error';
 
-function PerformanceBadge( { value }: { value: number } ) {
+function PerformanceBadge( { value }: { value: number | undefined } ) {
 	const badgeProps = { intent: 'error' as BadgeIntent, label: __( 'Poor' ) };
-	if ( value >= 90 ) {
+	if ( ! value ) {
+		badgeProps.label = __( 'Calculating…' );
+		badgeProps.intent = 'default';
+	} else if ( value >= 90 ) {
 		badgeProps.intent = 'success';
 		badgeProps.label = __( 'Excellent' );
 	} else if ( value >= 50 ) {
@@ -75,51 +77,31 @@ export default function PerformanceCards( { site }: { site: Site } ) {
 	const desktopLoaded = typeof data?.pagespeed?.desktop === 'object';
 	const mobileLoaded = typeof data?.pagespeed?.mobile === 'object';
 	const desktopScore =
-		desktopLoaded &&
-		typeof data.pagespeed.desktop === 'object' &&
-		Math.round( data.pagespeed.desktop.overall_score * 100 );
+		desktopLoaded && typeof data.pagespeed.desktop === 'object'
+			? Math.round( data.pagespeed.desktop.overall_score * 100 )
+			: undefined;
 	const mobileScore =
-		mobileLoaded &&
-		typeof data.pagespeed.mobile === 'object' &&
-		Math.round( data.pagespeed.mobile.overall_score * 100 );
+		mobileLoaded && typeof data.pagespeed.mobile === 'object'
+			? Math.round( data.pagespeed.mobile.overall_score * 100 )
+			: undefined;
 	return (
 		<>
 			<OverviewCard
 				title={ __( 'Desktop performance' ) }
 				icon={ desktop }
-				heading={ desktopLoaded ? `${ desktopScore }` : undefined }
+				heading={ desktopLoaded ? `${ desktopScore }` : '\u00A0' }
 			>
-				{ desktopLoaded ? (
-					<>
-						<OverviewCardProgressBar value={ desktopScore as number } />
-						<PerformanceBadge value={ desktopScore as number } />
-					</>
-				) : (
-					<Loader />
-				) }
+				<OverviewCardProgressBar value={ desktopScore } />
+				<PerformanceBadge value={ desktopScore } />
 			</OverviewCard>
 			<OverviewCard
 				title={ __( 'Mobile performance' ) }
 				icon={ mobile }
-				heading={ mobileLoaded ? `${ mobileScore }` : undefined }
+				heading={ mobileLoaded ? `${ mobileScore }` : '\u00A0' }
 			>
-				{ mobileLoaded ? (
-					<>
-						<OverviewCardProgressBar value={ mobileScore as number } />
-						<PerformanceBadge value={ mobileScore as number } />
-					</>
-				) : (
-					<Loader />
-				) }
+				<OverviewCardProgressBar value={ mobileScore } />
+				<PerformanceBadge value={ mobileScore } />
 			</OverviewCard>
 		</>
-	);
-}
-
-function Loader() {
-	return (
-		<HStack justify="center">
-			<Spinner />
-		</HStack>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

<img width="655" alt="image" src="https://github.com/user-attachments/assets/55645039-fb19-4f9f-90fa-35e978c130d1" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prevent a layout shift.
* It's more elegant than a spinner. The progress bar by default comes with a loading state, so let's make use of it!
* Remove `as number`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
