### PR TITLE
Stats: Remove feature flag stats/empty-module-v2

### DIFF
--- a/client/my-sites/stats/features/modules/stats-shares/stats-shares.tsx
+++ b/client/my-sites/stats/features/modules/stats-shares/stats-shares.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { StatsCard } from '@automattic/components';
 import { share } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -90,12 +89,11 @@ const StatShares: React.FC< StatSharesProps > = ( { siteId, className } ) => {
 	}
 
 	const title = translate( 'Number of Shares' );
-	const isEmptyStateV2 = config.isEnabled( 'stats/empty-module-v2' );
 
 	return (
 		<>
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="stats" /> }
-			{ isEmptyStateV2 && isLoading && (
+			{ isLoading && (
 				<StatsCardSkeleton
 					isLoading={ isLoading }
 					className={ className }
@@ -105,7 +103,7 @@ const StatShares: React.FC< StatSharesProps > = ( { siteId, className } ) => {
 			) }
 			{
 				// old module
-				( ( ! isLoading && !! data?.length ) || ! isEmptyStateV2 ) && (
+				! isLoading && !! data?.length && (
 					// @ts-expect-error TODO: Refactor StatsListCard with TypeScript.
 					<StatsListCard
 						className={ className }
@@ -125,16 +123,14 @@ const StatShares: React.FC< StatSharesProps > = ( { siteId, className } ) => {
 						}
 						loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
 						titleNodes={
-							isEmptyStateV2 && (
-								<StatsInfoArea>
-									{ translate( 'Learn where your content has been shared the most.' ) }
-								</StatsInfoArea>
-							)
+							<StatsInfoArea>
+								{ translate( 'Learn where your content has been shared the most.' ) }
+							</StatsInfoArea>
 						}
 					/>
 				)
 			}
-			{ isEmptyStateV2 && ! isLoading && ! data?.length && (
+			{ ! isLoading && ! data?.length && (
 				// show empty state
 				<StatsCard
 					className={ className }

--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -23,7 +23,6 @@ import AllTimeHighlightsSection from '../../sections/all-time-highlights-section
 import AllTimeViewsSection from '../../sections/all-time-views-section';
 import AnnualHighlightsSection from '../../sections/annual-highlights-section';
 import PostingActivity from '../../sections/posting-activity-section';
-import StatsModule from '../../stats-module';
 import PageViewTracker from '../../stats-page-view-tracker';
 import statsStrings from '../../stats-strings';
 import StatsUpsell from '../../stats-upsell/insights-upsell';
@@ -35,7 +34,6 @@ function StatsInsights() {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const translate = useTranslate();
 	const moduleStrings = statsStrings();
-	const isEmptyStateV2 = config.isEnabled( 'stats/empty-module-v2' );
 	const { isPending, data: usageInfo } = usePlanUsageQuery( siteId );
 	const reduxDispatch = useDispatch();
 
@@ -86,38 +84,19 @@ function StatsInsights() {
 						<PostingActivity siteId={ siteId } />
 						<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
 						<StatsModuleListing className="stats__module-list--insights" siteId={ siteId }>
-							{ isEmptyStateV2 && (
-								<StatsModuleTags
-									moduleStrings={ moduleStrings.tags }
-									hideSummaryLink
-									className={ clsx(
-										{
-											'stats__flexible-grid-item--half': isJetpack,
-											'stats__flexible-grid-item--full--large': isJetpack,
-										},
-										{
-											'stats__flexible-grid-item--full': ! isJetpack,
-										}
-									) }
-								/>
-							) }
-							{ ! isEmptyStateV2 && (
-								<StatsModule
-									path="tags-categories"
-									moduleStrings={ moduleStrings.tags }
-									statType="statsTags"
-									hideSummaryLink
-									className={ clsx(
-										{
-											'stats__flexible-grid-item--half': isJetpack,
-											'stats__flexible-grid-item--full--large': isJetpack,
-										},
-										{
-											'stats__flexible-grid-item--full': ! isJetpack,
-										}
-									) }
-								/>
-							) }
+							<StatsModuleTags
+								moduleStrings={ moduleStrings.tags }
+								hideSummaryLink
+								className={ clsx(
+									{
+										'stats__flexible-grid-item--half': isJetpack,
+										'stats__flexible-grid-item--full--large': isJetpack,
+									},
+									{
+										'stats__flexible-grid-item--full': ! isJetpack,
+									}
+								) }
+							/>
 
 							<StatsModuleComments
 								className={ clsx(

--- a/client/my-sites/stats/sections/all-time-views-section/all-time-views-section.tsx
+++ b/client/my-sites/stats/sections/all-time-views-section/all-time-views-section.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	Card,
 	SimplifiedSegmentedControl,
@@ -63,7 +62,6 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 		'is-loading': ! viewData,
 	} );
 
-	const isEmptyStateV2 = config.isEnabled( 'stats/empty-module-v2' );
 	const isRequestingData = useSelector( ( state: StatsStateProps ) =>
 		isRequestingSiteStatsForQuery( state, siteId, statType, query )
 	);
@@ -77,7 +75,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 			<div className="highlight-cards">
 				<h3 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h3>
 
-				{ isEmptyStateV2 && isRequestingData && (
+				{ isRequestingData && (
 					<div className="highlight-cards-list">
 						<Card className={ cardWrapperClassName }>
 							<div className="highlight-card-heading">
@@ -91,7 +89,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 						</Card>
 					</div>
 				) }
-				{ isEmptyStateV2 && ! isRequestingData && ! hasData && ! shouldGateStats && (
+				{ ! isRequestingData && ! hasData && ! shouldGateStats && (
 					<StatsCard
 						title={ translate( 'Total views' ) }
 						isEmpty
@@ -112,7 +110,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 					/>
 				) }
 
-				{ ( ( ! isRequestingData && hasData ) || ! isEmptyStateV2 ) && (
+				{ ! isRequestingData && hasData && (
 					<div className="highlight-cards-list">
 						{ /*
 								TODO: Refactor this card along with other similar structure cards to a component
@@ -122,13 +120,11 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 							<div className="highlight-card-heading">
 								<h4 className="highlight-card-heading__title">
 									<span>{ translate( 'Total views' ) }</span>
-									{ isEmptyStateV2 && (
-										<StatsInfoArea>
-											{ translate(
-												'Learn about views patterns by analysing total and average daily views to your site.'
-											) }
-										</StatsInfoArea>
-									) }
+									<StatsInfoArea>
+										{ translate(
+											'Learn about views patterns by analysing total and average daily views to your site.'
+										) }
+									</StatsInfoArea>
 								</h4>
 								{ viewData && (
 									<SimplifiedSegmentedControl

--- a/config/client.json
+++ b/config/client.json
@@ -23,7 +23,6 @@
 	"signup_url",
 	"stats/chart-library",
 	"stats/empty-module-traffic",
-	"stats/empty-module-v2",
 	"stats/real-time-tab",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",

--- a/config/development.json
+++ b/config/development.json
@@ -187,7 +187,6 @@
 		"ssr/prefetch-timebox": false,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": true,
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -124,7 +124,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/real-time-tab": false,
 		"stats/navigation-improvement": false,

--- a/config/production.json
+++ b/config/production.json
@@ -159,7 +159,6 @@
 		"ssr/sample-log-cache-misses": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": true,
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,7 +154,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": true,
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,

--- a/config/test.json
+++ b/config/test.json
@@ -117,7 +117,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": true,
 		"stats/navigation-improvement": false,
 		"subscribers-helper-library": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,7 +157,6 @@
 		"ssr/prefetch-timebox": true,
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
-		"stats/empty-module-v2": true,
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,


### PR DESCRIPTION
Fixes STATS-45

## Proposed Changes

* Remove unused feature flag `stats/empty-module-v2` from the configs and codes.

## Why are these changes being made?

* This feature flag is no longer in use and has been removed for code cleanup.

## Testing Instructions

* Open the Calypso feature branch.
* Remove the feature flag by adding this query param`flags=-stats/empty-module-v2`.
* There would be no change in stats.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
