### PR TITLE
Make developer toggle more prominent

### DIFF
--- a/client/me/developer/get-i-am-a-developer-copy.tsx
+++ b/client/me/developer/get-i-am-a-developer-copy.tsx
@@ -2,10 +2,11 @@ import { translate as translateFunction } from 'i18n-calypso';
 
 export const getIAmDeveloperCopy = ( translate: typeof translateFunction ) =>
 	translate(
-		'{{strong}}I am a developer.{{/strong}} Opt me into previews of new developer-focused features.',
+		'{{strong}}I am a developer{{/strong}} {{span}}Opt me into previews of new developer-focused features.{{/span}}',
 		{
 			components: {
 				strong: <strong />,
+				span: <span />,
 			},
 		}
 	);

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import clsx from 'clsx';
 import cookie from 'cookie';
@@ -122,19 +123,24 @@ class Developer extends Component {
 						className="developer__header"
 					/>
 
-					<form className="developer__form" onChange={ this.props.submitForm }>
-						<FormFieldset
-							className={ clsx( 'developer__is_dev_account-fieldset', {
+					<form onChange={ this.props.submitForm }>
+						<Card
+							className={ clsx( 'developer__is-dev-account-card', {
 								'is-loading': this.props.isFetchingUserSettings,
 							} ) }
 						>
-							<ToggleControl
-								disabled={ this.props.isFetchingUserSettings || this.props.isUpdatingUserSettings }
-								checked={ this.props.getSetting( 'is_dev_account' ) }
-								onChange={ this.handleToggleIsDevAccount }
-								label={ getIAmDeveloperCopy( this.props.translate ) }
-							/>
-						</FormFieldset>
+							<FormFieldset>
+								<ToggleControl
+									disabled={
+										this.props.isFetchingUserSettings || this.props.isUpdatingUserSettings
+									}
+									checked={ this.props.getSetting( 'is_dev_account' ) }
+									onChange={ this.handleToggleIsDevAccount }
+									label={ getIAmDeveloperCopy( this.props.translate ) }
+									__nextHasNoMarginBottom
+								/>
+							</FormFieldset>
+						</Card>
 					</form>
 
 					<DeveloperFeatures />

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -123,25 +123,27 @@ class Developer extends Component {
 						className="developer__header"
 					/>
 
-					<form onChange={ this.props.submitForm }>
+					<div className="developer-is-dev-account">
 						<Card
 							className={ clsx( 'developer__is-dev-account-card', {
 								'is-loading': this.props.isFetchingUserSettings,
 							} ) }
 						>
-							<FormFieldset>
-								<ToggleControl
-									disabled={
-										this.props.isFetchingUserSettings || this.props.isUpdatingUserSettings
-									}
-									checked={ this.props.getSetting( 'is_dev_account' ) }
-									onChange={ this.handleToggleIsDevAccount }
-									label={ getIAmDeveloperCopy( this.props.translate ) }
-									__nextHasNoMarginBottom
-								/>
-							</FormFieldset>
+							<form onChange={ this.props.submitForm }>
+								<FormFieldset>
+									<ToggleControl
+										disabled={
+											this.props.isFetchingUserSettings || this.props.isUpdatingUserSettings
+										}
+										checked={ this.props.getSetting( 'is_dev_account' ) }
+										onChange={ this.handleToggleIsDevAccount }
+										label={ getIAmDeveloperCopy( this.props.translate ) }
+										__nextHasNoMarginBottom
+									/>
+								</FormFieldset>
+							</form>
 						</Card>
-					</form>
+					</div>
 
 					<DeveloperFeatures />
 				</Main>

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -40,22 +40,34 @@
 	}
 }
 
-.developer__form {
-	text-align: center;
-}
-
-.form-fieldset.developer__is_dev_account-fieldset {
-	border-radius: 2px;
-	background: var(--studio-blue-0);
-	padding: 16px;
+.card.developer__is-dev-account-card {
 	margin: 0 auto 30px;
-	display: inline-block;
 
 	.components-toggle-control {
 		font-family: $font-sf-pro-text;
 		font-size: rem(14px);
 		display: inline-block;
-		margin-bottom: 0;
+	}
+
+	.components-h-stack {
+		align-items: start;
+	}
+
+	.components-toggle-control__label {
+		display:flex;
+		flex-flow: column wrap;
+	}
+
+	.components-toggle-control__label span {
+		font-size: rem(14px);
+		color: var(--color-text-subtle);
+		line-height: 20px;
+		letter-spacing: -0.15px;
+		margin-top: 10px;
+	}
+
+	.form-fieldset {
+		margin-bottom: 5px;
 	}
 
 	&.is-loading {

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -90,12 +90,16 @@
 		}
 	}
 
+	@media (max-width: $break-large) {
+		margin: 0 32px 24px 32px;
+	}
+
 	@media (max-width: $break-medium) {
 		position: fixed;
 		left: 0;
 		bottom: 0;
 		width: 100%;
-		margin-bottom: 0;
+		margin: 0 auto;
 		text-align: left;
 		padding: 16px 32px;
 		z-index: 2;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCOM-10700

Fixes https://github.com/Automattic/wp-calypso/issues/100382

## Proposed Changes

I propose to make the developer toggle more prominent.

|**Before**|**After**|
|---|---|
|![Screenshot 2025-04-29 at 15 47 39](https://github.com/user-attachments/assets/77c1c311-c1ce-4e59-9c70-f8aeb946635d) | ![Screenshot 2025-04-29 at 15 47 50](https://github.com/user-attachments/assets/b8d473ff-8620-470d-a348-5f04eb555016) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The developer toggle is very small compared to how prominent it otherwise feels. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/me/developer`
2. Test if toggle works fine
3. Test if toggle works fine in mobile view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
