### PR TITLE
Account Recovery: Update page layout

### DIFF
--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -1,4 +1,3 @@
-import { FormLabel } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -48,11 +47,6 @@ export class FormPhoneInput extends Component {
 		return (
 			<div className={ clsx( this.props.className, 'form-phone-input' ) }>
 				<FormFieldset className="form-phone-input__country">
-					<FormLabel htmlFor="country_code">
-						{ this.props.translate( 'Country code', {
-							context: 'The country code for the phone for the user.',
-						} ) }
-					</FormLabel>
 					<FormCountrySelect
 						{ ...this.props.countrySelectProps }
 						countriesList={ this.props.countriesList }
@@ -64,10 +58,10 @@ export class FormPhoneInput extends Component {
 				</FormFieldset>
 
 				<FormFieldset className="form-phone-input__phone-number">
-					<FormLabel htmlFor="phone_number">{ this.props.translate( 'Phone number' ) }</FormLabel>
 					<FormTelInput
 						{ ...this.props.phoneInputProps }
 						disabled={ this.props.isDisabled }
+						id="phone_number"
 						name="phone_number"
 						value={ this.state.phoneNumber }
 						onChange={ this.handlePhoneChange }

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -1,3 +1,4 @@
+import { FormLabel } from '@automattic/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -16,6 +17,7 @@ export class FormPhoneInput extends Component {
 		initialCountryCode: PropTypes.string,
 		initialPhoneNumber: PropTypes.string,
 		countriesList: PropTypes.array.isRequired,
+		isHideLabels: PropTypes.bool,
 		isDisabled: PropTypes.bool,
 		countrySelectProps: PropTypes.object,
 		phoneInputProps: PropTypes.object,
@@ -24,6 +26,7 @@ export class FormPhoneInput extends Component {
 	};
 
 	static defaultProps = {
+		isHideLabels: false,
 		isDisabled: false,
 		countrySelectProps: {},
 		phoneInputProps: {},
@@ -47,6 +50,13 @@ export class FormPhoneInput extends Component {
 		return (
 			<div className={ clsx( this.props.className, 'form-phone-input' ) }>
 				<FormFieldset className="form-phone-input__country">
+					{ ! this.props.isHideLabels && (
+						<FormLabel htmlFor="country_code">
+							{ this.props.translate( 'Country code', {
+								context: 'The country code for the phone for the user.',
+							} ) }
+						</FormLabel>
+					) }
 					<FormCountrySelect
 						{ ...this.props.countrySelectProps }
 						countriesList={ this.props.countriesList }
@@ -58,10 +68,12 @@ export class FormPhoneInput extends Component {
 				</FormFieldset>
 
 				<FormFieldset className="form-phone-input__phone-number">
+					{ ! this.props.isHideLabels && (
+						<FormLabel htmlFor="phone_number">{ this.props.translate( 'Phone number' ) }</FormLabel>
+					) }
 					<FormTelInput
 						{ ...this.props.phoneInputProps }
 						disabled={ this.props.isDisabled }
-						id="phone_number"
 						name="phone_number"
 						value={ this.state.phoneNumber }
 						onChange={ this.handlePhoneChange }

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -17,7 +17,6 @@ export class FormPhoneInput extends Component {
 		initialCountryCode: PropTypes.string,
 		initialPhoneNumber: PropTypes.string,
 		countriesList: PropTypes.array.isRequired,
-		isHideLabels: PropTypes.bool,
 		isDisabled: PropTypes.bool,
 		countrySelectProps: PropTypes.object,
 		phoneInputProps: PropTypes.object,
@@ -26,7 +25,6 @@ export class FormPhoneInput extends Component {
 	};
 
 	static defaultProps = {
-		isHideLabels: false,
 		isDisabled: false,
 		countrySelectProps: {},
 		phoneInputProps: {},
@@ -50,13 +48,11 @@ export class FormPhoneInput extends Component {
 		return (
 			<div className={ clsx( this.props.className, 'form-phone-input' ) }>
 				<FormFieldset className="form-phone-input__country">
-					{ ! this.props.isHideLabels && (
-						<FormLabel htmlFor="country_code">
-							{ this.props.translate( 'Country code', {
-								context: 'The country code for the phone for the user.',
-							} ) }
-						</FormLabel>
-					) }
+					<FormLabel htmlFor="country_code">
+						{ this.props.translate( 'Country code', {
+							context: 'The country code for the phone for the user.',
+						} ) }
+					</FormLabel>
 					<FormCountrySelect
 						{ ...this.props.countrySelectProps }
 						countriesList={ this.props.countriesList }
@@ -68,9 +64,7 @@ export class FormPhoneInput extends Component {
 				</FormFieldset>
 
 				<FormFieldset className="form-phone-input__phone-number">
-					{ ! this.props.isHideLabels && (
-						<FormLabel htmlFor="phone_number">{ this.props.translate( 'Phone number' ) }</FormLabel>
-					) }
+					<FormLabel htmlFor="phone_number">{ this.props.translate( 'Phone number' ) }</FormLabel>
 					<FormTelInput
 						{ ...this.props.phoneInputProps }
 						disabled={ this.props.isDisabled }

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -12,6 +12,7 @@ class SecurityAccountRecoveryManageContactButtons extends Component {
 		saveText: PropTypes.string,
 		onSave: PropTypes.func.isRequired,
 		onDelete: PropTypes.func.isRequired,
+		onCancel: PropTypes.func.isRequired,
 	};
 
 	render() {
@@ -24,6 +25,12 @@ class SecurityAccountRecoveryManageContactButtons extends Component {
 				{ this.props.isDeletable ? (
 					<FormButton isPrimary={ false } scary onClick={ this.props.onDelete }>
 						{ this.props.translate( 'Remove' ) }
+					</FormButton>
+				) : null }
+
+				{ this.props.onCancel ? (
+					<FormButton isPrimary={ false } onClick={ this.props.onCancel }>
+						{ this.props.translate( 'Cancel' ) }
 					</FormButton>
 				) : null }
 			</div>

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -12,7 +11,6 @@ class SecurityAccountRecoveryManageContactButtons extends Component {
 		isDeletable: PropTypes.bool,
 		saveText: PropTypes.string,
 		onSave: PropTypes.func.isRequired,
-		onCancel: PropTypes.func.isRequired,
 		onDelete: PropTypes.func.isRequired,
 	};
 
@@ -23,15 +21,10 @@ class SecurityAccountRecoveryManageContactButtons extends Component {
 					{ this.props.saveText ? this.props.saveText : this.props.translate( 'Save' ) }
 				</FormButton>
 
-				<FormButton isPrimary={ false } onClick={ this.props.onCancel }>
-					{ this.props.translate( 'Cancel' ) }
-				</FormButton>
-
 				{ this.props.isDeletable ? (
-					<button className="security-account-recovery__remove" onClick={ this.props.onDelete }>
-						<Gridicon icon="trash" size={ 24 } />
-						<span>{ this.props.translate( 'Remove' ) }</span>
-					</button>
+					<FormButton isPrimary={ false } scary onClick={ this.props.onDelete }>
+						{ this.props.translate( 'Remove' ) }
+					</FormButton>
 				) : null }
 			</div>
 		);

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -22,7 +22,7 @@ class SecurityAccountRecoveryManageContactButtons extends Component {
 					{ this.props.saveText ? this.props.saveText : this.props.translate( 'Save' ) }
 				</FormButton>
 
-				{ this.props.isDeletable ? (
+				{ this.props.isDeletable && this.props.onDelete ? (
 					<FormButton isPrimary={ false } scary onClick={ this.props.onDelete }>
 						{ this.props.translate( 'Remove' ) }
 					</FormButton>

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -11,8 +11,8 @@ class SecurityAccountRecoveryManageContactButtons extends Component {
 		isDeletable: PropTypes.bool,
 		saveText: PropTypes.string,
 		onSave: PropTypes.func.isRequired,
-		onDelete: PropTypes.func.isRequired,
 		onCancel: PropTypes.func.isRequired,
+		onDelete: PropTypes.func.isRequired,
 	};
 
 	render() {

--- a/client/me/security-account-recovery/edit-email.jsx
+++ b/client/me/security-account-recovery/edit-email.jsx
@@ -1,4 +1,4 @@
-import { FormInputValidation } from '@automattic/components';
+import { FormInputValidation, FormLabel } from '@automattic/components';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -14,7 +14,6 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 	static propTypes = {
 		storedEmail: PropTypes.string,
 		onSave: PropTypes.func,
-		onCancel: PropTypes.func,
 		onDelete: PropTypes.func,
 	};
 
@@ -59,15 +58,18 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 		return (
 			<div className={ this.props.className }>
 				<FormFieldset>
+					<FormLabel htmlFor="email">
+						{ this.props.translate( 'Recovery email address' ) }
+					</FormLabel>
 					<FormTextInput
 						isError={ this.state.isInvalid }
 						onKeyUp={ this.onKeyUp }
+						id="email"
 						name="email"
 						ref={ this.emailInputRef }
 						value={ this.state.email }
 						onChange={ this.handleChange }
 					/>
-
 					{ this.renderValidation() }
 					{ this.renderExplanation() }
 				</FormFieldset>
@@ -78,7 +80,6 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 					saveText={ this.props.translate( 'Save Email' ) }
 					onSave={ this.onSave }
 					onDelete={ this.onDelete }
-					onCancel={ this.onCancel }
 				/>
 			</div>
 		);
@@ -119,10 +120,6 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 		}
 
 		this.props.onSave( email );
-	};
-
-	onCancel = () => {
-		this.props.onCancel();
 	};
 
 	onDelete = () => {

--- a/client/me/security-account-recovery/edit-email.jsx
+++ b/client/me/security-account-recovery/edit-email.jsx
@@ -2,7 +2,7 @@ import { FormInputValidation, FormLabel } from '@automattic/components';
 import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component, createRef } from 'react';
+import { Component } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -21,14 +21,9 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 		storedEmail: null,
 	};
 
-	emailInputRef = createRef();
 	state = {
 		email: this.props.storedEmail || null,
 	};
-
-	componentDidMount() {
-		this.focusInput();
-	}
 
 	renderValidation = () => {
 		let validation = null;
@@ -58,9 +53,7 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 		return (
 			<div className={ this.props.className }>
 				<FormFieldset>
-					<FormLabel htmlFor="email">
-						{ this.props.translate( 'Recovery email address' ) }
-					</FormLabel>
+					<FormLabel htmlFor="email">{ this.props.translate( 'Email address' ) }</FormLabel>
 					<FormTextInput
 						isError={ this.state.isInvalid }
 						onKeyUp={ this.onKeyUp }
@@ -84,10 +77,6 @@ class SecurityAccountRecoveryRecoveryEmailEdit extends Component {
 			</div>
 		);
 	}
-
-	focusInput = () => {
-		this.emailInputRef.current.focus();
-	};
 
 	isSavable = () => {
 		if ( ! this.state.email ) {

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -55,9 +55,10 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 
 				<Buttons
 					isSavable={ this.isSavable() }
-					isDeletable={ false }
+					isDeletable={ havePhone }
 					saveText={ this.props.translate( 'Save Number' ) }
 					onSave={ this.onSave }
+					onDelete={ this.props.onDelete }
 					onCancel={ this.props.onCancel }
 				/>
 			</div>

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -1,4 +1,4 @@
-import { FormInputValidation } from '@automattic/components';
+import { FormInputValidation, FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -22,7 +22,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 			numberFull: PropTypes.string,
 		} ),
 		onSave: PropTypes.func,
-		onCancel: PropTypes.func,
 		onDelete: PropTypes.func,
 	};
 
@@ -34,6 +33,9 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 		return (
 			<div>
 				<FormFieldset>
+					<FormLabel htmlFor="phone_number">
+						{ this.props.translate( 'Recovery SMS number' ) }
+					</FormLabel>
 					<QuerySmsCountries />
 					<FormPhoneInput
 						countriesList={ this.props.countriesList }
@@ -56,7 +58,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 					saveText={ this.props.translate( 'Save Number' ) }
 					onSave={ this.onSave }
 					onDelete={ this.onDelete }
-					onCancel={ this.onCancel }
 				/>
 			</div>
 		);
@@ -109,10 +110,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 			number: phoneNumber.phoneNumber,
 			numberFull: phoneNumber.phoneNumberFull,
 		} );
-	};
-
-	onCancel = () => {
-		this.props.onCancel();
 	};
 
 	onDelete = () => {

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -58,7 +58,7 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 					isDeletable={ false }
 					saveText={ this.props.translate( 'Save Number' ) }
 					onSave={ this.onSave }
-					onCancel={ this.onCancel }
+					onCancel={ this.props.onCancel }
 				/>
 			</div>
 		);
@@ -111,10 +111,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 			number: phoneNumber.phoneNumber,
 			numberFull: phoneNumber.phoneNumberFull,
 		} );
-	};
-
-	onCancel = () => {
-		this.props.onCancel();
 	};
 }
 

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -22,7 +22,7 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 			numberFull: PropTypes.string,
 		} ),
 		onSave: PropTypes.func,
-		onDelete: PropTypes.func,
+		onCancel: PropTypes.func,
 	};
 
 	state = {};
@@ -44,6 +44,7 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 						phoneInputProps={ {
 							onKeyUp: this.onKeyUp,
 						} }
+						isHideLabels
 						onChange={ this.onChange }
 					/>
 
@@ -54,10 +55,10 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 
 				<Buttons
 					isSavable={ this.isSavable() }
-					isDeletable={ havePhone }
+					isDeletable={ false }
 					saveText={ this.props.translate( 'Save Number' ) }
 					onSave={ this.onSave }
-					onDelete={ this.onDelete }
+					onCancel={ this.onCancel }
 				/>
 			</div>
 		);
@@ -112,8 +113,8 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 		} );
 	};
 
-	onDelete = () => {
-		this.props.onDelete();
+	onCancel = () => {
+		this.props.onCancel();
 	};
 }
 

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -1,4 +1,4 @@
-import { FormInputValidation, FormLabel } from '@automattic/components';
+import { FormInputValidation } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -23,6 +23,7 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 		} ),
 		onSave: PropTypes.func,
 		onCancel: PropTypes.func,
+		onDelete: PropTypes.func,
 	};
 
 	state = {};
@@ -33,9 +34,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 		return (
 			<div>
 				<FormFieldset>
-					<FormLabel htmlFor="phone_number">
-						{ this.props.translate( 'Recovery SMS number' ) }
-					</FormLabel>
 					<QuerySmsCountries />
 					<FormPhoneInput
 						countriesList={ this.props.countriesList }

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -42,7 +42,6 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 						phoneInputProps={ {
 							onKeyUp: this.onKeyUp,
 						} }
-						isHideLabels
 						onChange={ this.onChange }
 					/>
 
@@ -68,7 +67,7 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends Component {
 			return false;
 		}
 
-		if ( ! this.state.phoneNumber.phoneNumberFull ) {
+		if ( ! this.state.phoneNumber.phoneNumber || ! this.state.phoneNumber.phoneNumberFull ) {
 			return false;
 		}
 

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { CompactCard } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -7,6 +7,7 @@ import QueryAccountRecoverySettings from 'calypso/components/data/query-account-
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -61,7 +62,7 @@ const SecurityAccountRecovery = ( props ) => (
 
 		<DocumentHead title={ props.translate( 'Account Recovery' ) } />
 
-		<CompactCard>
+		<Card>
 			<p className="security-account-recovery__text">
 				{ props.translate(
 					'Keep your account safe by adding a backup email address and phone number. ' +
@@ -69,40 +70,47 @@ const SecurityAccountRecovery = ( props ) => (
 						'you enter here to verify your identity.'
 				) }
 			</p>
-		</CompactCard>
+		</Card>
 
-		<CompactCard>
-			<RecoveryEmail
-				primaryEmail={ props.primaryEmail }
-				email={ props.accountRecoveryEmail }
-				updateEmail={ props.updateAccountRecoveryEmail }
-				deleteEmail={ props.deleteAccountRecoveryEmail }
-				isLoading={ props.accountRecoveryEmailActionInProgress }
-			/>
-			{ props.shouldPromptEmailValidationNotice && ! props.hasSentEmailValidation && (
-				<RecoveryEmailValidationNotice
-					onResend={ props.resendAccountRecoveryEmailValidation }
-					hasSent={ props.hasSentEmailValidation }
+		<div className="security-account-recovery__recovery-email">
+			<SectionHeader label={ props.translate( 'Email address' ) } />
+			<Card>
+				{ props.shouldPromptEmailValidationNotice && ! props.hasSentEmailValidation && (
+					<RecoveryEmailValidationNotice
+						onResend={ props.resendAccountRecoveryEmailValidation }
+						hasSent={ props.hasSentEmailValidation }
+					/>
+				) }
+				<RecoveryEmail
+					primaryEmail={ props.primaryEmail }
+					email={ props.accountRecoveryEmail }
+					updateEmail={ props.updateAccountRecoveryEmail }
+					deleteEmail={ props.deleteAccountRecoveryEmail }
+					isLoading={ props.accountRecoveryEmailActionInProgress }
 				/>
-			) }
-		</CompactCard>
+			</Card>
+		</div>
 
-		<CompactCard>
-			<RecoveryPhone
-				phone={ props.accountRecoveryPhone }
-				updatePhone={ props.updateAccountRecoveryPhone }
-				deletePhone={ props.deleteAccountRecoveryPhone }
-				isLoading={ props.accountRecoveryPhoneActionInProgress }
-			/>
-			{ props.shouldPromptPhoneValidationNotice && (
-				<RecoveryPhoneValidationNotice
-					onResend={ props.resendAccountRecoveryPhoneValidation }
-					onValidate={ props.validateAccountRecoveryPhone }
-					hasSent={ props.hasSentPhoneValidation }
-					isValidating={ props.validatingAccountRecoveryPhone }
+		<div className="security-account-recovery__recovery-sms-number">
+			<SectionHeader label={ props.translate( 'Phone number' ) } />
+			<Card>
+				<RecoveryPhone
+					phone={ props.accountRecoveryPhone }
+					updatePhone={ props.updateAccountRecoveryPhone }
+					deletePhone={ props.deleteAccountRecoveryPhone }
+					isLoading={ props.accountRecoveryPhoneActionInProgress }
+					isUpdateMode={ props.shouldPromptPhoneValidationNotice }
 				/>
-			) }
-		</CompactCard>
+				{ props.shouldPromptPhoneValidationNotice && (
+					<RecoveryPhoneValidationNotice
+						onResend={ props.resendAccountRecoveryPhoneValidation }
+						onValidate={ props.validateAccountRecoveryPhone }
+						hasSent={ props.hasSentPhoneValidation }
+						isValidating={ props.validatingAccountRecoveryPhone }
+					/>
+				) }
+			</Card>
+		</div>
 	</Main>
 );
 

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -92,7 +92,7 @@ const SecurityAccountRecovery = ( props ) => (
 		</div>
 
 		<div className="security-account-recovery__recovery-sms-number">
-			<SectionHeader label={ props.translate( 'Recovery phone number' ) } />
+			<SectionHeader label={ props.translate( 'Recovery SMS number' ) } />
 			<Card>
 				<RecoveryPhone
 					phone={ props.accountRecoveryPhone }

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -73,7 +73,7 @@ const SecurityAccountRecovery = ( props ) => (
 		</Card>
 
 		<div className="security-account-recovery__recovery-email">
-			<SectionHeader label={ props.translate( 'Email address' ) } />
+			<SectionHeader label={ props.translate( 'Recovery email address' ) } />
 			<Card>
 				{ props.shouldPromptEmailValidationNotice && ! props.hasSentEmailValidation && (
 					<RecoveryEmailValidationNotice
@@ -92,7 +92,7 @@ const SecurityAccountRecovery = ( props ) => (
 		</div>
 
 		<div className="security-account-recovery__recovery-sms-number">
-			<SectionHeader label={ props.translate( 'Phone number' ) } />
+			<SectionHeader label={ props.translate( 'Recovery phone number' ) } />
 			<Card>
 				<RecoveryPhone
 					phone={ props.accountRecoveryPhone }

--- a/client/me/security-account-recovery/manage-contact.jsx
+++ b/client/me/security-account-recovery/manage-contact.jsx
@@ -10,6 +10,7 @@ class ManageContact extends Component {
 				{ cloneElement( this.props.children, {
 					onSave: this.onSave,
 					onDelete: this.onDelete,
+					onCancel: this.onCancel,
 				} ) }
 			</div>
 		);
@@ -40,6 +41,11 @@ class ManageContact extends Component {
 	onDelete = () => {
 		this.props.onDelete();
 		this.recordEvent( 'delete' );
+	};
+
+	onCancel = () => {
+		this.props.onCancel();
+		this.recordEvent( 'cancel' );
 	};
 
 	recordEvent( action ) {

--- a/client/me/security-account-recovery/manage-contact.jsx
+++ b/client/me/security-account-recovery/manage-contact.jsx
@@ -10,7 +10,7 @@ class ManageContact extends Component {
 				{ cloneElement( this.props.children, {
 					onSave: this.onSave,
 					onDelete: this.onDelete,
-					onCancel: this.onCancel,
+					onCancel: this.props.onCancel && this.onCancel,
 				} ) }
 			</div>
 		);

--- a/client/me/security-account-recovery/manage-contact.jsx
+++ b/client/me/security-account-recovery/manage-contact.jsx
@@ -1,71 +1,18 @@
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { cloneElement, Component } from 'react';
-import FormButton from 'calypso/components/forms/form-button';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
-const views = {
-	VIEWING: 'VIEWING',
-	EDITING: 'EDITING',
-};
-
 class ManageContact extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			currentView: views.VIEWING,
-		};
-	}
-
-	renderHeader() {
-		const isEditing = views.EDITING === this.state.currentView;
-		const { translate } = this.props;
-
+	renderEdit() {
 		return (
-			<div className="security-account-recovery-contact__header">
-				<div className="security-account-recovery-contact__header-info">
-					<span className="security-account-recovery-contact__header-title">
-						{ this.props.title }
-					</span>
-					{ isEditing ? null : (
-						<span className="security-account-recovery-contact__header-subtitle">
-							{ this.props.subtitle }
-						</span>
-					) }
-				</div>
-
-				{ isEditing ? null : (
-					<div className="security-account-recovery-contact__header-action">
-						<FormButton
-							disabled={ this.props.disabled }
-							isPrimary={ false }
-							onClick={ this.onEdit }
-						>
-							{ this.props.hasValue ? translate( 'Edit' ) : translate( 'Add' ) }
-						</FormButton>
-					</div>
-				) }
+			<div className="security-account-recovery-contact__detail">
+				{ cloneElement( this.props.children, {
+					onSave: this.onSave,
+					onDelete: this.onDelete,
+				} ) }
 			</div>
 		);
-	}
-
-	renderEdit() {
-		let view = null;
-
-		if ( views.EDITING === this.state.currentView ) {
-			view = (
-				<div className="security-account-recovery-contact__detail">
-					{ cloneElement( this.props.children, {
-						onCancel: this.onCancel,
-						onSave: this.onSave,
-						onDelete: this.onDelete,
-					} ) }
-				</div>
-			);
-		}
-
-		return view;
 	}
 
 	renderLoading() {
@@ -82,38 +29,17 @@ class ManageContact extends Component {
 			return this.renderLoading();
 		}
 
-		return (
-			<div className="security-account-recovery-contact">
-				{ this.renderHeader() }
-				{ this.renderEdit() }
-			</div>
-		);
+		return <div className="security-account-recovery-contact">{ this.renderEdit() }</div>;
 	}
 
-	onEdit = () => {
-		this.setState( { currentView: views.EDITING }, function () {
-			this.recordEvent( this.props.hasValue ? 'edit' : 'add' );
-		} );
-	};
-
-	onCancel = () => {
-		this.setState( { currentView: views.VIEWING }, function () {
-			this.recordEvent( 'cancel' );
-		} );
-	};
-
 	onSave = ( data ) => {
-		this.setState( { currentView: views.VIEWING }, function () {
-			this.props.onSave( data );
-			this.recordEvent( 'save' );
-		} );
+		this.props.onSave( data );
+		this.recordEvent( 'save' );
 	};
 
 	onDelete = () => {
-		this.setState( { currentView: views.VIEWING }, function () {
-			this.props.onDelete();
-			this.recordEvent( 'delete' );
-		} );
+		this.props.onDelete();
+		this.recordEvent( 'delete' );
 	};
 
 	recordEvent( action ) {

--- a/client/me/security-account-recovery/manage-contact.jsx
+++ b/client/me/security-account-recovery/manage-contact.jsx
@@ -9,7 +9,7 @@ class ManageContact extends Component {
 			<div className="security-account-recovery-contact__detail">
 				{ cloneElement( this.props.children, {
 					onSave: this.onSave,
-					onDelete: this.onDelete,
+					onDelete: this.props.onDelete && this.onDelete,
 					onCancel: this.props.onCancel && this.onCancel,
 				} ) }
 			</div>

--- a/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
+++ b/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
@@ -42,7 +42,10 @@ class RecoveryPhoneValidationNotice extends Component {
 		const validateButtonText = isValidating ? translate( 'Validating' ) : translate( 'Validate' );
 
 		return (
-			<form onSubmit={ this.onSubmit }>
+			<form
+				className="security-account-recovery__recovery-phone-validation"
+				onSubmit={ this.onSubmit }
+			>
 				{ ! hasSent && (
 					<Notice
 						className="security-account-recovery__validation-notice"

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -42,7 +42,7 @@ class RecoveryPhone extends Component {
 				hasValue={ !! phone }
 				disabled={ disabled }
 				onSave={ this.onSave }
-				onCancel={ this.onCancel }
+				onCancel={ isEditing && this.onCancel }
 			>
 				<EditPhone storedPhone={ phone } />
 			</ManageContact>

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -42,6 +42,7 @@ class RecoveryPhone extends Component {
 				hasValue={ !! phone }
 				disabled={ disabled }
 				onSave={ this.onSave }
+				onCancel={ this.onCancel }
 			>
 				<EditPhone storedPhone={ phone } />
 			</ManageContact>
@@ -64,6 +65,10 @@ class RecoveryPhone extends Component {
 				deletePhone();
 			}
 		} );
+	};
+
+	onCancel = () => {
+		this.setState( { isEditing: false } );
 	};
 }
 

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -1,3 +1,4 @@
+import { Button, Card, FormLabel } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import accept from 'calypso/lib/accept';
@@ -5,8 +6,30 @@ import EditPhone from './edit-phone';
 import ManageContact from './manage-contact';
 
 class RecoveryPhone extends Component {
+	state = {
+		isEditing: false,
+	};
+
 	render() {
-		const { phone, isLoading, translate, disabled } = this.props;
+		const { phone, translate, disabled, isLoading, isUpdateMode } = this.props;
+		const { isEditing } = this.state;
+
+		if ( isUpdateMode && ! isEditing ) {
+			return (
+				<Card className="recovery-phone-edit">
+					<div className="recovery-phone-edit__information">
+						<FormLabel>{ translate( 'Recovery SMS number' ) }</FormLabel>
+						<h2>{ phone.numberFull }</h2>
+					</div>
+					<div className="recovery-phone-edit__actions">
+						<Button onClick={ this.onEdit }>{ translate( 'Edit' ) }</Button>
+						<Button scary onClick={ this.onDelete }>
+							{ translate( 'Remove' ) }
+						</Button>
+					</div>
+				</Card>
+			);
+		}
 
 		return (
 			<ManageContact
@@ -19,7 +42,6 @@ class RecoveryPhone extends Component {
 				hasValue={ !! phone }
 				disabled={ disabled }
 				onSave={ this.onSave }
-				onDelete={ this.onDelete }
 			>
 				<EditPhone storedPhone={ phone } />
 			</ManageContact>
@@ -28,6 +50,10 @@ class RecoveryPhone extends Component {
 
 	onSave = ( phone ) => {
 		this.props.updatePhone( phone );
+	};
+
+	onEdit = () => {
+		this.setState( { isEditing: true } );
 	};
 
 	onDelete = () => {

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -42,7 +42,7 @@ class RecoveryPhone extends Component {
 				hasValue={ !! phone }
 				disabled={ disabled }
 				onSave={ this.onSave }
-				onCancel={ isEditing && this.onCancel }
+				{ ...( isEditing ? { onCancel: this.onCancel } : { onDelete: this.onDelete } ) }
 			>
 				<EditPhone storedPhone={ phone } />
 			</ManageContact>

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -18,7 +18,7 @@ class RecoveryPhone extends Component {
 			return (
 				<Card className="recovery-phone-edit">
 					<div className="recovery-phone-edit__information">
-						<FormLabel>{ translate( 'Recovery SMS number' ) }</FormLabel>
+						<FormLabel>{ translate( 'Phone number' ) }</FormLabel>
 						<h2>{ phone.numberFull }</h2>
 					</div>
 					<div className="recovery-phone-edit__actions">

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -2,17 +2,6 @@
 	margin-bottom: 0;
 }
 
-.security-account-recovery-contact:not(:only-child) {
-	&::after {
-		background-color: var(--color-border-subtle);
-		content: '';
-		display: block;
-		height: 1px;
-		margin: 16px 0;
-		width: 100%;
-	}
-}
-
 .security-account-recovery-contact__detail .form-phone-input {
 	display: flex;
 	flex-direction: column;
@@ -136,4 +125,17 @@
 		flex-direction: row;
 		gap: 10px;
 	}
+}
+
+.security-account-recovery__recovery-sms-number {
+    .security-account-recovery-contact:not(:only-child) {
+    	&::after {
+    		background-color: var(--color-border-subtle);
+    		content: '';
+    		display: block;
+    		height: 1px;
+    		margin: 16px 0;
+    		width: 100%;
+    	}
+    }
 }

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -104,6 +104,12 @@
 	margin-bottom: 12px;
 }
 
+.security-account-recovery__recovery-phone-validation {
+	border-top: 1px solid var(--color-border-subtle);
+	margin-top: 12px;
+	padding-top: 8px;
+}
+
 .security-account-recovery__recovery-phone-validation-buttons {
 	margin-top: 12px;
 }

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -15,7 +15,7 @@
 	padding-right: 0;
 
 	@include breakpoint-deprecated( ">480px" ) {
-		padding-right: 20px;
+		padding-right: 10px;
 		margin-bottom: 0;
 	}
 }
@@ -104,16 +104,25 @@
 	margin-bottom: 12px;
 }
 
-.security-account-recovery__recovery-phone-validation {
-	border-top: 1px solid var(--color-border-subtle);
-	margin-top: 12px;
-	padding-top: 8px;
-}
-
 .security-account-recovery__recovery-phone-validation-buttons {
 	margin-top: 12px;
 }
 
 .security-account-recovery__recovery-phone-validation-label {
 	margin-top: 12px;
+}
+
+.recovery-phone-edit {
+	align-items: center;
+	display: flex;
+
+	&__information {
+		flex: 1;
+	}
+
+	&__actions {
+		display: flex;
+		flex-direction: row;
+		gap: 10px;
+	}
 }

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -2,6 +2,17 @@
 	margin-bottom: 0;
 }
 
+.security-account-recovery-contact:not(:only-child) {
+	&::after {
+		background-color: var(--color-border-subtle);
+		content: '';
+		display: block;
+		height: 1px;
+		margin: 16px 0;
+		width: 100%;
+	}
+}
+
 .security-account-recovery-contact__detail .form-phone-input {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Ref DOTCOM-12882
Related to https://github.com/Automattic/wp-calypso/issues/100366

## Proposed Changes
 
This PR improves the UX of the "Recovery Email" and "Recovery SMS Number" screens as follows:

The new screen directly shows the input fields, instead of having to click the Edit button.
| Before | After |
| --- | --- |
| ![SCR-20250508-nywy](https://github.com/user-attachments/assets/91e2d52b-fdbd-4ecc-bcc5-1f9c4c81c4ab) | ![SCR-20250508-nzco](https://github.com/user-attachments/assets/1723227f-6815-4cc8-8576-b8319a77c1a8) |

Email verification UI.
| Before | After |
| --- | --- |
| ![SCR-20250508-nzvt](https://github.com/user-attachments/assets/32e3af3f-6e40-4f15-8a32-a17c1eb32743) |  ![SCR-20250508-oacd](https://github.com/user-attachments/assets/a93f6c9c-d95e-4973-91e3-7ab38e696022) |

Phone verification UI.
| Before | After |
| --- | --- |
| ![SCR-20250508-obge](https://github.com/user-attachments/assets/5ab16cdb-bd60-42b4-b2c3-7dd9b517b0c2) | ![Screenshot 2025-05-08 at 3 56 13 PM](https://github.com/user-attachments/assets/ceab822d-d650-4c1f-b289-9392104481cb) |

Phone verification UI + Update existing phone number
| Before | After |
| --- | --- |
| ![SCR-20250508-obil](https://github.com/user-attachments/assets/b66746d9-b455-4652-93e5-2294fcbca85e) | ![SCR-20250508-obqi](https://github.com/user-attachments/assets/e74774e3-5c2a-4bd1-8516-beef741a1265) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall WP.com polish

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /me/security.
* Ensure that the "Recovery Email" and "Recovery SMS Number" screens are updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
