### PR TITLE
Happy Blocks: New content footer for /support

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -12,6 +12,35 @@ if ( ! isset( $args ) ) {
 }
 
 $site_type = isset( $args['site_type'] ) ? $args['site_type'] : '';
+$current_page_slug = isset( $args['current_page_slug'] ) ? $args['current_page_slug'] : '';
+
+if ( 'support_lp_2025' === $current_page_slug ) {
+	?>
+		<div class="happy-blocks-new-support-content-footer">
+			<h2 class="support-footer__heading"><?php esc_html_e( 'Couldn\'t find what you needed?', 'happy-blocks' ); ?></h2>
+			<div class="support-content-resources">
+				<div class="support-content-resource">
+					<div class="support-footer__icon-wrapper">
+					<svg class="support-footer__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+						<path d="M18 4H6C4.9 4 4 4.9 4 6V18.9C4 19.5 4.5 20 5.1 20C5.4 20 5.6 19.9 5.9 19.7L8.5 17H18C19.1 17 20 16.1 20 15V6C20 4.9 19.1 4 18 4ZM18.5 15C18.5 15.3 18.3 15.5 18 15.5H7.9L5.5 17.9V6C5.5 5.7 5.7 5.5 6 5.5H18C18.3 5.5 18.5 5.7 18.5 6V15Z" fill="white"/>
+					</svg>
+					</div>
+					<h3 class="support-footer__card-title"><?php esc_html_e( 'Contact us', 'happy-blocks' ); ?></h3>
+					<p class="support-footer__card-description"><?php esc_html_e( 'Get answers from our AI assistant, with access to 24/7 expert human support on paid plans.', 'happy-blocks' ); ?></p>
+				</div>
+				<div class="support-content-resource">
+					<div class="support-footer__icon-wrapper">
+						<svg class="support-footer__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M15.5 9.5C15.7652 9.5 16.0196 9.39464 16.2071 9.20711C16.3946 9.01957 16.5 8.76522 16.5 8.5C16.5 8.23478 16.3946 7.98043 16.2071 7.79289C16.0196 7.60536 15.7652 7.5 15.5 7.5C15.2348 7.5 14.9804 7.60536 14.7929 7.79289C14.6054 7.98043 14.5 8.23478 14.5 8.5C14.5 8.76522 14.6054 9.01957 14.7929 9.20711C14.9804 9.39464 15.2348 9.5 15.5 9.5ZM15.5 11C16.163 11 16.7989 10.7366 17.2678 10.2678C17.7366 9.79893 18 9.16304 18 8.5C18 7.83696 17.7366 7.20107 17.2678 6.73223C16.7989 6.26339 16.163 6 15.5 6C14.837 6 14.2011 6.26339 13.7322 6.73223C13.2634 7.20107 13 7.83696 13 8.5C13 9.16304 13.2634 9.79893 13.7322 10.2678C14.2011 10.7366 14.837 11 15.5 11ZM13.25 17V15C13.25 14.2707 12.9603 13.5712 12.4445 13.0555C11.9288 12.5397 11.2293 12.25 10.5 12.25H6.5C5.77065 12.25 5.07118 12.5397 4.55546 13.0555C4.03973 13.5712 3.75 14.2707 3.75 15V17H5.25V15C5.25 14.31 5.81 13.75 6.5 13.75H10.5C11.19 13.75 11.75 14.31 11.75 15V17H13.25ZM20.25 15V17H18.75V15C18.75 14.31 18.19 13.75 17.5 13.75H15V12.25H17.5C18.2293 12.25 18.9288 12.5397 19.4445 13.0555C19.9603 13.5712 20.25 14.2707 20.25 15ZM9.5 8.5C9.5 8.76522 9.39464 9.01957 9.20711 9.20711C9.01957 9.39464 8.76522 9.5 8.5 9.5C8.23478 9.5 7.98043 9.39464 7.79289 9.20711C7.60536 9.01957 7.5 8.76522 7.5 8.5C7.5 8.23478 7.60536 7.98043 7.79289 7.79289C7.98043 7.60536 8.23478 7.5 8.5 7.5C8.76522 7.5 9.01957 7.60536 9.20711 7.79289C9.39464 7.98043 9.5 8.23478 9.5 8.5ZM11 8.5C11 9.16304 10.7366 9.79893 10.2678 10.2678C9.79893 10.7366 9.16304 11 8.5 11C7.83696 11 7.20107 10.7366 6.73223 10.2678C6.26339 9.79893 6 9.16304 6 8.5C6 7.83696 6.26339 7.20107 6.73223 6.73223C7.20107 6.26339 7.83696 6 8.5 6C9.16304 6 9.79893 6.26339 10.2678 6.73223C10.7366 7.20107 11 7.83696 11 8.5Z" fill="white"/>
+						</svg>
+					</div>
+					<h3 class="support-footer__card-title"><?php esc_html_e( 'Ask a question in our forum', 'happy-blocks' ); ?></h3>
+					<p class="support-footer__card-description"><?php esc_html_e( 'Browse questions and get answers from other experienced users.', 'happy-blocks' ); ?></p>
+				</div>
+			</div>
+		</div>
+	<?php
+} else {
 
 //phpcs:ignore WPCOM.I18nRules.LocalizedUrl.LocalizedUrlAssignedToVariable
 $subscribe_block = '[wpcom_guides_learn_button is_unsubscribed_caption="' . __( 'Subscribe now!', 'happy-blocks' ) . '" is_subscribed_caption="' . __( 'Unsubscribe', 'happy-blocks' ) . '" busy_caption="' . __( 'Just a moment...', 'happy-blocks' ) . '"]';
@@ -111,4 +140,6 @@ $signup_url      = localized_wpcom_url( 'https://wordpress.com/log-in?redirect_t
 			</p>
 		</div>
 	</div>
-</div>
+	</div>
+	<?php
+}

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -1,11 +1,82 @@
-@import "@automattic/calypso-color-schemes";
+@import '@automattic/calypso-color-schemes';
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
 $search-icon: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"%3E%3Cpath d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3Cpath d="M17.5 17.5L13.875 13.875" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E';
-$system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
-	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+$system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI', 'Roboto',
+	'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$recoleta-font-family: 'Recoleta', serif;
+
+.happy-blocks-new-support-content-footer {
+	padding: 64px 96px;
+
+	@media ( max-width: $breakpoint-mobile ) {
+		padding: 32px 16px;
+	}
+
+	.support-footer__heading {
+		font-family: var( --wp--preset--font-family--recoleta );
+		font-size: 2.25rem;
+		margin-bottom: 24px;
+
+		@media ( max-width: $breakpoint-mobile ) {
+			font-size: 1.5rem;
+		}
+	}
+
+	.support-content-resources {
+		display: flex;
+		gap: 18px;
+
+		@media ( max-width: $breakpoint-mobile ) {
+			flex-direction: column;
+		}
+
+		.support-content-resource {
+			background-color: var( --studio-blue-5, #f7f8fe );
+			border-radius: 4px;
+			padding: 40px;
+			flex: 1;
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
+
+			@media ( max-width: $breakpoint-mobile ) {
+				padding: 24px;
+			}
+		}
+
+		.support-footer__icon-wrapper {
+			background-color: var( --studio-blue-50, #3858e9 );
+			border-radius: 50%;
+			padding: 8px;
+			margin-bottom: 24px;
+			display: inline-flex;
+		}
+
+		.support-footer__card-title {
+			font-size: 1.25rem;
+			margin-top: 0;
+			margin-bottom: 8px;
+
+			@media ( max-width: $breakpoint-mobile ) {
+				font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+			}
+		}
+
+		.support-footer__card-description {
+			font-size: 1rem;
+			color: var( --studio-gray-50, #646970 );
+			line-height: 24px;
+			margin: 0;
+
+			@media ( max-width: $breakpoint-mobile ) {
+				font-size: 0.875rem;
+			}
+		}
+	}
+}
 
 .happy-blocks-support-content-footer {
 	max-width: none !important;
@@ -24,10 +95,10 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		margin-bottom: 0;
 	}
 
-	>* {
+	> * {
 		margin-left: auto !important;
 		margin-right: auto !important;
-		max-width: var(--wp--style--global--wide-size);
+		max-width: var( --wp--style--global--wide-size );
 	}
 
 	.support-content-resources {
@@ -40,13 +111,13 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			min-width: 0;
 			overflow-wrap: break-word;
 			word-break: break-word;
-			border-bottom: 1px solid var(--studio-gray-0);
+			border-bottom: 1px solid var( --studio-gray-0 );
 			padding: 0 16px 32px 0;
 			font-size: 1.25rem;
 		}
 
 		p {
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 			margin-top: 16px;
 			margin-bottom: 28px;
 		}
@@ -58,10 +129,10 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 	.support-content-resource__title {
 		margin-top: 0;
-		font-family: var(--wp--preset--font-family--system-font);
+		font-family: var( --wp--preset--font-family--system-font );
 	}
 
-	@media (min-width: $breakpoint-mobile) {
+	@media ( min-width: $breakpoint-mobile ) {
 		.support-content-resource {
 			flex-basis: 0;
 			flex-grow: 1;
@@ -91,9 +162,8 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			margin-top: 0;
 		}
 
-
 		.support-content-subscribe-disclaimer {
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 			font-size: 0.75rem;
 			line-height: 20px;
 
@@ -126,7 +196,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 				}
 			}
 
-			@media screen and (max-width: 782px) {
+			@media screen and ( max-width: 782px ) {
 				flex-direction: column;
 				align-items: flex-start;
 
@@ -137,7 +207,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		}
 	}
 
-	@media (max-width: $breakpoint-mobile) {
+	@media ( max-width: $breakpoint-mobile ) {
 		padding: 12px 24px !important;
 
 		h4 {
@@ -161,7 +231,6 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 				.resource-link {
 					line-height: 20px;
 				}
-
 
 				p {
 					margin-top: 4px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 156305-ghe-Automattic/wpcom-a8c-themes

## Proposed Changes

*   Adds a new variation of the support content footer block pattern (`happy-blocks/support-content-footer`).
*   This new variation is displayed specifically when the `$current_page_slug` argument passed to the pattern is `'support_lp_2025'`.

![image](https://github.com/user-attachments/assets/6500588b-97eb-4bbd-a613-f00d233d33ca)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*   To provide a distinct footer experience for the 2025 support landing page, potentially highlighting different support resources (Contact Us, Forum).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1.  Navigate to wordpress.com/support/support_lp_2025/ and sandbox 156305-ghe-Automattic/wpcom-a8c-themes
2.  Verify that the new footer design (with "Contact us" and "Ask a question in our forum" cards) is displayed.
3.  Check the RgA5dOmf6lXrC75C8yro6Q-fi-470_9471 and layout against the design specifications.
4.  Verify that the original footer design (with "Go further", "Join the forum", etc.) is displayed correctly in /support.
5.  Test responsiveness if applicable.