### PR TITLE
Support grid card resizing

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -12,3 +12,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Customizable columns, spacing, and row height
 - Support for automated responsive layout by specifying minimum column widths
 - Support for drag-and-drop reordering of grid items
+- Suppoer for resizing grid items

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -47,7 +47,7 @@ The main component exported by this package.
 - `columns` (required): Total number of columns in the grid
 - `className` (optional): Additional CSS class to apply to the grid container
 - `spacing` (optional): Grid gap multiplier size, defaults to 2 (e.g. A spacing of 2 results in a gap of 8px, it's multiplied by 4)
-- `rowHeight` (optional): Height of each row (e.g., "50px", "auto")
+- `rowHeight` (optional): Height of each row in pixels or auto (e.g., 50, "auto")
 - `minColumnWidth` (optional): Minimum width in pixels for each column; when provided, enables responsive mode that automatically adjusts columns based on container width
 
 ## Standard vs. Responsive Mode

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -36,7 +36,7 @@ export function GridItem( {
 		gridRowEnd: `span ${ item.height || 1 }`,
 		cursor: disabled ? 'default' : dragCursor,
 		position: 'relative' as const,
-		zIndex: isDragging ? 1 : undefined,
+		zIndex: isDragging ? 2 : undefined,
 	};
 
 	// Inner content style with scaling effect
@@ -72,7 +72,7 @@ export function GridItem( {
 				border: '2px dashed var(--wp-admin-theme-color, #0087be)',
 				background: 'rgba(0, 135, 190, 0.1)',
 				pointerEvents: 'none',
-				zIndex: 10,
+				zIndex: 1,
 			} }
 		/>
 	) : null;

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -36,6 +36,18 @@ export function GridItem( {
 		gridRowEnd: `span ${ item.height || 1 }`,
 		cursor: disabled ? 'default' : dragCursor,
 		position: 'relative' as const,
+		zIndex: isDragging ? 1 : undefined,
+	};
+
+	// Inner content style with scaling effect
+	// The reason we need a separate "content" div is because the scaling animation
+	// impacts the computation done by useSortable if they're applied to the same div.
+	const contentStyle = {
+		position: 'relative' as const,
+		transition: 'transform 200ms ease, box-shadow 200ms ease',
+		transform: isDragging ? 'scale(1.05)' : undefined,
+		boxShadow: isDragging ? '0 5px 10px rgba(0,0,0,0.15)' : undefined,
+		height: '100%',
 	};
 
 	const handleResize = ( delta: { width: number; height: number } ) => {
@@ -67,14 +79,16 @@ export function GridItem( {
 
 	return (
 		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
-			{ children }
+			<div style={ contentStyle }>
+				{ children }
+				<ResizeHandle
+					disabled={ disabled }
+					itemId={ item.key }
+					onResize={ handleResize }
+					onResizeEnd={ handleResizeEnd }
+				/>
+			</div>
 			{ previewOverlay }
-			<ResizeHandle
-				disabled={ disabled }
-				itemId={ item.key }
-				onResize={ handleResize }
-				onResizeEnd={ handleResizeEnd }
-			/>
 		</div>
 	);
 }

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -1,0 +1,80 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useState } from 'react';
+import ResizeHandle from './resize-handle';
+import type { GridLayoutItem } from './types';
+
+export function GridItem( {
+	item,
+	maxColumns,
+	disabled = false,
+	children,
+	onResize,
+	onResizeEnd,
+}: {
+	item: GridLayoutItem;
+	maxColumns: number;
+	disabled?: boolean;
+	children: React.ReactNode;
+	onResize: ( delta: { width: number; height: number } ) => void;
+	onResizeEnd: () => void;
+} ) {
+	const [ previewDelta, setPreviewDelta ] = useState< { width: number; height: number } | null >(
+		null
+	);
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable( {
+		id: item.key,
+		disabled,
+	} );
+	const dragCursor = isDragging ? 'grabbing' : 'grab';
+	const style = {
+		transform: CSS.Translate.toString( transform ),
+		transition,
+		gridColumnEnd: `span ${
+			item.fullWidth ? maxColumns : Math.min( item.width ?? 1, maxColumns )
+		}`,
+		gridRowEnd: `span ${ item.height || 1 }`,
+		cursor: disabled ? 'default' : dragCursor,
+		position: 'relative' as const,
+	};
+
+	const handleResize = ( delta: { width: number; height: number } ) => {
+		setPreviewDelta( delta );
+		onResize( delta );
+	};
+
+	const handleResizeEnd = () => {
+		setPreviewDelta( null );
+		onResizeEnd();
+	};
+
+	// Preview overlay element (rendered directly in the GridItem)
+	const previewOverlay = previewDelta ? (
+		<div
+			style={ {
+				position: 'absolute',
+				top: 0,
+				left: 0,
+				right: -previewDelta.width,
+				bottom: -previewDelta.height,
+				border: '2px dashed var(--wp-admin-theme-color, #0087be)',
+				background: 'rgba(0, 135, 190, 0.1)',
+				pointerEvents: 'none',
+				zIndex: 10,
+			} }
+		/>
+	) : null;
+
+	return (
+		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
+			{ children }
+			{ previewOverlay }
+			<ResizeHandle
+				disabled={ disabled }
+				itemId={ item.key }
+				onResize={ handleResize }
+				onResizeEnd={ handleResizeEnd }
+			/>
+		</div>
+	);
+}

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -8,6 +8,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { useResizeObserver } from '@wordpress/compose';
 import { useMemo, Children, isValidElement, useState } from 'react';
+import ResizeHandle from './resize-handle';
 import type { GridLayoutItem, GridProps } from './types';
 import type { DragOverEvent } from '@dnd-kit/core';
 
@@ -35,11 +36,13 @@ export function GridItem( {
 		}`,
 		gridRowEnd: `span ${ item.height || 1 }`,
 		cursor: disabled ? 'default' : dragCursor,
+		position: 'relative' as const,
 	};
 
 	return (
 		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
 			{ children }
+			<ResizeHandle disabled={ disabled } />
 		</div>
 	);
 }

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,6 +1,6 @@
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
-import { useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver, useDebounce, useEvent } from '@wordpress/compose';
 import { useMemo, Children, isValidElement, useState } from 'react';
 import { GridItem } from './grid-item';
 import type { GridLayoutItem, GridProps } from './types';
@@ -80,7 +80,7 @@ export function Grid( {
 		} )
 	);
 
-	function handleDragOver( event: DragOverEvent ) {
+	const handleDragOver = useEvent( ( event: DragOverEvent ) => {
 		const { active, over } = event;
 
 		if ( over && active && active.id !== over.id ) {
@@ -96,7 +96,8 @@ export function Grid( {
 			} );
 			setTemporaryLayout( updatedLayout );
 		}
-	}
+	} );
+	const debouncedHandleDragOver = useDebounce( handleDragOver, 100 );
 
 	function persistTemporaryLayout() {
 		if ( ! onChangeLayout || ! temporaryLayout ) {
@@ -139,8 +140,11 @@ export function Grid( {
 	return (
 		<DndContext
 			sensors={ sensors }
-			onDragOver={ handleDragOver }
-			onDragEnd={ persistTemporaryLayout }
+			onDragOver={ debouncedHandleDragOver }
+			onDragEnd={ () => {
+				debouncedHandleDragOver.flush();
+				persistTemporaryLayout();
+			} }
 		>
 			<SortableContext items={ items } strategy={ () => null }>
 				<div

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -10,7 +10,6 @@ import { useResizeObserver } from '@wordpress/compose';
 import { useMemo, Children, isValidElement, useState } from 'react';
 import type { GridLayoutItem, GridProps } from './types';
 import type { DragOverEvent } from '@dnd-kit/core';
-import type { Transform } from '@dnd-kit/utilities';
 
 export function GridItem( {
 	item,
@@ -27,20 +26,15 @@ export function GridItem( {
 		id: item.key,
 		disabled,
 	} );
-	const ignoreScaleTransform: Transform = transform
-		? { ...transform }
-		: { x: 0, y: 0, scaleX: 1, scaleY: 1 };
-	ignoreScaleTransform.scaleX = 1;
-	ignoreScaleTransform.scaleY = 1;
-
+	const dragCursor = isDragging ? 'grabbing' : 'grab';
 	const style = {
-		transform: CSS.Transform.toString( ignoreScaleTransform ),
+		transform: CSS.Translate.toString( transform ),
 		transition,
 		gridColumnEnd: `span ${
 			item.fullWidth ? maxColumns : Math.min( item.width ?? 1, maxColumns )
 		}`,
 		gridRowEnd: `span ${ item.height || 1 }`,
-		cursor: isDragging ? 'grabbing' : 'grab',
+		cursor: disabled ? 'default' : dragCursor,
 	};
 
 	return (
@@ -61,13 +55,16 @@ export function Grid( {
 	editMode = false,
 	onChangeLayout,
 }: GridProps ) {
+	// Temporary layout to avoid updaing the layout while dragging
+	const [ temporaryLayout, setTemporaryLayout ] = useState< GridLayoutItem[] | undefined >(
+		layout
+	);
+	const activeLayout = temporaryLayout || layout;
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const resizeObserverRef = useResizeObserver( ( [ { contentRect } ] ) => {
 		setContainerWidth( contentRect.width );
 	} );
-
 	const gapPx = spacing * 4;
-
 	const effectiveColumns = useMemo( () => {
 		if ( ! minColumnWidth ) {
 			return columns;
@@ -80,18 +77,17 @@ export function Grid( {
 
 	const layoutMap = useMemo( () => {
 		const map = new Map< string, GridLayoutItem >();
-		layout.forEach( ( item ) => map.set( item.key, item ) );
+		activeLayout.forEach( ( item ) => map.set( item.key, item ) );
 		return map;
-	}, [ layout ] );
+	}, [ activeLayout ] );
 
 	const items = useMemo(
 		() =>
-			[ ...layout ]
+			[ ...activeLayout ]
 				.sort( ( a, b ) => ( a.order ?? Infinity ) - ( b.order ?? Infinity ) )
 				.map( ( item ) => item.key ),
-		[ layout ]
+		[ activeLayout ]
 	);
-	const [ currentItems, setCurrentItems ] = useState( items );
 
 	const [ childrenMap, remaining ] = useMemo( () => {
 		const map = new Map< string, React.ReactElement >();
@@ -125,32 +121,32 @@ export function Grid( {
 		const { active, over } = event;
 
 		if ( over && active && active.id !== over.id ) {
-			const oldIndex = currentItems.indexOf( String( active.id ) );
-			const newIndex = currentItems.indexOf( String( over.id ) );
-			const updatedItems = arrayMove( currentItems, oldIndex, newIndex );
-			setCurrentItems( updatedItems );
+			const oldIndex = items.indexOf( String( active.id ) );
+			const newIndex = items.indexOf( String( over.id ) );
+			const updatedItems = arrayMove( items, oldIndex, newIndex );
+			const updatedLayout = layout.map( ( item ) => {
+				const newOrder = updatedItems.indexOf( item.key );
+				return {
+					...item,
+					order: newOrder,
+				};
+			} );
+			setTemporaryLayout( updatedLayout );
 		}
 	}
 
 	function handleDragEnd() {
-		if ( currentItems === items ) {
+		if ( ! onChangeLayout || ! temporaryLayout ) {
 			return;
 		}
-		const updatedLayout = layout.map( ( item ) => {
-			const newOrder = currentItems.indexOf( item.key );
-			return {
-				...item,
-				order: newOrder,
-			};
-		} );
-		if ( onChangeLayout ) {
-			onChangeLayout( updatedLayout );
-		}
+
+		onChangeLayout( temporaryLayout );
+		setTemporaryLayout( undefined );
 	}
 
 	return (
 		<DndContext sensors={ sensors } onDragOver={ handleDragOver } onDragEnd={ handleDragEnd }>
-			<SortableContext items={ currentItems } strategy={ () => null }>
+			<SortableContext items={ items } strategy={ () => null }>
 				<div
 					ref={ resizeObserverRef }
 					className={ className }
@@ -161,7 +157,7 @@ export function Grid( {
 						gap: gapPx,
 					} }
 				>
-					{ currentItems.map( ( id ) => (
+					{ items.map( ( id ) => (
 						<GridItem
 							key={ id }
 							item={ layoutMap.get( id ) as GridLayoutItem }

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -17,11 +17,15 @@ export function GridItem( {
 	maxColumns,
 	disabled = false,
 	children,
+	onResize,
+	onResizeEnd,
 }: {
 	item: GridLayoutItem;
 	maxColumns: number;
 	disabled?: boolean;
 	children: React.ReactNode;
+	onResize?: ( delta: { width: number; height: number } ) => void;
+	onResizeEnd: () => void;
 } ) {
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable( {
 		id: item.key,
@@ -42,7 +46,12 @@ export function GridItem( {
 	return (
 		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
 			{ children }
-			<ResizeHandle disabled={ disabled } />
+			<ResizeHandle
+				disabled={ disabled }
+				itemId={ item.key }
+				onResize={ onResize }
+				onResizeEnd={ onResizeEnd }
+			/>
 		</div>
 	);
 }
@@ -77,6 +86,7 @@ export function Grid( {
 		const maxColumns = Math.floor( ( containerWidth + gapPx ) / totalWidthPerColumn );
 		return Math.max( 1, maxColumns );
 	}, [ minColumnWidth, gapPx, containerWidth, columns ] );
+	const columnWidth = ( containerWidth - gapPx ) / effectiveColumns;
 
 	const layoutMap = useMemo( () => {
 		const map = new Map< string, GridLayoutItem >();
@@ -138,7 +148,7 @@ export function Grid( {
 		}
 	}
 
-	function handleDragEnd() {
+	function persistTemporaryLayout() {
 		if ( ! onChangeLayout || ! temporaryLayout ) {
 			return;
 		}
@@ -147,8 +157,41 @@ export function Grid( {
 		setTemporaryLayout( undefined );
 	}
 
+	function handleResize( id: string, delta: { width: number; height: number } ) {
+		if ( ! editMode ) {
+			return;
+		}
+
+		const relativeDelta = {
+			width: Math.round( delta.width / ( columnWidth + gapPx ) ),
+			height: rowHeight === 'auto' ? 0 : Math.round( delta.height / ( rowHeight + gapPx ) ),
+		};
+
+		if ( relativeDelta.width !== 0 || relativeDelta.height !== 0 ) {
+			// Update the temporary layout with the new size
+			const updatedLayout = activeLayout.map( ( item ) => {
+				if ( item.key === id ) {
+					return {
+						...item,
+						width: Math.max(
+							1,
+							Math.min( ( item.width ?? 1 ) + relativeDelta.width, effectiveColumns )
+						),
+						height: Math.max( 1, ( item.height ?? 1 ) + relativeDelta.height ),
+					};
+				}
+				return item;
+			} );
+			setTemporaryLayout( updatedLayout );
+		}
+	}
+
 	return (
-		<DndContext sensors={ sensors } onDragOver={ handleDragOver } onDragEnd={ handleDragEnd }>
+		<DndContext
+			sensors={ sensors }
+			onDragOver={ handleDragOver }
+			onDragEnd={ persistTemporaryLayout }
+		>
 			<SortableContext items={ items } strategy={ () => null }>
 				<div
 					ref={ resizeObserverRef }
@@ -166,6 +209,8 @@ export function Grid( {
 							item={ layoutMap.get( id ) as GridLayoutItem }
 							maxColumns={ effectiveColumns }
 							disabled={ ! editMode }
+							onResize={ ( delta ) => handleResize( id, delta ) }
+							onResizeEnd={ persistTemporaryLayout }
 						>
 							{ childrenMap.get( id ) }
 						</GridItem>

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,60 +1,10 @@
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
-import {
-	arrayMove,
-	SortableContext,
-	sortableKeyboardCoordinates,
-	useSortable,
-} from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
+import { arrayMove, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { useResizeObserver } from '@wordpress/compose';
 import { useMemo, Children, isValidElement, useState } from 'react';
-import ResizeHandle from './resize-handle';
+import { GridItem } from './grid-item';
 import type { GridLayoutItem, GridProps } from './types';
 import type { DragOverEvent } from '@dnd-kit/core';
-
-export function GridItem( {
-	item,
-	maxColumns,
-	disabled = false,
-	children,
-	onResize,
-	onResizeEnd,
-}: {
-	item: GridLayoutItem;
-	maxColumns: number;
-	disabled?: boolean;
-	children: React.ReactNode;
-	onResize?: ( delta: { width: number; height: number } ) => void;
-	onResizeEnd: () => void;
-} ) {
-	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable( {
-		id: item.key,
-		disabled,
-	} );
-	const dragCursor = isDragging ? 'grabbing' : 'grab';
-	const style = {
-		transform: CSS.Translate.toString( transform ),
-		transition,
-		gridColumnEnd: `span ${
-			item.fullWidth ? maxColumns : Math.min( item.width ?? 1, maxColumns )
-		}`,
-		gridRowEnd: `span ${ item.height || 1 }`,
-		cursor: disabled ? 'default' : dragCursor,
-		position: 'relative' as const,
-	};
-
-	return (
-		<div ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
-			{ children }
-			<ResizeHandle
-				disabled={ disabled }
-				itemId={ item.key }
-				onResize={ onResize }
-				onResizeEnd={ onResizeEnd }
-			/>
-		</div>
-	);
-}
 
 export function Grid( {
 	layout,

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -1,2 +1,3 @@
 export * from './grid';
+export * from './resize-handle';
 export * from './types';

--- a/packages/grid/src/resize-handle.tsx
+++ b/packages/grid/src/resize-handle.tsx
@@ -1,0 +1,36 @@
+import { DndContext, useDraggable } from '@dnd-kit/core';
+
+interface ResizeHandleProps {
+	disabled?: boolean;
+}
+
+function ResizeHandle( { disabled = false }: ResizeHandleProps ) {
+	const { attributes, listeners, setNodeRef, transform } = useDraggable( {
+		id: 'draggable',
+	} );
+
+	const resizeHandleStyle = {
+		position: 'absolute' as const,
+		bottom: '0',
+		right: '0',
+		width: '0',
+		height: '0',
+		cursor: 'nwse-resize',
+		borderStyle: 'solid',
+		borderWidth: '0 0 12px 12px',
+		borderColor: 'transparent transparent var(--wp-admin-theme-color, #0087be) transparent',
+		zIndex: 1,
+		display: disabled ? 'none' : 'block',
+		transform: transform ? `translate3d(${ transform.x }px, ${ transform.y }px, 0)` : undefined,
+	};
+
+	return <div ref={ setNodeRef } style={ resizeHandleStyle } { ...listeners } { ...attributes } />;
+}
+
+export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
+	return (
+		<DndContext>
+			<ResizeHandle { ...props } />
+		</DndContext>
+	);
+}

--- a/packages/grid/src/resize-handle.tsx
+++ b/packages/grid/src/resize-handle.tsx
@@ -34,9 +34,10 @@ function ResizeHandle( { disabled = false, itemId }: ResizeHandleProps ) {
 
 export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 	const initialAnchorPosition = useRef< DOMRect | null >( null );
+
 	// Throttle the resize event to avoid excessive calls
-	// and improve performance during drag operations and drag and scroll behavior.
-	const throttleDelay = 100;
+	// and improve performance during drag operations
+	const throttleDelay = 60;
 	const throttledResize = useThrottle( ( delta: { width: number; height: number } ) => {
 		if ( props.onResize ) {
 			props.onResize( delta );

--- a/packages/grid/src/resize-handle.tsx
+++ b/packages/grid/src/resize-handle.tsx
@@ -1,12 +1,17 @@
-import { DndContext, useDraggable } from '@dnd-kit/core';
+import { DndContext, DragMoveEvent, useDraggable } from '@dnd-kit/core';
+import { useRef } from 'react';
 
 interface ResizeHandleProps {
 	disabled?: boolean;
+	itemId?: string;
+	onResize?: ( delta: { width: number; height: number } ) => void;
+	onResizeEnd?: () => void;
 }
 
-function ResizeHandle( { disabled = false }: ResizeHandleProps ) {
-	const { attributes, listeners, setNodeRef, transform } = useDraggable( {
+function ResizeHandle( { disabled = false, itemId }: ResizeHandleProps ) {
+	const { attributes, listeners, setNodeRef } = useDraggable( {
 		id: 'draggable',
+		data: { itemId },
 	} );
 
 	const resizeHandleStyle = {
@@ -21,15 +26,57 @@ function ResizeHandle( { disabled = false }: ResizeHandleProps ) {
 		borderColor: 'transparent transparent var(--wp-admin-theme-color, #0087be) transparent',
 		zIndex: 1,
 		display: disabled ? 'none' : 'block',
-		transform: transform ? `translate3d(${ transform.x }px, ${ transform.y }px, 0)` : undefined,
 	};
 
 	return <div ref={ setNodeRef } style={ resizeHandleStyle } { ...listeners } { ...attributes } />;
 }
 
 export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
+	const initialAnchorPosition = useRef< DOMRect | null >( null );
+
+	const handleDragStart = ( event: DragMoveEvent ) => {
+		// @ts-expect-error I expect this to be always defined.
+		initialAnchorPosition.current = event.activatorEvent.target.getBoundingClientRect();
+	};
+
+	const handleDragMove = ( event: DragMoveEvent ) => {
+		const { onResize } = props;
+		if ( ! initialAnchorPosition.current ) {
+			return;
+		}
+		// @ts-expect-error I expect this to be always defined.
+		const currentPosition = event.activatorEvent.target.getBoundingClientRect();
+		const deltaX = currentPosition.x - initialAnchorPosition.current.x;
+		const deltaY = currentPosition.y - initialAnchorPosition.current.y;
+		const anchorDelta = {
+			width: deltaX,
+			height: deltaY,
+		};
+
+		if ( onResize && event.active.id === 'draggable' ) {
+			const delta = {
+				width: event.delta.x - anchorDelta.width,
+				height: event.delta.y - anchorDelta.height,
+			};
+
+			onResize( delta );
+		}
+	};
+
+	const handleDragEnd = () => {
+		initialAnchorPosition.current = null;
+
+		if ( props.onResizeEnd ) {
+			props.onResizeEnd();
+		}
+	};
+
 	return (
-		<DndContext>
+		<DndContext
+			onDragStart={ handleDragStart }
+			onDragMove={ handleDragMove }
+			onDragEnd={ handleDragEnd }
+		>
 			<ResizeHandle { ...props } />
 		</DndContext>
 	);

--- a/packages/grid/src/resize-handle.tsx
+++ b/packages/grid/src/resize-handle.tsx
@@ -1,4 +1,5 @@
 import { DndContext, DragMoveEvent, useDraggable } from '@dnd-kit/core';
+import { useThrottle } from '@wordpress/compose';
 import { useRef } from 'react';
 
 interface ResizeHandleProps {
@@ -33,6 +34,14 @@ function ResizeHandle( { disabled = false, itemId }: ResizeHandleProps ) {
 
 export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 	const initialAnchorPosition = useRef< DOMRect | null >( null );
+	// Throttle the resize event to avoid excessive calls
+	// and improve performance during drag operations and drag and scroll behavior.
+	const throttleDelay = 100;
+	const throttledResize = useThrottle( ( delta: { width: number; height: number } ) => {
+		if ( props.onResize ) {
+			props.onResize( delta );
+		}
+	}, throttleDelay );
 
 	const handleDragStart = ( event: DragMoveEvent ) => {
 		// @ts-expect-error I expect this to be always defined.
@@ -40,7 +49,6 @@ export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 	};
 
 	const handleDragMove = ( event: DragMoveEvent ) => {
-		const { onResize } = props;
 		if ( ! initialAnchorPosition.current ) {
 			return;
 		}
@@ -53,13 +61,13 @@ export default function ResizeHandleWrapper( props: ResizeHandleProps ) {
 			height: deltaY,
 		};
 
-		if ( onResize && event.active.id === 'draggable' ) {
+		if ( event.active.id === 'draggable' ) {
 			const delta = {
 				width: event.delta.x - anchorDelta.width,
 				height: event.delta.y - anchorDelta.height,
 			};
 
-			onResize( delta );
+			throttledResize( delta );
 		}
 	};
 

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -137,7 +137,7 @@ export const EditableGrid: StoryObj< typeof Grid > = {
 			<Grid
 				layout={ layout }
 				minColumnWidth={ 160 }
-				rowHeight="100px"
+				rowHeight={ 100 }
 				spacing={ 2 }
 				editMode
 				onChangeLayout={ ( newLayout ) => setLayout( newLayout ) }
@@ -180,53 +180,6 @@ export const EditableGrid: StoryObj< typeof Grid > = {
 			description: {
 				story:
 					'This example demonstrates the Grid component in edit mode with drag, drop, and resize functionality. Use the edit mode to reorder and resize the cards. Grab and drag the handle in the bottom-right corner of each card to resize it. The layout and edit mode are managed with local state.',
-			},
-		},
-		layout: '',
-	},
-};
-
-/**
- * Example showing the Grid component in edit mode with non-resizable height (rowHeight="auto")
- */
-export const EditableAutoHeightGrid: StoryObj< typeof Grid > = {
-	render: function EditableAutoHeightGrid() {
-		const [ layout, setLayout ] = useState< GridLayoutItem[] >( [
-			{ key: 'a', width: 1 },
-			{ key: 'b', width: 2 },
-			{ key: 'c', width: 1 },
-			{ key: 'd', width: 2 },
-		] );
-
-		return (
-			<Grid
-				layout={ layout }
-				minColumnWidth={ 160 }
-				rowHeight="auto"
-				spacing={ 2 }
-				editMode
-				onChangeLayout={ ( newLayout ) => setLayout( newLayout ) }
-			>
-				<Card key="a" color="#f44336">
-					Card A (can only resize width when rowHeight="auto")
-				</Card>
-				<Card key="b" color="#2196f3">
-					Card B (can only resize width when rowHeight="auto")
-				</Card>
-				<Card key="c" color="#4caf50">
-					Card C (can only resize width when rowHeight="auto")
-				</Card>
-				<Card key="d" color="#ff9800">
-					Card D (can only resize width when rowHeight="auto")
-				</Card>
-			</Grid>
-		);
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'This example demonstrates the Grid component in edit mode with only width resizing enabled (since rowHeight="auto"). Height resizing is automatically disabled when rowHeight="auto".',
 			},
 		},
 		layout: '',

--- a/packages/grid/src/stories/grid.stories.tsx
+++ b/packages/grid/src/stories/grid.stories.tsx
@@ -121,23 +121,23 @@ export const ResponsiveGrid: StoryObj< typeof Grid > = {
 export const EditableGrid: StoryObj< typeof Grid > = {
 	render: function EditableGrid() {
 		const [ layout, setLayout ] = useState< GridLayoutItem[] >( [
-			{ key: 'a', width: 1 },
-			{ key: 'b', width: 2 },
-			{ key: 'c', width: 1 },
-			{ key: 'd', width: 2 },
-			{ key: 'e', width: 1 },
-			{ key: 'f', width: 1 },
-			{ key: 'g', width: 2 },
-			{ key: 'h', width: 1 },
-			{ key: 'i', width: 1 },
-			{ key: 'j', width: 1 },
+			{ key: 'a', width: 1, height: 1 },
+			{ key: 'b', width: 2, height: 1 },
+			{ key: 'c', width: 1, height: 1 },
+			{ key: 'd', width: 2, height: 1 },
+			{ key: 'e', width: 1, height: 1 },
+			{ key: 'f', width: 1, height: 1 },
+			{ key: 'g', width: 2, height: 1 },
+			{ key: 'h', width: 1, height: 1 },
+			{ key: 'i', width: 1, height: 1 },
+			{ key: 'j', width: 1, height: 1 },
 		] );
 
 		return (
 			<Grid
 				layout={ layout }
 				minColumnWidth={ 160 }
-				rowHeight="auto"
+				rowHeight="100px"
 				spacing={ 2 }
 				editMode
 				onChangeLayout={ ( newLayout ) => setLayout( newLayout ) }
@@ -179,7 +179,54 @@ export const EditableGrid: StoryObj< typeof Grid > = {
 		docs: {
 			description: {
 				story:
-					'This example demonstrates the Grid component in edit mode with drag and drop functionality. Use the edit mode to reorder the cards. The layout and edit mode are managed with local state.',
+					'This example demonstrates the Grid component in edit mode with drag, drop, and resize functionality. Use the edit mode to reorder and resize the cards. Grab and drag the handle in the bottom-right corner of each card to resize it. The layout and edit mode are managed with local state.',
+			},
+		},
+		layout: '',
+	},
+};
+
+/**
+ * Example showing the Grid component in edit mode with non-resizable height (rowHeight="auto")
+ */
+export const EditableAutoHeightGrid: StoryObj< typeof Grid > = {
+	render: function EditableAutoHeightGrid() {
+		const [ layout, setLayout ] = useState< GridLayoutItem[] >( [
+			{ key: 'a', width: 1 },
+			{ key: 'b', width: 2 },
+			{ key: 'c', width: 1 },
+			{ key: 'd', width: 2 },
+		] );
+
+		return (
+			<Grid
+				layout={ layout }
+				minColumnWidth={ 160 }
+				rowHeight="auto"
+				spacing={ 2 }
+				editMode
+				onChangeLayout={ ( newLayout ) => setLayout( newLayout ) }
+			>
+				<Card key="a" color="#f44336">
+					Card A (can only resize width when rowHeight="auto")
+				</Card>
+				<Card key="b" color="#2196f3">
+					Card B (can only resize width when rowHeight="auto")
+				</Card>
+				<Card key="c" color="#4caf50">
+					Card C (can only resize width when rowHeight="auto")
+				</Card>
+				<Card key="d" color="#ff9800">
+					Card D (can only resize width when rowHeight="auto")
+				</Card>
+			</Grid>
+		);
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'This example demonstrates the Grid component in edit mode with only width resizing enabled (since rowHeight="auto"). Height resizing is automatically disabled when rowHeight="auto".',
 			},
 		},
 		layout: '',

--- a/packages/grid/src/types.ts
+++ b/packages/grid/src/types.ts
@@ -60,9 +60,9 @@ interface BaseGridProps {
 	spacing?: number;
 
 	/**
-	 * Height of each row (e.g., "50px", "auto")
+	 * Height of each row in pixes or auto (e.g., 20, "auto")
 	 */
-	rowHeight?: string;
+	rowHeight?: number | 'auto';
 
 	/**
 	 * Whether the grid is in edit mode (allows dragging and repositioning items)


### PR DESCRIPTION
Fixes ARC-125

## Proposed Changes

This PR adds resize handles to Grid Cards to allow them to be resized. 
It is proving to be challenging, it's working but I can't get the animations to work properly as you resize the cards. The visual feedback is not great either. I would appreciate thoughts regardless.

## Testing Instructions

* cd packages/grid
* yarn storybook:start

Check the editable grid story.
