### PR TITLE
Dashboard v2: use site slug instead of ID in the URL

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -7,14 +7,9 @@ module.exports = {
 					{
 						group: [
 							'calypso/*',
-							// Allowed:
-							// - calypso/lib/url/http-utils
-							// - calypso/lib/wp
+							// Allowed: calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',
-							'!calypso/lib/url',
-							'calypso/lib/url/*',
-							'!calypso/lib/url/http-utils',
 							'!calypso/lib/wp',
 							// Allowed:
 							// - calypso/components/core/badge

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -8,11 +8,13 @@ module.exports = {
 						group: [
 							'calypso/*',
 							// Allowed:
-							// - calypso/lib/url
+							// - calypso/lib/url/http-utils
 							// - calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',
 							'!calypso/lib/url',
+							'calypso/lib/url/*',
+							'!calypso/lib/url/http-utils',
 							'!calypso/lib/wp',
 							// Allowed:
 							// - calypso/components/core/badge

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -7,9 +7,12 @@ module.exports = {
 					{
 						group: [
 							'calypso/*',
-							// Allowed: calypso/lib/wp
+							// Allowed:
+							// - calypso/lib/url
+							// - calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',
+							'!calypso/lib/url',
 							'!calypso/lib/wp',
 							// Allowed:
 							// - calypso/components/core/badge

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -22,17 +22,17 @@ export function sitesQuery() {
 	};
 }
 
-export function siteQuery( siteId: string ) {
+export function siteQuery( siteIdOrSlug: string ) {
 	return {
-		queryKey: [ 'site', siteId ],
+		queryKey: [ 'site', siteIdOrSlug ],
 		queryFn: async () => {
 			// Site usually takes the longest, so kick it off first.
-			const sitePromise = fetchSite( siteId );
+			const sitePromise = fetchSite( siteIdOrSlug );
 			// Kick off all independent promises in parallel.
-			const mediaStoragePromise = fetchSiteMediaStorage( siteId );
-			const currentPlanPromise = fetchCurrentPlan( siteId );
-			const primaryDomainPromise = fetchSitePrimaryDomain( siteId );
-			const engagementStatsPromise = fetchSiteEngagementStats( siteId );
+			const mediaStoragePromise = fetchSiteMediaStorage( siteIdOrSlug );
+			const currentPlanPromise = fetchCurrentPlan( siteIdOrSlug );
+			const primaryDomainPromise = fetchSitePrimaryDomain( siteIdOrSlug );
+			const engagementStatsPromise = fetchSiteEngagementStats( siteIdOrSlug );
 			const site = await sitePromise;
 			const [
 				mediaStorage,
@@ -48,9 +48,9 @@ export function siteQuery( siteId: string ) {
 				engagementStatsPromise,
 				// Kick off dependent promises in parallel.
 				site.jetpack && site.jetpack_modules.includes( 'monitor' )
-					? fetchSiteMonitorUptime( siteId )
+					? fetchSiteMonitorUptime( site.ID )
 					: undefined,
-				site.options?.is_wpcom_atomic ? fetchPHPVersion( siteId ) : undefined,
+				site.options?.is_wpcom_atomic ? fetchPHPVersion( site.ID ) : undefined,
 			] );
 			return {
 				site,

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -62,8 +62,8 @@ const sitesRoute = createRoute( {
 
 const siteRoute = createRoute( {
 	getParentRoute: () => rootRoute,
-	path: 'sites/$siteId',
-	loader: ( { params: { siteId } } ) => maybeAwaitFetch( siteQuery( siteId ) ),
+	path: 'sites/$siteSlug',
+	loader: ( { params: { siteSlug } } ) => maybeAwaitFetch( siteQuery( siteSlug ) ),
 } ).lazy( () =>
 	import( '../site' ).then( ( d ) =>
 		createLazyRoute( 'site' )( {

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -62,12 +62,12 @@ export const fetchSites = async (): Promise< Site[] > => {
 	return sites;
 };
 
-export const fetchSite = async ( id: string ): Promise< Site > => {
-	return await wpcom.req.get( `/sites/${ id }`, { fields: SITE_FIELDS } );
+export const fetchSite = async ( siteIdOrSlug: string ): Promise< Site > => {
+	return await wpcom.req.get( `/sites/${ siteIdOrSlug }`, { fields: SITE_FIELDS } );
 };
 
-export const fetchSiteMediaStorage = async ( id: string ): Promise< MediaStorage > => {
-	const mediaStorage = await wpcom.req.get( `/sites/${ id }/media-storage` );
+export const fetchSiteMediaStorage = async ( siteIdOrSlug: string ): Promise< MediaStorage > => {
+	const mediaStorage = await wpcom.req.get( `/sites/${ siteIdOrSlug }/media-storage` );
 	return {
 		maxStorageBytesFromAddOns: Number( mediaStorage.max_storage_bytes_from_add_ons ),
 		maxStorageBytes: Number( mediaStorage.max_storage_bytes ),
@@ -96,9 +96,9 @@ export const fetchPHPVersion = async ( id: string ): Promise< string | undefined
 	} );
 };
 
-export const fetchCurrentPlan = async ( id: string ): Promise< Plan > => {
+export const fetchCurrentPlan = async ( siteIdOrSlug: string ): Promise< Plan > => {
 	const plans: Record< string, Plan > = await wpcom.req.get( {
-		path: `/sites/${ id }/plans`,
+		path: `/sites/${ siteIdOrSlug }/plans`,
 		apiVersion: '1.3',
 	} );
 	const plan = Object.values( plans ).find( ( plan ) => plan.current_plan );
@@ -108,8 +108,8 @@ export const fetchCurrentPlan = async ( id: string ): Promise< Plan > => {
 	return plan;
 };
 
-export const fetchSiteEngagementStats = async ( id: string ) => {
-	const response = await wpcom.req.get( `/sites/${ id }/stats/visits`, {
+export const fetchSiteEngagementStats = async ( siteIdOrSlug: string ) => {
+	const response = await wpcom.req.get( `/sites/${ siteIdOrSlug }/stats/visits`, {
 		unit: 'day',
 		quantity: 14,
 		stat_fields: [ 'visitors', 'views', 'likes', 'comments' ].join( ',' ),
@@ -152,8 +152,10 @@ export const fetchSiteDomains = async ( id: string ): Promise< { domains: SiteDo
 	}
 };
 
-export const fetchSitePrimaryDomain = async ( id: string ): Promise< SiteDomain | undefined > => {
-	const { domains } = await fetchSiteDomains( id );
+export const fetchSitePrimaryDomain = async (
+	siteIdOrSlug: string
+): Promise< SiteDomain | undefined > => {
+	const { domains } = await fetchSiteDomains( siteIdOrSlug );
 	return domains.find( ( domain: SiteDomain ) => domain.primary_domain );
 };
 

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -1,4 +1,5 @@
 import wpcom from 'calypso/lib/wp';
+import { getSiteSlug } from '../utils/site-slug';
 import type {
 	Domain,
 	Email,
@@ -59,11 +60,12 @@ export const fetchSites = async (): Promise< Site[] > => {
 			fields: SITE_FIELDS,
 		}
 	);
-	return sites;
+	return sites.map( ( site: Site ) => ( { ...site, slug: getSiteSlug( site ) } ) );
 };
 
 export const fetchSite = async ( siteIdOrSlug: string ): Promise< Site > => {
-	return await wpcom.req.get( `/sites/${ siteIdOrSlug }`, { fields: SITE_FIELDS } );
+	const site = await wpcom.req.get( `/sites/${ siteIdOrSlug }`, { fields: SITE_FIELDS } );
+	return { ...site, slug: getSiteSlug( site ) };
 };
 
 export const fetchSiteMediaStorage = async ( siteIdOrSlug: string ): Promise< MediaStorage > => {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -66,6 +66,7 @@ export interface SiteOptions {
 	is_wpcom_atomic?: boolean;
 	blog_public: number;
 	is_redirect?: boolean;
+	unmapped_url?: string;
 }
 
 export interface Site {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -71,6 +71,7 @@ export interface SiteOptions {
 
 export interface Site {
 	ID: string;
+	slug: string;
 	name: string;
 	URL: string;
 	icon?: {

--- a/client/dashboard/site-menu/index.tsx
+++ b/client/dashboard/site-menu/index.tsx
@@ -8,7 +8,7 @@ const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
 				{ __( 'Deployments' ) }
 			</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to={ `/sites/${ siteId }/performance` }>
+			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 				{ __( 'Performance' ) }
 			</ResponsiveMenu.Item>
 		</ResponsiveMenu>

--- a/client/dashboard/site-menu/index.tsx
+++ b/client/dashboard/site-menu/index.tsx
@@ -1,11 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import ResponsiveMenu from '../responsive-menu';
 
-const SiteMenu = ( { siteId }: { siteId: string } ) => {
+const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
 	return (
 		<ResponsiveMenu label={ __( 'Site Menu' ) }>
-			<ResponsiveMenu.Item to={ `/sites/${ siteId }` }>{ __( 'Overview' ) }</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to={ `/sites/${ siteId }/deployments` }>
+			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` }>{ __( 'Overview' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
 				{ __( 'Deployments' ) }
 			</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to={ `/sites/${ siteId }/performance` }>

--- a/client/dashboard/site-overview/index.tsx
+++ b/client/dashboard/site-overview/index.tsx
@@ -26,8 +26,9 @@ import VisitorsCard from './visitors-card';
 import './style.scss';
 
 function SiteOverview() {
-	const { siteId } = siteRoute.useParams();
-	const { data } = useQuery( siteQuery( siteId ) );
+	const { siteSlug } = siteRoute.useParams();
+	const { data } = useQuery( siteQuery( siteSlug ) );
+
 	if ( ! data ) {
 		return;
 	}

--- a/client/dashboard/site/index.tsx
+++ b/client/dashboard/site/index.tsx
@@ -12,8 +12,8 @@ import Switcher from './switcher';
 
 function Site() {
 	const isDesktop = useViewportMatch( 'medium' );
-	const { siteId } = siteRoute.useParams();
-	const { data } = useQuery( siteQuery( siteId ) );
+	const { siteSlug } = siteRoute.useParams();
+	const { data } = useQuery( siteQuery( siteSlug ) );
 
 	if ( ! data ) {
 		return;
@@ -38,7 +38,7 @@ function Site() {
 						/>
 					</HeaderBar.Title>
 					{ isDesktop && <MenuDivider /> }
-					<SiteMenu siteId={ site.ID } />
+					<SiteMenu siteSlug={ siteSlug } />
 				</HStack>
 			</HeaderBar>
 			<Outlet />

--- a/client/dashboard/site/switcher.tsx
+++ b/client/dashboard/site/switcher.tsx
@@ -7,7 +7,6 @@ import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { sitesQuery } from '../app/queries';
 import SiteIcon from '../site-icon';
-import { getSiteSlug } from '../utils/site-slug';
 import type { View } from '@wordpress/dataviews';
 
 const fields = [ { id: 'name', enableGlobalSearch: true } ];
@@ -45,7 +44,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 					<MenuItem
 						key={ site.ID }
 						onClick={ async () => {
-							await navigate( { to: `/sites/${ getSiteSlug( site ) }` } );
+							await navigate( { to: `/sites/${ site.slug }` } );
 							onClose();
 						} }
 					>

--- a/client/dashboard/site/switcher.tsx
+++ b/client/dashboard/site/switcher.tsx
@@ -7,6 +7,7 @@ import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { sitesQuery } from '../app/queries';
 import SiteIcon from '../site-icon';
+import { getSiteSlug } from '../utils/site-slug';
 import type { View } from '@wordpress/dataviews';
 
 const fields = [ { id: 'name', enableGlobalSearch: true } ];
@@ -44,7 +45,7 @@ export default function Switcher( { onClose }: { onClose: () => void } ) {
 					<MenuItem
 						key={ site.ID }
 						onClick={ async () => {
-							await navigate( { to: `/sites/${ site.ID }` } );
+							await navigate( { to: `/sites/${ getSiteSlug( site ) }` } );
 							onClose();
 						} }
 					>

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -12,6 +12,7 @@ import PageLayout from '../page-layout';
 import SiteIcon from '../site-icon';
 import SitePreview from '../site-preview';
 import { isA8CSite } from '../utils/site-owner';
+import { getSiteSlug } from '../utils/site-slug';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import type { Site } from '../data/types';
 import type { View, Operator } from '@wordpress/dataviews';
@@ -192,7 +193,7 @@ export default function Sites() {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
 
 	const onClickItem = ( item: Site ) => {
-		navigate( { to: `/sites/${ item.ID }` } );
+		navigate( { to: `/sites/${ getSiteSlug( item ) }` } );
 	};
 
 	return (

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -12,7 +12,6 @@ import PageLayout from '../page-layout';
 import SiteIcon from '../site-icon';
 import SitePreview from '../site-preview';
 import { isA8CSite } from '../utils/site-owner';
-import { getSiteSlug } from '../utils/site-slug';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import type { Site } from '../data/types';
 import type { View, Operator } from '@wordpress/dataviews';
@@ -193,7 +192,7 @@ export default function Sites() {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( sites, view, fields );
 
 	const onClickItem = ( item: Site ) => {
-		navigate( { to: `/sites/${ getSiteSlug( item ) }` } );
+		navigate( { to: `/sites/${ item.slug }` } );
 	};
 
 	return (

--- a/client/dashboard/utils/site-slug.ts
+++ b/client/dashboard/utils/site-slug.ts
@@ -1,9 +1,10 @@
-import { urlToSlug, withoutHttp } from 'calypso/lib/url/http-utils';
 import type { Site } from '../data/types';
 
 export function getSiteSlug( site: Site ) {
-	if ( site.options?.is_redirect ) {
-		return withoutHttp( site.options?.unmapped_url ?? '' );
+	let url = site.URL;
+	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
+		url = site.options?.unmapped_url;
 	}
-	return urlToSlug( site.URL );
+
+	return new URL( url ).hostname;
 }

--- a/client/dashboard/utils/site-slug.ts
+++ b/client/dashboard/utils/site-slug.ts
@@ -1,4 +1,4 @@
-import { urlToSlug } from 'calypso/lib/url/http-utils';
+import { urlToSlug, withoutHttp } from 'calypso/lib/url/http-utils';
 import type { Site } from '../data/types';
 
 export function getSiteSlug( site: Site ) {

--- a/client/dashboard/utils/site-slug.ts
+++ b/client/dashboard/utils/site-slug.ts
@@ -1,7 +1,9 @@
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import type { Site } from '../data/types';
 
-// TODO: handle site collisions as well somehow. See: https://github.com/Automattic/wp-calypso/pull/65938
 export function getSiteSlug( site: Site ) {
+	if ( site.options?.is_redirect ) {
+		return withoutHttp( site.options?.unmapped_url ?? '' );
+	}
 	return urlToSlug( site.URL );
 }

--- a/client/dashboard/utils/site-slug.ts
+++ b/client/dashboard/utils/site-slug.ts
@@ -1,0 +1,7 @@
+import { urlToSlug } from 'calypso/lib/url';
+import type { Site } from '../data/types';
+
+// TODO: handle site collisions as well somehow. See: https://github.com/Automattic/wp-calypso/pull/65938
+export function getSiteSlug( site: Site ) {
+	return urlToSlug( site.URL );
+}

--- a/client/dashboard/utils/site-slug.ts
+++ b/client/dashboard/utils/site-slug.ts
@@ -1,4 +1,4 @@
-import { urlToSlug } from 'calypso/lib/url';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
 import type { Site } from '../data/types';
 
 // TODO: handle site collisions as well somehow. See: https://github.com/Automattic/wp-calypso/pull/65938


### PR DESCRIPTION
Related to DOTCOM-12936
Context: p1745846272962499-slack-C08JZTRS6NA

## Proposed Changes

This PR proposes that we use site slug instead of ID, in the hosting dashboard v2 URLs.

|Before|After|
|-|-|
|<img width="1021" alt="image" src="https://github.com/user-attachments/assets/cf0c7919-5e65-4dd0-adcb-a1042add2e44" />|<img width="1021" alt="image" src="https://github.com/user-attachments/assets/a3e9aacb-3aaa-4a18-966e-16a166814d77" />|


## Why are these changes being made?

Following v1 behavior.

## Testing Instructions

1. Go to /v2/sites.
2. Click around and verify that the current site's slug is always reflected in the URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?