### PR TITLE
JETCRM-10 Fix Bug: Invalid license error for mikestott.me

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -22,6 +22,7 @@ import {
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
 import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
+import CrmDownloads from 'calypso/my-sites/purchases/crm-downloads';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
@@ -272,5 +273,10 @@ export function changePaymentMethod( context, next ) {
 	};
 
 	context.primary = <ChangePaymentMethodWrapper />;
+	next();
+}
+
+export function crmDownloads( context, next ) {
+	context.primary = <CrmDownloads licenseKey={ context.params.licenseKey } />;
 	next();
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -51,6 +51,14 @@ export default ( router ) => {
 	);
 
 	router(
+		paths.purchasesRoot + '/crm-downloads/:licenseKey',
+		sidebar,
+		controller.crmDownloads,
+		makeLayout,
+		clientRender
+	);
+
+	router(
 		paths.purchasesRoot + '/subscription-removed',
 		sidebar,
 		membershipsController.cancelledSubscriptionReturnFromRedirect,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -687,7 +687,9 @@ class ManagePurchase extends Component<
 		};
 
 		// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
-		const path = `/purchases/crm-downloads/${ site.plan.license_key }`;
+		const path = isJetpackCloud()
+			? `/purchases/crm-downloads/${ site.plan.license_key }`
+			: `/me/purchases/crm-downloads/${ site.plan.license_key }`;
 
 		return (
 			<CompactCard href={ path } onClick={ handleCrmDownloadsClick }>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -669,26 +669,25 @@ class ManagePurchase extends Component<
 	}
 
 	renderCrmDownloadsNavItem() {
-		const { purchase, translate, siteSlug } = this.props;
+		const { site, translate } = this.props;
 
-		if ( ! purchase ) {
+		if ( ! site?.plan ) {
 			return null;
 		}
 
 		// Only show for Jetpack CRM Products
-		const productSlug = purchase.productSlug || '';
-		if ( ! isJetpackCrmProduct( productSlug ) ) {
+		if ( ! isJetpackCrmProduct( site.plan.license_key || '' ) ) {
 			return null;
 		}
 
 		const handleCrmDownloadsClick = () => {
 			recordTracksEvent( 'calypso_purchases_crm_downloads_click', {
-				product_slug: productSlug,
+				product_slug: site?.plan?.license_key || 'no_key',
 			} );
 		};
 
 		// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
-		const path = `/purchases/crm-downloads/${ siteSlug }/${ purchase.id }`;
+		const path = `/purchases/crm-downloads/${ site.plan.license_key }`;
 
 		return (
 			<CompactCard href={ path } onClick={ handleCrmDownloadsClick }>

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -105,11 +105,6 @@ export const receiptView = ( context, next ) => {
 };
 
 export const crmDownloads = ( context, next ) => {
-	context.primary = (
-		<CrmDownloads
-			siteSlug={ context.params.site }
-			purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-		/>
-	);
+	context.primary = <CrmDownloads licenseKey={ context.params.licenseKey } />;
 	next();
 };

--- a/client/my-sites/purchases/crm-downloads/index.tsx
+++ b/client/my-sites/purchases/crm-downloads/index.tsx
@@ -1,33 +1,21 @@
 import { useTranslate } from 'i18n-calypso';
-import {
-	CrmDownloadsContent,
-	CrmDownloadsError,
-} from 'calypso/components/crm-downloads/crm-downloads';
+import { CrmDownloadsContent } from 'calypso/components/crm-downloads/crm-downloads';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import { useSiteQuery } from 'calypso/data/sites/use-site-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import './style.scss';
 
-export function CrmDownloads( { purchaseId, siteSlug }: { purchaseId: number; siteSlug: string } ) {
+export function CrmDownloads( { licenseKey }: { licenseKey: string } ) {
 	const translate = useTranslate();
-
-	const { data, isError, isLoading } = useSiteQuery( siteSlug );
 
 	return (
 		<Main className="crm-downloads" wideLayout>
-			<PageViewTracker path="/purchases/:site/crm-downloads/:purchaseId" title="CRM Downloads" />
+			<PageViewTracker path="/purchases/crm-downloads/:licenseKey" title="CRM Downloads" />
 			<DocumentHead title={ translate( 'CRM Downloads' ) } />
-			<HeaderCake backHref={ `/purchases/subscriptions/${ siteSlug }/${ purchaseId }` }>
-				{ translate( 'CRM Downloads' ) }
-			</HeaderCake>
+			<HeaderCake backHref="/purchases/subscriptions/">{ translate( 'CRM Downloads' ) }</HeaderCake>
 
-			{ isError ? (
-				<CrmDownloadsError onReturnClick={ () => ( window.location.href = '/me/purchases' ) } />
-			) : (
-				<CrmDownloadsContent isLoading={ isLoading } licenseKey={ data?.plan?.license_key || '' } />
-			) }
+			<CrmDownloadsContent licenseKey={ licenseKey } />
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -113,7 +113,7 @@ export default ( router ) => {
 	);
 
 	page(
-		'/purchases/crm-downloads/:site/:purchaseId',
+		'/purchases/crm-downloads/:licenseKey',
 		...commonHandlers,
 		crmDownloads,
 		makeLayout,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes

* Remove reliance on fetching the site data in favor of just relying on the license key to render the CRM Downloads component
* Refactor to make it render under `/me/purchases/crm-downloads` on WordPress.com, it was previously using `/purchase/crm-downloads` which is a section that is only present on Jetpack Cloud and causes visual oddity when accessing on WordPress.com. Even though it could work, the experience is super slow ( because it loads a different section that what the user is usually at ).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To improve the experience on WordPress.com for Jetpack CRM Downloads
* To reduce the complexity and minimize liabilities on both WordPress.com and Jetpack Cloud.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
For WordPress.com
* Issue a Jetpack Complete license
* Assign it to a site
* Go to http://calypso.localhost:3000/me/purchases
* Click on that license purchase
* Click on "CRM Downloads"
* The program should show a page with a list of Jetpack CRM extensions that are allowed to be downloaded

For Jetpack Cloud
* Issue a Jetpack Complete license
* Assign it to a site
* Go to http://jetpack.cloud.localhost:3000/purchases
* Click on that license purchase
* Click on "CRM Downloads"
* The program should show a page with a list of Jetpack CRM extensions that are allowed to be downloaded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
