### PR TITLE
Experiment streamlining the plans grid + checkout: Modify the sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1432,8 +1432,8 @@ const SubmitButtonHeaderWrapper = styled.div`
 `;
 
 const WPCheckoutWrapper = styled.div< {
-	isLargeViewport: boolean;
-	isStreamlinedPrice: boolean;
+	isLargeViewport?: boolean;
+	isStreamlinedPrice?: boolean;
 } >`
 	background: ${ colorStudio.colors[ 'White' ] };
 	display: grid;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -861,7 +861,7 @@ export default function CheckoutMainContent( {
 	return (
 		<StepContainerV2CheckoutFixer
 			isLargeViewport={ isLargeViewport }
-			isStreamlinedPrice={ streamlinedPriceExperimentAssignment }
+			isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
 		>
 			<Step.TwoColumnLayout
 				firstColumnWidth={ 8 }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1060,6 +1060,15 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				padding-top: 32px;
 			}
 		` }
+	${ ( props ) =>
+		props.isLargeViewport &&
+		props.isStreamlinedPrice &&
+		css`
+			.checkout__summary-area,
+			.checkout-loading-sidebar {
+				min-width: 384px;
+			}
+		` }
 `;
 
 const CheckoutSummary = styled.div`

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -859,7 +859,10 @@ export default function CheckoutMainContent( {
 	}
 
 	return (
-		<StepContainerV2CheckoutFixer isLargeViewport={ isLargeViewport }>
+		<StepContainerV2CheckoutFixer
+			isLargeViewport={ isLargeViewport }
+			isStreamlinedPrice={ streamlinedPriceExperimentAssignment }
+		>
 			<Step.TwoColumnLayout
 				firstColumnWidth={ 8 }
 				secondColumnWidth={ 4 }
@@ -908,7 +911,10 @@ export default function CheckoutMainContent( {
 	);
 }
 
-const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
+const StepContainerV2CheckoutFixer = styled.div< {
+	isLargeViewport: boolean;
+	isStreamlinedPrice: boolean;
+} >`
 	background: ${ colorStudio.colors[ 'White' ] };
 
 	// This shouldn't exist. It's a hack to make the top bar appear on top of the checkout sidebar, which extends from the top of the page.
@@ -931,6 +937,15 @@ const StepContainerV2CheckoutFixer = styled.div< { isLargeViewport: boolean } >`
 		margin-inline: 0;
 		max-width: 100%;
 	}
+
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			div:has( .checkout-sidebar-content ) {
+				position: sticky;
+				top: 32px;
+			}
+		` }
 
 	${ ( props ) =>
 		! props.isLargeViewport &&

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -851,7 +851,11 @@ export default function CheckoutMainContent( {
 
 	if ( ! isStepContainerV2 ) {
 		return (
-			<WPCheckoutWrapper className="checkout-wrapper">
+			<WPCheckoutWrapper
+				className="checkout-wrapper"
+				isLargeViewport={ isLargeViewport }
+				isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+			>
 				{ checkoutSummary }
 				{ checkoutMainContent }
 			</WPCheckoutWrapper>
@@ -1427,7 +1431,10 @@ const SubmitButtonHeaderWrapper = styled.div`
 	}
 `;
 
-const WPCheckoutWrapper = styled.div`
+const WPCheckoutWrapper = styled.div< {
+	isLargeViewport: boolean;
+	isStreamlinedPrice: boolean;
+} >`
 	background: ${ colorStudio.colors[ 'White' ] };
 	display: grid;
 	grid-template-rows: auto;
@@ -1441,6 +1448,11 @@ const WPCheckoutWrapper = styled.div`
 		grid-template-columns: 1fr minmax( 500px, 688px ) 376px 1fr;
 		grid-template-areas: 'main-content main-content sidebar-content sidebar-content';
 		justify-items: end;
