### PR TITLE
Performance Profiler: Add error handling for wpscan errors

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -196,6 +196,7 @@ export interface UrlPerformanceInsightsQueryResponse {
 	};
 	wpscan: {
 		status: string;
+		errors?: Record< string, Array< string > >;
 	};
 }
 

--- a/client/data/site-profiler/use-url-performance-insights.ts
+++ b/client/data/site-profiler/use-url-performance-insights.ts
@@ -21,7 +21,8 @@ export const useUrlPerformanceInsightsQuery = ( url?: string, hash?: string ) =>
 		refetchOnWindowFocus: false,
 		refetchInterval: ( query ) =>
 			query.state.data?.pagespeed?.status === 'completed' &&
-			query.state.data?.wpscan?.status === 'completed'
+			( query.state.data?.wpscan?.status === 'completed' ||
+				Object.keys( query.state.data?.wpscan?.errors ?? {} ).length > 0 )
 				? false
 				: 5000, // 5 second
 	} );

--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -119,13 +119,15 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 	const isLoadingLlmAnswer = isLoading || ! isFetched;
 
 	const { data } = useUrlPerformanceInsightsQuery( url, hash );
-	const isWpscanLoading = data?.wpscan?.status !== 'completed';
+	const wpscanErrors = data?.wpscan?.errors;
+	const hasWpscanErrors = wpscanErrors && Object.keys( wpscanErrors ).length > 0;
+	const isWpscanLoading = data?.wpscan?.status !== 'completed' && ! hasWpscanErrors;
 
 	useEffect( () => {
-		if ( ! isWpscanLoading && cardOpen ) {
+		if ( ( ! isWpscanLoading || hasWpscanErrors ) && cardOpen ) {
 			setRetrieveInsight( true );
 		}
-	}, [ isWpscanLoading, cardOpen ] );
+	}, [ isWpscanLoading, hasWpscanErrors, cardOpen ] );
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const site = useSelector( getSelectedSite );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTDEV-121

Related convo: p1745590978955509-slack-C04GESRBWKW

## Proposed Changes

* Add error handling for wpscan results in the performance profiler. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The AI recommendation toggle stuck with following message:
```
We're still checking some details of your site to make the best possible recommendations.
```


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/speed-test-tool?url=https://ellaiseulde1.wpcomstaging.com/&hash=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTA2ODI5fQ.0mG46cg0cdxk1xArzYsVld0NDTVJidxr5JMq3Rbq7eY` on production. Notice that wpscan results in errors. There are repeated retries to get insights even if wpscan failed. 
* Now open the above URL on this branch.
* Even if wpscan results in errors you can see the AI insights

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?