### PR TITLE
Fix Accessibility on Several Green Texts

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -56,7 +56,7 @@ const CostOverridesListStyle = styled.div`
 	}
 
 	& .cost-overrides-list-item__reason--is-discount {
-		color: #008a20;
+		color: #007017;
 	}
 
 	& .cost-overrides-list-item__discount {

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -5,6 +5,7 @@ import {
 	isTriennially,
 	isYearly,
 } from '@automattic/calypso-products';
+import colorStudio from '@automattic/color-studio';
 import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
@@ -30,6 +31,10 @@ import { getAffiliateCouponLabel } from '../../utils';
 import type { Theme } from '@automattic/composite-checkout';
 import type { LineItemCostOverrideForDisplay } from '@automattic/wpcom-checkout';
 
+const PALETTE = colorStudio.colors;
+const COLOR_GRAY_40 = PALETTE[ 'Gray 40' ];
+const COLOR_GREEN_60 = PALETTE[ 'Green 60' ];
+
 const CostOverridesListStyle = styled.div`
 	display: flex;
 	flex-direction: column;
@@ -52,11 +57,11 @@ const CostOverridesListStyle = styled.div`
 	}
 
 	& .cost-overrides-list-item__actions-remove {
-		color: #787c82;
+		color: ${ COLOR_GRAY_40 };
 	}
 
 	& .cost-overrides-list-item__reason--is-discount {
-		color: #007017;
+		color: ${ COLOR_GREEN_60 };
 	}
 
 	& .cost-overrides-list-item__discount {

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -51,13 +51,13 @@
 
 .professional-email-upsell__pricing {
 	.professional-email-price__trial-badge {
-		background-color: var(--color-success);
-		color: var(--color-text-inverted);
+		background-color: var(--studio-green-5);
+		color: var(--studio-green-80);
 		margin-bottom: 4px;
 	}
 
 	.price-with-interval__sale-price {
-		color: var(--studio-green-50);
+		color: var(--studio-green-60);
 	}
 
 	.price__cost > span {

--- a/client/my-sites/email/email-providers-comparison/price-with-interval/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price-with-interval/style.scss
@@ -6,7 +6,7 @@
 	.promo-card__price {
 		.price__cost {
 			span.price-with-interval__sale-price {
-				color: var(--studio-green-50);
+				color: var(--studio-green-60);
 			}
 		}
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -143,7 +143,7 @@ body.is-section-stepper .domains__step-content,
 			}
 
 			.savings-message {
-				color: var(--studio-green);
+				color: var(--studio-green-60);
 				display: flex;
 				align-items: center;
 				font-size: 0.75rem;

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -332,7 +332,7 @@ $blueberry-color: #3858e9;
 
 	.domains-table__primary-domain-label {
 		background-color: inherit;
-		color: var(--studio-green-40, #00a32a);
+		color: var(--studio-green-60);
 		font-family: "SF Pro", $sans;
 		font-size: $font-body-extra-small;
 		font-weight: 500;

--- a/packages/composite-checkout/src/lib/theme.ts
+++ b/packages/composite-checkout/src/lib/theme.ts
@@ -70,7 +70,7 @@ const theme: Theme = {
 		highlightBorder: colorStudio.colors[ 'WordPress Blue 80' ],
 		highlightOver: colorStudio.colors[ 'WordPress Blue 60' ],
 		success: colorStudio.colors[ 'Green 30' ],
-		discount: colorStudio.colors[ 'Green 30' ],
+		discount: colorStudio.colors[ 'Green 60' ],
 		disabledPaymentButtons: colorStudio.colors[ 'Gray 5' ],
 		disabledPaymentButtonsAccent: colorStudio.colors[ 'Gray 20' ],
 		disabledButtons: colorStudio.colors[ 'White' ],

--- a/packages/domains-table/src/domains-table/style.scss
+++ b/packages/domains-table/src/domains-table/style.scss
@@ -126,7 +126,7 @@
 
 		&__status-success,
 		&__status-premium {
-			color: var(--studio-green-50);
+			color: var(--studio-green-60);
 		}
 
 		&__status-verifying,
@@ -144,8 +144,8 @@
 		gap: 2px;
 
 		&__active {
-			fill: var(--studio-green-50);
-			color: var(--studio-green-50);
+			fill: var(--studio-green-60);
+			color: var(--studio-green-60);
 		}
 
 		&__pending,

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -150,7 +150,7 @@ const UpgradeCreditPopover = styled( Popover )< { theme?: Theme } >`
 `;
 
 const DiscountCallout = styled.div< { theme?: Theme } >`
