### PR TITLE
Server: Impose header limits

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -920,6 +920,28 @@ export default function pages() {
 
 	app.set( 'views', __dirname );
 
+	// Limit allowed header sizes
+	app.use( ( req, res, next ) => {
+		const MAX_HEADER_LENGTH = 8192; // 8 KB total for all headers
+		const MAX_USER_AGENT_LENGTH = 1024; // 1 KB for User-Agent header
+
+		const totalHeaderSize = Object.entries( req.headers ).reduce(
+			( sum, [ key, value ] ) => sum + key.length + String( value ).length,
+			0
+		);
+
+		if ( totalHeaderSize > MAX_HEADER_LENGTH ) {
+			return res.status( 400 ).send( 'Headers too large.' );
+		}
+
+		const ua = req.get( 'User-Agent' );
+		if ( ua && ua.length > MAX_USER_AGENT_LENGTH ) {
+			return res.status( 400 ).send( 'User-Agent header too large.' );
+		}
+
+		next();
+	} );
+
 	app.use( logSectionResponse );
 	app.use( cookieParser() );
 	app.use( middlewareAssets() );


### PR DESCRIPTION
## Proposed Changes

Add header limits to Express. Based on some industry standards, we're going with:
- 8K for all headers;
- 1K for the User-Agent header.

## Why are these changes being made?

An extra safety layer. We're parsing the user agent in multiple places, so it only makes sense to make sure it's limited:

* Express' internal parsing of the user-agent
* Using ua-parser-js for parsing the user agent (in the logger middleware)
* Using browserslist-useragent for parsing user agent (the unsupported browser middleware)

So, some limits should be in place.

See p1745697310149529-slack-C02AVAR9B for additional motivation.

## Testing Instructions

See the bottom of this thread: p1745697310149529-slack-C02AVAR9B