### PR TITLE
Improve messaging in the refund page for transfers

### DIFF
--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -211,9 +211,8 @@ const CancelPurchaseDomainOptions = ( {
 	}
 
 	if (
-		! includedDomainPurchase ||
-		( ! isDomainMapping( includedDomainPurchase ) &&
-			! isDomainRegistration( includedDomainPurchase ) )
+		! isDomainMapping( includedDomainPurchase ) &&
+		! isDomainRegistration( includedDomainPurchase )
 	) {
 		return null;
 	}

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -181,7 +181,7 @@ const CancelPurchaseDomainOptions = ( {
 		</div>
 	);
 
-	if ( includedDomainTransfer && isDomainTransfer( includedDomainTransfer ) ) {
+	if ( includedDomainTransfer ) {
 		return <DomainTransferMessage />;
 	}
 

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -125,8 +125,8 @@ const CancelPurchaseDomainOptions = ( {
 		<div>
 			<p>
 				{ translate(
-					'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
+						'The domain transfer will not be removed along with the plan, to avoid any interruptions for your visitors.',
 					{
 						args: {
 							domain: includedDomainTransfer.meta,
@@ -142,8 +142,8 @@ const CancelPurchaseDomainOptions = ( {
 		<div>
 			<p>
 				{ translate(
-					'This plan includes mapping for the domain %(mappedDomain)s. ' +
-						"Cancelling will remove all the plan's features from your site, including the domain.",
+					'It seems you have a pending domain transfer for the domain %(mappedDomain)s. ' +
+						'In order to receive a full refund, please cancel the domain transfer before requesting the cancellation of your plan.',
 					{
 						args: {
 							mappedDomain: includedDomainTransfer.meta,
@@ -153,24 +153,7 @@ const CancelPurchaseDomainOptions = ( {
 			</p>
 			<p>
 				{ translate(
-					'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
-					{
-						args: {
-							mappedDomain: includedDomainTransfer.meta,
-							wordpressSiteUrl: purchase.domain,
-						},
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
-						'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
-					{
-						args: {
-							mappedDomain: includedDomainTransfer.meta,
-						},
-					}
+					'In some cases, a domain transfer has progressed too far to be canceled. Please contact support if you have questions about this'
 				) }
 			</p>
 		</div>

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -1,8 +1,4 @@
-import {
-	isDomainRegistration,
-	isDomainMapping,
-	isDomainTransfer,
-} from '@automattic/calypso-products';
+import { isDomainRegistration, isDomainMapping } from '@automattic/calypso-products';
 import { CompactCard, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { UPDATE_NAMESERVERS } from '@automattic/urls';

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -121,6 +121,22 @@ const CancelPurchaseDomainOptions = ( {
 		</div>
 	);
 
+	const IncludedDomainTransferPartialRefund = () => (
+		<p>
+			{ translate(
+				'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+					'minus %(domainCost)s for the domain.',
+				{
+					args: {
+						domainCost: includedDomainTransfer.priceText,
+						planCost: planCostText,
+						refundAmount: purchase.refundText,
+					},
+				}
+			) }
+		</p>
+	);
+
 	const NonRefundableDomainTransferMessage = () => (
 		<div>
 			<p>
@@ -135,19 +151,7 @@ const CancelPurchaseDomainOptions = ( {
 					}
 				) }
 			</p>
-			<p>
-				{ translate(
-					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-						'minus %(domainCost)s for the domain.',
-					{
-						args: {
-							domainCost: includedDomainTransfer.priceText,
-							planCost: planCostText,
-							refundAmount: purchase.refundText,
-						},
-					}
-				) }
-			</p>
+			<IncludedDomainTransferPartialRefund />
 		</div>
 	);
 
@@ -164,6 +168,7 @@ const CancelPurchaseDomainOptions = ( {
 					}
 				) }
 			</p>
+			<IncludedDomainTransferPartialRefund />
 			<p>
 				{ translate(
 					'In some cases, a domain transfer has progressed too far to be canceled. Please contact support if you have questions about this'

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -135,6 +135,19 @@ const CancelPurchaseDomainOptions = ( {
 					}
 				) }
 			</p>
+			<p>
+				{ translate(
+					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+						'minus %(domainCost)s for the domain.',
+					{
+						args: {
+							domainCost: includedDomainTransfer.priceText,
+							planCost: planCostText,
+							refundAmount: purchase.refundText,
+						},
+					}
+				) }
+			</p>
 		</div>
 	);
 
@@ -219,11 +232,7 @@ const CancelPurchaseDomainOptions = ( {
 		return <NonRefundableDomainPurchaseMessage />;
 	}
 
-	if (
-		isRefundable( purchase ) &&
-		! isRefundable( includedDomainPurchase ) &&
-		! isRefundable( includedDomainTransfer )
-	) {
+	if ( isRefundable( purchase ) && ! isRefundable( includedDomainPurchase ) ) {
 		return <RefundablePurchaseWithNonRefundableDomainMessage />;
 	}
 

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -1,4 +1,8 @@
-import { isDomainRegistration, isDomainMapping } from '@automattic/calypso-products';
+import {
+	isDomainRegistration,
+	isDomainMapping,
+	isDomainTransfer,
+} from '@automattic/calypso-products';
 import { CompactCard, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { UPDATE_NAMESERVERS } from '@automattic/urls';
@@ -10,6 +14,7 @@ import { getName, isRefundable, isSubscription } from 'calypso/lib/purchases';
 
 const CancelPurchaseDomainOptions = ( {
 	includedDomainPurchase,
+	includedDomainTransfer,
 	cancelBundledDomain,
 	confirmCancelBundledDomain = false,
 	purchase,
@@ -22,7 +27,7 @@ const CancelPurchaseDomainOptions = ( {
 		setConfirmCancel( confirmCancelBundledDomain );
 	}, [ confirmCancelBundledDomain ] );
 
-	if ( ! includedDomainPurchase || ! isSubscription( purchase ) ) {
+	if ( ( ! includedDomainPurchase && ! includedDomainTransfer ) || ! isSubscription( purchase ) ) {
 		return null;
 	}
 
@@ -116,6 +121,61 @@ const CancelPurchaseDomainOptions = ( {
 		</div>
 	);
 
+	const NonRefundableDomainTransferMessage = () => (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
+						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					{
+						args: {
+							domain: includedDomainTransfer.meta,
+							domainCost: includedDomainTransfer.priceText,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+
+	const CancelableDomainTransferMessage = () => (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes mapping for the domain %(mappedDomain)s. ' +
+						"Cancelling will remove all the plan's features from your site, including the domain.",
+					{
+						args: {
+							mappedDomain: includedDomainTransfer.meta,
+						},
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
+					{
+						args: {
+							mappedDomain: includedDomainTransfer.meta,
+							wordpressSiteUrl: purchase.domain,
+						},
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
+						'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
+					{
+						args: {
+							mappedDomain: includedDomainTransfer.meta,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+
 	const RefundablePurchaseWithNonRefundableDomainMessage = () => (
 		<div>
 			<p>
@@ -146,9 +206,18 @@ const CancelPurchaseDomainOptions = ( {
 		</div>
 	);
 
+	if ( includedDomainTransfer && isDomainTransfer( includedDomainTransfer ) ) {
+		if ( ! isRefundable( purchase ) ) {
+			return <NonRefundableDomainTransferMessage />;
+		}
+
+		return <CancelableDomainTransferMessage />;
+	}
+
 	if (
-		! isDomainMapping( includedDomainPurchase ) &&
-		! isDomainRegistration( includedDomainPurchase )
+		! includedDomainPurchase ||
+		( ! isDomainMapping( includedDomainPurchase ) &&
+			! isDomainRegistration( includedDomainPurchase ) )
 	) {
 		return null;
 	}
@@ -167,7 +236,11 @@ const CancelPurchaseDomainOptions = ( {
 		return <NonRefundableDomainPurchaseMessage />;
 	}
 
-	if ( isRefundable( purchase ) && ! isRefundable( includedDomainPurchase ) ) {
+	if (
+		isRefundable( purchase ) &&
+		! isRefundable( includedDomainPurchase ) &&
+		! isRefundable( includedDomainTransfer )
+	) {
 		return <RefundablePurchaseWithNonRefundableDomainMessage />;
 	}
 

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -121,28 +121,12 @@ const CancelPurchaseDomainOptions = ( {
 		</div>
 	);
 
-	const IncludedDomainTransferPartialRefund = () => (
-		<p>
-			{ translate(
-				'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-					'minus %(domainCost)s for the domain.',
-				{
-					args: {
-						domainCost: includedDomainTransfer.priceText,
-						planCost: planCostText,
-						refundAmount: purchase.refundText,
-					},
-				}
-			) }
-		</p>
-	);
-
-	const NonRefundableDomainTransferMessage = () => (
+	const DomainTransferMessage = () => (
 		<div>
 			<p>
 				{ translate(
 					'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
-						'The domain transfer will not be removed along with the plan, to avoid any interruptions for your visitors.',
+						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
 					{
 						args: {
 							domain: includedDomainTransfer.meta,
@@ -151,27 +135,17 @@ const CancelPurchaseDomainOptions = ( {
 					}
 				) }
 			</p>
-			<IncludedDomainTransferPartialRefund />
-		</div>
-	);
-
-	const CancelableDomainTransferMessage = () => (
-		<div>
 			<p>
 				{ translate(
-					'It seems you have a pending domain transfer for the domain %(mappedDomain)s. ' +
-						'In order to receive a full refund, please cancel the domain transfer before requesting the cancellation of your plan.',
+					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+						'minus %(domainCost)s for the domain.',
 					{
 						args: {
-							mappedDomain: includedDomainTransfer.meta,
+							domainCost: includedDomainTransfer.priceText,
+							planCost: planCostText,
+							refundAmount: purchase.refundText,
 						},
 					}
-				) }
-			</p>
-			<IncludedDomainTransferPartialRefund />
-			<p>
-				{ translate(
-					'In some cases, a domain transfer has progressed too far to be canceled. Please contact support if you have questions about this'
 				) }
 			</p>
 		</div>
@@ -208,11 +182,7 @@ const CancelPurchaseDomainOptions = ( {
 	);
 
 	if ( includedDomainTransfer && isDomainTransfer( includedDomainTransfer ) ) {
-		if ( ! isRefundable( purchase ) ) {
-			return <NonRefundableDomainTransferMessage />;
-		}
-
-		return <CancelableDomainTransferMessage />;
+		return <DomainTransferMessage />;
 	}
 
 	if (

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -43,6 +43,7 @@ import {
 	getSitePurchases,
 	hasLoadedUserPurchasesFromServer,
 	getIncludedDomainPurchase,
+	getIncludedDomainTransfer,
 } from 'calypso/state/purchases/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
@@ -351,6 +352,7 @@ class CancelPurchase extends Component {
 
 						<CancelPurchaseDomainOptions
 							includedDomainPurchase={ this.props.includedDomainPurchase }
+							includedDomainTransfer={ this.props.includedDomainTransfer }
 							cancelBundledDomain={ this.state.cancelBundledDomain }
 							onCancelConfirmationStateChange={ this.onCancelConfirmationStateChange }
 							purchase={ purchase }
@@ -429,6 +431,7 @@ export default connect( ( state, props ) => {
 		purchases,
 		productsList,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
+		includedDomainTransfer: getIncludedDomainTransfer( state, purchase ),
 		site: getSite( state, purchase ? purchase.siteId : null ),
 		isHundredYearDomain: selectedDomain?.isHundredYearDomain,
 	};

--- a/client/state/purchases/selectors/get-included-domain-purchase.ts
+++ b/client/state/purchases/selectors/get-included-domain-purchase.ts
@@ -1,8 +1,8 @@
 import { isDomainRegistration, isDomainMapping } from '@automattic/calypso-products';
-import { find } from 'lodash';
 import { isSubscription } from 'calypso/lib/purchases';
 import { getSitePurchases } from './get-site-purchases';
-
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { AppState } from 'calypso/types';
 import 'calypso/state/purchases/init';
 
 /**
@@ -11,15 +11,17 @@ import 'calypso/state/purchases/init';
  * Even if a domain registration was purchased with the subscription, it will
  * not be returned if the domain product was paid for separately (eg: if it was
  * renewed on its own).
- * @param   {Object} state  global state
- * @param   {Object} subscriptionPurchase  subscription purchase object
- * @returns {Object} domain purchase if there is one, null if none found or not a subscription object passed
+ * @param   {AppState} state  global state
+ * @param   {Purchase | null | undefined} subscriptionPurchase  subscription purchase object
+ * @returns {Purchase | null | undefined} domain purchase if there is one, null if none found or not a subscription object passed
  */
-export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
+export const getIncludedDomainPurchase = (
+	state: AppState,
+	subscriptionPurchase: Purchase | null | undefined
+): Purchase | null | undefined => {
 	if (
 		! subscriptionPurchase ||
 		! isSubscription( subscriptionPurchase ) ||
-		subscriptionPurchase.included_domain_purchase_amount ||
 		subscriptionPurchase.includedDomainPurchaseAmount
 	) {
 		return null;
@@ -27,12 +29,9 @@ export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
 
 	const { includedDomain } = subscriptionPurchase;
 	const sitePurchases = getSitePurchases( state, subscriptionPurchase.siteId );
-	const domainPurchase = find(
-		sitePurchases,
+	return sitePurchases.find(
 		( purchase ) =>
 			( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) &&
 			includedDomain === purchase.meta
 	);
-
-	return domainPurchase;
 };

--- a/client/state/purchases/selectors/get-included-domain-transfer.js
+++ b/client/state/purchases/selectors/get-included-domain-transfer.js
@@ -1,0 +1,29 @@
+import { isDomainTransfer } from '@automattic/calypso-products';
+import { find } from 'lodash';
+import { isSubscription } from 'calypso/lib/purchases';
+import { getSitePurchases } from './get-site-purchases';
+
+import 'calypso/state/purchases/init';
+
+/**
+ * Returns a purchase object that corresponds to that subscription's transferred domain
+ *
+ * Even if a domain transfer was purchased with the subscription, it will
+ * not be returned if the domain transfer product was paid for separately (eg: if it was
+ * renewed on its own).
+ * @param   {Object} state  global state
+ * @param   {Object} subscriptionPurchase  subscription purchase object
+ * @returns {Object} domain transfer purchase if there is one, null if none found or not a subscription object passed
+ */
+export const getIncludedDomainTransfer = ( state, subscriptionPurchase ) => {
+	if ( ! subscriptionPurchase || ! isSubscription( subscriptionPurchase ) ) {
+		return null;
+	}
+
+	const { includedDomain } = subscriptionPurchase;
+	const sitePurchases = getSitePurchases( state, subscriptionPurchase.siteId );
+	return find(
+		sitePurchases,
+		( purchase ) => isDomainTransfer( purchase ) && includedDomain === purchase.meta
+	);
+};

--- a/client/state/purchases/selectors/get-included-domain-transfer.ts
+++ b/client/state/purchases/selectors/get-included-domain-transfer.ts
@@ -1,8 +1,8 @@
 import { isDomainTransfer } from '@automattic/calypso-products';
-import { find } from 'lodash';
 import { isSubscription } from 'calypso/lib/purchases';
 import { getSitePurchases } from './get-site-purchases';
-
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { AppState } from 'calypso/types';
 import 'calypso/state/purchases/init';
 
 /**
@@ -11,19 +11,21 @@ import 'calypso/state/purchases/init';
  * Even if a domain transfer was purchased with the subscription, it will
  * not be returned if the domain transfer product was paid for separately (eg: if it was
  * renewed on its own).
- * @param   {Object} state  global state
- * @param   {Object} subscriptionPurchase  subscription purchase object
- * @returns {Object} domain transfer purchase if there is one, null if none found or not a subscription object passed
+ * @param   {AppState} state  global state
+ * @param   {Purchase | null | undefined} subscriptionPurchase  subscription purchase object
+ * @returns {Purchase | null | undefined} domain transfer purchase if there is one, null if none found or not a subscription object passed
  */
-export const getIncludedDomainTransfer = ( state, subscriptionPurchase ) => {
+export const getIncludedDomainTransfer = (
+	state: AppState,
+	subscriptionPurchase: Purchase | null | undefined
+): Purchase | null | undefined => {
 	if ( ! subscriptionPurchase || ! isSubscription( subscriptionPurchase ) ) {
 		return null;
 	}
 
 	const { includedDomain } = subscriptionPurchase;
 	const sitePurchases = getSitePurchases( state, subscriptionPurchase.siteId );
-	return find(
-		sitePurchases,
+	return sitePurchases.find(
 		( purchase ) => isDomainTransfer( purchase ) && includedDomain === purchase.meta
 	);
 };

--- a/client/state/purchases/selectors/get-included-domain-transfer.ts
+++ b/client/state/purchases/selectors/get-included-domain-transfer.ts
@@ -8,9 +8,6 @@ import 'calypso/state/purchases/init';
 /**
  * Returns a purchase object that corresponds to that subscription's transferred domain
  *
- * Even if a domain transfer was purchased with the subscription, it will
- * not be returned if the domain transfer product was paid for separately (eg: if it was
- * renewed on its own).
  * @param   {AppState} state  global state
  * @param   {Purchase | null | undefined} subscriptionPurchase  subscription purchase object
  * @returns {Purchase | null | undefined} domain transfer purchase if there is one, null if none found or not a subscription object passed
@@ -19,7 +16,11 @@ export const getIncludedDomainTransfer = (
 	state: AppState,
 	subscriptionPurchase: Purchase | null | undefined
 ): Purchase | null | undefined => {
-	if ( ! subscriptionPurchase || ! isSubscription( subscriptionPurchase ) ) {
+	if (
+		! subscriptionPurchase ||
+		! isSubscription( subscriptionPurchase ) ||
+		subscriptionPurchase.includedDomainPurchaseAmount
+	) {
 		return null;
 	}
 

--- a/client/state/purchases/selectors/index.js
+++ b/client/state/purchases/selectors/index.js
@@ -10,6 +10,7 @@ export { getByPurchaseId } from './get-by-purchase-id';
 export { getDowngradePlanFromPurchase } from './get-downgrade-plan-from-purchase';
 export { getDowngradePlanToMonthlyFromPurchase } from './get-downgrade-plan-to-monthly-from-purchase';
 export { getIncludedDomainPurchase } from './get-included-domain-purchase';
+export { getIncludedDomainTransfer } from './get-included-domain-transfer';
 export { getPurchases } from './get-purchases';
 export { getPurchasesError } from './get-purchases-error';
 export { getRenewableSitePurchases } from './get-renewable-site-purchases';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See https://github.com/Automattic/wp-calypso/pull/102709


| Refundable / non-refundable transfer messages: |
|----|
| <img width="300" alt="Screenshot 2025-04-30 at 09 51 35" src="https://github.com/user-attachments/assets/b2647f18-ec22-48c3-8854-c258140cbb21" /> |  

(edit: a slight change was added and it now says "domain transfer" instead of "custom domain")

## Proposed Changes

* Add latest feedback about the messaging
* See https://github.com/Automattic/wp-calypso/pull/102709

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* See https://github.com/Automattic/wp-calypso/pull/102709

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://github.com/Automattic/wp-calypso/pull/102709
