### PR TITLE
Refactor performance queries in Dashboards V2

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -16,7 +16,8 @@ import {
 	fetchPerformanceInsights,
 } from '../data';
 import { queryClient } from './query-client';
-import type { Profile, PerformanceInsightsQueryState } from '../data/types';
+import type { Profile, UrlPerformanceInsights } from '../data/types';
+import type { Query } from '@tanstack/react-query';
 
 export function sitesQuery() {
 	return {
@@ -126,7 +127,7 @@ export function performanceInsightsQuery( url: string, token: string ) {
 		queryFn: () => {
 			return fetchPerformanceInsights( url, token );
 		},
-		refetchInterval: ( query: PerformanceInsightsQueryState ) => {
+		refetchInterval: ( query: Query< UrlPerformanceInsights > ) => {
 			if ( query.state.data?.pagespeed?.status === 'completed' ) {
 				return false;
 			}

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -108,24 +108,15 @@ export function siteSettingsQuery( siteId: string ) {
 		queryFn: () => {
 			return fetchSiteSettings( siteId );
 		},
-		refetchOnWindowFocus: false,
-		retry: false,
-		enabled: !! siteId,
 	};
 }
 
-export function basicMetricsQuery(
-	url: string,
-	isLoadingSiteSettings: boolean,
-	cachedHash: string
-) {
+export function basicMetricsQuery( url: string ) {
 	return {
 		queryKey: [ 'url', 'basic-metrics', url ],
 		queryFn: () => {
 			return fetchBasicMetrics( url );
 		},
-		refetchOnWindowFocus: false,
-		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
 	};
 }
 
@@ -135,8 +126,6 @@ export function performanceInsightsQuery( url: string, token: string ) {
 		queryFn: () => {
 			return fetchPerformanceInsights( url, token );
 		},
-		enabled: !! url && !! token,
-		refetchOnWindowFocus: false,
 		refetchInterval: ( query: PerformanceInsightsQueryState ) => {
 			if ( query.state.data?.pagespeed?.status === 'completed' ) {
 				return false;

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -1,3 +1,5 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
 import {
 	fetchSites,
 	fetchSite,
@@ -13,7 +15,12 @@ import {
 	updateProfile,
 } from '../data';
 import { queryClient } from './query-client';
-import type { Profile } from '../data/types';
+import type {
+	Profile,
+	SiteSettings,
+	BasicMetricsData,
+	UrlPerformanceInsights,
+} from '../data/types';
 
 export function sitesQuery() {
 	return {
@@ -95,6 +102,107 @@ export function profileMutation() {
 			queryClient.setQueryData( profileQueryKey, ( oldData: Profile | undefined ) =>
 				oldData ? { ...oldData, ...newData } : newData
 			);
+		},
+	};
+}
+
+interface QueryState {
+	state: {
+		data?: {
+			pagespeed?: {
+				status: string;
+			};
+		};
+	};
+}
+
+export function usePerformanceData( siteId: string, url: string ) {
+	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery(
+		siteSettingsQuery( siteId )
+	);
+
+	const wpcomPerformanceReportUrl = siteSettings?.settings?.wpcom_performance_report_url || '';
+	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
+
+	const { data: basicMetricsData } = useQuery(
+		basicMetricsQuery( url, isLoadingSiteSettings, cachedHash )
+	);
+
+	const token = cachedHash || basicMetricsData?.token;
+
+	const { data: performanceData } = useQuery( performanceInsightsQuery( url, token || '' ) );
+
+	const desktopLoaded = typeof performanceData?.pagespeed?.desktop === 'object';
+	const mobileLoaded = typeof performanceData?.pagespeed?.mobile === 'object';
+
+	const desktopScore =
+		desktopLoaded && typeof performanceData?.pagespeed.desktop === 'object'
+			? Math.round( performanceData.pagespeed.desktop.overall_score * 100 )
+			: undefined;
+
+	const mobileScore =
+		mobileLoaded && typeof performanceData?.pagespeed.mobile === 'object'
+			? Math.round( performanceData.pagespeed.mobile.overall_score * 100 )
+			: undefined;
+
+	return {
+		desktopScore,
+		mobileScore,
+		desktopLoaded,
+		mobileLoaded,
+		isLoadingSiteSettings,
+	};
+}
+
+function siteSettingsQuery( siteId: string ) {
+	return {
+		queryKey: [ 'site-settings', siteId ],
+		queryFn: () =>
+			wp.req.get(
+				{ path: `/sites/${ siteId }/settings` },
+				{ apiVersion: '1.4' }
+			) as Promise< SiteSettings >,
+		refetchOnWindowFocus: false,
+		retry: false,
+		enabled: !! siteId,
+	};
+}
+
+function basicMetricsQuery( url: string, isLoadingSiteSettings: boolean, cachedHash: string ) {
+	return {
+		queryKey: [ 'url', 'basic-metrics', url ],
+		queryFn: () =>
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/basic',
+					apiNamespace: 'wpcom/v2',
+				},
+				// Important: advance=1 is needed to get the `token` and request advanced metrics.
+				{ url, advance: '1' }
+			) as Promise< BasicMetricsData >,
+		refetchOnWindowFocus: false,
+		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
+	};
+}
+
+function performanceInsightsQuery( url: string, token: string ) {
+	return {
+		queryKey: [ 'url', 'performance', url, token ],
+		queryFn: () =>
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/advanced/insights',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ url, advance: '1', hash: token }
+			) as Promise< UrlPerformanceInsights >,
+		enabled: !! url && !! token,
+		refetchOnWindowFocus: false,
+		refetchInterval: ( query: QueryState ) => {
+			if ( query.state.data?.pagespeed?.status === 'completed' ) {
+				return false;
+			}
+			return 5000;
 		},
 	};
 }

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -1,5 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
-import wp from 'calypso/lib/wp';
 import {
 	fetchSites,
 	fetchSite,
@@ -13,14 +11,12 @@ import {
 	fetchEmails,
 	fetchProfile,
 	updateProfile,
+	fetchSiteSettings,
+	fetchBasicMetrics,
+	fetchPerformanceInsights,
 } from '../data';
 import { queryClient } from './query-client';
-import type {
-	Profile,
-	SiteSettings,
-	BasicMetricsData,
-	UrlPerformanceInsights,
-} from '../data/types';
+import type { Profile, PerformanceInsightsQueryState } from '../data/types';
 
 export function sitesQuery() {
 	return {
@@ -106,99 +102,42 @@ export function profileMutation() {
 	};
 }
 
-interface QueryState {
-	state: {
-		data?: {
-			pagespeed?: {
-				status: string;
-			};
-		};
-	};
-}
-
-export function usePerformanceData( siteId: string, url: string ) {
-	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery(
-		siteSettingsQuery( siteId )
-	);
-
-	const wpcomPerformanceReportUrl = siteSettings?.settings?.wpcom_performance_report_url || '';
-	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
-
-	const { data: basicMetricsData } = useQuery(
-		basicMetricsQuery( url, isLoadingSiteSettings, cachedHash )
-	);
-
-	const token = cachedHash || basicMetricsData?.token;
-
-	const { data: performanceData } = useQuery( performanceInsightsQuery( url, token || '' ) );
-
-	const desktopLoaded = typeof performanceData?.pagespeed?.desktop === 'object';
-	const mobileLoaded = typeof performanceData?.pagespeed?.mobile === 'object';
-
-	const desktopScore =
-		desktopLoaded && typeof performanceData?.pagespeed.desktop === 'object'
-			? Math.round( performanceData.pagespeed.desktop.overall_score * 100 )
-			: undefined;
-
-	const mobileScore =
-		mobileLoaded && typeof performanceData?.pagespeed.mobile === 'object'
-			? Math.round( performanceData.pagespeed.mobile.overall_score * 100 )
-			: undefined;
-
-	return {
-		desktopScore,
-		mobileScore,
-		desktopLoaded,
-		mobileLoaded,
-		isLoadingSiteSettings,
-	};
-}
-
-function siteSettingsQuery( siteId: string ) {
+export function siteSettingsQuery( siteId: string ) {
 	return {
 		queryKey: [ 'site-settings', siteId ],
-		queryFn: () =>
-			wp.req.get(
-				{ path: `/sites/${ siteId }/settings` },
-				{ apiVersion: '1.4' }
-			) as Promise< SiteSettings >,
+		queryFn: () => {
+			return fetchSiteSettings( siteId );
+		},
 		refetchOnWindowFocus: false,
 		retry: false,
 		enabled: !! siteId,
 	};
 }
 
-function basicMetricsQuery( url: string, isLoadingSiteSettings: boolean, cachedHash: string ) {
+export function basicMetricsQuery(
+	url: string,
+	isLoadingSiteSettings: boolean,
+	cachedHash: string
+) {
 	return {
 		queryKey: [ 'url', 'basic-metrics', url ],
-		queryFn: () =>
-			wp.req.get(
-				{
-					path: '/site-profiler/metrics/basic',
-					apiNamespace: 'wpcom/v2',
-				},
-				// Important: advance=1 is needed to get the `token` and request advanced metrics.
-				{ url, advance: '1' }
-			) as Promise< BasicMetricsData >,
+		queryFn: () => {
+			return fetchBasicMetrics( url );
+		},
 		refetchOnWindowFocus: false,
 		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
 	};
 }
 
-function performanceInsightsQuery( url: string, token: string ) {
+export function performanceInsightsQuery( url: string, token: string ) {
 	return {
 		queryKey: [ 'url', 'performance', url, token ],
-		queryFn: () =>
-			wp.req.get(
-				{
-					path: '/site-profiler/metrics/advanced/insights',
-					apiNamespace: 'wpcom/v2',
-				},
-				{ url, advance: '1', hash: token }
-			) as Promise< UrlPerformanceInsights >,
+		queryFn: () => {
+			return fetchPerformanceInsights( url, token );
+		},
 		enabled: !! url && !! token,
 		refetchOnWindowFocus: false,
-		refetchInterval: ( query: QueryState ) => {
+		refetchInterval: ( query: PerformanceInsightsQueryState ) => {
 			if ( query.state.data?.pagespeed?.status === 'completed' ) {
 				return false;
 			}

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -295,7 +295,7 @@ export const fetchTwoStep = async (): Promise< TwoStep > => {
 export const fetchSiteSettings = async ( id: string ): Promise< SiteSettings > => {
 	return wpcom.req.get( {
 		path: `/sites/${ id }/settings`,
-		apiNamespace: 'rest/v1.1',
+		apiVersion: '1.4',
 	} );
 };
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -11,6 +11,9 @@ import type {
 	TwoStep,
 	EngagementStatsDataPoint,
 	SiteDomain,
+	BasicMetricsData,
+	SiteSettings,
+	UrlPerformanceInsights,
 } from './types';
 
 export const fetchProfile = async (): Promise< Profile > => {
@@ -287,4 +290,35 @@ export const fetchUser = async (): Promise< User > => {
 
 export const fetchTwoStep = async (): Promise< TwoStep > => {
 	return wpcom.req.get( '/me/two-step' );
+};
+
+export const fetchSiteSettings = async ( id: string ): Promise< SiteSettings > => {
+	return wpcom.req.get( {
+		path: `/sites/${ id }/settings`,
+		apiNamespace: 'rest/v1.1',
+	} );
+};
+
+export const fetchBasicMetrics = async ( url: string ): Promise< BasicMetricsData > => {
+	return wp.req.get(
+		{
+			path: '/site-profiler/metrics/basic',
+			apiNamespace: 'wpcom/v2',
+		},
+		// Important: advance=1 is needed to get the `token` and request advanced metrics.
+		{ url, advance: '1' }
+	);
+};
+
+export const fetchPerformanceInsights = async (
+	url: string,
+	token: string
+): Promise< UrlPerformanceInsights > => {
+	return wp.req.get(
+		{
+			path: '/site-profiler/metrics/advanced/insights',
+			apiNamespace: 'wpcom/v2',
+		},
+		{ url, advance: '1', hash: token }
+	);
 };

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -300,7 +300,7 @@ export const fetchSiteSettings = async ( id: string ): Promise< SiteSettings > =
 };
 
 export const fetchBasicMetrics = async ( url: string ): Promise< BasicMetricsData > => {
-	return wp.req.get(
+	return wpcom.req.get(
 		{
 			path: '/site-profiler/metrics/basic',
 			apiNamespace: 'wpcom/v2',
@@ -314,7 +314,7 @@ export const fetchPerformanceInsights = async (
 	url: string,
 	token: string
 ): Promise< UrlPerformanceInsights > => {
-	return wp.req.get(
+	return wpcom.req.get(
 		{
 			path: '/site-profiler/metrics/advanced/insights',
 			apiNamespace: 'wpcom/v2',

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -138,9 +138,22 @@ export interface EngagementStats {
 	previousData: EngagementStatsDataPoint;
 }
 
-export type PerformanceReport = {
+export interface SiteSettings {
+	settings: {
+		wpcom_performance_report_url?: string;
+		[ key: string ]: any;
+	};
+}
+
+export interface BasicMetricsData {
+	token?: string;
+	[ key: string ]: any;
+}
+
+export interface PerformanceReport {
 	overall_score: number;
-};
+}
+
 export interface UrlPerformanceInsights {
 	pagespeed: {
 		status: string;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -141,7 +141,6 @@ export interface EngagementStats {
 export interface SiteSettings {
 	settings: {
 		wpcom_performance_report_url?: string;
-		[ key: string ]: any;
 	};
 }
 
@@ -157,7 +156,6 @@ export interface PerformanceInsightsQueryState {
 
 export interface BasicMetricsData {
 	token?: string;
-	[ key: string ]: any;
 }
 
 export interface PerformanceReport {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -145,6 +145,16 @@ export interface SiteSettings {
 	};
 }
 
+export interface PerformanceInsightsQueryState {
+	state: {
+		data?: {
+			pagespeed?: {
+				status: string;
+			};
+		};
+	};
+}
+
 export interface BasicMetricsData {
 	token?: string;
 	[ key: string ]: any;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -144,16 +144,6 @@ export interface SiteSettings {
 	};
 }
 
-export interface PerformanceInsightsQueryState {
-	state: {
-		data?: {
-			pagespeed?: {
-				status: string;
-			};
-		};
-	};
-}
-
 export interface BasicMetricsData {
 	token?: string;
 }

--- a/client/dashboard/hooks/use-performance-data.ts
+++ b/client/dashboard/hooks/use-performance-data.ts
@@ -24,7 +24,7 @@ export function usePerformanceData( siteId: string, url: string ): PerformanceDa
 	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
 
 	const { data: basicMetricsData, isLoading: isLoadingBasicMetrics } = useQuery( {
-		...basicMetricsQuery( url, isLoadingSiteSettings, cachedHash ),
+		...basicMetricsQuery( url ),
 		refetchOnWindowFocus: false,
 		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
 	} );
@@ -51,6 +51,7 @@ export function usePerformanceData( siteId: string, url: string ): PerformanceDa
 			: undefined;
 
 	return {
+		performanceData,
 		desktopScore,
 		mobileScore,
 		desktopLoaded,

--- a/client/dashboard/hooks/use-performance-data.ts
+++ b/client/dashboard/hooks/use-performance-data.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import wp from 'calypso/lib/wp';
-import type { SiteSettings, BasicMetricsData, UrlPerformanceInsights } from '../data/types';
+import { siteSettingsQuery, basicMetricsQuery, performanceInsightsQuery } from '../app/queries';
 
 interface PerformanceData {
 	desktopScore: number | undefined;
@@ -8,69 +7,6 @@ interface PerformanceData {
 	desktopLoaded: boolean;
 	mobileLoaded: boolean;
 	isLoadingSiteSettings: boolean;
-}
-
-function siteSettingsQuery( siteId: string ) {
-	return {
-		queryKey: [ 'site-settings', siteId ],
-		queryFn: () =>
-			wp.req.get(
-				{ path: `/sites/${ siteId }/settings` },
-				{ apiVersion: '1.4' }
-			) as Promise< SiteSettings >,
-		refetchOnWindowFocus: false,
-		retry: false,
-		enabled: !! siteId,
-	};
-}
-
-function basicMetricsQuery( url: string, isLoadingSiteSettings: boolean, cachedHash: string ) {
-	return {
-		queryKey: [ 'url', 'basic-metrics', url ],
-		queryFn: () =>
-			wp.req.get(
-				{
-					path: '/site-profiler/metrics/basic',
-					apiNamespace: 'wpcom/v2',
-				},
-				// Important: advance=1 is needed to get the `token` and request advanced metrics.
-				{ url, advance: '1' }
-			) as Promise< BasicMetricsData >,
-		refetchOnWindowFocus: false,
-		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
-	};
-}
-
-interface QueryState {
-	state: {
-		data?: {
-			pagespeed?: {
-				status: string;
-			};
-		};
-	};
-}
-
-function performanceInsightsQuery( url: string, token: string ) {
-	return {
-		queryKey: [ 'url', 'performance', url, token ],
-		queryFn: () =>
-			wp.req.get(
-				{
-					path: '/site-profiler/metrics/advanced/insights',
-					apiNamespace: 'wpcom/v2',
-				},
-				{ url, advance: '1', hash: token }
-			) as Promise< UrlPerformanceInsights >,
-		enabled: !! url && !! token,
-		refetchOnWindowFocus: false,
-		refetchInterval: ( query: QueryState ) => {
-			if ( query.state.data?.pagespeed?.status === 'completed' ) {
-				return false;
-			}
-			return 5000;
-		},
-	};
 }
 
 export function usePerformanceData( siteId: string, url: string ): PerformanceData {

--- a/client/dashboard/hooks/use-performance-data.ts
+++ b/client/dashboard/hooks/use-performance-data.ts
@@ -1,0 +1,113 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import type { SiteSettings, BasicMetricsData, UrlPerformanceInsights } from '../data/types';
+
+interface PerformanceData {
+	desktopScore: number | undefined;
+	mobileScore: number | undefined;
+	desktopLoaded: boolean;
+	mobileLoaded: boolean;
+	isLoadingSiteSettings: boolean;
+}
+
+function siteSettingsQuery( siteId: string ) {
+	return {
+		queryKey: [ 'site-settings', siteId ],
+		queryFn: () =>
+			wp.req.get(
+				{ path: `/sites/${ siteId }/settings` },
+				{ apiVersion: '1.4' }
+			) as Promise< SiteSettings >,
+		refetchOnWindowFocus: false,
+		retry: false,
+		enabled: !! siteId,
+	};
+}
+
+function basicMetricsQuery( url: string, isLoadingSiteSettings: boolean, cachedHash: string ) {
+	return {
+		queryKey: [ 'url', 'basic-metrics', url ],
+		queryFn: () =>
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/basic',
+					apiNamespace: 'wpcom/v2',
+				},
+				// Important: advance=1 is needed to get the `token` and request advanced metrics.
+				{ url, advance: '1' }
+			) as Promise< BasicMetricsData >,
+		refetchOnWindowFocus: false,
+		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
+	};
+}
+
+interface QueryState {
+	state: {
+		data?: {
+			pagespeed?: {
+				status: string;
+			};
+		};
+	};
+}
+
+function performanceInsightsQuery( url: string, token: string ) {
+	return {
+		queryKey: [ 'url', 'performance', url, token ],
+		queryFn: () =>
+			wp.req.get(
+				{
+					path: '/site-profiler/metrics/advanced/insights',
+					apiNamespace: 'wpcom/v2',
+				},
+				{ url, advance: '1', hash: token }
+			) as Promise< UrlPerformanceInsights >,
+		enabled: !! url && !! token,
+		refetchOnWindowFocus: false,
+		refetchInterval: ( query: QueryState ) => {
+			if ( query.state.data?.pagespeed?.status === 'completed' ) {
+				return false;
+			}
+			return 5000;
+		},
+	};
+}
+
+export function usePerformanceData( siteId: string, url: string ): PerformanceData {
+	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery(
+		siteSettingsQuery( siteId )
+	);
+
+	const wpcomPerformanceReportUrl: string =
+		siteSettings?.settings?.wpcom_performance_report_url || '';
+	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
+
+	const { data: basicMetricsData } = useQuery(
+		basicMetricsQuery( url, isLoadingSiteSettings, cachedHash )
+	);
+
+	const token = cachedHash || basicMetricsData?.token;
+
+	const { data: performanceData } = useQuery( performanceInsightsQuery( url, token || '' ) );
+
+	const desktopLoaded = typeof performanceData?.pagespeed?.desktop === 'object';
+	const mobileLoaded = typeof performanceData?.pagespeed?.mobile === 'object';
+
+	const desktopScore =
+		desktopLoaded && typeof performanceData?.pagespeed.desktop === 'object'
+			? Math.round( performanceData.pagespeed.desktop.overall_score * 100 )
+			: undefined;
+
+	const mobileScore =
+		mobileLoaded && typeof performanceData?.pagespeed.mobile === 'object'
+			? Math.round( performanceData.pagespeed.mobile.overall_score * 100 )
+			: undefined;
+
+	return {
+		desktopScore,
+		mobileScore,
+		desktopLoaded,
+		mobileLoaded,
+		isLoadingSiteSettings,
+	};
+}

--- a/client/dashboard/hooks/use-performance-data.ts
+++ b/client/dashboard/hooks/use-performance-data.ts
@@ -12,23 +12,30 @@ interface PerformanceData {
 }
 
 export function usePerformanceData( siteId: string, url: string ): PerformanceData {
-	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery(
-		siteSettingsQuery( siteId )
-	);
+	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery( {
+		...siteSettingsQuery( siteId ),
+		refetchOnWindowFocus: false,
+		retry: false,
+		enabled: !! siteId,
+	} );
 
 	const wpcomPerformanceReportUrl: string =
 		siteSettings?.settings?.wpcom_performance_report_url || '';
 	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
 
-	const { data: basicMetricsData, isLoading: isLoadingBasicMetrics } = useQuery(
-		basicMetricsQuery( url, isLoadingSiteSettings, cachedHash )
-	);
+	const { data: basicMetricsData, isLoading: isLoadingBasicMetrics } = useQuery( {
+		...basicMetricsQuery( url, isLoadingSiteSettings, cachedHash ),
+		refetchOnWindowFocus: false,
+		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
+	} );
 
 	const token = cachedHash || basicMetricsData?.token;
 
-	const { data: performanceData, isLoading: isLoadingPerformanceInsights } = useQuery(
-		performanceInsightsQuery( url, token || '' )
-	);
+	const { data: performanceData, isLoading: isLoadingPerformanceInsights } = useQuery( {
+		...performanceInsightsQuery( url, token || '' ),
+		refetchOnWindowFocus: false,
+		enabled: !! url && !! token,
+	} );
 
 	const desktopLoaded = typeof performanceData?.pagespeed?.desktop === 'object';
 	const mobileLoaded = typeof performanceData?.pagespeed?.mobile === 'object';

--- a/client/dashboard/hooks/use-performance-data.ts
+++ b/client/dashboard/hooks/use-performance-data.ts
@@ -1,12 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { siteSettingsQuery, basicMetricsQuery, performanceInsightsQuery } from '../app/queries';
+import { UrlPerformanceInsights } from '../data/types';
 
 interface PerformanceData {
+	performanceData: UrlPerformanceInsights | undefined;
 	desktopScore: number | undefined;
 	mobileScore: number | undefined;
 	desktopLoaded: boolean;
 	mobileLoaded: boolean;
-	isLoadingSiteSettings: boolean;
+	isLoading: boolean;
 }
 
 export function usePerformanceData( siteId: string, url: string ): PerformanceData {
@@ -18,13 +20,15 @@ export function usePerformanceData( siteId: string, url: string ): PerformanceDa
 		siteSettings?.settings?.wpcom_performance_report_url || '';
 	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
 
-	const { data: basicMetricsData } = useQuery(
+	const { data: basicMetricsData, isLoading: isLoadingBasicMetrics } = useQuery(
 		basicMetricsQuery( url, isLoadingSiteSettings, cachedHash )
 	);
 
 	const token = cachedHash || basicMetricsData?.token;
 
-	const { data: performanceData } = useQuery( performanceInsightsQuery( url, token || '' ) );
+	const { data: performanceData, isLoading: isLoadingPerformanceInsights } = useQuery(
+		performanceInsightsQuery( url, token || '' )
+	);
 
 	const desktopLoaded = typeof performanceData?.pagespeed?.desktop === 'object';
 	const mobileLoaded = typeof performanceData?.pagespeed?.mobile === 'object';
@@ -44,6 +48,6 @@ export function usePerformanceData( siteId: string, url: string ): PerformanceDa
 		mobileScore,
 		desktopLoaded,
 		mobileLoaded,
-		isLoadingSiteSettings,
+		isLoading: isLoadingSiteSettings || isLoadingBasicMetrics || isLoadingPerformanceInsights,
 	};
 }

--- a/client/dashboard/site-overview/performance-cards.tsx
+++ b/client/dashboard/site-overview/performance-cards.tsx
@@ -1,10 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { desktop, mobile } from '@wordpress/icons';
 import CoreBadge from 'calypso/components/core/badge';
-import wp from 'calypso/lib/wp';
+import { usePerformanceData } from '../hooks/use-performance-data';
 import OverviewCard, { OverviewCardProgressBar } from '../overview-card';
-import type { Site, UrlPerformanceInsights } from '../data/types';
+import type { Site } from '../data/types';
 
 type BadgeIntent = 'default' | 'info' | 'success' | 'warning' | 'error';
 
@@ -28,62 +27,11 @@ function PerformanceBadge( { value }: { value: number | undefined } ) {
 }
 
 export default function PerformanceCards( { site }: { site: Site } ) {
-	const { data: siteSettings, isLoading: isLoadingSiteSettings } = useQuery( {
-		queryKey: [ 'site-settings', site.ID ],
-		queryFn: () => wp.req.get( { path: `/sites/${ site.ID }/settings` }, { apiVersion: '1.4' } ),
-		refetchOnWindowFocus: false,
-		retry: false,
-		enabled: !! site.ID,
-	} );
-	const wpcomPerformanceReportUrl = siteSettings?.settings?.wpcom_performance_report_url || '';
-	const [ , cachedHash ] = wpcomPerformanceReportUrl.split( '&hash=' );
-	const { URL: url } = site;
-	// First fetch basic metrics to get the token/hash.
-	const { data: basicMetricsData } = useQuery( {
-		queryKey: [ 'url', 'basic-metrics', url ],
-		queryFn: () =>
-			wp.req.get(
-				{
-					path: '/site-profiler/metrics/basic',
-					apiNamespace: 'wpcom/v2',
-				},
-				// Important: advance=1 is needed to get the `token` and request advanced metrics.
-				{ url, advance: '1' }
-			),
-		refetchOnWindowFocus: false,
-		enabled: !! url && ! isLoadingSiteSettings && ! cachedHash,
-	} );
-	const token = cachedHash || basicMetricsData?.token;
-	// Then use the token to fetch performance insights.
-	const { data } = useQuery< UrlPerformanceInsights >( {
-		queryKey: [ 'url', 'performance', url, token ],
-		queryFn: () =>
-			wp.req.get(
-				{
-					path: '/site-profiler/metrics/advanced/insights',
-					apiNamespace: 'wpcom/v2',
-				},
-				{ url, advance: '1', hash: token }
-			),
-		enabled: !! url && !! token,
-		refetchOnWindowFocus: false,
-		refetchInterval: ( query ) => {
-			if ( query.state.data?.pagespeed?.status === 'completed' ) {
-				return false;
-			}
-			return 5000;
-		},
-	} );
-	const desktopLoaded = typeof data?.pagespeed?.desktop === 'object';
-	const mobileLoaded = typeof data?.pagespeed?.mobile === 'object';
-	const desktopScore =
-		desktopLoaded && typeof data.pagespeed.desktop === 'object'
-			? Math.round( data.pagespeed.desktop.overall_score * 100 )
-			: undefined;
-	const mobileScore =
-		mobileLoaded && typeof data.pagespeed.mobile === 'object'
-			? Math.round( data.pagespeed.mobile.overall_score * 100 )
-			: undefined;
+	const { desktopScore, mobileScore, desktopLoaded, mobileLoaded } = usePerformanceData(
+		site.ID,
+		site.URL
+	);
+
 	return (
 		<>
 			<OverviewCard


### PR DESCRIPTION
Fixes DOTCOM-10690

Related to: https://github.com/Automattic/wp-calypso/pull/102955

## Proposed Changes

We'll need to use these functions for the `/performance` page. Let's centralize this.

## Questions:

I've abstracted the three queries into a hook and placed it in `/hooks`. 

I don't know if that follows our standards.

## Testing Instructions

Without cached values: (Delete LocalStorage: `REACT_QUERY_OFFLINE_CACHE` key)
- Visit `/v2/sites/:site` 
- Expect to see the performance cards start with the loading state, then populate with data.

With cached values:
- Visit `/v2/sites/:site` 
- Expect to see the performance cards populated with data on load.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
