### PR TITLE
Update experiment name and sending skip_step_render for all cases

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -8,10 +8,7 @@ import {
 	useIsPlaygroundEligible,
 	isPlaygroundEligible,
 } from 'calypso/landing/stepper/hooks/use-is-playground-eligible';
-import {
-	isMvpOnboardingExperiment,
-	useMvpOnboardingExperiment,
-} from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
+import { useMvpOnboardingExperiment } from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -55,16 +52,6 @@ const onboarding: FlowV2 = {
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
 	async initialize() {
-		if ( await isMvpOnboardingExperiment() ) {
-			return stepsWithRequiredLogin( [
-				STEPS.UNIFIED_DOMAINS,
-				STEPS.UNIFIED_PLANS,
-				STEPS.SITE_CREATION_STEP,
-				STEPS.PROCESSING,
-				STEPS.POST_CHECKOUT_ONBOARDING,
-			] );
-		}
-
 		const steps = stepsWithRequiredLogin( [
 			STEPS.UNIFIED_DOMAINS,
 			STEPS.USE_MY_DOMAIN,

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -57,6 +57,7 @@ const onboarding: FlowV2 = {
 	async initialize() {
 		if ( await isMvpOnboardingExperiment() ) {
 			return stepsWithRequiredLogin( [
+				STEPS.UNIFIED_DOMAINS,
 				STEPS.UNIFIED_PLANS,
 				STEPS.SITE_CREATION_STEP,
 				STEPS.PROCESSING,

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/hooks/use-step-route-tracking/index.tsx
@@ -130,7 +130,7 @@ export const useStepRouteTracking = ( { flow, stepSlug, skipStepRender }: Props 
 		const params = {
 			flow: flowName,
 			is_simplified_onboarding: isMvpOnboarding,
-			...( skipStepRender && { skip_step_render: skipStepRender } ),
+			skip_step_render: skipStepRender,
 			...reenteringStepAfterSignupCompleteProps,
 		};
 		recordPageView( pathname, pageTitle, params );

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -154,6 +154,7 @@ describe( 'StepRoute', () => {
 			expect( recordPageView ).toHaveBeenCalledWith( '/', 'Setup > some-flow > some-step-slug', {
 				flow: 'some-flow',
 				is_simplified_onboarding: false,
+				skip_step_render: false,
 			} );
 		} );
 

--- a/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
+++ b/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
@@ -2,13 +2,13 @@ import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 import { useIsPlaygroundEligible, isPlaygroundEligible } from './use-is-playground-eligible';
 import { useQuery } from './use-query';
 
-const MVP_ONBOARDING_EXPERIMENT_NAME = 'calypso_signup_onboarding_simplified_hosting_flow';
+const HOSTING_ONBOARDING_EXPERIMENT_NAME = 'calypso_signup_onboarding_simplified_hosting_flow_v2';
 
 export function useMvpOnboardingExperiment() {
 	const isPlaygroundEligible = useIsPlaygroundEligible();
 	const hasPlaygroundId = useQuery().has( 'playground' );
 
-	const [ isLoading, assignment ] = useExperiment( MVP_ONBOARDING_EXPERIMENT_NAME, {
+	const [ isLoading, assignment ] = useExperiment( HOSTING_ONBOARDING_EXPERIMENT_NAME, {
 		isEligible: ! isPlaygroundEligible || ! hasPlaygroundId,
 	} );
 
@@ -25,6 +25,6 @@ export async function isMvpOnboardingExperiment() {
 		}
 	}
 
-	const assignment = await loadExperimentAssignment( MVP_ONBOARDING_EXPERIMENT_NAME );
+	const assignment = await loadExperimentAssignment( HOSTING_ONBOARDING_EXPERIMENT_NAME );
 	return assignment.variationName === 'treatment';
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

More context: pet6gk-2cP-p2

## Proposed Changes

* We're adding the domain selection back
* We're updating the experiment name
* We're always sending the `skip_step_render` value even if it's `false` ( Slack thread: p1745608447080719/1745365046.683669-slack-C04H4NY6STW )

Users on /domains page:

![image](https://github.com/user-attachments/assets/8ed34679-89a1-4a0d-ae11-ce70858050fc)


`Control` users on /plans page:

![image](https://github.com/user-attachments/assets/42374669-2378-4650-b5d3-5e174928807f)


`Treatment` users on /plans page:

![image](https://github.com/user-attachments/assets/97b59b60-3425-4149-a9fe-f9a9cd22a92d)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're relaunching the experiment pet6gk-2cP-p2
* We're improving how we log `calypso_page_view` to help with Explat team analysis

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the new experiment to test: 22241-explat-experiment
* Follow the test instructions of the CfT post: pdtkmj-3zG-p2
* Make sure you see the Domains page in the `treatment` flow as well
* Ensure we fire `skip_step_render` as expected (in both true and false states).


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?