### PR TITLE
Stats: Apply new navigation header to Post Details page

### DIFF
--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -28,6 +28,10 @@
 	&__right-section {
 		display: flex;
 		align-items: center;
+
+		.button {
+			padding: 4px 8px;
+		}
 	}
 
 	&__back-link {

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -29,7 +29,8 @@
 		display: flex;
 		align-items: center;
 
-		.button {
+		.components-button {
+			height: 32px;
 			padding: 4px 8px;
 		}
 	}

--- a/client/components/navigation-header/navigation-header.tsx
+++ b/client/components/navigation-header/navigation-header.tsx
@@ -10,7 +10,7 @@ interface BackLinkProps {
 	onBackClick?: ( e: React.MouseEvent< HTMLAnchorElement > ) => void;
 }
 
-interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
+export interface HeaderProps extends React.HTMLAttributes< HTMLElement > {
 	title?: string;
 	titleLogo?: ReactNode;
 	backLinkProps?: BackLinkProps;

--- a/client/my-sites/stats/components/headers/page-header.tsx
+++ b/client/my-sites/stats/components/headers/page-header.tsx
@@ -1,9 +1,11 @@
 import config from '@automattic/calypso-config';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import NavigationHeaderImpr from 'calypso/components/navigation-header/navigation-header';
+import NavigationHeaderImpr, {
+	HeaderProps,
+} from 'calypso/components/navigation-header/navigation-header';
 import { STATS_PRODUCT_NAME, STATS_PRODUCT_NAME_IMPR } from '../../constants';
 
-function PageHeader() {
+function PageHeader( { titleProps, ...otherProps }: HeaderProps ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	if ( isOdysseyStats ) {
@@ -13,7 +15,9 @@ function PageHeader() {
 				titleProps={ {
 					title: STATS_PRODUCT_NAME,
 					titleLogo: <JetpackLogo size={ 24 } monochrome={ false } />,
+					...titleProps,
 				} }
+				{ ...otherProps }
 			/>
 		);
 	}
@@ -23,7 +27,9 @@ function PageHeader() {
 			className="stats__section-header modernized-header"
 			titleProps={ {
 				title: STATS_PRODUCT_NAME_IMPR,
+				...titleProps,
 			} }
+			{ ...otherProps }
 		/>
 	);
 }

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -201,6 +201,8 @@ class StatsPostDetail extends Component {
 		};
 		const titleProps = {
 			title: navigationItems[ 1 ].label,
+			// Remove the default logo for Odyssey stats.
+			titleLogo: null,
 		};
 
 		return (

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Button as CoreButton } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -218,9 +219,9 @@ class StatsPostDetail extends Component {
 							titleProps={ titleProps }
 							rightSection={
 								showViewLink && (
-									<Button onClick={ this.openPreview } primary>
+									<CoreButton onClick={ this.openPreview } variant="primary">
 										<span>{ actionLabel }</span>
-									</Button>
+									</CoreButton>
 								)
 							}
 						/>

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -191,15 +191,15 @@ class StatsPostDetail extends Component {
 			'is-odyssey-stats': isWPAdmin,
 		} );
 
+		// TODO: Refactor navigationItems to a single object with backLink and title attributes.
 		const navigationItems = this.getNavigationItemsWithTitle( this.getTitle() );
 
 		const backLinkProps = {
 			text: navigationItems[ 0 ].label,
 			url: navigationItems[ 0 ].href,
 		};
-
 		const titleProps = {
-			title: this.getTitle(),
+			title: navigationItems[ 1 ].label,
 		};
 
 		return (

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -213,7 +213,17 @@ class StatsPostDetail extends Component {
 
 				<div className={ postDetailPageClasses }>
 					{ config.isEnabled( 'stats/navigation-improvement' ) ? (
-						<PageHeader backLinkProps={ backLinkProps } titleProps={ titleProps } />
+						<PageHeader
+							backLinkProps={ backLinkProps }
+							titleProps={ titleProps }
+							rightSection={
+								showViewLink && (
+									<Button onClick={ this.openPreview } primary>
+										<span>{ actionLabel }</span>
+									</Button>
+								)
+							}
+						/>
 					) : (
 						<NavigationHeader navigationItems={ navigationItems }>
 							{ showViewLink && (

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -16,6 +16,7 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
 import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { getSitePost, getPostPreviewUrl } from 'calypso/state/posts/selectors';
 import { countPostLikes } from 'calypso/state/posts/selectors/count-post-likes';
@@ -200,13 +201,19 @@ class StatsPostDetail extends Component {
 				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } /> }
 
 				<div className={ postDetailPageClasses }>
-					<NavigationHeader navigationItems={ this.getNavigationItemsWithTitle( this.getTitle() ) }>
-						{ showViewLink && (
-							<Button onClick={ this.openPreview }>
-								<span>{ actionLabel }</span>
-							</Button>
-						) }
-					</NavigationHeader>
+					{ config.isEnabled( 'stats/navigation-improvement' ) ? (
+						<PageHeader />
+					) : (
+						<NavigationHeader
+							navigationItems={ this.getNavigationItemsWithTitle( this.getTitle() ) }
+						>
+							{ showViewLink && (
+								<Button onClick={ this.openPreview }>
+									<span>{ actionLabel }</span>
+								</Button>
+							) }
+						</NavigationHeader>
+					) }
 
 					<PostDetailHighlightsSection siteId={ siteId } postId={ postId } post={ passedPost } />
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -191,6 +191,17 @@ class StatsPostDetail extends Component {
 			'is-odyssey-stats': isWPAdmin,
 		} );
 
+		const navigationItems = this.getNavigationItemsWithTitle( this.getTitle() );
+
+		const backLinkProps = {
+			text: navigationItems[ 0 ].label,
+			url: navigationItems[ 0 ].href,
+		};
+
+		const titleProps = {
+			title: this.getTitle(),
+		};
+
 		return (
 			<Main fullWidthLayout>
 				<PageViewTracker
@@ -202,11 +213,9 @@ class StatsPostDetail extends Component {
 
 				<div className={ postDetailPageClasses }>
 					{ config.isEnabled( 'stats/navigation-improvement' ) ? (
-						<PageHeader />
+						<PageHeader backLinkProps={ backLinkProps } titleProps={ titleProps } />
 					) : (
-						<NavigationHeader
-							navigationItems={ this.getNavigationItemsWithTitle( this.getTitle() ) }
-						>
+						<NavigationHeader navigationItems={ navigationItems }>
 							{ showViewLink && (
 								<Button onClick={ this.openPreview }>
 									<span>{ actionLabel }</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to STATS-22

## Proposed Changes

* Apply the `PageHeader` that wraps the new `NavigationHeader` to the Post Details page.
* Pass props to the new `NavigationHeader` through the `PageHeader` wrapper.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the project **Stats: Improve navigation**.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page for a Simple site, whose post would be previewable.
* Click on any item of the `Posts & pages` module.
* Ensure the Post Details page header title, link to return to the Traffic page, and `View Post` button align with the design.

|Before|After|
|-|-|
|<img width="965" alt="截圖 2025-05-01 晚上9 37 38" src="https://github.com/user-attachments/assets/bc20f52b-64c6-403c-8760-50ae4eb76aca" />|<img width="970" alt="截圖 2025-05-01 晚上9 37 43" src="https://github.com/user-attachments/assets/f1640085-e38c-4e40-8dcb-ca4575644b1d" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
