### PR TITLE
Use more precise storage add-on space

### DIFF
--- a/client/my-sites/add-ons/components/storage-add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/storage-add-ons-card.tsx
@@ -139,7 +139,7 @@ export default function StorageAddOnCard( { siteId, actionPrimary }: Props ) {
 		siteIdOrSlug: siteId,
 	} );
 
-	const used = filesize( mediaStorage?.storageUsedBytes || 0, { round: 0 } );
+	const used = filesize( mediaStorage?.storageUsedBytes || 0, { round: 1 } );
 	const max = filesize( mediaStorage?.maxStorageBytes || 0, { round: 0 } );
 
 	const purchasedStorageAddOn = useGetPurchasedStorageAddOn( { siteId } );


### PR DESCRIPTION
Approaching the maximum cuts out hundreds of megabytes. For example, a site with a 3GB Storage limit will show 3/3 when it has nearly 500MB free and is at 2.51.

Related to DOTCOM-12929-linear-issue

## Proposed Changes

* Round to the first decimal point

## Why are these changes being made?

* Consistency with the Media Library which shows the space with a bit more accuracy. Within the media library and wp-admin, we display the space with more precision:

<img width="1397" alt="Screenshot 2025-04-30 at 14 51 55" src="https://github.com/user-attachments/assets/04063f17-f2cf-4c6a-b06f-e9b69fd9b827" />



## Testing Instructions

* Check a site that has some space, for example veselin.blog
* http://calypso.localhost:3000/add-ons/veselin.blog
* You can also hack different mediaStorage?.storageUsedBytes

Before and after with 1.7GB space used
<img width="45%" alt="Screenshot 2025-04-30 at 15 42 16" src="https://github.com/user-attachments/assets/f023d59c-8f31-4b77-b4da-90edbef64dfa" /> <img width="45%" alt="Screenshot 2025-04-30 at 15 42 00" src="https://github.com/user-attachments/assets/eb9b0b90-c6f9-435c-b4e3-2a7b0b7ca88b" />

Before and after with 2.6GB space used
<img width="45%" alt="Screenshot 2025-04-30 at 15 52 25" src="https://github.com/user-attachments/assets/06e5e1f0-8032-4da7-a9e3-7fcf1ecfadd4" /> <img width="45%" alt="Screenshot 2025-04-30 at 15 56 27" src="https://github.com/user-attachments/assets/0aa3d450-8c7a-4a81-b7f9-346e32212011" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
