### PR TITLE
Experiment streamlining the plans grid + checkout: Plans grid changes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -28,7 +28,10 @@ import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { useFCCARestrictions } from 'calypso/my-sites/plans-features-main/hooks/use-fcca-restrictions';
-import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPricePlansTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getStepUrl } from 'calypso/signup/utils';
 import { getDomainFromUrl } from 'calypso/site-profiler/utils/get-valid-url';
 import { useDispatch as reduxUseDispatch, useSelector } from 'calypso/state';
@@ -453,7 +456,7 @@ function UnifiedPlansStep( {
 	const experimentValue = streamlinedPriceExperimentAssignment as string;
 	if (
 		! isStreamlinedPriceExperimentLoading &&
-		experimentValue &&
+		isStreamlinedPricePlansTreatment( experimentValue ) &&
 		experimentValue.startsWith( 'plans_3y' )
 	) {
 		defaultIntervalType = shouldRestrict3YearPlans() ? '2yearly' : '3yearly';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -27,6 +27,8 @@ import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import { useFCCARestrictions } from 'calypso/my-sites/plans-features-main/hooks/use-fcca-restrictions';
+import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getStepUrl } from 'calypso/signup/utils';
 import { getDomainFromUrl } from 'calypso/site-profiler/utils/get-valid-url';
 import { useDispatch as reduxUseDispatch, useSelector } from 'calypso/state';
@@ -223,6 +225,8 @@ function UnifiedPlansStep( {
 	const initializedSitesBackUrl = useSelector( ( state ) =>
 		getCurrentUserSiteCount( state ) ? '/sites/' : null
 	);
+	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
+		useStreamlinedPriceExperiment();
 
 	useSiteGlobalStylesOnPersonal();
 
@@ -444,7 +448,18 @@ function UnifiedPlansStep( {
 		}
 	}
 
-	const intervalTypeValue = intervalType || getIntervalType( path );
+	const { shouldRestrict3YearPlans } = useFCCARestrictions();
+	let defaultIntervalType = 'yearly';
+	const experimentValue = streamlinedPriceExperimentAssignment as string;
+	if (
+		! isStreamlinedPriceExperimentLoading &&
+		experimentValue &&
+		experimentValue.startsWith( 'plans_3y' )
+	) {
+		defaultIntervalType = shouldRestrict3YearPlans() ? '2yearly' : '3yearly';
+	}
+
+	const intervalTypeValue = intervalType || getIntervalType( path, defaultIntervalType );
 
 	let paidDomainName = domainItem?.meta;
 

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -2,7 +2,7 @@ import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 
 const STREAMLINED_PRICE_EXPERIMENT_NAME = 'calypso_streamlined_plans_checkout';
 
-export function useStreamlinedPriceExperiment() {
+export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
 	const [ isLoading, assignment ] = useExperiment( STREAMLINED_PRICE_EXPERIMENT_NAME );
 	return [ isLoading, assignment?.variationName ?? null ];
 }

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -4,10 +4,17 @@ const STREAMLINED_PRICE_EXPERIMENT_NAME = 'calypso_streamlined_plans_checkout';
 
 export function useStreamlinedPriceExperiment() {
 	const [ isLoading, assignment ] = useExperiment( STREAMLINED_PRICE_EXPERIMENT_NAME );
-	return [ isLoading, assignment?.variationName ];
+	return [ isLoading, assignment?.variationName ?? null ];
 }
 
 export async function isStreamlinedPriceExperiment() {
 	const assignment = await loadExperimentAssignment( STREAMLINED_PRICE_EXPERIMENT_NAME );
 	return assignment?.variationName !== null;
+}
+
+export function isStreamlinedPricePlansTreatment( variationName?: string | null ) {
+	if ( ! variationName ) {
+		return false;
+	}
+	return ! variationName.includes( 'plans_control' );
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -479,6 +479,8 @@ const PlansFeaturesMain = ( {
 	let enableTermSavingsPriceDisplay = true;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
+	// We are also hiding the plan interval selector and showing terms savings prices
+	// for the compatible streamlined price experiment variations.
 	if (
 		redirectToAddDomainFlow === undefined &&
 		! hidePlanTypeSelector &&

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -878,6 +878,7 @@ const PlansFeaturesMain = ( {
 										enableLogosOnlyForEnterprisePlan={ showSimplifiedFeatures }
 										hideFeatureGroupTitles={ showSimplifiedFeatures }
 										enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
+										showStreamlinedBillingDescription={ showStreamlinedPriceExperiment }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }
@@ -940,6 +941,7 @@ const PlansFeaturesMain = ( {
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
 													enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
+													showStreamlinedBillingDescription={ showStreamlinedPriceExperiment }
 												/>
 											) }
 											<ComparisonGridToggle

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -470,9 +470,7 @@ const PlansFeaturesMain = ( {
 		useStreamlinedPriceExperiment();
 
 	const showStreamlinedPriceExperiment =
-		isInSignup &&
-		! isStreamlinedPriceExperimentLoading &&
-		Boolean( streamlinedPriceExperimentAssignment );
+		isInSignup && Boolean( streamlinedPriceExperimentAssignment );
 
 	let hidePlanSelector = true;
 	let enableTermSavingsPriceDisplay = true;
@@ -481,6 +479,7 @@ const PlansFeaturesMain = ( {
 	if (
 		redirectToAddDomainFlow === undefined &&
 		! hidePlanTypeSelector &&
+		! isStreamlinedPriceExperimentLoading &&
 		! showStreamlinedPriceExperiment
 	) {
 		hidePlanSelector = false;
@@ -879,7 +878,9 @@ const PlansFeaturesMain = ( {
 										enableLogosOnlyForEnterprisePlan={ showSimplifiedFeatures }
 										hideFeatureGroupTitles={ showSimplifiedFeatures }
 										enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
-										showStreamlinedBillingDescription={ showStreamlinedPriceExperiment }
+										showStreamlinedBillingDescription={
+											! isStreamlinedPriceExperimentLoading && showStreamlinedPriceExperiment
+										}
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }
@@ -942,7 +943,9 @@ const PlansFeaturesMain = ( {
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
 													enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
-													showStreamlinedBillingDescription={ showStreamlinedPriceExperiment }
+													showStreamlinedBillingDescription={
+														! isStreamlinedPriceExperimentLoading && showStreamlinedPriceExperiment
+													}
 												/>
 											) }
 											<ComparisonGridToggle

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -469,17 +469,21 @@ const PlansFeaturesMain = ( {
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
 		useStreamlinedPriceExperiment();
 
-	let hidePlanSelector = false;
-	let enableTermSavingsPriceDisplay = false;
-	// In the "purchase a plan and free domain" flow we do not want to show
-	// monthly plans because monthly plans do not come with a free domain.
+	const showStreamlinedPriceExperiment =
+		isInSignup &&
+		! isStreamlinedPriceExperimentLoading &&
+		Boolean( streamlinedPriceExperimentAssignment );
+
+	let hidePlanSelector = true;
+	let enableTermSavingsPriceDisplay = true;
+	// Only show plan selector if none of these conditions are true
 	if (
-		redirectToAddDomainFlow !== undefined ||
-		hidePlanTypeSelector ||
-		( isInSignup && ! isStreamlinedPriceExperimentLoading && streamlinedPriceExperimentAssignment )
+		redirectToAddDomainFlow === undefined &&
+		! hidePlanTypeSelector &&
+		! showStreamlinedPriceExperiment
 	) {
-		hidePlanSelector = true;
-		enableTermSavingsPriceDisplay = true;
+		hidePlanSelector = false;
+		enableTermSavingsPriceDisplay = false;
 	}
 
 	let _customerType = chooseDefaultCustomerType( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -80,7 +80,10 @@ import useGenerateActionHook from './hooks/use-generate-action-hook';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
 import useSelectedFeature from './hooks/use-selected-feature';
-import { useStreamlinedPriceExperiment } from './hooks/use-streamlined-price-experiment';
+import {
+	isStreamlinedPricePlansTreatment,
+	useStreamlinedPriceExperiment,
+} from './hooks/use-streamlined-price-experiment';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
 import type {
 	PlansIntent,
@@ -470,7 +473,7 @@ const PlansFeaturesMain = ( {
 		useStreamlinedPriceExperiment();
 
 	const showStreamlinedPriceExperiment =
-		isInSignup && Boolean( streamlinedPriceExperimentAssignment );
+		isInSignup && isStreamlinedPricePlansTreatment( streamlinedPriceExperimentAssignment );
 
 	let hidePlanSelector = true;
 	let enableTermSavingsPriceDisplay = true;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -841,7 +841,7 @@ const PlansFeaturesMain = ( {
 							data-e2e-plans="wpcom"
 						>
 							<div className="plans-wrapper">
-								{ gridPlansForFeaturesGrid && (
+								{ gridPlansForFeaturesGrid && ! isStreamlinedPriceExperimentLoading && (
 									<FeaturesGrid
 										allFeaturesList={ getFeaturesList() }
 										className="plans-features-main__features-grid"
@@ -878,9 +878,7 @@ const PlansFeaturesMain = ( {
 										enableLogosOnlyForEnterprisePlan={ showSimplifiedFeatures }
 										hideFeatureGroupTitles={ showSimplifiedFeatures }
 										enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
-										showStreamlinedBillingDescription={
-											! isStreamlinedPriceExperimentLoading && showStreamlinedPriceExperiment
-										}
+										showStreamlinedBillingDescription={ showStreamlinedPriceExperiment }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }
@@ -909,45 +907,45 @@ const PlansFeaturesMain = ( {
 														coupon={ coupon }
 													/>
 												) }
-											{ gridPlansForComparisonGrid && gridPlansForPlanTypeSelector && (
-												<ComparisonGrid
-													allFeaturesList={ getFeaturesList() }
-													className="plans-features-main__comparison-grid"
-													coupon={ coupon }
-													currentSitePlanSlug={ sitePlanSlug }
-													gridPlans={ gridPlansForComparisonGrid }
-													hideUnavailableFeatures={ hideUnavailableFeatures }
-													intent={ intent }
-													intervalType={ intervalType }
-													isInAdmin={ ! isInSignup }
-													isInSiteDashboard={ isInSiteDashboard }
-													isInSignup={ isInSignup }
-													onStorageAddOnClick={ handleStorageAddOnClick }
-													planTypeSelectorProps={
-														! hidePlanSelector
-															? { ...planTypeSelectorProps, plans: gridPlansForPlanTypeSelector }
-															: undefined
-													}
-													recordTracksEvent={ recordTracksEvent }
-													reflectStorageSelectionInPlanPrices
-													selectedFeature={ selectedFeature }
-													selectedPlan={ selectedPlan }
-													showUpgradeableStorage={ showUpgradeableStorage }
-													siteId={ siteId }
-													stickyRowOffset={ comparisonGridStickyRowOffset }
-													showRefundPeriod={ isAnyHostingFlow( flowName ) }
-													useAction={ useAction }
-													useCheckPlanAvailabilityForPurchase={
-														useCheckPlanAvailabilityForPurchase
-													}
-													enableFeatureTooltips
-													featureGroupMap={ featureGroupMapForComparisonGrid }
-													enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
-													showStreamlinedBillingDescription={
-														! isStreamlinedPriceExperimentLoading && showStreamlinedPriceExperiment
-													}
-												/>
-											) }
+											{ gridPlansForComparisonGrid &&
+												gridPlansForPlanTypeSelector &&
+												! isStreamlinedPriceExperimentLoading && (
+													<ComparisonGrid
+														allFeaturesList={ getFeaturesList() }
+														className="plans-features-main__comparison-grid"
+														coupon={ coupon }
+														currentSitePlanSlug={ sitePlanSlug }
+														gridPlans={ gridPlansForComparisonGrid }
+														hideUnavailableFeatures={ hideUnavailableFeatures }
+														intent={ intent }
+														intervalType={ intervalType }
+														isInAdmin={ ! isInSignup }
+														isInSiteDashboard={ isInSiteDashboard }
+														isInSignup={ isInSignup }
+														onStorageAddOnClick={ handleStorageAddOnClick }
+														planTypeSelectorProps={
+															! hidePlanSelector
+																? { ...planTypeSelectorProps, plans: gridPlansForPlanTypeSelector }
+																: undefined
+														}
+														recordTracksEvent={ recordTracksEvent }
+														reflectStorageSelectionInPlanPrices
+														selectedFeature={ selectedFeature }
+														selectedPlan={ selectedPlan }
+														showUpgradeableStorage={ showUpgradeableStorage }
+														siteId={ siteId }
+														stickyRowOffset={ comparisonGridStickyRowOffset }
+														showRefundPeriod={ isAnyHostingFlow( flowName ) }
+														useAction={ useAction }
+														useCheckPlanAvailabilityForPurchase={
+															useCheckPlanAvailabilityForPurchase
+														}
+														enableFeatureTooltips
+														featureGroupMap={ featureGroupMapForComparisonGrid }
+														enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
+														showStreamlinedBillingDescription={ showStreamlinedPriceExperiment }
+													/>
+												) }
 											<ComparisonGridToggle
 												onClick={ toggleShowPlansComparisonGrid }
 												label={ translate( 'Hide comparison' ) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -476,7 +476,8 @@ const PlansFeaturesMain = ( {
 
 	let hidePlanSelector = true;
 	let enableTermSavingsPriceDisplay = true;
-	// Only show plan selector if none of these conditions are true
+	// In the "purchase a plan and free domain" flow we do not want to show
+	// monthly plans because monthly plans do not come with a free domain.
 	if (
 		redirectToAddDomainFlow === undefined &&
 		! hidePlanTypeSelector &&

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -470,6 +470,7 @@ const PlansFeaturesMain = ( {
 		useStreamlinedPriceExperiment();
 
 	let hidePlanSelector = false;
+	let enableTermSavingsPriceDisplay = false;
 	// In the "purchase a plan and free domain" flow we do not want to show
 	// monthly plans because monthly plans do not come with a free domain.
 	if (
@@ -478,6 +479,7 @@ const PlansFeaturesMain = ( {
 		( isInSignup && ! isStreamlinedPriceExperimentLoading && streamlinedPriceExperimentAssignment )
 	) {
 		hidePlanSelector = true;
+		enableTermSavingsPriceDisplay = true;
 	}
 
 	let _customerType = chooseDefaultCustomerType( {
@@ -871,7 +873,7 @@ const PlansFeaturesMain = ( {
 										enableReducedFeatureGroupSpacing={ showSimplifiedFeatures }
 										enableLogosOnlyForEnterprisePlan={ showSimplifiedFeatures }
 										hideFeatureGroupTitles={ showSimplifiedFeatures }
-										enableTermSavingsPriceDisplay={ false }
+										enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 									/>
 								) }
 								{ showEscapeHatch && hidePlansFeatureComparison && viewAllPlansButton }
@@ -933,7 +935,7 @@ const PlansFeaturesMain = ( {
 													}
 													enableFeatureTooltips
 													featureGroupMap={ featureGroupMapForComparisonGrid }
-													enableTermSavingsPriceDisplay={ false }
+													enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 												/>
 											) }
 											<ComparisonGridToggle

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -21,6 +21,10 @@ jest.mock( '../hooks/use-suggested-free-domain-from-paid-domain', () => () => ( 
 	wpcomFreeDomainSuggestion: { isLoading: false, result: { domain_name: 'suggestion.com' } },
 	invalidateDomainSuggestionCache: () => {},
 } ) );
+jest.mock( '../hooks/use-streamlined-price-experiment', () => ( {
+	useStreamlinedPriceExperiment: () => [ false, null ],
+	isStreamlinedPriceExperiment: () => Promise.resolve( false ),
+} ) );
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getByPurchaseId: jest.fn(),
 } ) );

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -525,6 +525,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 		);
 	}
 );
+ComparisonGridHeader.displayName = 'ComparisonGridHeader';
 
 const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	feature?: FeatureObject;

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1159,6 +1159,7 @@ const WrappedComparisonGrid = ( {
 	featureGroupMap,
 	enableTermSavingsPriceDisplay,
 	reflectStorageSelectionInPlanPrices,
+	showStreamlinedBillingDescription,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -1206,6 +1207,7 @@ const WrappedComparisonGrid = ( {
 				hideUnsupportedFeatures={ hideUnsupportedFeatures }
 				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
 				reflectStorageSelectionInPlanPrices={ reflectStorageSelectionInPlanPrices }
+				showStreamlinedBillingDescription={ showStreamlinedBillingDescription }
 			>
 				<ComparisonGrid
 					intervalType={ intervalType }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -388,6 +388,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		hideFeatureGroupTitles,
 		enterpriseFeaturesList,
 		enableTermSavingsPriceDisplay,
+		showStreamlinedBillingDescription,
 	} = props;
 
 	const gridContainerRef = useRef< HTMLDivElement >( null );
@@ -445,6 +446,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				featureGroupMap={ featureGroupMap }
 				enterpriseFeaturesList={ enterpriseFeaturesList }
 				enableTermSavingsPriceDisplay={ enableTermSavingsPriceDisplay }
+				showStreamlinedBillingDescription={ showStreamlinedBillingDescription }
 			>
 				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/grid-context.tsx
+++ b/packages/plans-grid-next/src/grid-context.tsx
@@ -31,6 +31,7 @@ interface PlansGridContext {
 	hideFeatureGroupTitles?: boolean;
 	enterpriseFeaturesList?: string[];
 	reflectStorageSelectionInPlanPrices?: boolean;
+	showStreamlinedBillingDescription?: boolean;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -56,6 +57,7 @@ const PlansGridContextProvider = ( {
 	hideFeatureGroupTitles,
 	enterpriseFeaturesList,
 	reflectStorageSelectionInPlanPrices,
+	showStreamlinedBillingDescription,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -90,6 +92,7 @@ const PlansGridContextProvider = ( {
 				hideFeatureGroupTitles,
 				enterpriseFeaturesList,
 				reflectStorageSelectionInPlanPrices,
+				showStreamlinedBillingDescription,
 			} }
 		>
 			{ children }

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -35,7 +35,8 @@ export default function usePlanBillingDescription( {
 }: UsePlanBillingDescriptionProps ) {
 	const translate = useTranslate();
 	const { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer } = pricing || {};
-	const { reflectStorageSelectionInPlanPrices } = usePlansGridContext();
+	const { reflectStorageSelectionInPlanPrices, showStreamlinedBillingDescription } =
+		usePlansGridContext();
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 
 	const yearlyVariantPricing = Plans.usePricingMetaForGridPlans( {
@@ -282,6 +283,19 @@ export default function usePlanBillingDescription( {
 					comment: 'Excl. Taxes is short for excluding taxes',
 				}
 			);
+		}
+	} else if ( showStreamlinedBillingDescription ) {
+		// When streamlined price experiment is active, use simplified billing description
+		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, billed annually' );
+		}
+
+		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, billed every 2 years' );
+		}
+
+		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
+			return translate( 'per month, billed every 3 years' );
 		}
 	} else if ( originalPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -240,6 +240,11 @@ export type GridContextProps = {
 	 * calculating prices.
 	 */
 	reflectStorageSelectionInPlanPrices?: boolean;
+
+	/**
+	 * Enable streamlined billing description
+	 */
+	showStreamlinedBillingDescription?: boolean;
 };
 
 export type ComparisonGridExternalProps = Omit<


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-kUT-p2

## Proposed Changes

* Default to 1Y or 3Y plan prices for the corresponding variations
* Show term saving labels on top of the prices
* Show streamlined billing interval descriptions 

<img width="1825" alt="Screenshot 2025-05-01 at 13 49 26" src="https://github.com/user-attachments/assets/72ff3243-1aa9-4efe-a618-d21971e861cd" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're experimenting with streamlining the plans and checkout user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Control (unassigned)
* Go to `/setup/onboarding/plans`
* There should be no changes
<img width="1533" alt="Screenshot 2025-05-01 at 14 06 02" src="https://github.com/user-attachments/assets/5f20f2a0-64fa-4fee-b510-3cabb639ea0f" />


#### Control (plans_control_checkout_radio variation)
* Go to the `plans_control_checkout_radio ` experiment and assign yourself the `plans_1y_checkout_dropdown`. You might need to remove the `explat-experiment--calypso_streamlined_plans_checkout` entry from the localStorage to fetch the new assignment. 
* There should be no changes

#### 1Y plans
* Go to the `calypso_streamlined_plans_checkout` experiment and assign yourself the `plans_1y_checkout_dropdown`.
* You should see the 1Y plan version of the page
  * interval toggle should be hidden
  * prices should match the design
  * term saving label should be shown
  * the billing term description copy should be the same as in the design.
<img width="1627" alt="Screenshot 2025-05-01 at 14 03 00" src="https://github.com/user-attachments/assets/0ae5811b-d2c3-4e01-a561-a93f572813ec" />

#### 3Y plans
* Switch to the `plans_3y_checkout_control` variation.
* You should see the 3Y plan version of the page
<img width="1450" alt="Screenshot 2025-05-01 at 14 04 57" src="https://github.com/user-attachments/assets/8dd83915-51b9-438b-aee0-4f0770add084" />


#### 2Y plans (German)
* Set proxy/VPN to navigate from Germany
* You should see the 2Y plan version of the page

<img width="1677" alt="Screenshot 2025-05-01 at 14 16 58" src="https://github.com/user-attachments/assets/348b2bb4-6a6b-4d0e-87a5-f9ec7031f4c6" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
