### PR TITLE
Update/big sky strings

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.scss
@@ -28,6 +28,8 @@
 		font-size: $font-title-medium;
 		font-weight: 400;
 		line-height: 26px;
+		width: 100%;
+		text-align: left;
 	}
 
 	.design-choice__description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -31,7 +31,7 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 	const translate = useTranslate();
 	const { submit, goBack } = navigation;
 
-	const documentHeaderText = translate( 'Bring your vision to life' );
+	const documentHeaderText = translate( 'How would you like to design your site?' );
 	const headerText = translate(
 		'Time to build your site!{{br/}}How would you like to get started?',
 		{
@@ -72,7 +72,7 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 		<>
 			<DesignChoice
 				title={ translate( 'Choose a theme' ) }
-				description={ translate( 'Choose one of our professionally designed themes.' ) }
+				description={ translate( 'Our professionally designed themes make starting easy.' ) }
 				imageSrc={ themesIllustrationImage }
 				destination="design-setup"
 				onSelect={ handleSubmit }
@@ -82,7 +82,9 @@ const DesignChoicesStep: StepType< { submits: { destination: string } } > = ( {
 				<DesignChoice
 					className="design-choices__try-big-sky"
 					title={ translate( 'Create your site with AI' ) }
-					description={ translate( 'Tell our AI what you need, and watch it come to life.' ) }
+					description={ translate(
+						'Tell the AI what you need, and watch it build a custom site in seconds.'
+					) }
 					bgImageSrc={ hiBigSky }
 					destination="launch-big-sky"
 					onSelect={ ( destination ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -167,7 +167,7 @@ const LaunchBigSky: Step = function ( props ) {
 					<div className="big-sky-disclaimer">
 						<p>
 							{ translate(
-								'Please review our {{ai_guidelines}}AI Guidelines{{/ai_guidelines}} and the contents of your site to ensure it complies with our {{user_guidelines}}User Guidelines{{/user_guidelines}}.',
+								"You can review our {{ai_guidelines}}AI Guidelines{{/ai_guidelines}}, and all sites must comply with WordPress.com's {{user_guidelines}}User Guidelines{{/user_guidelines}}.",
 								{
 									components: {
 										ai_guidelines: (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -158,9 +158,9 @@ const LaunchBigSky: Step = function ( props ) {
 				<div className="processing-step__container">
 					<div className="processing-step">
 						{ ! isError && <ProgressBar key="main-progress" value={ progress } compact /> }
-						{ true && (
+						{ isError && (
 							<p className="processing-step__error">
-								{ __( "Sorry, but we've encountered an error. Please try again." ) }
+								{ __( 'Something unexpected happened. Please go back and try again.' ) }
 							</p>
 						) }
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -158,9 +158,9 @@ const LaunchBigSky: Step = function ( props ) {
 				<div className="processing-step__container">
 					<div className="processing-step">
 						{ ! isError && <ProgressBar key="main-progress" value={ progress } compact /> }
-						{ isError && (
+						{ true && (
 							<p className="processing-step__error">
-								{ __( 'Something unexpected happened. Please go back and try again.' ) }
+								{ __( "Sorry, but we've encountered an error. Please try again." ) }
 							</p>
 						) }
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/styles.scss
@@ -23,6 +23,10 @@ $color-big-sky-background: #000cb2;
 			margin-top: 0;
 			width: 100%;
 			max-width: 188px;
+
+			.processing-step__error {
+				color: $color-white;
+			}
 		}
 
 		.big-sky-disclaimer {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/styles.scss
@@ -9,7 +9,7 @@ $color-big-sky-background: #000cb2;
 	}
 
 	.wordpress-logo {
-		fill: $color-white;
+		fill: $color-white !important;
 	}
 
 	.processing-step__container {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/styles.scss
@@ -24,6 +24,10 @@ $color-big-sky-background: #000cb2;
 			width: 100%;
 			max-width: 188px;
 
+			&:has(.processing-step__error) {
+				max-width: 260px;
+			}
+
 			.processing-step__error {
 				color: $color-white;
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes BSKY-421
Fixes BSKY-420
Fixes BSKY-422

## Proposed Changes

Note that this header text expands to two lines now: 

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/54314d95-f465-4545-8834-b7dc8f0f4da8" />

Error text, user guidelines. Also logo color fixed to white. 

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/078a157c-43cf-40c7-8f80-15730bdf8dfc" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- Consistency with the plugin (guidelines)
- Fixes unreadable error text
- Design choices copy needed updating. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `http://calypso.localhost:3000/setup/site-setup/design-choices?siteSlug=YOURSITEURL`, for a site that has premium plan.
- Error text can only be tested by forcing the error in code
- Make sure things look ok with new strings. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
