### PR TITLE
[DataViews]: expose <FiltersToggle /> as a public subcomponent

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -3,6 +3,7 @@
 ## Next 
 
 - Expose `<DataViews.BulkActionToolbar />` component.
+- Expose `<DataViews.FiltersToggle />` component.
 - Expose `<DataViews.Layout />` component.
 - Expose `<DataViews.LayoutSwitcher />` component.
 - Expose `<DataViews.Pagination />` component.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -3,6 +3,7 @@
 ## Next 
 
 - Expose `<DataViews.BulkActionToolbar />` component.
+- Expose `<DataViews.Filters />` component.
 - Expose `<DataViews.FiltersToggle />` component.
 - Expose `<DataViews.Layout />` component.
 - Expose `<DataViews.LayoutSwitcher />` component.

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -11,6 +11,7 @@ import type {
 	Action,
 	NormalizedField,
 	SupportedLayouts,
+	NormalizedFilter,
 } from '../../types';
 import type { SetSelection } from '../../private-types';
 import { LAYOUT_TABLE } from '../../constants';
@@ -36,6 +37,7 @@ type DataViewsContextType< Item > = {
 	isItemClickable: ( item: Item ) => boolean;
 	containerWidth: number;
 	defaultLayouts: SupportedLayouts;
+	filters: NormalizedFilter[];
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {
@@ -55,6 +57,7 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	isItemClickable: () => true,
 	containerWidth: 0,
 	defaultLayouts: { list: {}, grid: {}, table: {} },
+	filters: [],
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -38,6 +38,8 @@ type DataViewsContextType< Item > = {
 	containerWidth: number;
 	defaultLayouts: SupportedLayouts;
 	filters: NormalizedFilter[];
+	isShowingFilter: boolean;
+	setIsShowingFilter: ( value: boolean ) => void;
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {
@@ -58,6 +60,8 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	containerWidth: 0,
 	defaultLayouts: { list: {}, grid: {}, table: {} },
 	filters: [],
+	isShowingFilter: false,
+	setIsShowingFilter: () => {},
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -173,7 +173,7 @@ function FilterVisibilityToggle( {
 	);
 }
 
-function Filters() {
+function Filters( { className }: { className?: string } ) {
 	const { fields, view, onChangeView, openedFilter, setOpenedFilter } =
 		useContext( DataViewsContext );
 	const addFilterRef = useRef< HTMLButtonElement >( null );
@@ -221,8 +221,8 @@ function Filters() {
 		<HStack
 			justify="flex-start"
 			style={ { width: 'fit-content' } }
-			className="dataviews-filters__container"
 			wrap
+			className={ className }
 		>
 			{ filterComponents }
 		</HStack>

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -72,20 +72,15 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 }
 
 export function FiltersToggle( {
-	filters,
-	view,
-	onChangeView,
-	setOpenedFilter,
 	isShowingFilter,
 	setIsShowingFilter,
 }: {
-	filters: NormalizedFilter[];
-	view: View;
-	onChangeView: ( view: View ) => void;
-	setOpenedFilter: ( filter: string | null ) => void;
 	isShowingFilter: boolean;
 	setIsShowingFilter: React.Dispatch< React.SetStateAction< boolean > >;
 } ) {
+	const { filters, view, onChangeView, setOpenedFilter } =
+		useContext( DataViewsContext );
+
 	const buttonRef = useRef< HTMLButtonElement >( null );
 	const onChangeViewWithFilterVisibility = useCallback(
 		( _view: View ) => {

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -71,15 +71,15 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 	}, [ fields, view ] );
 }
 
-export function FiltersToggle( {
-	isShowingFilter,
-	setIsShowingFilter,
-}: {
-	isShowingFilter: boolean;
-	setIsShowingFilter: React.Dispatch< React.SetStateAction< boolean > >;
-} ) {
-	const { filters, view, onChangeView, setOpenedFilter } =
-		useContext( DataViewsContext );
+export function FiltersToggle() {
+	const {
+		filters,
+		view,
+		onChangeView,
+		setOpenedFilter,
+		isShowingFilter,
+		setIsShowingFilter,
+	} = useContext( DataViewsContext );
 
 	const buttonRef = useRef< HTMLButtonElement >( null );
 	const onChangeViewWithFilterVisibility = useCallback(

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -176,6 +176,7 @@ function DataViews< Item >( {
 				onClickItem,
 				containerWidth,
 				defaultLayouts,
+				filters,
 			} }
 		>
 			<div className="dataviews-wrapper" ref={ containerRef }>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -189,6 +189,7 @@ function DataViews< Item >( {
 // Populate the DataViews sub components
 const DataViewsSubComponents = DataViews as typeof DataViews & {
 	BulkActionToolbar: typeof BulkActionsFooter;
+	FiltersToggle: typeof FiltersToggle;
 	Layout: typeof DataViewsLayout;
 	LayoutSwitcher: typeof ViewTypeMenu;
 	Pagination: typeof DataViewsPagination;
@@ -197,6 +198,7 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 };
 
 DataViewsSubComponents.BulkActionToolbar = BulkActionsFooter;
+DataViewsSubComponents.FiltersToggle = FiltersToggle;
 DataViewsSubComponents.Layout = DataViewsLayout;
 DataViewsSubComponents.LayoutSwitcher = ViewTypeMenu;
 DataViewsSubComponents.Pagination = DataViewsPagination;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -133,10 +133,6 @@ function DataViews< Item >( {
 				>
 					{ search && <DataViewsSearch label={ searchLabel } /> }
 					<FiltersToggle
-						filters={ filters }
-						view={ view! }
-						onChangeView={ onChangeView! }
-						setOpenedFilter={ setOpenedFilter }
 						setIsShowingFilter={ setIsShowingFilter }
 						isShowingFilter={ isShowingFilter }
 					/>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -132,10 +132,7 @@ function DataViews< Item >( {
 					className="dataviews__search"
 				>
 					{ search && <DataViewsSearch label={ searchLabel } /> }
-					<FiltersToggle
-						setIsShowingFilter={ setIsShowingFilter }
-						isShowingFilter={ isShowingFilter }
-					/>
+					<FiltersToggle />
 				</HStack>
 				<HStack
 					spacing={ 1 }
@@ -173,6 +170,8 @@ function DataViews< Item >( {
 				containerWidth,
 				defaultLayouts,
 				filters,
+				isShowingFilter,
+				setIsShowingFilter,
 			} }
 		>
 			<div className="dataviews-wrapper" ref={ containerRef }>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -184,6 +184,7 @@ function DataViews< Item >( {
 // Populate the DataViews sub components
 const DataViewsSubComponents = DataViews as typeof DataViews & {
 	BulkActionToolbar: typeof BulkActionsFooter;
+	Filters: typeof DataViewsFilters;
 	FiltersToggle: typeof FiltersToggle;
 	Layout: typeof DataViewsLayout;
 	LayoutSwitcher: typeof ViewTypeMenu;
@@ -193,6 +194,7 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 };
 
 DataViewsSubComponents.BulkActionToolbar = BulkActionsFooter;
+DataViewsSubComponents.Filters = DataViewsFilters;
 DataViewsSubComponents.FiltersToggle = FiltersToggle;
 DataViewsSubComponents.Layout = DataViewsLayout;
 DataViewsSubComponents.LayoutSwitcher = ViewTypeMenu;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -143,7 +143,9 @@ function DataViews< Item >( {
 					{ header }
 				</HStack>
 			</HStack>
-			{ isShowingFilter && <DataViewsFilters /> }
+			{ isShowingFilter && (
+				<DataViewsFilters className="dataviews-filters__container" />
+			) }
 			<DataViewsLayout />
 			<DataViewsFooter />
 		</>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -196,8 +196,16 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 				</VStack>
 			</Grid>
 
+<<<<<<< HEAD
 			<DataViews.Layout />
 		</>
+=======
+			<VStack spacing={ 2 }>
+				<DataViews.Search label={ __( 'moons by planet' ) } />
+				<DataViews.Filters />
+			</VStack>
+		</Card>
+>>>>>>> 56acc96041f (expose filters as DataViews.Filters)
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -180,13 +180,16 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 					</CardBody>
 				</Card>
 
-				<HStack justify="start">
-					<DataViews.FiltersToggle />
-					<DataViews.Search label={ __( 'moons by planet' ) } />
-				</HStack>
-
 				<VStack>
 					<HStack justify="start">
+						<DataViews.FiltersToggle />
+						<DataViews.Search label={ __( 'moons by planet' ) } />
+					</HStack>
+					<DataViews.Filters />
+				</VStack>
+
+				<VStack>
+					<HStack justify="end">
 						<DataViews.Pagination />
 						<DataViews.ViewConfig />
 						<DataViews.LayoutSwitcher />
@@ -194,8 +197,6 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 
 					<DataViews.BulkActionToolbar />
 				</VStack>
-
-				<DataViews.Filters />
 			</Grid>
 
 			<DataViews.Layout />

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -194,18 +194,12 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 
 					<DataViews.BulkActionToolbar />
 				</VStack>
+
+				<DataViews.Filters />
 			</Grid>
 
-<<<<<<< HEAD
 			<DataViews.Layout />
 		</>
-=======
-			<VStack spacing={ 2 }>
-				<DataViews.Search label={ __( 'moons by planet' ) } />
-				<DataViews.Filters />
-			</VStack>
-		</Card>
->>>>>>> 56acc96041f (expose filters as DataViews.Filters)
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -180,7 +180,10 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 					</CardBody>
 				</Card>
 
-				<DataViews.Search label={ __( 'moons by planet' ) } />
+				<HStack justify="start">
+					<DataViews.FiltersToggle />
+					<DataViews.Search label={ __( 'moons by planet' ) } />
+				</HStack>
 
 				<VStack>
 					<HStack justify="start">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes WOOA7S-125

## Proposed Changes

Exposes the `<FiltersToggle />` and `<Filters />` components.

These can now be used together to build custom UIs, combining the native toggle button with the Filters panel from DataViews.

Both components rely entirely on context state, making them safe to use in free-composition mode without requiring additional props.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

1. Run the Storybook app
```sh
yarn storybook:dataviews:start
```

2. Open the FreeComposition story.
3. Check that the ToggleFilters and Filters component behave as the controlled mode

https://github.com/user-attachments/assets/a0813015-bfeb-40ff-a08f-401668b3a588


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
