### PR TITLE
When using the FF, redirect onboarding users to the new Hosting Dashboard

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { DomainSuggestion, OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, clearStepPersistedState } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -118,6 +119,21 @@ const onboarding: FlowV2 = {
 						playground: playgroundId,
 					} ),
 					null,
+				];
+			}
+
+			/**
+			 * If the dashboard/v2/onboarding feature flag is enabled, we'll redirect the user to the new hosting Dashboard.
+			 * We aren't using the dashboard/v2 FF because it's enabled by default on wpcalypso.json which would break e2e tests.
+			 * Since we're aiming to remove steps after the isMvpOnboarding experiment ends,
+			 * we'll redirect the user to the new Dashboard here.
+			 */
+			if ( isEnabled( 'dashboard/v2/onboarding' ) ) {
+				return [
+					addQueryArgs( `/v2/sites/${ providedDependencies.siteSlug }`, { ref: flowName } ),
+					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
+						siteSlug: providedDependencies.siteSlug,
+					} ),
 				];
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p5j4vm-5e7-p2


## Proposed Changes

* Users coming from the onboarding flow [/setup/onboarding](https://wpcalypso.wordpress.com/setup/onboarding) will be redirected to the new Hosting Dashboard if using the `dashboard/v2/onboarding` feature flag 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to validate the new Hosting Dashboard with real users and get their feedback early

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Going through the [/setup/onboarding](http://calypso.localhost:3000/setup/onboarding?flags=dashboard/v2/onboarding) with the `dashboard/v2/onboarding` feature flag and selecting a free plan, will redirect users to the new Hosting Dashboard.

https://github.com/user-attachments/assets/93ef9a3f-9107-471d-bcfd-df0dd58e8163


* To persist a feature flag on reloads and being able to buy a plan, for instance, we can open f12 and type: `document.cookie = 'flags=dashboard/v2/onboarding;max-age=1209600;path=/'`. That will allow us test even after a browser refresh.

https://github.com/user-attachments/assets/ae383fd8-9d0d-4278-b072-e81b6f6be33b

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?