### PR TITLE
Remove Trigger for Classic Block Guide NUX

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -27,7 +27,6 @@ import { clearLastNonEditorRoute, setRoute } from 'calypso/state/route/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getEditorCloseConfig from 'calypso/state/selectors/get-editor-close-config';
 import getPostTypeTrashUrl from 'calypso/state/selectors/get-post-type-trash-url';
-import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
@@ -815,11 +814,6 @@ const mapStateToProps = (
 	// needed for loading the editor in SU sessions
 	if ( wpcom.addSupportParams ) {
 		queryArgs = wpcom.addSupportParams( queryArgs );
-	}
-
-	// Pass through to iframed editor if user is in editor deprecation group.
-	if ( 'classic' === getSelectedEditor( state, siteId ?? 0 ) ) {
-		queryArgs[ 'in-editor-deprecation-group' ] = 1;
 	}
 
 	// Add new Site Editor params introduced in https://github.com/WordPress/gutenberg/pull/38817.


### PR DESCRIPTION
## Proposed Changes

* Removes the logic that checks `getSelectedEditor` and adds the `in-editor-deprecation-group` query parameter.

## Why are these changes being made?

**Problem**:
The `CalypsoifyIframe` component (`client/gutenberg/editor/calypsoify-iframe.tsx`) currently adds an `in-editor-deprecation-group=1` query parameter to the Gutenberg editor iframe URL under specific conditions. This happens only if the `selectedEditor` state for the site is determined to be 'classic'.

**Why Remove It?**:

- This query parameter's sole purpose was to trigger a specific, one-time NUX (New User Experience) called the "Classic Block Guide" inside the wpcom-block-editor.
- This NUX was intended for users migrating from the Classic editor ~5 years ago.
- The NUX itself has been non-functional since August 2020 due to a JavaScript error related to a missing dependency (setWpcomNuxStatus from the wpcom-welcome-guide store). A fix at the time prevented the error by making the NUX component return null. (See p2:  p9F6qB-5Ja-p2).
- The NUX feature code is being removed entirely from wpcom-block-editor in a separate PR: #102985.
- The triggering condition `(selectedEditor === 'classic')` relies on state logic that is increasingly obsolete and being phased out elsewhere.
- This removal was planned years ago: #46472

**Impact:**

- No user-facing impact, as the NUX it triggered was already non-functional and is being removed.
  - Even if it was working in some cases, it stops displaying after dismissal, and users have had several years to dismiss it. New users don't get the `selectedEditor == classic`, so there's not a new incoming stream of users.
- Simplifies the CalypsoifyIframe component.
- Reduces reliance on the legacy `selectedEditor` state. 

## Testing Instructions


**Goal:** Verify the `in-editor-deprecation-group=1` query parameter is no longer added to the editor iframe URL, even when simulating the old trigger conditions.

**Setup:**
1.  Check out this PR's branch in your `wp-calypso` repository.
2.  **Modify Sandbox API:** Access your sandbox environment and edit `wp-content/rest-api-plugins/endpoints/sites-gutenberg-v3.php`. Temporarily change line ~26 to force the API to return `"classic"`:
    ```php
    $editor_web = 'classic'; // A8C\Gutenberg\get_editor( $user_id, $blog_id, 'web' );
    ```
    Save the file.
3.  **(Optional) Clear NUX localStorage:** In browser dev tools -> Application -> Local Storage for `calypso.live` (or your sandbox domain), delete the key `classic_block_guide_{your_site_id}_is_dismissed` if it exists. (This isn't strictly needed for *this* PR but relevant to the overall feature).
4.  **(If Necessary) Ensure Iframe Loads:** *Tester Note:* If the editor iframe doesn't load due to other checks (like `shouldLoadGutenframe`), you might need a temporary local hack like modifying `client/state/selectors/should-load-gutenframe.js` to always return `true` for testing purposes. Remember to revert this hack before committing/merging.

**Steps:**
1.  Navigate to Calypso Customer Home (`/home/<your-site-slug>`) to ensure the state is fresh after the API change.
2.  Navigate to create a new post or edit an existing one (e.g., `/post/<your-site-slug>`).
3.  Let the editor attempt to load.
4.  **Inspect the Iframe URL:** Use your browser's developer tools (Elements tab) to inspect the `<iframe>` element being loaded for the editor. Check its `src` attribute *after* the page has settled. Alternatively, check the Network tab for the request to `post-new.php` or `post.php`.
5.  **Expected Result (With PR):** The iframe URL should **NOT** contain the `in-editor-deprecation-group=1` query parameter.
6.  **Verification (Without PR):** Check out `master` (or the branch before these changes), repeat steps 1-4. The iframe URL **SHOULD** contain `in-editor-deprecation-group=1`.
7.  **Normal Case:** Revert the sandbox API change (`$editor_web = A8C\Gutenberg\get_editor...`). Load the editor normally. Confirm it still loads correctly and the query parameter is not present (as expected).
8.  **Cleanup:** Remember to revert the change made in `sites-gutenberg-v3.php` on your sandbox. Revert any local hacks like `shouldLoadGutenframe.js` if used.


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
