### PR TITLE
Big Sky: Only allow purchasing Premium and Business plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -45,7 +45,7 @@ function getPlansIntent( flowName: string | null, isWordCampPromo?: boolean ): P
 			}
 			return 'plans-new-hosted-site';
 		case AI_SITE_BUILDER_FLOW:
-			return 'plans-ai-assembler';
+			return 'plans-ai-assembler-free-trial';
 		default:
 			return null;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -44,6 +44,8 @@ function getPlansIntent( flowName: string | null, isWordCampPromo?: boolean ): P
 				return 'plans-new-hosted-site-business-only';
 			}
 			return 'plans-new-hosted-site';
+		case AI_SITE_BUILDER_FLOW:
+			return 'plans-ai-assembler';
 		default:
 			return null;
 	}
@@ -113,18 +115,6 @@ const PlansStepAdaptor: StepType< {
 	const isWordCampPromo = new URLSearchParams( location.search ).has( 'utm_source', 'wordcamp' );
 	const plansIntent = getPlansIntent( props.flow, isWordCampPromo );
 
-	let hidePlanProps;
-	if ( props.flow === AI_SITE_BUILDER_FLOW ) {
-		hidePlanProps = {
-			hideFreePlan: true,
-			hidePersonalPlan: true,
-			hideEcommercePlan: true,
-			hideEnterprisePlan: true,
-		};
-	} else {
-		hidePlanProps = getHidePlanPropsBasedOnThemeType( selectedThemeType || '' );
-	}
-
 	/**
 	 * The plans step has a quirk where it calls `submitSignupStep` then synchronously calls `goToNextStep` after it.
 	 * This doesn't give `setStepState` a chance to update and the data is not passed to `submit`.
@@ -144,7 +134,7 @@ const PlansStepAdaptor: StepType< {
 
 	return (
 		<UnifiedPlansStep
-			{ ...hidePlanProps }
+			{ ...getHidePlanPropsBasedOnThemeType( selectedThemeType || '' ) }
 			selectedSite={ site ?? undefined }
 			saveSignupStep={ ( step ) => {
 				setStepState( ( mostRecentState = { ...stepState, ...step } ) );

--- a/client/my-sites/plans-features-main/components/utils/utils.ts
+++ b/client/my-sites/plans-features-main/components/utils/utils.ts
@@ -22,7 +22,7 @@ export const shouldForceDefaultPlansBasedOnIntent = ( intent: PlansIntent | unde
 };
 
 export const hideEscapeHatchForIntent = ( intent: PlansIntent ) => {
-	return intent === 'plans-ai-assembler';
+	return intent === 'plans-ai-assembler-free-trial';
 };
 
 /**

--- a/client/my-sites/plans-features-main/components/utils/utils.ts
+++ b/client/my-sites/plans-features-main/components/utils/utils.ts
@@ -21,6 +21,10 @@ export const shouldForceDefaultPlansBasedOnIntent = ( intent: PlansIntent | unde
 	);
 };
 
+export const hideEscapeHatchForIntent = ( intent: PlansIntent ) => {
+	return intent === 'plans-ai-assembler';
+};
+
 /**
  * Determine which plans should be displayed based on the type of the selected theme.
  */

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -1,7 +1,9 @@
-import { useSiteIntent } from '@automattic/data-stores';
+import { useSiteIntent, Onboard } from '@automattic/data-stores';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { PlansIntent } from '@automattic/plans-grid-next';
+
+const { SiteIntent } = Onboard;
 
 interface IntentFromSiteMeta {
 	processing: boolean;
@@ -10,23 +12,33 @@ interface IntentFromSiteMeta {
 
 const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
-	const siteIntent = useSiteIntent( selectedSiteId );
+	const siteIntentResponse = useSiteIntent( selectedSiteId );
 
-	if ( siteIntent.isFetching ) {
+	if ( siteIntentResponse.isFetching ) {
 		return {
 			processing: true,
 			intent: undefined, // undefined -> we haven't observed any metadata yet
 		};
 	}
 
-	if ( 'newsletter' === ( siteIntent.data?.site_intent as string ) ) {
+	const siteIntent = siteIntentResponse.data?.site_intent;
+
+	if ( SiteIntent.AIAssembler === siteIntent ) {
+		return {
+			processing: false,
+			intent: 'plans-ai-assembler',
+		};
+	}
+
+	if ( SiteIntent.Newsletter === siteIntent ) {
 		return {
 			processing: false,
 			intent: 'plans-newsletter',
 		};
 	}
 
-	if ( 'videopress' === ( siteIntent.data?.site_intent as string ) ) {
+	// @ts-expect-error This is not a valid site intent, apparently. Can we remove it?
+	if ( 'videopress' === siteIntent ) {
 		return {
 			processing: false,
 			intent: 'plans-videopress',

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -1,6 +1,7 @@
 import { useSiteIntent, Onboard } from '@automattic/data-stores';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import type { PlansIntent } from '@automattic/plans-grid-next';
 
 const { SiteIntent } = Onboard;
@@ -12,6 +13,7 @@ interface IntentFromSiteMeta {
 
 const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteIntentResponse = useSiteIntent( selectedSiteId );
 
 	if ( siteIntentResponse.isFetching ) {
@@ -23,10 +25,14 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 
 	const siteIntent = siteIntentResponse.data?.site_intent;
 
-	if ( SiteIntent.AIAssembler === siteIntent ) {
+	// ai-site-builder flow is specifically the free trial for big sky
+	if (
+		SiteIntent.AIAssembler === siteIntent &&
+		selectedSite?.options?.site_creation_flow === 'ai-site-builder'
+	) {
 		return {
 			processing: false,
-			intent: 'plans-ai-assembler',
+			intent: 'plans-ai-assembler-free-trial',
 		};
 	}
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -96,6 +96,10 @@ const PlanComparisonHeader = styled.h1`
 	}
 `;
 
+const hideEscapeHatchForIntent = ( intent: PlansIntent ) => {
+	return intent === 'plans-ai-assembler';
+};
+
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;
 	intent?: PlansIntent | null;
@@ -338,7 +342,10 @@ const PlansFeaturesMain = ( {
 	] );
 
 	const showEscapeHatch =
-		intentFromSiteMeta.intent && ! isInSignup && defaultWpcomPlansIntent !== intent;
+		intentFromSiteMeta.intent &&
+		! isInSignup &&
+		defaultWpcomPlansIntent !== intent &&
+		! hideEscapeHatchForIntent( intentFromSiteMeta.intent );
 
 	/**
 	 * showSimplifiedFeatures should be true always and this variable should be removed.

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -55,7 +55,10 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
-import { shouldForceDefaultPlansBasedOnIntent } from 'calypso/my-sites/plans-features-main/components/utils/utils';
+import {
+	shouldForceDefaultPlansBasedOnIntent,
+	hideEscapeHatchForIntent,
+} from 'calypso/my-sites/plans-features-main/components/utils/utils';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
@@ -95,10 +98,6 @@ const PlanComparisonHeader = styled.h1`
 		margin: 48px 0;
 	}
 `;
-
-const hideEscapeHatchForIntent = ( intent: PlansIntent ) => {
-	return intent === 'plans-ai-assembler';
-};
 
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;

--- a/packages/data-stores/src/queries/use-site-intent.ts
+++ b/packages/data-stores/src/queries/use-site-intent.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import { SiteIntent } from '../onboard';
 
 export function useSiteIntent( siteId: string | number | undefined ) {
 	return useQuery< {
-		site_intent: '';
+		site_intent: SiteIntent;
 	} >( {
 		queryKey: [ 'site-intent', siteId ],
 		queryFn: async () =>

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -155,6 +155,9 @@ export const usePlanTypesWithIntent = ( {
 		case 'plans-new-hosted-site-business-only':
 			planTypes = [ TYPE_BUSINESS ];
 			break;
+		case 'plans-ai-assembler':
+			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
+			break;
 		case 'plans-import':
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -155,7 +155,7 @@ export const usePlanTypesWithIntent = ( {
 		case 'plans-new-hosted-site-business-only':
 			planTypes = [ TYPE_BUSINESS ];
 			break;
-		case 'plans-ai-assembler':
+		case 'plans-ai-assembler-free-trial':
 			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
 		case 'plans-import':

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -55,7 +55,7 @@ export type GridSize = 'small' | 'smedium' | 'medium' | 'large' | 'xlarge';
 
 export type PlansIntent =
 	| 'plans-affiliate'
-	| 'plans-ai-assembler'
+	| 'plans-ai-assembler-free-trial'
 	| 'plans-blog-onboarding'
 	| 'plans-newsletter'
 	| 'plans-new-hosted-site'

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -55,6 +55,7 @@ export type GridSize = 'small' | 'smedium' | 'medium' | 'large' | 'xlarge';
 
 export type PlansIntent =
 	| 'plans-affiliate'
+	| 'plans-ai-assembler'
 	| 'plans-blog-onboarding'
 	| 'plans-newsletter'
 	| 'plans-new-hosted-site'


### PR DESCRIPTION
Fixes BSKY-395. Supersedes https://github.com/Automattic/wp-calypso/pull/102937.

## Proposed Changes

Uses the plan intent mechanism to hide some non-Big Sky plans.

## Testing Instructions

Create a Big Sky site through `/setup/ai-site-builder` and verify that you can only pick the Premium or Business plan.