### PR TITLE
Fix/unit tests containerv2 migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -153,6 +153,7 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 					heading={ <Step.Heading text={ title } subText={ subHeaderText } /> }
 					className="site-migration-application-password-authorization-v2"
 				>
+					{ notice }
 					{ stepContent }
 				</Step.CenteredColumnLayout>
 			</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -178,6 +178,19 @@ const SiteMigrationIdentify: StepType< {
 		return isBackButtonSupported || urlQueryParams.has( 'back_to' );
 	};
 
+	const getBackButton = () => {
+		if ( ! shouldShowBackButton() ) {
+			return null;
+		}
+
+		const backToUrl = urlQueryParams.get( 'back_to' );
+		return backToUrl ? (
+			<Step.BackButton href={ backToUrl ?? '' } />
+		) : (
+			<Step.BackButton onClick={ navigation?.goBack } />
+		);
+	};
+
 	const [ isVisible, setIsVisible ] = useState( false );
 
 	const stepContent = (
@@ -195,19 +208,14 @@ const SiteMigrationIdentify: StepType< {
 	);
 
 	if ( isUsingStepContainerV2 ) {
+		const backButton = getBackButton();
 		return (
 			<>
 				<DocumentHead title={ translate( 'Import your site content' ) } />
 				<Step.CenteredColumnLayout
 					className="step-container-v2--site-migration-identify"
 					columnWidth={ 4 }
-					topBar={
-						<Step.TopBar
-							leftElement={
-								shouldShowBackButton() ? <Step.BackButton onClick={ navigation.goBack } /> : null
-							}
-						/>
-					}
+					topBar={ <Step.TopBar leftElement={ backButton } /> }
 					heading={
 						isVisible ? (
 							<Step.Heading

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
@@ -87,7 +87,7 @@ describe( 'Site Migration Import or Migrate Step', () => {
 
 		const { queryByText } = render();
 
-		expect( queryByText( /WP Engine/ ) ).toBeInTheDocument();
+		expect( queryByText( /WP Engine/ ) ).toBeVisible();
 	} );
 
 	it( "doesn't show the host identification message when the host is unknown", async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
@@ -85,9 +85,8 @@ describe( 'Site Migration Import or Migrate Step', () => {
 			},
 		} );
 
-		const { container, queryByText } = render();
+		const { queryByText } = render();
 
-		expect( container.querySelectorAll( '.formatted-header__subtitle' ) ).toHaveLength( 1 );
 		expect( queryByText( /WP Engine/ ) ).toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

related to DOTOBRD-123

## Proposed Changes

Fix tests and some code after running the test suite over the container v2 migration flow in [this PR](https://github.com/Automattic/wp-calypso/pull/102907)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix the behaviour and tests when enabling container v2 on the migration flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check this out to your local env
* make this change to `config/test.json`
```diff
diff --git a/config/test.json b/config/test.json
index 339b74a06fd..a1da4436d97 100644
--- a/config/test.json
+++ b/config/test.json
@@ -89,6 +89,7 @@
                "onboarding/import-from-wordpress": true,
                "onboarding/playground": true,
                "onboarding/step-container-v2-import-flow": true,
+               "onboarding/step-container-v2-migration-flow": true,
                "p2-enabled": false,
                "plans/hosting-trial": true,
                "plans/migration-trial": true,
```
* Run the following tests and verify they all pass:
  * `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/test/index.tsx`
  * `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx`
  * `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx`: this will show a red warning, but the tests should be all passed
* Verify tests pass on this PRs CI 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
