### PR TITLE
JETCRM-11 Fix Bug: CRM Downloads on Calypso does not work with user licenses just with partner licenses

### DIFF
--- a/client/components/crm-downloads/crm-downloads.tsx
+++ b/client/components/crm-downloads/crm-downloads.tsx
@@ -23,7 +23,7 @@ const LoadingSkeleton = () => (
 );
 
 interface CrmDownloadsProps {
-	licenseKey: string;
+	licenseKey?: string;
 	isLoading?: boolean;
 }
 

--- a/client/components/crm-downloads/crm-downloads.tsx
+++ b/client/components/crm-downloads/crm-downloads.tsx
@@ -160,7 +160,7 @@ export function CrmDownloadsContent( { licenseKey, isLoading }: CrmDownloadsProp
 									<div className="manage-purchase__license-clipboard">
 										<code className="manage-purchase__license-clipboard-code">{ licenseKey }</code>
 										<ClipboardButton
-											text={ licenseKey }
+											text={ licenseKey || null }
 											className="manage-purchase__license-clipboard-icon"
 											borderless
 											compact

--- a/client/components/crm-downloads/is-jetpack-crm-product.ts
+++ b/client/components/crm-downloads/is-jetpack-crm-product.ts
@@ -3,7 +3,11 @@
  * @param keyOrSlug string
  * @returns boolean Returns true if keyOrSlug looks like a Jetpack CRM product license key or slug, false if not
  */
-export default function isJetpackCrmProduct( keyOrSlug: string ) {
+export default function isJetpackCrmProduct( keyOrSlug?: string ) {
+	if ( ! keyOrSlug ) {
+		return false;
+	}
+
 	return (
 		keyOrSlug.startsWith( 'jetpack-complete' ) ||
 		keyOrSlug.startsWith( 'jetpack_complete' ) ||

--- a/client/data/jetpack-crm/use-handle-extensions-download-mutation.ts
+++ b/client/data/jetpack-crm/use-handle-extensions-download-mutation.ts
@@ -48,7 +48,7 @@ async function fetchExtensionDownloads( licenseKey: string, extensionSlug: strin
 	return data;
 }
 
-export default function useHandleExtensionsDownloadMutation( licenseKey: string ) {
+export default function useHandleExtensionsDownloadMutation( licenseKey?: string ) {
 	return useMutation( {
 		mutationKey: [ 'use-handle-jetpack-crm-extensions-download', licenseKey ],
 		mutationFn: ( extensionSlug: string ) => fetchExtensionDownloads( licenseKey, extensionSlug ),

--- a/client/data/jetpack-crm/use-handle-extensions-download-mutation.ts
+++ b/client/data/jetpack-crm/use-handle-extensions-download-mutation.ts
@@ -5,7 +5,7 @@ const BASE_CRM_APP_URL =
 		? 'https://devapp.jetpackcrm.com'
 		: 'https://app.jetpackcrm.com';
 
-async function fetchExtensionDownloads( licenseKey: string, extensionSlug: string ) {
+async function fetchExtensionDownloads( extensionSlug: string, licenseKey?: string ) {
 	// API URL for downloads
 	const apiUrl = `${ BASE_CRM_APP_URL }/api/downloads/jetpack-complete`;
 
@@ -51,6 +51,6 @@ async function fetchExtensionDownloads( licenseKey: string, extensionSlug: strin
 export default function useHandleExtensionsDownloadMutation( licenseKey?: string ) {
 	return useMutation( {
 		mutationKey: [ 'use-handle-jetpack-crm-extensions-download', licenseKey ],
-		mutationFn: ( extensionSlug: string ) => fetchExtensionDownloads( licenseKey, extensionSlug ),
+		mutationFn: ( extensionSlug: string ) => fetchExtensionDownloads( extensionSlug, licenseKey ),
 	} );
 }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -277,6 +277,11 @@ export function changePaymentMethod( context, next ) {
 }
 
 export function crmDownloads( context, next ) {
-	context.primary = <CrmDownloads licenseKey={ context.params.licenseKey } />;
+	const purchaseId =
+		'number' === typeof +context.params.licenseKey ? +context.params.licenseKey : 0;
+
+	context.primary = (
+		<CrmDownloads licenseKey={ context.params.licenseKey } purchaseId={ purchaseId } />
+	);
 	next();
 }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -35,7 +35,7 @@ import titles from './titles';
 import VatInfoPage from './vat-info';
 import useVatDetails from './vat-info/use-vat-details';
 
-const useDataViewPurchasesList = config.isEnabled( 'purchases/purchase-list-dataview' );
+const useDataViewPurchasesList = ! config.isEnabled( 'purchases/purchase-list-dataview' );
 
 function useLogPurchasesError( message ) {
 	return useCallback(
@@ -277,11 +277,6 @@ export function changePaymentMethod( context, next ) {
 }
 
 export function crmDownloads( context, next ) {
-	const purchaseId =
-		'number' === typeof +context.params.licenseKey ? +context.params.licenseKey : 0;
-
-	context.primary = (
-		<CrmDownloads licenseKey={ context.params.licenseKey } purchaseId={ purchaseId } />
-	);
+	context.primary = <CrmDownloads subscription={ context.params.subscription } />;
 	next();
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -51,7 +51,7 @@ export default ( router ) => {
 	);
 
 	router(
-		paths.purchasesRoot + '/crm-downloads/:licenseKey',
+		paths.purchasesRoot + '/crm-downloads/:subscription',
 		sidebar,
 		controller.crmDownloads,
 		makeLayout,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -669,25 +669,21 @@ class ManagePurchase extends Component<
 	}
 
 	renderCrmDownloadsNavItem() {
-		const { site, purchase, translate } = this.props;
-
-		if ( ! site?.plan ) {
-			return null;
-		}
+		const { purchase, translate } = this.props;
 
 		// Only show for Jetpack CRM Products
-		if ( ! isJetpackCrmProduct( site.plan.product_slug ) ) {
+		if ( ! isJetpackCrmProduct( purchase?.productSlug ) ) {
 			return null;
 		}
 
 		const handleCrmDownloadsClick = () => {
 			recordTracksEvent( 'calypso_purchases_crm_downloads_click', {
-				product_slug: site?.plan?.product_slug || '',
+				product_slug: purchase?.productSlug || '',
 			} );
 		};
 
 		// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
-		const path = `/purchases/crm-downloads/${ purchase?.id ?? site.plan.license_key }`;
+		const path = `/purchases/crm-downloads/${ purchase?.id }`;
 
 		return (
 			<CompactCard href={ path } onClick={ handleCrmDownloadsClick }>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -682,14 +682,12 @@ class ManagePurchase extends Component<
 
 		const handleCrmDownloadsClick = () => {
 			recordTracksEvent( 'calypso_purchases_crm_downloads_click', {
-				product_slug: site?.plan?.license_key || 'no_key',
+				product_slug: site?.plan?.product_slug || '',
 			} );
 		};
 
 		// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
-		const path = isJetpackCloud()
-			? `/purchases/crm-downloads/${ purchase?.id ?? site.plan.license_key }`
-			: `/me/purchases/crm-downloads/${ purchase?.id ?? site.plan.license_key }`;
+		const path = `/purchases/crm-downloads/${ purchase?.id ?? site.plan.license_key }`;
 
 		return (
 			<CompactCard href={ path } onClick={ handleCrmDownloadsClick }>

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -669,14 +669,14 @@ class ManagePurchase extends Component<
 	}
 
 	renderCrmDownloadsNavItem() {
-		const { site, translate } = this.props;
+		const { site, purchase, translate } = this.props;
 
 		if ( ! site?.plan ) {
 			return null;
 		}
 
 		// Only show for Jetpack CRM Products
-		if ( ! isJetpackCrmProduct( site.plan.license_key || '' ) ) {
+		if ( ! isJetpackCrmProduct( site.plan.product_slug ) ) {
 			return null;
 		}
 
@@ -688,8 +688,8 @@ class ManagePurchase extends Component<
 
 		// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
 		const path = isJetpackCloud()
-			? `/purchases/crm-downloads/${ site.plan.license_key }`
-			: `/me/purchases/crm-downloads/${ site.plan.license_key }`;
+			? `/purchases/crm-downloads/${ purchase?.id ?? site.plan.license_key }`
+			: `/me/purchases/crm-downloads/${ purchase?.id ?? site.plan.license_key }`;
 
 		return (
 			<CompactCard href={ path } onClick={ handleCrmDownloadsClick }>

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -105,11 +105,6 @@ export const receiptView = ( context, next ) => {
 };
 
 export const crmDownloads = ( context, next ) => {
-	const purchaseId =
-		'number' === typeof +context.params.licenseKey ? +context.params.licenseKey : 0;
-
-	context.primary = (
-		<CrmDownloads licenseKey={ context.params.licenseKey } purchaseId={ purchaseId } />
-	);
+	context.primary = <CrmDownloads subscription={ context.params.subscription } />;
 	next();
 };

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -105,7 +105,9 @@ export const receiptView = ( context, next ) => {
 };
 
 export const crmDownloads = ( context, next ) => {
-	const purchaseId = Number.isNumber( +context.params.licenseKey ) ? +context.params.licenseKey : 0;
+	const purchaseId =
+		'number' === typeof +context.params.licenseKey ? +context.params.licenseKey : 0;
+
 	context.primary = (
 		<CrmDownloads licenseKey={ context.params.licenseKey } purchaseId={ purchaseId } />
 	);

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -105,6 +105,9 @@ export const receiptView = ( context, next ) => {
 };
 
 export const crmDownloads = ( context, next ) => {
-	context.primary = <CrmDownloads licenseKey={ context.params.licenseKey } />;
+	const purchaseId = Number.isNumber( +context.params.licenseKey ) ? +context.params.licenseKey : 0;
+	context.primary = (
+		<CrmDownloads licenseKey={ context.params.licenseKey } purchaseId={ purchaseId } />
+	);
 	next();
 };

--- a/client/my-sites/purchases/crm-downloads/index.tsx
+++ b/client/my-sites/purchases/crm-downloads/index.tsx
@@ -1,13 +1,22 @@
 import { useTranslate } from 'i18n-calypso';
-import { CrmDownloadsContent } from 'calypso/components/crm-downloads/crm-downloads';
+import {
+	CrmDownloadsError,
+	CrmDownloadsContent,
+} from 'calypso/components/crm-downloads/crm-downloads';
+import isJetpackCrmProduct from 'calypso/components/crm-downloads/is-jetpack-crm-product';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/use-user-license-by-subscription-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import './style.scss';
 
-export function CrmDownloads( { licenseKey }: { licenseKey: string } ) {
+export function CrmDownloads( { licenseKey }: { licenseKey?: string } ) {
 	const translate = useTranslate();
+	const isLicense = isJetpackCrmProduct( licenseKey || '' );
+	const { data, isError, isLoading } = useUserLicenseBySubscriptionQuery(
+		isLicense ? 0 : licenseKey
+	);
 
 	return (
 		<Main className="crm-downloads" wideLayout>
@@ -15,7 +24,14 @@ export function CrmDownloads( { licenseKey }: { licenseKey: string } ) {
 			<DocumentHead title={ translate( 'CRM Downloads' ) } />
 			<HeaderCake backHref="/purchases/subscriptions/">{ translate( 'CRM Downloads' ) }</HeaderCake>
 
-			<CrmDownloadsContent licenseKey={ licenseKey } />
+			{ isError ? (
+				<CrmDownloadsError />
+			) : (
+				<CrmDownloadsContent
+					licenseKey={ isLicense ? licenseKey : data?.licenseKey }
+					isLoading={ isLoading }
+				/>
+			) }
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/crm-downloads/index.tsx
+++ b/client/my-sites/purchases/crm-downloads/index.tsx
@@ -10,15 +10,9 @@ import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/us
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import './style.scss';
 
-export function CrmDownloads( {
-	licenseKey,
-	purchaseId,
-}: {
-	licenseKey?: string;
-	purchaseId: number;
-} ) {
+export function CrmDownloads( { subscription }: { subscription: number } ) {
 	const translate = useTranslate();
-	const { data, isError, isLoading } = useUserLicenseBySubscriptionQuery( purchaseId );
+	const { data, isError, isLoading } = useUserLicenseBySubscriptionQuery( subscription );
 
 	return (
 		<Main className="crm-downloads" wideLayout>
@@ -29,10 +23,7 @@ export function CrmDownloads( {
 			{ isError ? (
 				<CrmDownloadsError />
 			) : (
-				<CrmDownloadsContent
-					licenseKey={ data?.licenseKey || licenseKey }
-					isLoading={ isLoading }
-				/>
+				<CrmDownloadsContent licenseKey={ data?.licenseKey } isLoading={ isLoading } />
 			) }
 		</Main>
 	);

--- a/client/my-sites/purchases/crm-downloads/index.tsx
+++ b/client/my-sites/purchases/crm-downloads/index.tsx
@@ -3,7 +3,6 @@ import {
 	CrmDownloadsError,
 	CrmDownloadsContent,
 } from 'calypso/components/crm-downloads/crm-downloads';
-import isJetpackCrmProduct from 'calypso/components/crm-downloads/is-jetpack-crm-product';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
@@ -11,12 +10,15 @@ import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/us
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import './style.scss';
 
-export function CrmDownloads( { licenseKey }: { licenseKey?: string } ) {
+export function CrmDownloads( {
+	licenseKey,
+	purchaseId,
+}: {
+	licenseKey?: string;
+	purchaseId: number;
+} ) {
 	const translate = useTranslate();
-	const isLicense = isJetpackCrmProduct( licenseKey || '' );
-	const { data, isError, isLoading } = useUserLicenseBySubscriptionQuery(
-		isLicense ? 0 : licenseKey
-	);
+	const { data, isError, isLoading } = useUserLicenseBySubscriptionQuery( purchaseId );
 
 	return (
 		<Main className="crm-downloads" wideLayout>
@@ -28,7 +30,7 @@ export function CrmDownloads( { licenseKey }: { licenseKey?: string } ) {
 				<CrmDownloadsError />
 			) : (
 				<CrmDownloadsContent
-					licenseKey={ isLicense ? licenseKey : data?.licenseKey }
+					licenseKey={ data?.licenseKey || licenseKey }
 					isLoading={ isLoading }
 				/>
 			) }

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -73,6 +73,14 @@ export default ( router ) => {
 	);
 
 	page(
+		'/purchases/crm-downloads/:licenseKey',
+		navigation,
+		crmDownloads,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/purchases/subscriptions/:site/:purchaseId/payment-method/change/:cardId',
 		...commonHandlers,
 		purchaseChangePaymentMethod,
@@ -108,14 +116,6 @@ export default ( router ) => {
 		'/purchases/payment-methods/:site',
 		...commonHandlers,
 		paymentMethods,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/purchases/crm-downloads/:licenseKey',
-		...commonHandlers,
-		crmDownloads,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -73,7 +73,7 @@ export default ( router ) => {
 	);
 
 	page(
-		'/purchases/crm-downloads/:licenseKey',
+		'/purchases/crm-downloads/:subscription',
 		navigation,
 		crmDownloads,
 		makeLayout,


### PR DESCRIPTION

## Proposed Changes

* Allow Jetpack Complete users with a user license to download Jetpack CRM Extensions

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* There's currently no easy way for customers that have a user license for Jetpack Complete to download Jetpack CRM Extensions from wordpress.com or Jetpack Cloud. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a jurassic.ninja site
* Assign a Jetpack Complete user license to it

**For WordPress.com**

Issue a Jetpack Complete license
Assign it to a site
Go to http://calypso.localhost:3000/me/purchases
Click on that license purchase
Click on "CRM Downloads"
The program should show a page with a list of Jetpack CRM extensions that are allowed to be downloaded

**For Jetpack Cloud**

Issue a Jetpack Complete license
Assign it to a site
Go to http://jetpack.cloud.localhost:3000/purchases
Click on that license purchase
Click on "CRM Downloads"
The program should show a page with a list of Jetpack CRM extensions that are allowed to be downloaded


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
