### PR TITLE
STATS-17: add new header for pages

### DIFF
--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { CALYPSO_CONTACT } from '@automattic/urls';
@@ -19,6 +20,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import GoogleMyBusinessLocation from 'calypso/my-sites/google-my-business/location';
 import GoogleMyBusinessStatsChart from 'calypso/my-sites/google-my-business/stats/chart';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { enhanceWithSiteType, recordTracksEvent } from 'calypso/state/analytics/actions';
 import getGoogleMyBusinessConnectedLocation from 'calypso/state/selectors/get-google-my-business-connected-location';
@@ -194,6 +196,7 @@ class GoogleMyBusinessStats extends Component {
 
 	render() {
 		const { isLocationVerified, locationData, siteId, siteSlug, translate } = this.props;
+		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 		return (
 			<Main fullWidthLayout>
@@ -209,27 +212,31 @@ class GoogleMyBusinessStats extends Component {
 				<QueryKeyringServices />
 
 				<div className="stats">
-					<NavigationHeader
-						className="stats__section-header modernized-header"
-						title={ translate( 'Jetpack Stats' ) }
-						subtitle={ translate(
-							'Integrate your business with Google and get stats on your locations. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
-							{
-								components: {
-									learnMoreLink: (
-										<a
-											href={ localizeUrl(
-												'https://wordpress.com/support/google-my-business-integration/#checking-the-impact-of-your-google-my-business-connection'
-											) }
-											target="_blank"
-											rel="noreferrer noopener"
-										/>
-									),
-								},
-							}
-						) }
-						screenReader={ navItems.googleMyBusiness?.label }
-					></NavigationHeader>
+					{ ! isStatsNavigationImprovementEnabled ? (
+						<NavigationHeader
+							className="stats__section-header modernized-header"
+							title={ translate( 'Jetpack Stats' ) }
+							subtitle={ translate(
+								'Integrate your business with Google and get stats on your locations. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+								{
+									components: {
+										learnMoreLink: (
+											<a
+												href={ localizeUrl(
+													'https://wordpress.com/support/google-my-business-integration/#checking-the-impact-of-your-google-my-business-connection'
+												) }
+												target="_blank"
+												rel="noreferrer noopener"
+											/>
+										),
+									},
+								}
+							) }
+							screenReader={ navItems.googleMyBusiness?.label }
+						></NavigationHeader>
+					) : (
+						<PageHeader />
+					) }
 
 					<StatsNavigation selectedItem="googleMyBusiness" siteId={ siteId } slug={ siteSlug } />
 

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -8,8 +8,13 @@ import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
+import NavigationHeaderImpr from 'calypso/components/navigation-header/navigation-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
-import { STATS_FEATURE_PAGE_INSIGHTS, STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
+import {
+	STATS_FEATURE_PAGE_INSIGHTS,
+	STATS_PRODUCT_NAME,
+	STATS_PRODUCT_NAME_IMPR,
+} from 'calypso/my-sites/stats/constants';
 import StatsModuleComments from 'calypso/my-sites/stats/features/modules/stats-comments';
 import StatShares from 'calypso/my-sites/stats/features/modules/stats-shares';
 import StatsModuleTags from 'calypso/my-sites/stats/features/modules/stats-tags';
@@ -52,6 +57,7 @@ function StatsInsights() {
 
 	const shouldGateInsights = useShouldGateStats( STATS_FEATURE_PAGE_INSIGHTS );
 	const shouldRendeUpsell = config.isEnabled( 'stats/paid-wpcom-v3' ) && shouldGateInsights;
+	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -67,13 +73,20 @@ function StatsInsights() {
 			<DocumentHead title={ STATS_PRODUCT_NAME } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<div className={ insightsPageClasses }>
-				<NavigationHeader
-					className="stats__section-header modernized-header"
-					title={ STATS_PRODUCT_NAME }
-					subtitle={ translate( "View your site's performance and learn from trends." ) }
-					screenReader={ navItems.insights?.label }
-					navigationItems={ [] }
-				></NavigationHeader>
+				{ ! isStatsNavigationImprovementEnabled ? (
+					<NavigationHeader
+						className="stats__section-header modernized-header"
+						title={ STATS_PRODUCT_NAME }
+						subtitle={ translate( "View your site's performance and learn from trends." ) }
+						screenReader={ navItems.insights?.label }
+						navigationItems={ [] }
+					></NavigationHeader>
+				) : (
+					<NavigationHeaderImpr
+						className="stats__section-header modernized-header"
+						title={ STATS_PRODUCT_NAME_IMPR }
+					/>
+				) }
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				{ shouldRendeUpsell ? (
 					<div id="my-stats-content" className="stats-content">

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -8,13 +8,9 @@ import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
-import NavigationHeaderImpr from 'calypso/components/navigation-header/navigation-header';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
-import {
-	STATS_FEATURE_PAGE_INSIGHTS,
-	STATS_PRODUCT_NAME,
-	STATS_PRODUCT_NAME_IMPR,
-} from 'calypso/my-sites/stats/constants';
+import { STATS_FEATURE_PAGE_INSIGHTS, STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsModuleComments from 'calypso/my-sites/stats/features/modules/stats-comments';
 import StatShares from 'calypso/my-sites/stats/features/modules/stats-shares';
 import StatsModuleTags from 'calypso/my-sites/stats/features/modules/stats-tags';
@@ -82,10 +78,7 @@ function StatsInsights() {
 						navigationItems={ [] }
 					></NavigationHeader>
 				) : (
-					<NavigationHeaderImpr
-						className="stats__section-header modernized-header"
-						title={ STATS_PRODUCT_NAME_IMPR }
-					/>
+					<PageHeader />
 				) }
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				{ shouldRendeUpsell ? (

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
@@ -8,6 +9,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsModuleCountries from 'calypso/my-sites/stats/features/modules/stats-countries';
@@ -45,6 +47,7 @@ function StatsRealtime() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const moduleStrings = statsStrings();
+	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 	const halfWidthModuleClasses = clsx(
 		'stats__flexible-grid-item--half',
@@ -102,13 +105,17 @@ function StatsRealtime() {
 			<DocumentHead title={ STATS_PRODUCT_NAME } />
 			<PageViewTracker path="/stats/realtime/:site" title="Stats > Realtime" />
 			<div className="stats">
-				<NavigationHeader
-					className="stats__section-header modernized-header"
-					title={ STATS_PRODUCT_NAME }
-					subtitle={ translate( "[Experimental] View your site's traffic in real-time." ) }
-					screenReader={ navItems.realtime?.label }
-					navigationItems={ [] }
-				></NavigationHeader>
+				{ ! isStatsNavigationImprovementEnabled ? (
+					<NavigationHeader
+						className="stats__section-header modernized-header"
+						title={ STATS_PRODUCT_NAME }
+						subtitle={ translate( "[Experimental] View your site's traffic in real-time." ) }
+						screenReader={ navItems.realtime?.label }
+						navigationItems={ [] }
+					></NavigationHeader>
+				) : (
+					<PageHeader />
+				) }
 				<StatsNavigation selectedItem="realtime" siteId={ siteId } slug={ siteSlug } />
 				<StatsRealtimeHeader />
 				<AsyncLoad

--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -7,6 +7,7 @@ import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsModuleEmails from 'calypso/my-sites/stats/features/modules/stats-emails';
@@ -76,6 +77,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	);
 	const today = new Date().toISOString().slice( 0, 10 );
 	const moduleStrings = statsStrings().emails as TranslationStringType;
+	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 	const className = clsx( 'subscribers-page', {
 		'is-email-stats-unavailable': ! supportsEmailStats,
@@ -122,13 +124,17 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 			<DocumentHead title={ STATS_PRODUCT_NAME } />
 			<PageViewTracker path="/stats/subscribers/:site" title="Stats > Subscribers" />
 			<div className={ subscribersPageClasses }>
-				<NavigationHeader
-					className="stats__section-header modernized-header"
-					title={ STATS_PRODUCT_NAME }
-					subtitle={ translate( 'Track your subscriber growth and engagement.' ) }
-					screenReader={ navItems.subscribers?.label }
-					navigationItems={ [] }
-				></NavigationHeader>
+				{ ! isStatsNavigationImprovementEnabled ? (
+					<NavigationHeader
+						className="stats__section-header modernized-header"
+						title={ STATS_PRODUCT_NAME }
+						subtitle={ translate( 'Track your subscriber growth and engagement.' ) }
+						screenReader={ navItems.subscribers?.label }
+						navigationItems={ [] }
+					></NavigationHeader>
+				) : (
+					<PageHeader />
+				) }
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
 				{ isLoading && <StatsModulePlaceholder className="is-subscriber-page" isLoading /> }
 				{ isError && <StatsSubscribersPageError /> }

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -19,6 +19,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -145,6 +146,7 @@ class WordAds extends Component {
 			this.props;
 
 		const { period, endOf } = this.props.period;
+		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 		const yesterday = moment.utc().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
 
@@ -177,12 +179,16 @@ class WordAds extends Component {
 				/>
 
 				<div className={ wordAdsPageClasses }>
-					<NavigationHeader
-						className="stats__section-header modernized-header"
-						title={ STATS_PRODUCT_NAME }
-						subtitle={ translate( 'See how ads are performing on your site.' ) }
-						screenReader={ navItems.wordads?.label }
-					></NavigationHeader>
+					{ ! isStatsNavigationImprovementEnabled ? (
+						<NavigationHeader
+							className="stats__section-header modernized-header"
+							title={ STATS_PRODUCT_NAME }
+							subtitle={ translate( 'See how ads are performing on your site.' ) }
+							screenReader={ navItems.wordads?.label }
+						></NavigationHeader>
+					) : (
+						<PageHeader />
+					) }
 
 					{ ! canAccessAds && (
 						<EmptyContent

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -14,6 +15,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import DatePicker from 'calypso/my-sites/stats/stats-date-picker';
 import StatsPeriodHeader from 'calypso/my-sites/stats/stats-period-header';
 import StatsPeriodNavigation from 'calypso/my-sites/stats/stats-period-navigation';
@@ -42,6 +44,7 @@ class StoreStats extends Component {
 		const { topListQuery } = getQueries( unit, selectedDate );
 		const topWidgets = [ topProducts, topCategories, topCoupons ];
 		const widgetPath = getWidgetPath( unit, slug, queryParams );
+		const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 		// For period option links
 		const store = {
@@ -67,14 +70,18 @@ class StoreStats extends Component {
 				) }
 
 				<div className="stats">
-					<NavigationHeader
-						className="stats__section-header modernized-header"
-						title={ translate( 'Jetpack Stats' ) }
-						subtitle={ translate(
-							'Learn valuable insights about the purchases made on your store.'
-						) }
-						screenReader={ navItems.store?.label }
-					></NavigationHeader>
+					{ ! isStatsNavigationImprovementEnabled ? (
+						<NavigationHeader
+							className="stats__section-header modernized-header"
+							title={ translate( 'Jetpack Stats' ) }
+							subtitle={ translate(
+								'Learn valuable insights about the purchases made on your store.'
+							) }
+							screenReader={ navItems.store?.label }
+						></NavigationHeader>
+					) : (
+						<PageHeader />
+					) }
 
 					<StatsNavigation selectedItem="store" siteId={ siteId } slug={ slug } interval={ unit } />
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to STATS-17

## Proposed Changes

Replace header for
- Insights
- Google My Business
- Realtime
- Ads
- Shop 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Introduce new header component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live and apply `flags=stats/navigation-improvement`
* Ensure all pages mentioned are using the new header

<img width="683" alt="image" src="https://github.com/user-attachments/assets/8e54aaab-f825-4e3c-beb8-5bb364eef8d7" />


<img width="984" alt="image" src="https://github.com/user-attachments/assets/ddd85e57-bd02-42d4-a6dd-39600299becb" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
