### PR TITLE
Quick Links: Remove classic editor check affecting edit homepage link visibility

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites/index.jsx
@@ -7,7 +7,6 @@ import { useDebouncedCallback } from 'use-debounce';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import getSelectedEditor from 'calypso/state/selectors/get-selected-editor';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { getSitePlanSlug, getSite, getSiteOption } from 'calypso/state/sites/selectors';
@@ -155,9 +154,7 @@ const QuickLinksForEcommerceSites = ( props ) => {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
-	const isStaticHomePage =
-		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
+	const isStaticHomePage = 'page' === getSiteOption( state, siteId, 'show_on_front' );
 
 	return {
 		isStaticHomePage,

--- a/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
@@ -7,7 +7,6 @@ import { useDebouncedCallback } from 'use-debounce';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import getSelectedEditor from 'calypso/state/selectors/get-selected-editor';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { getSitePlanSlug, getSite, getSiteOption } from 'calypso/state/sites/selectors';
@@ -148,9 +147,7 @@ const QuickLinksForHostedSites = ( props ) => {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
-	const isStaticHomePage =
-		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
+	const isStaticHomePage = 'page' === getSiteOption( state, siteId, 'show_on_front' );
 
 	return {
 		isStaticHomePage,

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -15,7 +15,6 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/ana
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
@@ -429,9 +428,7 @@ export const trackManageEmailsAction = ( isStaticHomePage ) => ( dispatch ) => {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
-	const isStaticHomePage =
-		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
+	const isStaticHomePage = 'page' === getSiteOption( state, siteId, 'show_on_front' );
 	const siteSlug = getSelectedSiteSlug( state );
 	const staticHomePageId = getSiteFrontPage( state, siteId );
 	const editHomePageUrl = isStaticHomePage && `/page/${ siteSlug }/${ staticHomePageId }`;

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -6,7 +6,6 @@ import { useDebouncedCallback } from 'use-debounce';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import { getSiteFrontPage, getCustomizerUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -133,9 +132,7 @@ const trackAddP2UsersAction = ( isStaticHomePage ) => ( dispatch ) => {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
-	const isStaticHomePage =
-		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
+	const isStaticHomePage = 'page' === getSiteOption( state, siteId, 'show_on_front' );
 	const siteSlug = getSelectedSiteSlug( state );
 	const staticHomePageId = getSiteFrontPage( state, siteId );
 	const editHomePageUrl = isStaticHomePage && `/page/${ siteSlug }/${ staticHomePageId }`;

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -35,7 +35,6 @@ import {
 } from 'calypso/state/plugins/installed/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getRequest from 'calypso/state/selectors/get-request';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isFetchingJetpackModules from 'calypso/state/selectors/is-fetching-jetpack-modules';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
@@ -361,7 +360,6 @@ const HomeContent = ( {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
 	const installedWooCommercePlugin = getPluginOnSite( state, siteId, 'woocommerce' );
 
 	return {
@@ -371,8 +369,7 @@ const mapStateToProps = ( state ) => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isNew7DUser: isUserRegistrationDaysWithinRange( state, null, 0, 7 ),
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
-		isStaticHomePage:
-			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
+		isStaticHomePage: 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		hasWooCommerceInstalled: !! ( installedWooCommercePlugin && installedWooCommercePlugin.active ),
 		isRequestingSitePlugins: isRequestingInstalledPlugins( state, siteId ),
 		isSiteWooExpressEcommerceTrial: isSiteOnWooExpressEcommerceTrial( state, siteId ),


### PR DESCRIPTION
## Proposed Changes

This PR removes the `!isClassicEditor` condition from the calculation:

```diff
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 -	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
 	const isStaticHomePage =
 -		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
 +		'page' === getSiteOption( state, siteId, 'show_on_front' );
 	// ...
 };
```

Now, `isStaticHomePage` correctly reflects the site's `show_on_front` setting exclusively.


## Why are these changes being made?

**Problem:**

On the Customer Home (`/home/<site>`) "Quick links" card, the "Edit homepage" link may be incorrectly hidden for sites that *do* use a static front page.

**Root Cause:**

The visibility of the "Edit homepage" link depends partly on an `isStaticHomePage` variable calculated within the component's `mapStateToProps`. This variable was defined as:

```javascript
const isStaticHomePage =
    ! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
```

The `isClassicEditor` variable is true if the `/wpcom/v3/sites/<siteid>/gutenberg` API endpoint returns `editor_web: "classic"`. While we aim to default users to the Block Editor (Gutenberg), this API *can* still return `"classic"` due to legacy user preferences or, more commonly, if a Jetpack site has the Classic Editor plugin active.

When `isClassicEditor` is true, `isStaticHomePage` is forced to `false`, hiding the "Edit homepage" link regardless of the actual `show_on_front` site setting. This logic appears to be a leftover artifact from a time when editing the homepage might have behaved differently based on the selected editor (#40276), but it no longer makes sense in the current Gutenberg-first approach. The other links on the card ("Write blog post", "Add a page") already point to the default editor URLs unconditionally.

This also affects the visibility logic for the "Manage comments" link (which is shown when *not* a static homepage) and the accuracy of analytics events that include the `is_static_home_page` property.


## Testing Instructions


**Prerequisites:**

1.  Have a sandboxed WP.com Simple site.
2.  Ensure the site is **NOT** using a Block Theme/Full Site Editing theme (e.g., use a theme like Radcliffe 2, Twenty Sixteen). If it *is* an FSE theme, you'll see "Edit site" instead of "Edit homepage" in Quick Links, and this specific test isn't applicable.
3.  Go to the site's WP Admin -> Settings -> Reading (`/wp-admin/options-reading.php`). Under "Your homepage displays", select "A static page" and choose a page (e.g., the default "Home" or "About" page). Save changes.

**Scenario 1: Default Behavior (Simulating `editor_web: "gutenberg"`)**

1.  Check out the `master` branch (or your current branch *before* this change).
2.  Navigate to Calypso Customer Home (`/home/<your-site-slug>`).
3.  Look at the "Quick links" card.
4.  **Expected Result:** You should see the "Edit homepage" link. You should *not* see the "Manage comments" link.

**Scenario 2: Simulating `editor_web: "classic"`**

1.  **Modify Sandbox:** Access your sandbox environment and edit the following file: `wp-content/rest-api-plugins/endpoints/sites-gutenberg-v3.php`.
2.  Find the line ` $editor_web = A8C\Gutenberg\get_editor( $user_id, $blog_id, 'web' );` (around line 26).
3.  Temporarily change it to force the return value:
    ```php
    $editor_web = 'classic'; // A8C\Gutenberg\get_editor( $user_id, $blog_id, 'web' );
    ```
4.  Save the file.
5.  **Test WITHOUT the PR:**
    *   Ensure you are still on the branch *before* this PR's changes.
    *   Hard refresh Customer Home (`/home/<your-site-slug>`).
    *   Look at the "Quick links" card.
    *   **Expected Result:** The "Edit homepage" link should **be missing**. The "Manage comments" link should **appear** (incorrectly).
6.  **Test WITH the PR:**
    *   Check out the branch containing this PR's changes.
    *   Hard refresh Customer Home (`/home/<your-site-slug>`).
    *   Look at the "Quick links" card.
    *   **Expected Result:** The "Edit homepage" link should **now appear**. The "Manage comments" link should **now be missing** (correctly).


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
