### PR TITLE
[DataViews]: Support dual rendering mode (controlled props or free composition)

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -1,5 +1,8 @@
 <!-- This file lists the modifications done to the base package `@wordpress/dataviews` that are published under `@automattic/dataviews`. -->
 
+## Next 
+- Add support for `free-composition` in the `DataViews` component
+
 ## 0.1.0
 
 - First release of the `@automattic/dataviews` package. It bundles all changes from `@wordpress/dataviews` 4.18.0.

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -12,17 +12,17 @@ import { LAYOUT_TABLE } from '../../constants';
 
 type DataViewsContextType< Item > = {
 	view: View;
-	onChangeView?: ( view: View ) => void;
+	onChangeView: ( view: View ) => void;
 	fields: NormalizedField< Item >[];
 	actions?: Action< Item >[];
 	data: Item[];
 	isLoading?: boolean;
-	paginationInfo?: {
+	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
 	};
 	selection: string[];
-	onChangeSelection?: SetSelection;
+	onChangeSelection: SetSelection;
 	openedFilter: string | null;
 	setOpenedFilter: ( openedFilter: string | null ) => void;
 	getItemId: ( item: Item ) => string;

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -10,7 +10,7 @@ import type { View, Action, NormalizedField } from '../../types';
 import type { SetSelection } from '../../private-types';
 import { LAYOUT_TABLE } from '../../constants';
 
-export type DataViewsContextType< Item > = {
+type DataViewsContextType< Item > = {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	fields: NormalizedField< Item >[];

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -11,18 +11,18 @@ import type { SetSelection } from '../../private-types';
 import { LAYOUT_TABLE } from '../../constants';
 
 type DataViewsContextType< Item > = {
-	view: View;
-	onChangeView: ( view: View ) => void;
+	view?: View;
+	onChangeView?: ( view: View ) => void;
 	fields: NormalizedField< Item >[];
 	actions?: Action< Item >[];
 	data: Item[];
 	isLoading?: boolean;
-	paginationInfo: {
+	paginationInfo?: {
 		totalItems: number;
 		totalPages: number;
 	};
 	selection: string[];
-	onChangeSelection: SetSelection;
+	onChangeSelection?: SetSelection;
 	openedFilter: string | null;
 	setOpenedFilter: ( openedFilter: string | null ) => void;
 	getItemId: ( item: Item ) => string;

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -11,7 +11,7 @@ import type { SetSelection } from '../../private-types';
 import { LAYOUT_TABLE } from '../../constants';
 
 type DataViewsContextType< Item > = {
-	view?: View;
+	view: View;
 	onChangeView?: ( view: View ) => void;
 	fields: NormalizedField< Item >[];
 	actions?: Action< Item >[];

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -10,7 +10,7 @@ import type { View, Action, NormalizedField } from '../../types';
 import type { SetSelection } from '../../private-types';
 import { LAYOUT_TABLE } from '../../constants';
 
-type DataViewsContextType< Item > = {
+export type DataViewsContextType< Item > = {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	fields: NormalizedField< Item >[];

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -24,9 +24,8 @@ import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
 import DataViewsViewConfig from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
-import { LAYOUT_TABLE } from '../../constants';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
-import type { SelectionOrUpdater, SetSelection } from '../../private-types';
+import type { SelectionOrUpdater } from '../../private-types';
 
 type ItemWithId = { id: string };
 
@@ -110,7 +109,7 @@ export default function DataViews< Item >( {
 		);
 	}, [ selection, data, getItemId ] );
 
-	const filters = useFilters( _fields, view ?? ( {} as View ) );
+	const filters = useFilters( _fields, view );
 	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( () =>
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -58,14 +58,14 @@ export type DataViewsControlledProps< Item > = {
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
 
-export type DataViewsWithChildren< Item > = {
+export type DataViewsCompositionProps< Item > = {
 	children: ReactNode;
 	data?: Item[];
 } & Partial< Omit< DataViewsControlledProps< Item >, 'children' | 'data' > >;
 
 export type DataViewsProps< Item > =
 	| DataViewsControlledProps< Item >
-	| DataViewsWithChildren< Item >;
+	| DataViewsCompositionProps< Item >;
 
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
@@ -92,7 +92,7 @@ export default function DataViews< Item >( props: DataViewsProps< Item > ) {
 		defaultLayouts,
 		children,
 	} = props as DataViewsControlledProps< Item > &
-		DataViewsWithChildren< Item >;
+		DataViewsCompositionProps< Item >;
 
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const containerRef = useResizeObserver(

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -31,21 +31,21 @@ import type { SelectionOrUpdater, SetSelection } from '../../private-types';
 type ItemWithId = { id: string };
 
 type DataViewsProps< Item > = {
-	view?: View;
-	onChangeView?: ( view: View ) => void;
-	fields?: Field< Item >[];
+	view: View;
+	onChangeView: ( view: View ) => void;
+	fields: Field< Item >[];
 	search?: boolean;
 	searchLabel?: string;
 	actions?: Action< Item >[];
 	data: Item[];
 	isLoading?: boolean;
-	paginationInfo?: {
+	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
 	};
-	defaultLayouts?: SupportedLayouts;
+	defaultLayouts: SupportedLayouts;
 	selection?: string[];
-	onChangeSelection?: SetSelection;
+	onChangeSelection?: ( items: string[] ) => void;
 	onClickItem?: ( item: Item ) => void;
 	isItemClickable?: ( item: Item ) => boolean;
 	header?: ReactNode;
@@ -60,9 +60,9 @@ const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
 export default function DataViews< Item >( {
-	view = { type: LAYOUT_TABLE },
-	onChangeView = () => {},
-	fields = [],
+	view,
+	onChangeView,
+	fields,
 	search = true,
 	searchLabel = undefined,
 	actions = EMPTY_ARRAY,
@@ -70,10 +70,10 @@ export default function DataViews< Item >( {
 	getItemId = defaultGetItemId,
 	getItemLevel,
 	isLoading = false,
-	paginationInfo = { totalItems: 0, totalPages: 0 },
+	paginationInfo,
 	defaultLayouts,
 	selection: selectionProperty,
-	onChangeSelection = () => {},
+	onChangeSelection,
 	onClickItem,
 	isItemClickable = defaultIsItemClickable,
 	header,

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -27,8 +27,6 @@ import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
 
-import type { DataViewsContextType } from '../dataviews-context';
-
 /**
  * External public props
  */
@@ -131,7 +129,7 @@ export default function DataViews< Item >( props: DataViewsProps< Item > ) {
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
-	const contextValue: DataViewsContextType< Item > = {
+	const contextValue = {
 		view: view as View,
 		onChangeView: onChangeView as ( view: View ) => void,
 		fields: _fields,

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -34,20 +34,26 @@ import type { DataViewsContextType } from '../dataviews-context';
  */
 type ItemWithId = { id: string };
 
-export type DataViewsControlledProps< Item > = {
-	view: View;
-	onChangeView: ( view: View ) => void;
-	fields: Field< Item >[];
+export type DataViewsProps< Item > = {
+	/** Required for both modes */
+	data: Item[];
+
+	/** Contextual children for free composition */
+	children?: ReactNode;
+
+	/** Controlled mode props */
+	view?: View;
+	onChangeView?: ( view: View ) => void;
+	fields?: Field< Item >[];
 	search?: boolean;
 	searchLabel?: string;
 	actions?: Action< Item >[];
-	data: Item[];
 	isLoading?: boolean;
-	paginationInfo: {
+	paginationInfo?: {
 		totalItems: number;
 		totalPages: number;
 	};
-	defaultLayouts: SupportedLayouts;
+	defaultLayouts?: SupportedLayouts;
 	selection?: string[];
 	onChangeSelection?: ( items: string[] ) => void;
 	onClickItem?: ( item: Item ) => void;
@@ -57,15 +63,6 @@ export type DataViewsControlledProps< Item > = {
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
-
-export type DataViewsCompositionProps< Item > = {
-	children: ReactNode;
-	data: Item[];
-} & Partial< Omit< DataViewsControlledProps< Item >, 'children' | 'data' > >;
-
-export type DataViewsProps< Item > =
-	| DataViewsControlledProps< Item >
-	| DataViewsCompositionProps< Item >;
 
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
@@ -91,8 +88,7 @@ export default function DataViews< Item >( props: DataViewsProps< Item > ) {
 		header,
 		defaultLayouts,
 		children,
-	} = props as DataViewsControlledProps< Item > &
-		DataViewsCompositionProps< Item >;
+	} = props;
 
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const containerRef = useResizeObserver(
@@ -159,16 +155,10 @@ export default function DataViews< Item >( props: DataViewsProps< Item > ) {
 
 	if ( children ) {
 		return (
-			<DataViewsContext.Provider
-				value={ contextValue as DataViewsContextType< any > }
-			>
+			<DataViewsContext.Provider value={ contextValue }>
 				{ children }
 			</DataViewsContext.Provider>
 		);
-	}
-
-	if ( ! data ) {
-		throw new Error( '`data` is required when `children` is not used.' );
 	}
 
 	return (

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -27,9 +27,14 @@ import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
 
+import type { DataViewsContextType } from '../dataviews-context';
+
+/**
+ * External public props
+ */
 type ItemWithId = { id: string };
 
-type DataViewsProps< Item > = {
+export type DataViewsControlledProps< Item > = {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	fields: Field< Item >[];
@@ -53,29 +58,42 @@ type DataViewsProps< Item > = {
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
 
+export type DataViewsWithChildren< Item > = {
+	children: ReactNode;
+	data?: Item[];
+} & Partial< Omit< DataViewsControlledProps< Item >, 'children' | 'data' > >;
+
+export type DataViewsProps< Item > =
+	| DataViewsControlledProps< Item >
+	| DataViewsWithChildren< Item >;
+
 const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
-export default function DataViews< Item >( {
-	view,
-	onChangeView,
-	fields,
-	search = true,
-	searchLabel = undefined,
-	actions = EMPTY_ARRAY,
-	data,
-	getItemId = defaultGetItemId,
-	getItemLevel,
-	isLoading = false,
-	paginationInfo,
-	defaultLayouts,
-	selection: selectionProperty,
-	onChangeSelection,
-	onClickItem,
-	isItemClickable = defaultIsItemClickable,
-	header,
-}: DataViewsProps< Item > ) {
+export default function DataViews< Item >( props: DataViewsProps< Item > ) {
+	const {
+		view,
+		onChangeView,
+		fields = [],
+		search = true,
+		searchLabel = undefined,
+		actions = EMPTY_ARRAY,
+		data,
+		selection: selectionProperty,
+		onChangeSelection,
+		paginationInfo,
+		getItemId = defaultGetItemId,
+		getItemLevel,
+		isLoading = false,
+		onClickItem,
+		isItemClickable = defaultIsItemClickable,
+		header,
+		defaultLayouts,
+		children,
+	} = props as DataViewsControlledProps< Item > &
+		DataViewsWithChildren< Item >;
+
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const containerRef = useResizeObserver(
 		( resizeObserverEntries: any ) => {
@@ -85,11 +103,13 @@ export default function DataViews< Item >( {
 		},
 		{ box: 'border-box' }
 	);
+
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const isUncontrolled =
 		selectionProperty === undefined || onChangeSelection === undefined;
 	const selection = isUncontrolled ? selectionState : selectionProperty;
 	const [ openedFilter, setOpenedFilter ] = useState< string | null >( null );
+
 	function setSelectionWithChange( value: SelectionOrUpdater ) {
 		const newValue =
 			typeof value === 'function' ? value( selection ) : value;
@@ -100,39 +120,59 @@ export default function DataViews< Item >( {
 			onChangeSelection( newValue );
 		}
 	}
+
 	const _fields = useMemo( () => normalizeFields( fields ), [ fields ] );
 	const _selection = useMemo( () => {
-		return selection.filter( ( id ) =>
-			data.some( ( item ) => getItemId( item ) === id )
+		return (
+			selection?.filter(
+				( id ) => data?.some( ( item ) => getItemId( item ) === id )
+			) || []
 		);
 	}, [ selection, data, getItemId ] );
 
-	const filters = useFilters( _fields, view );
+	const filters = useFilters( _fields, view ?? ( {} as View ) );
 	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( () =>
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
+	const contextValue: DataViewsContextType< Item > = {
+		view: view as View,
+		onChangeView: onChangeView as ( view: View ) => void,
+		fields: _fields,
+		actions,
+		data: ( data || [] ) as Item[],
+		isLoading,
+		paginationInfo: paginationInfo || {
+			totalItems: 0,
+			totalPages: 0,
+		},
+		selection: _selection,
+		onChangeSelection: setSelectionWithChange,
+		openedFilter,
+		setOpenedFilter,
+		getItemId: getItemId as ( item: Item ) => string,
+		getItemLevel,
+		isItemClickable,
+		onClickItem,
+		containerWidth,
+	};
+
+	if ( children ) {
+		return (
+			<DataViewsContext.Provider
+				value={ contextValue as DataViewsContextType< any > }
+			>
+				{ children }
+			</DataViewsContext.Provider>
+		);
+	}
+
+	if ( ! data ) {
+		throw new Error( '`data` is required when `children` is not used.' );
+	}
+
 	return (
-		<DataViewsContext.Provider
-			value={ {
-				view,
-				onChangeView,
-				fields: _fields,
-				actions,
-				data,
-				isLoading,
-				paginationInfo,
-				selection: _selection,
-				onChangeSelection: setSelectionWithChange,
-				openedFilter,
-				setOpenedFilter,
-				getItemId,
-				getItemLevel,
-				isItemClickable,
-				onClickItem,
-				containerWidth,
-			} }
-		>
+		<DataViewsContext.Provider value={ contextValue }>
 			<div className="dataviews-wrapper" ref={ containerRef }>
 				<HStack
 					alignment="top"
@@ -148,8 +188,8 @@ export default function DataViews< Item >( {
 						{ search && <DataViewsSearch label={ searchLabel } /> }
 						<FiltersToggle
 							filters={ filters }
-							view={ view }
-							onChangeView={ onChangeView }
+							view={ view! }
+							onChangeView={ onChangeView! }
 							setOpenedFilter={ setOpenedFilter }
 							setIsShowingFilter={ setIsShowingFilter }
 							isShowingFilter={ isShowingFilter }
@@ -161,7 +201,7 @@ export default function DataViews< Item >( {
 						style={ { flexShrink: 0 } }
 					>
 						<DataViewsViewConfig
-							defaultLayouts={ defaultLayouts }
+							defaultLayouts={ defaultLayouts! }
 						/>
 						{ header }
 					</HStack>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -24,13 +24,14 @@ import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
 import DataViewsViewConfig from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
+import { LAYOUT_TABLE } from '../../constants';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater, SetSelection } from '../../private-types';
 
 type ItemWithId = { id: string };
 
 type DataViewsProps< Item > = {
-	view: View;
+	view?: View;
 	onChangeView?: ( view: View ) => void;
 	fields?: Field< Item >[];
 	search?: boolean;
@@ -59,8 +60,8 @@ const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
 export default function DataViews< Item >( {
-	view,
-	onChangeView,
+	view = { type: LAYOUT_TABLE },
+	onChangeView = () => {},
 	fields = [],
 	search = true,
 	searchLabel = undefined,
@@ -69,10 +70,10 @@ export default function DataViews< Item >( {
 	getItemId = defaultGetItemId,
 	getItemLevel,
 	isLoading = false,
-	paginationInfo,
+	paginationInfo = { totalItems: 0, totalPages: 0 },
 	defaultLayouts,
 	selection: selectionProperty,
-	onChangeSelection,
+	onChangeSelection = () => {},
 	onClickItem,
 	isItemClickable = defaultIsItemClickable,
 	header,

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -25,7 +25,7 @@ import DataViewsSearch from '../dataviews-search';
 import DataViewsViewConfig from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
-import type { SelectionOrUpdater } from '../../private-types';
+import type { SelectionOrUpdater, SetSelection } from '../../private-types';
 
 type ItemWithId = { id: string };
 
@@ -44,7 +44,7 @@ type DataViewsProps< Item > = {
 	};
 	defaultLayouts?: SupportedLayouts;
 	selection?: string[];
-	onChangeSelection?: ( items: string[] ) => void;
+	onChangeSelection?: SetSelection;
 	onClickItem?: ( item: Item ) => void;
 	isItemClickable?: ( item: Item ) => boolean;
 	header?: ReactNode;
@@ -114,38 +114,54 @@ export default function DataViews< Item >( {
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
-	const contextValue = {
-		view: view as View,
-		onChangeView: onChangeView as ( view: View ) => void,
-		fields: _fields,
-		actions,
-		data: ( data || [] ) as Item[],
-		isLoading,
-		paginationInfo: paginationInfo || {
-			totalItems: 0,
-			totalPages: 0,
-		},
-		selection: _selection,
-		onChangeSelection: setSelectionWithChange,
-		openedFilter,
-		setOpenedFilter,
-		getItemId: getItemId as ( item: Item ) => string,
-		getItemLevel,
-		isItemClickable,
-		onClickItem,
-		containerWidth,
-	};
-
 	if ( children ) {
 		return (
-			<DataViewsContext.Provider value={ contextValue }>
+			<DataViewsContext.Provider
+				value={ {
+					view,
+					onChangeView,
+					fields: _fields,
+					actions,
+					data,
+					isLoading,
+					paginationInfo,
+					selection: _selection,
+					onChangeSelection: setSelectionWithChange,
+					openedFilter,
+					setOpenedFilter,
+					getItemId,
+					getItemLevel,
+					isItemClickable,
+					onClickItem,
+					containerWidth,
+				} }
+			>
 				{ children }
 			</DataViewsContext.Provider>
 		);
 	}
 
 	return (
-		<DataViewsContext.Provider value={ contextValue }>
+		<DataViewsContext.Provider
+			value={ {
+				view,
+				onChangeView,
+				fields: _fields,
+				actions,
+				data,
+				isLoading,
+				paginationInfo,
+				selection: _selection,
+				onChangeSelection: setSelectionWithChange,
+				openedFilter,
+				setOpenedFilter,
+				getItemId,
+				getItemLevel,
+				isItemClickable,
+				onClickItem,
+				containerWidth,
+			} }
+		>
 			<div className="dataviews-wrapper" ref={ containerRef }>
 				<HStack
 					alignment="top"

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -27,25 +27,16 @@ import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
 
-/**
- * External public props
- */
 type ItemWithId = { id: string };
 
-export type DataViewsProps< Item > = {
-	/** Required for both modes */
-	data: Item[];
-
-	/** Contextual children for free composition */
-	children?: ReactNode;
-
-	/** Controlled mode props */
+type DataViewsProps< Item > = {
 	view?: View;
 	onChangeView?: ( view: View ) => void;
 	fields?: Field< Item >[];
 	search?: boolean;
 	searchLabel?: string;
 	actions?: Action< Item >[];
+	data: Item[];
 	isLoading?: boolean;
 	paginationInfo?: {
 		totalItems: number;
@@ -58,6 +49,7 @@ export type DataViewsProps< Item > = {
 	isItemClickable?: ( item: Item ) => boolean;
 	header?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
+	children?: ReactNode;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -66,28 +58,26 @@ const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
-export default function DataViews< Item >( props: DataViewsProps< Item > ) {
-	const {
-		view,
-		onChangeView,
-		fields = [],
-		search = true,
-		searchLabel = undefined,
-		actions = EMPTY_ARRAY,
-		data,
-		selection: selectionProperty,
-		onChangeSelection,
-		paginationInfo,
-		getItemId = defaultGetItemId,
-		getItemLevel,
-		isLoading = false,
-		onClickItem,
-		isItemClickable = defaultIsItemClickable,
-		header,
-		defaultLayouts,
-		children,
-	} = props;
-
+export default function DataViews< Item >( {
+	view,
+	onChangeView,
+	fields = [],
+	search = true,
+	searchLabel = undefined,
+	actions = EMPTY_ARRAY,
+	data,
+	getItemId = defaultGetItemId,
+	getItemLevel,
+	isLoading = false,
+	paginationInfo,
+	defaultLayouts,
+	selection: selectionProperty,
+	onChangeSelection,
+	onClickItem,
+	isItemClickable = defaultIsItemClickable,
+	header,
+	children,
+}: DataViewsProps< Item > ) {
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const containerRef = useResizeObserver(
 		( resizeObserverEntries: any ) => {
@@ -97,13 +87,11 @@ export default function DataViews< Item >( props: DataViewsProps< Item > ) {
 		},
 		{ box: 'border-box' }
 	);
-
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const isUncontrolled =
 		selectionProperty === undefined || onChangeSelection === undefined;
 	const selection = isUncontrolled ? selectionState : selectionProperty;
 	const [ openedFilter, setOpenedFilter ] = useState< string | null >( null );
-
 	function setSelectionWithChange( value: SelectionOrUpdater ) {
 		const newValue =
 			typeof value === 'function' ? value( selection ) : value;
@@ -114,13 +102,10 @@ export default function DataViews< Item >( props: DataViewsProps< Item > ) {
 			onChangeSelection( newValue );
 		}
 	}
-
 	const _fields = useMemo( () => normalizeFields( fields ), [ fields ] );
 	const _selection = useMemo( () => {
-		return (
-			selection?.filter(
-				( id ) => data?.some( ( item ) => getItemId( item ) === id )
-			) || []
+		return selection.filter( ( id ) =>
+			data.some( ( item ) => getItemId( item ) === id )
 		);
 	}, [ selection, data, getItemId ] );
 

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -60,7 +60,7 @@ export type DataViewsControlledProps< Item > = {
 
 export type DataViewsCompositionProps< Item > = {
 	children: ReactNode;
-	data?: Item[];
+	data: Item[];
 } & Partial< Omit< DataViewsControlledProps< Item >, 'children' | 'data' > >;
 
 export type DataViewsProps< Item > =

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -30,7 +30,7 @@ import type { SelectionOrUpdater, SetSelection } from '../../private-types';
 type ItemWithId = { id: string };
 
 type DataViewsProps< Item > = {
-	view?: View;
+	view: View;
 	onChangeView?: ( view: View ) => void;
 	fields?: Field< Item >[];
 	search?: boolean;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -114,32 +114,43 @@ export default function DataViews< Item >( {
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
-	if ( children ) {
-		return (
-			<DataViewsContext.Provider
-				value={ {
-					view,
-					onChangeView,
-					fields: _fields,
-					actions,
-					data,
-					isLoading,
-					paginationInfo,
-					selection: _selection,
-					onChangeSelection: setSelectionWithChange,
-					openedFilter,
-					setOpenedFilter,
-					getItemId,
-					getItemLevel,
-					isItemClickable,
-					onClickItem,
-					containerWidth,
-				} }
+	const defaultUI = (
+		<div className="dataviews-wrapper" ref={ containerRef }>
+			<HStack
+				alignment="top"
+				justify="space-between"
+				className="dataviews__view-actions"
+				spacing={ 1 }
 			>
-				{ children }
-			</DataViewsContext.Provider>
-		);
-	}
+				<HStack
+					justify="start"
+					expanded={ false }
+					className="dataviews__search"
+				>
+					{ search && <DataViewsSearch label={ searchLabel } /> }
+					<FiltersToggle
+						filters={ filters }
+						view={ view! }
+						onChangeView={ onChangeView! }
+						setOpenedFilter={ setOpenedFilter }
+						setIsShowingFilter={ setIsShowingFilter }
+						isShowingFilter={ isShowingFilter }
+					/>
+				</HStack>
+				<HStack
+					spacing={ 1 }
+					expanded={ false }
+					style={ { flexShrink: 0 } }
+				>
+					<DataViewsViewConfig defaultLayouts={ defaultLayouts! } />
+					{ header }
+				</HStack>
+			</HStack>
+			{ isShowingFilter && <DataViewsFilters /> }
+			<DataViewsLayout />
+			<DataViewsFooter />
+		</div>
+	);
 
 	return (
 		<DataViewsContext.Provider
@@ -162,43 +173,7 @@ export default function DataViews< Item >( {
 				containerWidth,
 			} }
 		>
-			<div className="dataviews-wrapper" ref={ containerRef }>
-				<HStack
-					alignment="top"
-					justify="space-between"
-					className="dataviews__view-actions"
-					spacing={ 1 }
-				>
-					<HStack
-						justify="start"
-						expanded={ false }
-						className="dataviews__search"
-					>
-						{ search && <DataViewsSearch label={ searchLabel } /> }
-						<FiltersToggle
-							filters={ filters }
-							view={ view! }
-							onChangeView={ onChangeView! }
-							setOpenedFilter={ setOpenedFilter }
-							setIsShowingFilter={ setIsShowingFilter }
-							isShowingFilter={ isShowingFilter }
-						/>
-					</HStack>
-					<HStack
-						spacing={ 1 }
-						expanded={ false }
-						style={ { flexShrink: 0 } }
-					>
-						<DataViewsViewConfig
-							defaultLayouts={ defaultLayouts! }
-						/>
-						{ header }
-					</HStack>
-				</HStack>
-				{ isShowingFilter && <DataViewsFilters /> }
-				<DataViewsLayout />
-				<DataViewsFooter />
-			</div>
+			{ children || defaultUI }
 		</DataViewsContext.Provider>
 	);
 }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -195,11 +195,7 @@ export const FreeComposition = () => {
 	const getItemId = ( item: SpaceObject ) => item.id.toString();
 
 	return (
-		<DataViews
-			data={ shownData }
-			view={ DEFAULT_VIEW }
-			getItemId={ getItemId }
-		>
+		<DataViews data={ shownData } getItemId={ getItemId }>
 			<PlanetOverview planets={ planets } />
 		</DataViews>
 	);

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useContext } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Card,
@@ -12,7 +12,6 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
-
 /**
  * Internal dependencies
  */
@@ -26,7 +25,6 @@ import {
 } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
-import DataViewsContext from '../../dataviews-context';
 import type { View } from '../../../types';
 
 import './style.css';
@@ -185,12 +183,19 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
  * or pagination controls.
  */
 export const FreeComposition = () => {
-	const planets = data.filter( ( item ) =>
+	const { data: shownData } = useMemo( () => {
+		return filterSortAndPaginate( data, DEFAULT_VIEW, fields );
+	}, [] );
+
+	const planets = shownData.filter( ( item ) =>
 		item.categories.includes( 'Planet' )
 	);
 
 	return (
-		<DataViews data={ data } getItemId={ ( item ) => item.id.toString() }>
+		<DataViews
+			data={ shownData }
+			getItemId={ ( item ) => item.id.toString() }
+		>
 			<PlanetOverview planets={ planets } />
 		</DataViews>
 	);

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -63,7 +63,7 @@ export const Default = () => {
 			fields={ fields }
 			onChangeView={ setView }
 			actions={ actions }
-			onClickItem={ ( item ) => {
+			onClickItem={ ( item: SpaceObject ) => {
 				// eslint-disable-next-line no-alert
 				alert( 'Clicked: ' + item.title );
 			} }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -61,7 +61,7 @@ export const Default = () => {
 			fields={ fields }
 			onChangeView={ setView }
 			actions={ actions }
-			onClickItem={ ( item: SpaceObject ) => {
+			onClickItem={ ( item ) => {
 				// eslint-disable-next-line no-alert
 				alert( 'Clicked: ' + item.title );
 			} }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -1,7 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useContext } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
+import {
+	Card,
+	CardHeader,
+	CardBody,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -10,6 +20,7 @@ import DataViews from '../index';
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
+import DataViewsContext from '../../dataviews-context';
 import type { View } from '../../../types';
 
 import './style.css';
@@ -103,5 +114,65 @@ export const FieldsNoSortableNoHidable = () => {
 				table: {},
 			} }
 		/>
+	);
+};
+
+/**
+ * Custom composition example
+ */
+function PlanetOverview() {
+	const { data } = useContext( DataViewsContext );
+
+	const planets = data.filter( ( item ) =>
+		item.categories.includes( 'Planet' )
+	);
+	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
+
+	return (
+		<Card isBorderless style={ { padding: '12px 24px' } }>
+			<CardHeader>
+				<Heading level={ 2 }>{ __( 'Solar System numbers' ) }</Heading>
+			</CardHeader>
+
+			<CardBody>
+				<VStack spacing={ 2 }>
+					<Text size={ 18 } as="p">
+						{ createInterpolateElement(
+							_n(
+								'<PlanetsNumber /> planet',
+								'<PlanetsNumber /> planets',
+								planets.length
+							),
+							{
+								PlanetsNumber: (
+									<strong>{ planets.length } </strong>
+								),
+							}
+						) }
+					</Text>
+
+					<Text size={ 18 } as="p">
+						{ createInterpolateElement(
+							_n(
+								'<SatellitesNumber /> moon',
+								'<SatellitesNumber /> moons',
+								moons
+							),
+							{
+								SatellitesNumber: <strong>{ moons } </strong>,
+							}
+						) }
+					</Text>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
+export const FreeComposition = () => {
+	return (
+		<DataViews data={ data }>
+			<PlanetOverview />
+		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -190,7 +190,7 @@ export const FreeComposition = () => {
 	);
 
 	return (
-		<DataViews>
+		<DataViews data={ data }>
 			<PlanetOverview planets={ planets } />
 		</DataViews>
 	);

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -191,10 +191,14 @@ export const FreeComposition = () => {
 		item.categories.includes( 'Planet' )
 	);
 
+	// id` is a number in the data, but a string in the DataViews component.
+	const getItemId = ( item: SpaceObject ) => item.id.toString();
+
 	return (
 		<DataViews
 			data={ shownData }
-			getItemId={ ( item ) => item.id.toString() }
+			view={ DEFAULT_VIEW }
+			getItemId={ getItemId }
 		>
 			<PlanetOverview planets={ planets } />
 		</DataViews>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -183,6 +183,20 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
  * or pagination controls.
  */
 export const FreeComposition = () => {
+	const view = {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+	};
+
+	const paginationInfo = {
+		totalItems: data.length,
+		totalPages: 1,
+	};
+
 	const { data: shownData } = useMemo( () => {
 		return filterSortAndPaginate( data, DEFAULT_VIEW, fields );
 	}, [] );
@@ -195,7 +209,15 @@ export const FreeComposition = () => {
 	const getItemId = ( item: SpaceObject ) => item.id.toString();
 
 	return (
-		<DataViews data={ shownData } getItemId={ getItemId }>
+		<DataViews
+			data={ shownData }
+			getItemId={ getItemId }
+			view={ view }
+			onChangeView={ () => {} }
+			fields={ fields }
+			paginationInfo={ paginationInfo }
+			defaultLayouts={ defaultLayouts }
+		>
 			<PlanetOverview planets={ planets } />
 		</DataViews>
 	);

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -171,14 +171,13 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 }
 
 export const FreeComposition = () => {
-	const { data } = useContext( DataViewsContext );
-
+	console.log( { data } );
 	const planets = data.filter( ( item ) =>
 		item.categories.includes( 'Planet' )
 	);
 
 	return (
-		<DataViews data={ data }>
+		<DataViews>
 			<PlanetOverview planets={ planets } />
 		</DataViews>
 	);

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -170,8 +170,21 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 	);
 }
 
+/**
+ * This is a basic example of using the DataViews component in
+ * a free composition mode.
+ *
+ * Unlike the default usage where DataViews renders its own UI,
+ * here we use it purely to provide context and handle data-related logic.
+ *
+ * The UI is fully custom and composed externally via the
+ * `PlanetOverview` component.
+ *
+ * In future iterations, this story will showcase more advanced compositions
+ * using built-in subcomponents like <Search />, filters,
+ * or pagination controls.
+ */
 export const FreeComposition = () => {
-	console.log( { data } );
 	const planets = data.filter( ( item ) =>
 		item.categories.includes( 'Planet' )
 	);

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -190,7 +190,7 @@ export const FreeComposition = () => {
 	);
 
 	return (
-		<DataViews data={ data }>
+		<DataViews data={ data } getItemId={ ( item ) => item.id.toString() }>
 			<PlanetOverview planets={ planets } />
 		</DataViews>
 	);

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -17,7 +17,13 @@ import { __, _n } from '@wordpress/i18n';
  * Internal dependencies
  */
 import DataViews from '../index';
-import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
+import {
+	DEFAULT_VIEW,
+	actions,
+	data,
+	fields,
+	type SpaceObject,
+} from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
 import DataViewsContext from '../../dataviews-context';
@@ -120,12 +126,7 @@ export const FieldsNoSortableNoHidable = () => {
 /**
  * Custom composition example
  */
-function PlanetOverview() {
-	const { data } = useContext( DataViewsContext );
-
-	const planets = data.filter( ( item ) =>
-		item.categories.includes( 'Planet' )
-	);
+function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
 
 	return (
@@ -170,9 +171,15 @@ function PlanetOverview() {
 }
 
 export const FreeComposition = () => {
+	const { data } = useContext( DataViewsContext );
+
+	const planets = data.filter( ( item ) =>
+		item.categories.includes( 'Planet' )
+	);
+
 	return (
 		<DataViews data={ data }>
-			<PlanetOverview />
+			<PlanetOverview planets={ planets } />
 		</DataViews>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes WOOA7S-124

## Proposed Changes

* Refactor `<DataViews />` to support both `controlled` usage (as before) and a new `free-composition` mode, where consumers can pass `children` and compose their own layout.
* Introduce a new `defaultUI` block internally, which is conditionally rendered if no `children` are passed.
* Add a new Storybook example to illustrate the free composition approach.

## Why are these changes being made?

This update enables a more flexible usage of `<DataViews />`, allowing consumers to use the default internal UI or compose their own layout and behavior using children.

This pattern is helpful for cases where we want to build completely custom layouts while still relying on the shared context logic for selections, filtering, pagination, etc.

```ts
<DataViews data={ myData }>
  <DataViews.Search />
  <DataViews.Filters />
  <DataViews.ViewConfig />
  <MyCustomComponent />
  <DataViews.Layout />
</DataViews>
```

## Testing Instructions

1) Start the Storybook app

```
yarn dataviews:storybook:start
```

2) Run the existing stories and verify that the controlled version of `<DataViews />` still behaves as expected.

3) Open the new `FreeComposition` story:
   - Confirm that it renders using the context-based data.
   - Confirm no runtime or render errors.
   - Check that you can access filtered/paginated data from context or via the `filterSortAndPaginate()` utility.

<img width="920" alt="image" src="https://github.com/user-attachments/assets/8690d8c3-c8f5-49f1-ab1a-c8668ef72148" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?