### PR TITLE
Fix onboarding__write e2e test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -1,5 +1,6 @@
 import { Page } from 'playwright';
 import { reloadAndRetry } from '../../element-helper';
+import { plansPageUrl } from '../pages';
 
 const selectors = {
 	searchInput: '.search-component__input',
@@ -89,6 +90,17 @@ export class DomainSearchComponent {
 		}
 
 		await target.click();
+
+		// If multiple domain selections are enabled, the Continue button appears
+		// on the right hand sidebar.
+		// See: 21483-explat-experiment
+		// Note: this page object does not currently support multiple domain selection.
+		await Promise.race( [
+			this.page
+				.getByRole( 'button', { name: 'Continue', exact: true } )
+				.click( { timeout: 30 * 1000 } ),
+			this.page.waitForURL( plansPageUrl ),
+		] );
 
 		return selectedDomain;
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/103010

## Proposed Changes

* Reverts back a piece of test logic I removed here: https://github.com/Automattic/wp-calypso/pull/103010

## Why are these changes being made?

* https://github.com/Automattic/wp-calypso/pull/103010

## Testing Instructions

* Check if the pre-release tests pass against this PR
* https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/14818004?buildTab=tests&name=onboarding__write&suite=specs%2Fonboarding%2Fonboarding__write.ts%3A+Onboarding%3A+Write+Focus%3A+Register+as+new+user%3A+

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
