### PR TITLE
Account Me: Enabling 2FA is disabled on unverified accounts

### DIFF
--- a/client/me/security-checkup/navigation-item.jsx
+++ b/client/me/security-checkup/navigation-item.jsx
@@ -30,6 +30,7 @@ class SecurityCheckupNavigationItem extends Component {
 		onClick: PropTypes.func,
 		path: PropTypes.string,
 		text: PropTypes.string,
+		disabled: PropTypes.bool,
 	};
 
 	render() {
@@ -43,6 +44,7 @@ class SecurityCheckupNavigationItem extends Component {
 				onClick={ this.props.onClick }
 				external={ this.props.external }
 				className="security-checkup__nav-item"
+				disabled={ this.props.disabled }
 			>
 				<SecurityCheckupNavigationItemContents
 					materialIcon={ this.props.materialIcon }

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -2,6 +2,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import hasUserSettings from 'calypso/state/selectors/has-user-settings';
 import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
@@ -29,6 +30,7 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 			twoStepSmsPhoneNumber,
 			hasTwoStepSecurityKeyEnabled,
 			hasTwoStepEnhancedSecurity,
+			isEmailVerified,
 		} = this.props;
 
 		if ( ! areUserSettingsLoaded ) {
@@ -38,7 +40,12 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		let icon;
 		let description;
 
-		if ( ! hasTwoStepSmsEnabled && ! hasTwoStepEnabled ) {
+		if ( ! isEmailVerified ) {
+			icon = getWarningIcon();
+			description = translate(
+				'To enable Two-Step Authentication, please verify your email address first.'
+			);
+		} else if ( ! hasTwoStepSmsEnabled && ! hasTwoStepEnabled ) {
 			icon = getWarningIcon();
 			description = translate( 'You do not have two-step authentication enabled.' );
 		} else {
@@ -97,6 +104,7 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 				materialIcon={ icon }
 				text={ translate( 'Two-Step Authentication' ) }
 				description={ description }
+				disabled={ ! isEmailVerified }
 			/>
 		);
 	}
@@ -109,4 +117,5 @@ export default connect( ( state ) => ( {
 	twoStepSmsPhoneNumber: getUserSetting( state, 'two_step_sms_phone_number' ),
 	hasTwoStepSecurityKeyEnabled: getUserSetting( state, 'two_step_security_key_enabled' ),
 	hasTwoStepEnhancedSecurity: getUserSetting( state, 'two_step_enhanced_security' ),
+	isEmailVerified: isCurrentUserEmailVerified( state ),
 } ) )( localize( SecurityCheckupTwoFactorAuthentication ) );

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -19,6 +19,7 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		hasTwoStepEnhancedSecurity: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
 		twoStepSmsPhoneNumber: PropTypes.string,
+		isEmailVerified: PropTypes.bool,
 	};
 
 	render() {

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -41,6 +41,7 @@ class SecurityCheckupTwoFactorAuthentication extends Component {
 		let icon;
 		let description;
 
+		// Email verification is prioritized over other two-factor authentication conditions.
 		if ( ! isEmailVerified ) {
 			icon = getWarningIcon();
 			description = translate(

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -42,19 +43,13 @@ class TwoStep extends Component {
 
 	componentDidMount() {
 		if ( ! this.props.isFetchingUserSettings && ! this.props.isEmailVerified ) {
-			window.location.href = '/me/security';
+			page.redirect( '/me/security' );
 		}
 	}
 
-	componentDidUpdate( prevProps ) {
-		// Check if fetching just completed
-		if (
-			prevProps.isFetchingUserSettings &&
-			! this.props.isFetchingUserSettings &&
-			prevProps.isEmailVerified &&
-			! this.props.isEmailVerified
-		) {
-			window.location.href = '/me/security';
+	componentDidUpdate() {
+		if ( ! this.props.isFetchingUserSettings && ! this.props.isEmailVerified ) {
+			page.redirect( '/me/security' );
 		}
 	}
 

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -18,6 +18,7 @@ import Security2faDisable from 'calypso/me/security-2fa-disable';
 import Security2faKey from 'calypso/me/security-2fa-key';
 import Security2faSetup from 'calypso/me/security-2fa-setup';
 import SecuritySectionNav from 'calypso/me/security-section-nav';
+import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
 import { fetchUserSettings } from 'calypso/state/user-settings/actions';
@@ -38,6 +39,24 @@ class TwoStep extends Component {
 	onDisableFinished = () => {
 		this.props.fetchUserSettings();
 	};
+
+	componentDidMount() {
+		if ( ! this.props.isFetchingUserSettings && ! this.props.isEmailVerified ) {
+			window.location.href = '/me/security';
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		// Check if fetching just completed
+		if (
+			prevProps.isFetchingUserSettings &&
+			! this.props.isFetchingUserSettings &&
+			prevProps.isEmailVerified &&
+			! this.props.isEmailVerified
+		) {
+			window.location.href = '/me/security';
+		}
+	}
 
 	renderPlaceholders = () => {
 		const placeholders = [];
@@ -139,6 +158,7 @@ export default connect(
 		isFetchingUserSettings: isFetchingUserSettings( state ),
 		userSettings: getUserSettings( state ),
 		isTwoStepEnabled: isTwoStepEnabled( state ),
+		isEmailVerified: isCurrentUserEmailVerified( state ),
 	} ),
 	{
 		fetchUserSettings,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/issues/82057
- DOTCOM-12926

## Proposed Changes

* Disabled the navigation item when the user hasn't verified their email.
* Added an explanatory message about why it's disabled and what needs to happen for it to be enabled.

| Before | After |
|--------|--------|
|![Screenshot 2025-04-30 at 16 40 53](https://github.com/user-attachments/assets/cb066d1f-0052-40f7-8722-2ec73e728049)|![Screenshot 2025-04-30 at 16 37 52](https://github.com/user-attachments/assets/7fdd99a1-11d5-4c83-aa19-90296f4208d8)| 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The One Board

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a brand new wordpress.com account
* Don't click the email verification link, just immediately proceed to [wordpress.com/me/security](https://wordpress.com/me/security)
* You should see that the navigation item is disabled.
* You should see that there is a clear message that explains why it's disabled and how to enable the navigation item.
* Verify your email and reload
* You should see that the navigation is now enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
