### PR TITLE
Hosting Dashboard v1: simplify sidebar selection logic by passing correct current route

### DIFF
--- a/client/layout/global-sidebar/menu-items/menu-item.tsx
+++ b/client/layout/global-sidebar/menu-items/menu-item.tsx
@@ -42,15 +42,17 @@ const SidebarMenuItem = forwardRef< HTMLButtonElement | HTMLAnchorElement, Props
 		const preloadedRef = useRef( false );
 
 		const selectedSiteId = useSelector( getSelectedSiteId );
-		const { currentSection } = useCurrentRoute() as {
+		const { currentSection, currentRoute } = useCurrentRoute() as {
 			currentSection: false | { group?: string; name?: string };
+			currentRoute: string;
 		};
 		const isSidebarCollapsed = useSelector( ( state ) => {
-			return getShouldShowCollapsedGlobalSidebar(
+			return getShouldShowCollapsedGlobalSidebar( {
 				state,
-				selectedSiteId,
-				currentSection !== false ? currentSection?.group ?? '' : ''
-			);
+				siteId: selectedSiteId,
+				section: currentSection as { group?: string },
+				route: currentRoute,
+			} );
 		} );
 
 		const preload = () => {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -31,11 +31,7 @@ import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import {
-	getShouldShowCollapsedGlobalSidebar,
-	getShouldShowGlobalSidebar,
-	getShouldShowUnifiedSiteSidebar,
-} from 'calypso/state/global-sidebar/selectors';
+import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -342,18 +338,19 @@ export default withCurrentRoute(
 		const isWooJPC =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) && isWooJPCFlow( state );
 		const isBlazePro = getIsBlazePro( state );
-		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
-		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
+
+		const sidebarType = getSidebarType( {
 			state,
 			siteId,
-			sectionGroup
-		);
-		const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
-			state,
-			siteId,
-			sectionGroup,
-			sectionName
-		);
+			section: currentSection,
+			route: currentRoute,
+		} );
+
+		const shouldShowGlobalSidebar =
+			sidebarType === SidebarType.Global || sidebarType === SidebarType.GlobalCollapsed;
+		const shouldShowCollapsedGlobalSidebar = sidebarType === SidebarType.GlobalCollapsed;
+		const shouldShowUnifiedSiteSidebar = sidebarType === SidebarType.UnifiedSiteClassic;
+
 		const noMasterbarForRoute =
 			isJetpackLogin ||
 			currentRoute === '/me/account/closed' ||

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -250,9 +250,12 @@ class MeSidebar extends Component {
 export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
-			const sectionGroup = currentSection?.group ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( {
+				state,
+				siteId,
+				section: currentSection,
+			} );
 			return {
 				currentUser: getCurrentUser( state ),
 				shouldShowGlobalSidebar,

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -6,11 +6,7 @@ import { withCurrentRoute } from 'calypso/components/route';
 import GlobalSidebar, { GLOBAL_SIDEBAR_EVENTS } from 'calypso/layout/global-sidebar';
 import MySitesSidebarUnifiedBody from 'calypso/my-sites/sidebar/body';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import {
-	getShouldShowCollapsedGlobalSidebar,
-	getShouldShowGlobalSidebar,
-	getShouldShowUnifiedSiteSidebar,
-} from 'calypso/state/global-sidebar/selectors';
+import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -73,23 +69,22 @@ class MySitesNavigation extends Component {
 
 export default withCurrentRoute(
 	connect(
-		( state, { currentSection } ) => {
-			const sectionGroup = currentSection?.group ?? null;
-			const sectionName = currentSection?.name ?? null;
+		( state, { currentSection, currentRoute } ) => {
 			const siteId = getSelectedSiteId( state );
 			const siteDomain = getSiteDomain( state, siteId );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
-			const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar(
+
+			const sidebarType = getSidebarType( {
 				state,
 				siteId,
-				sectionGroup
-			);
-			const shouldShowUnifiedSiteSidebar = getShouldShowUnifiedSiteSidebar(
-				state,
-				siteId,
-				sectionGroup,
-				sectionName
-			);
+				section: currentSection,
+				route: currentRoute,
+			} );
+
+			const shouldShowGlobalSidebar =
+				sidebarType === SidebarType.Global || sidebarType === SidebarType.GlobalCollapsed;
+			const shouldShowCollapsedGlobalSidebar = sidebarType === SidebarType.GlobalCollapsed;
+			const shouldShowUnifiedSiteSidebar = sidebarType === SidebarType.UnifiedSiteClassic;
+
 			return {
 				siteDomain,
 				isGlobalSidebarVisible: shouldShowGlobalSidebar,

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -10,7 +10,6 @@ import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import { navigation, sites } from 'calypso/my-sites/controller';
 import PluginsSidebar from 'calypso/my-sites/plugins/sidebar';
 import { isUserLoggedIn, getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
-import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
@@ -389,16 +388,7 @@ export function renderPluginsSidebar( context, next ) {
 	}
 
 	if ( ! siteUrl ) {
-		context.secondary = (
-			<PluginsSidebar
-				path={ context.path }
-				isCollapsed={ getShouldShowCollapsedGlobalSidebar(
-					state,
-					undefined,
-					context.section.group
-				) }
-			/>
-		);
+		context.secondary = <PluginsSidebar path={ context.path } />;
 	}
 
 	next();

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -3,9 +3,13 @@ import { settings } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { connect } from 'react-redux';
+import { withCurrentRoute } from 'calypso/components/route';
 import GlobalSidebar from 'calypso/layout/global-sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
 import SidebarMenu from 'calypso/layout/sidebar/menu';
+import { getShouldShowCollapsedGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
+import { AppState } from 'calypso/types';
 import { SidebarIconPlugins } from '../../sidebar/static-data/global-sidebar-menu';
 import { SidebarIconCalendar } from './icons';
 import './style.scss';
@@ -77,4 +81,17 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 	);
 };
 
-export default PluginsSidebar;
+export default withCurrentRoute(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	connect( ( state: AppState, { currentSection, currentRoute }: any ) => {
+		const shouldShowCollapsedGlobalSidebar = getShouldShowCollapsedGlobalSidebar( {
+			state,
+			siteId: null,
+			section: currentSection,
+			route: currentRoute,
+		} );
+		return {
+			isCollapsed: shouldShowCollapsedGlobalSidebar,
+		};
+	} )( PluginsSidebar )
+);

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -30,9 +30,14 @@ const useSiteMenuItems = () => {
 	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, selectedSiteId ) );
 	const isPlanExpired = useSelector( ( state ) => !! getSelectedSite( state )?.plan?.expired );
 	const isAllDomainsView = '/domains/manage' === currentRoute;
-	const { currentSection } = useCurrentRoute();
+	const { currentSection, currentRoute: route } = useCurrentRoute();
 	const shouldShowGlobalSidebar = useSelector( ( state ) => {
-		return getShouldShowGlobalSidebar( state, selectedSiteId, currentSection?.group );
+		return getShouldShowGlobalSidebar( {
+			state,
+			siteId: selectedSiteId,
+			section: currentSection,
+			route,
+		} );
 	} );
 
 	/**

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -13,7 +13,10 @@ export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
 	const state = context.store.getState();
-	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader' );
+	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( {
+		state,
+		currentSection: { group: 'reader' },
+	} );
 	const isGlobalNotificationsOpen = getIsNotificationsOpen( state );
 
 	// Close the global notifications panel if it's already open.

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -321,9 +321,12 @@ export class ReaderSidebar extends Component {
 export default withCurrentRoute(
 	connect(
 		( state, { currentSection } ) => {
-			const sectionGroup = currentSection?.group ?? null;
 			const siteId = getSelectedSiteId( state );
-			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+			const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( {
+				state,
+				siteId,
+				section: currentSection,
+			} );
 
 			return {
 				isListsOpen: isListsOpen( state ),

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import GuidedTour from 'calypso/components/guided-tour';
 import { GuidedTourContextProvider } from 'calypso/components/guided-tour/data/guided-tour-context';
+import { useCurrentRoute } from 'calypso/components/route';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import Layout from 'calypso/layout/hosting-dashboard';
 import LayoutColumn from 'calypso/layout/hosting-dashboard/column';
@@ -382,8 +383,17 @@ const SitesDashboard = ( {
 		}
 	};
 
+	const { currentSection, currentRoute } = useCurrentRoute() as {
+		currentSection: false | { group?: string; name?: string };
+		currentRoute: string;
+	};
 	const showSiteDashboard = useSelector( ( state ) =>
-		shouldShowSiteDashboard( state, selectedSite?.ID ?? null )
+		shouldShowSiteDashboard( {
+			state,
+			siteId: selectedSite?.ID ?? null,
+			section: currentSection as { group?: string },
+			route: currentRoute,
+		} )
 	);
 	if ( !! selectedSite && ! showSiteDashboard ) {
 		return null;

--- a/client/state/selectors/is-scheduled-updates-multisite-route.js
+++ b/client/state/selectors/is-scheduled-updates-multisite-route.js
@@ -1,8 +1,4 @@
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-
-export function isScheduledUpdatesMultisiteBaseRoute( state ) {
-	const route = getCurrentRoute( state );
-
+export function isScheduledUpdatesMultisiteBaseRoute( route ) {
 	if ( ! route ) {
 		return false;
 	}
@@ -12,9 +8,7 @@ export function isScheduledUpdatesMultisiteBaseRoute( state ) {
 	return RGX.test( route );
 }
 
-export function isScheduledUpdatesMultisiteCreateRoute( state ) {
-	const route = getCurrentRoute( state );
-
+export function isScheduledUpdatesMultisiteCreateRoute( route ) {
 	if ( ! route ) {
 		return false;
 	}
@@ -24,9 +18,7 @@ export function isScheduledUpdatesMultisiteCreateRoute( state ) {
 	return RGX.test( route );
 }
 
-export function isScheduledUpdatesMultisiteEditRoute( state ) {
-	const route = getCurrentRoute( state );
-
+export function isScheduledUpdatesMultisiteEditRoute( route ) {
 	if ( ! route ) {
 		return false;
 	}
@@ -38,19 +30,17 @@ export function isScheduledUpdatesMultisiteEditRoute( state ) {
 
 /**
  * Returns true if the current route is a scheduled updates multisite route.
- * @param {Object} state Global state tree
+ * @param {string} route Current route
  * @returns {boolean}
  */
-export default function isScheduledUpdatesMultisiteRoute( state ) {
-	const route = getCurrentRoute( state );
-
+export default function isScheduledUpdatesMultisiteRoute( route ) {
 	if ( ! route ) {
 		return false;
 	}
 
 	return (
-		isScheduledUpdatesMultisiteBaseRoute( state ) ||
-		isScheduledUpdatesMultisiteCreateRoute( state ) ||
-		isScheduledUpdatesMultisiteEditRoute( state )
+		isScheduledUpdatesMultisiteBaseRoute( route ) ||
+		isScheduledUpdatesMultisiteCreateRoute( route ) ||
+		isScheduledUpdatesMultisiteEditRoute( route )
 	);
 }


### PR DESCRIPTION
Fixes paYKcK-5Qk-p2 once and for all

## Proposed Changes

When determining what left sidebar to show, we currently rely on the current section group:

https://github.com/Automattic/wp-calypso/blob/f8e72eb9e91b82f8ce75442b10e21e2d28a72020/client/layout/index.jsx#L336-L337

, and current route:

https://github.com/Automattic/wp-calypso/blob/f8e72eb9e91b82f8ce75442b10e21e2d28a72020/client/state/global-sidebar/selectors.ts#L43-L45

However, after some digging, it turns out that the current section and the current route does not always "match"! For example, it could be the case that the current section group is `sites-dashboard` but the route is already `/home/:siteSlug`. This has caused many layout flashes/glitches in the past, like the one in the linked P2 post above.

To fix this, it turns out that the `RouteContext`, which provides `currentSection`, also provides `currentRoute` 🤦 so this PR uses it instead.

It might be easier to review the unit tests first.

## Why are these changes being made?

Cleans up logic to prevent future regressions.

## Testing Instructions

Try clicking around Calypso and notice the sidebar is correct in every screen you test. See the unit test as example of what screens to test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?