### PR TITLE
Plan cancellation: Fix incorrect math when the domain is taxable

### DIFF
--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -104,12 +104,10 @@ const CancelPurchaseDomainOptions = ( {
 		<div>
 			<p>
 				{ translate(
-					'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
 					{
 						args: {
 							domain: includedDomainPurchase.meta,
-							domainCost: includedDomainPurchase.priceText,
 						},
 					}
 				) }
@@ -151,12 +149,10 @@ const CancelPurchaseDomainOptions = ( {
 		<div>
 			<p>
 				{ translate(
-					'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
 					{
 						args: {
 							domain: includedDomainPurchase.meta,
-							domainCost: includedDomainPurchase.priceText,
 						},
 					}
 				) }
@@ -167,7 +163,7 @@ const CancelPurchaseDomainOptions = ( {
 						'minus %(domainCost)s for the domain.',
 					{
 						args: {
-							domainCost: includedDomainPurchase.priceText,
+							domainCost: includedDomainPurchase.costToUnbundleText,
 							planCost: planCostText,
 							refundAmount: purchase.refundText,
 						},


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-152/when-a-plan-is-refundable-but-the-bundled-domain-isnt-text-on-plan

## Proposed Changes

If you buy a plan and free domain using a tax location where domains are taxed, wait until the domain refund window expires, and then go to cancel the plan, the cancellation screen shows incorrect math in the explanation of how much you'll be refunded (it does not take into account the taxes on the domain).

This pull request fixes that.

**Before (plan refundable, domain nonrefundable):**
![before-domain-nonrefundable](https://github.com/user-attachments/assets/87d075bc-e180-4cae-a2b7-846e136b4ca2)

**After (plan refundable, domain nonrefundable):**
![after-domain-nonrefundable](https://github.com/user-attachments/assets/7a0441da-32a1-43b8-953c-273f155ac836)

You can see in the above screenshots that I also removed the "normally a $28 purchase" wording from the first sentence, since it's a bit confusing in the case where taxes are included, and also unnecessary since the price is mentioned in the next paragraph anyway.

That above wording change ("normally a $28 purchase") makes sense to apply to the case where both the plan **and** domain are outside their refund window also, for consistency.  In this case we aren't refunding anything, so there's no real reason to show the domain price here either.

**Before (plan and domain both nonrefundable):**
![before-both-nonrefundable](https://github.com/user-attachments/assets/e43175ae-6fde-4b06-b543-6b7c0182b68a)

**After (plan and domain both nonrefundable):**
![after-both-nonrefundable](https://github.com/user-attachments/assets/993a092a-52e8-4549-a73d-56349f3fac26)

## Testing Instructions

To test this you will need the server-side changes from 181973-ghe-Automattic/wpcom applied.

1. Purchase a plan and domain (using the plan's domain credit to get the domain for free) using a postal code where taxes are charged on domains (United States postal code 98101 works).
2. Wait until the domain is outside the refund window (for the first set of screenshots above) or until both the plan and domain are outside the refund window (for the second set of screenshots above).  If you don't want to wait, you can just change the `Store_Subscription::is_refundable()` server-side code on your sandbox to return `false` either for domains that were purchased with the domain credit, or for everything.
3. Go to cancel the plan, and compare your results with the above screenshots.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?