### PR TITLE
Replace view site link with the frontend

### DIFF
--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -36,8 +36,11 @@ export class DoneButton extends PureComponent {
 			action: customizeSiteVariant ? 'customize-site' : 'view-site',
 		} );
 
-		const destination = customizeSiteVariant ? '/customize/' + ( siteSlug || '' ) : URL;
-		page( destination );
+		if ( customizeSiteVariant ) {
+			page( '/customize/' + ( siteSlug || '' ) );
+		} else {
+			window.open( URL, '_blank' );
+		}
 	};
 
 	componentWillUnmount() {

--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -25,7 +25,7 @@ export class DoneButton extends PureComponent {
 	handleClick = () => {
 		const {
 			importerStatus: { type },
-			site: { ID: siteId },
+			site: { ID: siteId, URL },
 			siteSlug,
 			customizeSiteVariant,
 		} = this.props;
@@ -36,9 +36,7 @@ export class DoneButton extends PureComponent {
 			action: customizeSiteVariant ? 'customize-site' : 'view-site',
 		} );
 
-		const destination = customizeSiteVariant
-			? '/customize/' + ( siteSlug || '' )
-			: '/view/' + ( siteSlug || '' );
+		const destination = customizeSiteVariant ? '/customize/' + ( siteSlug || '' ) : URL;
 		page( destination );
 	};
 


### PR DESCRIPTION
Related #102821 

## Proposed Changes

We've recently removed the access to the `/view` pages from the admin but there are still some small remaining links, mostly at the end of import success flows. 

This PR removes one link to the view page at the end of the import flow in the Admin. Instead of redirecting the "view site" link to the /view page, we can just show the frontend.

## Testing Instructions

- Open wp-admin
- Go to the import page under tools
- Import anything (exported xml works)
- Check the "view site" link on the "success panel".
 