### PR TITLE
A4A > Sites: Fix the actions menu overlapping issue

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss
@@ -238,11 +238,6 @@
 					justify-content: space-between;
 				}
 
-				.components-h-stack,
-				.dataviews-view-list__item {
-					width: 100%;
-				}
-
 				/* This styling is a bit of a hack: To make the site name clickable area larger, will need
 				 * to hide the other fields when in preview mode.
 				 */


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/2092

## Proposed Changes

This PR fixes an issue with the actions menu icon that was causing an overlap on the A4A Sites dashboard.

## Why are these changes being made?

* To fix the actions menu overlapping issues on the Sites dashboard on A4A.

## Testing Instructions

* Open the A4A live link
* Go to Sites > Open any site details > Verify the actions menu icon isn't overlapping with the site favicon 

| Before | After |
|--------|--------|
| <img width="1108" alt="Screenshot 2025-04-29 at 9 13 38 AM" src="https://github.com/user-attachments/assets/0126a535-093e-457c-86da-3cfc492cbd8d" /> | <img width="1173" alt="Screenshot 2025-04-29 at 9 15 17 AM" src="https://github.com/user-attachments/assets/d91addd6-2662-42a9-9aab-158c86560233" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
