### PR TITLE
Integrate Performance into V2.

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -11,6 +11,7 @@ import {
 	fetchEmails,
 	fetchProfile,
 	updateProfile,
+	fetchSiteSettings,
 } from '../data';
 import { queryClient } from './query-client';
 import type { Profile } from '../data/types';
@@ -96,5 +97,17 @@ export function profileMutation() {
 				oldData ? { ...oldData, ...newData } : newData
 			);
 		},
+	};
+}
+
+export function siteSettingsQuery( siteId: string ) {
+	return {
+		queryKey: [ 'siteSettings', siteId ],
+		queryFn: async () => {
+			return fetchSiteSettings( siteId );
+		},
+		refetchOnWindowFocus: false,
+		retry: false,
+		enabled: !! siteId,
 	};
 }

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -94,6 +94,17 @@ const siteDeploymentsRoute = createRoute( {
 	)
 );
 
+const sitePerformanceRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'performance',
+} ).lazy( () =>
+	import( '../site-performance' ).then( ( d ) =>
+		createLazyRoute( 'site-performance' )( {
+			component: d.default,
+		} )
+	)
+);
+
 const domainsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains',
@@ -252,7 +263,7 @@ const createRouteTree = ( config: AppConfig ) => {
 	if ( config.supports.sites ) {
 		children.push(
 			sitesRoute,
-			siteRoute.addChildren( [ siteOverviewRoute, siteDeploymentsRoute ] )
+			siteRoute.addChildren( [ siteOverviewRoute, siteDeploymentsRoute, sitePerformanceRoute ] )
 		);
 	}
 
@@ -301,6 +312,7 @@ export {
 	siteRoute,
 	siteOverviewRoute,
 	siteDeploymentsRoute,
+	sitePerformanceRoute,
 	domainsRoute,
 	emailsRoute,
 	meRoute,

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -11,6 +11,7 @@ import type {
 	TwoStep,
 	EngagementStatsDataPoint,
 	SiteDomain,
+	SiteSettingsResponse,
 } from './types';
 
 export const fetchProfile = async (): Promise< Profile > => {
@@ -36,6 +37,7 @@ export const updateProfile = async ( data: Partial< Profile > ) => {
 
 const SITE_FIELDS = [
 	'ID',
+	'slug',
 	'URL',
 	'name',
 	'icon',
@@ -51,6 +53,7 @@ const SITE_FIELDS = [
 	'site_owner',
 	'jetpack',
 	'jetpack_modules',
+	'is_a4a_dev_site',
 ].join( ',' );
 
 export const fetchSites = async (): Promise< Site[] > => {
@@ -317,4 +320,13 @@ export const fetchTwoStep = async (): Promise< TwoStep > => {
 		path: '/me/two-step?http_envelope=1',
 		apiNamespace: 'rest/v1.1',
 	} );
+};
+
+export const fetchSiteSettings = async ( id: string ): Promise< SiteSettingsResponse > => {
+	return wpcom.req.get(
+		{
+			path: `/sites/${ id }/settings`,
+		},
+		{ apiVersion: '1.4' }
+	);
 };

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -80,10 +80,12 @@ export interface Site {
 	subscribers_count: number;
 	// Can be undefined for deleted sites.
 	options?: SiteOptions;
+	is_a4a_dev_site: boolean;
 	is_deleted: boolean;
 	is_coming_soon: boolean;
 	is_private: boolean;
 	launch_status: string | boolean;
+	slug: string;
 	site_migration: {
 		migration_status: string;
 	} | null;
@@ -150,4 +152,12 @@ export interface UrlPerformanceInsights {
 	wpscan: {
 		status: string;
 	};
+}
+
+export interface SiteSettings {
+	wpcom_performance_report_url: string;
+}
+
+export interface SiteSettingsResponse {
+	settings: SiteSettings;
 }

--- a/client/dashboard/site-menu/index.tsx
+++ b/client/dashboard/site-menu/index.tsx
@@ -8,6 +8,9 @@ const SiteMenu = ( { siteId }: { siteId: string } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteId }/deployments` }>
 				{ __( 'Deployments' ) }
 			</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to={ `/sites/${ siteId }/performance` }>
+				{ __( 'Performance' ) }
+			</ResponsiveMenu.Item>
 		</ResponsiveMenu>
 	);
 };

--- a/client/dashboard/site-performance/index.tsx
+++ b/client/dashboard/site-performance/index.tsx
@@ -1,0 +1,8 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../page-layout';
+
+function SitePerformance() {
+	return <PageLayout title={ __( 'Performance' ) } />;
+}
+
+export default SitePerformance;

--- a/client/dashboard/site-performance/index.tsx
+++ b/client/dashboard/site-performance/index.tsx
@@ -1,8 +1,187 @@
+import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
+import { usePerformanceReport } from 'calypso/hosting/performance/hooks/usePerformanceReport';
+import { useSitePerformancePageReports } from 'calypso/hosting/performance/hooks/useSitePerformancePageReports';
+import { SitePerformanceContent } from 'calypso/hosting/performance/site-performance';
+import {
+	DeviceTabProvider,
+	useDeviceTab,
+} from 'calypso/hosting/performance/contexts/device-tab-context';
+import { siteQuery, siteSettingsQuery } from '../app/queries';
+import { siteRoute } from '../app/router';
 import PageLayout from '../page-layout';
 
 function SitePerformance() {
-	return <PageLayout title={ __( 'Performance' ) } />;
+	const { siteId, pageId } = siteRoute.useParams();
+	const { data } = useQuery( siteQuery( siteId ) );
+	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery(
+		siteSettingsQuery( siteId )
+	);
+	const { activeTab, setActiveTab } = useDeviceTab();
+	const isSitePublic = data?.site.options?.blog_public === 1;
+	const isSiteAtomic = data?.site.options?.is_wpcom_atomic;
+
+	const {
+		pages,
+		isInitialLoading,
+		savePerformanceReportUrl,
+		refetch: refetchPages,
+	} = useSitePerformancePageReports( {
+		site: data?.site,
+		reportUrl: siteSettings?.settings?.wpcom_performance_report_url,
+	} );
+
+	console.log( pageId );
+	const currentPageId = pageId ?? '0';
+
+	// Stores any page selection made by the user, `undefined` by default. See
+	// `currentPage` below for logic regarding the default page if the user
+	// hasn't selected one yet.
+	const [ currentPageUserSelection, setCurrentPageUserSelection ] =
+		useState< ( typeof pages )[ number ] >();
+
+	const [ isSavingPerformanceReportUrl, setIsSavingPerformanceReportUrl ] = useState( false );
+
+	const [ prevSiteId, setPrevSiteId ] = useState( siteId );
+	if ( prevSiteId !== siteId ) {
+		setPrevSiteId( siteId );
+		setCurrentPageUserSelection( undefined );
+	}
+
+	const currentPage =
+		currentPageUserSelection ?? pages?.find( ( page ) => page.value === currentPageId );
+
+	const performanceReport = usePerformanceReport(
+		setIsSavingPerformanceReportUrl,
+		refetchPages,
+		savePerformanceReportUrl,
+		currentPageId,
+		isSitePublic ? currentPage?.wpcom_performance_report_url : undefined,
+		activeTab
+	);
+
+	useEffect( () => {
+		if ( performanceReport.isBasicMetricsFetched && performanceReport.url ) {
+			performance.mark( 'test-started' );
+			// recordTracksEvent( 'calypso_performance_profiler_test_started', {
+			// 	url: performanceReport.url,
+			// 	version: profilerVersion(),
+			// } );
+		}
+	}, [ performanceReport.isBasicMetricsFetched, performanceReport.url ] );
+
+	const retestPage = () => {
+		//recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
+		performance.mark( 'test-started' );
+
+		performanceReport.testAgain().then( ( { data } ) => {
+			if ( data?.token && data.token !== currentPage?.wpcom_performance_report_url?.hash ) {
+				savePerformanceReportUrl( currentPageId, {
+					url: data.final_url,
+					hash: data.token,
+				} );
+			}
+		} );
+	};
+
+	const onLaunchSiteClick = () => {
+		if ( true ) {
+			//recordTracksEvent( 'calypso_performance_profiler_prepare_launch_cta_click' );
+			location.href = `/sites/settings/site/${ data.site.slug }`;
+			return;
+		}
+		//dispatch( launchSite( siteId! ) );
+		//recordTracksEvent( 'calypso_performance_profiler_launch_site_cta_click' );
+	};
+
+	const disableControls =
+		performanceReport.isLoading ||
+		isInitialLoading ||
+		! isSitePublic ||
+		isSavingPerformanceReportUrl;
+
+	const handleDeviceTabChange = ( tab: TabType ) => {
+		setActiveTab( tab );
+		// recordTracksEvent( 'calypso_performance_profiler_device_tab_change', {
+		// 	device: tab,
+		// } );
+	};
+
+	// const subtitle =
+	// 	! performanceReport.isLoading && performanceReport.performanceReport
+	// 		? translate( 'Tested on {{span}}%(testedDate)s{{/span}}. {{button}}Test again{{/button}}', {
+	// 				args: {
+	// 					testedDate: moment( performanceReport.performanceReport.timestamp ).format(
+	// 						'MMMM Do, YYYY h:mm:ss A'
+	// 					),
+	// 				},
+	// 				components: {
+	// 					button: (
+	// 						<Button
+	// 							css={ {
+	// 								textDecoration: 'none !important',
+	// 								':hover': {
+	// 									textDecoration: 'underline !important',
+	// 								},
+	// 								fontSize: 'inherit',
+	// 								whiteSpace: 'nowrap',
+	// 							} }
+	// 							variant="link"
+	// 							onClick={ retestPage }
+	// 						/>
+	// 					),
+	// 					span: (
+	// 						<span
+	// 							style={ {
+	// 								fontVariantNumeric: 'tabular-nums',
+	// 							} }
+	// 						/>
+	// 					),
+	// 				},
+	// 		  } )
+	// 		: translate(
+	// 				'Optimize your site for lightning-fast performance. {{link}}Learn more.{{/link}}',
+	// 				{
+	// 					components: {
+	// 						link: <InlineSupportLink { ...getSupportLinkProps() } />,
+	// 					},
+	// 				}
+	// 		  );
+
+	// Ensure booleans are always boolean
+	const isSiteAtomicBool = Boolean( isSiteAtomic );
+	const isSitePublicBool = Boolean( isSitePublic );
+	const isInitialLoadingBool = Boolean( isInitialLoading );
+	const disableControlsBool = Boolean( disableControls );
+
+	// Ensure pageSelector is always a valid ReactElement
+	const validPageSelector = <></>;
+
+	if ( ! isSiteAtomicBool ) {
+		return null;
+	}
+
+	return (
+		<PageLayout title={ __( 'Performance' ) }>
+			<DeviceTabProvider>
+				<SitePerformanceContent
+					activeTab={ activeTab }
+					isSitePublic={ isSitePublicBool }
+					isInitialLoading={ isInitialLoadingBool }
+					disableControls={ disableControlsBool }
+					pageSelector={ validPageSelector }
+					subtitle={ 'sdf' }
+					siteIsLaunching={ false }
+					onLaunchSiteClick={ onLaunchSiteClick }
+					retestPage={ retestPage }
+					handleDeviceTabChange={ handleDeviceTabChange }
+					performanceReport={ performanceReport }
+					currentPage={ currentPage }
+				/>
+			</DeviceTabProvider>
+		</PageLayout>
+	);
 }
 
 export default SitePerformance;

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -165,7 +165,6 @@ export function useSavePerformanceReportUrl( siteId: number ) {
 					saveSiteSettings( siteId, { wpcom_performance_report_url: performanceReportUrl } )
 				);
 			}
-
 			return await savePageMeta( siteId, parseInt( pageId, 10 ), performanceReportUrl );
 		},
 		[ siteId, dispatch ]

--- a/client/hosting/performance/hooks/useSitePerformancePageReports.ts
+++ b/client/hosting/performance/hooks/useSitePerformancePageReports.ts
@@ -3,11 +3,10 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useCallback, useMemo } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
-import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { saveSiteSettings } from 'calypso/state/site-settings/actions';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isValidURL } from '../utils';
+import type { SiteDetails } from '@automattic/data-stores';
 
 interface SitePage {
 	id: number;
@@ -72,10 +71,17 @@ const toPerformanceReportUrl = ( { url, hash }: PerformanceReportUrl ) => {
 
 const HOME_PAGE_ID = '0';
 
-export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
+export const useSitePerformancePageReports = ( {
+	query = '',
+	site,
+	reportUrl,
+}: {
+	query?: string;
+	site: SiteDetails | undefined | null;
+	reportUrl: string;
+} ) => {
 	const { __ } = useI18n();
 
-	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
 
 	const {
@@ -110,13 +116,10 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 		},
 	} );
 
-	const { getSiteSetting } = useSiteSettings( site?.slug );
-	const homePagePerformanceUrl: SitePage[ 'wpcom_performance_report_url' ] = getSiteSetting(
-		'wpcom_performance_report_url'
-	);
+	const homePagePerformanceUrl: SitePage[ 'wpcom_performance_report_url' ] = reportUrl;
 
 	const pages = useMemo( () => {
-		if ( ! site?.URL ) {
+		if ( ! site?.URL || ! homePagePerformanceUrl ) {
 			return [];
 		}
 
@@ -139,9 +142,13 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 		return data ?? [];
 	}, [ query, data, site?.URL, __, homePagePerformanceUrl ] );
 
+	return { pages, isInitialLoading, refetch };
+};
+
+export function useSavePerformanceReportUrl( siteId: number ) {
 	const dispatch = useDispatch();
 
-	const savePerformanceReportUrl = useCallback(
+	return useCallback(
 		async ( pageId: string, performanceReport: PerformanceReportUrl ) => {
 			if ( ! siteId ) {
 				return;
@@ -158,10 +165,9 @@ export const useSitePerformancePageReports = ( { query = '' } = {} ) => {
 					saveSiteSettings( siteId, { wpcom_performance_report_url: performanceReportUrl } )
 				);
 			}
+
 			return await savePageMeta( siteId, parseInt( pageId, 10 ), performanceReportUrl );
 		},
 		[ siteId, dispatch ]
 	);
-
-	return { pages, isInitialLoading, savePerformanceReportUrl, refetch };
-};
+}

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -30,7 +30,10 @@ import { ReportUnavailable } from './components/ReportUnavailable';
 import { DeviceTabControls } from './components/device-tab-control';
 import { ExpiredReportNotice } from './components/expired-report-notice/expired-report-notice';
 import { usePerformanceReport } from './hooks/usePerformanceReport';
-import { useSitePerformancePageReports } from './hooks/useSitePerformancePageReports';
+import {
+	useSitePerformancePageReports,
+	useSavePerformanceReportUrl,
+} from './hooks/useSitePerformancePageReports';
 import { getSupportLinkProps } from './utils';
 
 import './style.scss';
@@ -44,35 +47,24 @@ const statsQuery = {
 	max: 0,
 };
 
-const SitePerformanceContent = () => {
-	const dispatch = useDispatch();
-	const { activeTab, setActiveTab } = useDeviceTab();
-	const site = useSelector( getSelectedSite );
-	const siteId = site?.ID;
-	const { getSiteSetting } = useSiteSettings( site?.slug );
-	const blog_public = getSiteSetting( 'blog_public' );
-	const isSitePublic = site && blog_public === 1;
-	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+interface PageSelectorProps {
+	siteId: number;
+	pages: { label: string; value: string }[];
+	currentPage: { label: string; value: string };
+	setCurrentPageUserSelection: ( page: { label: string; value: string } | undefined ) => void;
+	disableControls: boolean;
+}
 
+const PageSelectorContainer: React.FC< PageSelectorProps > = ( {
+	siteId,
+	pages,
+	currentPage,
+	setCurrentPageUserSelection,
+	disableControls,
+} ) => {
 	const stats = useSelector( ( state ) =>
 		getSiteStatsNormalizedData( state, siteId, statType, statsQuery )
 	) as { id: number; value: number }[];
-
-	useEffect( () => {
-		if ( ! siteId ) {
-			return;
-		}
-
-		dispatch( requestSiteStats( siteId, statType, statsQuery ) );
-	}, [ dispatch, siteId ] );
-
-	const queryParams = useSelector( getCurrentQueryArguments );
-	const {
-		pages,
-		isInitialLoading,
-		savePerformanceReportUrl,
-		refetch: refetchPages,
-	} = useSitePerformancePageReports();
 
 	const orderedPages = useMemo( () => {
 		return [ ...pages ].sort( ( a, b ) => {
@@ -82,27 +74,6 @@ const SitePerformanceContent = () => {
 		} );
 	}, [ pages, stats ] );
 
-	const currentPageId = queryParams?.page_id?.toString() ?? '0';
-	const filter = queryParams?.filter?.toString();
-	const [ recommendationsFilter, setRecommendationsFilter ] = useState( filter );
-
-	// Stores any page selection made by the user, `undefined` by default. See
-	// `currentPage` below for logic regarding the default page if the user
-	// hasn't selected one yet.
-	const [ currentPageUserSelection, setCurrentPageUserSelection ] =
-		useState< ( typeof pages )[ number ] >();
-
-	const [ isSavingPerformanceReportUrl, setIsSavingPerformanceReportUrl ] = useState( false );
-
-	const [ prevSiteId, setPrevSiteId ] = useState( siteId );
-	if ( prevSiteId !== siteId ) {
-		setPrevSiteId( siteId );
-		setCurrentPageUserSelection( undefined );
-	}
-
-	const currentPage =
-		currentPageUserSelection ?? pages?.find( ( page ) => page.value === currentPageId );
-
 	const pageOptions = useMemo( () => {
 		const options = currentPage
 			? [ currentPage, ...orderedPages.filter( ( p ) => p.value !== currentPage.value ) ]
@@ -111,6 +82,103 @@ const SitePerformanceContent = () => {
 		// Add a disabled option at the end that will show a disclaimer message.
 		return [ ...options, { label: '', value: '-1', path: '', disabled: true } ];
 	}, [ currentPage, orderedPages ] );
+
+	const [ prevSiteId, setPrevSiteId ] = useState( siteId );
+	if ( prevSiteId !== siteId ) {
+		setPrevSiteId( siteId );
+		setCurrentPageUserSelection( undefined );
+	}
+
+	// This forces a no pages found message in the dropdown
+	const [ noPagesFound, setNoPagesFound ] = useState( { query: '', found: true } );
+
+	const options = ! noPagesFound.found
+		? [
+				{
+					label: noPagesFound.query,
+					value: '-2',
+					disabled: true,
+				},
+		  ]
+		: pageOptions;
+
+	return (
+		<PageSelector
+			onFilterValueChange={ ( value ) => {
+				const filter = pageOptions.find( ( option ) =>
+					option.label.toLowerCase().startsWith( value )
+				);
+
+				if ( filter ) {
+					setNoPagesFound( { query: '', found: true } );
+					return;
+				}
+				setNoPagesFound( { query: value, found: false } );
+			} }
+			allowReset={ false }
+			onBlur={ () => {
+				// if no pages found, reset so that the previous selected page is shown
+				if ( ! noPagesFound.found ) {
+					setNoPagesFound( { query: '', found: true } );
+				}
+			} }
+			options={ options }
+			disabled={ disableControls }
+			onChange={ ( page_id ) => {
+				const url = new URL( window.location.href );
+				recordTracksEvent( 'calypso_performance_profiler_page_selector_change', {
+					is_home: page_id === '0',
+					version: profilerVersion(),
+				} );
+				if ( page_id ) {
+					setCurrentPageUserSelection( pages.find( ( page ) => page.value === page_id ) );
+					url.searchParams.set( 'page_id', page_id );
+				} else {
+					setCurrentPageUserSelection( undefined );
+					url.searchParams.delete( 'page_id' );
+				}
+
+				page.replace( url.pathname + url.search );
+			} }
+			value={ currentPage?.value }
+		/>
+	);
+};
+
+interface SitePerformanceContentProps {
+	activeTab: TabType;
+	isSitePublic: boolean;
+	isInitialLoading: boolean;
+	disableControls: boolean;
+	pageSelector: React.ReactElement;
+	subtitle: React.ReactNode;
+	siteIsLaunching: boolean;
+	onLaunchSiteClick: () => void;
+	retestPage: () => void;
+	handleDeviceTabChange: ( tab: TabType ) => void;
+	performanceReport: ReturnType< typeof usePerformanceReport >;
+	currentPage: { label: string; value: string };
+	queryParams: { filter: string };
+}
+
+const SitePerformanceContent: React.FC< SitePerformanceContentProps > = ( {
+	activeTab,
+	isSitePublic,
+	isInitialLoading,
+	disableControls,
+	pageSelector,
+	subtitle,
+	siteIsLaunching,
+	onLaunchSiteClick,
+	retestPage,
+	handleDeviceTabChange,
+	performanceReport,
+	currentPage,
+	queryParams,
+} ) => {
+	const filter = queryParams?.filter?.toString();
+	const [ recommendationsFilter, setRecommendationsFilter ] = useState( filter );
+	const isMobile = useMobileBreakpoint();
 
 	const handleRecommendationsFilterChange = ( filter?: string ) => {
 		setRecommendationsFilter( filter );
@@ -125,6 +193,106 @@ const SitePerformanceContent = () => {
 		window.history.replaceState( {}, '', url.toString() );
 	};
 
+	return (
+		<div className="site-performance">
+			<div className="site-performance-device-tab-controls__container">
+				{ isMobile ? (
+					<MobileHeader
+						pageTitle={ currentPage?.label ?? '' }
+						pageSelector={ pageSelector }
+						subtitle={ subtitle }
+					/>
+				) : (
+					<NavigationHeader
+						className="site-performance__navigation-header"
+						title={ translate( 'Performance' ) }
+						subtitle={ subtitle }
+					/>
+				) }
+				{ ! isMobile && pageSelector }
+				<DeviceTabControls
+					showTitle={ ! isMobile }
+					onDeviceTabChange={ handleDeviceTabChange }
+					disabled={ disableControls }
+					value={ activeTab }
+				/>
+			</div>
+			{ isInitialLoading && isSitePublic ? (
+				<PerformanceReportLoading isLoadingPages isSavedReport={ false } pageTitle="" />
+			) : (
+				<>
+					{ ! isSitePublic ? (
+						<ReportUnavailable
+							isLaunching={ siteIsLaunching }
+							onLaunchSiteClick={ onLaunchSiteClick }
+							ctaText={
+								// @ts-ignore site is not available in props, should be handled in container
+								translate( 'Launch your site' )
+							}
+						/>
+					) : (
+						currentPage && (
+							<>
+								<ExpiredReportNotice
+									reportTimestamp={ performanceReport.performanceReport?.timestamp }
+									onRetest={ retestPage }
+								/>
+								<PerformanceReport
+									{ ...performanceReport }
+									pageTitle={ currentPage.label }
+									onRetestClick={ retestPage }
+									onFilterChange={ handleRecommendationsFilterChange }
+									filter={ recommendationsFilter }
+								/>
+							</>
+						)
+					) }
+				</>
+			) }
+		</div>
+	);
+};
+
+const SitePerformanceContainer: React.FC = () => {
+	const dispatch = useDispatch();
+	const { activeTab, setActiveTab } = useDeviceTab();
+	const site = useSelector( getSelectedSite );
+	const siteId = site?.ID;
+	const { getSiteSetting } = useSiteSettings( site?.slug );
+	const blog_public = getSiteSetting( 'blog_public' );
+	const isSitePublic = site && blog_public === 1;
+	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		dispatch( requestSiteStats( siteId, statType, statsQuery ) );
+	}, [ dispatch, siteId ] );
+
+	const queryParams = useSelector( getCurrentQueryArguments );
+	const {
+		pages,
+		isInitialLoading,
+		refetch: refetchPages,
+	} = useSitePerformancePageReports( {
+		site,
+		reportUrl: getSiteSetting( 'wpcom_performance_report_url' ),
+	} );
+
+	const currentPageId = queryParams?.page_id?.toString() ?? '0';
+
+	// Stores any page selection made by the user, `undefined` by default.
+	const [ currentPageUserSelection, setCurrentPageUserSelection ] =
+		useState< ( typeof pages )[ number ] >();
+
+	const [ isSavingPerformanceReportUrl, setIsSavingPerformanceReportUrl ] = useState( false );
+
+	const currentPage =
+		currentPageUserSelection ?? pages?.find( ( page ) => page.value === currentPageId );
+
+	const savePerformanceReportUrl = useSavePerformanceReportUrl( site?.ID );
 	const performanceReport = usePerformanceReport(
 		setIsSavingPerformanceReportUrl,
 		refetchPages,
@@ -172,7 +340,6 @@ const SitePerformanceContent = () => {
 		recordTracksEvent( 'calypso_performance_profiler_launch_site_cta_click' );
 	};
 
-	const isMobile = useMobileBreakpoint();
 	const disableControls =
 		performanceReport.isLoading ||
 		isInitialLoading ||
@@ -185,61 +352,6 @@ const SitePerformanceContent = () => {
 			device: tab,
 		} );
 	};
-
-	// This forces a no pages found message in the dropdown
-	const [ noPagesFound, setNoPagesFound ] = useState( { query: '', found: true } );
-
-	const options = ! noPagesFound.found
-		? [
-				{
-					label: noPagesFound.query,
-					value: '-2',
-					disabled: true,
-				},
-		  ]
-		: pageOptions;
-
-	const pageSelector = (
-		<PageSelector
-			onFilterValueChange={ ( value ) => {
-				const filter = pageOptions.find( ( option ) =>
-					option.label.toLowerCase().startsWith( value )
-				);
-
-				if ( filter ) {
-					setNoPagesFound( { query: '', found: true } );
-					return;
-				}
-				setNoPagesFound( { query: value, found: false } );
-			} }
-			allowReset={ false }
-			onBlur={ () => {
-				// if no pages found, reset so that the previous selected page is shown
-				if ( ! noPagesFound.found ) {
-					setNoPagesFound( { query: '', found: true } );
-				}
-			} }
-			options={ options }
-			disabled={ disableControls }
-			onChange={ ( page_id ) => {
-				const url = new URL( window.location.href );
-				recordTracksEvent( 'calypso_performance_profiler_page_selector_change', {
-					is_home: page_id === '0',
-					version: profilerVersion(),
-				} );
-				if ( page_id ) {
-					setCurrentPageUserSelection( pages.find( ( page ) => page.value === page_id ) );
-					url.searchParams.set( 'page_id', page_id );
-				} else {
-					setCurrentPageUserSelection( undefined );
-					url.searchParams.delete( 'page_id' );
-				}
-
-				page.replace( url.pathname + url.search );
-			} }
-			value={ currentPageId }
-		/>
-	);
 
 	const subtitle =
 		! performanceReport.isLoading && performanceReport.performanceReport
@@ -282,75 +394,56 @@ const SitePerformanceContent = () => {
 					}
 			  );
 
-	if ( ! isSiteAtomic ) {
+	// Ensure booleans are always boolean
+	const isSiteAtomicBool = Boolean( isSiteAtomic );
+	const isSitePublicBool = Boolean( isSitePublic );
+	const isInitialLoadingBool = Boolean( isInitialLoading );
+	const disableControlsBool = Boolean( disableControls );
+
+	// Ensure pageSelector is always a valid ReactElement
+
+	const pageSelector = (
+		<PageSelectorContainer
+			siteId={ siteId }
+			pages={ pages }
+			currentPage={ currentPage }
+			disableControls={ disableControls }
+			currentPageUserSelection={ currentPageUserSelection }
+			setCurrentPageUserSelection={ setCurrentPageUserSelection }
+		/>
+	);
+
+	const validPageSelector = pageSelector ?? <></>;
+
+	if ( ! isSiteAtomicBool ) {
 		return null;
 	}
 
 	return (
-		<div className="site-performance">
-			<div className="site-performance-device-tab-controls__container">
-				{ isMobile ? (
-					<MobileHeader
-						pageTitle={ currentPage?.label ?? '' }
-						pageSelector={ pageSelector }
-						subtitle={ subtitle }
-					/>
-				) : (
-					<NavigationHeader
-						className="site-performance__navigation-header"
-						title={ translate( 'Performance' ) }
-						subtitle={ subtitle }
-					/>
-				) }
-				{ ! isMobile && pageSelector }
-				<DeviceTabControls
-					showTitle={ ! isMobile }
-					onDeviceTabChange={ handleDeviceTabChange }
-					disabled={ disableControls }
-					value={ activeTab }
-				/>
-			</div>
-			{ isInitialLoading && isSitePublic ? (
-				<PerformanceReportLoading isLoadingPages isSavedReport={ false } pageTitle="" />
-			) : (
-				<>
-					{ ! isSitePublic ? (
-						<ReportUnavailable
-							isLaunching={ siteIsLaunching }
-							onLaunchSiteClick={ onLaunchSiteClick }
-							ctaText={
-								site?.is_a4a_dev_site
-									? translate( 'Prepare for launch' )
-									: translate( 'Launch your site' )
-							}
-						/>
-					) : (
-						currentPage && (
-							<>
-								<ExpiredReportNotice
-									reportTimestamp={ performanceReport.performanceReport?.timestamp }
-									onRetest={ retestPage }
-								/>
-								<PerformanceReport
-									{ ...performanceReport }
-									pageTitle={ currentPage.label }
-									onRetestClick={ retestPage }
-									onFilterChange={ handleRecommendationsFilterChange }
-									filter={ recommendationsFilter }
-								/>
-							</>
-						)
-					) }
-				</>
-			) }
-		</div>
+		<SitePerformanceContent
+			queryParams={ queryParams }
+			activeTab={ activeTab }
+			isSitePublic={ isSitePublicBool }
+			isInitialLoading={ isInitialLoadingBool }
+			disableControls={ disableControlsBool }
+			pageSelector={ validPageSelector }
+			subtitle={ subtitle }
+			siteIsLaunching={ siteIsLaunching }
+			onLaunchSiteClick={ onLaunchSiteClick }
+			retestPage={ retestPage }
+			handleDeviceTabChange={ handleDeviceTabChange }
+			performanceReport={ performanceReport }
+			currentPage={ currentPage }
+		/>
 	);
 };
 
 export const SitePerformance = () => {
 	return (
 		<DeviceTabProvider>
-			<SitePerformanceContent />
+			<SitePerformanceContainer />
 		</DeviceTabProvider>
 	);
 };
+
+export { SitePerformanceContent };


### PR DESCRIPTION
Related to DOTCOM-10675

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
