### PR TITLE
Logged-out themes showcase: Add window check to prevent error with SSR

### DIFF
--- a/client/landing/stepper/utils/get-flow-from-url.ts
+++ b/client/landing/stepper/utils/get-flow-from-url.ts
@@ -15,6 +15,11 @@ export const getFlowFromURL = ( pathname?: string, search?: string ) => {
 };
 
 export const getStepFromURL = () => {
+	// For SSR, e.g. the logged-out themes section.
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
 	const fromPath = matchPath( { path: '/setup/:flow/:step' }, window.location.pathname )?.params
 		?.step;
 	return fromPath;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* When going to https://calypso.localhost:3000/themes/filter/education, there's an error:
```
    at QueryClientProvider (/Users/gmovr/Developer/a8c/wp-calypso/node_modules/@tanstack/react-query/build/modern/QueryClientProvider.cjs:54:3)
    at RouteProvider (/Users/gmovr/Developer/a8c/wp-calypso/build/server.js:13044:3)
    at I18nProvider (/Users/gmovr/Developer/a8c/wp-calypso/node_modules/@wordpress/react-i18n/build/index.js:61:5)
    at LocaleProvider (/Users/gmovr/Developer/a8c/wp-calypso/build/server.js:141005:3)
    at CalypsoI18nProvider (/Users/gmovr/Developer/a8c/wp-calypso/build/server.js:9120:3)
    at ProviderWrappedLoggedOutLayout (/Users/gmovr/Developer/a8c/wp-calypso/build/server.js:17454:3)
23:35:43.655Z ERROR calypso: window is not defined (reqId=b2190a97-446b-4881-852e-87e3e243374a, url=/themes/filter/education, env=development, userAgent="Mobile Safari 16", path=/themes/filter/education)
    ReferenceError: window is not defined
        at getStepFromURL (/Users/gmovr/Developer/a8c/wp-calypso/build/webpack:/wp-calypso/client/landing/stepper/utils/get-flow-from-url.ts:18:62)
```
* This appears to be causing the SSR not to work, and the pages being rendered client-side which is worse for SEO.
This is because `window` is not defined in this context. This PR adds a check here, and returns `null` if `window` is `undefined`. 
* Maybe this change should be done closer to the theme badge component.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Bug fixing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Turn off javascript in the browser's developer tool "debug" section
* Go to http://calypso.localhost:3000/themes/filter/education. The page will just show in a loading state.
* You can log around here and you'll see the above error https://github.com/Automattic/wp-calypso/blob/trunk/client/server/render/index.js#L104
* Check out this PR, restart `yarn`
* Go to the same URL, you will see that the page loads, and the above error is gone.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
