### PR TITLE
Plans Grid: Only show available plans to Big Sky free trial sites

### DIFF
--- a/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
+++ b/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
@@ -1,13 +1,4 @@
-import {
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_MONTHLY,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_BUSINESS_3_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_MONTHLY,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PREMIUM_3_YEARS,
-} from '@automattic/calypso-products';
+import { isBigSkySupportedPlan } from '@automattic/calypso-products';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentPlan } from '.';
 import type { AppState } from 'calypso/types';
@@ -26,22 +17,11 @@ export default function isSiteBigSkyTrial( state: AppState, siteId: number ) {
 	}
 
 	const currentPlan = getCurrentPlan( state, siteId );
-	const bigSkyPlans = [
-		PLAN_BUSINESS,
-		PLAN_BUSINESS_MONTHLY,
-		PLAN_BUSINESS_2_YEARS,
-		PLAN_BUSINESS_3_YEARS,
-		PLAN_PREMIUM,
-		PLAN_PREMIUM_MONTHLY,
-		PLAN_PREMIUM_2_YEARS,
-		PLAN_PREMIUM_3_YEARS,
-	];
-
 	const productSlug = currentPlan?.productSlug || site?.plan?.product_slug;
 
 	if ( ! productSlug ) {
 		return true;
 	}
 
-	return ! bigSkyPlans.includes( productSlug );
+	return ! isBigSkySupportedPlan( productSlug );
 }

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -375,6 +375,13 @@ export function is100YearPlan( planSlug: string ): boolean {
 	return planMatches( planSlug, { type: TYPE_100_YEAR } );
 }
 
+export function isBigSkySupportedPlan( planSlug: string ): boolean {
+	return (
+		planMatches( planSlug, { type: TYPE_BUSINESS } ) ||
+		planMatches( planSlug, { type: TYPE_PREMIUM } )
+	);
+}
+
 // Checks if it is an Enterprise plan (a.k.a VIP), introduced as part of pdgrnI-1Qp-p2.
 // This is not a real plan, but added to display Enterprise in the pricing grid.
 export function isWpcomEnterpriseGridPlan( planSlug: string ): boolean {

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -23,6 +23,7 @@ import {
 	isPremiumPlan,
 	isFreePlan,
 	isPersonalPlan,
+	isBigSkySupportedPlan,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { isSamePlan } from '../../lib/is-same-plan';
@@ -62,6 +63,13 @@ const isGridPlanVisible = ( {
 	selectedPlan?: PlanSlug;
 } ): boolean => {
 	let isVisible = planSlugsForIntent.includes( planSlug );
+
+	// TODO: actually check if the site is a big sky trial
+	const isBigSkyTrial = true;
+
+	if ( isBigSkyTrial ) {
+		isVisible = isBigSkySupportedPlan( planSlug );
+	}
 
 	if ( isDisplayingPlansNeededForFeature && selectedPlan ) {
 		if ( isEcommercePlan( selectedPlan ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes [BSKY-395](https://linear.app/a8c/issue/BSKY-395/prevent-users-from-buying-personalcommerce-plans-on-big-sky-sites)

## Proposed Changes

Only show relevant plans to Big Sky free trial sites in all plans grids. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Free trial sites support Premium and Business type plans. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up a free trial site at wordpress.com/ai
- Go to every place that has a plan grid. You should only see Premium and Business. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
