### PR TITLE
Update/dataviews decouple search component

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -8,4 +8,4 @@
 
 - Introduce and expose `useDataViewsContext` custom hook
 - Add support for `children` prop in DataViews component
-- Expose DataViews.Search component
+- Expose `DataViews.Search` as a standalone sub-component to allow custom layouts.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -7,4 +7,4 @@
 ## Next
 
 - Introduce and expose `useDataViewsContext` custom hook
-- Add DataViews children prop support
+- Add support for `children` prop in DataViews component

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -8,3 +8,4 @@
 
 - Introduce and expose `useDataViewsContext` custom hook
 - Add support for `children` prop in DataViews component
+- Expose DataViews.Search component

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -9,3 +9,4 @@
 - Introduce and expose `useDataViewsContext` custom hook
 - Add support for `children` prop in DataViews component
 - Expose `DataViews.Search` as a standalone sub-component to allow custom layouts.
+- Expose `useDataViewsContext` custom hook

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -9,4 +9,3 @@
 - Introduce and expose `useDataViewsContext` custom hook
 - Add support for `children` prop in DataViews component
 - Expose `DataViews.Search` as a standalone sub-component to allow custom layouts.
-- Expose `useDataViewsContext` custom hook

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -7,3 +7,4 @@
 ## Next
 
 - Introduce and expose `useDataViewsContext` custom hook
+- Add DataViews children prop support

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -3,3 +3,7 @@
 ## 0.1.0
 
 - First release of the `@automattic/dataviews` package. It bundles all changes from `@wordpress/dataviews` 4.18.0.
+
+## Next
+
+- Introduce and expose `useDataViewsContext` custom hook

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -12,19 +12,18 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { useMemo, useState, useRef, useContext } from '@wordpress/element';
+import { useMemo, useState, useRef } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
 import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import DataViewsContext from '../dataviews-context';
+import { useDataViewsContext } from '../..';
 import { ActionModal } from '../dataviews-item-actions';
 import type { Action, ActionModal as ActionModalType } from '../../types';
 import type { SetSelection } from '../../private-types';
 import type { ActionTriggerProps } from '../dataviews-item-actions';
