### PR TITLE
Fix domain purchase part of the domains__add e2e test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -1,6 +1,5 @@
 import { Page } from 'playwright';
 import { reloadAndRetry } from '../../element-helper';
-import { plansPageUrl } from '../pages';
 
 const selectors = {
 	searchInput: '.search-component__input',
@@ -90,17 +89,6 @@ export class DomainSearchComponent {
 		}
 
 		await target.click();
-
-		// If multiple domain selections are enabled, the Continue button appears
-		// on the right hand sidebar.
-		// See: 21483-explat-experiment
-		// Note: this page object does not currently support multiple domain selection.
-		await Promise.race( [
-			this.page
-				.getByRole( 'button', { name: 'Continue', exact: true } )
-				.click( { timeout: 30 * 1000 } ),
-			this.page.waitForURL( plansPageUrl ),
-		] );
 
 		return selectedDomain;
 	}

--- a/packages/calypso-e2e/src/lib/components/navbar-cart-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-cart-component.ts
@@ -26,6 +26,7 @@ export class NavbarCartComponent {
 	 * Opens the popover cart.
 	 */
 	async openCart(): Promise< void > {
+		await this.page.locator( selectors.cartButton ).waitFor( { state: 'visible', timeout: 3000 } );
 		await this.page.locator( selectors.cartButton ).click();
 		await this.page.locator( selectors.popover ).waitFor();
 		// Sometimes there is background work happening when you open the popover. This can interrupt later actions taken.
@@ -60,5 +61,14 @@ export class NavbarCartComponent {
 			// Since we're going one by one and removing them all, we can always just remove the first item until there are none.
 			await this.removeCartItem( { index: 0 } );
 		}
+	}
+
+	/**
+	 * Checks if the cart button is visible.
+	 *
+	 * @returns {Promise<boolean>} True if the cart button is visible, false otherwise.
+	 */
+	async isCartButtonVisible(): Promise< boolean > {
+		return ( await this.page.locator( selectors.cartButton ).isVisible() ) ?? false;
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/domains-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/domains-page.ts
@@ -2,6 +2,7 @@ import { Page } from 'playwright';
 
 const selectors = {
 	// Domain actions
+	addDomainButton: '.button:text("Add new domain")',
 	searchForDomainButton: 'a:text-matches("search", "i")',
 	useADomainIOwnButton: 'text=Use a domain I own',
 
@@ -30,10 +31,7 @@ export class DomainsPage {
 	 * Clicks on the button to add a domain to the site.
 	 */
 	async addDomain(): Promise< void > {
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.click( selectors.searchForDomainButton ),
-		] );
+		await Promise.all( [ this.page.click( selectors.addDomainButton ) ] );
 	}
 
 	/**

--- a/test/e2e/specs/domains/domains__add.ts
+++ b/test/e2e/specs/domains/domains__add.ts
@@ -18,7 +18,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
 	let page: Page;
 	let sidebarComponent: SidebarComponent;
 	let domainSearchComponent: DomainSearchComponent;

--- a/test/e2e/specs/domains/domains__add.ts
+++ b/test/e2e/specs/domains/domains__add.ts
@@ -18,7 +18,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
+describe( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), function () {
 	let page: Page;
 	let sidebarComponent: SidebarComponent;
 	let domainSearchComponent: DomainSearchComponent;
@@ -45,12 +45,15 @@ describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), fu
 			await sidebarComponent.navigate( 'Upgrades', 'Domains' );
 		} );
 
-		// TODO: Just use the rest API to clear the cart!
 		it( 'If required, clear the cart', async function () {
 			domainsPage = new DomainsPage( page );
 			navbarCartComponent = new NavbarCartComponent( page );
-			await navbarCartComponent.openCart();
-			await navbarCartComponent.emptyCart();
+
+			// Only attempt to clear the cart if the cart has items
+			if ( await navbarCartComponent.isCartButtonVisible() ) {
+				await navbarCartComponent.openCart();
+				await navbarCartComponent.emptyCart();
+			}
 		} );
 
 		it( 'Add domain to site', async function () {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTCOM-10629/review-quarantined-e2e-tests

## Proposed Changes

* Fixed the domain purchase part of the e2e test
* We will keep this test "skipped" to avoid domain purchasing without the option to clean up the domain list (more info here: https://github.com/Automattic/wp-calypso/pull/58130)

## Why are these changes being made?

https://linear.app/a8c/issue/DOTCOM-10629/review-quarantined-e2e-tests

## Testing Instructions

* Set local environment
* run `yarn workspace @automattic/calypso-e2e build`
* Remove the "skip" method from [the line](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/domains/domains__add.ts#L21)
* run `yarn workspace wp-e2e-tests test -- specs/domains/domains__add.ts`
* Check if it passes the "Purchase domain" segment and fails later on "Cancel domain" part

I'm aware that this is not a a completely fixed e2e test, but since we are not able to manage domain canceling right now, I don't want to waste the effort I put into fixing the the first part.

Currently, we are blocked to Cancel previously purchased domains because the [purchase](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx#L28) object is an empty one and the [domain object missing some data](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx#L29). It's probably something related to the testing environment.

The missing settings card:
<img width="1580" alt="Screenshot 2025-04-30 at 14 28 34" src="https://github.com/user-attachments/assets/29d3422b-7ceb-4f51-b069-4eab8057651c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
