### PR TITLE
Differently show the third party cookies notice

### DIFF
--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -32,6 +32,12 @@
 			gap: 4px;
 			color: var( --studio-gray-70 );
 
+			&:disabled {
+				pointer-events: none;
+				color: var( --studio-gray-30 );
+				border-color: var( --studio-gray-30 );
+			}
+
 			&:hover {
 				border: 1px solid var( --studio-gray-20 );
 				cursor: pointer;

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -2,6 +2,7 @@ import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { useGetSupportInteractionById } from '../../data';
@@ -17,6 +18,7 @@ interface GetSupportProps {
 }
 
 interface ButtonConfig {
+	disabled?: boolean;
 	text: string;
 	action: () => Promise< void >;
 	waitTimeText?: string;
@@ -74,12 +76,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 		return null;
 	}
 
-	if (
+	const disabledButton =
 		! ( canConnectToZendesk || contextCanConnectToZendesk ) &&
-		( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport )
-	) {
-		return <NewThirdPartyCookiesNotice />;
-	}
+		( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport );
 
 	const getButtonConfig = (): ButtonConfig[] => {
 		if ( isUserEligibleForPaidSupport || contextIsUserEligibleForPaidSupport ) {
@@ -98,6 +97,10 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 					hideButton: !! supportInteraction,
 				},
 				{
+					disabled: disabledButton,
+					className: clsx( 'odie__transfer-chat--button', {
+						'odie__transfer-chat--button--disabled': disabledButton,
+					} ),
 					text: __( 'Chat with support', __i18n_text_domain__ ),
 					waitTimeText: __( 'Average wait time < 5 minutes', __i18n_text_domain__ ),
 					action: async () => {
@@ -135,7 +138,9 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 				( button, index ) =>
 					button.hideButton !== false && (
 						<div className="odie__transfer-chat--button-container" key={ index }>
-							<button onClick={ ( e ) => handleClick( e, button ) }>{ button.text }</button>
+							<button onClick={ ( e ) => handleClick( e, button ) } disabled={ button.disabled }>
+								{ button.text }
+							</button>
 							{ button.waitTimeText && (
 								<span className="odie__transfer-chat--wait-time">{ button.waitTimeText }</span>
 							) }

--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -18,6 +18,7 @@ interface GetSupportProps {
 }
 
 interface ButtonConfig {
+	className?: string;
 	disabled?: boolean;
 	text: string;
 	action: () => Promise< void >;

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -224,6 +224,11 @@ $blueberry-color: #3858e9;
 		}
 	}
 
+	.chat-feedback-wrapper-third-party-cookies {
+		margin-left: 0;
+		width: 80%;
+	}
+
 	.odie-feedback-component-container {
 		&.odie-question-collapse {
 			margin-top: 0;

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -46,6 +46,14 @@ export const ODIE_TRANSFER_MESSAGE: Message[] = [
 	},
 ];
 
+export const ODIE_THIRD_PARTY_MESSAGE = `${ __(
+	'I’m happy to connect you to a human! However, it looks like 3rd party cookies are disabled in your browser. We need you to turn them on for our live chat to work properly. [Use our guide](https://wordpress.com/support/third-party-cookies/)',
+	__i18n_text_domain__
+) } \n\n ${ __(
+	'Once you’re done, you can come back here to start talking with someone by clicking on the following button.',
+	__i18n_text_domain__
+) }`;
+
 export const ODIE_WRONG_FILE_TYPE_MESSAGE: Message = {
 	content: __(
 		'Sorry! The file you are trying to upload is not supported. Please upload a .jpg, .png, or .gif file.',

--- a/packages/odie-client/src/constants.ts
+++ b/packages/odie-client/src/constants.ts
@@ -47,7 +47,7 @@ export const ODIE_TRANSFER_MESSAGE: Message[] = [
 ];
 
 export const ODIE_THIRD_PARTY_MESSAGE = `${ __(
-	'I’m happy to connect you to a human! However, it looks like 3rd party cookies are disabled in your browser. We need you to turn them on for our live chat to work properly. [Use our guide](https://wordpress.com/support/third-party-cookies/)',
+	'I’m happy to connect you to a human! However, it looks like 3rd party cookies are disabled in your browser. Please turn them on for our live chat to work properly. [Use our guide](https://wordpress.com/support/third-party-cookies/)',
 	__i18n_text_domain__
 ) } \n\n ${ __(
 	'Once you’re done, you can come back here to start talking with someone by clicking on the following button.',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1745411989129209/1744907358.012229-slack-C05FNGX7SKX

## Proposed Changes

When the user cannot reach user support via Zendesk, we are showing a Third Party Cookies Notice (which is most likely the thing that is happening to prevent the user escalation). We are adding an alternative way for those cases where the user can't escalate, the only minus is that the chat conversation is not sent via email, but HE's can't look for the conversation manually.

![image](https://github.com/user-attachments/assets/2ea10b8c-9b96-4611-818a-8bf22c3dd9d9)


## Why are these changes being made?

We believe this would help the user when they are stuck, asking for human support within the Help Center through the AI Assistant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You should block the URL for getting the configuration to connect to Zendesk, You can use the ModResponse Chrome Extension and block the URL: 379f3-pb/

Once the URL is blocked:

**Test 1**

1. Start a new conversation
2. Trigger the human support
3. Assert that it happens the same as the previously provided screenshot
4. Restore the blocking URL and reload the site
5. Assert that you see a button to connect to Zendesk in your conversation

**Test 2** (Regression test)

1. Start a conversation and just chat normally, assert that the conversation has no rendering issues with the AI Assistant header
2. Trigger the human support, assert that everything flows normally (eg, when you ask for human support with no context, the AI asks for context, and if you have enough context, you should be transferred automatically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?