### PR TITLE
CalypsoifyIframe: Remove obsolete AnchorFm Data

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -58,11 +58,6 @@ interface Props {
 	editorType: 'site' | 'post'; // Note: a page or other CPT is a type of post.
 	pressThisData: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	bloggingPromptData: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-	anchorFmData: {
-		anchor_podcast: string | undefined;
-		anchor_episode: string | undefined;
-		spotify_url: string | undefined;
-	};
 	siteAdminUrl: T.URL | null;
 	parentPostId: T.PostId;
 	stripeConnectSuccess: 'gutenberg' | null;
@@ -777,7 +772,6 @@ const mapStateToProps = (
 		creatingNewHomepage,
 		editorType = 'post',
 		stripeConnectSuccess,
-		anchorFmData,
 		showDraftPostModal,
 		pressThisData,
 		bloggingPromptData,
@@ -803,7 +797,6 @@ const mapStateToProps = (
 		'environment-id': config( 'env_id' ),
 		'new-homepage': creatingNewHomepage,
 		...( !! stripeConnectSuccess && { stripe_connect_success: stripeConnectSuccess } ),
-		...anchorFmData,
 		openSidebar: getQueryArg( window.location.href, 'openSidebar' ),
 		showDraftPostModal,
 		...pressThisData,

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -237,11 +237,6 @@ function getBloggingPromptData( query ) {
 	return answer_prompt ? { answer_prompt } : null;
 }
 
-function getAnchorFmData( query ) {
-	const { anchor_podcast, anchor_episode, spotify_url } = query;
-	return { anchor_podcast, anchor_episode, spotify_url };
-}
-
 function getSessionStorageOneTimeValue( key ) {
 	const value = window.sessionStorage.getItem( key );
 	window.sessionStorage.removeItem( key );
@@ -265,7 +260,6 @@ export const post = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 	const pressThisData = getPressThisData( context.query );
 	const bloggingPromptData = getBloggingPromptData( context.query );
-	const anchorFmData = getAnchorFmData( context.query );
 	const parentPostId = parseInt( context.query.parent_post, 10 ) || null;
 
 	// Set postId on state.editor.postId, so components like editor revisions can read from it.
@@ -282,7 +276,6 @@ export const post = ( context, next ) => {
 			duplicatePostId={ duplicatePostId }
 			pressThisData={ pressThisData }
 			bloggingPromptData={ bloggingPromptData }
-			anchorFmData={ anchorFmData }
 			parentPostId={ parentPostId }
 			creatingNewHomepage={ postType === 'page' && context.query.hasOwnProperty( 'new-homepage' ) }
 			stripeConnectSuccess={ context.query.stripe_connect_success ?? null }


### PR DESCRIPTION
Remove obsolete AnchorFm data. The project was sunset 2 years ago and mostly removed here: #78958. These bits of data don't need to be passed to the editor, as nothing is looking for them.

An example of their usage is in #48065 - this is mostly gone now.

## Proposed Changes

*

## Why are these changes being made?

*

## Testing Instructions


* Make sure the CalypsoifyIframe works. You might have to locally modify `client/state/selectors/should-load-gutenframe.js` to always return true. Then visit `http://calypso.localhost:3000/post/<sitename>`

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
