### PR TITLE
Optimize allowed path checking for unsupported browser 

### DIFF
--- a/client/server/middleware/test/unsupported-browser.test.ts
+++ b/client/server/middleware/test/unsupported-browser.test.ts
@@ -66,7 +66,7 @@ describe( 'unsupported-browser', () => {
 	it( 'should call next() for allowed paths', () => {
 		// Use an unsupported browser that should normally be redirected
 		req.useragent = parseUserAgent(
-			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36'
+			'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko'
 		);
 
 		const allowedPaths = [

--- a/client/server/middleware/test/unsupported-browser.test.ts
+++ b/client/server/middleware/test/unsupported-browser.test.ts
@@ -63,27 +63,6 @@ describe( 'unsupported-browser', () => {
 		expect( res.redirect ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call next() for allowed paths', () => {
-		// Use an unsupported browser that should normally be redirected
-		req.useragent = parseUserAgent(
-			'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko'
-		);
-
-		const allowedPaths = [
-			'/browsehappy',
-			'/themes',
-			'/es/themes',
-			'/theme/twentytwenty',
-			'/calypso/style.css',
-		];
-
-		allowedPaths.forEach( ( path ) => {
-			unsupportedBrowserMiddleware()( { ...req, path }, res, next );
-			expect( next ).toHaveBeenCalled();
-			expect( res.redirect ).not.toHaveBeenCalled();
-		} );
-	} );
-
 	it( 'should call next() if bypass_target_redirection cookie is true', () => {
 		req.cookies.bypass_target_redirection = 'true';
 
@@ -111,6 +90,29 @@ describe( 'unsupported-browser', () => {
 		);
 		expect( next ).toHaveBeenCalled();
 		expect( res.redirect ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'allowed paths', () => {
+		beforeEach( () => {
+			// Use an unsupported browser that should normally be redirected
+			req.useragent = parseUserAgent(
+				'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko'
+			);
+		} );
+
+		it.each( [
+			{ path: '/browsehappy', allowed: true },
+			{ path: '/themes', allowed: true },
+			{ path: '/es/themes', allowed: true },
+			{ path: '/theme/twentytwenty', allowed: true },
+			{ path: '/calypso/style.css', allowed: true },
+			{ path: '/themeshaper', allowed: false },
+		] )( 'should not redirect for allowed paths', ( { path, allowed } ) => {
+			unsupportedBrowserMiddleware()( { ...req, path }, res, next );
+
+			expect( next ).toHaveBeenCalledTimes( allowed ? 1 : 0 );
+			expect( res.redirect ).toHaveBeenCalledTimes( allowed ? 0 : 1 );
+		} );
 	} );
 
 	describe( 'unsupported browsers', () => {

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -13,7 +13,7 @@ const SUPPORTED_LOCALES = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
 const ALLOWED_PATHS = [ 'browsehappy', 'themes', 'theme', 'calypso' ];
 
 /**
- * Regular expression matching paths that are allowed even if the browser is unsupported.
+ * We allow some paths even if the browser is unsupported.
  */
 const ALLOWED_PATH_PATTERN = new RegExp(
 	`^/((${ SUPPORTED_LOCALES.join( '|' ) })/)?(${ ALLOWED_PATHS.join( '|' ) })($|/)`

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -16,7 +16,7 @@ const ALLOWED_PATHS = [ 'browsehappy', 'themes', 'theme', 'calypso' ];
  * Regular expression matching paths that are allowed even if the browser is unsupported.
  */
 const ALLOWED_PATH_PATTERN = new RegExp(
-	`^(/(${ SUPPORTED_LOCALES.join( '|' ) }))?/${ ALLOWED_PATHS.join( '|' ) }/?`
+	`^/((${ SUPPORTED_LOCALES.join( '|' ) })/)?(${ ALLOWED_PATHS.join( '|' ) })($|/)`
 );
 
 /**

--- a/client/server/middleware/unsupported-browser.js
+++ b/client/server/middleware/unsupported-browser.js
@@ -3,6 +3,23 @@ import { addQueryArgs } from 'calypso/lib/url';
 import analytics from 'calypso/server/lib/analytics';
 
 /**
+ * The locales that are supported in exempting browser support checks.
+ */
+const SUPPORTED_LOCALES = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
+
+/**
+ * The paths that are allowed even if the browser is unsupported.
+ */
+const ALLOWED_PATHS = [ 'browsehappy', 'themes', 'theme', 'calypso' ];
+
+/**
+ * Regular expression matching paths that are allowed even if the browser is unsupported.
+ */
+const ALLOWED_PATH_PATTERN = new RegExp(
+	`^(/(${ SUPPORTED_LOCALES.join( '|' ) }))?/${ ALLOWED_PATHS.join( '|' ) }/?`
+);
+
+/**
  * @typedef {import('express-useragent').Details} UserAgentDetails
  */
 
@@ -55,21 +72,7 @@ const isUnsupportedBrowser = ( req ) =>
 /**
  * These public pages work even in unsupported browsers, so we do not redirect them.
  */
-function allowPath( path ) {
-	const locales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
-	const prefixedLocale = locales.find( ( locale ) => path.startsWith( `/${ locale }/` ) );
-
-	// If the path starts with a locale, replace it (e.g. '/es/log-in' => '/log-in')
-	const parsedPath = prefixedLocale
-		? path.replace( new RegExp( `^/${ prefixedLocale }` ), '' )
-		: path;
-
-	// '/calypso' is the static assets path, and should never be redirected. (Can
-	// cause CDN caching issues if an asset gets cached with a redirect.)
-	const allowedPaths = [ '/browsehappy', '/themes', '/theme', '/calypso' ];
-	// For example, match either exactly "/themes" or "/themes/*"
-	return allowedPaths.some( ( p ) => parsedPath === p || parsedPath.startsWith( p + '/' ) );
-}
+const isAllowedPath = ( path ) => ALLOWED_PATH_PATTERN.test( path );
 
 export default () => ( req, res, next ) => {
 	if ( ! config.isEnabled( 'redirect-fallback-browsers' ) ) {
@@ -78,7 +81,7 @@ export default () => ( req, res, next ) => {
 	}
 
 	// Permitted paths even if the browser is unsupported.
-	if ( allowPath( req.path ) ) {
+	if ( isAllowedPath( req.path ) ) {
 		next();
 		return;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/102984#issuecomment-2841862710

## Proposed Changes

* Optimizes path exemptions during unsupported browser checks

The previous implementation was not as slow as I suspected it might be, but there's still a **19x performance improvement** with these changes. I also find the implementation a bit simpler to follow, so long as you don't mind regular expressions.

```
before x 5,655,002 ops/sec ±0.32% (98 runs sampled)
after x 105,867,467 ops/sec ±1.77% (90 runs sampled)
```

<details><summary>Benchmark script</summary>
<pre><code>import Benchmark from 'benchmark';
import config from './client/server/config/index.js';

const suite = new Benchmark.Suite();

function before( path ) {
	const locales = [ 'en', ...config( 'magnificent_non_en_locales' ) ];
	const prefixedLocale = locales.find( ( locale ) => path.startsWith( `/${ locale }/` ) );

	const parsedPath = prefixedLocale
		? path.replace( new RegExp( `^/${ prefixedLocale }` ), '' )
		: path;

	const allowedPaths = [ '/browsehappy', '/themes', '/theme', '/calypso' ];
	return allowedPaths.some( ( p ) => parsedPath === p || parsedPath.startsWith( p + '/' ) );
}

const SUPPORTED_LOCALES = [ 'en', ...config( 'magnificent_non_en_locales' ) ];

const ALLOWED_PATHS = [ 'browsehappy', 'themes', 'theme', 'calypso' ];

const ALLOWED_PATH_PATTERN = new RegExp(
	`^(/(${ SUPPORTED_LOCALES.join( '|' ) }))?/${ ALLOWED_PATHS.join( '|' ) }/?`
);

const after = ( path ) => ALLOWED_PATH_PATTERN.test( path );

suite
	.add( 'before', function () {
		before( 'test' );
	} )
	.add( 'after', function () {
		after( 'test' );
	} )
	.on( 'cycle', function ( event ) {
		console.log( String( event.target ) );
	} )
	.run( { async: true } );
</code></pre>
</summary></details>

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Improve performance in a common server middleware executed for every request

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify that Calypso redirects for an unsupported browser:

1. Run the server with `ENABLE_FEATURES=redirect-fallback-browsers yarn start` ([redirecting unsupported browsers is disabled in development](https://github.com/Automattic/wp-calypso/blob/d1a4e4259956807b0d2973d7d8f8c3c0cad28e19/config/development.json#L170))
2. Check request with an unsupported browser
   - `curl -I -A "Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko" http://calypso.localhost:3000`
   - Observe `HTTP/1.1 302 Found` and `Location: /browsehappy?from=%2F`
3. Check request with a not-unsupported browser
   - `curl -I http://calypso.localhost:3000`
   - Observe `HTTP/1.1 200 OK`

Verify existing test coverage continues to pass:

* `yarn client/server/middleware/test/unsupported-browser.test.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
