### PR TITLE
i18n: Migrate remaining `formatCurrency` cases to `@automattic/number-formatters`

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/hosting-plan-details.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/hosting-plan-details.tsx
@@ -1,6 +1,7 @@
+import { formatNumberCompact } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { Icon, close, arrowUpLeft } from '@wordpress/icons';
-import { numberFormatCompact, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import {
 	A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
 	A4A_MARKETPLACE_HOSTING_WPCOM_LINK,
@@ -64,7 +65,7 @@ const PressablePlanDetails = ( { productId }: { productId: number } ) => {
 							} ),
 							translate( '%(count)s visits per month', {
 								args: {
-									count: numberFormatCompact( selectedPlanInfo?.visits ?? 0 ),
+									count: formatNumberCompact( selectedPlanInfo?.visits ?? 0 ),
 								},
 								comment: '%(count)d is the number of visits.',
 							} ),

--- a/client/sites/components/storage-add-ons/storage-add-ons-dropdown/index.tsx
+++ b/client/sites/components/storage-add-ons/storage-add-ons-dropdown/index.tsx
@@ -1,7 +1,8 @@
 import { AddOns, StorageAddOnSlug } from '@automattic/data-stores';
 import { useGetPurchasedStorageAddOn } from '@automattic/data-stores/src/add-ons';
+import { formatCurrency } from '@automattic/number-formatters';
 import { CustomSelectControl } from '@wordpress/components';
-import { formatCurrency, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 
 import './style.scss';

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -38,6 +38,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/load-script": "workspace:^",
+		"@automattic/number-formatters": "^1.0.0",
 		"@automattic/oauth-token": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@tanstack/react-query": "^5.15.5",

--- a/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
+++ b/packages/data-stores/src/add-ons/hooks/use-add-on-prices.ts
@@ -1,5 +1,5 @@
+import { formatCurrency } from '@automattic/number-formatters';
 import { useMemo } from '@wordpress/element';
-import { formatCurrency } from 'i18n-calypso';
 import * as ProductsList from '../../products-list';
 import type { AddOnMeta } from '../types';
 

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -1,5 +1,5 @@
+import { formatCurrency } from '@automattic/number-formatters';
 import deterministicStringify from 'fast-json-stable-stringify';
-import { formatCurrency } from 'i18n-calypso';
 import type { DomainSuggestionQuery, DomainSuggestionSelectorOptions } from './types';
 
 /**

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -1,4 +1,4 @@
-import { formatCurrency } from 'i18n-calypso';
+import { formatCurrency } from '@automattic/number-formatters';
 import { stringify } from 'qs';
 import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
 import { setFeatures, setFeaturesByType, setPlanProducts, setPlans } from './actions';

--- a/packages/i18n-calypso/src/test/localize.js
+++ b/packages/i18n-calypso/src/test/localize.js
@@ -34,7 +34,7 @@ describe( 'localize()', () => {
 		expect( LocalizedComponent.displayName ).toBe( 'Localized(MyComponent)' );
 	} );
 
-	it( 'should provide translate, locale and numberFormat props to rendered child', () => {
+	it( 'should provide translate and locale props to rendered child', () => {
 		const renderer = new ShallowRenderer();
 		const LocalizedComponent = localize( () => null );
 
@@ -42,7 +42,6 @@ describe( 'localize()', () => {
 		const result = renderer.getRenderOutput();
 
 		expect( result.props.translate ).toBeInstanceOf( Function );
-		expect( result.props.numberFormat ).toBeInstanceOf( Function );
 		expect( result.props.locale ).toBe( i18n.getLocaleSlug() );
 	} );
 } );

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -38,6 +38,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/number-formatters": "^1.0.0",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@emotion/react": "11.11.1",

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -6,8 +6,9 @@ import {
 	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
 import { AddOns, WpcomPlansUI } from '@automattic/data-stores';
+import { formatCurrency } from '@automattic/number-formatters';
 import { useSelect } from '@wordpress/data';
-import { formatCurrency, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
 import { usePlanPricingInfoFromGridPlans } from '../../../hooks/use-plan-pricing-info-from-grid-plans';

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -4,8 +4,9 @@ import {
 	isWooExpressPlan,
 	isFreePlan,
 } from '@automattic/calypso-products';
+import { formatCurrency } from '@automattic/number-formatters';
 import styled from '@emotion/styled';
-import { useTranslate, formatCurrency, fixMe } from 'i18n-calypso';
+import { useTranslate, fixMe } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import usePlanBillingDescription from '../../../hooks/data-store/use-plan-billing-description';
 import type { GridPlan } from '../../../types';

--- a/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/storage-feature-label.tsx
@@ -1,6 +1,7 @@
 import { PlanSlug } from '@automattic/calypso-products';
+import { formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
-import { formatCurrency, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../../grid-context';
 import useIsLargeCurrency from '../../../../hooks/use-is-large-currency';
 import usePlanStorage from '../hooks/use-plan-storage';

--- a/packages/plans-grid-next/src/components/test/billing-timeframe.tsx
+++ b/packages/plans-grid-next/src/components/test/billing-timeframe.tsx
@@ -34,8 +34,8 @@ import {
 	PLAN_TRIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
+import { formatCurrency } from '@automattic/number-formatters';
 import { render } from '@testing-library/react';
-import { formatCurrency } from 'i18n-calypso';
 import React from 'react';
 import { usePlansGridContext } from '../../grid-context';
 import BillingTimeframe from '../shared/billing-timeframe';

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -10,7 +10,8 @@ import {
 	PLAN_HOSTING_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
-import { useTranslate, formatCurrency } from 'i18n-calypso';
+import { formatCurrency } from '@automattic/number-formatters';
+import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../grid-context';
 import type { GridPlan } from '../../types';
 

--- a/packages/plans-grid-next/src/hooks/use-is-large-currency.ts
+++ b/packages/plans-grid-next/src/hooks/use-is-large-currency.ts
@@ -1,5 +1,5 @@
+import { formatCurrency } from '@automattic/number-formatters';
 import { useMemo } from '@wordpress/element';
-import { formatCurrency } from 'i18n-calypso';
 const LARGE_ADD_ON_CURRENCY_CHAR_THRESHOLD = 7;
 const LARGE_CURRENCY_CHAR_THRESHOLD = 6;
 const LARGE_CURRENCY_COMBINED_CHAR_THRESHOLD = 9;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,6 +1691,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/number-formatters": "npm:^1.0.0"
     "@automattic/onboarding": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/typography": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -764,6 +764,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/js-utils": "workspace:^"
     "@automattic/load-script": "workspace:^"
+    "@automattic/number-formatters": "npm:^1.0.0"
     "@automattic/oauth-token": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@remix-run/router": "npm:^1.5.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See PT: pxLjZ-9ME-p2
Part of addressing https://github.com/Automattic/i18n-issues/issues/942

## Proposed Changes

A few more cases left of `formatCurrency` imports from `i18n-calypso` that were left in previous migration PRs. Somehow these slipped (or added after):
- `@automattic/data-stores` package
- `@automattic/plans-grid-next` package
- storage add-ons in `client`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is part of addressing https://github.com/Automattic/i18n-issues/issues/939 and https://github.com/Automattic/i18n-issues/issues/942, which aim at unifying number & currency-number formatting.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Build passing. We've tested the migration thoroughly so far, so these _should_ follow through without issues.
- Formatted currencies on the action buttons in plans-grid when scrolled:

<img width="1347" alt="Screenshot 2025-05-01 at 6 01 44 PM" src="https://github.com/user-attachments/assets/68c3115e-4a0e-44e6-8b50-7af0f7583d66" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?