### PR TITLE
Scope the Help Center theme colors to itself

### DIFF
--- a/apps/help-center/postcss.config.js
+++ b/apps/help-center/postcss.config.js
@@ -18,6 +18,11 @@ module.exports = {
 					return selector === '.count' ? prefixedSelector : selector;
 				}
 
+				// Replace :root with .help-center to avoid stylizing the document and scope all the help center variables to the help center.
+				if ( selector === ':root' ) {
+					return '.help-center';
+				}
+
 				return selector;
 			},
 		} ),


### PR DESCRIPTION
Fixes p1745577165923789-slack-C04DZ8M0GHW

## Proposed Changes

* Transforms `:root` selector to `.help-center` class to properly scope CSS variables and avoid CSS leakage.
* Prevents Help Center styles from affecting the global document scope, thus interfering with the theme styles.

## Why are these changes being made?

* Some sites have CSS variables that clash with those of the Help Center. 

## Testing Instructions

1. In apps/help-center run `yarn dev --sync`.
2. Go to the Network Admin homepage.
3. Open the Help Center.
4. The buttons and the search bar should have their borders.
5. Inspect a button, find its border color variable.
6. The variable should be scoped to `.help-center`, not `:root`.
