### PR TITLE
Experiment streamlining the plans grid + checkout: Use assignment to hide plans and checkout sections

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -63,6 +63,7 @@ import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import useOneDollarOfferTrack from 'calypso/my-sites/plans/hooks/use-onedollar-offer-track';
+import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -389,6 +390,8 @@ export default function CheckoutMainContent( {
 
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
 
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const isSignupCheckout = searchParams.get( 'signup' ) === '1';
@@ -624,7 +627,7 @@ export default function CheckoutMainContent( {
 							<WPCheckoutOrderSummary
 								siteId={ siteId }
 								onChangeSelection={ changeSelection }
-								showFeaturesList
+								showFeaturesList={ ! streamlinedPriceExperimentAssignment }
 							/>
 							<CheckoutSidebarNudge
 								addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -390,7 +390,8 @@ export default function CheckoutMainContent( {
 
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
 
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
+		useStreamlinedPriceExperiment();
 
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
@@ -627,7 +628,9 @@ export default function CheckoutMainContent( {
 							<WPCheckoutOrderSummary
 								siteId={ siteId }
 								onChangeSelection={ changeSelection }
-								showFeaturesList={ ! streamlinedPriceExperimentAssignment }
+								showFeaturesList={
+									! isStreamlinedPriceExperimentLoading && ! streamlinedPriceExperimentAssignment
+								}
 							/>
 							<CheckoutSidebarNudge
 								addItemToCart={ addItemToCart }
@@ -1246,7 +1249,7 @@ function CheckoutTermsAndCheckboxes( {
 					onChange={ setIs3PDAccountConsentAccepted }
 					isSubmitted={ isSubmitted }
 					message={ translate(
-						'You agree that an account may be created on a third party developer’s site related to the products you have purchased.'
+						"You agree that an account may be created on a third party developer's site related to the products you have purchased."
 					) }
 				/>
 			) }

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -96,7 +96,8 @@ export default function BeforeSubmitCheckoutHeader() {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const translate = useTranslate();
 
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
+		useStreamlinedPriceExperiment();
 
 	const totalAdjustments = getTotalDiscountsWithoutCredits( responseCart );
 	const adjustmentLineItem: LineItemType = {
@@ -126,7 +127,7 @@ export default function BeforeSubmitCheckoutHeader() {
 			<CheckoutTermsWrapper>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsWrapper>
-			{ ! streamlinedPriceExperimentAssignment && (
+			{ ! isStreamlinedPriceExperimentLoading && ! streamlinedPriceExperimentAssignment && (
 				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -12,6 +12,7 @@ import {
 import styled from '@emotion/styled';
 import { formatCurrency, useTranslate } from 'i18n-calypso';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import CheckoutTerms from '../components/checkout-terms';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
 
@@ -95,6 +96,8 @@ export default function BeforeSubmitCheckoutHeader() {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const translate = useTranslate();
 
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+
 	const totalAdjustments = getTotalDiscountsWithoutCredits( responseCart );
 	const adjustmentLineItem: LineItemType = {
 		id: 'total-adjustments',
@@ -123,24 +126,26 @@ export default function BeforeSubmitCheckoutHeader() {
 			<CheckoutTermsWrapper>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsWrapper>
-			<WPOrderReviewSection>
-				<NonTotalPrices>
-					<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-					{ totalAdjustments !== 0 && (
-						<NonProductLineItem subtotal lineItem={ adjustmentLineItem } />
-					) }
-					{ taxLineItems.map( ( taxLineItem ) => (
-						<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
-					) ) }
-					{ creditsLineItem && responseCart.sub_total_integer > 0 && (
-						<NonProductLineItem subtotal lineItem={ creditsLineItem } />
-					) }
-				</NonTotalPrices>
-				<TotalPrice>
-					<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
-				</TotalPrice>
-				{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
-			</WPOrderReviewSection>
+			{ ! streamlinedPriceExperimentAssignment && (
+				<WPOrderReviewSection>
+					<NonTotalPrices>
+						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
+						{ totalAdjustments !== 0 && (
+							<NonProductLineItem subtotal lineItem={ adjustmentLineItem } />
+						) }
+						{ taxLineItems.map( ( taxLineItem ) => (
+							<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
+						) ) }
+						{ creditsLineItem && responseCart.sub_total_integer > 0 && (
+							<NonProductLineItem subtotal lineItem={ creditsLineItem } />
+						) }
+					</NonTotalPrices>
+					<TotalPrice>
+						<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
+					</TotalPrice>
+					{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
+				</WPOrderReviewSection>
+			) }
 		</>
 	);
 }

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -1,0 +1,13 @@
+import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
+
+const STREAMLINED_PRICE_EXPERIMENT_NAME = 'calypso_streamlined_plans_checkout';
+
+export function useStreamlinedPriceExperiment() {
+	const [ isLoading, assignment ] = useExperiment( STREAMLINED_PRICE_EXPERIMENT_NAME );
+	return [ isLoading, assignment?.variationName ];
+}
+
+export async function isStreamlinedPriceExperiment() {
+	const assignment = await loadExperimentAssignment( STREAMLINED_PRICE_EXPERIMENT_NAME );
+	return assignment.variationName !== 'control';
+}

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -9,5 +9,5 @@ export function useStreamlinedPriceExperiment() {
 
 export async function isStreamlinedPriceExperiment() {
 	const assignment = await loadExperimentAssignment( STREAMLINED_PRICE_EXPERIMENT_NAME );
-	return assignment.variationName !== false;
+	return assignment?.variationName !== null;
 }

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -9,5 +9,5 @@ export function useStreamlinedPriceExperiment() {
 
 export async function isStreamlinedPriceExperiment() {
 	const assignment = await loadExperimentAssignment( STREAMLINED_PRICE_EXPERIMENT_NAME );
-	return assignment.variationName !== 'control';
+	return assignment.variationName !== false;
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -466,7 +466,8 @@ const PlansFeaturesMain = ( {
 		( { planSlug } ) => planSlug === PLAN_FREE
 	);
 
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
+		useStreamlinedPriceExperiment();
 
 	let hidePlanSelector = false;
 	// In the "purchase a plan and free domain" flow we do not want to show
@@ -474,7 +475,7 @@ const PlansFeaturesMain = ( {
 	if (
 		redirectToAddDomainFlow !== undefined ||
 		hidePlanTypeSelector ||
-		( isInSignup && streamlinedPriceExperimentAssignment )
+		( isInSignup && ! isStreamlinedPriceExperimentLoading && streamlinedPriceExperimentAssignment )
 	) {
 		hidePlanSelector = true;
 	}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -80,6 +80,7 @@ import useGenerateActionHook from './hooks/use-generate-action-hook';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
 import useSelectedFeature from './hooks/use-selected-feature';
+import { useStreamlinedPriceExperiment } from './hooks/use-streamlined-price-experiment';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
 import type {
 	PlansIntent,
@@ -465,10 +466,16 @@ const PlansFeaturesMain = ( {
 		( { planSlug } ) => planSlug === PLAN_FREE
 	);
 
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+
 	let hidePlanSelector = false;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
-	if ( redirectToAddDomainFlow !== undefined || hidePlanTypeSelector ) {
+	if (
+		redirectToAddDomainFlow !== undefined ||
+		hidePlanTypeSelector ||
+		( isInSignup && streamlinedPriceExperimentAssignment )
+	) {
 		hidePlanSelector = true;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-kUT-p2

## Proposed Changes

* Add streamlined price experiment hook for consistent experiment assignment access
* Hide plan interval selector in signup flow for streamlined price experiment participants
* Hide features list and order review section in checkout for experiment participants

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're experimenting with streamlining the plans and checkout user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to one of the experiment variations of `calypso_streamlined_plans_checkout`
* Check that the plans page doesn't show the plan interval selector in signup flow
<img width="320" alt="Screenshot 2025-04-29 at 12 41 21" src="https://github.com/user-attachments/assets/6827c7ba-1cb2-48f9-ade2-4fc01cea4408" />

* In checkout, confirm the checkout features list on the right is not visible
<img width="320" alt="Screenshot 2025-04-29 at 12 41 37" src="https://github.com/user-attachments/assets/ad6b3e48-f780-485d-a816-b383d505c4c6" />

* Also, check that the order review section on the bottom is not visible
<img width="320" alt="Screenshot 2025-04-29 at 12 41 44" src="https://github.com/user-attachments/assets/128bb2be-462f-48f2-851e-75f30bff050a" />


* Switch your experiment assignment to control. You might need to remove the `explat-experiment--calypso_streamlined_plans_checkout` entry from the localStorage to fetch the new assignment.
* Plans and checkout page should be unaffected.

Plans page
<img width="320" alt="Screenshot 2025-04-30 at 09 29 11" src="https://github.com/user-attachments/assets/1dbad471-1d33-419f-9c97-1d7fd83a4ca5" />

Checkout features list
<img width="320" alt="Screenshot 2025-04-30 at 09 29 23" src="https://github.com/user-attachments/assets/51b1a253-aa9a-44e7-8f5a-3d4c93983040" />

Checkout bottom order review
<img width="320" alt="Screenshot 2025-04-30 at 09 29 27" src="https://github.com/user-attachments/assets/011e0569-f956-4c63-ab76-bd7223eac804" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?