### PR TITLE
Add PoweredBy component

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -71,3 +71,4 @@ export { ExperienceControl } from './experience-control';
 export { default as SummaryButton } from './summary-button';
 export { default as CoreBadge } from './core-badge';
 export { default as Menu } from './menu';
+export { PoweredBy } from './powered-by';

--- a/packages/components/src/logos/jetpack-logo/index.tsx
+++ b/packages/components/src/logos/jetpack-logo/index.tsx
@@ -8,6 +8,8 @@ const PALETTE = colorStudio.colors;
 const COLOR_JETPACK = PALETTE[ 'Jetpack Green 40' ];
 const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
 
+export type JetpackLogoColorVariant = 'color' | 'black' | 'white';
+
 type JetpackLogoProps = {
 	/**
 	 * Whether to render the full logo.
@@ -24,27 +26,46 @@ type JetpackLogoProps = {
 	 * @default false
 	 */
 	monochrome?: boolean;
+	/**
+	 * Color variant
+	 * @default 'color'
+	 */
+	colorVariant?: JetpackLogoColorVariant;
+	className?: string;
 };
 
-const LogoPathSize32 = ( { monochrome = false }: Pick< JetpackLogoProps, 'monochrome' > ) => {
-	const primary = monochrome ? 'white' : COLOR_JETPACK;
-	const secondary = monochrome ? 'black' : COLOR_WHITE;
+const getJetpackColors = ( colorVariant: JetpackLogoColorVariant ) => {
+	switch ( colorVariant ) {
+		case 'black':
+			return { primary: 'black', secondary: 'white' };
+		case 'white':
+			return { primary: 'white', secondary: 'black' };
+		case 'color':
+		default:
+			return { primary: COLOR_JETPACK, secondary: COLOR_WHITE };
+	}
+};
 
+const LogoPathSize32 = ( {
+	colorVariant = 'color',
+	monochrome = false,
+}: Pick< JetpackLogoProps, 'colorVariant' | 'monochrome' > ) => {
+	const { primary, secondary } = getJetpackColors( colorVariant );
 	return (
 		<>
 			<path
 				className="jetpack-logo__icon-circle"
-				fill={ primary }
+				fill={ monochrome ? 'white' : primary }
 				d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
 			/>
 			<polygon
 				className="jetpack-logo__icon-triangle"
-				fill={ secondary }
+				fill={ monochrome ? 'black' : secondary }
 				points="15,19 7,19 15,3 "
 			/>
 			<polygon
 				className="jetpack-logo__icon-triangle"
-				fill={ secondary }
+				fill={ monochrome ? 'black' : secondary }
 				points="17,29 17,13 25,13 "
 			/>
 		</>
@@ -64,22 +85,40 @@ const LogoPathSize32Monochrome = () => (
 	</>
 );
 
+/**
+ * JetpackLogo component
+ *
+ * The 'colorVariant' prop controls the color scheme of the logo: 'color', 'black', or 'white'.
+ * - 'color': Uses Jetpack green and white (default).
+ * - 'black': Renders the logo in black and white.
+ * - 'white': Renders the logo in white and black (for dark backgrounds).
+ *
+ * The 'monochrome' prop, when true, overrides the 'colorVariant' and renders the logo and text in a single color scheme:
+ * - The icon is white, and the text and triangles are black, regardless of the 'colorVariant'.
+ */
 export const JetpackLogo = ( {
 	full = false,
 	monochrome = false,
 	size = 32,
+	colorVariant = 'color',
 	className,
 	...props
 }: JetpackLogoProps & React.SVGProps< SVGSVGElement > ) => {
 	const classes = clsx( 'jetpack-logo', className );
 
 	if ( full === true ) {
+		const textFill = colorVariant === 'white' && ! monochrome ? '#fff' : '#151E25';
 		return (
 			<svg height={ size } className={ classes } viewBox="0 0 118 32" { ...props }>
 				<title>Jetpack</title>
-				{ monochrome ? <LogoPathSize32Monochrome /> : <LogoPathSize32 /> }
+				{ monochrome ? (
+					<LogoPathSize32Monochrome />
+				) : (
+					<LogoPathSize32 colorVariant={ colorVariant } />
+				) }
 				<path
 					className="jetpack-logo__text"
+					fill={ textFill }
 					d="M41.3 26.6c-.5-.7-.9-1.4-1.3-2.1 2.3-1.4 3-2.5 3-4.6V8h-3V6h6v13.4C46 22.8 45 24.8 41.3 26.6zM58.5 21.3c-1.5.5-2.7.6-4.2.6-3.6 0-5.8-1.8-5.8-6 0-3.1 1.9-5.9 5.5-5.9s4.9 2.5 4.9 4.9c0 .8 0 1.5-.1 2h-7.3c.1 2.5 1.5 2.8 3.6 2.8 1.1 0 2.2-.3 3.4-.7C58.5 19 58.5 21.3 58.5 21.3zM56 15c0-1.4-.5-2.9-2-2.9-1.4 0-2.3 1.3-2.4 2.9C51.6 15 56 15 56 15zM65 18.4c0 1.1.8 1.3 1.4 1.3.5 0 2-.2 2.6-.4v2.1c-.9.3-2.5.5-3.7.5-1.5 0-3.2-.5-3.2-3.1V12H60v-2h2.1V7.1H65V10h4v2h-4V18.4zM71 10h3v1.3c1.1-.8 1.9-1.3 3.3-1.3 2.5 0 4.5 1.8 4.5 5.6s-2.2 6.3-5.8 6.3c-.9 0-1.3-.1-2-.3V28h-3V10zM76.5 12.3c-.8 0-1.6.4-2.5 1.2v5.9c.6.1.9.2 1.8.2 2 0 3.2-1.3 3.2-3.9C79 13.4 78.1 12.3 76.5 12.3zM93 22h-3v-1.5c-.9.7-1.9 1.5-3.5 1.5-1.5 0-3.1-1.1-3.1-3.2 0-2.9 2.5-3.4 4.2-3.7l2.4-.3v-.3c0-1.5-.5-2.3-2-2.3-.7 0-2.3.5-3.7 1.1L84 11c1.2-.4 3-1 4.4-1 2.7 0 4.6 1.4 4.6 4.7L93 22zM90 16.4l-2.2.4c-.7.1-1.4.5-1.4 1.6 0 .9.5 1.4 1.3 1.4s1.5-.5 2.3-1V16.4zM104.5 21.3c-1.1.4-2.2.6-3.5.6-4.2 0-5.9-2.4-5.9-5.9 0-3.7 2.3-6 6.1-6 1.4 0 2.3.2 3.2.5V13c-.8-.3-2-.6-3.2-.6-1.7 0-3.2.9-3.2 3.6 0 2.9 1.5 3.8 3.3 3.8.9 0 1.9-.2 3.2-.7V21.3zM110 15.2c.2-.3.2-.8 3.8-5.2h3.7l-4.6 5.7 5 6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z"
 				/>
 			</svg>
@@ -96,7 +135,11 @@ export const JetpackLogo = ( {
 
 	return (
 		<svg className={ classes } height={ size } width={ size } viewBox="0 0 32 32" { ...props }>
-			{ monochrome ? <LogoPathSize32Monochrome /> : <LogoPathSize32 /> }
+			{ monochrome ? (
+				<LogoPathSize32Monochrome />
+			) : (
+				<LogoPathSize32 colorVariant={ colorVariant } />
+			) }
 		</svg>
 	);
 };

--- a/packages/components/src/logos/jetpack-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/jetpack-logo/stories/index.stories.tsx
@@ -9,16 +9,44 @@ export default meta;
 
 type Story = StoryObj< typeof JetpackLogo >;
 
-export const Default: Story = {};
+export const Color: Story = {
+	args: { colorVariant: 'color' },
+};
 
-export const Full: Story = {
-	args: {
-		full: true,
-	},
+export const Black: Story = {
+	args: { colorVariant: 'black' },
+};
+
+export const White: Story = {
+	args: { colorVariant: 'white' },
+	decorators: [
+		( Story ) => (
+			<div style={ { background: '#000', padding: '20px' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const FullColor: Story = {
+	args: { full: true, colorVariant: 'color' },
+};
+
+export const FullBlack: Story = {
+	args: { full: true, colorVariant: 'black' },
+};
+
+export const FullWhite: Story = {
+	args: { full: true, colorVariant: 'white' },
+	decorators: [
+		( Story ) => (
+			<div style={ { background: '#000', padding: '20px' } }>
+				<Story />
+			</div>
+		),
+	],
 };
 
 export const Monochrome: Story = {
-	args: {
-		monochrome: true,
-	},
+	args: { monochrome: true },
 };

--- a/packages/components/src/logos/woo-logo/index.tsx
+++ b/packages/components/src/logos/woo-logo/index.tsx
@@ -1,42 +1,60 @@
-export const WooLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
-	<svg
-		version="1.1"
-		id="Layer_1"
-		xmlns="http://www.w3.org/2000/svg"
-		xmlnsXlink="http://www.w3.org/1999/xlink"
-		x="0px"
-		y="0px"
-		width="30"
-		height="19"
-		viewBox="0 0 183.6 47.5"
-		{ ...props }
-	>
-		<style type="text/css">
-			{ `
-				.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#873EFF;}
-				.st1{fill-rule:evenodd;clip-rule:evenodd;}
-				.st2{fill:#873EFF;}
-				.st3{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
-				.st4{fill:#FFFFFF;}
-			` }
-		</style>
-		<g>
-			<path
-				className="st0"
-				d="M77.4,0c-4.3,0-7.1,1.4-9.6,6.1L56.4,27.6V8.5c0-5.7-2.7-8.5-7.7-8.5s-7.1,1.7-9.6,6.5L28.3,27.6V8.7
-				c0-6.1-2.5-8.7-8.6-8.7H7.3C2.6,0,0,2.2,0,6.2s2.5,6.4,7.1,6.4h5.1v24.1c0,6.8,4.6,10.8,11.2,10.8s9.6-2.6,12.9-8.7l7.2-13.5v11.4
-				c0,6.7,4.4,10.8,11.1,10.8s9.2-2.3,13-8.7l16.6-28C87.8,4.7,85.3,0,77.3,0C77.3,0,77.3,0,77.4,0z"
-			/>
-			<path
-				className="st0"
-				d="M108.6,0C95,0,84.7,10.1,84.7,23.8s10.4,23.7,23.9,23.7s23.8-10.1,23.9-23.7C132.5,10.1,122.1,0,108.6,0z
-				 M108.6,32.9c-5.1,0-8.6-3.8-8.6-9.1s3.5-9.2,8.6-9.2s8.6,3.9,8.6,9.2S113.8,32.9,108.6,32.9z"
-			/>
-			<path
-				className="st0"
-				d="M159.7,0c-13.5,0-23.9,10.1-23.9,23.8s10.4,23.7,23.9,23.7s23.9-10.1,23.9-23.7S173.2,0,159.7,0z M159.7,32.9
-				c-5.2,0-8.5-3.8-8.5-9.1s3.4-9.2,8.5-9.2s8.6,3.9,8.6,9.2S164.9,32.9,159.7,32.9z"
-			/>
-		</g>
-	</svg>
-);
+import colorStudio from '@automattic/color-studio';
+
+const PALETTE = colorStudio.colors;
+const COLOR_WOO_PURPLE = PALETTE[ 'WooCommerce Purple 40' ];
+
+export type WooLogoColorVariant = 'color' | 'black' | 'white';
+
+interface WooLogoProps extends React.SVGProps< SVGSVGElement > {
+	colorVariant?: WooLogoColorVariant;
+	height?: number;
+	width?: number;
+}
+
+export const WooLogo = ( {
+	colorVariant = 'color',
+	height = 19,
+	width = 30,
+	...props
+}: WooLogoProps ) => {
+	let fill = COLOR_WOO_PURPLE;
+	if ( colorVariant === 'white' ) {
+		fill = '#fff';
+	} else if ( colorVariant === 'black' ) {
+		fill = '#000';
+	}
+
+	return (
+		<svg
+			version="1.1"
+			id="Layer_1"
+			xmlns="http://www.w3.org/2000/svg"
+			xmlnsXlink="http://www.w3.org/1999/xlink"
+			x="0px"
+			y="0px"
+			width={ width }
+			height={ height }
+			viewBox="0 0 183.6 47.5"
+			{ ...props }
+		>
+			<g>
+				<path
+					fill={ fill }
+					d="M77.4,0c-4.3,0-7.1,1.4-9.6,6.1L56.4,27.6V8.5c0-5.7-2.7-8.5-7.7-8.5s-7.1,1.7-9.6,6.5L28.3,27.6V8.7
+					c0-6.1-2.5-8.7-8.6-8.7H7.3C2.6,0,0,2.2,0,6.2s2.5,6.4,7.1,6.4h5.1v24.1c0,6.8,4.6,10.8,11.2,10.8s9.6-2.6,12.9-8.7l7.2-13.5v11.4
+					c0,6.7,4.4,10.8,11.1,10.8s9.2-2.3,13-8.7l16.6-28C87.8,4.7,85.3,0,77.3,0C77.3,0,77.3,0,77.4,0z"
+				/>
+				<path
+					fill={ fill }
+					d="M108.6,0C95,0,84.7,10.1,84.7,23.8s10.4,23.7,23.9,23.7s23.8-10.1,23.9-23.7C132.5,10.1,122.1,0,108.6,0z
+					 M108.6,32.9c-5.1,0-8.6-3.8-8.6-9.1s3.5-9.2,8.6-9.2s8.6,3.9,8.6,9.2S113.8,32.9,108.6,32.9z"
+				/>
+				<path
+					fill={ fill }
+					d="M159.7,0c-13.5,0-23.9,10.1-23.9,23.8s10.4,23.7,23.9,23.7s23.9-10.1,23.9-23.7S173.2,0,159.7,0z M159.7,32.9
+					c-5.2,0-8.5-3.8-8.5-9.1s3.4-9.2,8.5-9.2s8.6,3.9,8.6,9.2S164.9,32.9,159.7,32.9z"
+				/>
+			</g>
+		</svg>
+	);
+};

--- a/packages/components/src/logos/woo-logo/stories/index.stories.tsx
+++ b/packages/components/src/logos/woo-logo/stories/index.stories.tsx
@@ -9,4 +9,21 @@ export default meta;
 
 type Story = StoryObj< typeof WooLogo >;
 
-export const Default: Story = {};
+export const Color: Story = {
+	args: { colorVariant: 'color' },
+};
+
+export const Black: Story = {
+	args: { colorVariant: 'black' },
+};
+
+export const White: Story = {
+	args: { colorVariant: 'white' },
+	decorators: [
+		( Story ) => (
+			<div style={ { background: '#000', padding: '20px' } }>
+				<Story />
+			</div>
+		),
+	],
+};

--- a/packages/components/src/powered-by/README.md
+++ b/packages/components/src/powered-by/README.md
@@ -1,0 +1,27 @@
+# PoweredBy (JSX)
+
+A React component for displaying "Powered by" branding with a logo for Jetpack, WooCommerce, or WordPress.com.
+
+---
+
+## How to use
+
+```js
+import { PoweredBy } from '@automattic/components';
+
+export default function Example() {
+	return (
+		<div>
+			<PoweredBy brand="jetpack" />
+			<PoweredBy brand="woocommerce" colorVariant="black" />
+			<PoweredBy brand="wpcom" colorVariant="white" />
+		</div>
+	);
+}
+```
+
+## Props
+
+- `brand` : (string, required) One of `'jetpack'`, `'woocommerce'`, `'wpcom'`
+- `colorVariant` : (string) One of `'color'`, `'black'`, `'white'`. Default is `'color'`
+- `className` : (string) Additional CSS class names

--- a/packages/components/src/powered-by/index.tsx
+++ b/packages/components/src/powered-by/index.tsx
@@ -1,0 +1,82 @@
+import './style.scss';
+
+import colorStudio from '@automattic/color-studio';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import React from 'react';
+import { JetpackLogo } from '../logos/jetpack-logo';
+import { WooLogo } from '../logos/woo-logo';
+import WordPressWordmark from '../wordpress-wordmark';
+
+const PALETTE = colorStudio.colors;
+const COLOR_WPCOM_BLUE = PALETTE[ 'Blue 50' ];
+const COLOR_WHITE = PALETTE[ 'White' ];
+const COLOR_BLACK = PALETTE[ 'Black' ];
+
+export type PoweredByBrand = 'jetpack' | 'woocommerce' | 'wpcom';
+export type PoweredByVariant = 'color' | 'black' | 'white';
+
+interface PoweredByProps {
+	brand: PoweredByBrand;
+	colorVariant?: PoweredByVariant;
+	className?: string;
+}
+
+const getBrandName = ( brand: PoweredByBrand ) => {
+	switch ( brand ) {
+		case 'jetpack':
+			return 'Jetpack';
+		case 'woocommerce':
+			return 'WooCommerce';
+		case 'wpcom':
+			return 'WordPress.com';
+	}
+};
+
+const getWordPressWordmarkColor = ( colorVariant: PoweredByVariant ) => {
+	switch ( colorVariant ) {
+		case 'white':
+			return COLOR_WHITE;
+		case 'black':
+			return COLOR_BLACK;
+		default:
+			return COLOR_WPCOM_BLUE;
+	}
+};
+
+const PoweredBy = ( { brand, colorVariant = 'color', className }: PoweredByProps ) => {
+	let LogoComponent: React.ReactNode = null;
+
+	switch ( brand ) {
+		case 'jetpack':
+			LogoComponent = <JetpackLogo colorVariant={ colorVariant } size={ 25 } full />;
+			break;
+		case 'woocommerce':
+			LogoComponent = <WooLogo colorVariant={ colorVariant } height={ 25 } width={ 66 } />;
+			break;
+		case 'wpcom':
+			LogoComponent = (
+				<WordPressWordmark
+					color={ getWordPressWordmarkColor( colorVariant ) }
+					size={ { height: 25, width: 'auto' } }
+				/>
+			);
+			break;
+	}
+
+	return (
+		<p className={ clsx( 'powered-by', className, `is-${ brand }`, `is-${ colorVariant }` ) }>
+			{ createInterpolateElement( __( '<text>Powered by</text> <logo/>', 'calypso' ), {
+				text: <span className="powered-by__text" />,
+				logo: (
+					<span className="powered-by__logo" aria-label={ getBrandName( brand ) }>
+						{ LogoComponent }
+					</span>
+				),
+			} ) }
+		</p>
+	);
+};
+
+export { PoweredBy };

--- a/packages/components/src/powered-by/powered-by.stories.tsx
+++ b/packages/components/src/powered-by/powered-by.stories.tsx
@@ -1,0 +1,91 @@
+import { PoweredBy } from './index';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof PoweredBy > = {
+	title: 'packages/components/PoweredBy',
+	component: PoweredBy,
+};
+export default meta;
+
+type Story = StoryObj< typeof PoweredBy >;
+
+export const Jetpack: Story = {
+	args: {
+		brand: 'jetpack',
+	},
+};
+
+export const JetpackBlack: Story = {
+	args: {
+		brand: 'jetpack',
+		colorVariant: 'black',
+	},
+};
+
+export const JetpackWhite: Story = {
+	args: {
+		brand: 'jetpack',
+		colorVariant: 'white',
+	},
+	decorators: [
+		( Story ) => (
+			<div style={ { background: '#000', padding: '20px' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const WPCom: Story = {
+	args: {
+		brand: 'wpcom',
+	},
+};
+
+export const WPComBlack: Story = {
+	args: {
+		brand: 'wpcom',
+		colorVariant: 'black',
+	},
+};
+
+export const WPComWhite: Story = {
+	args: {
+		brand: 'wpcom',
+		colorVariant: 'white',
+	},
+	decorators: [
+		( Story ) => (
+			<div style={ { background: '#000', padding: '20px' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const WooCommerce: Story = {
+	args: {
+		brand: 'woocommerce',
+	},
+};
+
+export const WooCommerceBlack: Story = {
+	args: {
+		brand: 'woocommerce',
+		colorVariant: 'black',
+	},
+};
+
+export const WooCommerceWhite: Story = {
+	args: {
+		brand: 'woocommerce',
+		colorVariant: 'white',
+	},
+	decorators: [
+		( Story ) => (
+			<div style={ { background: '#000', padding: '20px' } }>
+				<Story />
+			</div>
+		),
+	],
+};

--- a/packages/components/src/powered-by/style.scss
+++ b/packages/components/src/powered-by/style.scss
@@ -1,0 +1,30 @@
+@import '@wordpress/base-styles/variables';
+
+.powered-by {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: $grid-unit-10;
+	margin: 20px;
+
+	&__text {
+		color: var( --color-text );
+		white-space: nowrap;
+	}
+
+	&__logo {
+		display: inline-flex;
+
+		.wpcom-wordmark {
+			margin-top: -4px; // Adjust vertical alignment for WordPress.com wordmark
+		}
+	}
+
+	&.is-white &__text {
+		color: #fff;
+	}
+
+	.powered-by-logo {
+		display: block;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #102185 / DS-54

## Proposed Changes

Add a PoweredBy automattic/component like in this figma: [dhW7zYBamXJIeJIE3wy5f4-fi-111_474](https://href.li/?https://www.figma.com/file/dhW7zYBamXJIeJIE3wy5f4/?node-id=111-474)
Make it available in the branding colours, and in black and white

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The PoweredBy component will be used to bring consistency to the product across WordPress.com and beyond. Sometimes we say " powered" and sometimes we say "Powered by ", this state of affairs cannot continue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### PoweredBy

1. Checkout the branch locally
2. Run `yarn && yarn run start` as normal
3. Run `yarn components:storybook:start`
4. Go to the `PoweredBy` component and have a play

You should see it looks like this:

![Screen Shot 2025-04-30 at 21 54 11-fullpage](https://github.com/user-attachments/assets/b92b4cf4-5f6a-447b-8cfb-29f08f248e83)



If you look at the JetpackLogo and WooLogo components, you will see that by default they look identically to how they do in the trunk storybook.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
