### PR TITLE
Stop switch user button being obscured on wide screens

### DIFF
--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -7,7 +7,7 @@
 	color: var(--color-text-subtle);
 	font-size: $font-body-small;
 	text-align: center;
-	height: calc(65vh - 80px); /* The values here are set so that the Not-you line gets pushed to the bottom of the screen on mobile */
+	height: calc(65vh - 47px); /* The values here are set so that the Not-you line gets pushed to the bottom of the screen on mobile */
 	margin: 48px auto 0;
 	position: relative;
 	max-width: 400px;
@@ -50,7 +50,6 @@
 	.continue-as-user__not-you {
 		display: block;
 		bottom: 0;
-		margin-bottom: -33px;
 		position: absolute;
 		text-align: center;
 		width: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes DOTCOM-10676

## Proposed Changes

Stops the switch user button from being pushed below the `main` content container which has overflow hidden, causing the UI to be cut off.

This is achieved by removing the negative bottom margin and moving this positioning adjustment to the overall height calculation of the screen container.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This button being inaccessible represents a significant hurdle for users in the login flow. They must continue with the current logged in user, log out once they reach a different UI and then finally login again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in
* Visit `/log-in` again
* Test the screen at various viewport widths; mobile, < 1400px, > 1400px
* The bottom text reading 'Not you? Log in with another account' should be visible and the link within should work as expected; logging out the current user and starting a fresh login flow.

### Screenshots

#### Mobile

| Before | After |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(iPhone 12 Pro)](https://github.com/user-attachments/assets/cef25b8d-d25d-4809-b5ac-60347bf5ff83) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(iPhone 12 Pro) (1)](https://github.com/user-attachments/assets/0971dd08-f153-49ae-8c0f-a4ad8fc2a735) |

#### iPad

| Before | After |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(iPad)](https://github.com/user-attachments/assets/6a2d64fa-d0ea-4291-bce5-ead22ba1238e) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(iPad) (1)](https://github.com/user-attachments/assets/3d7238bf-3559-42f8-9283-9ed7452268e7) |

#### Small desktop (1366x768)

| Before | After |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(2 1366x768)](https://github.com/user-attachments/assets/04d08a5a-eabf-4bfb-bfee-6a4d06c52d2d) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(2 1366x768) (1)](https://github.com/user-attachments/assets/0e9f3283-d659-455e-80f3-7ca836aaf840) |

#### Wide desktop (1440x900)

| Before | After |
|-|-|
| ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(5 1440x900)](https://github.com/user-attachments/assets/48ab39a6-c5a5-4103-a516-ccc39bb5acec) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(5 1440x900) (1)](https://github.com/user-attachments/assets/b63480ca-cb37-47c5-9b1e-9c84ac8c44c6) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
