### PR TITLE
Subscriber details: show skeleton when loading

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -196,19 +196,10 @@ const SubscriberDataViews = ( {
 		// If we have details and they match the current URL, use them
 		if ( subscriberDetails && subscriberId === getSubscriptionIdString( subscriberDetails ) ) {
 			setSelectedSubscriber( subscriberDetails );
-			return;
 		}
-
-		// Only try to find subscriber in the list if we don't have matching details yet
-		if ( ! subscriberDetails || subscriberId !== getSubscriptionIdString( subscriberDetails ) ) {
-			const subscriberFromList = subscribersQueryResult?.subscribers.find(
-				( s ) => subscriberId === getSubscriptionIdString( s )
-			);
-			if ( subscriberFromList ) {
-				setSelectedSubscriber( subscriberFromList );
-			}
-		}
-	}, [ subscriberId, subscriberDetails, subscribersQueryResult?.subscribers ] );
+		// Don't clear selectedSubscriber - let it keep showing the previous subscriber while loading
+		// The SubscriberDetailsSkeleton will show because subscriberDetails won't match subscriberId
+	}, [ subscriberId, subscriberDetails ] );
 
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId ?? null );
 	const grandTotal = subscribersTotals?.email_subscribers ?? 0;
@@ -613,7 +604,7 @@ const SubscriberDataViews = ( {
 					</>
 				) }
 			</section>
