### PR TITLE
Help Center: Use resolved interactions in Help Center home

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -54,8 +54,10 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const { sectionName } = useHelpCenterContext();
 	const { startNewInteraction } = useManageSupportInteraction();
 	const { data } = useSupportStatus();
-	const { data: openSupportInteraction, isLoading: isLoadingOpenSupportInteractions } =
-		useGetSupportInteractions( 'help-center' );
+	const { data: openSupportInteractions, isLoading: isLoadingOpenSupportInteractions } =
+		useGetSupportInteractions( 'help-center', 1, 'open' );
+	const { data: resolvedSupportInteractions, isLoading: isLoadingResolvedSupportInteractions } =
+		useGetSupportInteractions( 'help-center', 1, 'resolved' );
 
 	const { currentSupportInteraction, navigateToRoute, isMinimized, allowPremiumSupport } =
 		useSelect( ( select ) => {
@@ -86,18 +88,27 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	useEffect( () => {
 		if (
 			! isLoadingOpenSupportInteractions &&
-			openSupportInteraction === null &&
+			! isLoadingResolvedSupportInteractions &&
+			openSupportInteractions === null &&
+			resolvedSupportInteractions === null &&
 			! currentSupportInteraction
 		) {
 			startNewInteraction( {
 				event_source: 'help-center',
 				event_external_id: crypto.randomUUID(),
 			} );
-		} else if ( openSupportInteraction && ! currentSupportInteraction ) {
-			setCurrentSupportInteraction( openSupportInteraction[ 0 ] );
+		} else if (
+			( openSupportInteractions || resolvedSupportInteractions ) &&
+			! currentSupportInteraction
+		) {
+			if ( resolvedSupportInteractions?.length ) {
+				setCurrentSupportInteraction( resolvedSupportInteractions[ 0 ] );
+			} else if ( openSupportInteractions?.length ) {
+				setCurrentSupportInteraction( openSupportInteractions[ 0 ] );
+			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ openSupportInteraction, isLoadingOpenSupportInteractions ] );
+	}, [ openSupportInteractions, isLoadingOpenSupportInteractions ] );
 
 	useEffect( () => {
 		if ( navigateToRoute ) {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -108,7 +108,12 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ openSupportInteractions, isLoadingOpenSupportInteractions ] );
+	}, [
+		openSupportInteractions,
+		resolvedSupportInteractions,
+		isLoadingOpenSupportInteractions,
+		isLoadingResolvedSupportInteractions,
+	] );
 
 	useEffect( () => {
 		if ( navigateToRoute ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

I found a bug in the Help Center that will result in users losing their chats with Happiness Engineers.
In the Help Center homepage, we have a useEffect that sets the current support implementation searching the database for any `open` interaction. 

The problem is that when a chat evolves into a chat with Happiness Engineers, the status of the interaction becomes `resolved`.

If a user escalates to Happiness Engineers, than goes back to home, and then returns to the chat, the chat with HEs will be lost and we'll show a new chat with AI instead.

### DISCLAIMER

This solution is inelegant, as we have duplicate code for multiple chat statuses.
We now have support for multiple statuses in the backend API, but we need to address the fact that we want to give priority to resolved chats rather then open ones, when setting the current support interaction.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


### What happens on prod right now?

* Create a new paid user
* Click on "Still need help?"
* Chat with AI and ask to talk with a human. 
* When you manage to escalate the chat(asking to talk to a human) (nobody will answer you since you're in Zendesk staging), go back to the Help Center homepage (Back button top left).
* Now go back to the chat( Click on "Still need help?" again)
* You should see AI.

### What whis this PR?
* Create a new paid user
* Open Help Center (maybe you want to log the support interactions returned)
* Click on "Still need help?"
* Chat with AI and ask to talk with a human. 
* When you manage to escalate the chat (nobody will answer you since you're in Zendesk staging), go back to the homepage.
* Now go back to the chat( Click on "Still need help?" again)
* You should see your previous chat.