### PR TITLE
Security2faEnhancedSecuritySetting: Add notice if two_step_enhanced_security_forced is on

### DIFF
--- a/client/me/security-2fa-enhanced-security-setting/index.jsx
+++ b/client/me/security-2fa-enhanced-security-setting/index.jsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import { useSelector } from 'calypso/state';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
@@ -13,6 +14,8 @@ const Security2faEnhancedSecuritySetting = () => {
 	const userSettings = useSelector( getUserSettings );
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const { two_step_enhanced_security, two_step_enhanced_security_forced } = userSettings;
 	const toggleSetting = ( settingValue ) => {
 		dispatch( setUserSetting( 'two_step_enhanced_security', settingValue ) );
 	};
@@ -27,11 +30,22 @@ const Security2faEnhancedSecuritySetting = () => {
 				<form onChange={ () => dispatch( saveUserSettings() ) }>
 					<FormFieldset>
 						<FormLabel>{ translate( 'Enhanced account security' ) }</FormLabel>
+
+						{ two_step_enhanced_security_forced && (
+							<Notice status="is-info" showDismiss={ false }>
+								<strong>{ translate( 'Enforced by your organization' ) }</strong>
+								<br />
+								{ translate(
+									'Your account is currently required to use security keys (passkeys) as a second factor, regardless of the toggle below. You can use this toggle to set your preference in case this requirement no longer applies to your account.'
+								) }
+							</Notice>
+						) }
+
 						<ToggleControl
 							label={ translate(
 								'Secure your account by requiring the use of security keys (passkeys) as second factor.'
 							) }
-							checked={ userSettings.two_step_enhanced_security }
+							checked={ two_step_enhanced_security }
 							onChange={ toggleSetting }
 						/>
 						<FormSettingExplanation>


### PR DESCRIPTION
Add this notice if `two_step_enhanced_security_forced` is on (see 181086-ghe-Automattic/wpcom) 

<img width="1083" alt="Screenshot 2025-05-01 at 11 25 47 AM" src="https://github.com/user-attachments/assets/7b3d9d94-c41c-46f0-b36e-53de2fc6e627" />


## Proposed Changes

*

## Why are these changes being made?

* Clarity

## Testing Instructions


* Visit http://calypso.localhost:3000/me/security/two-step

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?