### PR TITLE
Fix and update quarantine `invite__new-user` test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/account-closed-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/account-closed-page.ts
@@ -1,7 +1,7 @@
 import { Page } from 'playwright';
 
 const selectors = {
-	accountClosedMessage: ':text("Your account has been closed")',
+	accountClosedMessage: ':text("Your account has been deleted")',
 };
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -3,7 +3,8 @@ import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
 	continue: 'button:text("Continue"),a:text("Continue")',
-	loginWithAnotherAccount: ':text("Log in with another account")',
+	loginWithAnotherAccount: ':text("another account")',
+	useUsernamePasswordInstead: 'button:text("Use username and password instead")',
 };
 
 /**
@@ -179,6 +180,36 @@ export class LoginPage {
 	async clickSignUp(): Promise< Locator > {
 		const locator = await this.page.locator( ':text-is("Sign Up")' );
 		await locator.click();
+
+		return locator;
+	}
+
+	/**
+	 * Clicks the "Continue" button.
+	 */
+	async clickContinue(): Promise< Locator > {
+		const locator = await this.page.locator( selectors.continue );
+		await locator.click();
+
+		return locator;
+	}
+
+	/**
+	 * Clicks the Login with another account link.
+	 */
+	async clickLoginWithAnotherAccount(): Promise< Locator > {
+		const locator = await this.page.locator( selectors.loginWithAnotherAccount );
+		await locator.click();
+
+		return locator;
+	}
+
+	/**
+	 * Clicks the "use username and password instead" link.
+	 */
+	async clickUseUsernamePasswordInstead(): Promise< Locator > {
+		const locator = await this.page.locator( selectors.useUsernamePasswordInstead );
+		// await locator.click();
 
 		return locator;
 	}

