### PR TITLE
Update import list to container v2

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -38,8 +38,8 @@ export default function ListStep( props: Props ) {
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 	const fromSite = urlQueryParams.get( 'from' );
-	const title = props.title || __( 'Import content from another platform or file' );
-	const subTitle = props.subTitle || __( "Select the platform you're coming from" );
+	const title = props.title;
+	const subTitle = props.subTitle;
 
 	// We need to remove the wix importer from the primary importers list.
 	const primaryListOptions: ImporterOption[] = getImportersAsImporterOption( 'primary' ).filter(
@@ -71,10 +71,12 @@ export default function ListStep( props: Props ) {
 				</div>
 			) }
 			<div className="list__wrapper">
-				<div className="import__heading import__heading-center">
-					<Title>{ title }</Title>
-					<SubTitle>{ subTitle }</SubTitle>
-				</div>
+				{ title && subTitle && (
+					<div className="import__heading import__heading-center">
+						<Title>{ title }</Title>
+						<SubTitle>{ subTitle }</SubTitle>
+					</div>
+				) }
 				<div className="list__importers list__importers-primary">
 					{ primaryListOptions.map( ( x ) => (
 						<Button

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -22,6 +22,7 @@ interface Props {
 	siteSlug: string | null;
 	title?: string;
 	subTitle?: string;
+	renderHeading?: boolean;
 	submit?: ( dependencies: { platform: ImporterPlatform; url: string } ) => void;
 	getFinalImporterUrl: (
 		siteSlug: string,
@@ -38,6 +39,7 @@ export default function ListStep( props: Props ) {
 	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 	const backToFlow = urlQueryParams.get( 'backToFlow' );
 	const fromSite = urlQueryParams.get( 'from' );
+	const renderHeading = props.renderHeading ?? true;
 	const title = props.title;
 	const subTitle = props.subTitle;
 
@@ -71,7 +73,7 @@ export default function ListStep( props: Props ) {
 				</div>
 			) }
 			<div className="list__wrapper">
-				{ title && subTitle && (
+				{ renderHeading && (
 					<div className="import__heading import__heading-center">
 						<Title>{ title }</Title>
 						<SubTitle>{ subTitle }</SubTitle>

--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -23,14 +23,6 @@ html[dir="rtl"] {
 	}
 }
 
-.is-section-stepper > .wpcom-site > .import-list {
-	padding: 2rem 0;
-
-	@include break-small {
-		padding: 3.75rem 0 0 0;
-	}
-}
-
 .import__onboarding-page {
 	.import-layout {
 		flex-direction: column;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import ListStep from 'calypso/blocks/import/list';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
+import { shouldUseStepContainerV2ImportFlow } from '../../../helpers/should-use-step-container-v2';
 import { ImportWrapper } from '../import';
 import { getFinalImporterUrl } from '../import/helper';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -18,7 +19,9 @@ const ImportList: Step< {
 	};
 } > = function ImportStep( props ) {
 	const siteSlug = useSiteSlug();
-	const { navigation } = props;
+	const { navigation, flow } = props;
+	const useContainerV2 = shouldUseStepContainerV2ImportFlow( flow );
+
 	const text = __( 'Import content from another platform or file' );
 	const subText = __( "Select the platform you're coming from" );
 
@@ -29,6 +32,9 @@ const ImportList: Step< {
 				submit={ navigation.submit }
 				getFinalImporterUrl={ getFinalImporterUrl }
 				{ ...props }
+				renderHeading={ ! useContainerV2 }
+				title={ text }
+				subTitle={ subText }
 			/>
 		</ImportWrapper>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import ListStep from 'calypso/blocks/import/list';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { ImportWrapper } from '../import';
@@ -18,9 +19,11 @@ const ImportList: Step< {
 } > = function ImportStep( props ) {
 	const siteSlug = useSiteSlug();
 	const { navigation } = props;
+	const text = __( 'Import content from another platform or file' );
+	const subText = __( "Select the platform you're coming from" );
 
 	return (
-		<ImportWrapper { ...props }>
+		<ImportWrapper { ...props } text={ text } subText={ subText }>
 			<ListStep
 				siteSlug={ siteSlug }
 				submit={ navigation.submit }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -24,7 +24,7 @@ export const ImportWrapper: StepType< {
 } > = function ( props ) {
 	const { __ } = useI18n();
 	const { navigation, children, flow, stepName, text, subText } = props;
-	const useContainerV2 = shouldUseStepContainerV2ImportFlow( flow );
+	const useContainerV2 = shouldUseStepContainerV2ImportFlow( flow ) && stepName === 'importList';
 	const documentTitle = __( 'Import your site content' );
 	const showHeading = text && subText;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -1,28 +1,54 @@
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { ReactElement } from 'react';
 import CaptureStep from 'calypso/blocks/import/capture';
 import DocumentHead from 'calypso/components/data/document-head';
+import { shouldUseStepContainerV2ImportFlow } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { generateStepPath } from './helper';
-import type { Step } from '../../types';
+import type { Step as StepType } from '../../types';
 import type { ImporterPlatform } from 'calypso/lib/importer/types';
 import './style.scss';
 
-export const ImportWrapper: Step< {
+export const ImportWrapper: StepType< {
 	submits: {
 		platform: ImporterPlatform;
 		url: string;
 	};
+	accepts: {
+		text?: string;
+		subText?: string;
+	};
 } > = function ( props ) {
 	const { __ } = useI18n();
-	const { navigation, children, stepName } = props;
+	const { navigation, children, flow, stepName, text, subText } = props;
+	const useContainerV2 = shouldUseStepContainerV2ImportFlow( flow );
+	const documentTitle = __( 'Import your site content' );
+	const showHeading = text && subText;
+
+	if ( useContainerV2 ) {
+		return (
+			<>
+				<DocumentHead title={ documentTitle } />
+				<Step.CenteredColumnLayout
+					className="importv2__onboarding-page"
+					columnWidth={ 4 }
+					topBar={
+						<Step.TopBar leftElement={ <Step.BackButton onClick={ navigation.goBack } /> } />
+					}
+					heading={ showHeading ? <Step.Heading text={ text } subText={ subText } /> : undefined }
+				>
+					{ children as ReactElement }
+				</Step.CenteredColumnLayout>
+			</>
+		);
+	}
 
 	return (
 		<>
-			<DocumentHead title={ __( 'Import your site content' ) } />
+			<DocumentHead title={ documentTitle } />
 
 			<StepContainer
 				stepName={ stepName || 'import-step' }
@@ -39,7 +65,7 @@ export const ImportWrapper: Step< {
 	);
 };
 
-const ImportStep: Step< {
+const ImportStep: StepType< {
 	submits: {
 		platform: ImporterPlatform;
 		url: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes DOTOBRD-62

## Proposed Changes

Upgrade the import list to use container v2
| Before | After |
|--------|--------|
|<img width="1421" alt="image" src="https://github.com/user-attachments/assets/d6e896db-0cb6-40d5-8781-5913200d9b93" />|<img width="1419" alt="image" src="https://github.com/user-attachments/assets/6af4a18b-c423-4643-ab3f-136c888a05e1" />|
|<img width="464" alt="image" src="https://github.com/user-attachments/assets/88cacf8a-bc09-4e70-bb74-9f5405065cfc" />|<img width="462" alt="image" src="https://github.com/user-attachments/assets/9118bce3-d269-429f-9d0d-d0940fd968ea" />|
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To unify the onboarding look&feel

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live link below
* Go to /sites
* Click on `Import` in the `Add new site` CTA <img width="918" alt="image" src="https://github.com/user-attachments/assets/bbf80f7c-6040-4767-bacc-577b0cddfa95" />
* Verify the import list looks like the one on the before column (both desktop & mobile)
* Add the `flags=onboarding%2Fstep-container-v2-import-flow` query arg to the URL and reload
* Verify the import list looks like the one on the after column (both desktop & mobile)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