-	color: ${ ( props ) => props.theme.colors.success };
+	color: ${ ( props ) => props.theme.colors.discount };
 	display: block;
 `;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/101301
Fixes https://github.com/Automattic/wp-calypso/issues/102776
Fixes https://github.com/Automattic/wp-calypso/issues/102777

Update several instances of green texts as instructed to fix accessibility issues caused by inadequate contrast.

* Text on light background: `--studio-green-60` (`#007017`).
* Text on dark background: `--studio-green-10` (`#68de86`).

### Screenshots

| Location | Before | After |
|--------|--------|--------|
| Onboarding (Domains) | ![image](https://github.com/user-attachments/assets/c7c45876-377d-4ddd-96f0-f2d6690408b2) | ![Screenshot 2025-04-25 at 16 55 38](https://github.com/user-attachments/assets/e330f3ab-85c4-496a-92c6-de3c7d743835) |
| Hosting Dashboard (Site Panel) | ![image](https://github.com/user-attachments/assets/74d9b4bf-17b0-4e68-90a5-b2c9cb6bbd7c) | ![Screenshot 2025-05-07 at 15 20 29](https://github.com/user-attachments/assets/6696ede1-655e-4501-aa4f-6b7d8409c341) |
| Checkout | ![image](https://github.com/user-attachments/assets/fad3dbb6-9265-494b-addd-b27ebfc55606) ![image](https://github.com/user-attachments/assets/c7fa3169-da54-4193-8be2-bbcb1a32c519) | ![Screenshot 2025-04-25 at 17 05 30](https://github.com/user-attachments/assets/040db16e-7fc0-4943-9450-2055a291cfeb) |
| Add Professional Email Address | ![Screenshot 2025-05-07 at 15 25 03](https://github.com/user-attachments/assets/32455480-2f99-4617-b8cc-8b40b659b67a) | ![Screenshot 2025-05-07 at 15 24 51](https://github.com/user-attachments/assets/8a779634-3fa2-4ba1-95d4-9eccb9a86587) |


### Testing Instructions

* Onboarding (Domains)
   * Create a new site and get to the Domains step.
   * Select a domain.
   * Confirm that the "Free for the first year with annual paid plans." text uses the `--studio-green-60` color.
* Hosting Dashboard (Site Panel)
   * Enter the Hosting Dashboard (`/sites`).
   * Pick a site.
   * Scroll to the Active Domains section.
   * Confirm that the "Primary site address" text uses the `--studio-green-60` color.
* Checkout
   * Select a free site.
   * Navigate to Plans (`/plans/:site`) and select a paid plan to put the upgrade in cart.
   * Now navigate to Domains (`/domains/manage/:site`).
   * Click on "Add new domain", select a domain to put it in cart.
   * The "Add a professional email address" screen will open.
   * Confirm that the discounted price uses the `--studio-green-60` color.
   * Confirm that the "3 months free" badge uses `--studio-green-80` for text and `--studio-green-5` for background (there should be no visible changes as this is a fallback normally overridden by the generic badge colors).
   * Open the cart (`/checkout/:site`).
   * Confirm that the following texts all use the `--studio-green-60` color:
      * The "Save xx%" suffix in the plan interval dropdown.
      * "Discount for first year" in the domain item.
      * "Free domain for first year" in the checkout summary (right sidebar).