### PR TITLE
Add context option to fixMe

### DIFF
--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.5.0
+
+- Add `translationOptions` to fixMe so it can work on translations with context.
+
 ## 7.4.0
 
 - Add type for `fixMe` method

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -223,6 +223,19 @@ i18n.fixMe( {
 } );
 ```
 
+If the newCopy requires translation context that it must also be passed with `translationOptions`.
+
+```js
+const i18n = require( 'i18n-calypso' );
+
+i18n.fixMe( {
+	text: 'new copy',
+	newCopy: i18n.translate( 'new copy', { context: 'verb' } ),
+	oldCopy: i18n.translate( 'old copy' ),
+	translationOptions: { context: 'verb' },
+} );
+```
+
 ## hasTranslation Method
 
 Using the method `hasTranslation` you can check whether a translation for a given string exists. As the `translate()` function will always return screen text that can be displayed (will supply the source text if no translation exists), it is unsuitable to determine whether text is translated. Other factors are optional [key hashing](#key-hashing) as well as purposeful translation to the source text.

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -371,14 +371,18 @@ I18N.prototype.hasTranslation = function () {
  * @param {string} options.text - The text to check for translation.
  * @param {string | Object} options.newCopy - The translation to return if the text is translated.
  * @param {string | Object | undefined } options.oldCopy - The fallback to return if the text is not translated.
+ * @param {Object} options.translationOptions - The options to pass to the `hasTranslation` method, e.g. translation context.
  */
-I18N.prototype.fixMe = function ( { text, newCopy, oldCopy } ) {
+I18N.prototype.fixMe = function ( { text, newCopy, oldCopy, translationOptions = {} } ) {
 	if ( typeof text !== 'string' ) {
 		warn( 'fixMe() requires an object with a proper text property (string)' );
 		return null;
 	}
 
-	if ( [ 'en', 'en-gb' ].includes( this.getLocaleSlug() ) || this.hasTranslation( text ) ) {
+	if (
+		[ 'en', 'en-gb' ].includes( this.getLocaleSlug() ) ||
+		this.hasTranslation( text, translationOptions )
+	) {
 		return newCopy;
 	}
 

--- a/packages/i18n-calypso/src/test/index.js
+++ b/packages/i18n-calypso/src/test/index.js
@@ -308,6 +308,16 @@ describe( 'I18n', function () {
 	} );
 
 	describe( 'fixMe', () => {
+		let originalHasTranslation;
+
+		beforeEach( () => {
+			originalHasTranslation = i18n.hasTranslation;
+		} );
+
+		afterEach( () => {
+			i18n.hasTranslation = originalHasTranslation;
+		} );
+
 		it( 'should return null if text is missing or wrong type', () => {
 			const result = i18n.fixMe( {} );
 			expect( result ).toBe( null );

--- a/packages/i18n-calypso/src/test/index.js
+++ b/packages/i18n-calypso/src/test/index.js
@@ -353,5 +353,28 @@ describe( 'I18n', function () {
 			} );
 			expect( result ).toBe( 'hi' );
 		} );
+
+		it( 'should return newCopy if text has a translation with context', function () {
+			const result = i18n.fixMe( {
+				text: 'test3',
+				newCopy: 'translation3',
+				oldCopy: 'not test 3',
+				translationOptions: {
+					context: 'thecontext',
+				},
+			} );
+			expect( result ).toBe( 'translation3' );
+		} );
+		it( 'should return oldCopy if text does not have a translation with this context', function () {
+			const result = i18n.fixMe( {
+				text: 'test3',
+				newCopy: 'translation3',
+				oldCopy: 'not test 3',
+				translationOptions: {
+					context: 'notthecontext',
+				},
+			} );
+			expect( result ).toBe( 'not test 3' );
+		} );
 	} );
 } );

--- a/packages/i18n-calypso/src/types/index.d.ts
+++ b/packages/i18n-calypso/src/types/index.d.ts
@@ -146,17 +146,22 @@ export interface I18N {
 	 * @param options.text - The text to check for translation.
 	 * @param options.newCopy - The translation to return if the text is translated.
 	 * @param options.oldCopy - The fallback to return if the text is not translated.
+	 * @param options.translationOptions - Optional. The options to pass to the translation.
 	 * @example
 	 * i18n.fixMe( {
 	 * 	text: 'new copy',
 	 * 	newCopy: i18n.translate( 'new copy' ),
 	 * 	oldCopy: i18n.translate( 'old copy' ),
+	 * 	translationOptions: {
+	 * 		context: 'Some disambiguating context if needed for the translation',
+	 * 	}
 	 * } );
 	 */
 	fixMe( options: {
 		text: string;
 		newCopy: ExistingReactNode;
 		oldCopy?: ExistingReactNode;
+		translationOptions?: TranslateOptions;
 	} ): ExistingReactNode | null;
 }
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCOM-12947 / #100420 where i'm changing some strings that have context

## Proposed Changes

The fixMe utility doesn't work where the string to be translated is translated with a context - it won't find the translations. This change allows the translation context to be passed to fixMe.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

I want to use fixMe on some strings that have context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Unit tests supplied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
