### PR TITLE
New hosted site: Add E2E tests

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -160,7 +160,7 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"purchases/purchase-list-dataview": true,
+		"purchases/purchase-list-dataview": false,
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,

--- a/packages/calypso-e2e/src/lib/components/index.ts
+++ b/packages/calypso-e2e/src/lib/components/index.ts
@@ -36,6 +36,7 @@ export * from './full-side-editor-data-views-component';
 export * from './editor-dimensions-component';
 export * from './jetpack-instant-search-modal-component';
 export * from './wp-admin-notice-component';
+export * from './wp-admin-sidebar-component';
 
 export * from './me';
 

--- a/packages/calypso-e2e/src/lib/components/wp-admin-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/wp-admin-sidebar-component.ts
@@ -1,0 +1,86 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+
+const selectors = {
+	sidebar: '#adminmenu',
+
+	// Buttons and links within Sidebar
+	linkWithText: ( text: string ) => `a:has-text("${ text }")`,
+};
+
+/**
+ * Component representing the sidebar in WP Admin.
+ *
+ */
+export class WPAdminSidebarComponent {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Waits for the WordPress.com Calypso sidebar to be ready on the page.
+	 */
+	async waitForSidebarInitialization(): Promise< void > {
+		const sidebarLocator = this.page.locator( selectors.sidebar );
+
+		await Promise.all( [
+			this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),
+			sidebarLocator.waitFor( { timeout: 20 * 1000 } ),
+		] );
+	}
+
+	/* Main sidebar action */
+
+	/**
+	 * Navigates to given (sub)item of the sidebar menu.
+	 *
+	 * @param {string} item Plaintext representation of the top level heading.
+	 * @param {string} subitem Plaintext representation of the child level heading.
+	 * @returns {Promise<void>} No return value.
+	 */
+	async navigate( item: string, subitem?: string ): Promise< void > {
+		await this.waitForSidebarInitialization();
+
+		// Top level menu item selector.
+		const itemSelector = `${ selectors.sidebar } :text-is("${ item }"):visible`;
+		await this.page.dispatchEvent( itemSelector, 'click' );
+
+		// Sub-level menu item selector.
+		if ( subitem ) {
+			const subitemSelector = `.is-toggle-open :text-is("${ subitem }"):visible`;
+			await Promise.all( [
+				this.page.waitForNavigation( { timeout: 30 * 1000 } ),
+				this.page.dispatchEvent( subitemSelector, 'click' ),
+			] );
+		}
+
+		const currentURL = this.page.url();
+		// Do not verify selected menu items or retry if navigation takes user out of Calypso (eg. WP-Admin, Widgets editor)...
+		if ( ! currentURL.startsWith( getCalypsoURL() ) ) {
+			return;
+		}
+		// ... or to a page in Calypso that closes the sidebar.
+		if ( currentURL.match( /\/(post|page|site-editor)\// ) ) {
+			return;
+		}
+
+		// Some menu items (eg. Comments, Stats) do not have a submenu. In these cases,
+		// the `.selected` class is applied to the top level menu.
+		let selectedMenuItem = `${ selectors.sidebar } .selected :text-is("${ item }")`;
+
+		if ( subitem ) {
+			selectedMenuItem = `${ selectors.sidebar } .selected :text-is("${ subitem }")`;
+		}
+
+		// Verify the expected item or subitem is selected.
+		const locator = this.page.locator( selectedMenuItem );
+		await locator.waitFor( { state: 'attached' } );
+	}
+}

--- a/packages/calypso-e2e/src/lib/components/wp-admin-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/wp-admin-sidebar-component.ts
@@ -1,11 +1,7 @@
 import { Page } from 'playwright';
-import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
 	sidebar: '#adminmenu',
-
-	// Buttons and links within Sidebar
-	linkWithText: ( text: string ) => `a:has-text("${ text }")`,
 };
 
 /**
@@ -48,39 +44,13 @@ export class WPAdminSidebarComponent {
 	async navigate( item: string, subitem?: string ): Promise< void > {
 		await this.waitForSidebarInitialization();
 
-		// Top level menu item selector.
-		const itemSelector = `${ selectors.sidebar } :text-is("${ item }"):visible`;
-		await this.page.dispatchEvent( itemSelector, 'click' );
-
-		// Sub-level menu item selector.
-		if ( subitem ) {
-			const subitemSelector = `.is-toggle-open :text-is("${ subitem }"):visible`;
-			await Promise.all( [
-				this.page.waitForNavigation( { timeout: 30 * 1000 } ),
-				this.page.dispatchEvent( subitemSelector, 'click' ),
-			] );
-		}
-
-		const currentURL = this.page.url();
-		// Do not verify selected menu items or retry if navigation takes user out of Calypso (eg. WP-Admin, Widgets editor)...
-		if ( ! currentURL.startsWith( getCalypsoURL() ) ) {
-			return;
-		}
-		// ... or to a page in Calypso that closes the sidebar.
-		if ( currentURL.match( /\/(post|page|site-editor)\// ) ) {
-			return;
-		}
-
-		// Some menu items (eg. Comments, Stats) do not have a submenu. In these cases,
-		// the `.selected` class is applied to the top level menu.
-		let selectedMenuItem = `${ selectors.sidebar } .selected :text-is("${ item }")`;
+		const menuItem = this.page.locator( selectors.sidebar ).getByRole( 'link', { name: item } );
 
 		if ( subitem ) {
-			selectedMenuItem = `${ selectors.sidebar } .selected :text-is("${ subitem }")`;
+			await menuItem.hover();
+			await this.page.locator( selectors.sidebar ).getByRole( 'link', { name: subitem } ).click();
+		} else {
+			await menuItem.click();
 		}
-
-		// Verify the expected item or subitem is selected.
-		const locator = this.page.locator( selectedMenuItem );
-		await locator.waitFor( { state: 'attached' } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/components/wp-admin-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/wp-admin-sidebar-component.ts
@@ -1,6 +1,8 @@
 import { Page } from 'playwright';
+import envVariables from '../../env-variables';
 
 const selectors = {
+	sidebarToggle: ( page: Page ) => page.getByRole( 'menuitem', { name: 'Menu' } ),
 	sidebar: '#adminmenu',
 };
 
@@ -24,11 +26,14 @@ export class WPAdminSidebarComponent {
 	 * Waits for the WordPress.com Calypso sidebar to be ready on the page.
 	 */
 	async waitForSidebarInitialization(): Promise< void > {
-		const sidebarLocator = this.page.locator( selectors.sidebar );
+		const sidebarOrSidebarToggle =
+			envVariables.VIEWPORT_NAME === 'mobile'
+				? selectors.sidebarToggle( this.page )
+				: this.page.locator( selectors.sidebar );
 
 		await Promise.all( [
 			this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),
-			sidebarLocator.waitFor( { timeout: 20 * 1000 } ),
+			sidebarOrSidebarToggle.waitFor( { timeout: 20 * 1000 } ),
 		] );
 	}
 
