### PR TITLE
Remove instant launch for anchor_podcast sites

### DIFF
--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -4,7 +4,7 @@ import 'calypso/state/data-layer/wpcom/sites/launch';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import isSiteBigSkyTrial from 'calypso/state/sites/plans/selectors/is-site-big-sky-trial';
-import { getSiteSlug, isCurrentPlanPaid, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import { isSiteOnHostingTrial } from '../plans/selectors';
 
 export const launchSite = ( siteId ) => ( {
@@ -39,12 +39,11 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 			return;
 		}
 
-		const isAnchorPodcast = getSiteOption( getState(), siteId, 'anchor_podcast' );
 		const isPaidWithDomain =
 			isCurrentPlanPaid( getState(), siteId ) &&
 			getDomainsBySiteId( getState(), siteId ).length > 1;
 
-		if ( isPaidWithDomain || isAnchorPodcast || isSiteOnHostingTrial( getState(), siteId ) ) {
+		if ( isPaidWithDomain || isSiteOnHostingTrial( getState(), siteId ) ) {
 			dispatch( launchSite( siteId ) );
 			return;
 		}


### PR DESCRIPTION


## Proposed Changes

* Remove instant launch for anchor_podcast sites

## Why are these changes being made?

* It has not been possible to make an anchor_podcast site for 2 years.

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
