### PR TITLE
Extend `selectDoman` e2e method to support multiple flow cases

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -74,7 +74,7 @@ export class DomainSearchComponent {
 	 * @param {string} keyword Unique keyword to select domains.
 	 * @returns {string} Domain that was selected.
 	 */
-	async selectDomain( keyword: string ): Promise< string > {
+	async selectDomain( keyword: string, waitForContinueButton: boolean = true ): Promise< string > {
 		const targetRow = this.page.locator( selectors.domainSuggestionRow ).filter( {
 			has: this.page.getByLabel( keyword ),
 		} );
@@ -95,12 +95,14 @@ export class DomainSearchComponent {
 		// on the right hand sidebar.
 		// See: 21483-explat-experiment
 		// Note: this page object does not currently support multiple domain selection.
-		await Promise.race( [
-			this.page
-				.getByRole( 'button', { name: 'Continue', exact: true } )
-				.click( { timeout: 30 * 1000 } ),
-			this.page.waitForURL( plansPageUrl ),
-		] );
+		if ( waitForContinueButton ) {
+			await Promise.race( [
+				this.page
+					.getByRole( 'button', { name: 'Continue', exact: true } )
+					.click( { timeout: 30 * 1000 } ),
+				this.page.waitForURL( plansPageUrl ),
+			] );
+		}
 
 		return selectedDomain;
 	}

--- a/test/e2e/specs/domains/domains__add.ts
+++ b/test/e2e/specs/domains/domains__add.ts
@@ -66,7 +66,7 @@ describe.skip( DataHelper.createSuiteTitle( 'Domains: Add to current site' ), fu
 		} );
 
 		it( 'Choose the .live TLD', async function () {
-			selectedDomain = await domainSearchComponent.selectDomain( '.live' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.live', false );
 		} );
 
 		it( 'Decline Titan Email upsell', async function () {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/103010
Related to https://github.com/Automattic/wp-calypso/pull/103020

## Proposed Changes

* Extend `selectDoman` e2e method to support multiple flow cases
* Fix domain purchase part of the domains__add e2e test

## Why are these changes being made?

https://linear.app/a8c/issue/DOTCOM-10629/review-quarantined-e2e-tests

## Testing Instructions

* Set local environment
* run `yarn workspace @automattic/calypso-e2e build`
* Remove the "skip" method from [the line](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/specs/domains/domains__add.ts#L21)
* run `yarn workspace wp-e2e-tests test -- specs/domains/domains__add.ts`
* Check if it passes the "Purchase domain" segment and fails later on "Cancel domain" part

Anyway, the pre-release tests are all green: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release?branch=fix%2Fquarantined-tests-3&mode=builds#all-projects

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