@@ -44,13 +49,35 @@ export class WPAdminSidebarComponent {
 	async navigate( item: string, subitem?: string ): Promise< void > {
 		await this.waitForSidebarInitialization();
 
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await this.openMobileSidebar();
+		}
+
 		const menuItem = this.page.locator( selectors.sidebar ).getByRole( 'link', { name: item } );
 
 		if ( subitem ) {
-			await menuItem.hover();
+			if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+				await menuItem.click();
+			} else {
+				await menuItem.hover();
+			}
+
 			await this.page.locator( selectors.sidebar ).getByRole( 'link', { name: subitem } ).click();
 		} else {
 			await menuItem.click();
 		}
+	}
+
+	/**
+	 * Opens the mobile variant of the sidebar into view.
+	 *
+	 * For mobile sized viewports, the sidebar is by default hidden off screen.
+	 * In order to interact with the sidebar, the hamburger menu button on top left must first
+	 * be clicked to bring the mobile sidebar into view.
+	 */
+	private async openMobileSidebar(): Promise< void > {
+		await selectors.sidebarToggle( this.page ).click();
+
+		await this.page.waitForSelector( selectors.sidebar );
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -3,6 +3,13 @@ import { Page } from 'playwright';
 type CancelReason = 'Another reason…';
 
 /**
+ * Cancels a purchased subscription.
+ */
+export async function cancelSubscriptionFlow( page: Page ) {
+	await page.getByRole( 'button', { name: 'Submit and cancel product' } ).click();
+}
+
+/**
  * Cancels a purchased plan.
  */
 export async function cancelPurchaseFlow(

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -24,3 +24,42 @@ export async function cancelPurchaseFlow(
 
 	await page.getByRole( 'button', { name: /Submit and (remove|cancel) plan/ } ).click();
 }
+
+/**
+ * Cancels a purchased Atomic site.
+ */
+export async function cancelAtomicPurchaseFlow(
+	page: Page,
+	feedback: {
+		reason: CancelReason;
+		customReasonText: string;
+	}
+) {
+	await page
+		.getByRole( 'combobox', { name: 'Why would you like to cancel?' } )
+		.selectOption( feedback.reason );
+
+	await page
+		.getByRole( 'textbox', { name: 'Can you please specify?' } )
+		.fill( feedback.customReasonText );
+
+	// Submit first step.
+	await page.getByRole( 'button', { name: 'Submit' } ).click();
+
+	// Submit second step.
+	await page.getByRole( 'button', { name: 'Submit' } ).click();
+
+	// Submit caution step.
+	await page.getByRole( 'checkbox', { name: 'Any themes/plugins you have installed' } ).click();
+	await page.getByRole( 'checkbox', { name: 'your site will return to its original' } ).click();
+
+	const hasContentCheck = page.getByRole( 'checkbox', {
+		name: 'Your posts, pages, and media added after upgrading will be automatically imported to your downgraded site.',
+	} );
+
+	if ( await hasContentCheck.isVisible() ) {
+		await hasContentCheck.click();
+	}
+
+	await page.getByRole( 'button', { name: /Submit and cancel plan/ } ).click();
+}

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -29,7 +29,10 @@ export async function cancelPurchaseFlow(
 
 	await page.getByRole( 'button', { name: 'Submit' } ).click();
 
-	await page.getByRole( 'button', { name: /Submit and (remove|cancel) plan/ } ).click();
+	await Promise.all( [
+		page.waitForNavigation(),
+		page.getByRole( 'button', { name: /Submit and (remove|cancel) plan/ } ).click(),
+	] );
 }
 
 /**
@@ -68,5 +71,8 @@ export async function cancelAtomicPurchaseFlow(
 		await hasContentCheck.click();
 	}
 
-	await page.getByRole( 'button', { name: /Submit and cancel plan/ } ).click();
+	await Promise.all( [
+		page.waitForNavigation(),
+		page.getByRole( 'button', { name: /Submit and cancel plan/ } ).click(),
+	] );
 }

--- a/packages/calypso-e2e/src/lib/pages/dashboard-site-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/dashboard-site-page.ts
@@ -1,0 +1,52 @@
+import { Locator, Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+
+const selectors = {
+	guidedTourContainer: '.guided-tour__popover',
+	guidedTourGotItButton: ( locator: Locator ) => locator.getByRole( 'button', { name: 'Got it' } ),
+};
+
+/**
+ * Represents the Sites > Site page.
+ */
+export class DashboardSitePage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Visits the `/sites/$siteSlug` endpoint.
+	 *
+	 * @param {string} siteSlug Site URL.
+	 */
+	async visit( siteSlug: string ): Promise< void > {
+		await this.page.goto( getCalypsoURL( `sites/${ siteSlug }` ), {
+			timeout: 20 * 1000,
+		} );
+	}
+
+	/**
+	 * Closes the guided tour if it is visible.
+	 */
+	async maybeCloseGuidedTour(): Promise< void > {
+		const guidedTourContainer = this.page.locator( selectors.guidedTourContainer );
+
+		try {
+			await guidedTourContainer.waitFor( {
+				timeout: 5 * 1000,
+			} );
+		} catch ( error ) {
+			// The guided tour is not visible.
+			return;
+		}
+
+		await selectors.guidedTourGotItButton( guidedTourContainer ).click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -3,6 +3,7 @@ export * from './add-people-page';
 export * from './cart-checkout-page';
 export * from './checkout-thank-you-page';
 export * from './dashboard-page';
+export * from './dashboard-site-page';
 export * from './domains-page';
 export * from './editor-page';
 export * from './full-site-editor-page';

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -6,7 +6,8 @@ type PurchaseActions =
 	| 'Renew monthly'
 	| 'Pick another plan'
 	| 'Remove plan'
-	| 'Cancel plan';
+	| 'Cancel plan'
+	| 'Cancel subscription';
 
 /**
  * Represents the /me endpoint.
@@ -64,7 +65,7 @@ export class PurchasesPage {
 			this.page.getByRole( 'link', { name: action } ).click(),
 		] );
 
-		if ( action === 'Cancel plan' ) {
+		if ( action === 'Cancel plan' || action === 'Cancel subscription' ) {
 			await this.page.getByRole( 'button', { name: 'Cancel Subscription' } ).click();
 		}
 	}

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -1,13 +1,7 @@
 import { Page } from 'playwright';
 import { getCalypsoURL } from '../../../data-helper';
 
-type PurchaseActions =
-	| 'Renew annually'
-	| 'Renew monthly'
-	| 'Pick another plan'
-	| 'Remove plan'
-	| 'Cancel plan'
-	| 'Cancel subscription';
+type PurchaseActions = 'Cancel plan' | 'Cancel subscription';
 
 /**
  * Represents the /me endpoint.
@@ -50,23 +44,15 @@ export class PurchasesPage {
 	/* Purchase detail view */
 
 	/**
-	 * Clicks on an action for the purchase.
+	 * Clicks a cancellation action for the purchase.
 	 *
 	 * @param {PurchaseActions} action Action to click.
 	 */
-	async purchaseAction( action: PurchaseActions ) {
-		if ( action === 'Pick another plan' ) {
-			await this.page.getByRole( 'link', { name: action } ).click();
-			return await this.page.waitForURL( /plan/ );
-		}
-
-		await Promise.race( [
-			this.page.getByRole( 'button', { name: action } ).click(),
-			this.page.getByRole( 'link', { name: action } ).click(),
-		] );
+	async cancelPurchase( action: PurchaseActions ) {
+		await this.page.getByRole( 'link', { name: action } ).click();
 
 		if ( action === 'Cancel plan' || action === 'Cancel subscription' ) {
-			await this.page.getByRole( 'button', { name: 'Cancel Subscription' } ).click();
+			await this.page.getByRole( 'button', { name: 'Cancel subscription' } ).click();
 		}
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -21,6 +21,11 @@ const selectors = {
 	// Generic
 	placeholder: '.is-placeholder',
 	managePlanButton: 'a:has-text("Manage plan")',
+	addOnCombobox: ( name: Plans ) => {
+		return `.plans-grid-next-plan-storage[data-plan-title="${ name }"]`;
+	},
+	addOnComboboxButton: 'button[role="combobox"]',
+	addOnComboboxOption: ( addOn: string ) => `[role="option"]:has-text("${ addOn }")`,
 	selectPlanButton: ( name: Plans ) => {
 		if ( name === 'Free' ) {
 			// Free plan is a pseudo-button presented as a
@@ -91,6 +96,24 @@ export class PlansPage {
 	}
 
 	/* Plans */
+
+	/**
+	 * Selects the add-on for the target plan.
+	 *
+	 * @param {Plans} plan Plan to select.
+	 * @param {string} addOn Add-on to select.
+	 */
+	async selectAddOn( plan: Plans, addOn: string ): Promise< void > {
+		const combobox = this.page.locator( selectors.addOnCombobox( plan ) );
+
+		const comboboxSelect = combobox.locator( selectors.addOnComboboxButton );
+		await comboboxSelect.first().click();
+
+		const comboboxOption = combobox.locator(
+			selectors.addOnComboboxOption( `50 GB + ${ addOn }` )
+		);
+		await comboboxOption.first().click();
+	}
 
 	/**
 	 * Selects the target plan on the plans grid.

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -6,7 +6,7 @@ import type { SiteDetails, NewSiteResponse } from '../../../types/rest-api-clien
  * The plans page URL regex.
  */
 export const plansPageUrl =
-	/.*setup\/onboarding\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
+	/.*setup\/(onboarding|new-hosted-site)\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
 
 /**
  * Represents the Signup > Pick a Plan page.

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -6,7 +6,7 @@ import type { SiteDetails, NewSiteResponse } from '../../../types/rest-api-clien
  * The plans page URL regex.
  */
 export const plansPageUrl =
-	/.*setup\/(onboarding|new-hosted-site)\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
+	/.*setup\/onboarding\/plans|start\/plans|start\/with-theme\/plans-theme-preselected.*/;
 
 /**
  * Represents the Signup > Pick a Plan page.

--- a/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-settings-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { envVariables } from '../..';
 import { getCalypsoURL } from '../../data-helper';
 
 /**
@@ -34,6 +35,19 @@ export class SiteSettingsPage {
 	async launchSite(): Promise< void > {
 		const launchSite = this.page.getByRole( 'button', { name: 'Launch site' } ).first();
 		await launchSite.click();
+	}
+
+	/**
+	 * Navigates to a given item in the sidebar.
+	 *
+	 * @param {string} item Item to navigate to.
+	 */
+	async navigateToSubmenu( item: string ) {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			await this.page.getByRole( 'button', { name: 'General' } ).click();
+		}
+
+		await this.page.getByRole( 'link', { name: item } ).click();
 	}
 
 	/**

--- a/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
+++ b/packages/plans-grid-next/src/components/shared/storage/components/plan-storage.tsx
@@ -21,7 +21,7 @@ const PlanStorage = ( {
 	showUpgradeableStorage,
 }: Props ) => {
 	const { siteId, gridPlansIndex } = usePlansGridContext();
-	const { availableForPurchase, current } = gridPlansIndex[ planSlug ];
+	const { availableForPurchase, current, planTitle } = gridPlansIndex[ planSlug ];
 	const availableStorageAddOns = AddOns.useAvailableStorageAddOns( { siteId } );
 
 	if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -38,7 +38,7 @@ const PlanStorage = ( {
 		ELIGIBLE_PLANS_FOR_STORAGE_UPGRADE.includes( planSlug );
 
 	return (
-		<div className="plans-grid-next-plan-storage">
+		<div className="plans-grid-next-plan-storage" data-plan-title={ planTitle }>
 			{ canUpgradeStorageForPlan ? (
 				<StorageDropdown planSlug={ planSlug } onStorageAddOnClick={ onStorageAddOnClick } />
 			) : (

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -228,7 +228,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 				`WordPress.com ${ planName }`,
 				newSiteDetails.blog_details.site_slug
 			);
-			await purchasesPage.purchaseAction( 'Cancel plan' );
+			await purchasesPage.cancelPurchase( 'Cancel plan' );
 		} );
 
 		it( 'Cancel plan renewal', async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -17,6 +17,7 @@ import {
 	cancelSubscriptionFlow,
 	cancelAtomicPurchaseFlow,
 	WPAdminSidebarComponent,
+	SiteSettingsPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -93,6 +94,8 @@ describe(
 				await page.waitForURL( /wp-admin/, {
 					timeout: 180 * 1000,
 				} );
+
+				siteSlug = new URL( page.url() ).hostname;
 			} );
 
 			it( 'Navigate to Hosting > Site Settings', async function () {
@@ -101,11 +104,10 @@ describe(
 			} );
 
 			it( 'Navigate to Server > Server Settings', async function () {
-				await page.getByRole( 'link', { name: 'Server' } ).click();
-				await page.getByRole( 'heading', { name: 'Server Settings' } ).waitFor();
+				const siteSettings = new SiteSettingsPage( page );
+				await siteSettings.navigateToSubmenu( 'Server' );
 
-				const url = new URL( page.url() );
-				siteSlug = url.pathname.split( '/' ).at( -1 )!;
+				await page.getByRole( 'heading', { name: 'Server Settings' } ).waitFor();
 			} );
 		} );
 

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -16,77 +16,277 @@ import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain' ), function () {
-	const planName = 'Business';
-	const blogName = DataHelper.getBlogName();
-	const testUser = DataHelper.getNewTestUser();
+describe(
+	DataHelper.createSuiteTitle(
+		'New Hosted Site Flow: Go to checkout with a paid site and storage add-on'
+	),
+	function () {
+		const planName = 'Business';
+		const testUser = DataHelper.getNewTestUser();
 
-	let newUserDetails: NewUserResponse;
-	let plansPage: PlansPage;
-	let cartCheckoutPage: CartCheckoutPage;
-	let domainSearchComponent: DomainSearchComponent;
-	let page: Page;
-	let selectedDomain: string;
+		let newUserDetails: NewUserResponse;
+		let plansPage: PlansPage;
+		let cartCheckoutPage: CartCheckoutPage;
+		let page: Page;
 
-	beforeAll( async function () {
-		page = await browser.newPage();
-	} );
-
-	it( 'Enter the flow', async function () {
-		const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
-			showDomainStep: 'true',
+		beforeAll( async function () {
+			page = await browser.newPage();
 		} );
 
-		await page.goto( flowUrl );
-	} );
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site' );
 
-	it( 'Sign up as a new user', async function () {
-		const userSignupPage = new UserSignupPage( page );
-		newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
-	} );
-
-	it( 'Select a domain name', async function () {
-		domainSearchComponent = new DomainSearchComponent( page );
-		await domainSearchComponent.search( blogName + '.io' );
-		selectedDomain = await domainSearchComponent.selectDomain( '.io' );
-	} );
-
-	it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
-		plansPage = new PlansPage( page );
-		await plansPage.selectAddOn( planName, '50 GB' );
-	} );
-
-	it( `Pick the ${ planName } plan`, async function () {
-		plansPage = new PlansPage( page );
-
-		await plansPage.selectPlan( planName );
-	} );
-
-	it( 'See domain, plan and add-on at checkout', async function () {
-		cartCheckoutPage = new CartCheckoutPage( page );
-
-		await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-		await cartCheckoutPage.validateCartItem( selectedDomain );
-		await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
-	} );
-
-	afterAll( async function () {
-		if ( ! newUserDetails ) {
-			return;
-		}
-
-		const restAPIClient = new RestAPIClient(
-			{
-				username: testUser.username,
-				password: testUser.password,
-			},
-			newUserDetails.body.bearer_token
-		);
-
-		await apiCloseAccount( restAPIClient, {
-			userID: newUserDetails.body.user_id,
-			username: newUserDetails.body.username,
-			email: testUser.email,
+			await page.goto( flowUrl );
 		} );
-	} );
-} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		} );
+
+		it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
+			plansPage = new PlansPage( page );
+			await plansPage.selectAddOn( planName, '50 GB' );
+		} );
+
+		it( `Pick the ${ planName } plan`, async function () {
+			plansPage = new PlansPage( page );
+
+			await plansPage.selectPlan( planName );
+		} );
+
+		it( 'See domain, plan and add-on at checkout', async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
+		} );
+
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
+			);
+
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
+		} );
+	}
+);
+
+describe(
+	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain selection' ),
+	function () {
+		const planName = 'Business';
+		const blogName = DataHelper.getBlogName();
+		const testUser = DataHelper.getNewTestUser();
+
+		let newUserDetails: NewUserResponse;
+		let plansPage: PlansPage;
+		let cartCheckoutPage: CartCheckoutPage;
+		let domainSearchComponent: DomainSearchComponent;
+		let page: Page;
+		let selectedDomain: string;
+
+		beforeAll( async function () {
+			page = await browser.newPage();
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
+				showDomainStep: 'true',
+			} );
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		} );
+
+		it( 'Select a domain name', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( blogName + '.io' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.io' );
+		} );
+
+		it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
+			plansPage = new PlansPage( page );
+			await plansPage.selectAddOn( planName, '50 GB' );
+		} );
+
+		it( `Pick the ${ planName } plan`, async function () {
+			plansPage = new PlansPage( page );
+
+			await plansPage.selectPlan( planName );
+		} );
+
+		it( 'See domain, plan and add-on at checkout', async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+			await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
+		} );
+
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
+			);
+
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
+		} );
+	}
+);
+
+/**
+ * We need this test to ensure that the post-domain selection navigation
+ * sends the user to the plans page or checkout.
+ */
+describe(
+	DataHelper.createSuiteTitle(
+		'New Hosted Site Flow: With domain selection and pre-selected plan'
+	),
+	function () {
+		const planSlug = 'business-bundle';
+		const planName = 'Business';
+		const blogName = DataHelper.getBlogName();
+		const testUser = DataHelper.getNewTestUser();
+
+		let newUserDetails: NewUserResponse;
+		let cartCheckoutPage: CartCheckoutPage;
+		let domainSearchComponent: DomainSearchComponent;
+		let page: Page;
+		let selectedDomain: string;
+
+		beforeAll( async function () {
+			page = await browser.newPage();
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
+				showDomainStep: 'true',
+				plan: planSlug,
+			} );
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		} );
+
+		it( 'Select a domain name', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( blogName + '.io' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.io' );
+		} );
+
+		it( 'See domain and plan at checkout', async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
+		} );
+
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
+			);
+
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
+		} );
+	}
+);
+
+describe(
+	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With pre-selected plan' ),
+	function () {
+		const planSlug = 'business-bundle';
+		const planName = 'Business';
+		const testUser = DataHelper.getNewTestUser();
+
+		let newUserDetails: NewUserResponse;
+		let cartCheckoutPage: CartCheckoutPage;
+		let page: Page;
+
+		beforeAll( async function () {
+			page = await browser.newPage();
+		} );
+
+		it( 'Enter the flow', async function () {
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
+				plan: planSlug,
+			} );
+
+			await page.goto( flowUrl );
+		} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		} );
+
+		it( 'See plan at checkout', async function () {
+			cartCheckoutPage = new CartCheckoutPage( page );
+
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+		} );
+
+		afterAll( async function () {
+			if ( ! newUserDetails ) {
+				return;
+			}
+
+			const restAPIClient = new RestAPIClient(
+				{
+					username: testUser.username,
+					password: testUser.password,
+				},
+				newUserDetails.body.bearer_token
+			);
+
+			await apiCloseAccount( restAPIClient, {
+				userID: newUserDetails.body.user_id,
+				username: newUserDetails.body.username,
+				email: testUser.email,
+			} );
+		} );
+	}
+);

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -126,7 +126,7 @@ describe(
 				purchasesPage = new PurchasesPage( page );
 
 				await purchasesPage.clickOnPurchase( 'Storage Add-On Space Upgrade 50 GB', siteSlug );
-				await purchasesPage.purchaseAction( 'Cancel subscription' );
+				await purchasesPage.cancelPurchase( 'Cancel subscription' );
 			} );
 
 			it( 'Cancel add-on renewal', async function () {
@@ -156,7 +156,7 @@ describe(
 				purchasesPage = new PurchasesPage( page );
 
 				await purchasesPage.clickOnPurchase( `WordPress.com ${ planName }`, siteSlug );
-				await purchasesPage.purchaseAction( 'Cancel plan' );
+				await purchasesPage.cancelPurchase( 'Cancel plan' );
 			} );
 
 			it( 'Cancel plan renewal', async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -9,6 +9,12 @@ import {
 	UserSignupPage,
 	CartCheckoutPage,
 	PlansPage,
+	NoticeComponent,
+	PurchasesPage,
+	MyProfilePage,
+	MeSidebarComponent,
+	cancelPurchaseFlow,
+	WPAdminSidebarComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -16,14 +22,13 @@ import { apiCloseAccount } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle(
-		'New Hosted Site Flow: Go to checkout with a paid site and storage add-on'
-	),
+	DataHelper.createSuiteTitle( 'New Hosted Site Flow: Purchase a hosted site and cancel it' ),
 	function () {
 		const planName = 'Business';
 		const testUser = DataHelper.getNewTestUser();
 
 		let newUserDetails: NewUserResponse;
+		let siteSlug: string;
 		let plansPage: PlansPage;
 		let cartCheckoutPage: CartCheckoutPage;
 		let page: Page;
@@ -32,33 +37,97 @@ describe(
 			page = await browser.newPage();
 		} );
 
-		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site' );
+		describe( 'Purchase site', function () {
+			it( 'Enter the flow', async function () {
+				const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site' );
 
-			await page.goto( flowUrl );
+				await page.goto( flowUrl );
+			} );
+
+			it( 'Sign up as a new user', async function () {
+				const userSignupPage = new UserSignupPage( page );
+				newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+			} );
+
+			it( `Pick the ${ planName } plan`, async function () {
+				plansPage = new PlansPage( page );
+
+				await plansPage.selectPlan( planName );
+			} );
+
+			it( 'See plan at checkout', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			it( 'Enter billing and payment details', async function () {
+				const paymentDetails = DataHelper.getTestPaymentDetails();
+				await cartCheckoutPage.enterBillingDetails( paymentDetails );
+				await cartCheckoutPage.enterPaymentDetails( paymentDetails );
+			} );
+
+			it( 'Make purchase', async function () {
+				await cartCheckoutPage.purchase( { timeout: 90 * 1000 } );
+			} );
+
+			it( 'Wait for the Atomic transfer to complete', async function () {
+				await page.waitForURL( /.*transferring-hosted-site.*/ );
+			} );
 		} );
 
-		it( 'Sign up as a new user', async function () {
-			const userSignupPage = new UserSignupPage( page );
-			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		describe( 'View server settings', function () {
+			it( 'See WP Admin', async function () {
+				await page.waitForURL( /wp-admin/, {
+					timeout: 180 * 1000,
+				} );
+			} );
+
+			it( 'Navigate to Hosting > Site Settings', async function () {
+				const wpAdminSidebarComponent = new WPAdminSidebarComponent( page );
+				await wpAdminSidebarComponent.navigate( 'Hosting', 'Site Settings' );
+			} );
+
+			it( 'Navigate to Server > Server Settings', async function () {
+				await page.getByRole( 'link', { name: 'Server' } ).click();
+				await page.getByRole( 'heading', { name: 'Server Settings' } ).waitFor();
+
+				const url = new URL( page.url() );
+				siteSlug = url.pathname.split( '/' ).at( -1 )!;
+			} );
 		} );
 
-		it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
-			plansPage = new PlansPage( page );
-			await plansPage.selectAddOn( planName, '50 GB' );
-		} );
+		describe( 'Cancel and remove plan', function () {
+			let noticeComponent: NoticeComponent;
+			let purchasesPage: PurchasesPage;
 
-		it( `Pick the ${ planName } plan`, async function () {
-			plansPage = new PlansPage( page );
+			it( 'Navigate to Me > Purchases', async function () {
+				const mePage = new MyProfilePage( page );
+				await mePage.visit();
 
-			await plansPage.selectPlan( planName );
-		} );
+				const meSidebarComponent = new MeSidebarComponent( page );
+				await meSidebarComponent.openMobileMenu();
+				await meSidebarComponent.navigate( 'Purchases' );
+			} );
 
-		it( 'See domain, plan and add-on at checkout', async function () {
-			cartCheckoutPage = new CartCheckoutPage( page );
+			it( 'View details of purchased plan', async function () {
+				purchasesPage = new PurchasesPage( page );
 
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-			await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
+				await purchasesPage.clickOnPurchase( `WordPress.com ${ planName }`, siteSlug );
+				await purchasesPage.purchaseAction( 'Cancel plan' );
+			} );
+
+			it( 'Cancel plan renewal', async function () {
+				await cancelPurchaseFlow( page, {
+					reason: 'Another reason…',
+					customReasonText: 'E2E TEST CANCELLATION',
+				} );
+
+				noticeComponent = new NoticeComponent( page );
+				await noticeComponent.noticeShown( 'You successfully canceled your purchase', {
+					timeout: 30 * 1000,
+				} );
+			} );
 		} );
 
 		afterAll( async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -1,0 +1,92 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	RestAPIClient,
+	DomainSearchComponent,
+	NewUserResponse,
+	UserSignupPage,
+	CartCheckoutPage,
+	PlansPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiCloseAccount } from '../shared';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain' ), function () {
+	const planName = 'Business';
+	const blogName = DataHelper.getBlogName();
+	const testUser = DataHelper.getNewTestUser();
+
+	let newUserDetails: NewUserResponse;
+	let plansPage: PlansPage;
+	let cartCheckoutPage: CartCheckoutPage;
+	let domainSearchComponent: DomainSearchComponent;
+	let page: Page;
+	let selectedDomain: string;
+
+	beforeAll( async function () {
+		page = await browser.newPage();
+	} );
+
+	it( 'Enter the flow', async function () {
+		const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
+			showDomainStep: 'true',
+		} );
+
+		await page.goto( flowUrl );
+	} );
+
+	it( 'Sign up as a new user', async function () {
+		const userSignupPage = new UserSignupPage( page );
+		newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+	} );
+
+	it( 'Select a domain name', async function () {
+		domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.search( blogName + '.io' );
+		selectedDomain = await domainSearchComponent.selectDomain( '.io' );
+	} );
+
+	it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
+		plansPage = new PlansPage( page );
+		await plansPage.selectAddOn( planName, '50 GB' );
+	} );
+
+	it( `Pick the ${ planName } plan`, async function () {
+		plansPage = new PlansPage( page );
+
+		await plansPage.selectPlan( planName );
+	} );
+
+	it( 'See domain, plan and add-on at checkout', async function () {
+		cartCheckoutPage = new CartCheckoutPage( page );
+
+		await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+		await cartCheckoutPage.validateCartItem( selectedDomain );
+		await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
+	} );
+
+	afterAll( async function () {
+		if ( ! newUserDetails ) {
+			return;
+		}
+
+		const restAPIClient = new RestAPIClient(
+			{
+				username: testUser.username,
+				password: testUser.password,
+			},
+			newUserDetails.body.bearer_token
+		);
+
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
+		} );
+	} );
+} );

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -4,6 +4,7 @@
 
 import {
 	DataHelper,
+	BrowserManager,
 	RestAPIClient,
 	NewUserResponse,
 	UserSignupPage,
@@ -38,6 +39,10 @@ describe(
 		} );
 
 		describe( 'Purchase site', function () {
+			beforeAll( async function () {
+				await BrowserManager.setStoreCookie( page, { currency: 'GBP' } );
+			} );
+
 			it( 'Enter the flow', async function () {
 				const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site' );
 

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -14,6 +14,7 @@ import {
 	PurchasesPage,
 	MyProfilePage,
 	MeSidebarComponent,
+	cancelSubscriptionFlow,
 	cancelAtomicPurchaseFlow,
 	WPAdminSidebarComponent,
 } from '@automattic/calypso-e2e';
@@ -54,16 +55,22 @@ describe(
 				newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 			} );
 
+			it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
+				plansPage = new PlansPage( page );
+				await plansPage.selectAddOn( planName, '50 GB' );
+			} );
+
 			it( `Pick the ${ planName } plan`, async function () {
 				plansPage = new PlansPage( page );
 
 				await plansPage.selectPlan( planName );
 			} );
 
-			it( 'See plan at checkout', async function () {
+			it( 'See plan and storage add-on at checkout', async function () {
 				cartCheckoutPage = new CartCheckoutPage( page );
 
 				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+				await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
 			} );
 
 			it( 'Enter billing and payment details', async function () {
@@ -99,6 +106,36 @@ describe(
 
 				const url = new URL( page.url() );
 				siteSlug = url.pathname.split( '/' ).at( -1 )!;
+			} );
+		} );
+
+		describe( 'Cancel and remove storage add-on', function () {
+			let noticeComponent: NoticeComponent;
+			let purchasesPage: PurchasesPage;
+
+			it( 'Navigate to Me > Purchases', async function () {
+				const mePage = new MyProfilePage( page );
+				await mePage.visit();
+
+				const meSidebarComponent = new MeSidebarComponent( page );
+				await meSidebarComponent.openMobileMenu();
+				await meSidebarComponent.navigate( 'Purchases' );
+			} );
+
+			it( 'View details of purchased add-on', async function () {
+				purchasesPage = new PurchasesPage( page );
+
+				await purchasesPage.clickOnPurchase( 'Storage Add-On Space Upgrade 50 GB', siteSlug );
+				await purchasesPage.purchaseAction( 'Cancel subscription' );
+			} );
+
+			it( 'Cancel add-on renewal', async function () {
+				await cancelSubscriptionFlow( page );
+
+				noticeComponent = new NoticeComponent( page );
+				await noticeComponent.noticeShown( 'You successfully canceled your purchase', {
+					timeout: 30 * 1000,
+				} );
 			} );
 		} );
 

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -18,6 +18,7 @@ import {
 	cancelAtomicPurchaseFlow,
 	WPAdminSidebarComponent,
 	SiteSettingsPage,
+	DashboardSitePage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -104,6 +105,9 @@ describe(
 			} );
 
 			it( 'Navigate to Server > Server Settings', async function () {
+				const dashboardSitePage = new DashboardSitePage( page );
+				await dashboardSitePage.maybeCloseGuidedTour();
+
 				const siteSettings = new SiteSettingsPage( page );
 				await siteSettings.navigateToSubmenu( 'Server' );
 

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.ts
@@ -14,7 +14,7 @@ import {
 	PurchasesPage,
 	MyProfilePage,
 	MeSidebarComponent,
-	cancelPurchaseFlow,
+	cancelAtomicPurchaseFlow,
 	WPAdminSidebarComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
@@ -123,7 +123,7 @@ describe(
 			} );
 
 			it( 'Cancel plan renewal', async function () {
-				await cancelPurchaseFlow( page, {
+				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
 				} );

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -17,7 +17,7 @@ import { apiCloseAccount } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain selection' ),
+	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain and storage add-on selection' ),
 	function () {
 		const planName = 'Business';
 		const blogName = DataHelper.getBlogName();

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -17,7 +17,7 @@ import { apiCloseAccount } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain and storage add-on selection' ),
+	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain selection' ),
 	function () {
 		const planName = 'Business';
 		const blogName = DataHelper.getBlogName();
@@ -49,8 +49,8 @@ describe(
 
 		it( 'Select a domain name', async function () {
 			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.io' );
-			selectedDomain = await domainSearchComponent.selectDomain( '.io' );
+			await domainSearchComponent.search( blogName + '.live' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.live', false );
 		} );
 
 		it( `Pick the ${ planName } plan`, async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -5,6 +5,7 @@
 import {
 	DataHelper,
 	RestAPIClient,
+	DomainSearchComponent,
 	NewUserResponse,
 	UserSignupPage,
 	CartCheckoutPage,
@@ -16,24 +17,27 @@ import { apiCloseAccount } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle(
-		'New Hosted Site Flow: Go to checkout with a paid site and storage add-on'
-	),
+	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With domain selection' ),
 	function () {
 		const planName = 'Business';
+		const blogName = DataHelper.getBlogName();
 		const testUser = DataHelper.getNewTestUser();
 
 		let newUserDetails: NewUserResponse;
 		let plansPage: PlansPage;
 		let cartCheckoutPage: CartCheckoutPage;
+		let domainSearchComponent: DomainSearchComponent;
 		let page: Page;
+		let selectedDomain: string;
 
 		beforeAll( async function () {
 			page = await browser.newPage();
 		} );
 
 		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site' );
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
+				showDomainStep: 'true',
+			} );
 
 			await page.goto( flowUrl );
 		} );
@@ -41,6 +45,12 @@ describe(
 		it( 'Sign up as a new user', async function () {
 			const userSignupPage = new UserSignupPage( page );
 			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
+		} );
+
+		it( 'Select a domain name', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( blogName + '.io' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.io' );
 		} );
 
 		it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
@@ -58,6 +68,7 @@ describe(
 			cartCheckoutPage = new CartCheckoutPage( page );
 
 			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
 			await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
 		} );
 

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection.ts
@@ -53,23 +53,17 @@ describe(
 			selectedDomain = await domainSearchComponent.selectDomain( '.io' );
 		} );
 
-		it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
-			plansPage = new PlansPage( page );
-			await plansPage.selectAddOn( planName, '50 GB' );
-		} );
-
 		it( `Pick the ${ planName } plan`, async function () {
 			plansPage = new PlansPage( page );
 
 			await plansPage.selectPlan( planName );
 		} );
 
-		it( 'See domain, plan and add-on at checkout', async function () {
+		it( 'See domain and plan at checkout', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
 
 			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
 			await cartCheckoutPage.validateCartItem( selectedDomain );
-			await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
 		} );
 
 		afterAll( async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
@@ -55,8 +55,8 @@ describe(
 
 		it( 'Select a domain name', async function () {
 			domainSearchComponent = new DomainSearchComponent( page );
-			await domainSearchComponent.search( blogName + '.io' );
-			selectedDomain = await domainSearchComponent.selectDomain( '.io' );
+			await domainSearchComponent.search( blogName + '.live' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.live', false );
 		} );
 
 		it( 'See domain and plan at checkout', async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__domain-selection__pre-selected-plan.ts
@@ -5,35 +5,45 @@
 import {
 	DataHelper,
 	RestAPIClient,
+	DomainSearchComponent,
 	NewUserResponse,
 	UserSignupPage,
 	CartCheckoutPage,
-	PlansPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
 
+/**
+ * We need this test to ensure that the post-domain selection navigation
+ * sends the user to the plans page or checkout.
+ */
 describe(
 	DataHelper.createSuiteTitle(
-		'New Hosted Site Flow: Go to checkout with a paid site and storage add-on'
+		'New Hosted Site Flow: With domain selection and pre-selected plan'
 	),
 	function () {
+		const planSlug = 'business-bundle';
 		const planName = 'Business';
+		const blogName = DataHelper.getBlogName();
 		const testUser = DataHelper.getNewTestUser();
 
 		let newUserDetails: NewUserResponse;
-		let plansPage: PlansPage;
 		let cartCheckoutPage: CartCheckoutPage;
+		let domainSearchComponent: DomainSearchComponent;
 		let page: Page;
+		let selectedDomain: string;
 
 		beforeAll( async function () {
 			page = await browser.newPage();
 		} );
 
 		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site' );
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
+				showDomainStep: 'true',
+				plan: planSlug,
+			} );
 
 			await page.goto( flowUrl );
 		} );
@@ -43,22 +53,17 @@ describe(
 			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 		} );
 
-		it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
-			plansPage = new PlansPage( page );
-			await plansPage.selectAddOn( planName, '50 GB' );
+		it( 'Select a domain name', async function () {
+			domainSearchComponent = new DomainSearchComponent( page );
+			await domainSearchComponent.search( blogName + '.io' );
+			selectedDomain = await domainSearchComponent.selectDomain( '.io' );
 		} );
 
-		it( `Pick the ${ planName } plan`, async function () {
-			plansPage = new PlansPage( page );
-
-			await plansPage.selectPlan( planName );
-		} );
-
-		it( 'See domain, plan and add-on at checkout', async function () {
+		it( 'See domain and plan at checkout', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
 
 			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-			await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
+			await cartCheckoutPage.validateCartItem( selectedDomain );
 		} );
 
 		afterAll( async function () {

--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site__pre-selected-plan.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site__pre-selected-plan.ts
@@ -8,7 +8,6 @@ import {
 	NewUserResponse,
 	UserSignupPage,
 	CartCheckoutPage,
-	PlansPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { apiCloseAccount } from '../shared';
@@ -16,15 +15,13 @@ import { apiCloseAccount } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle(
-		'New Hosted Site Flow: Go to checkout with a paid site and storage add-on'
-	),
+	DataHelper.createSuiteTitle( 'New Hosted Site Flow: With pre-selected plan' ),
 	function () {
+		const planSlug = 'business-bundle';
 		const planName = 'Business';
 		const testUser = DataHelper.getNewTestUser();
 
 		let newUserDetails: NewUserResponse;
-		let plansPage: PlansPage;
 		let cartCheckoutPage: CartCheckoutPage;
 		let page: Page;
 
@@ -33,7 +30,9 @@ describe(
 		} );
 
 		it( 'Enter the flow', async function () {
-			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site' );
+			const flowUrl = DataHelper.getCalypsoURL( '/setup/new-hosted-site', {
+				plan: planSlug,
+			} );
 
 			await page.goto( flowUrl );
 		} );
@@ -43,22 +42,10 @@ describe(
 			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 		} );
 
-		it( `Pick the 50 GB storage add-on for the ${ planName } plan`, async function () {
-			plansPage = new PlansPage( page );
-			await plansPage.selectAddOn( planName, '50 GB' );
-		} );
-
-		it( `Pick the ${ planName } plan`, async function () {
-			plansPage = new PlansPage( page );
-
-			await plansPage.selectPlan( planName );
-		} );
-
-		it( 'See domain, plan and add-on at checkout', async function () {
+		it( 'See plan at checkout', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
 
 			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-			await cartCheckoutPage.validateCartItem( 'Storage Add-On' );
 		} );
 
 		afterAll( async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -161,7 +161,7 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 				`WordPress.com ${ planName }`,
 				newSiteDetails.blog_details.site_slug
 			);
-			await purchasesPage.purchaseAction( 'Cancel plan' );
+			await purchasesPage.cancelPurchase( 'Cancel plan' );
 		} );
 
 		it( 'Cancel plan renewal', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -149,7 +149,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 				`WordPress.com ${ planName }`,
 				newSiteDetails.blog_details.site_slug
 			);
-			await purchasesPage.purchaseAction( 'Cancel plan' );
+			await purchasesPage.cancelPurchase( 'Cancel plan' );
 		} );
 
 		it( 'Cancel plan renewal', async function () {


### PR DESCRIPTION
Fixes DOTOBRD-122.

## Proposed Changes

Adds four different tests for the `/setup/new-hosted-site` flow:
- regular flow: purchases a site with a storage add-on and cancels both
- pre-selected plan: enters the flow with a `?plan` and verifies it ends up in the cart
- domain selection: enters the flow with `?showDomainStep` as a parameter and verifies the domain ends up in the cart
- domain selection and pre-selected plan: aggregation of the above

## Why are these changes being made?

To prevent regressions in a complex flow.

## Testing Instructions

Verify the pre-release E2E tests pass. They're not passing, currently. There's something wrong with domain selection and add-on cancelation.