### PR TITLE
Upgrade importers to container v2

### DIFF
--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -27,6 +27,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 		startImport,
 		resetImport,
 		stepNavigator,
+		renderHeading,
 	} = props;
 
 	/**
@@ -118,6 +119,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 							site={ site }
 							importerData={ getImportDragConfig( importer, stepNavigator?.supportLinkModal ) }
 							importerStatus={ job }
+							renderHeading={ renderHeading }
 						/>
 					);
 				} )() }

--- a/client/blocks/importer/components/importer-drag/index.tsx
+++ b/client/blocks/importer/components/importer-drag/index.tsx
@@ -38,19 +38,22 @@ interface Props {
 	importerData: ImporterConfig;
 	site: SiteDetails | null | undefined;
 	urlData?: UrlData | null;
+	renderHeading?: boolean;
 	startImport: ( siteId: number, type: string ) => void;
 }
 const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {
-	const { importerStatus, importerData, site, urlData /*, startImport*/ } = props;
+	const { importerStatus, importerData, site, urlData, renderHeading } = props;
 	const { errorData, importerState } = importerStatus;
 	const isEnabled = appStates.DISABLED !== importerState;
 
 	return (
 		<div className={ clsx( 'importer-drag', `importer-drag-${ importerData?.engine }` ) }>
-			<div className="import__heading import__heading-center">
-				<Title>{ importerData?.title }</Title>
-				<SubTitle>{ importerData?.description }</SubTitle>
-			</div>
+			{ renderHeading && (
+				<div className="import__heading import__heading-center">
+					<Title>{ importerData?.title }</Title>
+					<SubTitle>{ importerData?.description }</SubTitle>
+				</div>
+			) }
 			{ errorData && (
 				<ErrorPane
 					type={ errorData.type }

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -27,6 +27,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 		startImport,
 		resetImport,
 		stepNavigator,
+		renderHeading,
 	} = props;
 
 	/**
@@ -118,6 +119,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 							site={ site }
 							importerData={ getImportDragConfig( importer, stepNavigator?.supportLinkModal ) }
 							importerStatus={ job }
+							renderHeading={ renderHeading }
 						/>
 					);
 				} )() }

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -27,6 +27,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 		startImport,
 		resetImport,
 		stepNavigator,
+		renderHeading,
 	} = props;
 
 	/**
@@ -118,6 +119,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 							site={ site }
 							importerData={ getImportDragConfig( importer, stepNavigator?.supportLinkModal ) }
 							importerStatus={ job }
+							renderHeading={ renderHeading }
 						/>
 					);
 				} )() }

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -89,4 +89,5 @@ export interface ImporterBaseProps {
 	startImport: ( siteId: number, type: string ) => void;
 	resetImport: ( siteId: number, importerId: string ) => void;
 	stepNavigator?: StepNavigator;
+	renderHeading?: boolean;
 }

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -33,6 +33,7 @@ interface Props {
 	siteSlug: string;
 	siteAnalyzedData: UrlData | null;
 	stepNavigator?: StepNavigator;
+	renderHeading?: boolean;
 }
 
 const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
@@ -43,7 +44,8 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	 ↓ Fields
 	 */
 	const [ renderState, setRenderState ] = useState< RenderState >( 'idle' );
-	const { job, importer, siteItem, siteSlug, siteAnalyzedData, stepNavigator } = props;
+	const { job, importer, siteItem, siteSlug, siteAnalyzedData, stepNavigator, renderHeading } =
+		props;
 	const isSiteCompatible = siteItem && isTargetSitePlanCompatible( siteItem );
 	const planName = getPlan( PLAN_BUSINESS )?.getTitle() || '';
 
@@ -190,6 +192,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 					urlData={ siteAnalyzedData }
 					importerData={ getImportDragConfig( importer, stepNavigator?.supportLinkModal ) }
 					importerStatus={ job }
+					renderHeading={ renderHeading }
 				/>
 			) }
 

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -12,12 +12,13 @@ interface Props {
 	siteId: number;
 	siteSlug: string;
 	stepNavigator?: StepNavigator;
+	renderHeading?: boolean;
 }
 
 export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => {
 	const importer: Importer = 'wordpress';
 
-	const { job, siteSlug, siteId, stepNavigator } = props;
+	const { job, siteSlug, siteId, stepNavigator, renderHeading } = props;
 
 	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 	const isSiteAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
@@ -64,6 +65,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 						siteSlug={ siteSlug }
 						siteAnalyzedData={ fromSiteAnalyzedData }
 						stepNavigator={ stepNavigator }
+						renderHeading={ renderHeading }
 					/>
 				);
 			} )() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-blogger/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-blogger/index.tsx
@@ -2,7 +2,6 @@ import BloggerImporter from 'calypso/blocks/importer/blogger';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { withImporterWrapper } from '../importer';
 import './style.scss';
-
 const Importer = withImporterWrapper( BloggerImporter );
 
 const ImporterBlogger: Step< { submits: Record< string, unknown > } > = function ( props ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Step, StepContainer } from '@automattic/onboarding';
