### PR TITLE
onboard: Remove unused interfaces CreateSiteActionParameters and CreateSiteBaseActionParameters

### DIFF
--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -34,19 +34,6 @@ export const setSiteUrl = ( siteUrl: string ) => ( {
 	siteUrl,
 } );
 
-export interface CreateSiteBaseActionParameters {
-	username: string;
-	languageSlug: string;
-	visibility: number;
-}
-
-export interface CreateSiteActionParameters extends CreateSiteBaseActionParameters {
-	bearerToken?: string;
-	anchorFmPodcastId: string | null;
-	anchorFmEpisodeId: string | null;
-	anchorFmSpotifyUrl: string | null;
-}
-
 export function* createSenseiSite( {
 	username = '',
 	languageSlug = '',


### PR DESCRIPTION


## Proposed Changes

Remove these two interfaces that are no longer used: `CreateSiteActionParameters` and `CreateSiteBaseActionParameters`.

- Originally added for `createSite()` in #47980
- `createSite()` removed in #86156 (when /new was removed)

- Split to `ActionParams` and `BaseActionParams` done in #67539 - because VideoPress wanted to use it
- VideoPress removed in #95763 and #95751

## Why are these changes being made?

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
