### PR TITLE
Use a single button in DIFM flows

### DIFF
--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -79,7 +79,7 @@ export default function NewOrExistingSiteStep( props: Props ) {
 					onPrimarySubmit={ () => handleSiteChoice( getPrimarySiteChoice() ) }
 					onSecondarySubmit={ () => handleSiteChoice( 'existing-site' ) }
 					showNewOrExistingSiteChoice={ showTwoButtons }
-					isStoreFlow={ ! showTwoButtons }
+					isStoreFlow={ 'do-it-for-me-store' === flowName }
 				/>
 			}
 			hideFormattedHeader

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,4 +1,4 @@
-import { DIFM_FLOW } from '@automattic/onboarding';
+import { DIFM_FLOW, DIFM_FLOW_STORE } from '@automattic/onboarding';
 import { useEffect } from 'react';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
@@ -36,8 +36,8 @@ export default function NewOrExistingSiteStep( props: Props ) {
 		triggerGuidesForStep( flowName, stepName );
 	}, [ dispatch, flowName, stepName ] );
 
-	// Show one button only for DIFM_FLOW, two buttons for all other flows
-	const showTwoButtons = flowName !== DIFM_FLOW;
+	// Show one button only for DIFM_FLOW and DIFM_FLOW_STORE, two buttons for all other flows
+	const showTwoButtons = ! [ DIFM_FLOW, DIFM_FLOW_STORE ].includes( flowName );
 
 	const branchSteps = useBranchSteps( stepName, () => [ 'difm-site-picker' ] );
 

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,3 +1,4 @@
+import { DIFM_FLOW } from '@automattic/onboarding';
 import { useEffect } from 'react';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
@@ -35,14 +36,23 @@ export default function NewOrExistingSiteStep( props: Props ) {
 		triggerGuidesForStep( flowName, stepName );
 	}, [ dispatch, flowName, stepName ] );
 
+	// Show one button only for DIFM_FLOW, two buttons for all other flows
+	const showTwoButtons = flowName !== DIFM_FLOW;
+
 	const branchSteps = useBranchSteps( stepName, () => [ 'difm-site-picker' ] );
 
-	const newOrExistingSiteSelected = ( value: ChoiceType ) => {
-		// If 'new-site' is selected, skip the `difm-site-picker` step.
-		if ( 'new-site' === value ) {
+	const handleSiteChoice = ( value: ChoiceType ) => {
+		// Skip site picker when:
+		// 1. In DIFM flow with no existing sites, or
+		// 2. In other flows when explicitly choosing new site
+		if (
+			( ! showTwoButtons && existingSiteCount === 0 ) ||
+			( showTwoButtons && value === 'new-site' )
+		) {
 			branchSteps( {} );
 			dispatch( removeSiteSlugDependency() );
 		}
+
 		dispatch(
 			submitSignupStep(
 				{ stepName: stepName },
@@ -55,20 +65,21 @@ export default function NewOrExistingSiteStep( props: Props ) {
 		goToNextStep();
 	};
 
-	const showNewOrExistingSiteChoice = existingSiteCount > 0;
+	const getPrimarySiteChoice = () => {
+		if ( showTwoButtons ) {
+			return 'new-site';
+		}
+		return existingSiteCount > 0 ? 'existing-site' : 'new-site';
+	};
 
 	return (
 		<StepWrapper
 			stepContent={
 				<DIFMLanding
-					onPrimarySubmit={ () =>
-						showNewOrExistingSiteChoice
-							? newOrExistingSiteSelected( 'new-site' )
-							: newOrExistingSiteSelected( 'existing-site' )
-					}
-					onSecondarySubmit={ () => newOrExistingSiteSelected( 'existing-site' ) }
-					showNewOrExistingSiteChoice={ showNewOrExistingSiteChoice }
-					isStoreFlow={ 'do-it-for-me-store' === flowName }
+					onPrimarySubmit={ () => handleSiteChoice( getPrimarySiteChoice() ) }
+					onSecondarySubmit={ () => handleSiteChoice( 'existing-site' ) }
+					showNewOrExistingSiteChoice={ showTwoButtons }
+					isStoreFlow={ ! showTwoButtons }
 				/>
 			}
 			hideFormattedHeader


### PR DESCRIPTION
Use a single button in the DIFM signup flows

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* It was requested by @mikeicode that we have a single Get Started button will either point to a site picker, or to a new site, depending on if the user has sites. 0 sites goes to a new site flow, 1 and more - to site picker.
* I attempted a full cleanup of the secondary button but it is used in StepContainerV2DIFMStartingPoint and the logic around going from onboarding to the difm step outside of the do-it-for-me flows. I'm not sure I hit all use cases there because the difmStartingPoint can be triggered from any flow and felt uncomfortable merging untested changes.

## Why are these changes being made?

* To prevent confusion coming from people who want to apply DIFM to an existing site but end up with a new site.

## Testing Instructions

You need to go over http://calypso.localhost:3000/start/do-it-for-me-store/ and http://calypso.localhost:3000/start/do-it-for-me/ with both a new and an existing user.

1. With a new user, go over both flows, and make sure there's no site picker
2. With an existing user that already has a site, go over both and make sure site picker is displayed

do-it-for-me-store before and after with 1 or more existing sites
<img width="45%" alt="Screenshot 2025-05-02 at 15 19 39" src="https://github.com/user-attachments/assets/ed41c773-3266-48b6-a162-8313a02022f9" /> <img width="45%" alt="Screenshot 2025-05-02 at 15 18 43" src="https://github.com/user-attachments/assets/99b30f3a-635f-46c7-90bc-06ba46c6d330" />

do-it-for-me before and after with 1 or more existing sites
<img width="45%" alt="Screenshot 2025-05-02 at 15 19 26" src="https://github.com/user-attachments/assets/e208e2ca-ab6e-4e81-9982-424e795b9e3c" /> <img width="45%" alt="Screenshot 2025-05-02 at 15 18 58" src="https://github.com/user-attachments/assets/8c5681ca-8567-4592-9af0-cbe315fa13de" />



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
