### PR TITLE
Stats: Navigation improvement fix menu item text alignment

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -166,6 +166,7 @@ class StatsNavigation extends Component {
 
 		const wrapperClass = clsx( 'stats-navigation', {
 			'stats-navigation--modernized': ! isLegacy,
+			'stats-navigation--improved': isStatsNavigationImprovementEnabled,
 		} );
 
 		// Module settings for Odyssey are not supported until stats-admin@0.9.0-alpha.

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -3,6 +3,15 @@
 .stats-navigation {
 	box-shadow: inset 0 -1px 0 #0000000d;
 
+	// When the feature flag is enabled, adjust TabPanel padding
+	.stats-navigation__tabs {
+		margin: 0 -16px;  // This creates a negative margin to counteract the parent's padding
+		
+		.components-tab-panel__tabs {
+			padding: 0 16px;  // This sets the actual padding to 16px
+		}
+	}
+
 	.section-nav__panel {
 		padding-right: 0;
 
@@ -39,12 +48,29 @@
 		}
 	}
 
+	&.stats-navigation--improved {
+		.stats-navigation__tabs {
+			margin-left: -16px;
+
+			.components-tab-panel__tabs {
+				padding-left: 0;
+			}
+		}
+	}
+
 	// Modernize styles except for GoogleMyBusinessStats and StatsOverview pages
 	&.stats-navigation--modernized {
 		// For aligning the `.page-modules-settings` action button.
 		position: relative;
 		display: flex;
 		align-items: center;
+
+		// Only apply these styles when using the new TabPanel navigation
+		.stats-navigation__tabs {
+			width: calc(100% + 32px);  // Extend width to counter the parent padding
+			margin-left: -16px;        // Pull left to counter parent padding
+			margin-right: -16px;       // Pull right to counter parent padding
+		}
 
 		.section-nav {
 			margin: 0;

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -55,6 +55,15 @@
 			.components-tab-panel__tabs {
 				padding-left: 0;
 			}
+
+			@media (max-width: $break-small) {
+				margin-left: 0;
+				
+				.components-tab-panel__tabs {
+					padding-left: 16px;
+					padding-right: 16px;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Aligns the text of the first navigation tab to the header text

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live branch
* Apply the feature flag `stats/navigation-improvement`
* Check how the new navigation alignment as demonstrated below:

![image](https://github.com/user-attachments/assets/960bc096-e1c9-4d4b-87c4-80274b8af5a9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
