### PR TITLE
Use optional chaining for backups in site list.

### DIFF
--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -75,7 +75,7 @@ export interface Site {
 	icon?: {
 		ico: string;
 	};
-	plan: SitePlan;
+	plan?: SitePlan;
 	active_modules?: string[];
 	subscribers_count: number;
 	// Can be undefined for deleted sites.

--- a/client/dashboard/site-overview/site-card.tsx
+++ b/client/dashboard/site-overview/site-card.tsx
@@ -109,6 +109,10 @@ function PlanDetails( {
 	currentPlan: Plan;
 	primaryDomain?: SiteDomain;
 } ) {
+	if ( ! site.plan || ! currentPlan ) {
+		return null;
+	}
+
 	const {
 		plan: { product_name_short, is_free: isFree },
 	} = site;

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -64,7 +64,11 @@ const DEFAULT_FIELDS = [
 			{ value: undefined, label: __( 'Disabled' ) },
 		],
 		render: ( { item }: { item: Site } ) =>
-			item.plan.features.active.includes( 'backups' ) ? <Icon icon={ check } /> : __( 'Disabled' ),
+			item.plan?.features?.active?.includes( 'backups' ) ? (
+				<Icon icon={ check } />
+			) : (
+				__( 'Disabled' )
+			),
 		filterBy: {
 			operators: [ 'is' as Operator ],
 		},

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -58,7 +58,7 @@ const DEFAULT_FIELDS = [
 		id: 'backups',
 		label: __( 'Backups' ),
 		getValue: ( { item }: { item: Site } ) =>
-			item.plan.features.active.includes( 'backups' ) || undefined,
+			item.plan?.features?.active?.includes( 'backups' ) || undefined,
 		elements: [
 			{ value: true, label: __( 'Enabled' ) },
 			{ value: undefined, label: __( 'Disabled' ) },


### PR DESCRIPTION
Fixes: DOTCOM-12918.

## Proposed Changes

Deleted sites can appear in the site list, but they don't have plans. We can't assume a site has a plan.

## Thoughts

@youknowriad Where are we on unit tests? I see that we have guidance for E2E tests, but nothing about unit tests.


## Testing Instructions
With an account with a delete plan

* Visit `/v2/`
* Expect the "table" layout to display.

_Note: The grid layout will display properly without this fix because it has different fields._

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
