### PR TITLE
Remove products request from base flow component

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -24,7 +24,6 @@ import { useDispatch as useReduxDispatch } from 'calypso/state';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { STEPPER_TRACKS_EVENT_STEP_NAV_SUBMIT } from '../../../constants';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
-import { useMarketplaceThemeProducts } from '../../../hooks/use-marketplace-theme-products';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
@@ -92,8 +91,6 @@ const onboarding: FlowV2< typeof initialize > = {
 		const coupon = useQuery().get( 'coupon' );
 
 		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
-
-		const { selectedMarketplaceProduct } = useMarketplaceThemeProducts();
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -215,6 +212,7 @@ const onboarding: FlowV2< typeof initialize > = {
 					return navigate( 'plans' );
 				case 'plans': {
 					const cartItems = providedDependencies.cartItems;
+					const selectedMarketplaceProduct = providedDependencies.selectedMarketplaceProduct;
 					const [ pickedPlan, ...products ] = cartItems ?? [];
 
 					setPlanCartItem( pickedPlan );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -212,7 +212,6 @@ const onboarding: FlowV2< typeof initialize > = {
 					return navigate( 'plans' );
 				case 'plans': {
 					const cartItems = providedDependencies.cartItems;
-					const selectedMarketplaceProduct = providedDependencies.selectedMarketplaceProduct;
 					const [ pickedPlan, ...products ] = cartItems ?? [];
 
 					setPlanCartItem( pickedPlan );
@@ -230,10 +229,7 @@ const onboarding: FlowV2< typeof initialize > = {
 					}
 
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.
-					setProductCartItems( [
-						...( selectedMarketplaceProduct ? [ selectedMarketplaceProduct ] : [] ),
-						...products.filter( ( product ) => product !== null ),
-					] );
+					setProductCartItems( products.filter( ( product ) => product !== null ) );
 
 					setSignupCompleteFlowName( flowName );
 					return navigate( 'create-site', undefined, false );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,7 +1,5 @@
 import { isDomainUpsellFlow, isStartWritingFlow, StepContainer } from '@automattic/onboarding';
-import { useMarketplaceThemeProducts } from 'calypso/landing/stepper/hooks/use-marketplace-theme-products';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import { useQuery } from '../../../../hooks/use-query';
 import PlansWrapper from './plans-wrapper';
 import type { Step } from '../../types';
@@ -15,12 +13,9 @@ const plans: Step< {
 		goToCheckout: boolean;
 		// Fake type just to make the this step types isomorphic to unified-plans.
 		cartItems?: undefined;
-		selectedMarketplaceProduct?: ProductListItem;
 	};
 } > = function Plans( { navigation, flow } ) {
 	const { goBack, submit } = navigation;
-
-	const { selectedMarketplaceProduct } = useMarketplaceThemeProducts();
 
 	const query = useQuery();
 	const queryParams = Object.fromEntries( query );
@@ -30,7 +25,6 @@ const plans: Step< {
 		const providedDependencies = {
 			plan,
 			goToCheckout: isDomainUpsellFlow( flow ) || isStartWritingFlow( flow ),
-			selectedMarketplaceProduct,
 		};
 
 		submit?.( providedDependencies );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,5 +1,7 @@
 import { isDomainUpsellFlow, isStartWritingFlow, StepContainer } from '@automattic/onboarding';
+import { useMarketplaceThemeProducts } from 'calypso/landing/stepper/hooks/use-marketplace-theme-products';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import { useQuery } from '../../../../hooks/use-query';
 import PlansWrapper from './plans-wrapper';
 import type { Step } from '../../types';
@@ -13,9 +15,12 @@ const plans: Step< {
 		goToCheckout: boolean;
 		// Fake type just to make the this step types isomorphic to unified-plans.
 		cartItems?: undefined;
+		selectedMarketplaceProduct?: ProductListItem;
 	};
 } > = function Plans( { navigation, flow } ) {
 	const { goBack, submit } = navigation;
+
+	const { selectedMarketplaceProduct } = useMarketplaceThemeProducts();
 
 	const query = useQuery();
 	const queryParams = Object.fromEntries( query );
@@ -25,6 +30,7 @@ const plans: Step< {
 		const providedDependencies = {
 			plan,
 			goToCheckout: isDomainUpsellFlow( flow ) || isStartWritingFlow( flow ),
+			selectedMarketplaceProduct,
 		};
 
 		submit?.( providedDependencies );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p58i-kIo-p2#comment-67515

## Proposed Changes

* Moves `useMarketplaceThemeProducts` out of base stepper flow into specific component whose submission handler uses the query hook value (`Plans`)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To eliminate a hefty (40kb+) network request being loaded in critical paths like the [account creation screen](https://wordpress.com/setup/onboarding/user)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify no network requests for `/products` endpoint on account creation screen

* Go to https://wordpress.com/setup/onboarding/user
* Open browser DevTools Network tab
* Optional: Filter requests to "products" to easily identify
* Refresh page
* Observe no matching `/products` network requests

Repeat Testing Instructions from #99744, where this was introduced. It's unclear whether this specific behavior is still relevant, since it doesn't appear that there are any flows that include `FLOWS.PLANS` and which also include a theme selection step prior to the plans step. The `<Plans />` component itself is also marked as "deprecated", but it appears a number of flows currently use it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?