### PR TITLE
Copy changes for invite errors

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -175,7 +175,9 @@ class InviteAccept extends Component {
 				newCopy: this.props.translate( 'That invite is not valid', {
 					context: 'Title that is displayed to users when attempting to accept an invalid invite.',
 				} ),
-				oldCopy: this.props.translate( 'Oops, that invite is not valid' ),
+				oldCopy: this.props.translate( 'Oops, that invite is not valid', {
+					context: 'Title that is display to users when attempting to accept an invalid invite.',
+				} ),
 				translationOptions: {
 					context: 'Title that is displayed to users when attempting to accept an invalid invite.',
 				},

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -1,10 +1,9 @@
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import Debug from 'debug';
-import { localize } from 'i18n-calypso';
+import { localize, default as i18n } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import whoopsImage from 'calypso/assets/images/illustrations/whoops.svg';
 import EmptyContent from 'calypso/components/empty-content';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Notice from 'calypso/components/notice';
@@ -171,13 +170,20 @@ class InviteAccept extends Component {
 		debug( 'Rendering error: %o', error );
 
 		const props = {
-			title: this.props.translate( 'Oops, that invite is not valid', {
-				context: 'Title that is display to users when attempting to accept an invalid invite.',
+			title: i18n.fixMe( {
+				text: 'That invite is not valid',
+				newCopy: this.props.translate( 'That invite is not valid', {
+					context: 'Title that is displayed to users when attempting to accept an invalid invite.',
+				} ),
+				oldCopy: this.props.translate( 'Oops, that invite is not valid' ),
+				translationOptions: {
+					context: 'Title that is displayed to users when attempting to accept an invalid invite.',
+				},
 			} ),
 			line: this.props.translate( "We weren't able to verify that invitation.", {
 				context: 'Message that is displayed to users when an invitation is invalid.',
 			} ),
-			illustration: whoopsImage,
+			illustration: false,
 		};
 
 		if ( error.error && error.message ) {
@@ -189,17 +195,30 @@ class InviteAccept extends Component {
 						line: this.props.translate(
 							'Would you like to accept the invite with a different account?'
 						),
-						action: this.props.translate( 'Switch Accounts' ),
+						action: i18n.fixMe( {
+							text: 'Switch accounts',
+							newCopy: this.props.translate( 'Switch accounts' ),
+							oldCopy: this.props.translate( 'Switch Accounts' ),
+						} ),
 						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
 				case 'unauthorized_created_by_self':
 					Object.assign( props, {
 						line: error.message, // "You can not use an invitation that you have created for someone else."
-						action: this.props.translate( 'Switch Accounts' ),
+						action: i18n.fixMe( {
+							text: 'Switch accounts',
+							newCopy: this.props.translate( 'Switch accounts' ),
+							oldCopy: this.props.translate( 'Switch Accounts' ),
+						} ),
 						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
+				case 'invalid_input_invite_used':
+					Object.assign( props, {
+						title: this.props.translate( 'This invite has already been used' ),
+						line: error.message,
+					} );
 				default:
 					Object.assign( props, {
 						line: error.message,
@@ -207,7 +226,6 @@ class InviteAccept extends Component {
 					break;
 			}
 		}
-
 		return <EmptyContent { ...props } />;
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCOM-12948 / #100420

## Proposed Changes

 * Remove the outdated illustration
 * Change some copy

Note that this change does not include the proposed page formatting changes (see DOTCOM-12950) and also needs 181976-ghe-Automattic/wpcom to apply some of the text changes.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The current screens have old illustrations and clunky copy e.g. without clear next steps.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 0. Use the calypso.live link below
 1. Apply 181976-ghe-Automattic/wpcom to your sandbox
 2. Sandbox public-api.wordpress.com
 3. Choose a site and go to https://wordpress.com/people/new/:siteSlug (Users → Add new user)

### You click on an old link when a new one has been sent
 4. Send an invite to a user which doesn't already belong to the site
 5. Send a new invite to the same user for the same site (don't use the resend button)
 6. As a non-a12 (e.g. in a different/incognito window), open the link in the *first* email, . 
 7. It will redirect you to an address that starts with https://wordpress.com/accept-invite/ that shows an error message.
 8. Copy the URL  and paste everything after wordpress.com/ to the end of your calypso.live domain.
 9. Compare the two pages

Before | After
-------|------
 <img width="695" alt="Screenshot 2025-05-09 at 16 17 24" src="https://github.com/user-attachments/assets/f7c72f3b-2276-4bc3-a321-529d5c23d897" /> | <img width="695" alt="Screenshot 2025-05-09 at 16 17 50" src="https://github.com/user-attachments/assets/76cb0627-e4af-4637-9996-fc4031f16e31" />



### You click on a link that has already been used

 11. Send an invite to a user which does already belong to the site (or just use the second email from above)
 12. As a non-a12 (e.g. in a different/incognito window), open the link in the email
 13. Accept the invitation to become part of the site
 14. Click the link in the email *again* 
 15. It will redirect you to an address that starts with https://wordpress.com/accept-invite/ that shows an error message.
 16. Copy the URL  and paste everything after wordpress.com/ to the end of your calypso.live domain.
 17. Compare the two pages

Before | After
-------|------
 <img width="695" alt="Screenshot 2025-05-09 at 16 18 52" src="https://github.com/user-attachments/assets/4ae39cc7-529f-45e5-9e46-a3dba74776fe" /> | <img width="695" alt="Screenshot 2025-05-09 at 16 19 17" src="https://github.com/user-attachments/assets/5e493074-0c3e-44db-a1fd-fa9a9ed5338b" />



### You click on a link when you're already a member of a site
 19. On a different site, send an invite to a user which does not already belong to the site
 20. Visit the link from the email in your main account
 21. It will redirect you to an address that starts with https://wordpress.com/accept-invite/ that shows an error message.
 22. Copy the URL  and paste everything after wordpress.com/ to the end of your calypso.live domain.
 23. Compare the two pages

Before | After
-------|------
<img width="695" alt="Screenshot 2025-05-09 at 16 21 25" src="https://github.com/user-attachments/assets/6e22522b-b50a-44c7-8d92-187643628350" /> | <img width="695" alt="Screenshot 2025-05-09 at 16 21 46" src="https://github.com/user-attachments/assets/f86bb40a-9178-4fac-9588-c1f9ac425c9c" />



## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?