### PR TITLE
Use `@automattic/dataviews` instead of `@wordpress/dataviews`

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
 							'!@automattic/components/src',
 							'@automattic/components/src/*',
 							'!@automattic/components/src/summary-button',
+							'!@automattic/dataviews',
 							// Please do not add exceptions unless agreed on
 							// with the #architecture group.
 						],

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -1,5 +1,5 @@
 @import '@wordpress/base-styles/variables';
-@import '@wordpress/dataviews/build-style/style.css';
+@import '@automattic/dataviews/build-style/style.css';
 
 // Should be implemented differently once v2 is not loaded via the v1 stack
 // I'm tempted to even just replace all this with a display:none on the logo
@@ -35,6 +35,6 @@ a {
 }
 
 h1 {
-	font-family: var(--dashboard-h1__font-family);
-	font-weight: var(--dashboard-h1__font-weight) !important;
+	font-family: var( --dashboard-h1__font-family );
+	font-weight: var( --dashboard-h1__font-weight ) !important;
 }

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -1,6 +1,6 @@
+import { DataViews, filterSortAndPaginate, View } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate, View } from '@wordpress/dataviews';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -1,14 +1,14 @@
+import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button, ExternalLink, Notice } from '@wordpress/components';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import { emailsQuery } from '../app/queries';
 import DataViewsCard from '../dataviews-card';
 import PageLayout from '../page-layout';
 import type { Email } from '../data/types';
-import type { View } from '@wordpress/dataviews';
+import type { View } from '@automattic/dataviews';
 
 const fields = [
 	{

--- a/client/dashboard/profile/index.tsx
+++ b/client/dashboard/profile/index.tsx
@@ -1,3 +1,4 @@
+import { DataForm } from '@automattic/dataviews';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
 	Button,
@@ -13,7 +14,6 @@ import {
 	ExternalLink,
 	TextControl,
 } from '@wordpress/components';
-import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -21,7 +21,7 @@ import { profileQuery, profileMutation } from '../app/queries';
 import EditGravatar from '../edit-gravatar';
 import PageLayout from '../page-layout';
 import type { Profile as ProfileType } from '../data/types';
-import type { Field } from '@wordpress/dataviews';
+import type { Field } from '@automattic/dataviews';
 
 import './style.scss';
 

--- a/client/dashboard/site/switcher.tsx
+++ b/client/dashboard/site/switcher.tsx
@@ -1,13 +1,13 @@
+import { filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { MenuGroup, MenuItem, SearchControl, Icon } from '@wordpress/components';
-import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { sitesQuery } from '../app/queries';
 import SiteIcon from '../site-icon';
-import type { View } from '@wordpress/dataviews';
+import type { View } from '@automattic/dataviews';
 
 const fields = [ { id: 'name', enableGlobalSearch: true } ];
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,8 +1,8 @@
+import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useState, useMemo } from 'react';
@@ -14,7 +14,7 @@ import SitePreview from '../site-preview';
 import { isA8CSite } from '../utils/site-owner';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import type { Site } from '../data/types';
-import type { View, Operator } from '@wordpress/dataviews';
+import type { View, Operator } from '@automattic/dataviews';
 
 const actions = [
 	{

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
 		"@automattic/composite-checkout": "workspace:^",
 		"@automattic/create-calypso-config": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/dataviews": "workspace:^",
 		"@automattic/design-picker": "workspace:^",
 		"@automattic/design-preview": "workspace:^",
 		"@automattic/domain-picker": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,7 +798,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/dataviews@workspace:packages/dataviews":
+"@automattic/dataviews@workspace:^, @automattic/dataviews@workspace:packages/dataviews":
   version: 0.0.0-use.local
   resolution: "@automattic/dataviews@workspace:packages/dataviews"
   dependencies:
@@ -13428,6 +13428,7 @@ __metadata:
     "@automattic/composite-checkout": "workspace:^"
     "@automattic/create-calypso-config": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/dataviews": "workspace:^"
     "@automattic/design-picker": "workspace:^"
     "@automattic/design-preview": "workspace:^"
     "@automattic/domain-picker": "workspace:^"


### PR DESCRIPTION
Related to DOTCOM-12931

## Proposed Changes

This PR switches from `@wordpress/dataviews` to `@automattic/dataviews`.

## Why are these changes being made?

So we can use the latest.

## How to test

Test the dashboard locally and smoke test DataViews works as expected (e.g., sites view).
