### PR TITLE
i18n: Use user locale for the admin menu request

### DIFF
--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -10,7 +10,7 @@ export const requestFetchAdminMenu = ( action ) =>
 	http(
 		{
 			method: 'GET',
-			path: `/sites/${ action.siteId }/admin-menu/`,
+			path: `/sites/${ action.siteId }/admin-menu/?_locale=user`,
 			apiNamespace: 'wpcom/v2',
 		},
 		action

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -15,7 +15,7 @@ describe( 'requestFetchAdminMenu', () => {
 			http(
 				{
 					method: 'GET',
-					path: '/sites/73738/admin-menu/',
+					path: '/sites/73738/admin-menu/?_locale=user',
 					apiNamespace: 'wpcom/v2',
 				},
 				action


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCOM-12951

## Proposed Changes

* Force the admin-menu endpoint to use the user locale in Calypso.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* When the site locale is different from the user locale, the sidebar navigation in Calypso is shown using the site locale, which is inconsistent with the standard approach of displaying all admin UIs using the user locale.
* This is caused by the fact that for API requests from Calypso the result of `is_admin` function is `false`, so the code in `determine_locale` doesn't switch to the locale of the user. Adding the `_locale=user` request parameter forces the switch.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:
<img width="1156" alt="Screenshot 2025-05-01 at 20 08 32" src="https://github.com/user-attachments/assets/fd3d5083-7e4a-48ff-bd0c-7aeb5df40ed5" />
After:
<img width="1156" alt="Screenshot 2025-05-01 at 20 08 07" src="https://github.com/user-attachments/assets/016a185d-457d-47d4-9231-aea2c58ad959" />


* Switch to a non-English locale in Calypso.
* Create a new simple site and confirm that the menu language doesn't match the selected locale.
* Test the branch on calypso.live or local instance and confirm that its fixed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