+		${ ( props ) =>
+			props.isStreamlinedPrice &&
+			css`
+				grid-template-columns: 1fr minmax( 500px, 688px ) 475px 1fr;
+			` }
 	}
 
 	& > * {
@@ -1455,6 +1467,25 @@ const WPCheckoutWrapper = styled.div`
 	& *:focus {
 		outline: ${ ( props ) => props.theme.colors.outline } solid 2px;
 	}
+
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			.checkout__summary-area {
+				position: sticky;
+				top: 32px;
+			}
+		` }
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		props.isLargeViewport &&
+		css`
+			.checkout__summary-body,
+			.checkout-loading-sidebar,
+			.checkout-sidebar-plan-upsell {
+				min-width: 384px;
+			}
+		` }
 `;
 
 const WPCheckoutCompletedWrapper = styled.div`

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -9,6 +9,7 @@ import { formatCurrency } from 'i18n-calypso';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
@@ -108,6 +109,7 @@ export function CheckoutSidebarPlanUpsell() {
 	const plan = responseCart.products.find(
 		( product ) => isPlan( product ) && ! isJetpackPlan( product )
 	);
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	const variants = useGetProductVariants( plan );
 
@@ -202,9 +204,13 @@ export function CheckoutSidebarPlanUpsell() {
 
 	const { cardTitle, cellLabel, ctaText } = upsellText;
 
+	const checkoutSidebarPlanUpsellClassName =
+		'checkout-sidebar-plan-upsell' +
+		( streamlinedPriceExperimentAssignment ? ' checkout-sidebar-plan-upsell-streamlined' : '' );
+
 	return (
 		<>
-			<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">
+			<PromoCard title={ cardTitle } className={ checkoutSidebarPlanUpsellClassName }>
 				<div className="checkout-sidebar-plan-upsell__plan-grid">
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 						<strong>{ __( 'Plan' ) }</strong>

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -15,6 +15,11 @@
 	line-height: 1.2;
 }
 
+.promo-card.checkout-sidebar-plan-upsell-streamlined .action-panel__title {
+	font-size: $font-title-small;
+	line-height: 1.3;
+}
+
 .checkout-sidebar-plan-upsell__plan-grid {
 	display: grid;
 	grid-template-rows: 1fr 1fr;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -842,7 +842,13 @@ const pulse = keyframes`
 `;
 
 const CheckoutSummaryCard = styled.div`
-	border-bottom: none 0;
+	border: none;
+	border-radius: 4px;
+	background: #fff;
+	padding: 28px;
+	box-shadow:
+		0 3px 1px rgb( 0 0 0 / 4% ),
+		0 3px 8px rgb( 0 0 0 / 12% );
 `;
 
 const CheckoutSummaryFeatures = styled.div`

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -194,7 +194,9 @@ function CheckoutSummaryPriceList() {
 				</CheckoutSummaryTitle>
 			) }
 			<ProductsAndCostOverridesList responseCart={ responseCart } />
-			<CheckoutSummaryAmountWrapper>
+			<CheckoutSummaryAmountWrapper
+				isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+			>
 				<CheckoutSubtotalSection>
 					{ streamlinedPriceExperimentAssignment && (
 						<CheckoutSummarySubtotal key="checkout-summary-line-item-subtotal">
@@ -969,7 +971,7 @@ CheckoutSummaryFeaturesListItem.defaultProps = {
 };
 
 const CheckoutSummaryTitle = styled.div`
-	margin-bottom: 8px;
+	margin-bottom: 16px;
 	color: ${ ( props ) => props.theme.colors.textColorDark };
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	line-height: 26px;
@@ -982,10 +984,16 @@ const CheckoutSubtotalSection = styled.div`
 	padding-bottom: 20px;
 `;
 
-const CheckoutSummaryAmountWrapper = styled.div`
+const CheckoutSummaryAmountWrapper = styled.div< { isStreamlinedPrice: boolean } >`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	padding: 20px 0;
 	margin-top: 20px;
+
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			padding: 20px 0 0 0;
+		` }
 `;
 
 const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -188,9 +188,11 @@ function CheckoutSummaryPriceList() {
 
 	return (
 		<>
-			<CheckoutSummaryTitle>
-				<span>{ translate( 'Your order' ) }</span>
-			</CheckoutSummaryTitle>
+			{ streamlinedPriceExperimentAssignment && (
+				<CheckoutSummaryTitle>
+					<span>{ translate( 'Your order' ) }</span>
+				</CheckoutSummaryTitle>
+			) }
 			<ProductsAndCostOverridesList responseCart={ responseCart } />
 			<CheckoutSummaryAmountWrapper>
 				<CheckoutSubtotalSection>
@@ -1008,7 +1010,7 @@ const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
 	margin-bottom: 0px;
 	font-size: 20px;
 	& .wp-checkout-order-summary__subtotal-price {
-		font-size: 14px; }
+		font-size: 14px;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -1001,9 +1001,6 @@ const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
 	line-height: 26px;
 	margin-bottom: 0px;
 	font-size: 20px;
-	& span {
-		font-family: 'Recoleta', sans-serif;
-	}
 	& .wp-checkout-order-summary__subtotal-price {
 		font-size: 14px; }
 	}
@@ -1016,12 +1013,12 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )< { isStreamlinedP
 	margin-bottom: 0px;
 	font-size: 20px;
 
-	& span {
-		font-family: 'Recoleta', sans-serif;
-	}
 	${ ( props ) =>
 		! props.isStreamlinedPrice &&
 		css`
+	& span {
+		font-family: 'Recoleta', sans-serif;
+	}
 	& .wp-checkout-order-summary__label {
 		font-size: 28px;
 		line-height: 40px;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -88,11 +88,13 @@ export function WPCheckoutOrderSummary( {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isCartUpdating = FormStatus.VALIDATING === formStatus;
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	return (
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
+			isStreamlinedPrice={ streamlinedPriceExperimentAssignment }
 		>
 			{ showFeaturesList && (
 				<CheckoutSummaryFeaturedList
@@ -859,16 +861,20 @@ const pulse = keyframes`
 	100% { opacity: 1; }
 `;
 
-const CheckoutSummaryCard = styled.div`
-	border: none;
-	border-radius: 4px;
-	background: #fff;
-	padding: 28px;
-	box-shadow:
-		0 3px 1px rgb( 0 0 0 / 4% ),
-		0 3px 8px rgb( 0 0 0 / 12% );
+const CheckoutSummaryCard = styled.div< { isStreamlinedPrice: boolean } >`
+	border-bottom: none 0;
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			border: none;
+			border-radius: 4px;
+			background: #fff;
+			padding: 28px;
+			box-shadow:
+				0 3px 1px rgb( 0 0 0 / 4% ),
+				0 3px 8px rgb( 0 0 0 / 12% );
+		` }
 `;
-
 const CheckoutSummaryFeatures = styled.div`
 	padding: 24px 0;
 	justify-self: flex-start;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -35,7 +35,7 @@ import {
 	getTotalLineItemFromCart,
 	getCreditsLineItemFromCart,
 } from '@automattic/wpcom-checkout';
-import { keyframes } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { formatCurrency, useTranslate } from 'i18n-calypso';
@@ -43,6 +43,7 @@ import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -181,21 +182,35 @@ function CheckoutSummaryPriceList() {
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	return (
 		<>
 			<ProductsAndCostOverridesList responseCart={ responseCart } />
 			<CheckoutSummaryAmountWrapper>
 				<CheckoutSubtotalSection>
-					<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
-						<span>{ translate( 'Subtotal' ) }</span>
-						<span>
-							{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
-								isSmallestUnit: true,
-								stripZeros: true,
-							} ) }
-						</span>
-					</CheckoutSummaryLineItem>
+					{ streamlinedPriceExperimentAssignment && (
+						<CheckoutSummarySubtotal key="checkout-summary-line-item-subtotal">
+							<span>{ translate( 'Subtotal' ) }</span>
+							<span className="wp-checkout-order-summary__subtotal-price">
+								{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
+									isSmallestUnit: true,
+									stripZeros: true,
+								} ) }
+							</span>
+						</CheckoutSummarySubtotal>
+					) }
+					{ ! streamlinedPriceExperimentAssignment && (
+						<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
+							<span>{ translate( 'Subtotal' ) }</span>
+							<span>
+								{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
+									isSmallestUnit: true,
+									stripZeros: true,
+								} ) }
+							</span>
+						</CheckoutSummaryLineItem>
+					) }
 					{ taxLineItems.map( ( taxLineItem ) => (
 						<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + taxLineItem.id }>
 							<span>{ taxLineItem.label }</span>
@@ -211,7 +226,7 @@ function CheckoutSummaryPriceList() {
 					) }
 				</CheckoutSubtotalSection>
 
-				<CheckoutSummaryTotal>
+				<CheckoutSummaryTotal isStreamlinedPrice={ streamlinedPriceExperimentAssignment }>
 					<span className="wp-checkout-order-summary__label">
 						{ translate( 'Total', {
 							context: 'The label of the total line item in checkout',
@@ -969,7 +984,21 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 	}
 `;
 
-const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
+const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+	line-height: 26px;
+	margin-bottom: 0px;
+	font-size: 20px;
+	& span {
+		font-family: 'Recoleta', sans-serif;
+	}
+	& .wp-checkout-order-summary__subtotal-price {
+		font-size: 14px; }
+	}
+`;
+
+const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )< { isStreamlinedPrice: boolean } >`
 	color: ${ ( props ) => props.theme.colors.textColorDark };
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	line-height: 26px;
@@ -979,7 +1008,9 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 	& span {
 		font-family: 'Recoleta', sans-serif;
 	}
-
+	${ ( props ) =>
+		! props.isStreamlinedPrice &&
+		css`
 	& .wp-checkout-order-summary__label {
 		font-size: 28px;
 		line-height: 40px;
@@ -988,6 +1019,7 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 	& .wp-checkout-order-summary__total-price {
 		font-size: 40px; line-height: 44px; }
 	}
+	` }
 `;
 
 const LoadingCopy = styled.p`

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -94,7 +94,7 @@ export function WPCheckoutOrderSummary( {
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
-			isStreamlinedPrice={ streamlinedPriceExperimentAssignment }
+			isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
 		>
 			{ showFeaturesList && (
 				<CheckoutSummaryFeaturedList
@@ -233,7 +233,7 @@ function CheckoutSummaryPriceList() {
 					) }
 				</CheckoutSubtotalSection>
 
-				<CheckoutSummaryTotal isStreamlinedPrice={ streamlinedPriceExperimentAssignment }>
+				<CheckoutSummaryTotal isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }>
 					<span className="wp-checkout-order-summary__label">
 						{ translate( 'Total', {
 							context: 'The label of the total line item in checkout',

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -186,6 +186,9 @@ function CheckoutSummaryPriceList() {
 
 	return (
 		<>
+			<CheckoutSummaryTitle>
+				<span>{ translate( 'Your order' ) }</span>
+			</CheckoutSummaryTitle>
 			<ProductsAndCostOverridesList responseCart={ responseCart } />
 			<CheckoutSummaryAmountWrapper>
 				<CheckoutSubtotalSection>
@@ -956,6 +959,14 @@ const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean 
 CheckoutSummaryFeaturesListItem.defaultProps = {
 	isSupported: true,
 };
+
+const CheckoutSummaryTitle = styled.div`
+	margin-bottom: 8px;
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+	line-height: 26px;
+	font-size: 20px;
+`;
 
 const CheckoutSubtotalSection = styled.div`
 	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-kUT-p2 and M4R73CH-798

## Proposed Changes

Change the visual style of the Order Summary Sidebar to match the proposed Figma designs.
The changes for the individual line items and the addition of the Discount line would be addressed in a separate PR.

Before:
<img width="1194" alt="Screenshot 2025-04-30 at 17 13 06" src="https://github.com/user-attachments/assets/afd30182-a1b7-4555-9a10-ac896d729094" />
After:
<img width="1194" alt="Screenshot 2025-04-30 at 15 49 35" src="https://github.com/user-attachments/assets/4a783bb7-6e53-4402-92c3-b39d1f136b98" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're experimenting with streamlining the plans and checkout user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to one of the experiment variations of calypso_streamlined_plans_checkout
* Add several products to the cart, a plan, some domains etc.
* Proceed to the checkout step and confirm that the order sidebar is:

1. Sticky and remains visible on scroll.
2. The Summary is displayed within a white card with a drop shadow and rounded corners.
3. Same size and font family are used for "Your order", "Subtotal", "Total" and the title in the upsell card.
4. All the prices in the summary are using the same font size, except for the total.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
