### PR TITLE
Revert "Revert "Update text-wrap styles across multiple screens""

### DIFF
--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,6 +1,21 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/calypso-color-schemes";
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+caption,
+figcaption,
+p,
+ul,
+ol,
+blockquote {
+	text-wrap: pretty;
+}
+
 .help-center.entry-point-button {
 	&.is-active {
 		background: #1e1e1e;

--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -9,3 +9,9 @@
 		}
 	}
 }
+
+.a4a-plugins-jetpack-banner-container {
+	p {
+		line-height: 1.4;
+	}
+}

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -145,11 +145,13 @@ h4,
 h5,
 h6 {
 	clear: both;
-	text-wrap: balance;
+	text-wrap: balance; // TODO: remove this fallback once `pretty` is globally supported.
+	text-wrap: pretty;
 }
 caption,
 figcaption {
 	text-wrap: balance;
+	text-wrap: pretty;
 }
 hr {
 	background: var(--color-neutral-10);

--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -307,9 +307,9 @@ export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, transl
 									<div className="eligibility-warnings__message-title">
 										{ holdMessages[ hold ].title }
 									</div>
-									<div className="eligibility-warnings__message-description">
+									<p className="eligibility-warnings__message-description">
 										{ holdMessages[ hold ].description }
-									</div>
+									</p>
 								</div>
 								{ holdMessages[ hold ].supportUrl && (
 									<div className="eligibility-warnings__hold-action">

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -88,6 +88,10 @@
 		}
 	}
 
+	.eligibility-warnings__message-description {
+		margin-bottom: 0;
+	}
+
 	&.eligibility-warnings--without-title {
 		padding: 24px;
 		box-shadow: 0 0 0 1px var(--color-border-subtle);

--- a/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
+++ b/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
@@ -25,7 +25,7 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
         />
       </svg>
     </span>
-    <span
+    <p
       class="calypso-notice__content"
     >
       <span
@@ -33,7 +33,7 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
       >
         This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
       </span>
-    </span>
+    </p>
     <button
       aria-label="Dismiss"
       class="calypso-notice__dismiss"

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -226,10 +226,10 @@ export class Banner extends Component {
 		}
 		if ( typeof description === 'string' ) {
 			return (
-				<div
+				<p
 					className="banner__description"
 					dangerouslySetInnerHTML={ { __html: this.sanitize( description ) } } // eslint-disable-line react/no-danger
-				></div>
+				></p>
 			);
 		}
 		return <div className="banner__description">{ description }</div>;
@@ -274,7 +274,7 @@ export class Banner extends Component {
 					/>
 				) }
 				<div className="banner__info">
-					<div className="banner__title">{ title }</div>
+					<p className="banner__title">{ title }</p>
 					{ this.renderDescription( description ) }
 					{ size( list ) > 0 && (
 						<ul className="banner__list">

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -167,11 +167,13 @@
 	.banner__title {
 		font-size: $font-body-small;
 		font-weight: 600;
+		margin-bottom: 0;
 	}
 
 	.banner__description {
 		font-size: $font-body-extra-small;
 		margin-top: 3px;
+		margin-bottom: 0;
 	}
 
 	.banner__list {

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -150,7 +150,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index, menu } ) => 
 					>
 						<Gridicon icon={ backIcon } size={ 18 } />
 					</Button>
-					<div className="blogging-prompt__prompt-text">{ getPrompt()?.text }</div>
+					<p className="blogging-prompt__prompt-text">{ getPrompt()?.text }</p>
 					<Button
 						aria-label={ translate( 'Show next prompt' ) }
 						borderless={ false }

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -41,7 +41,7 @@
 			font-size: $font-title-small;
 			font-weight: 500;
 			line-height: 26px;
-			text-wrap: pretty;
+			margin-bottom: 0;
 		}
 		button.navigation-link {
 			border-radius: 50%;

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -26,7 +26,7 @@ exports[`<GlobalNotices /> should render notices with the expected structure 1`]
           />
         </svg>
       </span>
-      <span
+      <p
         class="calypso-notice__content"
       >
         <span
@@ -34,7 +34,7 @@ exports[`<GlobalNotices /> should render notices with the expected structure 1`]
         >
           A test notice
         </span>
-      </span>
+      </p>
       <button
         aria-label="Dismiss"
         class="calypso-notice__dismiss"

--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -120,9 +120,9 @@ export default function Notice( {
 				{ iconNeedsDrop && <span className="calypso-notice__icon-wrapper-drop" /> }
 				{ renderedIcon }
 			</span>
-			<span className="calypso-notice__content">
+			<p className="calypso-notice__content">
 				<span className="calypso-notice__text">{ text ? text : children }</span>
-			</span>
+			</p>
 			{ text ? children : null }
 			{ showDismiss && (
 				<button

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -175,6 +175,7 @@
 	padding: 13px;
 	font-size: $font-body-extra-small;
 	flex-grow: 1;
+	margin-bottom: 0;
 
 	.calypso-notice__text {
 		a,

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -144,7 +144,7 @@ export default function ThemeCollection( {
 			<div className="theme-collection__meta">
 				<div className="theme-collection__headings">
 					<h2 className="theme-collection__title">{ title }</h2>
-					<div className="theme-collection__description">{ preventWidows( description ) }</div>
+					<p className="theme-collection__description">{ preventWidows( description ) }</p>
 				</div>
 				<div className="theme-collection__carousel-controls">
 					<Button className="theme-collection__see-all" onClick={ onSeeAllAction }>

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -54,6 +54,7 @@
 	color: var(--studio-gray-60);
 	font-size: $font-body-small;
 	line-height: 1.4;
+	margin-bottom: 0;
 
 	& > * {
 		margin-bottom: 0;

--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -28,7 +28,7 @@ exports[`JetpackConnectNotices Should render non-terminal notice if callback sup
           />
         </svg>
       </span>
-      <span
+      <p
         class="calypso-notice__content"
       >
         <span
@@ -36,7 +36,7 @@ exports[`JetpackConnectNotices Should render non-terminal notice if callback sup
         >
           In some cases, authorization can take a few attempts. Please try again.
         </span>
-      </span>
+      </p>
     </div>
   </div>
 </div>
@@ -70,7 +70,7 @@ exports[`JetpackConnectNotices Should render notice 1`] = `
           />
         </svg>
       </span>
-      <span
+      <p
         class="calypso-notice__content"
       >
         <span
@@ -78,7 +78,7 @@ exports[`JetpackConnectNotices Should render notice 1`] = `
         >
           This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.
         </span>
-      </span>
+      </p>
     </div>
   </div>
 </div>

--- a/client/my-sites/add-ons/components/storage-add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/storage-add-ons-card.tsx
@@ -238,7 +238,9 @@ export default function StorageAddOnCard( { siteId, actionPrimary }: Props ) {
 					</div>
 				</CardHeader>
 				<CardBody className="storage-add-ons-card__body">
-					{ translate( 'Make more space for high-quality photos, videos, and other media.' ) }
+					<p>
+						{ translate( 'Make more space for high-quality photos, videos, and other media.' ) }
+					</p>
 					{ selectControlOptions.length ? (
 						<div className="storage-add-ons-card__storage-dropdown">
 							<CustomSelectControl

--- a/client/my-sites/add-ons/components/storage-add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/storage-add-ons-card.tsx
@@ -72,6 +72,10 @@ const Container = styled.div`
 		padding-top: 0;
 		padding-bottom: 0;
 
+		p {
+			margin-bottom: 0;
+		}
+
 		.storage-add-ons-card__storage-dropdown {
 			margin: 16px 0;
 

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -68,7 +68,6 @@ $plan-features-header-banner-height: 20px;
 .calypso-notice.plan-features-main__notice {
 	margin: 0 20px 24px;
 	width: unset;
-	text-wrap: pretty;
 
 	@include plans-section-custom-mobile-breakpoint {
 		margin: 0 0 24px;

--- a/client/my-sites/plugins/plugins-results-header/index.tsx
+++ b/client/my-sites/plugins/plugins-results-header/index.tsx
@@ -33,7 +33,7 @@ export default function PluginsResultsHeader( {
 			{ ( title || subtitle ) && (
 				<div className="plugins-results-header__titles">
 					{ title && <TitleTag className="plugins-results-header__title">{ title }</TitleTag> }
-					{ subtitle && <div className="plugins-results-header__subtitle">{ subtitle }</div> }
+					{ subtitle && <p className="plugins-results-header__subtitle">{ subtitle }</p> }
 				</div>
 			) }
 			{ ( browseAllLink || resultCount ) && (

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -21,6 +21,7 @@
 			font-size: $font-body-small;
 			line-height: 20px;
 			color: var(--studio-gray-80);
+			margin-bottom: 0;
 		}
 	}
 

--- a/client/sites/components/add-ons/add-ons-card/index.tsx
+++ b/client/sites/components/add-ons/add-ons-card/index.tsx
@@ -144,7 +144,9 @@ const AddOnCard = ( { addOnMeta, actionPrimary, actionSecondary, highlightFeatur
 						<div className="add-ons-card__billing">{ addOnMeta.displayCost }</div>
 					</div>
 				</CardHeader>
-				<CardBody className="add-ons-card__body">{ addOnMeta.description }</CardBody>
+				<CardBody as="p" className="add-ons-card__body">
+					{ addOnMeta.description }
+				</CardBody>
 				<CardFooter isBorderless className="add-ons-card__footer">
 					{ shouldRenderLoadingState && (
 						<Spinner size={ 24 } className="spinner-button__spinner" />

--- a/client/sites/components/add-ons/add-ons-card/index.tsx
+++ b/client/sites/components/add-ons/add-ons-card/index.tsx
@@ -77,6 +77,7 @@ const Container = styled.div`
 		font-size: 0.875rem;
 		padding-top: 0;
 		padding-bottom: 0;
+		margin-bottom: 0;
 	}
 
 	.add-ons-card__footer {

--- a/client/sites/components/plan-pricing/index.tsx
+++ b/client/sites/components/plan-pricing/index.tsx
@@ -88,9 +88,9 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 					height="16px"
 				/>
 			) : (
-				<div className="plan-price-info">
+				<p className="plan-price-info">
 					{ price } { getBillingDetails() }
-				</div>
+				</p>
 			);
 		}
 
@@ -106,7 +106,7 @@ export default function PlanPricing( { inline }: PlanPricingProps ) {
 						} ) }
 					</span>
 				</div>
-				<div className="plan-price-info">{ getBillingDetails() }</div>
+				<p className="plan-price-info">{ getBillingDetails() }</p>
 			</>
 		);
 	};

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -342,22 +342,22 @@ const FeaturesGrid = ( {
 				<div className="plan-features-2023-grid__content">
 					<div>
 						{ 'large' === gridSize && (
-							<div className="plan-features-2023-grid__desktop-view">
+							<p className="plan-features-2023-grid__desktop-view">
 								<Table { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-							</div>
+							</p>
 						) }
 						{ 'medium' === gridSize && (
-							<div className="plan-features-2023-grid__tablet-view">
+							<p className="plan-features-2023-grid__tablet-view">
 								<TabletView { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-							</div>
+							</p>
 						) }
 						{ 'small' === gridSize && (
-							<div className="plan-features-2023-grid__mobile-view">
+							<p className="plan-features-2023-grid__mobile-view">
 								<MobileView
 									{ ...planFeaturesProps }
 									enableShowAllFeaturesButton={ enableShowAllFeaturesButton }
 								/>
-							</div>
+							</p>
 						) }
 					</div>
 				</div>

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -342,22 +342,22 @@ const FeaturesGrid = ( {
 				<div className="plan-features-2023-grid__content">
 					<div>
 						{ 'large' === gridSize && (
-							<p className="plan-features-2023-grid__desktop-view">
+							<div className="plan-features-2023-grid__desktop-view">
 								<Table { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-							</p>
+							</div>
 						) }
 						{ 'medium' === gridSize && (
-							<p className="plan-features-2023-grid__tablet-view">
+							<div className="plan-features-2023-grid__tablet-view">
 								<TabletView { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-							</p>
+							</div>
 						) }
 						{ 'small' === gridSize && (
-							<p className="plan-features-2023-grid__mobile-view">
+							<div className="plan-features-2023-grid__mobile-view">
 								<MobileView
 									{ ...planFeaturesProps }
 									enableShowAllFeaturesButton={ enableShowAllFeaturesButton }
 								/>
-							</p>
+							</div>
 						) }
 					</div>
 				</div>

--- a/packages/plans-grid-next/src/components/features-grid/plan-tagline.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-tagline.tsx
@@ -16,7 +16,7 @@ const PlanTagline = ( { options, renderedGridPlans }: PlanTaglineProps ) => {
 				className="plan-features-2023-grid__table-item"
 				isTableCell={ options?.isTableCell }
 			>
-				<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
+				<p className="plan-features-2023-grid__header-tagline">{ tagline }</p>
 			</PlanDivOrTdContainer>
 		);
 	} );

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -211,6 +211,7 @@
 	color: var(--studio-gray-80);
 	font-weight: 400;
 	padding: 0 20px 24px 20px;
+	margin-bottom: 0;
 
 	@include plans-grid-medium-large {
 		font-size: $font-body-small;
@@ -352,7 +353,8 @@
 		font-weight: 400;
 		line-height: 20px;
 		overflow-wrap: break-word;
-		text-wrap: balance;
+		text-wrap: balance; // Fallback until Safari supports `pretty`.
+		text-wrap: pretty;
 		margin: 0;
 		flex: 1 0 0;
 		width: 100%;

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -18,6 +18,10 @@ const DiscountPromotion = styled.div`
 	margin-top: 6px;
 `;
 
+const BillingTimeframeContainer = styled.p`
+	margin-bottom: 0;
+`;
+
 interface RefundNoticeProps {
 	showRefundPeriod?: boolean;
 	planSlug: string;
@@ -70,10 +74,10 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		( ! introOffer || introOffer.isOfferComplete )
 	) {
 		return (
-			<div>
+			<BillingTimeframeContainer>
 				<div>{ billingTimeframe }</div>
 				<DiscountPromotion>{ planBillingDescription }</DiscountPromotion>
-			</div>
+			</BillingTimeframeContainer>
 		);
 	}
 
@@ -81,7 +85,7 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 		const price = formatCurrency( 25000, 'USD', { stripZeros: true } );
 
 		return (
-			<div>
+			<BillingTimeframeContainer>
 				{ fixMe( {
 					text: 'Starts at {{b}}%(price)s{{/b}} annually',
 					newCopy: translate( 'Starts at {{b}}%(price)s{{/b}} annually', {
@@ -95,19 +99,19 @@ const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 						comment: 'Translators: the price is in US dollars for all users (US$25,000)',
 					} ),
 				} ) }
-			</div>
+			</BillingTimeframeContainer>
 		);
 	}
 
 	return (
-		<div>
+		<BillingTimeframeContainer>
 			{ description }
 			<RefundNotice
 				showRefundPeriod={ showRefundPeriod }
 				planSlug={ planSlug }
 				billingPeriod={ billingPeriod }
 			/>
-		</div>
+		</BillingTimeframeContainer>
 	);
 };
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#102969

Adds back the changes from #102646 plus the necessary fixes.

I've now added `margin-bottom: 0`  to all the places I changed a `div` or `span` to a `p`, except for where the element already had a custom `margin-bottom`.

These fixes mostly apply to notices that appear conditionally all over the UI, so ideally the PR should be tested with both a free and a paid plan. 

Places to look include themes and plugins marketplaces:

<img width="1195" alt="Screenshot 2025-04-30 at 10 12 23 am" src="https://github.com/user-attachments/assets/91aee618-d5fd-446e-b122-457bdc1e988b" />

<img width="1007" alt="Screenshot 2025-04-30 at 11 46 32 am" src="https://github.com/user-attachments/assets/3fe4492c-11f2-4469-913c-92588005255e" />

Plugins upload (free plan):

<img width="672" alt="Screenshot 2025-04-30 at 11 53 55 am" src="https://github.com/user-attachments/assets/786e7c58-f6e3-46ac-9815-91ca5ad4bc7f" />

Login screen:

<img width="425" alt="Screenshot 2025-04-30 at 10 04 12 am" src="https://github.com/user-attachments/assets/78fb09fe-4667-43bc-a704-bc1de1912bac" />

☝️ that's the generic notice component, which can also be seen in a few other places:

<img width="544" alt="Screenshot 2025-04-30 at 10 03 48 am" src="https://github.com/user-attachments/assets/009fe23b-289f-437b-a5c6-9bd3961dabbb" />

<img width="1093" alt="Screenshot 2025-04-30 at 11 40 28 am" src="https://github.com/user-attachments/assets/cac6f43c-bef0-4928-9639-6e1e4a0648ce" />

Home screen:

<img width="273" alt="Screenshot 2025-04-30 at 10 04 27 am" src="https://github.com/user-attachments/assets/8b751946-e86e-4154-a0f2-bb5ccf1a8b47" />

(differs slightly between free and paid plans)

Add-ons:

<img width="1082" alt="Screenshot 2025-04-30 at 11 50 46 am" src="https://github.com/user-attachments/assets/22b31f61-01a8-480c-825b-223352a5dd98" />

Plans:

<img width="1083" alt="Screenshot 2025-04-30 at 11 51 41 am" src="https://github.com/user-attachments/assets/aab6311a-9aab-4a0b-9746-a8dfcddce60d" />

