### PR TITLE
Unified Domains: Hide side content column if empty

### DIFF
--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -5,7 +5,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { shouldUseMultipleDomainsInCart } from './utils';
 
 // Referenced from WordAds_Ads_Txt
 const wpcomSubdomains = [
@@ -223,13 +222,6 @@ export class DomainsMiniCart extends Component {
 	};
 
 	render() {
-		if (
-			! shouldUseMultipleDomainsInCart( this.props.flowName ) ||
-			( this.props.cartIsLoading && this.props.domainsInCart.length === 0 )
-		) {
-			return null;
-		}
-
 		if ( this.props.isMobile ) {
 			return this.mobile();
 		}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -956,6 +956,29 @@ class RenderDomainsStepComponent extends Component {
 		} );
 	};
 
+	getDomainsMiniCart = ( domainsInCart ) => {
+		const cartIsLoading = this.props.shoppingCartManager.isLoading;
+
+		if ( cartIsLoading && domainsInCart.length === 0 ) {
+			return null;
+		}
+
+		return (
+			<DomainsMiniCart
+				isMobile={ ! this.props.isDesktop }
+				domainsInCart={ domainsInCart }
+				domainRemovalQueue={ this.state.domainRemovalQueue }
+				flowName={ this.props.flowName }
+				removeDomainClickHandler={ this.removeDomainClickHandler }
+				isMiniCartContinueButtonBusy={ this.state.isMiniCartContinueButtonBusy }
+				goToNext={ this.goToNext }
+				handleSkip={ this.handleSkip }
+				wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
+				freeDomainRemoveClickHandler={ this.freeDomainRemoveClickHandler }
+			/>
+		);
+	};
+
 	getSideContent = () => {
 		const { flowName } = this.props;
 		const domainsInCart = getDomainsInCart( this.props.cart );
@@ -971,8 +994,6 @@ class RenderDomainsStepComponent extends Component {
 		if ( additionalDomains.length > 0 ) {
 			domainsInCart.push( ...additionalDomains );
 		}
-
-		const cartIsLoading = this.props.shoppingCartManager.isLoading;
 
 		const useYourDomain = ! this.shouldHideUseYourDomain() ? (
 			<div
@@ -990,36 +1011,23 @@ class RenderDomainsStepComponent extends Component {
 		const shouldShowSkip = this.props.allowSkipWithoutSearch || hasSearchedDomains;
 
 		const content = [
-			domainsInCart.length > 0 || this.state.wpcomSubdomainSelected ? (
-				<DomainsMiniCart
-					isMobile={ ! this.props.isDesktop }
-					domainsInCart={ domainsInCart }
-					domainRemovalQueue={ this.state.domainRemovalQueue }
-					cartIsLoading={ cartIsLoading }
-					flowName={ flowName }
-					removeDomainClickHandler={ this.removeDomainClickHandler }
-					isMiniCartContinueButtonBusy={ this.state.isMiniCartContinueButtonBusy }
-					goToNext={ this.goToNext }
-					handleSkip={ this.handleSkip }
-					wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
-					freeDomainRemoveClickHandler={ this.freeDomainRemoveClickHandler }
-				/>
-			) : (
-				! this.shouldHideDomainExplainer() &&
-				shouldShowSkip && (
-					<div className="domains__domain-side-content domains__free-domain">
-						<SideExplainer
-							onClick={ this.handleDomainExplainerClick }
-							type={
-								this.props.isPlanSelectionAvailableLaterInFlow
-									? 'free-domain-explainer-check-paid-plans'
-									: 'free-domain-explainer'
-							}
-							flowName={ flowName }
-						/>
-					</div>
-				)
-			),
+			shouldUseMultipleDomainsInCart( flowName ) &&
+			( domainsInCart.length > 0 || this.state.wpcomSubdomainSelected )
+				? this.getDomainsMiniCart( domainsInCart )
+				: ! this.shouldHideDomainExplainer() &&
+				  shouldShowSkip && (
+						<div className="domains__domain-side-content domains__free-domain">
+							<SideExplainer
+								onClick={ this.handleDomainExplainerClick }
+								type={
+									this.props.isPlanSelectionAvailableLaterInFlow
+										? 'free-domain-explainer-check-paid-plans'
+										: 'free-domain-explainer'
+								}
+								flowName={ flowName }
+							/>
+						</div>
+				  ),
 			useYourDomain,
 			this.shouldDisplayDomainOnlyExplainer() && (
 				<div className="domains__domain-side-content">
@@ -1031,9 +1039,7 @@ class RenderDomainsStepComponent extends Component {
 			),
 		];
 
-		const nonEmptyElements = Children.toArray( content )
-			.map( ( element ) => element.children )
-			.filter( isValidElement );
+		const nonEmptyElements = Children.toArray( content ).filter( isValidElement );
 
 		if ( nonEmptyElements.length === 0 ) {
 			return null;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -20,7 +20,7 @@ import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { parse } from 'qs';
-import { Component } from 'react';
+import { Children, Component, isValidElement } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -1029,9 +1029,13 @@ class RenderDomainsStepComponent extends Component {
 					/>
 				</div>
 			),
-		].filter( Boolean );
+		];
 
-		if ( content.length === 0 ) {
+		const nonEmptyElements = Children.toArray( content )
+			.map( ( element ) => element.children )
+			.filter( isValidElement );
+
+		if ( nonEmptyElements.length === 0 ) {
 			return null;
 		}
 
@@ -1041,7 +1045,7 @@ class RenderDomainsStepComponent extends Component {
 					'is-sticky': !! useYourDomain,
 				} ) }
 			>
-				{ content }
+				{ nonEmptyElements }
 			</div>
 		);
 	};


### PR DESCRIPTION
## Proposed Changes

Let's filter out the elements who are childless. Right now we're seeing an empty side column, which is not desirable.

| Before | After |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/40251ab6-46eb-4e5b-be3e-7b1ea66ad5eb) | ![image](https://github.com/user-attachments/assets/be5100e6-ab25-4f56-8f6e-e3582d1932f4) |

## Testing Instructions

Add some domain to the cart and enter `/setup/new-hosted-site?showDomainStep` and verify that the side column isn't displayed. Enter `/setup/onboarding` and verify it does show up.