### PR TITLE
[DataViews]: add `children` property support

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -3,3 +3,7 @@
 ## 0.1.0
 
 - First release of the `@automattic/dataviews` package. It bundles all changes from `@wordpress/dataviews` 4.18.0.
+
+## Next
+
+- Add DataViews children prop support

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -6,4 +6,4 @@
 
 ## Next
 
-- Add DataViews children prop support
+- Add support for `children` prop in DataViews component

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -48,6 +48,7 @@ type DataViewsProps< Item > = {
 	onClickItem?: ( item: Item ) => void;
 	isItemClickable?: ( item: Item ) => boolean;
 	header?: ReactNode;
+	children?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
@@ -75,6 +76,7 @@ export default function DataViews< Item >( {
 	onClickItem,
 	isItemClickable = defaultIsItemClickable,
 	header,
+	children,
 }: DataViewsProps< Item > ) {
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const containerRef = useResizeObserver(
@@ -166,6 +168,9 @@ export default function DataViews< Item >( {
 						{ header }
 					</HStack>
 				</HStack>
+
+				{ children }
+
 				{ isShowingFilter && <DataViewsFilters /> }
 				<DataViewsLayout />
 				<DataViewsFooter />

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -11,7 +11,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -128,7 +128,10 @@ export const WithChildren = () => {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ view ] );
 
-	const moons = shownData.reduce( ( sum, item ) => sum + item.satellites, 0 );
+	const planets = shownData.filter( ( item ) =>
+		item.categories.includes( 'Planet' )
+	);
+	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
 
 	return (
 		<DataViews
@@ -143,17 +146,23 @@ export const WithChildren = () => {
 		>
 			<Card isBorderless style={ { padding: '12px 24px' } }>
 				<CardHeader>
-					<Heading>{ __( 'Solar System numbers' ) }</Heading>
+					<Heading level={ 2 }>
+						{ __( 'Solar System numbers' ) }
+					</Heading>
 				</CardHeader>
 
 				<CardBody>
 					<VStack>
 						<Text size={ 18 } as="p">
 							{ createInterpolateElement(
-								__( '<PlanetsNumber /> planets' ),
+								_n(
+									'<PlanetsNumber /> planet',
+									'<PlanetsNumber /> planets',
+									planets.length
+								),
 								{
 									PlanetsNumber: (
-										<strong>{ shownData.length } </strong>
+										<strong>{ planets.length } </strong>
 									),
 								}
 							) }
@@ -161,7 +170,11 @@ export const WithChildren = () => {
 
 						<Text size={ 18 } as="p">
 							{ createInterpolateElement(
-								__( '<SatellitesNumber /> moons' ),
+								_n(
+									'<SatellitesNumber /> moon',
+									'<SatellitesNumber /> moons',
+									moons
+								),
 								{
 									SatellitesNumber: (
 										<strong>{ moons } </strong>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useContext } from '@wordpress/element';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Card,
@@ -20,6 +20,7 @@ import DataViews from '../index';
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
+import DataViewsContext from '../../dataviews-context';
 import type { View } from '../../../types';
 
 import './style.css';
@@ -116,6 +117,58 @@ export const FieldsNoSortableNoHidable = () => {
 	);
 };
 
+/**
+ * Custom composition example
+ */
+function PlanetOverview() {
+	const { data } = useContext( DataViewsContext );
+
+	const planets = data.filter( ( item ) =>
+		item.categories.includes( 'Planet' )
+	);
+	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
+
+	return (
+		<Card isBorderless style={ { padding: '12px 24px' } }>
+			<CardHeader>
+				<Heading level={ 2 }>{ __( 'Solar System numbers' ) }</Heading>
+			</CardHeader>
+
+			<CardBody>
+				<VStack spacing={ 2 }>
+					<Text size={ 18 } as="p">
+						{ createInterpolateElement(
+							_n(
+								'<PlanetsNumber /> planet',
+								'<PlanetsNumber /> planets',
+								planets.length
+							),
+							{
+								PlanetsNumber: (
+									<strong>{ planets.length } </strong>
+								),
+							}
+						) }
+					</Text>
+
+					<Text size={ 18 } as="p">
+						{ createInterpolateElement(
+							_n(
+								'<SatellitesNumber /> moon',
+								'<SatellitesNumber /> moons',
+								moons
+							),
+							{
+								SatellitesNumber: <strong>{ moons } </strong>,
+							}
+						) }
+					</Text>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
 export const CustomComposition = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
@@ -144,47 +197,7 @@ export const CustomComposition = () => {
 			actions={ actions }
 			defaultLayouts={ defaultLayouts }
 		>
-			<Card isBorderless style={ { padding: '12px 24px' } }>
-				<CardHeader>
-					<Heading level={ 2 }>
-						{ __( 'Solar System numbers' ) }
-					</Heading>
-				</CardHeader>
-
-				<CardBody>
-					<VStack spacing={ 2 }>
-						<Text size={ 18 } as="p">
-							{ createInterpolateElement(
-								_n(
-									'<PlanetsNumber /> planet',
-									'<PlanetsNumber /> planets',
-									planets.length
-								),
-								{
-									PlanetsNumber: (
-										<strong>{ planets.length } </strong>
-									),
-								}
-							) }
-						</Text>
-
-						<Text size={ 18 } as="p">
-							{ createInterpolateElement(
-								_n(
-									'<SatellitesNumber /> moon',
-									'<SatellitesNumber /> moons',
-									moons
-								),
-								{
-									SatellitesNumber: (
-										<strong>{ moons } </strong>
-									),
-								}
-							) }
-						</Text>
-					</VStack>
-				</CardBody>
-			</Card>
+			<PlanetOverview />
 		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -2,6 +2,16 @@
  * WordPress dependencies
  */
 import { useState, useMemo } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -103,5 +113,65 @@ export const FieldsNoSortableNoHidable = () => {
 				table: {},
 			} }
 		/>
+	);
+};
+
+export const WithChildren = () => {
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: [ 'categories' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+	} );
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+
+	const moons = shownData.reduce( ( sum, item ) => sum + item.satellites, 0 );
+
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+			actions={ actions }
+			defaultLayouts={ defaultLayouts }
+		>
+			<Card isBorderless style={ { padding: '12px 24px' } }>
+				<CardHeader>
+					<Heading>{ __( 'Solar System numbers' ) }</Heading>
+				</CardHeader>
+
+				<CardBody>
+					<VStack>
+						<Text size={ 18 } as="p">
+							{ createInterpolateElement(
+								__( '<PlanetsNumber /> planets' ),
+								{
+									PlanetsNumber: (
+										<strong>{ shownData.length } </strong>
+									),
+								}
+							) }
+						</Text>
+
+						<Text size={ 18 } as="p">
+							{ createInterpolateElement(
+								__( '<SatellitesNumber /> moons' ),
+								{
+									SatellitesNumber: (
+										<strong>{ moons } </strong>
+									),
+								}
+							) }
+						</Text>
+					</VStack>
+				</CardBody>
+			</Card>
+		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -116,7 +116,7 @@ export const FieldsNoSortableNoHidable = () => {
 	);
 };
 
-export const WithChildren = () => {
+export const CustomComposition = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'categories' ],
@@ -152,7 +152,7 @@ export const WithChildren = () => {
 				</CardHeader>
 
 				<CardBody>
-					<VStack>
+					<VStack spacing={ 2 }>
 						<Text size={ 18 } as="p">
 							{ createInterpolateElement(
 								_n(


### PR DESCRIPTION
Closes WOOA7S-124

# Proposed Changes

* Add support for an optional `children` prop to the `DataViews` component.
* Render the `children` content between the header (search, view config) and the layout/grid.
* Add a new Storybook example (`WithChildren`) demonstrating usage with a custom Solar System summary card.

# Why are these changes being made?

Currently, DataViews is a monolithic component where all content is tightly coupled.

Adding support for `children` allows developers to inject custom content, such as charts, metrics, or additional UI, without modifying the internal structure.

This change improves the flexibility of DataViews for more customized layouts and prepares the ground for future modularization efforts.

# Testing Instructions

* Run `yarn dataviews:storybook:start`.
* Navigate to the "DataViews / WithChildren" story.
* Verify that the custom Solar System summary (the Card with planets and moons) appears between the header actions and the data grid.
* Check that other stories like "Default" and "Empty" continue to work as expected.
* Inspect the HTML structure to confirm that the `children` are rendered without breaking the default layout.
* Optionally, check responsiveness by resizing the container width.

![dataviews-children](https://github.com/user-attachments/assets/b048c152-69e8-4f5a-9f89-94c17ece467f)


# Pre-merge Checklist

* [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
* [ ] Have you written new tests for your changes?
* [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
* [ ] Have you checked for TypeScript, React, or other console errors?
* [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors.
* [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
  * [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
* [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?