-
 interface ActionWithModalProps< Item > {
 	action: ActionModalType< Item >;
 	items: Item[];
@@ -383,7 +382,7 @@ export function BulkActionsFooter() {
 		actions = EMPTY_ARRAY,
 		onChangeSelection,
 		getItemId,
-	} = useContext( DataViewsContext );
+	} = useDataViewsContext();
 	return (
 		<FooterContent
 			selection={ selection }

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -3,7 +3,6 @@
  */
 import {
 	memo,
-	useContext,
 	useRef,
 	useMemo,
 	useCallback,
@@ -16,12 +15,12 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { useDataViewsContext } from '../..';
+import { sanitizeOperators } from '../../utils';
+import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from '../../constants';
 import FilterSummary from './filter-summary';
 import { default as AddFilter, AddFilterMenu } from './add-filter';
 import ResetFilters from './reset-filters';
-import DataViewsContext from '../dataviews-context';
-import { sanitizeOperators } from '../../utils';
-import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from '../../constants';
 import type { NormalizedFilter, NormalizedField, View } from '../../types';
 
 export function useFilters( fields: NormalizedField< any >[], view: View ) {
@@ -180,7 +179,7 @@ function FilterVisibilityToggle( {
 
 function Filters() {
 	const { fields, view, onChangeView, openedFilter, setOpenedFilter } =
-		useContext( DataViewsContext );
+		useDataViewsContext();
 	const addFilterRef = useRef< HTMLButtonElement >( null );
 	const filters = useFilters( fields, view );
 	const addFilter = (

--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -2,12 +2,11 @@
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import DataViewsContext from '../dataviews-context';
+import { useDataViewsContext } from '../..';
 import DataViewsPagination from '../dataviews-pagination';
 import {
 	BulkActionsFooter,
@@ -23,7 +22,7 @@ export default function DataViewsFooter() {
 		paginationInfo: { totalItems = 0, totalPages },
 		data,
 		actions = EMPTY_ARRAY,
-	} = useContext( DataViewsContext );
+	} = useDataViewsContext();
 	const hasBulkActions =
 		useSomeItemHasAPossibleBulkAction( actions, data ) &&
 		[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type );

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -4,14 +4,9 @@
 import type { ComponentType } from 'react';
 
 /**
- * WordPress dependencies
- */
-import { useContext } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
-import DataViewsContext from '../dataviews-context';
+import { useDataViewsContext } from '../..';
 import { VIEW_LAYOUTS } from '../../dataviews-layouts';
 import type { ViewBaseProps } from '../../types';
 
@@ -30,7 +25,7 @@ export default function DataViewsLayout() {
 		setOpenedFilter,
 		onClickItem,
 		isItemClickable,
-	} = useContext( DataViewsContext );
+	} = useDataViewsContext();
 
 	const ViewComponent = VIEW_LAYOUTS.find( ( v ) => v.type === view.type )
 		?.component as ComponentType< ViewBaseProps< any > >;

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -3,24 +3,24 @@
  */
 import {
 	Button,
-	__experimentalHStack as HStack,
 	SelectControl,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { createInterpolateElement, memo, useContext } from '@wordpress/element';
+import { createInterpolateElement, memo } from '@wordpress/element';
 import { sprintf, __, _x, isRTL } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import DataViewsContext from '../dataviews-context';
+import { useDataViewsContext } from '../..';
 
 function DataViewsPagination() {
 	const {
 		view,
 		onChangeView,
 		paginationInfo: { totalItems = 0, totalPages },
-	} = useContext( DataViewsContext );
+	} = useDataViewsContext();
 
 	if ( ! totalItems || ! totalPages ) {
 		return null;

--- a/packages/dataviews/src/components/dataviews-search/index.tsx
+++ b/packages/dataviews/src/components/dataviews-search/index.tsx
@@ -15,9 +15,10 @@ interface SearchProps {
 }
 
 /**
- * DataViewsSearch is a component that renders a search input
- * for the DataViews component.
- * It connects to the DataViewsContext to handle the search input.
+ * DataViewsSearch is a controlled search input that updates the `search` property
+ * in the current DataViews `view` object, using a debounced value.
+ *
+ * It relies on DataViewsContext and must be rendered inside a <DataViews> tree.
  */
 const DataViewsSearch = memo( function Search( { label }: SearchProps ) {
 	const { view, onChangeView } = useDataViewsContext();

--- a/packages/dataviews/src/components/dataviews-search/index.tsx
+++ b/packages/dataviews/src/components/dataviews-search/index.tsx
@@ -14,20 +14,29 @@ interface SearchProps {
 	label?: string;
 }
 
+/**
+ * DataViewsSearch is a component that renders a search input
+ * for the DataViews component.
+ * It connects to the DataViewsContext to handle the search input.
+ */
 const DataViewsSearch = memo( function Search( { label }: SearchProps ) {
 	const { view, onChangeView } = useDataViewsContext();
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput(
 		view.search
 	);
+
 	useEffect( () => {
 		setSearch( view.search ?? '' );
 	}, [ view.search, setSearch ] );
+
 	const onChangeViewRef = useRef( onChangeView );
 	const viewRef = useRef( view );
+
 	useEffect( () => {
 		onChangeViewRef.current = onChangeView;
 		viewRef.current = view;
 	}, [ onChangeView, view ] );
+
 	useEffect( () => {
 		if ( debouncedSearch !== viewRef.current?.search ) {
 			onChangeViewRef.current( {
@@ -37,7 +46,9 @@ const DataViewsSearch = memo( function Search( { label }: SearchProps ) {
 			} );
 		}
 	}, [ debouncedSearch ] );
+
 	const searchLabel = label || __( 'Search' );
+
 	return (
 		<SearchControl
 			className="dataviews-search"

--- a/packages/dataviews/src/components/dataviews-search/index.tsx
+++ b/packages/dataviews/src/components/dataviews-search/index.tsx
@@ -2,21 +2,20 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, memo, useContext } from '@wordpress/element';
+import { useEffect, useRef, memo } from '@wordpress/element';
 import { SearchControl } from '@wordpress/components';
 import { useDebouncedInput } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import DataViewsContext from '../dataviews-context';
-
+import { useDataViewsContext } from '../..';
 interface SearchProps {
 	label?: string;
 }
 
 const DataViewsSearch = memo( function Search( { label }: SearchProps ) {
-	const { view, onChangeView } = useContext( DataViewsContext );
+	const { view, onChangeView } = useDataViewsContext();
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput(
 		view.search
 	);

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -27,7 +27,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { memo, useContext, useMemo, useState } from '@wordpress/element';
+import { memo, useMemo, useState } from '@wordpress/element';
 import {
 	chevronDown,
 	chevronUp,
@@ -43,11 +43,11 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { useDataViewsContext } from '../..';
 import { SORTING_DIRECTIONS, sortIcons, sortLabels } from '../../constants';
 import { VIEW_LAYOUTS } from '../../dataviews-layouts';
-import type { NormalizedField, SupportedLayouts, View } from '../../types';
-import DataViewsContext from '../dataviews-context';
 import { unlock } from '../../lock-unlock';
+import type { NormalizedField, SupportedLayouts, View } from '../../types';
 
 const { Menu } = unlock( componentsPrivateApis );
 
@@ -64,7 +64,7 @@ const DATAVIEWS_CONFIG_POPOVER_PROPS = {
 function ViewTypeMenu( {
 	defaultLayouts = { list: {}, grid: {}, table: {} },
 }: ViewTypeMenuProps ) {
-	const { view, onChangeView } = useContext( DataViewsContext );
+	const { view, onChangeView } = useDataViewsContext();
 	const availableLayouts = Object.keys( defaultLayouts );
 	if ( availableLayouts.length <= 1 ) {
 		return null;
@@ -127,7 +127,7 @@ function ViewTypeMenu( {
 }
 
 function SortFieldControl() {
-	const { view, fields, onChangeView } = useContext( DataViewsContext );
+	const { view, fields, onChangeView } = useDataViewsContext();
 	const orderOptions = useMemo( () => {
 		const sortableFields = fields.filter(
 			( field ) => field.enableSorting !== false
@@ -162,7 +162,7 @@ function SortFieldControl() {
 }
 
 function SortDirectionControl() {
-	const { view, fields, onChangeView } = useContext( DataViewsContext );
+	const { view, fields, onChangeView } = useDataViewsContext();
 
 	const sortableFields = fields.filter(
 		( field ) => field.enableSorting !== false
@@ -220,7 +220,7 @@ function SortDirectionControl() {
 
 const PAGE_SIZE_VALUES = [ 10, 20, 50, 100 ];
 function ItemsPerPageControl() {
-	const { view, onChangeView } = useContext( DataViewsContext );
+	const { view, onChangeView } = useDataViewsContext();
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom
@@ -544,7 +544,7 @@ function isDefined< T >( item: T | undefined ): item is T {
 }
 
 function FieldControl() {
-	const { view, fields, onChangeView } = useContext( DataViewsContext );
+	const { view, fields, onChangeView } = useDataViewsContext();
 
 	const togglableFields = [
 		view?.titleField,
@@ -762,7 +762,7 @@ function SettingsSection( {
 }
 
 function DataviewsViewConfigDropdown() {
-	const { view } = useContext( DataViewsContext );
+	const { view } = useDataViewsContext();
 	const popoverId = useInstanceId(
 		_DataViewsViewConfig,
 		'dataviews-view-config-dropdown'

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -48,6 +48,7 @@ type DataViewsProps< Item > = {
 	onClickItem?: ( item: Item ) => void;
 	isItemClickable?: ( item: Item ) => boolean;
 	header?: ReactNode;
+	children?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
@@ -75,6 +76,7 @@ export default function DataViews< Item >( {
 	onClickItem,
 	isItemClickable = defaultIsItemClickable,
 	header,
+	children,
 }: DataViewsProps< Item > ) {
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const containerRef = useResizeObserver(
@@ -166,6 +168,9 @@ export default function DataViews< Item >( {
 						{ header }
 					</HStack>
 				</HStack>
+
+				{ children }
+
 				{ isShowingFilter && <DataViewsFilters /> }
 				<DataViewsLayout />
 				<DataViewsFooter />

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -58,7 +58,7 @@ const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
-export function DataViews< Item >( {
+export function BaseDataViews< Item >( {
 	view,
 	onChangeView,
 	fields,

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -58,7 +58,7 @@ const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
-export function BaseDataViews< Item >( {
+export function DataViewsRoot< Item >( {
 	view,
 	onChangeView,
 	fields,

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -58,7 +58,7 @@ const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
-export default function DataViews< Item >( {
+export function DataViews< Item >( {
 	view,
 	onChangeView,
 	fields,

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -11,7 +11,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -128,7 +128,10 @@ export const WithChildren = () => {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ view ] );
 
-	const moons = shownData.reduce( ( sum, item ) => sum + item.satellites, 0 );
+	const planets = shownData.filter( ( item ) =>
+		item.categories.includes( 'Planet' )
+	);
+	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
 
 	return (
 		<DataViews
@@ -143,17 +146,23 @@ export const WithChildren = () => {
 		>
 			<Card isBorderless style={ { padding: '12px 24px' } }>
 				<CardHeader>
-					<Heading>{ __( 'Solar System numbers' ) }</Heading>
+					<Heading level={ 2 }>
+						{ __( 'Solar System numbers' ) }
+					</Heading>
 				</CardHeader>
 
 				<CardBody>
 					<VStack>
 						<Text size={ 18 } as="p">
 							{ createInterpolateElement(
-								__( '<PlanetsNumber /> planets' ),
+								_n(
+									'<PlanetsNumber /> planet',
+									'<PlanetsNumber /> planets',
+									planets.length
+								),
 								{
 									PlanetsNumber: (
-										<strong>{ shownData.length } </strong>
+										<strong>{ planets.length } </strong>
 									),
 								}
 							) }
@@ -161,7 +170,11 @@ export const WithChildren = () => {
 
 						<Text size={ 18 } as="p">
 							{ createInterpolateElement(
-								__( '<SatellitesNumber /> moons' ),
+								_n(
+									'<SatellitesNumber /> moon',
+									'<SatellitesNumber /> moons',
+									moons
+								),
 								{
 									SatellitesNumber: (
 										<strong>{ moons } </strong>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useContext } from '@wordpress/element';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Card,
@@ -20,6 +20,7 @@ import DataViews from '../index';
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
+import DataViewsContext from '../../dataviews-context';
 import type { View } from '../../../types';
 
 import './style.css';
@@ -116,6 +117,58 @@ export const FieldsNoSortableNoHidable = () => {
 	);
 };
 
+/**
+ * Custom composition example
+ */
+function PlanetOverview() {
+	const { data } = useContext( DataViewsContext );
+
+	const planets = data.filter( ( item ) =>
+		item.categories.includes( 'Planet' )
+	);
+	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
+
+	return (
+		<Card isBorderless style={ { padding: '12px 24px' } }>
+			<CardHeader>
+				<Heading level={ 2 }>{ __( 'Solar System numbers' ) }</Heading>
+			</CardHeader>
+
+			<CardBody>
+				<VStack spacing={ 2 }>
+					<Text size={ 18 } as="p">
+						{ createInterpolateElement(
+							_n(
+								'<PlanetsNumber /> planet',
+								'<PlanetsNumber /> planets',
+								planets.length
+							),
+							{
+								PlanetsNumber: (
+									<strong>{ planets.length } </strong>
+								),
+							}
+						) }
+					</Text>
+
+					<Text size={ 18 } as="p">
+						{ createInterpolateElement(
+							_n(
+								'<SatellitesNumber /> moon',
+								'<SatellitesNumber /> moons',
+								moons
+							),
+							{
+								SatellitesNumber: <strong>{ moons } </strong>,
+							}
+						) }
+					</Text>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
 export const CustomComposition = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
@@ -144,47 +197,7 @@ export const CustomComposition = () => {
 			actions={ actions }
 			defaultLayouts={ defaultLayouts }
 		>
-			<Card isBorderless style={ { padding: '12px 24px' } }>
-				<CardHeader>
-					<Heading level={ 2 }>
-						{ __( 'Solar System numbers' ) }
-					</Heading>
-				</CardHeader>
-
-				<CardBody>
-					<VStack spacing={ 2 }>
-						<Text size={ 18 } as="p">
-							{ createInterpolateElement(
-								_n(
-									'<PlanetsNumber /> planet',
-									'<PlanetsNumber /> planets',
-									planets.length
-								),
-								{
-									PlanetsNumber: (
-										<strong>{ planets.length } </strong>
-									),
-								}
-							) }
-						</Text>
-
-						<Text size={ 18 } as="p">
-							{ createInterpolateElement(
-								_n(
-									'<SatellitesNumber /> moon',
-									'<SatellitesNumber /> moons',
-									moons
-								),
-								{
-									SatellitesNumber: (
-										<strong>{ moons } </strong>
-									),
-								}
-							) }
-						</Text>
-					</VStack>
-				</CardBody>
-			</Card>
+			<PlanetOverview />
 		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -204,12 +204,7 @@ export const CustomComposition = () => {
 		>
 			<PlanetOverview />
 
-			<HStack
-				alignment="top"
-				justify="space-between"
-				className="dataviews__view-actions"
-				spacing={ 1 }
-			>
+			<HStack style={ { padding: `8px 48px` } }>
 				<DataViews.Search />
 			</HStack>
 		</DataViews>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -2,6 +2,16 @@
  * WordPress dependencies
  */
 import { useState, useMemo } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -103,5 +113,65 @@ export const FieldsNoSortableNoHidable = () => {
 				table: {},
 			} }
 		/>
+	);
+};
+
+export const WithChildren = () => {
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: [ 'categories' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+	} );
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+
+	const moons = shownData.reduce( ( sum, item ) => sum + item.satellites, 0 );
+
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+			actions={ actions }
+			defaultLayouts={ defaultLayouts }
+		>
+			<Card isBorderless style={ { padding: '12px 24px' } }>
+				<CardHeader>
+					<Heading>{ __( 'Solar System numbers' ) }</Heading>
+				</CardHeader>
+
+				<CardBody>
+					<VStack>
+						<Text size={ 18 } as="p">
+							{ createInterpolateElement(
+								__( '<PlanetsNumber /> planets' ),
+								{
+									PlanetsNumber: (
+										<strong>{ shownData.length } </strong>
+									),
+								}
+							) }
+						</Text>
+
+						<Text size={ 18 } as="p">
+							{ createInterpolateElement(
+								__( '<SatellitesNumber /> moons' ),
+								{
+									SatellitesNumber: (
+										<strong>{ moons } </strong>
+									),
+								}
+							) }
+						</Text>
+					</VStack>
+				</CardBody>
+			</Card>
+		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { __, _n } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import DataViews from '../index';
+import { DataViews } from '../index';
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -2,11 +2,30 @@
  * WordPress dependencies
  */
 import { useState, useMemo } from '@wordpress/element';
+<<<<<<< HEAD
+=======
+import { createInterpolateElement } from '@wordpress/element';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, _n } from '@wordpress/i18n';
+>>>>>>> d86f84eae69 (Replace useContext with useDataViewsContext hook)
 
 /**
  * Internal dependencies
  */
+<<<<<<< HEAD
 import DataViews from '../index';
+=======
+import { DataViews } from '../../';
+import { useDataViewsContext } from '../../../';
+>>>>>>> d86f84eae69 (Replace useContext with useDataViewsContext hook)
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -9,6 +9,7 @@ import {
 	CardBody,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
@@ -199,7 +200,15 @@ export const CustomComposition = () => {
 			search={ false }
 		>
 			<PlanetOverview />
-			<DataViews.Search />
+
+			<HStack
+				alignment="top"
+				justify="space-between"
+				className="dataviews__view-actions"
+				spacing={ 1 }
+			>
+				<DataViews.Search />
+			</HStack>
 		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -16,7 +16,7 @@ import { __, _n } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { DataViews } from '../index';
+import { DataViews } from '../../';
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
@@ -196,8 +196,10 @@ export const CustomComposition = () => {
 			onChangeView={ setView }
 			actions={ actions }
 			defaultLayouts={ defaultLayouts }
+			search={ false }
 		>
 			<PlanetOverview />
+			<DataViews.Search />
 		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -26,10 +26,13 @@ import type { View } from '../../../types';
 
 import './style.css';
 
-const meta = {
+import type { Meta } from '@storybook/react';
+
+const meta: Meta< typeof DataViews > = {
 	title: 'DataViews/DataViews',
 	component: DataViews,
 };
+
 export default meta;
 
 const defaultLayouts = {

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -2,30 +2,11 @@
  * WordPress dependencies
  */
 import { useState, useMemo } from '@wordpress/element';
-<<<<<<< HEAD
-=======
-import { createInterpolateElement } from '@wordpress/element';
-import {
-	Card,
-	CardHeader,
-	CardBody,
-	__experimentalHeading as Heading,
-	__experimentalText as Text,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
-import { __, _n } from '@wordpress/i18n';
->>>>>>> d86f84eae69 (Replace useContext with useDataViewsContext hook)
 
 /**
  * Internal dependencies
  */
-<<<<<<< HEAD
 import DataViews from '../index';
-=======
-import { DataViews } from '../../';
-import { useDataViewsContext } from '../../../';
->>>>>>> d86f84eae69 (Replace useContext with useDataViewsContext hook)
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -116,7 +116,7 @@ export const FieldsNoSortableNoHidable = () => {
 	);
 };
 
-export const WithChildren = () => {
+export const CustomComposition = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'categories' ],
@@ -152,7 +152,7 @@ export const WithChildren = () => {
 				</CardHeader>
 
 				<CardBody>
-					<VStack>
+					<VStack spacing={ 2 }>
 						<Text size={ 18 } as="p">
 							{ createInterpolateElement(
 								_n(

--- a/packages/dataviews/src/components/index.ts
+++ b/packages/dataviews/src/components/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { BaseDataViews } from './dataviews';
+import DataViewsSearch from './dataviews-search';
+
+type DataViewsProps = typeof BaseDataViews & {
+	Search: typeof DataViewsSearch;
+};
+
+export const DataViews = BaseDataViews as DataViewsProps;
+
+// Expose composable DataViews components
+DataViews.Search = DataViewsSearch;

--- a/packages/dataviews/src/components/index.ts
+++ b/packages/dataviews/src/components/index.ts
@@ -1,14 +1,14 @@
 /**
  * Internal dependencies
  */
-import { BaseDataViews } from './dataviews';
+import { DataViewsRoot } from './dataviews';
 import DataViewsSearch from './dataviews-search';
 
-type DataViewsProps = typeof BaseDataViews & {
+type DataViewsProps = typeof DataViewsRoot & {
 	Search: typeof DataViewsSearch;
 };
 
-export const DataViews = BaseDataViews as DataViewsProps;
+export const DataViews = DataViewsRoot as DataViewsProps;
 
 // Expose composable DataViews components
 DataViews.Search = DataViewsSearch;

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -3,12 +3,12 @@
  */
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useContext } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import DataViewsContext from '../../components/dataviews-context';
+import { useDataViewsContext } from '../../hooks/use-dataviews-context';
 import type { ViewGrid } from '../../types';
 
 const viewportBreaks: {
@@ -34,7 +34,7 @@ const BREAKPOINTS = {
 };
 
 function useViewPortBreakpoint() {
-	const containerWidth = useContext( DataViewsContext ).containerWidth;
+	const containerWidth = useDataViewsContext().containerWidth;
 	for ( const [ key, value ] of Object.entries( BREAKPOINTS ) ) {
 		if ( containerWidth >= value ) {
 			return key;
@@ -44,7 +44,7 @@ function useViewPortBreakpoint() {
 }
 
 export function useUpdatedPreviewSizeOnViewportChange() {
-	const view = useContext( DataViewsContext ).view as ViewGrid;
+	const view = useDataViewsContext().view as ViewGrid;
 	const viewport = useViewPortBreakpoint();
 	return useMemo( () => {
 		const previewSize = view.layout?.previewSize;
@@ -65,7 +65,7 @@ export function useUpdatedPreviewSizeOnViewportChange() {
 
 export default function PreviewSizePicker() {
 	const viewport = useViewPortBreakpoint();
-	const context = useContext( DataViewsContext );
+	const context = useDataViewsContext();
 	const view = context.view as ViewGrid;
 	const breakValues = viewportBreaks[ viewport ];
 	const previewSizeToUse = view.layout?.previewSize || breakValues.default;

--- a/packages/dataviews/src/dataviews-layouts/table/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/density-picker.tsx
@@ -6,16 +6,15 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import DataViewsContext from '../../components/dataviews-context';
+import { useDataViewsContext } from '../../hooks/use-dataviews-context';
 import type { ViewTable, Density } from '../../types';
 
 export default function DensityPicker() {
-	const context = useContext( DataViewsContext );
+	const context = useDataViewsContext();
 	const view = context.view as ViewTable;
 	return (
 		<ToggleGroupControl

--- a/packages/dataviews/src/hooks/use-dataviews-context/index.ts
+++ b/packages/dataviews/src/hooks/use-dataviews-context/index.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViewsContext from '../../components/dataviews-context';
+
+/**
+ * Custom hook to access the DataViews context.
+ * Ensures the hook is used within a <DataViews> tree.
+ */
+export function useDataViewsContext() {
+	const context = useContext( DataViewsContext );
+
+	if ( context === undefined ) {
+		throw new Error(
+			'`useDataViewsContext` must be used within a <DataViews> component.'
+		);
+	}
+
+	return context;
+}

--- a/packages/dataviews/src/index.ts
+++ b/packages/dataviews/src/index.ts
@@ -1,4 +1,4 @@
-export { default as DataViews } from './components/dataviews';
+export { DataViews } from './components';
 export { default as DataForm } from './components/dataform';
 export { VIEW_LAYOUTS } from './dataviews-layouts';
 export { filterSortAndPaginate } from './filter-and-sort-data-view';

--- a/packages/dataviews/src/index.ts
+++ b/packages/dataviews/src/index.ts
@@ -4,3 +4,4 @@ export { VIEW_LAYOUTS } from './dataviews-layouts';
 export { filterSortAndPaginate } from './filter-and-sort-data-view';
 export type * from './types';
 export { isItemValid } from './validation';
+export { useDataViewsContext } from './hooks/use-dataviews-context';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Expose `DataViews.Search` as a sub-component of `DataViews`, allowing usage outside the default layout.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This change continues the modularization of the DataViews UI. By exposing `Search` as a standalone component, we give consumers the ability to render it wherever they need, in combination with custom UI.

It builds on top of the previous work to support `children` and introduce the context hook, but focuses exclusively on `Search`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `yarn dataviews:storybook:start`

Check the `CustomComposition` story. You should be able to see the `Search` input rendered independently of the default layout.

Typing in the input should still update the view state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?