### PR TITLE
Add the performance route to Dashboard V2

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -94,6 +94,17 @@ const siteDeploymentsRoute = createRoute( {
 	)
 );
 
+const sitePerformanceRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'performance',
+} ).lazy( () =>
+	import( '../site-performance' ).then( ( d ) =>
+		createLazyRoute( 'site-performance' )( {
+			component: d.default,
+		} )
+	)
+);
+
 const domainsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains',
@@ -252,7 +263,7 @@ const createRouteTree = ( config: AppConfig ) => {
 	if ( config.supports.sites ) {
 		children.push(
 			sitesRoute,
-			siteRoute.addChildren( [ siteOverviewRoute, siteDeploymentsRoute ] )
+			siteRoute.addChildren( [ siteOverviewRoute, siteDeploymentsRoute, sitePerformanceRoute ] )
 		);
 	}
 
@@ -301,6 +312,7 @@ export {
 	siteRoute,
 	siteOverviewRoute,
 	siteDeploymentsRoute,
+	sitePerformanceRoute,
 	domainsRoute,
 	emailsRoute,
 	meRoute,

--- a/client/dashboard/site-menu/index.tsx
+++ b/client/dashboard/site-menu/index.tsx
@@ -8,6 +8,9 @@ const SiteMenu = ( { siteId }: { siteId: string } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteId }/deployments` }>
 				{ __( 'Deployments' ) }
 			</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to={ `/sites/${ siteId }/performance` }>
+				{ __( 'Performance' ) }
+			</ResponsiveMenu.Item>
 		</ResponsiveMenu>
 	);
 };

--- a/client/dashboard/site-performance/index.tsx
+++ b/client/dashboard/site-performance/index.tsx
@@ -1,0 +1,8 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../page-layout';
+
+function SitePerformance() {
+	return <PageLayout title={ __( 'Performance' ) } />;
+}
+
+export default SitePerformance;


### PR DESCRIPTION
Related to DOTCOM-10674

## Proposed Changes

This PR adds the `Performance` route to the new dashboard.

## Why are these changes being made?

We'll need this route.

We could add it at the end or with the final PR but since we'll need multiple different refactors, it's probably best to do this in small parts.

## Testing Instructions

- Visit `/v2/sites/{site_id}/performance`
- You should see a blank page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
