### PR TITLE
Newsletter importer and add subscribers modal - mark add subscribers launchpad tasks as complete when importing subscribers.

### DIFF
--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -12,6 +12,7 @@ import {
 import { useResetMutation } from 'calypso/data/paid-newsletter/use-reset-mutation';
 import { useSkipNextStepMutation } from 'calypso/data/paid-newsletter/use-skip-next-step-mutation';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
+import { useCompleteImportSubscribersTask } from 'calypso/my-sites/subscribers/hooks/use-complete-import-subscribers-task';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import Content from './content';
@@ -63,10 +64,10 @@ export default function NewsletterImporter( {
 }: NewsletterImporterProps ) {
 	const fromSite = getQueryArg( window.location.href, 'from' ) as string;
 	const selectedSite = useSelector( getSelectedSite ) ?? undefined;
-
 	const [ validFromSite, setValidFromSite ] = useState( false );
 	const [ autoFetchData, setAutoFetchData ] = useState( false );
 	const [ shouldResetImport, setShouldResetImport ] = useState( step === 'reset' );
+	const completeImportSubscribersTask = useCompleteImportSubscribersTask();
 	const previousFromSite = useRef( fromSite );
 
 	// Reset validFromSite when fromSite changes or is removed
@@ -104,6 +105,16 @@ export default function NewsletterImporter( {
 		setAutoFetchData,
 		paidNewsletterData?.steps,
 	] );
+
+	useEffect( () => {
+		// Mark the task complete once importing starts. Since we prompt users to leave the page while
+		// importing is happening, it may not be called if we wait until completion.
+		if ( paidNewsletterData?.steps?.subscribers?.status === 'importing' ) {
+			// We do this here instead of in the Subscribers component because steps ship over the
+			// component when not importing paid subscribers.
+			completeImportSubscribersTask();
+		}
+	}, [ paidNewsletterData?.steps?.subscribers?.status, completeImportSubscribersTask ] );
 
 	const { currentStepNumber, nextStepSlug } = stepSlugs.reduce(
 		function ( result, curr, index ) {

--- a/client/my-sites/importer/newsletter/importer.tsx
+++ b/client/my-sites/importer/newsletter/importer.tsx
@@ -110,7 +110,7 @@ export default function NewsletterImporter( {
 		// Mark the task complete once importing starts. Since we prompt users to leave the page while
 		// importing is happening, it may not be called if we wait until completion.
 		if ( paidNewsletterData?.steps?.subscribers?.status === 'importing' ) {
-			// We do this here instead of in the Subscribers component because steps ship over the
+			// We do this here instead of in the Subscribers component because steps skip over the
 			// component when not importing paid subscribers.
 			completeImportSubscribersTask();
 		}

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -13,6 +13,7 @@ import { useTranslate } from 'i18n-calypso';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { useCompleteImportSubscribersTask } from 'calypso/my-sites/subscribers/hooks/use-complete-import-subscribers-task';
 import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -41,6 +42,7 @@ const AddSubscribersModal = ( {
 		siteHasFeature( state, site?.ID, FEATURE_UNLIMITED_SUBSCRIBERS )
 	);
 	const isJetpack = useSelector( ( state: AppState ) => isJetpackSite( state, site?.ID ) );
+	const completeImportSubscribersTask = useCompleteImportSubscribersTask();
 	// There is also a separate `importers/substack` flag but that refers to a separate Substack content importer.
 	// This flag refers to Substack free/paid subscriber + content importer.
 	const isSubstackSubscriberImporterEnabled = isEnabled( 'importers/newsletter' );
@@ -56,7 +58,12 @@ const AddSubscribersModal = ( {
 	} );
 
 	const [ isUploading, setIsUploading ] = useState( false );
-	const onImportStarted = ( hasFile: boolean ) => setIsUploading( hasFile );
+	const onImportStarted = ( hasFile: boolean ) => {
+		// Mark this task complete on starting the import, as relying on completion is unreliable
+		// since we may prompt users to navigate elsewhere they are no longer mounted.
+		completeImportSubscribersTask();
+		setIsUploading( hasFile );
+	};
 
 	const isImportInProgress = useInProgressState();
 	const hasStaleImportJobs = useHasStaleImportJobs();

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -60,7 +60,7 @@ const AddSubscribersModal = ( {
 	const [ isUploading, setIsUploading ] = useState( false );
 	const onImportStarted = ( hasFile: boolean ) => {
 		// Mark this task complete on starting the import, as relying on completion is unreliable
-		// since we may prompt users to navigate elsewhere they are no longer mounted.
+		// since we prompt users to navigate elsewhere while it completes.
 		completeImportSubscribersTask();
 		setIsUploading( hasFile );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/635 /  https://linear.app/a8c/issue/CML-352/improve-newsletter-import-flow-for-new-sites  and p1746118512214489-slack-C03NLNTPZ2T

## Proposed Changes

This uses the `useCompleteImportSubscribersTask` hook to mark the task complete when importing subscribers from the add subscribers modal as well as the substack importer.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Before this change, the task is only completed in the migrate subscribers modal.
* its absence from the add subscribers modal was likely not noticed for a long time since adding subscribers removes the checklist so the outdated task status would never be seen. The above slack link notes an issue with subscribers caching which highlighted this issue.
* the substack importer also failed to mark the task as complete when importing subscribers, as noted in the above issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site.
* go to the subscribers page
* click the task to add subscribers.
* verify both adding subscribers manually and by csv completes the add subscribers task. If you no longer see the checklist you may need to check your sites blog option for 'launchpad_checklist_tasks_statuses' to verify the subscribers task has been marked complete.
* Either create another new site or clear the launchpad task statuses in the site options.
* Go through the substack importer and import subscribers. Again verify this marks the launchpad task as complete (either by looking at a corresponding checklist or checking the blog option).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?