### PR TITLE
Fix `filterSortAndPaginate` function for `undefined` values with `is` filter

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -59,11 +59,10 @@ const DEFAULT_FIELDS = [
 	{
 		id: 'backups',
 		label: __( 'Backups' ),
-		getValue: ( { item }: { item: Site } ) =>
-			item.plan?.features?.active?.includes( 'backups' ) || undefined,
+		getValue: ( { item }: { item: Site } ) => !! item.plan?.features?.active?.includes( 'backups' ),
 		elements: [
 			{ value: true, label: __( 'Enabled' ) },
-			{ value: undefined, label: __( 'Disabled' ) },
+			{ value: false, label: __( 'Disabled' ) },
 		],
 		render: ( { item }: { item: Site } ) =>
 			item.plan?.features?.active?.includes( 'backups' ) ? (
@@ -78,13 +77,12 @@ const DEFAULT_FIELDS = [
 	{
 		id: 'protect',
 		label: __( 'Protect' ),
-		getValue: ( { item }: { item: Site } ) =>
-			item.active_modules?.includes( 'protect' ) || undefined,
+		getValue: ( { item }: { item: Site } ) => !! item.active_modules?.includes( 'protect' ),
 		render: ( { item }: { item: Site } ) =>
 			item.active_modules?.includes( 'protect' ) ? <Icon icon={ check } /> : __( 'Disabled' ),
 		elements: [
 			{ value: true, label: __( 'Enabled' ) },
-			{ value: undefined, label: __( 'Disabled' ) },
+			{ value: false, label: __( 'Disabled' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as Operator ],
@@ -100,10 +98,10 @@ const DEFAULT_FIELDS = [
 	{
 		id: 'a8c_owned',
 		label: __( 'A8C Owned' ),
-		getValue: ( { item }: { item: Site } ) => isA8CSite( item ) || undefined,
+		getValue: ( { item }: { item: Site } ) => isA8CSite( item ),
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
-			{ value: undefined, label: __( 'No' ) },
+			{ value: false, label: __( 'No' ) },
 		],
 		filterBy: {
 			operators: [ 'is' as Operator ],
@@ -179,7 +177,7 @@ export default function Sites() {
 						{
 							field: 'a8c_owned',
 							operator: 'is',
-							value: undefined,
+							value: false,
 						},
 					],
 			  }

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -4,6 +4,7 @@
 
 - Expose `<DataViews.Search />` component.
 - Add support for `free-composition` in the `DataViews` component
+- Fix `filterSortAndPaginate` to handle undefined values for the `is` filter.
 
 ## 0.1.0
 

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -121,7 +121,10 @@ export function filterSortAndPaginate< Item >(
 					} );
 				} else if ( filter.operator === OPERATOR_IS ) {
 					filteredData = filteredData.filter( ( item ) => {
-						return filter.value === field.getValue( { item } );
+						return (
+							filter.value === field.getValue( { item } ) ||
+							filter.value === undefined
+						);
 					} );
 				} else if ( filter.operator === OPERATOR_IS_NOT ) {
 					filteredData = filteredData.filter( ( item ) => {

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -230,6 +230,34 @@ describe( 'filters', () => {
 		expect( result[ 1 ].title ).toBe( 'Space' );
 		expect( result[ 2 ].title ).toBe( 'NASA' );
 	} );
+
+	it( 'should search using IS filter and return all values if filter.value is undefined', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'type',
+						operator: 'is',
+						value: undefined,
+					},
+				],
+			},
+			fields
+		);
+		expect( result ).toHaveLength( 11 );
+		expect( result[ 0 ].title ).toBe( 'Apollo' );
+		expect( result[ 1 ].title ).toBe( 'Space' );
+		expect( result[ 2 ].title ).toBe( 'NASA' );
+		expect( result[ 3 ].title ).toBe( 'Neptune' );
+		expect( result[ 4 ].title ).toBe( 'Mercury' );
+		expect( result[ 5 ].title ).toBe( 'Venus' );
+		expect( result[ 6 ].title ).toBe( 'Earth' );
+		expect( result[ 7 ].title ).toBe( 'Mars' );
+		expect( result[ 8 ].title ).toBe( 'Jupiter' );
+		expect( result[ 9 ].title ).toBe( 'Saturn' );
+		expect( result[ 10 ].title ).toBe( 'Uranus' );
+	} );
 } );
 
 describe( 'sorting', () => {


### PR DESCRIPTION
Related to DOTCOM-12935

## Proposed Changes

- Updates `a8c_owned`, `protected`, and `backup` fields to be boolean values.
- Fixes `filterSortAndPaginate` function to work well with undefined values.

## Why are these changes being made?

There are situations when a filter value can be undefined: when the user added the filter but haven't set a value, when the filter is primary without a value, etc. In those scenarios, when the filter is undefined, `filterSortAndPaginate` should consider there's no filter applied to the field.

## Testing Instructions

Verify that the `backups`, `protect`, and `a8c_owned` work as expected. For example, when the user initially adds the filter we shouldn't have any value set yet (to prevent changing the set before the user does any action, to prevent side effects such as network requests from triggering, etc.).

https://github.com/user-attachments/assets/5077d2b2-713f-4bab-ae79-de9ea541885d

