### PR TITLE
[DataViews]: introduce and expose useDataViewsContext hook

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -1,5 +1,9 @@
 <!-- This file lists the modifications done to the base package `@wordpress/dataviews` that are published under `@automattic/dataviews`. -->
 
+## Next
+
+- Introduced `useDataViewsContext()` custom hook to access the DataViews context.
+
 ## 0.1.0
 
 - First release of the `@automattic/dataviews` package. It bundles all changes from `@wordpress/dataviews` 4.18.0.

--- a/packages/dataviews/src/components/dataviews-context/use-data-views-context.ts
+++ b/packages/dataviews/src/components/dataviews-context/use-data-views-context.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViewsContext from './';
+
+export function useDataViewsContext() {
+	const context = useContext( DataViewsContext );
+
+	if ( context === undefined ) {
+		throw new Error(
+			'`useDataViewsContext` must be used within a <DataViews> component.'
+		);
+	}
+
+	return context;
+}

--- a/packages/dataviews/src/index.ts
+++ b/packages/dataviews/src/index.ts
@@ -4,3 +4,4 @@ export { VIEW_LAYOUTS } from './dataviews-layouts';
 export { filterSortAndPaginate } from './filter-and-sort-data-view';
 export type * from './types';
 export { isItemValid } from './validation';
+export { useDataViewsContext } from './components/dataviews-context/use-data-views-context';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes WOOA7S-127

## Proposed Changes

This PR introduces and exports a new hook: `useDataViewsContext`.

It provides access to the `DataViews` context when using a custom layout or composition inside `DataViews` — for example, to read filtered, sorted, or selected items in a child component.

The hook is now available from the root package:

```ts
import { useDataViewsContext } from '@automattic/dataviews';
```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When using `DataViews` with custom children (free composition), there’s no current way to access the context from outside internal components. This hook provides a clean and explicit mechanism to do so, similar to how other context-based components work across the WordPress ecosystem.

This is a foundational piece to support full flexibility in custom layouts and external integrations.

## Testing Instructions

- Use this hook inside a `DataViews` custom child component:

```tsx
import { useDataViewsContext } from '@automattic/dataviews';

function CustomStatsPanel() {
	const { data, selection, view } = useDataViewsContext();
	// render custom stuff based on filtered or selected items
}
```

- Try placing it outside of a `DataViews` tree and confirm it throws the correct error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?