### PR TITLE
/me: Improve username description and email verification banner

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -487,7 +487,7 @@ class Account extends Component {
 		}
 
 		if ( isAutomattician ) {
-			return <span>{ translate( 'Automatticians cannot change their username' ) }</span>;
+			return <span>{ translate( 'Automatticians cannot change their username.' ) }</span>;
 		}
 
 		return this.renderJoinDate();

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -911,15 +911,6 @@ class Account extends Component {
 							) : (
 								<FormSettingExplanation>
 									{ this.renderUsernameDescription() }
-									{ ! this.props.isEmailVerified ? (
-										<span>
-											{ translate(
-												'Username can be changed once your email address is verified.'
-											) }
-										</span>
-									) : (
-										this.renderJoinDate()
-									) }
 								</FormSettingExplanation>
 							) }
 						</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -46,6 +46,7 @@ import canDisplayCommunityTranslator from 'calypso/state/selectors/can-display-c
 import getUnsavedUserSettings from 'calypso/state/selectors/get-unsaved-user-settings';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
+import { isA8cTeamMember } from 'calypso/state/teams/selectors';
 import {
 	clearUnsavedUserSettings,
 	removeUnsavedUserSetting,
@@ -476,6 +477,22 @@ class Account extends Component {
 		);
 	}
 
+	renderUsernameDescription() {
+		const { translate, isAutomattician, isEmailVerified } = this.props;
+
+		if ( ! isEmailVerified ) {
+			return (
+				<span>{ translate( 'Username can be changed once your email address is verified.' ) }</span>
+			);
+		}
+
+		if ( isAutomattician ) {
+			return <span>{ translate( 'Automatticians cannot change their username' ) }</span>;
+		}
+
+		return this.renderJoinDate();
+	}
+
 	renderPrimarySite() {
 		const { requestingMissingSites, translate, visibleSiteCount } = this.props;
 
@@ -893,6 +910,7 @@ class Account extends Component {
 								this.renderUsernameValidation()
 							) : (
 								<FormSettingExplanation>
+									{ this.renderUsernameDescription() }
 									{ ! this.props.isEmailVerified ? (
 										<span>
 											{ translate(
@@ -1012,6 +1030,7 @@ export default compose(
 			unsavedUserSettings: getUnsavedUserSettings( state ),
 			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
+			isAutomattician: isA8cTeamMember( state ),
 		} ),
 		{
 			clearUnsavedUserSettings,

--- a/client/me/email-verification-banner/index.tsx
+++ b/client/me/email-verification-banner/index.tsx
@@ -35,12 +35,12 @@ const EmailVerificationBanner: React.FC< {
 			) }
 			<Banner
 				className="email-verification-banner"
-				title={ translate( 'Please, verify your email address.' ) }
+				title={ translate( 'Verify your email address.' ) }
 				description={
 					customDescription
 						? customDescription
 						: translate(
-								'Verifying your email helps you secure your WordPress.com account and enables key features.'
+								'Verifying your email helps you secure your WordPress.com account and enables key features, like changing your username.'
 						  )
 				}
 				callToAction={ translate( 'Verify email' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100163

## Proposed Changes

This PR improves the explanations of why the username cannot be changed.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall polish of WP.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With an a11n account. Head to /me/account.
  * Ensure that the username field description is "Automatticians cannot change their username"
* With a non-a11n account, email verified. Head to /me/account.
  * Ensure that the username field description is "Joined on ${date}"
* With a non-a11n account, email not verified. Head to /me/account. 
  * Ensure that the username field description is "Username can be changed once your email address is verified."
  * Also ensure that the email verification banner is updated to say:

Verify email address
Verifying your email helps you secure your WordPress.com account and enables key features, like changing your username.
[[Verify email]]

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
