### PR TITLE
DOTOBRD-123: enable containerv2 on migration flow

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,6 +86,7 @@
 		"onboarding/create-course": false,
 		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
+		"onboarding/step-container-v2-migration-flow": true,
 		"p2-enabled": false,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -112,6 +112,7 @@
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
+		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -109,6 +109,7 @@
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
+		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid": false,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,

--- a/config/test.json
+++ b/config/test.json
@@ -88,6 +88,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": true,
+		"onboarding/step-container-v2-migration-flow": true,
 		"p2-enabled": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -114,6 +114,7 @@
 		"onboarding/interval-dropdown": true,
 		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,
+		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,
 		"onboarding/trail-map-feature-grid": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-123

## Proposed Changes

Enable feature flags

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To publish the upgrade to containerv2 on production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `yarn feature-search onboarding/step-container-v2-migration-flow` and compare with the following output:
<img width="587" alt="image" src="https://github.com/user-attachments/assets/0fb1c02f-46aa-4c3d-831b-a543e8b2aa3c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