+import { ProgressBar } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useEffect, useMemo } from 'react';
@@ -185,10 +186,18 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		}
 
 		const renderStepContent = () => {
-			if ( isLoading ) {
+			if ( ! useContainerV2 && isLoading ) {
 				return (
 					<div className="import-layout__center">
 						<Loading />
+					</div>
+				);
+			}
+
+			if ( useContainerV2 && isLoading ) {
+				return (
+					<div className="step-container-v2--loading import-layout__center">
+						<ProgressBar className="step-container-v2--loading__progress-bar" />
 					</div>
 				);
 			}
@@ -222,8 +231,10 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		};
 
 		const importJob = getImportJob( importer );
+
 		if ( useContainerV2 ) {
 			const importerData = getImportDragConfig( importer, stepNavigator?.supportLinkModal );
+
 			return (
 				<>
 					<QuerySites siteId={ siteId } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -239,7 +239,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 								[ `importer-wrapper__${ importer }` ]: !! importer,
 							}
 						) }
-						columnWidth={ 4 }
+						columnWidth={ 6 }
 						topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ onGoBack } /> } /> }
 						heading={
 							<Step.Heading text={ importerData.title } subText={ importerData.description } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -3,7 +3,7 @@ import { Step, StepContainer } from '@automattic/onboarding';
 import { ProgressBar } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { getImportDragConfig } from 'calypso/blocks/importer/components/importer-drag/config';
 import NotAuthorized from 'calypso/blocks/importer/components/not-authorized';
 import NotFound from 'calypso/blocks/importer/components/not-found';
@@ -90,6 +90,13 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const isLoading = useMemo( () => {
 			return ! isImporterStatusHydrated || ! hasAllSitesFetched || isRequestingCurrentSite;
 		}, [ isImporterStatusHydrated, hasAllSitesFetched, isRequestingCurrentSite ] );
+
+		const skipToDashboardAction = useCallback( () => {
+			recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
+				from: 'success-step',
+			} );
+			stepNavigator?.goToDashboardPage?.();
+		}, [ stepNavigator ] );
 
 		useSaveHostingFlowPathStep( flow, currentPath );
 
@@ -234,7 +241,13 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 
 		if ( useContainerV2 ) {
 			const importerData = getImportDragConfig( importer, stepNavigator?.supportLinkModal );
+			const showHeading =
+				importJob?.importerState === appStates.MAP_AUTHORS ||
+				importJob?.importerState === appStates.READY_FOR_UPLOAD ||
+				importJob?.importerState === appStates.UPLOAD_PROCESSING ||
+				importJob?.importerState === appStates.UPLOADING;
 
+			const showBackButton = importJob?.importerState !== appStates.IMPORT_SUCCESS;
 			return (
 				<>
 					<QuerySites siteId={ siteId } />
@@ -251,9 +264,22 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 							}
 						) }
 						columnWidth={ 6 }
-						topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ onGoBack } /> } /> }
+						topBar={
+							<Step.TopBar
+								leftElement={ showBackButton ? <Step.BackButton onClick={ onGoBack } /> : null }
+								rightElement={
+									! showBackButton ? (
+										<Step.SkipButton onClick={ skipToDashboardAction }>
+											{ __( 'Skip to dashboard' ) }
+										</Step.SkipButton>
+									) : null
+								}
+							/>
+						}
 						heading={
-							<Step.Heading text={ importerData.title } subText={ importerData.description } />
+							showHeading && (
+								<Step.Heading text={ importerData.title } subText={ importerData.description } />
+							)
 						}
 					>
 						{ renderStepContent() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -1,8 +1,9 @@
 import config from '@automattic/calypso-config';
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useEffect, useMemo } from 'react';
+import { getImportDragConfig } from 'calypso/blocks/importer/components/importer-drag/config';
 import NotAuthorized from 'calypso/blocks/importer/components/not-authorized';
 import NotFound from 'calypso/blocks/importer/components/not-found';
 import { getImporterTypeForEngine } from 'calypso/blocks/importer/util';
@@ -32,6 +33,7 @@ import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { requestSites } from 'calypso/state/sites/actions';
 import { isRequestingSite, hasAllSitesList } from 'calypso/state/sites/selectors';
+import { shouldUseStepContainerV2ImportFlow } from '../../../helpers/should-use-step-container-v2';
 import { StepProps } from '../../types';
 import { useAtomicTransferQueryParamUpdate } from './hooks/use-atomic-transfer-query-param-update';
 import { useInitialQueryRun } from './hooks/use-initial-query-run';
@@ -78,6 +80,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const stepNavigator = useStepNavigator( flow, navigation, siteId, siteSlug, site, fromSite );
 		const currentPath = window.location.pathname + window.location.search;
 		const hasAllSitesFetched = useSelector( hasAllSitesList );
+		const useContainerV2 = shouldUseStepContainerV2ImportFlow( flow );
 
 		const isRequestingCurrentSite = useSelector( ( state ) =>
 			siteId ? isRequestingSite( state, siteId ) : false
@@ -213,11 +216,41 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 					fromSite={ fromSite }
 					urlData={ fromSiteData ?? undefined }
 					stepNavigator={ stepNavigator }
+					renderHeading={ ! useContainerV2 }
 				/>
 			);
 		};
 
 		const importJob = getImportJob( importer );
