### PR TITLE
Experiment streamlining the plans grid + checkout: Modify the line items

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -288,6 +288,7 @@ function CheckoutSidebarNudge( {
 	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
 	const isPurchaseRenewal = responseCart?.products?.some?.( ( product ) => product.is_renewal );
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	const domainWithoutPlanInCartOrSite =
 		areThereDomainProductsInCart && ! hasPlan( responseCart ) && ! siteHasPaidPlan( selectedSite );
@@ -302,7 +303,9 @@ function CheckoutSidebarNudge( {
 
 	if ( isDIFMInCart ) {
 		return (
-			<CheckoutSidebarNudgeWrapper>
+			<CheckoutSidebarNudgeWrapper
+				isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+			>
 				<CheckoutNextSteps responseCart={ responseCart } />
 			</CheckoutSidebarNudgeWrapper>
 		);
@@ -314,7 +317,9 @@ function CheckoutSidebarNudge( {
 	 */
 
 	return (
-		<CheckoutSidebarNudgeWrapper>
+		<CheckoutSidebarNudgeWrapper
+			isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+		>
 			{ ! ( productsWithVariants.length > 1 ) && (
 				<>
 					<CheckoutSidebarPlanUpsell />
@@ -1217,7 +1222,9 @@ const CheckoutSummaryBody = styled.div`
 	}
 `;
 
-const CheckoutSidebarNudgeWrapper = styled.div`
+const CheckoutSidebarNudgeWrapper = styled.div< {
+	isStreamlinedPrice: boolean;
+} >`
 	display: flex;
 	flex-direction: column;
 	grid-area: nudge;
@@ -1225,6 +1232,11 @@ const CheckoutSidebarNudgeWrapper = styled.div`
 
 	& > * {
 		max-width: 288px;
+		${ ( props ) =>
+			props.isStreamlinedPrice &&
+			css`
+				max-width: 384px;
+			` }
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -212,12 +212,16 @@ export function CheckoutSidebarPlanUpsell() {
 		<>
 			<PromoCard title={ cardTitle } className={ checkoutSidebarPlanUpsellClassName }>
 				<div className="checkout-sidebar-plan-upsell__plan-grid">
-					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-						<strong>{ __( 'Plan' ) }</strong>
-					</div>
-					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-						<strong>{ isComparisonWithIntroOffer ? cellLabel : __( 'Cost' ) }</strong>
-					</div>
+					{ ! streamlinedPriceExperimentAssignment && (
+						<>
+							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+								<strong>{ __( 'Plan' ) }</strong>
+							</div>
+							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
+								<strong>{ isComparisonWithIntroOffer ? cellLabel : __( 'Cost' ) }</strong>
+							</div>
+						</>
+					) }
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 						{ currentVariant.variantLabel.adjective }
 					</div>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -373,7 +373,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 			}
 
 			& s {
-				color: #787c82;
+				color: ${ COLOR_GRAY_40 };
 			}
 
 			& span {
@@ -456,7 +456,7 @@ export function CouponCostOverride( {
 			}
 
 			& .cost-overrides-list-item__discount {
-				color: #008a20;
+				color: ${ COLOR_GREEN_60 };
 				font-weight: 500;
 			}
 		`;

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -327,26 +327,24 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	);
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	if ( streamlinedPriceExperimentAssignment ) {
-		let isDiscounted;
 		let streamlinedActualAmountDisplay;
-		let originalAmountDisplay;
-		if ( ! doesIntroductoryOfferHavePriceIncrease( product ) ) {
-			// logic taken from packages/wpcom-checkout/src/checkout-line-items.tsx
-			const originalAmountInteger = product.item_original_subtotal_integer;
-			originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
-				isSmallestUnit: true,
-				stripZeros: true,
-			} );
-			const itemSubtotalInteger = product.item_subtotal_integer;
-			streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
-				isSmallestUnit: true,
-				stripZeros: true,
-			} );
-			isDiscounted = Boolean(
-				itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
-			);
-		} else {
-			isDiscounted = false;
+
+		// logic taken from packages/wpcom-checkout/src/checkout-line-items.tsx
+		const originalAmountInteger = product.item_original_subtotal_integer;
+		const originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
+		const itemSubtotalInteger = product.item_subtotal_integer;
+		streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
+		const isDiscounted = Boolean(
+			itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
+		);
+
+		if ( ! isDiscounted ) {
 			streamlinedActualAmountDisplay = actualAmountDisplay;
 		}
 

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -57,6 +57,9 @@ const CostOverridesListStyle = styled.div< {
 				padding-right: 24px;
 				padding-left: 0;
 			}
+			& svg {
+				top: 0px;
+			}
 		` }
 
 	& .cost-overrides-list-item {

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -225,6 +225,7 @@ function LineItemCostOverride( {
 	product: ResponseCartProduct;
 } ) {
 	const isPriceIncrease = doesIntroductoryOfferHavePriceIncrease( product );
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	if ( isPriceIncrease ) {
 		return (
 			<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
@@ -239,6 +240,7 @@ function LineItemCostOverride( {
 			</span>
 			<span className="cost-overrides-list-item__discount">
 				{ costOverride.discountAmount &&
+					! streamlinedPriceExperimentAssignment &&
 					formatCurrency( -costOverride.discountAmount, product.currency, {
 						isSmallestUnit: true,
 						signForPositive: true, // TODO clk numberFormatCurrency signForPositive only usage
@@ -325,6 +327,29 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	);
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	if ( streamlinedPriceExperimentAssignment ) {
+		let isDiscounted;
+		let streamlinedActualAmountDisplay;
+		let originalAmountDisplay;
+		if ( ! doesIntroductoryOfferHavePriceIncrease( product ) ) {
+			// logic taken from packages/wpcom-checkout/src/checkout-line-items.tsx
+			const originalAmountInteger = product.item_original_subtotal_integer;
+			originalAmountDisplay = formatCurrency( originalAmountInteger, product.currency, {
+				isSmallestUnit: true,
+				stripZeros: true,
+			} );
+			const itemSubtotalInteger = product.item_subtotal_integer;
+			streamlinedActualAmountDisplay = formatCurrency( itemSubtotalInteger, product.currency, {
+				isSmallestUnit: true,
+				stripZeros: true,
+			} );
+			isDiscounted = Boolean(
+				itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
+			);
+		} else {
+			isDiscounted = false;
+			streamlinedActualAmountDisplay = actualAmountDisplay;
+		}
+
 		const StreamlinedSingleProductAndCostOverridesListWrapper = styled(
 			SingleProductAndCostOverridesListWrapper
 		)`
@@ -341,7 +366,10 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 				<WPCheckoutCheckIcon />
 				<ProductTitleAreaForCostOverridesList>
 					<span className="cost-overrides-list-product__title">{ label }</span>
-					<LineItemPrice actualAmount={ actualAmountDisplay } />
+					<LineItemPrice
+						actualAmount={ streamlinedActualAmountDisplay }
+						crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
+					/>
 				</ProductTitleAreaForCostOverridesList>
 				<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
 			</StreamlinedSingleProductAndCostOverridesListWrapper>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -23,11 +23,13 @@ import {
 	isOverrideCodeIntroductoryOffer,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
+import { formatCurrency, useTranslate } from 'i18n-calypso';
+import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useSelector } from 'calypso/state';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import useCartKey from '../../use-cart-key';
 import { getAffiliateCouponLabel } from '../../utils';
+import { CheckIcon } from './check-icon';
 import type { Theme } from '@automattic/composite-checkout';
 import type { LineItemCostOverrideForDisplay } from '@automattic/wpcom-checkout';
 
@@ -294,6 +296,21 @@ const ProductTitleAreaForCostOverridesList = styled.div`
 	}
 `;
 
+const WPCheckoutCheckIcon = styled( CheckIcon )`
+	fill: ${ ( props ) => props.theme.colors.success };
+	margin-right: 4px;
+	position: absolute;
+	top: 1px;
+	left: 0;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 4px;
+		right: 0;
+		left: auto;
+	}
+`;
+
 function SingleProductAndCostOverridesList( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const costOverridesList = filterCostOverridesForLineItem( product, translate );
@@ -306,6 +323,30 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 			stripZeros: true,
 		}
 	);
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	if ( streamlinedPriceExperimentAssignment ) {
+		const StreamlinedSingleProductAndCostOverridesListWrapper = styled.div`
+			margin-bottom: 4px;
+			padding-left: 24px;
+			position: relative;
+			overflow-wrap: break-word;
+
+			.rtl & {
+				padding-right: 24px;
+				padding-left: 0;
+			}
+		`;
+		return (
+			<StreamlinedSingleProductAndCostOverridesListWrapper>
+				<WPCheckoutCheckIcon />
+				<ProductTitleAreaForCostOverridesList>
+					<span className="cost-overrides-list-product__title">{ label }</span>
+					<LineItemPrice actualAmount={ actualAmountDisplay } />
+				</ProductTitleAreaForCostOverridesList>
+				<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
+			</StreamlinedSingleProductAndCostOverridesListWrapper>
+		);
+	}
 	return (
 		<SingleProductAndCostOverridesListWrapper>
 			<ProductTitleAreaForCostOverridesList>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -325,11 +325,11 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 	);
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	if ( streamlinedPriceExperimentAssignment ) {
-		const StreamlinedSingleProductAndCostOverridesListWrapper = styled.div`
-			margin-bottom: 4px;
+		const StreamlinedSingleProductAndCostOverridesListWrapper = styled(
+			SingleProductAndCostOverridesListWrapper
+		)`
 			padding-left: 24px;
 			position: relative;
-			overflow-wrap: break-word;
 
 			.rtl & {
 				padding-right: 24px;
@@ -369,6 +369,7 @@ export function CouponCostOverride( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const isOnboardingAffiliateFlow = useSelector( getIsOnboardingAffiliateFlow );
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
 	if ( ! responseCart.coupon || ! responseCart.coupon_savings_total_integer ) {
 		return null;
@@ -380,6 +381,47 @@ export function CouponCostOverride( {
 	} );
 
 	const label = isOnboardingAffiliateFlow ? getAffiliateCouponLabel() : couponLabel;
+
+	if ( streamlinedPriceExperimentAssignment ) {
+		const StreamlinedCostOverridesListStyle = styled( CostOverridesListStyle )`
+			padding-left: 24px;
+			position: relative;
+
+			.rtl & {
+				padding-right: 24px;
+				padding-left: 0;
+			}
+		`;
+		return (
+			<StreamlinedCostOverridesListStyle>
+				<WPCheckoutCheckIcon />
+				<div className="cost-overrides-list-item cost-overrides-list-item--coupon">
+					<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
+						{ label }
+					</span>
+					<span className="cost-overrides-list-item__discount">
+						{ formatCurrency( -responseCart.coupon_savings_total_integer, responseCart.currency, {
+							isSmallestUnit: true,
+						} ) }
+					</span>
+				</div>
+				{ removeCoupon && (
+					<span className="cost-overrides-list-item__actions">
+						<DeleteButton
+							buttonType="text-button"
+							disabled={ isDisabled }
+							className="cost-overrides-list-item__actions-remove"
+							onClick={ removeCoupon }
+							aria-label={ translate( 'Remove coupon' ) }
+						>
+							{ translate( 'Remove' ) }
+						</DeleteButton>
+					</span>
+				) }
+			</StreamlinedCostOverridesListStyle>
+		);
+	}
+
 	return (
 		<CostOverridesListStyle>
 			<div className="cost-overrides-list-item cost-overrides-list-item--coupon">

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -22,6 +22,7 @@ import {
 	getLabel,
 	isOverrideCodeIntroductoryOffer,
 } from '@automattic/wpcom-checkout';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
@@ -37,13 +38,26 @@ const PALETTE = colorStudio.colors;
 const COLOR_GRAY_40 = PALETTE[ 'Gray 40' ];
 const COLOR_GREEN_60 = PALETTE[ 'Green 60' ];
 
-const CostOverridesListStyle = styled.div`
+const CostOverridesListStyle = styled.div< {
+	isStreamlinedPrice?: boolean;
+} >`
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	font-size: 12px;
 	font-weight: 400;
 	gap: 2px;
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			padding-left: 24px;
+			position: relative;
+
+			.rtl & {
+				padding-right: 24px;
+				padding-left: 0;
+			}
+		` }
 
 	& .cost-overrides-list-item {
 		display: grid;
@@ -68,6 +82,12 @@ const CostOverridesListStyle = styled.div`
 
 	& .cost-overrides-list-item__discount {
 		white-space: nowrap;
+		${ ( props ) =>
+			props.isStreamlinedPrice &&
+			css`
+				color: ${ COLOR_GREEN_60 };
+				font-weight: 500;
+			` }
 	}
 `;
 
@@ -298,6 +318,54 @@ const ProductTitleAreaForCostOverridesList = styled.div`
 	}
 `;
 
+const StreamlinedSingleProductAndCostOverridesListWrapper = styled(
+	SingleProductAndCostOverridesListWrapper
+)`
+	padding-left: 24px;
+	position: relative;
+
+	.rtl & {
+		padding-right: 24px;
+		padding-left: 0;
+	}
+`;
+
+const StreamlinedLineItemPriceWrapper = styled.span`
+	display: flex;
+	flex: 0 0 auto;
+	gap: 4px;
+	margin-left: 12px;
+	font-size: inherit;
+
+	.rtl & {
+		margin-right: 12px;
+		margin-left: 0;
+	}
+
+	& s {
+		color: ${ COLOR_GRAY_40 };
+	}
+
+	& span {
+		font-weight: 500;
+	}
+`;
+
+const StreamlinedLineItemPrice = function ( {
+	actualAmount,
+	crossedOutAmount,
+}: {
+	actualAmount?: string;
+	crossedOutAmount?: string;
+} ) {
+	return (
+		<StreamlinedLineItemPriceWrapper>
+			{ crossedOutAmount && <s>{ crossedOutAmount }</s> }
+			<span>{ actualAmount }</span>
+		</StreamlinedLineItemPriceWrapper>
+	);
+};
+
 const WPCheckoutCheckIcon = styled( CheckIcon )`
 	fill: ${ ( props ) => props.theme.colors.success };
 	margin-right: 4px;
@@ -348,54 +416,6 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 			streamlinedActualAmountDisplay = actualAmountDisplay;
 		}
 
-		const StreamlinedSingleProductAndCostOverridesListWrapper = styled(
-			SingleProductAndCostOverridesListWrapper
-		)`
-			padding-left: 24px;
-			position: relative;
-
-			.rtl & {
-				padding-right: 24px;
-				padding-left: 0;
-			}
-		`;
-
-		const StreamlinedLineItemPriceWrapper = styled.span`
-			display: flex;
-			flex: 0 0 auto;
-			gap: 4px;
-			margin-left: 12px;
-			font-size: inherit;
-
-			.rtl & {
-				margin-right: 12px;
-				margin-left: 0;
-			}
-
-			& s {
-				color: ${ COLOR_GRAY_40 };
-			}
-
-			& span {
-				font-weight: 500;
-			}
-		`;
-
-		const StreamlinedLineItemPrice = function ( {
-			actualAmount,
-			crossedOutAmount,
-		}: {
-			actualAmount?: string;
-			crossedOutAmount?: string;
-		} ) {
-			return (
-				<StreamlinedLineItemPriceWrapper>
-					{ crossedOutAmount && <s>{ crossedOutAmount }</s> }
-					<span>{ actualAmount }</span>
-				</StreamlinedLineItemPriceWrapper>
-			);
-		};
-
 		return (
 			<StreamlinedSingleProductAndCostOverridesListWrapper>
 				<WPCheckoutCheckIcon />
@@ -445,53 +465,9 @@ export function CouponCostOverride( {
 
 	const label = isOnboardingAffiliateFlow ? getAffiliateCouponLabel() : couponLabel;
 
-	if ( streamlinedPriceExperimentAssignment ) {
-		const StreamlinedCostOverridesListStyle = styled( CostOverridesListStyle )`
-			padding-left: 24px;
-			position: relative;
-
-			.rtl & {
-				padding-right: 24px;
-				padding-left: 0;
-			}
-
-			& .cost-overrides-list-item__discount {
-				color: ${ COLOR_GREEN_60 };
-				font-weight: 500;
-			}
-		`;
-		return (
-			<StreamlinedCostOverridesListStyle>
-				<WPCheckoutCheckIcon />
-				<div className="cost-overrides-list-item cost-overrides-list-item--coupon">
-					<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
-						{ label }
-					</span>
-					<span className="cost-overrides-list-item__discount">
-						{ formatCurrency( -responseCart.coupon_savings_total_integer, responseCart.currency, {
-							isSmallestUnit: true,
-						} ) }
-					</span>
-				</div>
-				{ removeCoupon && (
-					<span className="cost-overrides-list-item__actions">
-						<DeleteButton
-							buttonType="text-button"
-							disabled={ isDisabled }
-							className="cost-overrides-list-item__actions-remove"
-							onClick={ removeCoupon }
-							aria-label={ translate( 'Remove coupon' ) }
-						>
-							{ translate( 'Remove' ) }
-						</DeleteButton>
-					</span>
-				) }
-			</StreamlinedCostOverridesListStyle>
-		);
-	}
-
 	return (
-		<CostOverridesListStyle>
+		<CostOverridesListStyle isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }>
+			{ streamlinedPriceExperimentAssignment && <WPCheckoutCheckIcon /> }
 			<div className="cost-overrides-list-item cost-overrides-list-item--coupon">
 				<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 					{ label }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -23,7 +23,7 @@ import {
 	isOverrideCodeIntroductoryOffer,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { formatCurrency, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useSelector } from 'calypso/state';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -361,12 +361,49 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 				padding-left: 0;
 			}
 		`;
+
+		const StreamlinedLineItemPriceWrapper = styled.span`
+			display: flex;
+			flex: 0 0 auto;
+			gap: 4px;
+			margin-left: 12px;
+			font-size: inherit;
+
+			.rtl & {
+				margin-right: 12px;
+				margin-left: 0;
+			}
+
+			& s {
+				color: #787c82;
+			}
+
+			& span {
+				font-weight: 500;
+			}
+		`;
+
+		const StreamlinedLineItemPrice = function ( {
+			actualAmount,
+			crossedOutAmount,
+		}: {
+			actualAmount?: string;
+			crossedOutAmount?: string;
+		} ) {
+			return (
+				<StreamlinedLineItemPriceWrapper>
+					{ crossedOutAmount && <s>{ crossedOutAmount }</s> }
+					<span>{ actualAmount }</span>
+				</StreamlinedLineItemPriceWrapper>
+			);
+		};
+
 		return (
 			<StreamlinedSingleProductAndCostOverridesListWrapper>
 				<WPCheckoutCheckIcon />
 				<ProductTitleAreaForCostOverridesList>
 					<span className="cost-overrides-list-product__title">{ label }</span>
-					<LineItemPrice
+					<StreamlinedLineItemPrice
 						actualAmount={ streamlinedActualAmountDisplay }
 						crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
 					/>
@@ -418,6 +455,11 @@ export function CouponCostOverride( {
 			.rtl & {
 				padding-right: 24px;
 				padding-left: 0;
+			}
+
+			& .cost-overrides-list-item__discount {
+				color: #008a20;
+				font-weight: 500;
 			}
 		`;
 		return (

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -912,6 +912,7 @@ const CheckoutSummaryCard = styled.div< { isStreamlinedPrice: boolean } >`
 			box-shadow:
 				0 3px 1px rgb( 0 0 0 / 4% ),
 				0 3px 8px rgb( 0 0 0 / 12% );
+			margin-bottom: 20px;
 		` }
 `;
 const CheckoutSummaryFeatures = styled.div`

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -31,8 +31,6 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { isNewsletterFlow, isAnyHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
-	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
-	doesIntroductoryOfferHavePriceIncrease,
 	isBillingInfoEmpty,
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
@@ -193,22 +191,11 @@ function CheckoutSummaryPriceList() {
 	let totalDiscount = 0;
 	if ( streamlinedPriceExperimentAssignment ) {
 		for ( const product of responseCart.products ) {
-			// Calculate due today amount for introductory offers, based on the code from LineItemIntroOfferCostOverrideDetail
-			if (
-				doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
-					product.cost_overrides,
-					product.introductory_offer_terms,
-					product.months_per_bill_period
-				) ||
-				doesIntroductoryOfferHavePriceIncrease( product )
-			) {
-				// While cost_overrides is an array, it seems that it only contains one item for now
-				const dueTodayAmount =
-					product.cost_overrides[ 0 ]?.new_subtotal_integer ?? product.item_subtotal_integer;
-				subtotalBeforeDiscounts += dueTodayAmount;
-			} else {
-				subtotalBeforeDiscounts += product.item_original_subtotal_integer;
-			}
+			// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
+			subtotalBeforeDiscounts += Math.max(
+				product.item_subtotal_integer,
+				product.item_original_subtotal_integer
+			);
 		}
 		totalDiscount = subtotalBeforeDiscounts - responseCart.sub_total_integer;
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -24,6 +24,7 @@ import {
 	isSenseiProduct,
 	PLAN_100_YEARS,
 } from '@automattic/calypso-products';
+import colorStudio from '@automattic/color-studio';
 import { Gridicon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
@@ -60,6 +61,10 @@ import type { TranslateResult } from 'i18n-calypso';
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
+
+const PALETTE = colorStudio.colors;
+const COLOR_GRAY_40 = PALETTE[ 'Gray 40' ];
+const COLOR_GREEN_60 = PALETTE[ 'Green 60' ];
 
 const StyledIcon = styled( Icon )`
 	fill: '#1E1E1E';
@@ -1067,7 +1072,7 @@ const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
 		}
 
 		& s {
-			color: #787c82;
+			color: ${ COLOR_GRAY_40 };
 		}
 
 		& span {
@@ -1078,7 +1083,7 @@ const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
 
 const CheckoutSummaryTotalDiscount = styled( CheckoutSummaryLineItem )`
 	& .wp-checkout-order-summary__subtotal-discount {
-		color: #008a20;
+		color: ${ COLOR_GREEN_60 };
 		font-weight: 500;
 	}
 `;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -31,6 +31,8 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { isNewsletterFlow, isAnyHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
+	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
+	doesIntroductoryOfferHavePriceIncrease,
 	isBillingInfoEmpty,
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
@@ -187,6 +189,30 @@ function CheckoutSummaryPriceList() {
 	const translate = useTranslate();
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 
+	let subtotalBeforeDiscounts = 0;
+	let totalDiscount = 0;
+	if ( streamlinedPriceExperimentAssignment ) {
+		for ( const product of responseCart.unmerged_products ) {
+			// Calculate due today amount for introductory offers, based on the code from LineItemIntroOfferCostOverrideDetail
+			if (
+				doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+					product.cost_overrides,
+					product.introductory_offer_terms,
+					product.months_per_bill_period
+				) ||
+				doesIntroductoryOfferHavePriceIncrease( product )
+			) {
+				// While cost_overrides is an array, it seems that it only contains one item for now
+				const dueTodayAmount =
+					product.cost_overrides[ 0 ]?.new_subtotal_integer ?? product.item_subtotal_integer;
+				subtotalBeforeDiscounts += dueTodayAmount;
+			} else {
+				subtotalBeforeDiscounts += product.item_original_subtotal_integer;
+			}
+		}
+		totalDiscount = subtotalBeforeDiscounts - responseCart.sub_total_integer;
+	}
+
 	return (
 		<>
 			{ streamlinedPriceExperimentAssignment && (
@@ -203,13 +229,35 @@ function CheckoutSummaryPriceList() {
 						<CheckoutSummarySubtotal key="checkout-summary-line-item-subtotal">
 							<span>{ translate( 'Subtotal' ) }</span>
 							<span className="wp-checkout-order-summary__subtotal-price">
-								{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
+								{ totalDiscount > 0 && (
+									<s>
+										{ formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
+											isSmallestUnit: true,
+											stripZeros: true,
+										} ) }
+									</s>
+								) }
+								<span>
+									{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
+										isSmallestUnit: true,
+										stripZeros: true,
+									} ) }
+								</span>
+							</span>
+						</CheckoutSummarySubtotal>
+					) }
+					{ streamlinedPriceExperimentAssignment && totalDiscount > 0 && (
+						<CheckoutSummaryTotalDiscount>
+							<span>{ translate( 'Discount' ) }</span>
+							<span className="wp-checkout-order-summary__subtotal-discount">
+								{ formatCurrency( totalDiscount, responseCart.currency, {
 									isSmallestUnit: true,
 									stripZeros: true,
 								} ) }
 							</span>
-						</CheckoutSummarySubtotal>
+						</CheckoutSummaryTotalDiscount>
 					) }
+
 					{ ! streamlinedPriceExperimentAssignment && (
 						<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
 							<span>{ translate( 'Subtotal' ) }</span>
@@ -1019,6 +1067,31 @@ const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )`
 	font-size: 20px;
 	& .wp-checkout-order-summary__subtotal-price {
 		font-size: 14px;
+
+		display: flex;
+		flex: 0 0 auto;
+		gap: 4px;
+		margin-left: 12px;
+
+		.rtl & {
+			margin-right: 12px;
+			margin-left: 0;
+		}
+
+		& s {
+			color: #787c82;
+		}
+
+		& span {
+			font-weight: 500;
+		}
+	}
+`;
+
+const CheckoutSummaryTotalDiscount = styled( CheckoutSummaryLineItem )`
+	& .wp-checkout-order-summary__subtotal-discount {
+		color: #008a20;
+		font-weight: 500;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -192,7 +192,7 @@ function CheckoutSummaryPriceList() {
 	let subtotalBeforeDiscounts = 0;
 	let totalDiscount = 0;
 	if ( streamlinedPriceExperimentAssignment ) {
-		for ( const product of responseCart.unmerged_products ) {
+		for ( const product of responseCart.products ) {
 			// Calculate due today amount for introductory offers, based on the code from LineItemIntroOfferCostOverrideDetail
 			if (
 				doesIntroductoryOfferHaveDifferentTermLengthThanProduct(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-kUT-p2 and M4R73CH-798
Follow-up to https://github.com/Automattic/wp-calypso/pull/102972

## Proposed Changes

* Change the visual style of the products list in the summary card in checkout to match the Figma designs.

|Before|After|
|------|-----|
|<img width="445" alt="checkout-before" src="https://github.com/user-attachments/assets/a911a173-9269-4298-8e9c-6b81d2d06459" />|<img width="429" alt="checkout-experiment" src="https://github.com/user-attachments/assets/db257312-ff0e-4614-87dc-f26ec611f411" />|

|Example with price increase|Domain/email purchase|Prorated email plan renewal
|------|------|------|
|<img width="407" alt="Screenshot 2025-05-07 at 02 54 32" src="https://github.com/user-attachments/assets/435e68b7-768d-45d8-8b2d-8e718db5b521" />|<img width="407" alt="Screenshot 2025-05-07 at 02 59 39" src="https://github.com/user-attachments/assets/726173ca-768d-4536-805a-ae871a857add" />|<img width="407" alt="Screenshot 2025-05-07 at 03 11 30" src="https://github.com/user-attachments/assets/6b904aad-55c9-4536-a683-db377bbf48e8" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We're experimenting with streamlining the plans and checkout user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to one of the experiment variations of calypso_streamlined_plans_checkout.
* Test the checkout using the following scenarios:
1. A cart with a product with no discounts.
2. A cart with some discounts - a coupon, free domain for the first year, .blog registration.
3. A cart with products with unusual pricing, for example a premium domain registration like ping.global.
4. A cart with an introductory offer.
5. A cart with a renewal for a Titan Email subscription (purchase a new subscription with three free months and immediately renew it).
6. A cart with a product added from Jetpack.com
7. A cart with a product added from Akismet.com
8. Any other use cases you can think of.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
