### PR TITLE
Stats: Navigation polish, replace SectionNav with TabPanel component

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -205,9 +205,7 @@ class StatsNavigation extends Component {
 					>
 						{ ( tab ) => {
 							if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-								page(
-									`${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`
-								);
+								window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
 							} else if ( tab.path ) {
 								page( tab.path );
 							}

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -36,6 +36,8 @@ import PageModuleToggler from './page-module-toggler';
 
 import './style.scss';
 
+const isNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
+
 // Helper to expose logic for default module listing.
 export function getAvailablePageModules( selectedItem, hasVideoPress ) {
 	return ( AVAILABLE_PAGE_MODULES[ selectedItem ] || [] ).map( ( toggleItem ) => {

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -237,50 +237,84 @@ class StatsNavigation extends Component {
 		return (
 			<div className={ wrapperClass }>
 				{ siteId && <QueryJetpackModules siteId={ siteId } /> }
-				<SectionNav selectedText={ label }>
-					<NavTabs selectedText={ label }>
-						{ Object.keys( navItems )
+				{ isNavigationImprovementEnabled ? (
+					<TabPanel
+						className="stats-navigation__tabs"
+						tabs={ Object.keys( navItems )
 							.filter( this.isValidItem )
 							.map( ( item ) => {
 								const navItem = navItems[ item ];
 								const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
 								const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-								const className = 'stats-navigation__' + item;
-								if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-									return (
-										<NavItem
-											className={ className }
-											key={ item }
-											onClick={ () =>
-												( window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview` )
-											}
-											selected={ false }
-										>
-											{ navItem.label }
-										</NavItem>
-									);
-								}
-								return (
-									<NavItem
-										className={ className }
-										key={ item }
-										path={ itemPath }
-										selected={ selectedItem === item }
-									>
-										{ navItem.label }
-										{ navItem.paywall && showLock && ' 🔒' }
-									</NavItem>
-								);
+
+								return {
+									name: item,
+									title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
+									className: 'stats-navigation__' + item,
+									path: itemPath,
+								};
 							} ) }
-					</NavTabs>
+						onSelect={ ( tab ) => {
+							if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+								window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
+								return;
+							}
+							if ( tab.path ) {
+								window.location.href = tab.path;
+							}
+						} }
+					>
+						{ () => null /* TabPanel requires children but we handle navigation in onSelect */ }
+					</TabPanel>
+				) : (
+					//TODO: remove this SectionNav in favour of above TabPanel once Navigation Improvement is fully launched
+					<>
+						<SectionNav selectedText={ label }>
+							<NavTabs selectedText={ label }>
+								{ Object.keys( navItems )
+									.filter( this.isValidItem )
+									.map( ( item ) => {
+										const navItem = navItems[ item ];
+										const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
+										const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+										const className = 'stats-navigation__' + item;
+										if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+											return (
+												<NavItem
+													className={ className }
+													key={ item }
+													onClick={ () =>
+														( window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview` )
+													}
+													selected={ false }
+												>
+													{ navItem.label }
+												</NavItem>
+											);
+										}
+										return (
+											<NavItem
+												className={ className }
+												key={ item }
+												path={ itemPath }
+												selected={ selectedItem === item }
+											>
+												{ navItem.label }
+												{ navItem.paywall && showLock && ' 🔒' }
+											</NavItem>
+										);
+									} ) }
+							</NavTabs>
 
-					{ isLegacy && showIntervals && (
-						<Intervals selected={ interval } pathTemplate={ pathTemplate } />
-					) }
-				</SectionNav>
+							{ isLegacy && showIntervals && (
+								<Intervals selected={ interval } pathTemplate={ pathTemplate } />
+							) }
+						</SectionNav>
 
-				{ isLegacy && showIntervals && (
-					<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
+						{ isLegacy && showIntervals && (
+							<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
+						) }
+					</>
 				) }
 
 				{ shouldRenderModuleToggler && (

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -247,7 +248,6 @@ class StatsNavigation extends Component {
 								const navItem = navItems[ item ];
 								const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
 								const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-
 								return {
 									name: item,
 									title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
@@ -255,17 +255,18 @@ class StatsNavigation extends Component {
 									path: itemPath,
 								};
 							} ) }
-						onSelect={ ( tab ) => {
-							if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-								window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
-								return;
-							}
-							if ( tab.path ) {
-								window.location.href = tab.path;
-							}
-						} }
+						initialTabName={ selectedItem }
 					>
-						{ () => null /* TabPanel requires children but we handle navigation in onSelect */ }
+						{ ( tab ) => {
+							if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+								page(
+									`${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`
+								);
+							} else if ( tab.path ) {
+								page( tab.path );
+							}
+							return <div className="stats-navigation__content" />; // Placeholder div since content is rendered elsewhere
+						} }
 					</TabPanel>
 				) : (
 					//TODO: remove this SectionNav in favour of above TabPanel once Navigation Improvement is fully launched

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -227,6 +227,7 @@ class StatsNavigation extends Component {
 
 		const shouldRenderModuleToggler =
 			! isLegacy &&
+			! isNavigationImprovementEnabled &&
 			isModuleSettingsSupported &&
 			AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] &&
 			! hideModuleSettings &&

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -175,7 +175,6 @@ class StatsNavigation extends Component {
 
 		const shouldRenderModuleToggler =
 			! isLegacy &&
-			! isNavigationImprovementEnabled &&
 			isModuleSettingsSupported &&
 			AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] &&
 			! hideModuleSettings &&
@@ -186,7 +185,7 @@ class StatsNavigation extends Component {
 		return (
 			<div className={ wrapperClass }>
 				{ siteId && <QueryJetpackModules siteId={ siteId } /> }
-				{ isNavigationImprovementEnabled ? (
+				{ isStatsNavigationImprovementEnabled ? (
 					<TabPanel
 						className="stats-navigation__tabs"
 						tabs={ Object.keys( navItems )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Replaces `SectionNav` from `calypso/components/` with `TabPanel` from `@wordpress/components`
* Provides the styling from the relevant figma designs

**Note:**

- There will be a follow up PR to check + address the Jetpack colouring in Odyssey

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Polishing the navigation tabs according to design specifications, particularly for desktop view.
* Part of [Stats: Improve navigation](https://linear.app/a8c/project/stats-improve-navigation-26f1f0cd5616) project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live branch
* Apply the feature flag `stats/navigation-improvement`
* Check how the new navigation layout works referring to the image below:

| Before  | After | Figma Design |
| ------------- | ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/1535065c-0bd5-4d1e-9b2f-0e2ce1b7ad9f) | ![image](https://github.com/user-attachments/assets/5043841d-5329-4108-b802-8b02d3a27eef) | ![image](https://github.com/user-attachments/assets/1662b491-4b34-473d-95ab-eaa2236aeb55)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
