### PR TITLE
Components: Start using CSS Modules

### DIFF
--- a/packages/components/src/logos/wordpress-logo/index.tsx
+++ b/packages/components/src/logos/wordpress-logo/index.tsx
@@ -1,4 +1,5 @@
-import './style.scss';
+import clsx from 'clsx';
+import styles from './style.module.scss';
 
 type Props = {
 	/**
@@ -17,7 +18,10 @@ type Props = {
 };
 
 export const WordPressLogo: React.FunctionComponent< Props > = ( {
-	className = 'wordpress-logo',
+	// TODO: This behavior of the `className` prop overriding the default classes are not standard,
+	// and should be normalized to be merged instead. Ideally, we also remove the `wordpress-logo`
+	// class because it clashes very easily.
+	className = clsx( styles.wordpressLogo, 'wordpress-logo' ),
 	size = 72,
 } ) => {
 	return (

--- a/packages/components/src/logos/wordpress-logo/style.module.scss
+++ b/packages/components/src/logos/wordpress-logo/style.module.scss
@@ -1,4 +1,4 @@
-.wordpress-logo {
+.wordpressLogo {
 	fill: var(--color-text-inverted);
 	margin: 0 auto 20px;
 }

--- a/packages/components/src/types.d.ts
+++ b/packages/components/src/types.d.ts
@@ -5,5 +5,12 @@ declare module '*.svg' {
 
 declare const __i18n_text_domain__: string;
 
-declare module '*.module.css';
-declare module '*.module.scss';
+declare module '*.module.css' {
+	const classes: { [ key: string ]: string };
+	export default classes;
+}
+
+declare module '*.module.scss' {
+	const classes: { [ key: string ]: string };
+	export default classes;
+}

--- a/packages/components/src/types.d.ts
+++ b/packages/components/src/types.d.ts
@@ -4,3 +4,6 @@ declare module '*.svg' {
 }
 
 declare const __i18n_text_domain__: string;
+
+declare module '*.module.css';
+declare module '*.module.scss';


### PR DESCRIPTION
Closes ARC-85

## Proposed Changes

This lays the foundations so we can start using CSS Modules for new components added to `@automattic/components`.

Webpack already supports this, so all we need to add is some type declarations for better devex. I converted `WordPressLogo` as a simple example — we can't actually remove the problematic `wordpress-logo` class until the existing usages are addressed.

An IDE extension like [this](https://marketplace.visualstudio.com/items?itemName=clinyong.vscode-css-modules) is recommend for autocompletion and go to definition. I would've liked to also add [`typescript-plugin-css-modules`](https://www.npmjs.com/package/typescript-plugin-css-modules), but we're blocked by [this limitation](https://github.com/mrmckeb/typescript-plugin-css-modules/issues/222).

## Why are these changes being made?

Non-obscured CSS classes have been problematic as they encourage consumers to override inner styles, making them fragile to changes. We also see name collision issues due to poor namespacing. CSS Modules also tend to be safer for AI-assisted coding since we don't have to worry about name collisions.

## Testing Instructions

- `yarn components:storybook:start` and check the WordPressLogo story. The classname containing the styles should be obscured, while the `wordpress-logo` classname is kept for back compat.
- Check one of the existing usages for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
