### PR TITLE
Stepper: remove all goNext props where skip is hidden

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -338,12 +338,10 @@ const DomainsStep: Step< {
 			isWideLayout
 			hideBack={ shouldHideBackButton() }
 			backLabelText={ getBackLabelText() }
-			hideSkip
 			flowName={ flow as string }
 			stepContent={ <div className="domains__content">{ renderContent() }</div> }
 			recordTracksEvent={ recordTracksEvent }
 			goBack={ () => handleGoBack( goBack ) }
-			goNext={ () => submit?.( undefined ) }
 			formattedHeader={
 				<FormattedHeader
 					id="domains-header"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -17,8 +17,7 @@ const WarningsOrHoldsSection = styled.div`
 	margin-top: 40px;
 `;
 
-const ErrorStep: StepType = function ErrorStep( { navigation, flow, variantSlug } ) {
-	const { goBack, goNext } = navigation;
+const ErrorStep: StepType = function ErrorStep( { flow, variantSlug } ) {
 	const { __ } = useI18n();
 	const siteDomains = useSiteDomains();
 	const { error, message } = useSiteSetupError();
@@ -83,8 +82,6 @@ const ErrorStep: StepType = function ErrorStep( { navigation, flow, variantSlug 
 	return (
 		<StepContainer
 			stepName="error-step"
-			goBack={ goBack }
-			goNext={ goNext }
 			isHorizontalLayout={ false }
 			formattedHeader={
 				<>
@@ -94,9 +91,6 @@ const ErrorStep: StepType = function ErrorStep( { navigation, flow, variantSlug 
 			}
 			stepContent={ getContent() }
 			recordTracksEvent={ recordTracksEvent }
-			hideBack
-			hideSkip
-			hideNext
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -28,10 +28,8 @@ export const ImportWrapper: Step< {
 				stepName={ stepName || 'import-step' }
 				flowName="importer"
 				className="import__onboarding-page"
-				hideSkip
 				hideFormattedHeader
 				goBack={ navigation.goBack }
-				goNext={ navigation.goNext }
 				skipLabelText={ __( "I don't have a site address" ) }
 				isFullLayout
 				stepContent={ children as ReactElement }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-already-wpcom/index.tsx
@@ -68,9 +68,7 @@ const SiteMigrationAlreadyWPCOM: StepType = ( { stepName, flow, navigation } ) =
 			<StepContainer
 				stepName={ stepName }
 				flowName={ flow }
-				hideSkip
 				goBack={ navigation?.goBack }
-				goNext={ navigation?.submit }
 				formattedHeader={
 					<FormattedHeader
 						subHeaderAs="div"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -167,8 +167,6 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 				stepName="site-migration-application-password-authorization"
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
-				goNext={ () => navigation?.submit?.( undefined ) }
-				hideSkip
 				notice={ notice }
 				formattedHeader={ formattedHeader }
 				stepContent={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/index.tsx
@@ -175,8 +175,6 @@ const SiteMigrationCredentials: StepType< {
 				stepName="site-migration-credentials"
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
-				goNext={ () => navigation?.submit?.( undefined ) }
-				hideSkip
 				isFullLayout
 				formattedHeader={
 					<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-fallback-credentials/index.tsx
@@ -67,8 +67,6 @@ const SiteMigrationFallbackCredentials: StepType< {
 				stepName="site-migration-fallback-credentials"
 				flowName="site-migration"
 				goBack={ navigation?.goBack }
-				goNext={ () => navigation?.submit?.( undefined ) }
-				hideSkip
 				isFullLayout
 				formattedHeader={
 					<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/index.tsx
@@ -240,10 +240,8 @@ const SiteMigrationIdentify: StepType< {
 				className="import__onboarding-page"
 				hideBack={ ! shouldShowBackButton() }
 				backUrl={ urlQueryParams.get( 'back_to' ) || undefined }
-				hideSkip
 				hideFormattedHeader
 				goBack={ navigation?.goBack }
-				goNext={ () => navigation?.submit?.( undefined ) }
 				isFullLayout
 				stepContent={
 					<div className="import__capture-wrapper">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-other-platform-detected-import/index.tsx
@@ -118,8 +118,6 @@ const SiteMigrationOtherPlatform: StepType< {
 			<StepContainer
 				stepName="site-migration-other-platform"
 				goBack={ navigation?.goBack }
-				goNext={ navigation?.submit }
-				hideSkip
 				isFullLayout
 				formattedHeader={
 					isAnalyzingUrl ? (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/index.tsx
@@ -32,7 +32,7 @@ const SiteOptions: Step< {
 		[]
 	);
 
-	const { goBack, goNext, submit } = navigation;
+	const { goBack, submit } = navigation;
 	const [ siteTitle, setSiteTitle ] = React.useState( currentSiteTitle ?? '' );
 	const [ tagline, setTagline ] = React.useState( currentTagline ?? '' );
 	const [ formTouched, setFormTouched ] = React.useState( false );
@@ -166,9 +166,7 @@ const SiteOptions: Step< {
 				shouldHideNavButtons={ false }
 				className={ `is-step-${ intent }` }
 				headerImageUrl={ headerImage }
-				hideSkip
 				goBack={ goBack }
-				goNext={ goNext }
 				isHorizontalLayout
 				formattedHeader={
 					<FormattedHeader id="site-options-header" headerText={ headerText } align="left" />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -103,8 +103,6 @@ const SitePickerStep: Step< {
 				stepName="site-picker"
 				hideBack
 				goBack={ navigation.goBack }
-				hideSkip
-				goNext={ createNewSite }
 				stepContent={
 					<SitePicker
 						page={ page }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -48,7 +48,7 @@ const CityZipRow = styled.div`
 `;
 
 const StoreAddress: Step = function StoreAddress( { navigation } ) {
-	const { goBack, goNext, submit } = navigation;
+	const { goBack, submit } = navigation;
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
@@ -310,7 +310,6 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 		<StepContainer
 			stepName="store-address"
 			className={ `is-step-${ intent }` }
-			goNext={ goNext }
 			goBack={ goBack }
 			isHorizontalLayout
 			formattedHeader={
@@ -326,7 +325,6 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 			intent={ intent }
 			stepContent={ getContent() }
 			recordTracksEvent={ recordTracksEvent }
-			hideSkip
 			hideBack={ ! comingFromThemeActivation }
 		/>
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/102103

## Proposed Changes

`goNext` and `hideSkip` together don't make sense. Since `goNext` is called when `skip` is called. This remove all goNext handlers when `handleSkip` is set to true.

## Why are these changes being made?
To make https://github.com/Automattic/wp-calypso/pull/102103 easier to test and review.

## Testing Instructions

Green TS and passing tests should be enough.
