### PR TITLE
Preserve semantics in notice content

### DIFF
--- a/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
+++ b/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
@@ -25,7 +25,7 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
         />
       </svg>
     </span>
-    <p
+    <span
       class="calypso-notice__content"
     >
       <span
@@ -33,7 +33,7 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
       >
         This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
       </span>
-    </p>
+    </span>
     <button
       aria-label="Dismiss"
       class="calypso-notice__dismiss"

--- a/client/components/global-notices/test/__snapshots__/index.js.snap
+++ b/client/components/global-notices/test/__snapshots__/index.js.snap
@@ -26,7 +26,7 @@ exports[`<GlobalNotices /> should render notices with the expected structure 1`]
           />
         </svg>
       </span>
-      <p
+      <span
         class="calypso-notice__content"
       >
         <span
@@ -34,7 +34,7 @@ exports[`<GlobalNotices /> should render notices with the expected structure 1`]
         >
           A test notice
         </span>
-      </p>
+      </span>
       <button
         aria-label="Dismiss"
         class="calypso-notice__dismiss"

--- a/client/components/notice/index.tsx
+++ b/client/components/notice/index.tsx
@@ -120,9 +120,9 @@ export default function Notice( {
 				{ iconNeedsDrop && <span className="calypso-notice__icon-wrapper-drop" /> }
 				{ renderedIcon }
 			</span>
-			<p className="calypso-notice__content">
+			<span className="calypso-notice__content">
 				<span className="calypso-notice__text">{ text ? text : children }</span>
-			</p>
+			</span>
 			{ text ? children : null }
 			{ showDismiss && (
 				<button

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -175,7 +175,7 @@
 	padding: 13px;
 	font-size: $font-body-extra-small;
 	flex-grow: 1;
-	margin-bottom: 0;
+	text-wrap: pretty;
 
 	.calypso-notice__text {
 		a,

--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -28,7 +28,7 @@ exports[`JetpackConnectNotices Should render non-terminal notice if callback sup
           />
         </svg>
       </span>
-      <p
+      <span
         class="calypso-notice__content"
       >
         <span
@@ -36,7 +36,7 @@ exports[`JetpackConnectNotices Should render non-terminal notice if callback sup
         >
           In some cases, authorization can take a few attempts. Please try again.
         </span>
-      </p>
+      </span>
     </div>
   </div>
 </div>
@@ -70,7 +70,7 @@ exports[`JetpackConnectNotices Should render notice 1`] = `
           />
         </svg>
       </span>
-      <p
+      <span
         class="calypso-notice__content"
       >
         <span
@@ -78,7 +78,7 @@ exports[`JetpackConnectNotices Should render notice 1`] = `
         >
           This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.
         </span>
-      </p>
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up from #102991

After deploying I started seeing a console error on some login pages: `Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>. Error Component Stack`

Turns out it was due to the use of Notice component here:

<img width="488" alt="Screenshot 2025-05-01 at 4 06 27 pm" src="https://github.com/user-attachments/assets/79987bd1-970b-46f7-9d26-605893c791e0" />

where it has some `div`s nested in its content. Given that Notice allows any type of children, we probably shouldn't be wrapping its content in a `p` tag 😅 

So I switched it back to a `span` and added a custom `text-wrap: pretty` to it.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This particular notice can be seen on Login screens, but I'm not sure what are the actual conditions for it to appear, because I don't see it when logging in from a private window.
* I guess try to make it show up and then check that it looks as expected 😄 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
