### PR TITLE
wpcom.js: allow setting apiVersion is request params

### DIFF
--- a/packages/wpcom.js/src/index.js
+++ b/packages/wpcom.js/src/index.js
@@ -8,7 +8,6 @@ import Site from './lib/site';
 import Users from './lib/users';
 import Pinghub from './lib/util/pinghub';
 import Request from './lib/util/request';
-import sendRequest from './lib/util/send-request';
 
 /**
  * Local module constants
@@ -142,22 +141,6 @@ WPCOM.prototype.batch = function () {
  */
 WPCOM.prototype.freshlyPressed = function ( query, fn ) {
 	return this.req.get( '/freshly-pressed', query, fn );
-};
-
-// Expose send-request
-// TODO: use `this.req` instead of this method
-WPCOM.prototype.sendRequest = function ( params, query, body, fn ) {
-	const msg = 'WARN! Don use `sendRequest() anymore. Use `this.req` method.';
-
-	/* eslint-disable no-console */
-	if ( console && console.warn ) {
-		console.warn( msg );
-	} else {
-		console.log( msg );
-	}
-	/* eslint-enable no-console */
-
-	return sendRequest.call( this, params, query, body, fn );
 };
 
 /**

--- a/packages/wpcom.js/src/lib/util/request.js
+++ b/packages/wpcom.js/src/lib/util/request.js
@@ -29,15 +29,24 @@ Req.prototype.get = function ( params, query, fn ) {
  * Make `update` request
  * @param {Object | string} params
  * @param {Object} [query] - query object parameter
- * @param {Object} body - body object parameter
+ * @param {Object} [body] - body object parameter
  * @param {Function} fn - callback function
  */
 Req.prototype.post = Req.prototype.put = function ( params, query, body, fn ) {
 	if ( undefined === fn ) {
 		if ( undefined === body ) {
-			body = query;
-			query = {};
+			if ( 'function' === typeof query ) {
+				// post( params, fn )
+				fn = query;
+				body = null;
+				query = {};
+			} else {
+				// post( params, body )
+				body = query;
+				query = {};
+			}
 		} else if ( 'function' === typeof body ) {
+			// post( params, body, fn )
 			fn = body;
 			body = query;
 			query = {};

--- a/packages/wpcom.js/src/lib/util/send-request.js
+++ b/packages/wpcom.js/src/lib/util/send-request.js
@@ -42,7 +42,11 @@ export default function sendRequest( params, query, body, fn ) {
 		params.apiVersion = query.apiVersion;
 		debug( 'apiVersion: %o', params.apiVersion );
 		delete query.apiVersion;
-	} else {
+	}
+
+	// Set default value of `params.apiVersion` if it wasn't specified. This WPCOM client uses `1.1` as the default,
+	// while the REST proxy itself will default to `1` if the client doesn't specify an explicit `apiVersion`.
+	if ( ! params.apiVersion ) {
 		params.apiVersion = this.apiVersion;
 	}
 

--- a/packages/wpcom.js/src/lib/util/send-request.js
+++ b/packages/wpcom.js/src/lib/util/send-request.js
@@ -7,8 +7,8 @@ const debug_res = debugFactory( 'wpcom:send-request:res' );
 /**
  * Request to WordPress REST API
  * @param {string | Object} params - params object
- * @param {Object} [query] - query object parameter
- * @param {Object} [body] - body object parameter
+ * @param {Object} query - query object parameter
+ * @param {Object} body - body object parameter
  * @param {Function} fn - callback function
  * @returns {Function} request handler
  */
@@ -20,18 +20,6 @@ export default function sendRequest( params, query, body, fn ) {
 
 	// set `method` request param
 	params.method = ( params.method || 'get' ).toUpperCase();
-
-	// `query` is optional
-	if ( 'function' === typeof query ) {
-		fn = query;
-		query = {};
-	}
-
-	// `body` is optional
-	if ( 'function' === typeof body ) {
-		fn = body;
-		body = null;
-	}
 
 	// query could be `null`
 	query = query || {};
@@ -65,10 +53,7 @@ export default function sendRequest( params, query, body, fn ) {
 	}
 
 	// Stringify query object before to send
-	query = qs.stringify( query, { arrayFormat: 'brackets' } );
-
-	// pass `query` and/or `body` to request params
-	params.query = query;
+	params.query = qs.stringify( query, { arrayFormat: 'brackets' } );
 
 	if ( body ) {
 		params.body = body;


### PR DESCRIPTION
Fixes a bug described in https://github.com/Automattic/wp-calypso/pull/102816#discussion_r2063157068: the `apiVersion` param cannot be in `wp.req.get` first argument (`params`) where it naturally belongs:
```js
wp.req.get( { path: '/me/sites', apiVersion: '1.2' } ) // will use 1.1 instead!
```
but it must be in the second (`query`) argument, where it's just a compatibility quirk, mixed with the "real" query params:
```js
wp.req.get( '/me/sites', { apiVersion: '1.2' } )
```

This PR fixes that by fixing the code that assigns the default value (`this.apiVersion` which is `"1.1"`).

There's a second commit that removes unused code from `sendRequest`. `sendRequest` is an internal helper that's always called with all four arguments:
```js
sendRequest( params, query, body, fn );
```
Therefore we don't need the code that supports the alternative forms with missing arguments like:
```js
sendRequest( params, fn );
```
or
```js
sendRequest( params, query, fn );
```

## Testing instructions:
Find some REST request (`/me/sites` in the hosting dashboard is ideal) and rewrite it to the `params` form:
```js
wp.req.get( { path: '/me/sites', apiVersion: '1.2' }, { site_visibility: 'all', /* other query params */ } );
```
Verify that before this PR it didn't work (`1.1` is used, i.e., `/rest/v1.1/me/sites`). And that after this PR it's fixed, i.e., there is `/rest/v1.2` in the path.