### PR TITLE
Use `is_a8c` field instead of `site_owner` to check if site is A8C-related

### DIFF
--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -39,6 +39,7 @@ const SITE_FIELDS = [
 	'subscribers_count',
 	'plan',
 	'active_modules',
+	'is_a8c',
 	'is_deleted',
 	'is_coming_soon',
 	'is_private',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -46,7 +46,6 @@ const SITE_FIELDS = [
 	'launch_status',
 	'site_migration',
 	'options',
-	'site_owner',
 	'jetpack',
 	'jetpack_modules',
 ].join( ',' );

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -89,7 +89,6 @@ export interface Site {
 	site_migration: {
 		migration_status: string;
 	} | null;
-	site_owner: number;
 	jetpack: boolean;
 	jetpack_modules: string[];
 }

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -81,6 +81,7 @@ export interface Site {
 	subscribers_count: number;
 	// Can be undefined for deleted sites.
 	options?: SiteOptions;
+	is_a8c: boolean;
 	is_deleted: boolean;
 	is_coming_soon: boolean;
 	is_private: boolean;

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -9,7 +9,6 @@ import {
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import SitePreview from '../site-preview';
-import { isA8CSite } from '../utils/site-owner';
 import { getSiteStatusLabel } from '../utils/site-status';
 import type { Site, SiteDomain, Plan } from '../data/types';
 
@@ -30,7 +29,7 @@ export default function SiteCard( {
 	const { options, URL: url, is_private } = site;
 	// If the site is a private A8C site, X-Frame-Options is set to same
 	// origin.
-	const iframeDisabled = isA8CSite( site ) && is_private;
+	const iframeDisabled = site.is_a8c && is_private;
 	return (
 		<Card>
 			<VStack spacing={ 6 }>

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -11,7 +11,6 @@ import DataViewsCard from '../dataviews-card';
 import PageLayout from '../page-layout';
 import SiteIcon from '../site-icon';
 import SitePreview from '../site-preview';
-import { isA8CSite } from '../utils/site-owner';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import type { Site } from '../data/types';
 import type { View, Operator } from '@automattic/dataviews';
@@ -98,7 +97,7 @@ const DEFAULT_FIELDS = [
 	{
 		id: 'a8c_owned',
 		label: __( 'A8C Owned' ),
-		getValue: ( { item }: { item: Site } ) => isA8CSite( item ),
+		getValue: ( { item }: { item: Site } ) => item.is_a8c,
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
 			{ value: false, label: __( 'No' ) },
@@ -106,7 +105,7 @@ const DEFAULT_FIELDS = [
 		filterBy: {
 			operators: [ 'is' as Operator ],
 		},
-		render: ( { item }: { item: Site } ) => ( isA8CSite( item ) ? __( 'Yes' ) : __( 'No' ) ),
+		render: ( { item }: { item: Site } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
 	},
 	{
 		id: 'preview',
@@ -116,7 +115,7 @@ const DEFAULT_FIELDS = [
 			const { is_deleted, is_private, URL: url } = item;
 			// If the site is a private A8C site, X-Frame-Options is set to same
 			// origin.
-			const iframeDisabled = is_deleted || ( isA8CSite( item ) && is_private );
+			const iframeDisabled = is_deleted || ( item.is_a8c && is_private );
 			return (
 				<>
 					{ resizeListener }
@@ -168,7 +167,7 @@ const DEFAULT_VIEW: View = {
 export default function Sites() {
 	const navigate = useNavigate();
 	const sites = useQuery( sitesQuery() ).data;
-	const hasA8CSites = sites?.some( isA8CSite );
+	const hasA8CSites = sites?.some( ( site ) => site.is_a8c );
 	const [ view, setView ] = useState< View >(
 		hasA8CSites
 			? {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -95,9 +95,8 @@ const DEFAULT_FIELDS = [
 		render: ( { item }: { item: Site } ) => getSiteStatusLabel( item ),
 	},
 	{
-		id: 'a8c_owned',
+		id: 'is_a8c',
 		label: __( 'A8C Owned' ),
-		getValue: ( { item }: { item: Site } ) => item.is_a8c,
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
 			{ value: false, label: __( 'No' ) },
@@ -174,7 +173,7 @@ export default function Sites() {
 					...DEFAULT_VIEW,
 					filters: [
 						{
-							field: 'a8c_owned',
+							field: 'is_a8c',
 							operator: 'is',
 							value: false,
 						},
@@ -184,7 +183,7 @@ export default function Sites() {
 	);
 	const fields = useMemo(
 		() =>
-			hasA8CSites ? DEFAULT_FIELDS : DEFAULT_FIELDS.filter( ( field ) => field.id !== 'a8c_owned' ),
+			hasA8CSites ? DEFAULT_FIELDS : DEFAULT_FIELDS.filter( ( field ) => field.id !== 'is_a8c' ),
 		[ hasA8CSites ]
 	);
 

--- a/client/dashboard/utils/site-owner.ts
+++ b/client/dashboard/utils/site-owner.ts
@@ -1,5 +1,5 @@
 import type { Site } from '../data/types';
 
 export function isA8CSite( site: Site ) {
-	return site.site_owner === 26957695;
+	return site.is_a8c;
 }

--- a/client/dashboard/utils/site-owner.ts
+++ b/client/dashboard/utils/site-owner.ts
@@ -1,5 +1,0 @@
-import type { Site } from '../data/types';
-
-export function isA8CSite( site: Site ) {
-	return site.is_a8c;
-}

--- a/client/sites/components/sites-dashboard.tsx
+++ b/client/sites/components/sites-dashboard.tsx
@@ -304,7 +304,7 @@ const SitesDashboard = ( {
 
 	const hasA8CSitesFilter =
 		dataViewsState.filters?.some(
-			( { field, operator, value } ) => field === 'a8c_owned' && operator === 'is' && value === true
+			( { field, operator, value } ) => field === 'is_a8c' && operator === 'is' && value === true
 		) ?? false;
 
 	const includeA8CSites = siteType === 'p2' || hasA8CSitesFilter;

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -172,7 +172,7 @@ const DotcomSitesDataViews = ( {
 
 		if ( isAutomattician && siteType === 'non-p2' ) {
 			dataViewFields.push( {
-				id: 'a8c_owned',
+				id: 'is_a8c',
 				label: __( 'Include A8C sites' ),
 				enableHiding: false,
 				elements: [

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -31,6 +31,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_deleted',
 	'is_a4a_client',
 	'is_a4a_dev_site',
+	'is_a8c',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -126,6 +126,7 @@ export interface SiteDetails {
 	description: string;
 	domain: string;
 	icon?: { ico: string; img: string; media_id: number };
+	is_a8c?: boolean;
 	is_coming_soon?: boolean;
 	is_multisite?: boolean;
 	is_private?: boolean;

--- a/packages/sites/src/site-excerpt-constants.ts
+++ b/packages/sites/src/site-excerpt-constants.ts
@@ -21,6 +21,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'user_interactions',
 	'lang',
 	'site_owner',
+	'is_a8c',
 ] as const;
 
 export const SITE_EXCERPT_COMPUTED_FIELDS = [ 'slug' ] as const;

--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -12,7 +12,6 @@ export interface MinimumSite {
 	launch_status?: string;
 	user_interactions?: string[];
 	is_wpcom_staging_site?: boolean;
-	site_owner?: number;
 	options?: {
 		wpcom_production_blog_id?: number;
 		wpcom_staging_blog_ids?: number[];

--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -5,6 +5,7 @@ export interface MinimumSite {
 	slug: string;
 	title: string;
 	visible?: boolean;
+	is_a8c?: boolean;
 	is_coming_soon?: boolean;
 	is_private?: boolean;
 	is_deleted?: boolean;

--- a/packages/sites/src/use-sites-list-filtering.tsx
+++ b/packages/sites/src/use-sites-list-filtering.tsx
@@ -9,9 +9,9 @@ export interface SitesFilterOptions {
 	includeA8CSites?: boolean;
 }
 
-type SiteForFiltering = Pick< MinimumSite, 'URL' | 'name' | 'slug' | 'title' | 'site_owner' >;
+type SiteForFiltering = Pick< MinimumSite, 'URL' | 'name' | 'slug' | 'title' | 'is_a8c' >;
 
-const isA8CSite = ( site: SiteForFiltering ) => site.site_owner === 26957695;
+const isA8CSite = ( site: SiteForFiltering ) => site.is_a8c;
 
 export function useSitesListFiltering< T extends SiteForFiltering >(
 	sites: T[],

--- a/packages/sites/src/use-sites-list-filtering.tsx
+++ b/packages/sites/src/use-sites-list-filtering.tsx
@@ -11,8 +11,6 @@ export interface SitesFilterOptions {
 
 type SiteForFiltering = Pick< MinimumSite, 'URL' | 'name' | 'slug' | 'title' | 'is_a8c' >;
 
-const isA8CSite = ( site: SiteForFiltering ) => site.is_a8c;
-
 export function useSitesListFiltering< T extends SiteForFiltering >(
 	sites: T[],
 	{ search, includeA8CSites = false }: SitesFilterOptions
@@ -25,7 +23,7 @@ export function useSitesListFiltering< T extends SiteForFiltering >(
 
 	return useMemo( () => {
 		if ( ! includeA8CSites ) {
-			return filteredSites.filter( ( site ) => ! isA8CSite( site ) );
+			return filteredSites.filter( ( site ) => ! site.is_a8c );
 		}
 
 		return filteredSites;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves DOTCOM-10699-linear-issue

## Proposed Changes

* use `is_a8c` field instead of `site_owner` to check if the site is A8C-related

The new `is_a8c` field was introduced just recently and we have been using it in Studio already: 181408-ghe-Automattic/wpcom 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* DOTCOM-10699-linear-issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `yarn start` (or use the Calypso Live link below).
2. Head over to the the Sites dashboard at http://calypso.localhost:3000/sites.
3. Try to use the `Include A8C` sites filter:

![Markup on 2025-04-29 at 15:40:26](https://github.com/user-attachments/assets/4ec576b9-4b9b-4626-8fec-7e2deffa9acd)

4. It should work as expected - filtering for A8C sites.
5. Similar filtering should work at http://calypso.localhost:3000/v2/sites as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?