### PR TITLE
Help Center: Fix GetSupport new conversation

### DIFF
--- a/packages/odie-client/src/components/message/get-support.tsx
+++ b/packages/odie-client/src/components/message/get-support.tsx
@@ -1,3 +1,4 @@
+import { useResetSupportInteraction } from '@automattic/help-center/src/hooks/use-reset-support-interaction';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
@@ -53,12 +54,14 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 } ) => {
 	const navigate = useNavigate();
 	const newConversation = useCreateZendeskConversation();
+	const resetSupportInteraction = useResetSupportInteraction();
 	const location = useLocation();
 	const {
 		chat,
 		isUserEligibleForPaidSupport: contextIsUserEligibleForPaidSupport,
 		canConnectToZendesk: contextCanConnectToZendesk,
 		trackEvent,
+		isChatLoaded,
 	} = useOdieAssistantContext();
 
 	const { mostRecentSupportInteractionId } = useGetMostRecentOpenConversation();
@@ -102,7 +105,15 @@ export const GetSupport: React.FC< GetSupportProps > = ( {
 					waitTimeText: __( 'Average wait time < 5 minutes', __i18n_text_domain__ ),
 					action: async () => {
 						onClickAdditionalEvent?.( 'chat' );
-						await newConversation( { createdFrom: 'chat_support_button' } );
+						resetSupportInteraction().then( ( interaction ) => {
+							if ( isChatLoaded ) {
+								newConversation( {
+									avoidTransfer: true,
+									interactionId: interaction?.uuid,
+									createdFrom: 'chat_support_button',
+								} );
+							}
+						} );
 					},
 				},
 			];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DOTSUP-4/investigate-multiple-interactions-and-blank-chats-for-users

## Proposed Changes

Some users get duplicate conversations with the same support interaction id. This causes duplicate tickets in Zendesk and many times an Happiness Engineer may write in one while the user is reading in the other.

A case where this happens is when a user directly escalate to Happiness Engineers by AI and then goes and clicks thumbs down on an article and clicks on get support.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start new chat with AI in the Help Center.
- Ask to talk to a human and get to the direct escalation to HE.
- Go back, open an article and click on thumbs down at the end of it.
- Click to Get Support.
- A mess is created, with duplicated interactions.