### PR TITLE
A4A: Have a default value for user billing type if not set.

### DIFF
--- a/client/state/a8c-for-agencies/agency/selectors.ts
+++ b/client/state/a8c-for-agencies/agency/selectors.ts
@@ -46,7 +46,7 @@ export function isAgencyClientUser( state: A4AStore ): boolean {
 }
 
 export function getUserBillingType( state: A4AStore ): UserBillingType {
-	return state.a8cForAgencies.agencies.userBillingType;
+	return state.a8cForAgencies.agencies.userBillingType || 'legacy';
 }
 
 export function hasAgencyCapability( state: A4AStore, capability: string ): boolean {


### PR DESCRIPTION
There was a regression in the previous PR because we didn't assume that the userBillingType could never be set during client session.

For the first referral, client accounts are not considered clients until they make a purchase. Hence, our entire logic regarding the billing type won't be triggered.


Follow up on https://github.com/Automattic/wp-calypso/pull/102528

## Proposed Changes

* This PR ensures that our selector for userBillingType returns 'legacy' as default.

## Why are these changes being made?

* We have a regression on the A4A client page.

## Testing Instructions


* Create a referral for a new client (without an existing referral).
* Log in as the client and use the A4A live link to go to `/client/subscriptions`.
* Access the 'Payment methods' or 'Invoices' page.
* Verify that you can navigate.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
