### PR TITLE
Subscriber Stats: Keep at least one tick for the Y-axis

### DIFF
--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -75,12 +75,17 @@ function StatsLineChart( {
 
 	const yNumTicks = useMemo( () => {
 		const uniqueValues = [
-			...new Set( chartData.flatMap( ( series ) => series.data.map( ( d ) => d.value ) ) ),
+			...new Set( chartData.flatMap( ( series ) => series.data.map( ( d ) => d.value ?? 0 ) ) ),
 		];
 
 		const maxTicks = uniqueValues.length > 5 ? 5 : uniqueValues.length;
 
 		if ( fixedDomain ) {
+			return maxTicks;
+		}
+
+		// The only one tick, e.g. [ 2 ] or two ticks not [ 1, 2 ], e.g. [ 1, 3 ].
+		if ( maxTicks === 1 || ( maxTicks === 2 && Math.max( ...uniqueValues ) > 2 ) ) {
 			return maxTicks;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Keep at least one tick for the Y-axis when there is only a unique number.
* Avoid only showing one tick `2` for the case with counts `1` and `3`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The chart library would automatically patch the Y-axis tick by itself, which might cause incorrect numbers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Subscribers page.
* Ensure the chart shows with reasonable Y-axis tick numbers.

#### Y-axis tick: [ 2 ]
|Before|After|
|-|-|
|<img width="1138" alt="截圖 2025-04-29 凌晨2 41 22" src="https://github.com/user-attachments/assets/af1ddda9-3f4b-4700-8602-9a686acd17ab" />|<img width="1138" alt="截圖 2025-04-29 凌晨2 41 37" src="https://github.com/user-attachments/assets/0ffe963e-2e64-4198-8fd8-45bc9e6f817f" />|

#### Y-axis ticks: [ 1, 3 ]
|Before|After|
|-|-|
|<img width="1141" alt="截圖 2025-04-29 凌晨2 41 10" src="https://github.com/user-attachments/assets/274aee36-7e50-45ed-8299-d2c672eb7fbb" />|<img width="1144" alt="截圖 2025-04-29 凌晨2 41 14" src="https://github.com/user-attachments/assets/655402a9-797c-4e25-b714-ff8811b8849d" />|

#### Y-axis ticks: [ 1, 2 ] - Not changed
|Before|After|
|-|-|
|<img width="1143" alt="截圖 2025-04-29 凌晨2 41 47" src="https://github.com/user-attachments/assets/13979ea5-b6ca-493f-9010-317836526a5c" />|<img width="1137" alt="截圖 2025-04-29 凌晨2 41 54" src="https://github.com/user-attachments/assets/878f95a0-35fc-4ff1-b0c7-e3e5ced245fe" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
