### PR TITLE
Remove unused onComplete prop from SecurityKeyForm

### DIFF
--- a/.cursor/rules/calypso-client-rules.mdc
+++ b/.cursor/rules/calypso-client-rules.mdc
@@ -87,5 +87,6 @@ Remember: Always prioritize WordPress coding standards and best practices while 
 - Run tests for individual files using the command `yarn test-client filename`, substituting `filename` with the relative path to the file you want to test.
 - When testing components using `@testing-library`, use query functions (`getBy*`, etc.) from the return value of `render`, not from the `screen` import.
 - Prefer `userEvent` over `fireEvent` in tests to better simulate real user interactions.
+- Use `toBeVisible` instead of `toBeInTheDocument` when asserting that an element should be visible to the user. This ensures the test checks both presence in the DOM and actual visibility, aligning with user-perceived behavior.
 
 

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -8,7 +8,7 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 import './security-key-form.scss';
 
-class SecurityKeyForm extends Component {
+export class SecurityKeyForm extends Component {
 	static propTypes = {
 		twoStepAuthorization: PropTypes.object.isRequired,
 		onComplete: PropTypes.func,

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -11,8 +11,6 @@ import './security-key-form.scss';
 export class SecurityKeyForm extends Component {
 	static propTypes = {
 		twoStepAuthorization: PropTypes.object.isRequired,
-		onComplete: PropTypes.func,
-
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -30,7 +28,6 @@ export class SecurityKeyForm extends Component {
 
 		this.props.twoStepAuthorization
 			.loginUserWithSecurityKey( { user_id: this.props.currentUserId } )
-			.then( ( response ) => this.onComplete( null, response ) )
 			.catch( ( error ) => {
 				const errors = error?.data?.errors ?? [];
 				if ( errors.some( ( e ) => e.code === 'invalid_two_step_nonce' ) ) {
@@ -40,20 +37,12 @@ export class SecurityKeyForm extends Component {
 						} else {
 							// We only retry once, so let's show the original error.
 							this.setState( { isAuthenticating: false, showError: true } );
-							this.onComplete( error, null );
 						}
 					} );
 					return;
 				}
 				this.setState( { isAuthenticating: false, showError: true } );
-				this.onComplete( error, null );
 			} );
-	};
-
-	onComplete = ( error, data ) => {
-		if ( this.props.onComplete ) {
-			this.props.onComplete( error, data );
-		}
 	};
 
 	render() {

--- a/client/me/reauth-required/test/security-key-form.test.tsx
+++ b/client/me/reauth-required/test/security-key-form.test.tsx
@@ -34,9 +34,9 @@ describe( 'SecurityKeyForm', () => {
 		const { findByText, getByText, getByRole } = setup();
 
 		await findByText( 'Waiting for security key' );
-		expect( getByText( 'Waiting for security key' ) ).toBeInTheDocument();
-		expect( getByText( /Connect and touch your security key to log in/ ) ).toBeInTheDocument();
-		expect( getByRole( 'button', { name: 'Continue with security key' } ) ).toBeInTheDocument();
+		expect( getByText( 'Waiting for security key' ) ).toBeVisible();
+		expect( getByText( /Connect and touch your security key to log in/ ) ).toBeVisible();
+		expect( getByRole( 'button', { name: 'Continue with security key' } ) ).toBeVisible();
 	} );
 
 	test( 'shows error and allows user to retry authentication on client failure', async () => {
@@ -52,7 +52,7 @@ describe( 'SecurityKeyForm', () => {
 		reject( new Error() );
 
 		await waitFor( () => {
-			expect( getByText( /An error occurred, please try again/ ) ).toBeInTheDocument();
+			expect( getByText( /An error occurred, please try again/ ) ).toBeVisible();
 		} );
 
 		// Now click the button to trigger another authentication

--- a/client/me/reauth-required/test/security-key-form.test.tsx
+++ b/client/me/reauth-required/test/security-key-form.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SecurityKeyForm } from '../security-key-form';
+
+describe( 'SecurityKeyForm', () => {
+	const currentUserId = 123;
+	const translate = ( str: string ) => str;
+	const loginUserWithSecurityKey = jest.fn();
+	const fetch = jest.fn();
+	const onComplete = jest.fn();
+
+	const setup = () =>
+		render(
+			<SecurityKeyForm
+				twoStepAuthorization={ {
+					loginUserWithSecurityKey,
+					fetch,
+				} }
+				translate={ translate }
+				onComplete={ onComplete }
+				currentUserId={ currentUserId }
+			/>
+		);
+
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	test( 'prompts immediately and shows spinner and waiting message', async () => {
+		// Never resolves, simulates loading
+		loginUserWithSecurityKey.mockReturnValue( new Promise( () => {} ) );
+
+		setup();
+
+		await screen.findByText( 'Waiting for security key' );
+		expect( screen.getByText( 'Waiting for security key' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /Connect and touch your security key to log in/ )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Continue with security key' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'shows error and allows user to retry authentication on client failure', async () => {
+		const { reject, promise } = Promise.withResolvers();
+		loginUserWithSecurityKey.mockReturnValue( promise );
+		setup();
+
+		// Wait for the spinner to appear (auth in progress)
+		await screen.findByText( 'Waiting for security key' );
+
+		// Resolve the initial authentication
+		reject( new Error() );
+
+		await waitFor( () => {
+			expect( screen.getByText( /An error occurred, please try again/ ) ).toBeInTheDocument();
+		} );
+
+		// Now click the button to trigger another authentication
+		await userEvent.click( screen.getByRole( 'button', { name: 'Continue with security key' } ) );
+		await waitFor( () => {
+			expect( loginUserWithSecurityKey ).toHaveBeenCalledTimes( 2 );
+			expect( loginUserWithSecurityKey ).toHaveBeenLastCalledWith( { user_id: currentUserId } );
+		} );
+	} );
+
+	test( 'retries once automatically on invalid_two_step_nonce', async () => {
+		const error = { data: { errors: [ { code: 'invalid_two_step_nonce' } ] } };
+		loginUserWithSecurityKey.mockRejectedValue( error );
+		fetch.mockImplementation( ( cb ) => cb() );
+
+		setup();
+
+		await waitFor( () => {
+			expect( fetch ).toHaveBeenCalledTimes( 2 );
+			expect( loginUserWithSecurityKey ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+} );

--- a/client/me/reauth-required/test/security-key-form.test.tsx
+++ b/client/me/reauth-required/test/security-key-form.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SecurityKeyForm } from '../security-key-form';
 
@@ -33,35 +33,32 @@ describe( 'SecurityKeyForm', () => {
 		// Never resolves, simulates loading
 		loginUserWithSecurityKey.mockReturnValue( new Promise( () => {} ) );
 
-		setup();
+		const { findByText, getByText, getByRole } = setup();
 
-		await screen.findByText( 'Waiting for security key' );
-		expect( screen.getByText( 'Waiting for security key' ) ).toBeInTheDocument();
-		expect(
-			screen.getByText( /Connect and touch your security key to log in/ )
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole( 'button', { name: 'Continue with security key' } )
-		).toBeInTheDocument();
+		await findByText( 'Waiting for security key' );
+		expect( getByText( 'Waiting for security key' ) ).toBeInTheDocument();
+		expect( getByText( /Connect and touch your security key to log in/ ) ).toBeInTheDocument();
+		expect( getByRole( 'button', { name: 'Continue with security key' } ) ).toBeInTheDocument();
 	} );
 
 	test( 'shows error and allows user to retry authentication on client failure', async () => {
 		const { reject, promise } = Promise.withResolvers();
 		loginUserWithSecurityKey.mockReturnValue( promise );
-		setup();
+
+		const { findByText, getByText, getByRole } = setup();
 
 		// Wait for the spinner to appear (auth in progress)
-		await screen.findByText( 'Waiting for security key' );
+		await findByText( 'Waiting for security key' );
 
 		// Resolve the initial authentication
 		reject( new Error() );
 
 		await waitFor( () => {
-			expect( screen.getByText( /An error occurred, please try again/ ) ).toBeInTheDocument();
+			expect( getByText( /An error occurred, please try again/ ) ).toBeInTheDocument();
 		} );
 
 		// Now click the button to trigger another authentication
-		await userEvent.click( screen.getByRole( 'button', { name: 'Continue with security key' } ) );
+		await userEvent.click( getByRole( 'button', { name: 'Continue with security key' } ) );
 		await waitFor( () => {
 			expect( loginUserWithSecurityKey ).toHaveBeenCalledTimes( 2 );
 			expect( loginUserWithSecurityKey ).toHaveBeenLastCalledWith( { user_id: currentUserId } );

--- a/client/me/reauth-required/test/security-key-form.test.tsx
+++ b/client/me/reauth-required/test/security-key-form.test.tsx
@@ -10,7 +10,6 @@ describe( 'SecurityKeyForm', () => {
 	const translate = ( str: string ) => str;
 	const loginUserWithSecurityKey = jest.fn();
 	const fetch = jest.fn();
-	const onComplete = jest.fn();
 
 	const setup = () =>
 		render(
@@ -20,7 +19,6 @@ describe( 'SecurityKeyForm', () => {
 					fetch,
 				} }
 				translate={ translate }
-				onComplete={ onComplete }
 				currentUserId={ currentUserId }
 			/>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to ARC-129

## Proposed Changes

* Removes unused `onComplete` prop from `SecurityKeyForm` component
* Adds test coverage for `SecurityKeyForm`

It appears this prop became unused as of #87078

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Incremental step toward removal of `TwoStepAction` `EventEmitter` class, where consuming components are being refactored to function components to start using hooks equivalents to the event emitter data. The changes here simplify the function component refactoring.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Repeat Testing Instructions from #87078

Verify that added tests pass:

```
yarn test-client client/me/reauth-required/test/security-key-form.test.tsx
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
