### PR TITLE
Revert "Include user locale when submitting application password info…

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-credentials/hooks/use-credentials-form.ts
@@ -25,8 +25,7 @@ export const analyzeUrl = async ( domain: string ): Promise< UrlData | undefined
 
 export const getApplicationPasswordsInfo = async (
 	siteId: number,
-	from: string,
-	locale: string
+	from: string
 ): Promise< ApplicationPasswordsInfo | undefined > => {
 	try {
 		return await wp.req.post( {
@@ -34,7 +33,6 @@ export const getApplicationPasswordsInfo = async (
 			apiNamespace: 'wpcom/v2',
 			body: {
 				source: from,
-				locale,
 			},
 		} );
 	} catch ( error ) {
@@ -167,15 +165,11 @@ export const useCredentialsForm = (
 				} );
 				onSubmit( siteInfoResult );
 			} else {
-				const applicationPasswordsInfoResult = await getApplicationPasswordsInfo(
-					siteId,
-					from,
-					locale
-				);
+				const applicationPasswordsInfoResult = await getApplicationPasswordsInfo( siteId, from );
 				onSubmit( siteInfoResult, applicationPasswordsInfoResult );
 			}
 		},
-		[ onSubmit, siteSlug, sendTicketAsync, locale ]
+		[ onSubmit, siteSlug, sendTicketAsync ]
 	);
 
 	const submitHandler = handleSubmit( async ( data: CredentialsFormData ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCON-23-linear-issue

## Proposed Changes

This reverts commit 542024ed453560aafde247c7b7c59287149f0f63.

We don't actually need to do this. The endpoint can use the built-in _locale parameter.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply 181784-ghe-Automattic/wpcom to your sandbox and make sure the public-api is sandboxed.
* In your [WordPress.com account settings](https://wordpress.com/me/account), change to a non-English locale.
* Run this branch locally or use the calypso.live url.
* Go through `/start` and choose "Import or Migrate" on the goals step.
* Continue with a DIFM migration. 
* Share credentials (calypso.localhost or calypso.live) or authorize the application (calypso.live-only) to complete the migration request.
* Go to ZenDesk and locate your migration ticket.
* Verify that the initial message has the correct locale.

![image](https://github.com/user-attachments/assets/c70922e9-2a34-4e3d-a7da-a928cb7cece2)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?