-			{ selectedSubscriber && siteId && (
+			{ subscriberId && siteId && (
 				<section className="subscriber-data-views__details">
 					{ isLoadingNewsletterCategories ||
 					isLoadingDetails ||

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -168,10 +168,7 @@ const SubscriberDataViews = ( {
 		subscriberId && ! isNaN( parseInt( subscriberId, 10 ) )
 			? parseInt( subscriberId, 10 )
 			: undefined,
-		// Only pass user_id if it's a valid number (WordPress.com user)
-		typeof selectedSubscriber?.user_id === 'number' && ! isNaN( selectedSubscriber.user_id )
-			? selectedSubscriber.user_id
-			: undefined
+		undefined // We only need the subscriberId to fetch details
 	);
 
 	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -31,6 +31,7 @@ import {
 import { Subscriber } from '../../types';
 import { JetpackEmptyListView } from '../jetpack-empty-list-view';
 import { SubscriberDetails } from '../subscriber-details';
+import { SubscriberDetailsSkeleton } from '../subscriber-details/skeleton';
 import { SubscriberLaunchpad } from '../subscriber-launchpad';
 import SubscriberTotals from '../subscriber-totals';
 import { SubscribersHeader } from '../subscribers-header';
@@ -173,30 +174,6 @@ const SubscriberDataViews = ( {
 			: undefined
 	);
 
-	// Single effect to handle all subscriber selection scenarios
-	useEffect( () => {
-		// If URL changes or we get new subscriber details, update the selection
-		if ( subscriberId ) {
-			// If we have details and they match the current URL
-			if ( subscriberDetails && subscriberId === getSubscriptionIdString( subscriberDetails ) ) {
-				setSelectedSubscriber( subscriberDetails );
-			}
-			// If we don't have matching details yet, try to find in current list
-			else {
-				const subscriberFromList = subscribersQueryResult?.subscribers.find(
-					( s ) => subscriberId === getSubscriptionIdString( s )
-				);
-				if ( subscriberFromList ) {
-					setSelectedSubscriber( subscriberFromList );
-				}
-			}
-		} else if ( ! subscriberId && selectedSubscriber ) {
-			setSelectedSubscriber( null );
-		}
-		// We don't need to re-run this effect when selectedSubscriber changes.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ subscriberId, subscriberDetails, subscribersQueryResult?.subscribers ] );
-
 	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
 		useSubscribedNewsletterCategories( {
 			siteId: siteId as number,
@@ -207,6 +184,31 @@ const SubscriberDataViews = ( {
 			userId: subscriberDetails?.user_id,
 			enabled: !! subscriberId && !! siteId,
 		} );
+
+	// Single effect to handle all subscriber selection scenarios
+	useEffect( () => {
+		// If no subscriberId in URL, immediately clear selection
+		if ( ! subscriberId ) {
+			setSelectedSubscriber( null );
+			return;
+		}
+
+		// If we have details and they match the current URL, use them
+		if ( subscriberDetails && subscriberId === getSubscriptionIdString( subscriberDetails ) ) {
+			setSelectedSubscriber( subscriberDetails );
+			return;
+		}
+
+		// Only try to find subscriber in the list if we don't have matching details yet
+		if ( ! subscriberDetails || subscriberId !== getSubscriptionIdString( subscriberDetails ) ) {
+			const subscriberFromList = subscribersQueryResult?.subscribers.find(
+				( s ) => subscriberId === getSubscriptionIdString( s )
+			);
+			if ( subscriberFromList ) {
+				setSelectedSubscriber( subscriberFromList );
+			}
+		}
+	}, [ subscriberId, subscriberDetails, subscribersQueryResult?.subscribers ] );
 
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId ?? null );
 	const grandTotal = subscribersTotals?.email_subscribers ?? 0;
@@ -289,8 +291,9 @@ const SubscriberDataViews = ( {
 		]
 	);
 
-	// Modify the onClose handler in SubscriberDetails to preserve the page when going back to the list
+	// Modify the onClose handler to clear selection before navigation
 	const handleClose = useCallback( () => {
+		setSelectedSubscriber( null );
 		const urlParams = new URLSearchParams( window.location.search );
 		const pageParam = urlParams.get( 'page' );
 		if ( pageParam ) {
@@ -610,23 +613,26 @@ const SubscriberDataViews = ( {
 					</>
 				) }
 			</section>
-			{ selectedSubscriber &&
-				siteId &&
-				! isLoadingNewsletterCategories &&
-				! isLoadingDetails &&
-				subscriberDetails && (
-					<section className="subscriber-data-views__details">
+			{ selectedSubscriber && siteId && (
+				<section className="subscriber-data-views__details">
+					{ isLoadingNewsletterCategories ||
+					isLoadingDetails ||
+					! subscriberDetails ||
+					getSubscriptionIdString( subscriberDetails ) !== subscriberId ? (
+						<SubscriberDetailsSkeleton />
+					) : (
 						<SubscriberDetails
 							subscriber={ subscriberDetails }
 							siteId={ siteId }
-							subscriptionId={ getSubscriptionId( selectedSubscriber ) }
+							subscriptionId={ getSubscriptionId( subscriberDetails ) }
 							onClose={ handleClose }
 							onUnsubscribe={ ( subscriber ) => handleUnsubscribe( [ subscriber ] ) }
 							newsletterCategoriesEnabled={ subscribedNewsletterCategoriesData?.enabled }
 							newsletterCategories={ subscribedNewsletterCategoriesData?.newsletterCategories }
 						/>
-					</section>
-				) }
+					) }
+				</section>
+			) }
 			<UnsubscribeModal
 				subscribers={ currentSubscribers }
 				onCancel={ resetSubscribers }

--- a/client/my-sites/subscribers/components/subscriber-details/skeleton.scss
+++ b/client/my-sites/subscribers/components/subscriber-details/skeleton.scss
@@ -1,0 +1,112 @@
+.subscriber-details {
+	// ... existing styles ...
+
+	&--is-placeholder {
+		.subscriber-details__header {
+			display: flex;
+			align-items: center;
+			margin-bottom: 24px;
+		}
+
+		.subscriber-details__info {
+			margin-left: 16px;
+		}
+
+		.subscriber-details__name {
+			margin-bottom: 8px;
+		}
+
+		.subscriber-details__meta {
+			margin: 24px 0;
+
+			.subscriber-details__meta-item {
+				margin-bottom: 16px;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+
+		.subscriber-details__actions {
+			margin-top: 24px;
+		}
+	}
+}
+
+.subscriber-details-skeleton {
+	.subscriber-details-skeleton__header {
+		display: flex;
+		align-items: center;
+		margin-bottom: 24px;
+	}
+
+	.subscriber-details-skeleton__title-group {
+		margin-left: 16px;
+		flex-grow: 1;
+	}
+
+	.subscriber-details-skeleton__stats {
+		display: flex;
+		gap: 24px;
+		margin-bottom: 32px;
+		padding: 16px 0;
+		border-top: 1px solid var(--color-border-subtle);
+		border-bottom: 1px solid var(--color-border-subtle);
+	}
+
+	.subscriber-details-skeleton__stat {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		flex: 1;
+	}
+
+	.subscriber-details-skeleton__stat-text {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		flex-grow: 1;
+	}
+
+	.subscriber-details-skeleton__section {
+		margin-bottom: 24px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.subscriber-details-skeleton__label {
+		margin-bottom: 8px;
+	}
+
+	.subscriber-details-skeleton__footer {
+		margin-top: 32px;
+		padding-top: 16px;
+		border-top: 1px solid var(--color-border-subtle);
+	}
+
+	.subscriber-details-skeleton__block {
+		box-sizing: border-box;
+		background-color: var(--studio-gray-5);
+		animation: subscriber-details-skeleton-shimmer 1.5s infinite;
+		border-radius: 4px;
+
+		&--circle {
+			border-radius: 50%;
+		}
+	}
+}
+
+@keyframes subscriber-details-skeleton-shimmer {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+} 

--- a/client/my-sites/subscribers/components/subscriber-details/skeleton.tsx
+++ b/client/my-sites/subscribers/components/subscriber-details/skeleton.tsx
@@ -1,0 +1,100 @@
+import { Card } from '@wordpress/components';
+import clsx from 'clsx';
+import type { HTMLAttributes } from 'react';
+import './skeleton.scss';
+
+interface SkeletonProps extends HTMLAttributes< HTMLDivElement > {
+	shape?: 'circle' | 'rect';
+	height?: string;
+	width?: string;
+}
+
+const Skeleton = ( {
+	shape = 'rect',
+	height,
+	width,
+	style,
+	className,
+	...rest
+}: SkeletonProps ) => {
+	const classes = clsx(
+		'subscriber-details-skeleton__block',
+		{
+			'subscriber-details-skeleton__block--circle': shape === 'circle',
+		},
+		className
+	);
+
+	const styles = {
+		...style,
+		...( height && { height } ),
+		...( width && { width } ),
+	};
+
+	return <div { ...rest } className={ classes } style={ styles } />;
+};
+
+export const SubscriberDetailsSkeleton = () => {
+	return (
+		<Card className="subscriber-details-skeleton">
+			<div className="subscriber-details-skeleton__header">
+				<Skeleton
+					shape="circle"
+					width="48px"
+					height="48px"
+					className="subscriber-details-skeleton__avatar"
+				/>
+				<div className="subscriber-details-skeleton__title-group">
+					<Skeleton width="80%" height="24px" className="subscriber-details-skeleton__email" />
+				</div>
+			</div>
+
+			<div className="subscriber-details-skeleton__stats">
+				<div className="subscriber-details-skeleton__stat">
+					<Skeleton width="24px" height="24px" className="subscriber-details-skeleton__stat-icon" />
+					<div className="subscriber-details-skeleton__stat-text">
+						<Skeleton width="100%" height="16px" />
+						<Skeleton width="60%" height="24px" />
+					</div>
+				</div>
+				<div className="subscriber-details-skeleton__stat">
+					<Skeleton width="24px" height="24px" className="subscriber-details-skeleton__stat-icon" />
+					<div className="subscriber-details-skeleton__stat-text">
+						<Skeleton width="100%" height="16px" />
+						<Skeleton width="60%" height="24px" />
+					</div>
+				</div>
+				<div className="subscriber-details-skeleton__stat">
+					<Skeleton width="24px" height="24px" className="subscriber-details-skeleton__stat-icon" />
+					<div className="subscriber-details-skeleton__stat-text">
+						<Skeleton width="100%" height="16px" />
+						<Skeleton width="60%" height="24px" />
+					</div>
+				</div>
+			</div>
+
+			<div className="subscriber-details-skeleton__content">
+				<div className="subscriber-details-skeleton__section">
+					<Skeleton width="30%" height="16px" className="subscriber-details-skeleton__label" />
+					<Skeleton width="70%" height="24px" className="subscriber-details-skeleton__value" />
+				</div>
+				<div className="subscriber-details-skeleton__section">
+					<Skeleton width="35%" height="16px" className="subscriber-details-skeleton__label" />
+					<Skeleton width="80%" height="24px" className="subscriber-details-skeleton__value" />
+				</div>
+				<div className="subscriber-details-skeleton__section">
+					<Skeleton width="25%" height="16px" className="subscriber-details-skeleton__label" />
+					<Skeleton width="40%" height="24px" className="subscriber-details-skeleton__value" />
+				</div>
+				<div className="subscriber-details-skeleton__section">
+					<Skeleton width="30%" height="16px" className="subscriber-details-skeleton__label" />
+					<Skeleton width="20%" height="24px" className="subscriber-details-skeleton__value" />
+				</div>
+			</div>
+
+			<div className="subscriber-details-skeleton__footer">
+				<Skeleton width="160px" height="36px" className="subscriber-details-skeleton__button" />
+			</div>
+		</Card>
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/loop/issues/669

## Proposed Changes

* Show a skeleton when loading, instead of old data flickering. 

<img width="1617" alt="Screenshot 2025-04-28 at 5 32 10 PM" src="https://github.com/user-attachments/assets/af5fdc39-395e-4108-9d20-5050fee38555" />

* Improve subscriber selection management by decoupling the UI state from URL state, allowing the previous subscriber details to remain visible while loading new subscriber data. This prevents jarring UI transitions and maintains a smoother user experience when navigating between subscribers.
* Fix an issue where going back didn't load the correct subscriber.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve the experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers/{site url}
* Click on a subscriber and verify that the correct details load.
* Click on another subscriber and verify that you see the skeleton, and no flashes of old data.
* Change the page and click on another subscriber.
* Use the browser back button to go back to the previous subscriber and verify that the id in the URL changes and that the correct subscriber details load.
* Refresh the page and verify that the same subscriber details load.
* Visit the url of a subscriber with no page number and verify that the correct details load.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
