### PR TITLE
JETCRM-3: Fix feature flag definition on build config for enabling CRM Downloads on A4A

### DIFF
--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -44,7 +44,8 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-wc-asia-signup-enabled": true,
-		"a4a-client-checkout-v2": true
+		"a4a-client-checkout-v2": true,
+		"jetpack/crm-downloads": true
 	},
 	"enable_all_sections": false,
 	"sections": {
@@ -65,8 +66,7 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true,
-		"jetpack/crm-downloads": true
+		"a8c-for-agencies-woopayments": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -37,7 +37,8 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-wc-asia-signup-enabled": true,
-		"a4a-client-checkout-v2": false
+		"a4a-client-checkout-v2": false,
+		"jetpack/crm-downloads": false
 	},
 	"enable_all_sections": false,
 	"sections": {
@@ -58,8 +59,7 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true,
-		"jetpack/crm-downloads": false
+		"a8c-for-agencies-woopayments": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -39,7 +39,8 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-wc-asia-signup-enabled": true,
-		"a4a-client-checkout-v2": false
+		"a4a-client-checkout-v2": false,
+		"jetpack/crm-downloads": true
 	},
 	"enable_all_sections": false,
 	"sections": {
@@ -60,8 +61,7 @@
 		"a8c-for-agencies-client": true,
 		"a8c-for-agencies-team": true,
 		"a8c-for-agencies-agency-tier": true,
-		"a8c-for-agencies-woopayments": true,
-		"jetpack/crm-downloads": true
+		"a8c-for-agencies-woopayments": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This is a simple fix on the build configuration, the feature flag key was placed on the `sections` property of the config instead of the `features` property. Because of this, the feature wasn't enabled in any environment.
* Now the feature should be enabled on the staging environment, as well as for the development environment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the a4a development build locally, try to access the CRM Downloads via the licenses list on Automattic For Agencies ( you should be able to access )
* Run the a4a stage build locally, try to access the CRM Downloads via the licenses list on A4A ( you should be able to access )
* Run the a4a production build locally, try to access the CRM Downloads via the licenses list on A4A ( you should not be able to access )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
