### PR TITLE
MetricInsights: Show migration banner for non-wpcom sites (remove redux selectors)

### DIFF
--- a/client/performance-profiler/components/metrics-insight/index.tsx
+++ b/client/performance-profiler/components/metrics-insight/index.tsx
@@ -2,7 +2,6 @@ import { FoldableCard } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import {
 	FullPageScreenshot,
 	PerformanceMetricsItemQueryResponse,
@@ -12,8 +11,6 @@ import { useDeviceTab } from 'calypso/hosting/performance/contexts/device-tab-co
 import { Tip } from 'calypso/performance-profiler/components/tip';
 import { useSupportChatLLMQuery } from 'calypso/performance-profiler/hooks/use-support-chat-llm-query';
 import { loggedInTips, tips } from 'calypso/performance-profiler/utils/tips';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { InsightContent } from './insight-content';
 import { InsightHeader } from './insight-header';
 
@@ -129,17 +126,10 @@ export const MetricsInsight: React.FC< MetricsInsightProps > = ( props ) => {
 		}
 	}, [ isWpscanLoading, hasWpscanErrors, cardOpen ] );
 
-	const isLoggedIn = useSelector( isUserLoggedIn );
-	const site = useSelector( getSelectedSite );
-
-	const tip = isLoggedIn && isWpcom ? loggedInTips[ insight.id ] : tips[ insight.id ];
+	const tip = isWpcom ? loggedInTips[ insight.id ] : tips[ insight.id ];
 
 	if ( props.url && tip && ! isWpcom ) {
 		tip.link = `https://wordpress.com/setup/site-migration?from=${ props.url }&ref=performance-profiler-dashboard`;
-	}
-
-	if ( tip && isWpcom && ! site?.is_wpcom_atomic ) {
-		tip.link = '';
 	}
 
 	return (


### PR DESCRIPTION
An alternative to https://github.com/Automattic/wp-calypso/pull/103033.

Fixes: DOTCOM-10691

## Proposed Changes

As explained in #103033, our new dashboards won't use the redux store. We want to use this component temporarily as we refactor the undesirable parts. This PR removes the use of `useSelector`, so we don't need that store anymore and it doesn't break!

This approach differs from #103033 and decides to show the loggedIn Tips if the site is hosted with WordPress.com and the normal tips if the site is not hosted with WordPress.com.

**That's weird, why?**

While the code was written to accommodate many tips, there are only 2 tips:
- A tip about using JetPack - Shown to logged-in users
- A tip about migrating to WordPress.com - Shown to logged-out users

Given those constraints, I think it's more than fair to show the JetPack tip to WordPress.com-hosted sites and migration to others. 

I don't think we need to care whether the user is logged in.

It's also not clear in the [original Pull Request](https://github.com/Automattic/wp-calypso/pull/94691) why showing the link would not be appropriate. 


## Testing Instructions

**Logged In**

- Visit an Atomic site on `/sites`
- Click Performance tab
- Run an audit
- Expand the recommendation section
- Expect to see a JetPack boost add 
- Click the link

Do the same thing using the `Automattic for Agencies` link below.


<img width="394" alt="Screenshot 2025-05-01 at 2 45 07 PM" src="https://github.com/user-attachments/assets/c25afc15-e1ed-44d0-b65e-38739aec89db" />


**Logged Out**
- Visit `/speed-test-tool`
- Run an audit
- Expand the recommendation section
- Expect to see a tip about a migration.

<img width="402" alt="Screenshot 2025-05-01 at 2 46 37 PM" src="https://github.com/user-attachments/assets/b9fe5db3-6433-49f3-ad9f-6dbdbc14ab55" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
