### PR TITLE
Simplified Hosting Onboarding: Redirecting users to /home instead of /overview

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -123,7 +123,7 @@ const onboarding: FlowV2 = {
 
 			if ( isMvpOnboarding ) {
 				return [
-					addQueryArgs( `/overview/${ providedDependencies.siteSlug }`, { ref: flowName } ),
+					addQueryArgs( `/home/${ providedDependencies.siteSlug }`, { ref: flowName } ),
 					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
 						siteSlug: providedDependencies.siteSlug,
 					} ),

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,4 +1,4 @@
-import { DomainSuggestion, OnboardActions, OnboardSelect } from '@automattic/data-stores';
+import { DomainSuggestion, Onboard, OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -25,7 +25,7 @@ import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useMarketplaceThemeProducts } from '../../../hooks/use-marketplace-theme-products';
 import { useQuery } from '../../../hooks/use-query';
-import { ONBOARD_STORE } from '../../../stores';
+import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { STEPS } from '../../internals/steps';
@@ -69,6 +69,7 @@ const onboarding: FlowV2 = {
 	},
 
 	useStepNavigation( currentStepSlug, navigate ) {
+		const { setIntentOnSite } = useDispatch( SITE_STORE );
 		const flowName = this.name;
 		const isPlaygroundEligible = useIsPlaygroundEligible();
 		const [ , isMvpOnboarding ] = useMvpOnboardingExperiment();
@@ -238,6 +239,11 @@ const onboarding: FlowV2 = {
 					persistSignupDestination( destination );
 					setSignupCompleteFlowName( flowName );
 					setSignupCompleteSlug( providedDependencies.siteSlug );
+
+					// For the simplified onboarding flow, we'll use the build intent since user can't choose the intent.
+					if ( isMvpOnboarding ) {
+						setIntentOnSite( providedDependencies.siteSlug, Onboard.SiteIntent.Build );
+					}
 
 					if ( providedDependencies.goToCheckout ) {
 						const siteSlug = providedDependencies.siteSlug as string;

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,4 +1,4 @@
-import { DomainSuggestion, Onboard, OnboardActions, OnboardSelect } from '@automattic/data-stores';
+import { DomainSuggestion, OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -25,7 +25,7 @@ import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useMarketplaceThemeProducts } from '../../../hooks/use-marketplace-theme-products';
 import { useQuery } from '../../../hooks/use-query';
-import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
+import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
 import { STEPS } from '../../internals/steps';
@@ -69,7 +69,6 @@ const onboarding: FlowV2 = {
 	},
 
 	useStepNavigation( currentStepSlug, navigate ) {
-		const { setIntentOnSite } = useDispatch( SITE_STORE );
 		const flowName = this.name;
 		const isPlaygroundEligible = useIsPlaygroundEligible();
 		const [ , isMvpOnboarding ] = useMvpOnboardingExperiment();
@@ -239,11 +238,6 @@ const onboarding: FlowV2 = {
 					persistSignupDestination( destination );
 					setSignupCompleteFlowName( flowName );
 					setSignupCompleteSlug( providedDependencies.siteSlug );
-
-					// For the simplified onboarding flow, we'll use the build intent since user can't choose the intent.
-					if ( isMvpOnboarding ) {
-						setIntentOnSite( providedDependencies.siteSlug, Onboard.SiteIntent.Build );
-					}
 
 					if ( providedDependencies.goToCheckout ) {
 						const siteSlug = providedDependencies.siteSlug as string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1745952515530529/1745877515.309769-slack-C04H4NY6STW

## Proposed Changes

* We're redirecting user to /home instead of /overview on both free and paid plans

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this backend code in your sandbox: 181797-ghe-Automattic/wpcom
* Use the following experiment: 22241-explat-experiment
* On `control` group, you should get production behavior
* On `treatment` group, you won't see goals + design selection.
* Make sure both groups always land on `/home` as if you were at prod.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?