+		if ( useContainerV2 ) {
+			const importerData = getImportDragConfig( importer, stepNavigator?.supportLinkModal );
+			return (
+				<>
+					<QuerySites siteId={ siteId } />
+					<DocumentHead title={ __( 'Import your site content' ) } />
+					<Interval onTick={ fetchImporters } period={ EVERY_FIVE_SECONDS } />
+					<Step.CenteredColumnLayout
+						className={ clsx(
+							'import__onboarding-page',
+							'importer-wrapper',
+							'step-container-v2--site-migration-identify',
+							'import__onboarding-page--redesign',
+							{
+								[ `importer-wrapper__${ importer }` ]: !! importer,
+							}
+						) }
+						columnWidth={ 4 }
+						topBar={ <Step.TopBar leftElement={ <Step.BackButton onClick={ onGoBack } /> } /> }
+						heading={
+							<Step.Heading text={ importerData.title } subText={ importerData.description } />
+						}
+					>
+						{ renderStepContent() }
+					</Step.CenteredColumnLayout>
+				</>
+			);
+		}
+
 		return (
 			<>
 				<QuerySites siteId={ siteId } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -241,13 +241,15 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 
 		if ( useContainerV2 ) {
 			const importerData = getImportDragConfig( importer, stepNavigator?.supportLinkModal );
-			const showHeading =
-				importJob?.importerState === appStates.MAP_AUTHORS ||
-				importJob?.importerState === appStates.READY_FOR_UPLOAD ||
-				importJob?.importerState === appStates.UPLOAD_PROCESSING ||
-				importJob?.importerState === appStates.UPLOADING;
-
+			const statesToShowHeading: string[] = [
+				appStates.MAP_AUTHORS,
+				appStates.READY_FOR_UPLOAD,
+				appStates.UPLOAD_PROCESSING,
+				appStates.UPLOADING,
+			];
+			const showHeading = statesToShowHeading.includes( importJob?.importerState ?? '' );
 			const showBackButton = importJob?.importerState !== appStates.IMPORT_SUCCESS;
+			const showSkipButton = importJob?.importerState === appStates.IMPORT_SUCCESS;
 			return (
 				<>
 					<QuerySites siteId={ siteId } />
@@ -257,7 +259,6 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 						className={ clsx(
 							'import__onboarding-page',
 							'importer-wrapper',
-							'step-container-v2--site-migration-identify',
 							'import__onboarding-page--redesign',
 							{
 								[ `importer-wrapper__${ importer }` ]: !! importer,
@@ -268,7 +269,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 							<Step.TopBar
 								leftElement={ showBackButton ? <Step.BackButton onClick={ onGoBack } /> : null }
 								rightElement={
-									! showBackButton ? (
+									showSkipButton ? (
 										<Step.SkipButton onClick={ skipToDashboardAction }>
 											{ __( 'Skip to dashboard' ) }
 										</Step.SkipButton>

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -101,7 +101,7 @@ function getConfig( {
 		description: (
 			<p>
 				{ translate(
-					'Import posts, pages, comments, tags, and images from a . wakaca %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
+					'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
 					{
 						args: {
 							importerName: 'Blogger',

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -101,7 +101,7 @@ function getConfig( {
 		description: (
 			<p>
 				{ translate(
-					'Import posts, pages, comments, tags, and images from a %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
+					'Import posts, pages, comments, tags, and images from a . wakaca %(importerName)s export file to {{b}}%(siteTitle)s{{/b}}.',
 					{
 						args: {
 							importerName: 'Blogger',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related DOTOBRD-129

## Proposed Changes

Upgrade all the importers in this list to support container v2
<img width="514" alt="image" src="https://github.com/user-attachments/assets/14ee8e37-a4ef-4df4-906e-9f3f7eaad4c1" />

I introduced changes on the generic import wrapper, but the individual steps also need to be tweaked.

This PR  introduces containerv2 design to the old import flow. The approach in itself is hacky, since the import flow is embedded in stepper but it's not directly built with it. A non-hacky approach would involve rewriting big chunks of the import flow.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To apply container v2 looks to the old importer flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**The main purpose of the test is to verify that the current view is not broken by the changes.**
* Use the calypso.live link below
* Go to /sites
* Click on `Import` in the `Add new site` CTA <img width="918" alt="image" src="https://github.com/user-attachments/assets/bbf80f7c-6040-4767-bacc-577b0cddfa95" />
* For each of the modified options (WordPress, Blogger, Medium, Squarespace)
  * Verify that everything looks unchanged: header, back buttons, titles, import component
  * Go through the import flow, upload a file and verify everything looks as expected
 
The containerv2 looks should work too and you can test them by adding the query arg `flags=onboarding%2Fstep-container-v2-import-flow` to the url of each individual importer. This is not the main aim of this PR since that will be tested as a whole when toggling the feature flag.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
