### PR TITLE
focused launchpad - add newsletter as supported creation flow

### DIFF
--- a/client/state/selectors/should-show-launchpad-first.ts
+++ b/client/state/selectors/should-show-launchpad-first.ts
@@ -9,14 +9,16 @@ const SiteIntent = Onboard.SiteIntent;
  * @returns Whether launchpad should be shown first
  */
 export const shouldShowLaunchpadFirst = ( site: SiteExcerptData ): boolean => {
-	const wasSiteCreatedOnboardingFlow = site.options?.site_creation_flow === 'onboarding';
+	const wasSupportedCreationFlow = [ 'onboarding', 'newsletter' ].includes(
+		site.options?.site_creation_flow || ''
+	);
 	const isBigSkyIntent = site?.options?.site_intent === SiteIntent.AIAssembler;
 	const isMigrationIntent = site?.options?.site_intent === SiteIntent.SiteMigration;
 	// If we don't have a site intent, fall through to the next option.
 	const siteHasNoIntent =
 		site && site.options && ( site.options.site_intent === '' || ! site.options.site_intent );
 
-	if ( isBigSkyIntent || ! wasSiteCreatedOnboardingFlow || siteHasNoIntent || isMigrationIntent ) {
+	if ( isBigSkyIntent || ! wasSupportedCreationFlow || siteHasNoIntent || isMigrationIntent ) {
 		return false;
 	}
 

--- a/client/state/selectors/test/should-show-launchpad-first.ts
+++ b/client/state/selectors/test/should-show-launchpad-first.ts
@@ -1,23 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { shouldShowLaunchpadFirst } from '../should-show-launchpad-first';
 import type { SiteDetails } from '@automattic/data-stores';
-
-jest.mock( 'calypso/lib/explat', () => ( {
-	loadExperimentAssignment: jest.fn(),
-} ) );
 
 beforeEach( () => {
 	jest.clearAllMocks();
 } );
 
 describe( 'shouldShowLaunchpadFirst', () => {
-	it( 'should return true when site was created via onboarding flow, has an intent, and assigned to experiment', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
+	it( 'should return true when site was created via onboarding flow and has an intent', async () => {
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
@@ -28,10 +20,18 @@ describe( 'shouldShowLaunchpadFirst', () => {
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( true );
 	} );
 
-	it( 'should return false when site was created via onboarding flow, has the ai-assembler intent, and assigned to experiment', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
+	it( 'should return true when site was created via newsletter flow and has an intent', async () => {
+		const site = {
+			options: {
+				site_creation_flow: 'newsletter',
+				site_intent: 'newsletter',
+			},
+		} as SiteDetails;
+
+		expect( await shouldShowLaunchpadFirst( site ) ).toBe( true );
+	} );
+
+	it( 'should return false when site was created via onboarding flow and has the ai-assembler intent', async () => {
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
@@ -42,10 +42,7 @@ describe( 'shouldShowLaunchpadFirst', () => {
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 
-	it( 'should return false when site was created via onboarding flow, has no intent, and assigned to experiment', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
+	it( 'should return false when site was created via onboarding flow and has no intent', async () => {
 		const site = {
 			options: {
 				site_creation_flow: 'onboarding',
@@ -56,13 +53,11 @@ describe( 'shouldShowLaunchpadFirst', () => {
 		expect( await shouldShowLaunchpadFirst( site ) ).toBe( false );
 	} );
 
-	it( 'should return false when site was not created via onboarding flow', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
+	it( 'should return false when site was not created via onboarding or newsletter flow, regardless of intent', async () => {
 		const site = {
 			options: {
 				site_creation_flow: 'other',
+				site_intent: 'build',
 			},
 		} as SiteDetails;
 
@@ -70,9 +65,6 @@ describe( 'shouldShowLaunchpadFirst', () => {
 	} );
 
 	it( 'should return false when site has no creation flow information', async () => {
-		( loadExperimentAssignment as jest.Mock ).mockResolvedValue( {
-			variationName: 'treatment_cumulative',
-		} );
 		const site = {
 			options: {},
 		} as SiteDetails;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/673 / https://linear.app/a8c/issue/CML-436/enable-focused-launchpad-for-newsletter-tailored-flows

## Proposed Changes

Enables the focused launchpad for sites created in the newsletter tailored onboarding flow.

BEFORE
![Screenshot 2025-04-30 at 10 05 34 AM](https://github.com/user-attachments/assets/81adaebe-b2bc-4191-9319-e455f4c243a4)

AFTER
![Screenshot 2025-04-30 at 10 05 19 AM](https://github.com/user-attachments/assets/cd770cb7-d957-4e27-ac6d-bf6e02e79144)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* to get with the times. Use the new design and format that the rest of onboarding is. Stop duplicating forms and other interfaces in stepper.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the backend diff 181853-ghe-Automattic/wpcom
* sandbox the public API
* create a site through WordPress.com/newsletter (or use an existing one if it is still in the initial launchpad).
* run this calypso build
* try to visit my home or the launchpad, you should see the focused my home launchpad instead of the full screen stepper version.
* regression test - create a site through general onboarding flows, verify it still uses the focused launchpad as expected as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?