### PR TITLE
Hosting Dashboard: Add SiteMonitoring component and its entry point

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -94,6 +94,17 @@ const siteDeploymentsRoute = createRoute( {
 	)
 );
 
+const siteMonitoringRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'monitoring',
+} ).lazy( () =>
+	import( '../site-monitoring' ).then( ( d ) =>
+		createLazyRoute( 'site-monitoring' )( {
+			component: d.default,
+		} )
+	)
+);
+
 const sitePerformanceRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'performance',
@@ -263,7 +274,12 @@ const createRouteTree = ( config: AppConfig ) => {
 	if ( config.supports.sites ) {
 		children.push(
 			sitesRoute,
-			siteRoute.addChildren( [ siteOverviewRoute, siteDeploymentsRoute, sitePerformanceRoute ] )
+			siteRoute.addChildren( [
+				siteOverviewRoute,
+				siteDeploymentsRoute,
+				siteMonitoringRoute,
+				sitePerformanceRoute,
+			] )
 		);
 	}
 
@@ -312,6 +328,7 @@ export {
 	siteRoute,
 	siteOverviewRoute,
 	siteDeploymentsRoute,
+	siteMonitoringRoute,
 	sitePerformanceRoute,
 	domainsRoute,
 	emailsRoute,

--- a/client/dashboard/site-menu/index.tsx
+++ b/client/dashboard/site-menu/index.tsx
@@ -8,6 +8,9 @@ const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
 				{ __( 'Deployments' ) }
 			</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/monitoring` }>
+				{ __( 'Monitoring' ) }
+			</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 				{ __( 'Performance' ) }
 			</ResponsiveMenu.Item>

--- a/client/dashboard/site-monitoring/index.tsx
+++ b/client/dashboard/site-monitoring/index.tsx
@@ -1,0 +1,8 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../page-layout';
+
+function SiteMonitoring() {
+	return <PageLayout title={ __( 'Monitoring' ) } />;
+}
+
+export default SiteMonitoring;


### PR DESCRIPTION
## Proposed Changes

Create SiteMonitoring component and its entry point as /site/:siteSlug/monitoring.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Hosting Dashboard implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that /v2/sites/:siteSlug/monitoring is accessible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
