### PR TITLE
Stepper: Remove unused goNext definitions

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/00-example-flow/example.ts
+++ b/client/landing/stepper/declarative-flow/flows/00-example-flow/example.ts
@@ -4,7 +4,6 @@ import { dispatch, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useLaunchpadDecider } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider';
-import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import {
 	clearSignupDestinationCookie,
@@ -14,7 +13,6 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useCreateSite } from '../../../hooks/use-create-site-hook';
 import { useExitFlow } from '../../../hooks/use-exit-flow';
-import { useSiteIdParam } from '../../../hooks/use-site-id-param';
 import { useSiteSlug } from '../../../hooks/use-site-slug';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
@@ -57,7 +55,6 @@ const newsletter: Flow = {
 
 	useStepNavigation( _currentStep, navigate ) {
 		const flowName = this.name;
-		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
 		const { get, set } = useFlowState();
 		const { exitFlow } = useExitFlow();
@@ -164,25 +161,11 @@ const newsletter: Flow = {
 			return;
 		};
 
-		const goNext = async () => {
-			switch ( _currentStep ) {
-				case 'launchpad':
-					skipLaunchpad( {
-						siteId,
-						siteSlug,
-					} );
-					return;
-
-				default:
-					return navigate( 'newsletterSetup' );
-			}
-		};
-
 		const goToStep = ( step: string ) => {
 			navigate( step );
 		};
 
-		return { goNext, goBack, goToStep, submit };
+		return { goBack, goToStep, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/flows/copy-site/copy-site.tsx
@@ -137,10 +137,6 @@ const copySite: Flow = {
 			return;
 		};
 
-		const goNext = () => {
-			return;
-		};
-
 		const goToStep = ( step: StepperStep[ 'slug' ] ) => {
 			navigate( step );
 		};
@@ -149,7 +145,7 @@ const copySite: Flow = {
 			window.location.assign( location );
 		};
 
-		return { goNext, goBack, goToStep, submit, exitFlow };
+		return { goBack, goToStep, submit, exitFlow };
 	},
 
 	useAssertConditions() {

--- a/client/landing/stepper/declarative-flow/flows/domain-user-transfer/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-user-transfer/domain-user-transfer.ts
@@ -29,15 +29,11 @@ const domainUserTransfer: Flow = {
 			return;
 		};
 
-		const goNext = () => {
-			return;
-		};
-
 		const goToStep = ( step: string ) => {
 			navigate( step );
 		};
 
-		return { goNext, goBack, goToStep, submit };
+		return { goBack, goToStep, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/plugin-bundle-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/plugin-bundle-flow/plugin-bundle-flow.ts
@@ -235,19 +235,11 @@ const pluginBundleFlow: FlowV1 = {
 			return navigate( 'checkForPlugins' );
 		};
 
-		const goNext = () => {
-			switch ( currentStep ) {
-				// TODO - Do we need anything here?
-				default:
-					return navigate( 'checkForPlugins' );
-			}
-		};
-
 		const goToStep = ( step: string ) => {
 			navigate( step );
 		};
 
-		return { goNext, goBack, goToStep, submit, exitFlow };
+		return { goBack, goToStep, submit, exitFlow };
 	},
 
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
@@ -70,7 +70,6 @@ const SiteMigrationAlreadyWPCOM: StepType = ( { stepName, flow, navigation } ) =
 				flowName={ flow }
 				hideSkip
 				goBack={ navigation?.goBack }
-				goNext={ navigation?.submit }
 				formattedHeader={
 					<FormattedHeader
 						subHeaderAs="div"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -164,7 +164,6 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 				stepName="site-migration-application-password-authorization"
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
-				goNext={ navigation?.submit }
 				hideSkip
 				notice={ notice }
 				formattedHeader={ formattedHeader }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -173,7 +173,6 @@ const SiteMigrationCredentials: StepType< {
 				stepName="site-migration-credentials"
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
-				goNext={ navigation?.submit }
 				hideSkip
 				isFullLayout
 				formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -38,7 +38,6 @@ const SiteMigrationFallbackCredentials: Step< {
 				stepName="site-migration-fallback-credentials"
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
-				goNext={ navigation?.submit }
 				hideSkip
 				isFullLayout
 				formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
@@ -118,7 +118,6 @@ const SiteMigrationOtherPlatform: StepType< {
 			<StepContainer
 				stepName="site-migration-other-platform"
 				goBack={ navigation?.goBack }
-				goNext={ navigation?.submit }
 				hideSkip
 				isFullLayout
 				formattedHeader={


### PR DESCRIPTION
## Proposed Changes

Some flows and steps define `goNext` for no reason. A step needs to define the deprecated `goNext` function if any of the flows that use it defines `goNext`. So reviewing this would entail verifying that every step altered here is not part of a flow that defined `goNext`. 

## Why are these changes being made?

The most common `goNext` definition is like this `goNext={ navigation.submit }`. And since `goNext` doesn't submit any information, the Step submitted types will be `{ someActualSubmittedData: value } | undefined`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