--- a/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/account-settings-page.ts
@@ -5,15 +5,16 @@ import type { LanguageSlug } from '@automattic/languages';
 
 const selectors = {
 	// Close account
-	closeAccountLink: 'p:text("Close your account permanently")',
-	closeAccountButton: 'button:text("Close account")',
+	closeAccountLink: 'p:text("Delete your account permanently")',
+	closeAccountButton: 'button:text("Delete account")',
 	deletedItemsSidebar: 'text=These items will be deleted',
 
 	// Modal
 	modalContinueButton: 'button:text("Continue")',
 	usernameSpan: 'span.account-close__confirm-dialog-target-username',
 	usernameConfirmationInput: 'input[id="confirmAccountCloseInput"]',
-	modalCloseAccountButton: 'button:text("Close your account")',
+	// The delete button is outside the confirm dialog but has the is-scary class
+	modalCloseAccountButton: 'button.is-scary',
 
 	// UI Language
 	uiLanguageButton: 'button.language-picker',
@@ -81,13 +82,19 @@ export class AccountSettingsPage {
 		// `Are you sure?` modal.
 		await this.page.click( selectors.modalContinueButton );
 
-		// Final attempt to save the situation in getting the user to type their account username.
+		// Get username and fill the input
 		const username = await this.page
 			.waitForSelector( selectors.usernameSpan )
 			.then( ( element ) => element.innerText() );
+
+		// Fill the input and ensure it's focused
+		await this.page.focus( selectors.usernameConfirmationInput );
 		await this.page.fill( selectors.usernameConfirmationInput, username );
-		// Confirm closure.
-		await this.page.click( selectors.modalCloseAccountButton );
+
+		// Press Tab twice to reach the button and then press Enter
+		await this.page.keyboard.press( 'Tab' );
+		await this.page.keyboard.press( 'Tab' );
+		await this.page.keyboard.press( 'Enter' );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -11,9 +11,8 @@ const selectors = {
 
 	// Team people
 	teamUser: ( username: string ) => `.people-profile:has(:text("${ username }"))`,
-	deletedUserContentAction: ( action: 'reassign' | 'delete' ) => `input[value="${ action }"]`,
-	deleteUserButton: 'button:text("Delete user")',
-	deleteConfirmBanner: ':text("Successfully deleted")',
+	clearUserButton: 'button:text("Clear")',
+	deleteConfirmBanner: ':text("Invite deleted.")',
 
 	// Header
 	addPeopleButton: 'a:text("Add a user")',
@@ -94,31 +93,7 @@ export class PeoplePage {
 	 * Delete the user from site.
 	 */
 	async deleteUser(): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle', { timeout: 20 * 1000 } );
-
-		const elementHandle = await this.page.waitForSelector(
-			selectors.deletedUserContentAction( 'delete' )
-		);
-
-		// Invoke scroll directly via JavaScript.
-		// Playwright's built-in `click` or `check` methods are not able to
-		// scroll the radio buttons into view for uncertain reasons.
-		await this.page.evaluate(
-			( element: SVGElement | HTMLElement ) => element.scrollIntoView(),
-			elementHandle
-		);
-
-		// Native `page.check` sometimes fails here. Instead, click on the radio and wait for the
-		// Delete user button to become enabled.
-		await this.page.click( selectors.deletedUserContentAction( 'delete' ) );
-		await this.page.waitForSelector(
-			`${ selectors.deletedUserContentAction( 'delete' ) }:checked`
-		);
-
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( selectors.deleteUserButton ),
-		] );
+		await this.page.click( selectors.clearUserButton );
 		await this.page.waitForSelector( selectors.deleteConfirmBanner );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/people-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/people-page.ts
@@ -11,8 +11,11 @@ const selectors = {
 
 	// Team people
 	teamUser: ( username: string ) => `.people-profile:has(:text("${ username }"))`,
-	clearUserButton: 'button:text("Clear")',
+	clearUserButton: 'button:has-text("Clear")',
+	removeUserButton: ( username: string ) => `button:has-text("Remove ${ username }")`,
 	deleteConfirmBanner: ':text("Invite deleted.")',
+	removeConfirmButton: '.dialog__action-buttons button:has-text("Remove")',
+	removeConfirmBanner: ':text("Successfully removed")',
 
 	// Header
 	addPeopleButton: 'a:text("Add a user")',
@@ -92,9 +95,23 @@ export class PeoplePage {
 	/**
 	 * Delete the user from site.
 	 */
-	async deleteUser(): Promise< void > {
-		await this.page.click( selectors.clearUserButton );
-		await this.page.waitForSelector( selectors.deleteConfirmBanner );
+	async deleteUser( username: string ): Promise< void > {
+		// Try the Clear button first (for pending invites)
+		const clearButton = this.page.locator( selectors.clearUserButton );
+		try {
+			await clearButton.waitFor( { state: 'visible', timeout: 2000 } );
+			if ( await clearButton.isVisible() ) {
+				await clearButton.click();
+				await this.page.waitForSelector( selectors.deleteConfirmBanner );
+				return;
+			}
+		} catch ( e ) {}
+
+		// If Clear button not found, try Remove flow (for accepted invites)
+		const removeButton = this.page.locator( selectors.removeUserButton( username ) );
+		await removeButton.click();
+		await this.page.click( selectors.removeConfirmButton );
+		await this.page.waitForSelector( selectors.removeConfirmBanner );
 	}
 
 	/* Invites */

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -167,7 +167,7 @@ export class UserSignupPage {
 		} );
 
 		// Ensure response is captured correctly
-		const responsePromise = this.page.waitForResponse( /.*users\/new\?.*/ );
+		const responsePromise = this.page.waitForResponse( /\/users\/new\?[^?]*$/ );
 		await this.page.click( selectors.submitButton );
 
 		const [ response ] = await Promise.all( [ responsePromise, redirectDetected ] );
@@ -190,7 +190,7 @@ export class UserSignupPage {
 		await this.page.fill( selectors.emailInput, email );
 
 		const [ response ] = await Promise.all( [
-			this.page.waitForResponse( /.*new\?.*/ ),
+			this.page.waitForResponse( /\/users\/new\?[^?]*$/ ),
 			this.page.click( selectors.createAccountButton ),
 		] );
 

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -15,6 +15,7 @@ const selectors = {
 
 	// Buttons
 	submitButton: 'button[type="submit"]',
+	createAccountButton: 'button:text("Create an account")',
 };
 
 /**
@@ -177,6 +178,27 @@ export class UserSignupPage {
 
 		const responseBody: NewUserResponse = await response.json();
 		return responseBody;
+	}
+
+	/**
+	 * Signs up through an invite acceptance flow.
+	 *
+	 * @param {string} email Email address of the new user.
+	 * @returns {NewUserResponse} Response from the REST API.
+	 */
+	async signupThroughInvite( email: string ): Promise< NewUserResponse > {
+		await this.page.fill( selectors.emailInput, email );
+
+		const [ response ] = await Promise.all( [
+			this.page.waitForResponse( /.*new\?.*/ ),
+			this.page.click( selectors.createAccountButton ),
+		] );
+
+		if ( ! response ) {
+			throw new Error( 'Failed to create new user through invite.' );
+		}
+
+		return await response.json();
 	}
 
 	/**

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -1,3 +1,7 @@
+/**
+ * @group calypso-pr
+ */
+
 import {
 	DataHelper,
 	EmailClient,

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -1,7 +1,3 @@
-/**
- * @group quarantined
- */
-
 import {
 	DataHelper,
 	EmailClient,

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -9,7 +9,6 @@ import {
 	AddPeoplePage,
 	InvitePeoplePage,
 	PeoplePage,
-	LoginPage,
 	UserSignupPage,
 	RoleValue,
 	CloseAccountFlow,
@@ -90,11 +89,7 @@ describe( DataHelper.createSuiteTitle( 'Invite: New User' ), function () {
 			invitePage = await browser.newContext().then( ( context ) => context.newPage() );
 		} );
 
-		afterAll( async () => {
-			if ( invitePage ) {
-				await invitePage.context().close();
-			}
-		} );
+		// Keep invitePage open as we'll need it for the close account flow
 
 		it( 'Invite email was received for test user', async function () {
 			const emailClient = new EmailClient();
@@ -145,23 +140,22 @@ describe( DataHelper.createSuiteTitle( 'Invite: New User' ), function () {
 		} );
 
 		it( 'Remove invited user from site', async function () {
-			await peoplePage.deleteUser();
+			await peoplePage.deleteUser( testUser.username );
 		} );
 	} );
 
 	describe( 'Close account', function () {
-		it( 'Log in as invited user', async function () {
-			const loginPage = new LoginPage( invitePage );
-			await loginPage.visit();
-			await Promise.all( [
-				invitePage.waitForNavigation( { url: '**/reader' } ),
-				loginPage.logInWithCredentials( testUser.email, testUser.password ),
-			] );
-		} );
-
 		it( 'Close account', async function () {
+			// Use the existing authenticated session from invitePage
 			const closeAccountFlow = new CloseAccountFlow( invitePage );
 			await closeAccountFlow.closeAccount();
+		} );
+
+		afterAll( async () => {
+			// Now we can close invitePage since we're done with all tests
+			if ( invitePage ) {
+				await invitePage.context().close();
+			}
 		} );
 	} );
 } );

--- a/test/e2e/specs/users/invite__new-user.ts
+++ b/test/e2e/specs/users/invite__new-user.ts
@@ -30,6 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Invite: New User' ), function () {
 	let userManagementRevampFeature = false;
 	let acceptInviteLink: string;
 	let page: Page;
+	let invitePage: Page;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -84,6 +85,17 @@ describe( DataHelper.createSuiteTitle( 'Invite: New User' ), function () {
 	} );
 
 	describe( 'Accept invite', function () {
+		beforeAll( async () => {
+			// Create a fresh context in the same browser for invite acceptance
+			invitePage = await browser.newContext().then( ( context ) => context.newPage() );
+		} );
+
+		afterAll( async () => {
+			if ( invitePage ) {
+				await invitePage.context().close();
+			}
+		} );
+
 		it( 'Invite email was received for test user', async function () {
 			const emailClient = new EmailClient();
 			const message = await emailClient.getLastMatchingMessage( {
@@ -98,10 +110,10 @@ describe( DataHelper.createSuiteTitle( 'Invite: New User' ), function () {
 		} );
 
 		it( 'Sign up as invited user from the invite link', async function () {
-			await page.goto( acceptInviteLink );
+			await invitePage.goto( acceptInviteLink );
 
-			const userSignupPage = new UserSignupPage( page );
-			await userSignupPage.signup( testUser.email, testUser.username, testUser.password );
+			const userSignupPage = new UserSignupPage( invitePage );
+			await userSignupPage.signupThroughInvite( testUser.email );
 		} );
 
 		it( 'User sees welcome banner after signup', async function () {
@@ -109,7 +121,7 @@ describe( DataHelper.createSuiteTitle( 'Invite: New User' ), function () {
 			// TODO: Once PostsPage is implemented, call a method from that
 			// POM instead.
 			const bannerText = `You're now an ${ role } of: `;
-			await page.waitForSelector( `:has-text("${ bannerText }")` );
+			await invitePage.waitForSelector( `:has-text("${ bannerText }")` );
 		} );
 	} );
 
@@ -139,16 +151,16 @@ describe( DataHelper.createSuiteTitle( 'Invite: New User' ), function () {
 
 	describe( 'Close account', function () {
 		it( 'Log in as invited user', async function () {
-			const loginPage = new LoginPage( page );
+			const loginPage = new LoginPage( invitePage );
 			await loginPage.visit();
 			await Promise.all( [
-				page.waitForNavigation( { url: '**/reader' } ),
+				invitePage.waitForNavigation( { url: '**/reader' } ),
 				loginPage.logInWithCredentials( testUser.email, testUser.password ),
 			] );
 		} );
 
 		it( 'Close account', async function () {
-			const closeAccountFlow = new CloseAccountFlow( page );
+			const closeAccountFlow = new CloseAccountFlow( invitePage );
 			await closeAccountFlow.closeAccount();
 		} );
 	} );


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTCOM-10629/review-quarantined-e2e-tests

## Proposed Changes

* Fixes quarantine `invite__new-user` test
* Updates will match the flow and screen changes that happened in the meantime.
* Remove quarantine tag and into calypso PR group

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This test didn't work properly; it was flaky. However, I think it's good to have in a pre-release battery of tests. It tests the invitation flow and deleting temporarily created accounts on the user's account page.

## Testing Instructions

* If you want to run it locally
* run `yarn workspace @automattic/calypso-e2e build`
* and then `yarn workspace wp-e2e-tests test -- specs/users/invite__new-user.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
