### PR TITLE
HAPD-904 - Remove /learn/ from the nav and footer

### DIFF
--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -2,7 +2,6 @@
 import {
 	localizeUrl as pureLocalizeUrl,
 	removeLocaleFromPathLocaleInFront,
-	useIsEnglishLocale,
 	useLocale,
 	useLocalizeUrl,
 } from '@automattic/i18n-utils';
@@ -64,8 +63,6 @@ export const PureUniversalNavbarFooter = ( {
 	locale,
 	languageOptions = allLanguageOptions,
 }: PureFooterProps ) => {
-	const isEnglishLocale = locale === 'en';
-
 	const languageEntries = Object.entries( languageOptions );
 
 	return (
@@ -234,13 +231,6 @@ export const PureUniversalNavbarFooter = ( {
 									<a href={ localizeUrl( 'https://wordpress.com/reader/search/' ) } target="_self">
 										{ __( 'Blog Search', __i18n_text_domain__ ) }
 									</a>
-								</li>
-								<li>
-									{ isEnglishLocale && (
-										<a href={ localizeUrl( 'https://wordpress.com/learn/' ) } target="_self">
-											{ __( 'Learn WordPress', __i18n_text_domain__ ) }
-										</a>
-									) }
 								</li>
 								<li>
 									<a
@@ -465,7 +455,6 @@ const UniversalNavbarFooter = ( {
 	const localizeUrl = useLocalizeUrl();
 	const locale = useLocale();
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const pathNameWithoutLocale =
 		currentRoute && removeLocaleFromPathLocaleInFront( currentRoute ).slice( 1 );
 	const [ automatticBranding, setAutomatticBranding ] = useState<
@@ -485,13 +474,12 @@ const UniversalNavbarFooter = ( {
 	return (
 		<PureUniversalNavbarFooter
 			locale={ locale }
-			isEnglishLocale={ isEnglishLocale }
-			automatticBranding={ automatticBranding }
 			isLoggedIn={ isLoggedIn }
 			currentRoute={ pathNameWithoutLocale }
 			additionalCompanyLinks={ additionalCompanyLinks }
 			onLanguageChange={ onLanguageChange }
 			localizeUrl={ localizeUrl }
+			automatticBranding={ automatticBranding }
 		/>
 	);
 };

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -301,15 +301,6 @@ const UniversalNavbarHeader = ( {
 															type="dropdown"
 															target="_self"
 														/>
-														{ isEnglishLocale && (
-															<ClickableItem
-																titleValue=""
-																content={ __( 'Learn WordPress', __i18n_text_domain__ ) }
-																urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
-																type="dropdown"
-																target="_self"
-															/>
-														) }
 													</ul>
 												</div>
 											</li>
@@ -620,14 +611,6 @@ const UniversalNavbarHeader = ( {
 												urlValue={ localizeUrl( '//wordpress.com/reader/search/' ) }
 												type="menu"
 											/>
-											{ isEnglishLocale && (
-												<ClickableItem
-													titleValue=""
-													content={ __( 'Learn WordPress', __i18n_text_domain__ ) }
-													urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
-													type="menu"
-												/>
-											) }
 										</ul>
 									</div>
 								</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to HAPD-904


## Proposed Changes

* Removes /learn/ link from nav
* Removes /learn/ link from footer

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* /learn/ has been merged with /support/, so we are now removing the unnecessary links from the nav and footer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Use the live testing link, or visit http://calypso.localhost:3000/plugins
* Verify that the links to `Learn WordPress` have been removed from the `Resources` section within the nav and footer
<img width="1193" alt="Screenshot 2025-04-30 at 10 24 56 PM" src="https://github.com/user-attachments/assets/488a0661-480c-442d-977a-70c15af86890" />
<img width="1273" alt="Screenshot 2025-04-30 at 10 25 08 PM" src="https://github.com/user-attachments/assets/6be33edf-fdc3-4882-916b-01f85c076c41" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
