### PR TITLE
Substack import - update author mapping to and from labels.

### DIFF
--- a/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/importing-pane.jsx
@@ -211,7 +211,7 @@ export class ImportingPane extends PureComponent {
 	render() {
 		const {
 			importerStatus,
-			site: { ID: siteId, name: siteName },
+			site: { ID: siteId },
 			sourceType,
 			site,
 			invalidateCardData,
@@ -257,8 +257,12 @@ export class ImportingPane extends PureComponent {
 						siteId={ siteId }
 						sourceType={ sourceType }
 						sourceAuthors={ customData.sourceAuthors }
-						sourceTitle={ customData.siteTitle || this.props.translate( 'Original Site' ) }
-						targetTitle={ siteName }
+						sourceTitle={
+							sourceType === 'Substack'
+								? this.props.translate( 'Substack' )
+								: customData.siteTitle || this.props.translate( 'Original Site' )
+						}
+						targetTitle={ this.props.translate( 'WordPress.com' ) }
 						importerStatus={ importerStatus }
 						site={ site }
 					/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/584

## Proposed Changes

Updates the from and to labels for author mapping in substack imports. Instead of trying to use site names, we use "Substack" and "WordPress.com"

BEFORE
![Screenshot 2025-04-29 at 6 27 30 AM](https://github.com/user-attachments/assets/85d8e4b4-d877-41ad-87f2-db3edb26583e)

AFTER
![Screenshot 2025-04-29 at 6 27 58 AM](https://github.com/user-attachments/assets/2f129f79-0f99-40e6-88a9-f876d593dfd9)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Design direction thought this would be more clear to use these items. Normally the substack site name falls back to saying "Original site" here and the to site title may not be set yet, instead design notes that it is more clear to use "Substack" and "WordPress.com".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /import/newsletter/substack
* start the process of importing a substack with multiple authors (right now draft posts count as a separate author as well, separate 'bug')
* In the author mapping, verify the to and from labels are now updated as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
