### PR TITLE
[DataViews]: expose self-sufficient subcomponents (Search, Filters, ViewConfig, Layout, Footer)

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,12 @@
 
 ## Next 
 
+- Expose self-sufficient DataViews subcomponents:
+	- `<DataViews.Search />`
+	- `<DataViews.Filters />`
+	- `<DataViews.ViewConfig />`
+	- `<DataViews.Layout />`
+	- `<DataViews.Pagination />`
 - Expose `<DataViews.Search />` component.
 - Add support for `free-composition` in the `DataViews` component
 - Fix `filterSortAndPaginate` to handle undefined values for the `is` filter.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -3,7 +3,6 @@
 ## Next 
 
 - Expose self-sufficient DataViews subcomponents:
-	- `<DataViews.Filters />`
 	- `<DataViews.ViewConfig />`
 	- `<DataViews.ViewTypeMenu />`
 	- `<DataViews.Layout />`

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -6,6 +6,7 @@
 	- `<DataViews.Search />`
 	- `<DataViews.Filters />`
 	- `<DataViews.ViewConfig />`
+	- `<DataViews.ViewTypeMenu />`
 	- `<DataViews.Layout />`
 	- `<DataViews.Pagination />`
 - Expose `<DataViews.Search />` component.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,13 +2,12 @@
 
 ## Next 
 
-- Expose self-sufficient DataViews subcomponents:
-	- `<DataViews.BulkActionToolbar />`
-	- `<DataViews.Layout />`
-	- `<DataViews.LayoutSwitcher />`
-	- `<DataViews.Pagination />`
-	- `<DataViews.ViewConfig />`
+- Expose `<DataViews.BulkActionToolbar />` component.
+- Expose `<DataViews.Layout />` component.
+- Expose `<DataViews.LayoutSwitcher />` component.
+- Expose `<DataViews.Pagination />` component.
 - Expose `<DataViews.Search />` component.
+- Expose `<DataViews.ViewConfig />` component.
 - Add support for `free-composition` in the `DataViews` component
 - Fix `filterSortAndPaginate` to handle undefined values for the `is` filter.
 

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -3,7 +3,6 @@
 ## Next 
 
 - Expose self-sufficient DataViews subcomponents:
-	- `<DataViews.Search />`
 	- `<DataViews.Filters />`
 	- `<DataViews.ViewConfig />`
 	- `<DataViews.ViewTypeMenu />`

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -7,6 +7,7 @@
 	- `<DataViews.ViewTypeMenu />`
 	- `<DataViews.Layout />`
 	- `<DataViews.Pagination />`
+	- `<DataViews.BulkActionToolbar />`
 - Expose `<DataViews.Search />` component.
 - Add support for `free-composition` in the `DataViews` component
 - Fix `filterSortAndPaginate` to handle undefined values for the `is` filter.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -3,11 +3,11 @@
 ## Next 
 
 - Expose self-sufficient DataViews subcomponents:
-	- `<DataViews.ViewConfig />`
-	- `<DataViews.ViewTypeMenu />`
-	- `<DataViews.Layout />`
-	- `<DataViews.Pagination />`
 	- `<DataViews.BulkActionToolbar />`
+	- `<DataViews.Layout />`
+	- `<DataViews.LayoutSwitcher />`
+	- `<DataViews.Pagination />`
+	- `<DataViews.ViewConfig />`
 - Expose `<DataViews.Search />` component.
 - Add support for `free-composition` in the `DataViews` component
 - Fix `filterSortAndPaginate` to handle undefined values for the `is` filter.

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -6,7 +6,12 @@ import { createContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { View, Action, NormalizedField } from '../../types';
+import type {
+	View,
+	Action,
+	NormalizedField,
+	SupportedLayouts,
+} from '../../types';
 import type { SetSelection } from '../../private-types';
 import { LAYOUT_TABLE } from '../../constants';
 
@@ -30,6 +35,7 @@ type DataViewsContextType< Item > = {
 	onClickItem?: ( item: Item ) => void;
 	isItemClickable: ( item: Item ) => boolean;
 	containerWidth: number;
+	defaultLayouts: SupportedLayouts;
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {
@@ -48,6 +54,7 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	getItemId: ( item ) => item.id,
 	isItemClickable: () => true,
 	containerWidth: 0,
+	defaultLayouts: { list: {}, grid: {}, table: {} },
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -15,7 +15,7 @@ import { next, previous } from '@wordpress/icons';
  */
 import DataViewsContext from '../dataviews-context';
 
-function DataViewsPagination() {
+export function DataViewsPagination() {
 	const {
 		view,
 		onChangeView,

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -61,10 +61,9 @@ const DATAVIEWS_CONFIG_POPOVER_PROPS = {
 	offset: 9,
 };
 
-export function ViewTypeMenu( {
-	defaultLayouts = { list: {}, grid: {}, table: {} },
-}: ViewTypeMenuProps ) {
-	const { view, onChangeView } = useContext( DataViewsContext );
+export function ViewTypeMenu() {
+	const { view, onChangeView, defaultLayouts } =
+		useContext( DataViewsContext );
 	const availableLayouts = Object.keys( defaultLayouts );
 	if ( availableLayouts.length <= 1 ) {
 		return null;
@@ -815,14 +814,10 @@ export function DataviewsViewConfigDropdown() {
 	);
 }
 
-function _DataViewsViewConfig( {
-	defaultLayouts = { list: {}, grid: {}, table: {} },
-}: {
-	defaultLayouts?: SupportedLayouts;
-} ) {
+function _DataViewsViewConfig() {
 	return (
 		<>
-			<ViewTypeMenu defaultLayouts={ defaultLayouts } />
+			<ViewTypeMenu />
 			<DataviewsViewConfigDropdown />
 		</>
 	);

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -761,7 +761,7 @@ function SettingsSection( {
 	);
 }
 
-function DataviewsViewConfigDropdown() {
+export function DataviewsViewConfigDropdown() {
 	const { view } = useContext( DataViewsContext );
 	const popoverId = useInstanceId(
 		_DataViewsViewConfig,

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -61,7 +61,7 @@ const DATAVIEWS_CONFIG_POPOVER_PROPS = {
 	offset: 9,
 };
 
-function ViewTypeMenu( {
+export function ViewTypeMenu( {
 	defaultLayouts = { list: {}, grid: {}, table: {} },
 }: ViewTypeMenuProps ) {
 	const { view, onChangeView } = useContext( DataViewsContext );

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -181,8 +181,16 @@ function DataViews< Item >( {
 // Populate the DataViews sub components
 const DataViewsSubComponents = DataViews as typeof DataViews & {
 	Search: typeof DataViewsSearch;
+	ViewConfig: typeof DataViewsViewConfig;
+	Filters: typeof DataViewsFilters;
+	Layout: typeof DataViewsLayout;
+	Pagination: typeof DataViewsFooter;
 };
 
 DataViewsSubComponents.Search = DataViewsSearch;
+DataViewsSubComponents.ViewConfig = DataViewsViewConfig;
+DataViewsSubComponents.Filters = DataViewsFilters;
+DataViewsSubComponents.Layout = DataViewsLayout;
+DataViewsSubComponents.Pagination = DataViewsFooter;
 
 export default DataViewsSubComponents;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -22,7 +22,9 @@ import {
 import DataViewsLayout from '../dataviews-layout';
 import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
-import DataViewsViewConfig from '../dataviews-view-config';
+import DataViewsViewConfig, {
+	DataviewsViewConfigDropdown,
+} from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
@@ -181,14 +183,14 @@ function DataViews< Item >( {
 // Populate the DataViews sub components
 const DataViewsSubComponents = DataViews as typeof DataViews & {
 	Search: typeof DataViewsSearch;
-	ViewConfig: typeof DataViewsViewConfig;
+	ViewConfig: typeof DataviewsViewConfigDropdown;
 	Filters: typeof DataViewsFilters;
 	Layout: typeof DataViewsLayout;
 	Pagination: typeof DataViewsFooter;
 };
 
 DataViewsSubComponents.Search = DataViewsSearch;
-DataViewsSubComponents.ViewConfig = DataViewsViewConfig;
+DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
 DataViewsSubComponents.Filters = DataViewsFilters;
 DataViewsSubComponents.Layout = DataViewsLayout;
 DataViewsSubComponents.Pagination = DataViewsFooter;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -186,7 +186,6 @@ function DataViews< Item >( {
 const DataViewsSubComponents = DataViews as typeof DataViews & {
 	Search: typeof DataViewsSearch;
 	ViewConfig: typeof DataviewsViewConfigDropdown;
-	Filters: typeof DataViewsFilters;
 	Layout: typeof DataViewsLayout;
 	Pagination: typeof DataViewsFooter;
 	ViewTypeMenu: typeof ViewTypeMenu;
@@ -194,7 +193,6 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 
 DataViewsSubComponents.Search = DataViewsSearch;
 DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
-DataViewsSubComponents.Filters = DataViewsFilters;
 DataViewsSubComponents.Layout = DataViewsLayout;
 DataViewsSubComponents.Pagination = DataViewsFooter;
 DataViewsSubComponents.ViewTypeMenu = ViewTypeMenu;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -174,6 +174,7 @@ function DataViews< Item >( {
 				isItemClickable,
 				onClickItem,
 				containerWidth,
+				defaultLayouts,
 			} }
 		>
 			{ children || defaultUI }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -145,7 +145,7 @@ function DataViews< Item >( {
 					expanded={ false }
 					style={ { flexShrink: 0 } }
 				>
-					<DataViewsViewConfig defaultLayouts={ defaultLayouts! } />
+					<DataViewsViewConfig />
 					{ header }
 				</HStack>
 			</HStack>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -119,7 +119,7 @@ function DataViews< Item >( {
 	);
 
 	const defaultUI = (
-		<div className="dataviews-wrapper" ref={ containerRef }>
+		<>
 			<HStack
 				alignment="top"
 				justify="space-between"
@@ -153,7 +153,7 @@ function DataViews< Item >( {
 			{ isShowingFilter && <DataViewsFilters /> }
 			<DataViewsLayout />
 			<DataViewsFooter />
-		</div>
+		</>
 	);
 
 	return (
@@ -178,7 +178,9 @@ function DataViews< Item >( {
 				defaultLayouts,
 			} }
 		>
-			{ children || defaultUI }
+			<div className="dataviews-wrapper" ref={ containerRef }>
+				{ children || defaultUI }
+			</div>
 		</DataViewsContext.Provider>
 	);
 }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -22,6 +22,7 @@ import {
 import DataViewsLayout from '../dataviews-layout';
 import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
+import { BulkActionsFooter } from '../dataviews-bulk-actions';
 import { DataViewsPagination } from '../dataviews-pagination';
 import DataViewsViewConfig, {
 	DataviewsViewConfigDropdown,
@@ -30,7 +31,6 @@ import DataViewsViewConfig, {
 import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
-
 type ItemWithId = { id: string };
 
 type DataViewsProps< Item > = {
@@ -189,6 +189,7 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 	ViewConfig: typeof DataviewsViewConfigDropdown;
 	Layout: typeof DataViewsLayout;
 	Pagination: typeof DataViewsPagination;
+	BulkActionToolbar: typeof BulkActionsFooter;
 	ViewTypeMenu: typeof ViewTypeMenu;
 };
 
@@ -197,5 +198,6 @@ DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
 DataViewsSubComponents.Layout = DataViewsLayout;
 DataViewsSubComponents.Pagination = DataViewsPagination;
 DataViewsSubComponents.ViewTypeMenu = ViewTypeMenu;
+DataViewsSubComponents.BulkActionToolbar = BulkActionsFooter;
 
 export default DataViewsSubComponents;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -187,19 +187,19 @@ function DataViews< Item >( {
 
 // Populate the DataViews sub components
 const DataViewsSubComponents = DataViews as typeof DataViews & {
+	BulkActionToolbar: typeof BulkActionsFooter;
+	Layout: typeof DataViewsLayout;
+	LayoutSwitcher: typeof ViewTypeMenu;
+	Pagination: typeof DataViewsPagination;
 	Search: typeof DataViewsSearch;
 	ViewConfig: typeof DataviewsViewConfigDropdown;
-	Layout: typeof DataViewsLayout;
-	Pagination: typeof DataViewsPagination;
-	BulkActionToolbar: typeof BulkActionsFooter;
-	LayoutSwitcher: typeof ViewTypeMenu;
 };
 
+DataViewsSubComponents.BulkActionToolbar = BulkActionsFooter;
+DataViewsSubComponents.Layout = DataViewsLayout;
+DataViewsSubComponents.LayoutSwitcher = ViewTypeMenu;
+DataViewsSubComponents.Pagination = DataViewsPagination;
 DataViewsSubComponents.Search = DataViewsSearch;
 DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
-DataViewsSubComponents.Layout = DataViewsLayout;
-DataViewsSubComponents.Pagination = DataViewsPagination;
-DataViewsSubComponents.LayoutSwitcher = ViewTypeMenu;
-DataViewsSubComponents.BulkActionToolbar = BulkActionsFooter;
 
 export default DataViewsSubComponents;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -24,6 +24,7 @@ import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
 import DataViewsViewConfig, {
 	DataviewsViewConfigDropdown,
+	ViewTypeMenu,
 } from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
@@ -187,6 +188,7 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 	Filters: typeof DataViewsFilters;
 	Layout: typeof DataViewsLayout;
 	Pagination: typeof DataViewsFooter;
+	ViewTypeMenu: typeof ViewTypeMenu;
 };
 
 DataViewsSubComponents.Search = DataViewsSearch;
@@ -194,5 +196,6 @@ DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
 DataViewsSubComponents.Filters = DataViewsFilters;
 DataViewsSubComponents.Layout = DataViewsLayout;
 DataViewsSubComponents.Pagination = DataViewsFooter;
+DataViewsSubComponents.ViewTypeMenu = ViewTypeMenu;
 
 export default DataViewsSubComponents;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -192,14 +192,14 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 	Layout: typeof DataViewsLayout;
 	Pagination: typeof DataViewsPagination;
 	BulkActionToolbar: typeof BulkActionsFooter;
-	ViewTypeMenu: typeof ViewTypeMenu;
+	LayoutSwitcher: typeof ViewTypeMenu;
 };
 
 DataViewsSubComponents.Search = DataViewsSearch;
 DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
 DataViewsSubComponents.Layout = DataViewsLayout;
 DataViewsSubComponents.Pagination = DataViewsPagination;
-DataViewsSubComponents.ViewTypeMenu = ViewTypeMenu;
+DataViewsSubComponents.LayoutSwitcher = ViewTypeMenu;
 DataViewsSubComponents.BulkActionToolbar = BulkActionsFooter;
 
 export default DataViewsSubComponents;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -22,6 +22,7 @@ import {
 import DataViewsLayout from '../dataviews-layout';
 import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
+import { DataViewsPagination } from '../dataviews-pagination';
 import DataViewsViewConfig, {
 	DataviewsViewConfigDropdown,
 	ViewTypeMenu,
@@ -187,14 +188,14 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 	Search: typeof DataViewsSearch;
 	ViewConfig: typeof DataviewsViewConfigDropdown;
 	Layout: typeof DataViewsLayout;
-	Pagination: typeof DataViewsFooter;
+	Pagination: typeof DataViewsPagination;
 	ViewTypeMenu: typeof ViewTypeMenu;
 };
 
 DataViewsSubComponents.Search = DataViewsSearch;
 DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
 DataViewsSubComponents.Layout = DataViewsLayout;
-DataViewsSubComponents.Pagination = DataViewsFooter;
+DataViewsSubComponents.Pagination = DataViewsPagination;
 DataViewsSubComponents.ViewTypeMenu = ViewTypeMenu;
 
 export default DataViewsSubComponents;

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -583,6 +583,7 @@ export const actions: Action< SpaceObject >[] = [
 		icon: trash,
 		hideModalHeader: true,
 		modalFocusOnMount: 'firstContentElement',
+		supportsBulk: true,
 		RenderModal: ( { items, closeModal } ) => {
 			return (
 				<VStack spacing="5">

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -181,15 +181,17 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 					</CardBody>
 				</Card>
 
-				<HStack justify="end">
-					<DataViews.Search label={ __( 'moons by planet' ) } />
-				</HStack>
+				<DataViews.Search label={ __( 'moons by planet' ) } />
 
-				<HStack justify="end">
-					<DataViews.Pagination />
-					<DataViews.ViewConfig />
-					<DataViews.ViewTypeMenu />
-				</HStack>
+				<VStack>
+					<HStack justify="start">
+						<DataViews.Pagination />
+						<DataViews.ViewConfig />
+						<DataViews.ViewTypeMenu />
+					</HStack>
+
+					<DataViews.BulkActionToolbar />
+				</VStack>
 			</Grid>
 
 			<DataViews.Layout />
@@ -235,6 +237,7 @@ export const FreeComposition = () => {
 			data={ processedData }
 			view={ view }
 			fields={ fields }
+			actions={ actions }
 			onChangeView={ setView }
 			defaultLayouts={ {
 				table: {},

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -188,7 +188,7 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 				<HStack justify="end">
 					<DataViews.Pagination />
 					<DataViews.ViewConfig />
-					<DataViews.ViewTypeMenu defaultLayouts={ defaultLayouts } />
+					<DataViews.ViewTypeMenu />
 				</HStack>
 			</Grid>
 

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -238,7 +238,10 @@ export const FreeComposition = () => {
 			view={ view }
 			fields={ fields }
 			onChangeView={ setView }
-			defaultLayouts={ defaultLayouts }
+			defaultLayouts={ {
+				table: {},
+				grid: {},
+			} }
 		>
 			<PlanetOverview planets={ planets } />
 		</DataViews>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -195,7 +195,6 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 			<DataViews.Filters />
 
 			<DataViews.Layout />
-			<DataViews.Pagination />
 		</>
 	);
 }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -8,8 +8,10 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
+	__experimentalGrid as Grid,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
@@ -130,44 +132,72 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
 
 	return (
-		<Card isBorderless style={ { padding: '12px 24px' } }>
-			<CardHeader>
-				<Heading level={ 2 }>{ __( 'Solar System numbers' ) }</Heading>
-				<DataViews.Search label={ __( 'moons by planet' ) } />
-			</CardHeader>
+		<>
+			<Grid
+				templateColumns="repeat(auto-fit, minmax(330px, 1fr))"
+				justify="left"
+				align="flex-start"
+				className="dataviews-sticky-header"
+			>
+				<Card variant="secondary">
+					<CardHeader>
+						<Heading level={ 2 }>
+							{ __( 'Solar System numbers' ) }
+						</Heading>
+					</CardHeader>
 
-			<CardBody>
-				<VStack spacing={ 2 }>
-					<Text size={ 18 } as="p">
-						{ createInterpolateElement(
-							_n(
-								'<PlanetsNumber /> planet',
-								'<PlanetsNumber /> planets',
-								planets.length
-							),
-							{
-								PlanetsNumber: (
-									<strong>{ planets.length } </strong>
-								),
-							}
-						) }
-					</Text>
+					<CardBody>
+						<VStack>
+							<Text size={ 18 } as="p">
+								{ createInterpolateElement(
+									_n(
+										'<PlanetsNumber /> planet',
+										'<PlanetsNumber /> planets',
+										planets.length
+									),
+									{
+										PlanetsNumber: (
+											<strong>{ planets.length } </strong>
+										),
+									}
+								) }
+							</Text>
 
-					<Text size={ 18 } as="p">
-						{ createInterpolateElement(
-							_n(
-								'<SatellitesNumber /> moon',
-								'<SatellitesNumber /> moons',
-								moons
-							),
-							{
-								SatellitesNumber: <strong>{ moons } </strong>,
-							}
-						) }
-					</Text>
-				</VStack>
-			</CardBody>
-		</Card>
+							<Text size={ 18 } as="p">
+								{ createInterpolateElement(
+									_n(
+										'<SatellitesNumber /> moon',
+										'<SatellitesNumber /> moons',
+										moons
+									),
+									{
+										SatellitesNumber: (
+											<strong>{ moons } </strong>
+										),
+									}
+								) }
+							</Text>
+						</VStack>
+					</CardBody>
+				</Card>
+
+				<HStack spacing={ 4 } justify="end" style={ { width: 'auto' } }>
+					<DataViews.Search label={ __( 'moons by planet' ) } />
+					<div>
+						<DataViews.ViewConfig
+							defaultLayouts={ defaultLayouts! }
+						/>
+					</div>
+				</HStack>
+
+				<DataViews.Pagination />
+			</Grid>
+
+			<DataViews.Filters />
+
+			<DataViews.Layout />
+			<DataViews.Pagination />
+		</>
 	);
 }
 
@@ -208,7 +238,7 @@ export const FreeComposition = () => {
 			paginationInfo={ paginationInfo }
 			data={ processedData }
 			view={ view }
-			fields={ [] }
+			fields={ fields }
 			onChangeView={ setView }
 			defaultLayouts={ defaultLayouts }
 		>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -135,9 +135,8 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 		<>
 			<Grid
 				templateColumns="repeat(auto-fit, minmax(330px, 1fr))"
-				justify="left"
 				align="flex-start"
-				className="dataviews-sticky-header"
+				className="free-composition-header"
 			>
 				<Card variant="secondary">
 					<CardHeader>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -187,7 +187,7 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 					<HStack justify="start">
 						<DataViews.Pagination />
 						<DataViews.ViewConfig />
-						<DataViews.ViewTypeMenu />
+						<DataViews.LayoutSwitcher />
 					</HStack>
 
 					<DataViews.BulkActionToolbar />

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -181,16 +181,15 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 					</CardBody>
 				</Card>
 
-				<HStack spacing={ 4 } justify="end" style={ { width: 'auto' } }>
+				<HStack justify="end">
 					<DataViews.Search label={ __( 'moons by planet' ) } />
-					<div>
-						<DataViews.ViewConfig
-							defaultLayouts={ defaultLayouts! }
-						/>
-					</div>
 				</HStack>
 
-				<DataViews.Pagination />
+				<HStack justify="end">
+					<DataViews.Pagination />
+					<DataViews.ViewConfig />
+					<DataViews.ViewTypeMenu defaultLayouts={ defaultLayouts } />
+				</HStack>
 			</Grid>
 
 			<DataViews.Filters />

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -192,8 +192,6 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 				</HStack>
 			</Grid>
 
-			<DataViews.Filters />
-
 			<DataViews.Layout />
 		</>
 	);

--- a/packages/dataviews/src/components/dataviews/stories/style.css
+++ b/packages/dataviews/src/components/dataviews/stories/style.css
@@ -3,10 +3,6 @@
     text-wrap: pretty;
 }
 
-.dataviews-sticky-header {
-	position: sticky;
-	top: 16px;
-	padding-bottom: 16px;
-	background-color: #fff;
-	z-index: 100;
+.free-composition-header {
+    padding: 16px 48px;
 }

--- a/packages/dataviews/src/components/dataviews/stories/style.css
+++ b/packages/dataviews/src/components/dataviews/stories/style.css
@@ -2,3 +2,11 @@
     text-wrap: balance;
     text-wrap: pretty;
 }
+
+.dataviews-sticky-header {
+	position: sticky;
+	top: 16px;
+	padding-bottom: 16px;
+	background-color: #fff;
+	z-index: 100;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of WOOA7S-113

## Proposed Changes

* Expose `Search`, `ViewConfig`, `Layout`, `Pagination`, `LayoutSwitcher`, and `BulkActionToolbar` as self-contained subcomponents of DataViews.
* Update the Free Composition story to use the new subcomponents and demonstrate context-based rendering.

## Why are these changes being made?

We want to enable developers to compose their own custom DataViews-based UIs using smaller, self-contained parts. These subcomponents are already used internally by the main `DataViews` layout and are capable of rendering in isolation when context is properly provided.

This improves flexibility in layout and composition while avoiding the need to duplicate internal logic outside the package.

## Testing Instructions

* Run the Storybook with:

```
yarn dataviews:storybook:start
```

* Open the `FreeComposition` story.
* Verify that all subcomponents (`Search`, `ViewConfig`, `Filters`, `Layout`, and `Pagination`) are rendered as expected and interact correctly with the context.
* Confirm that custom styling via `className` works on `<DataViewsFooter />`.

https://github.com/user-attachments/assets/ec6d1697-48d2-4071-8b17-92a52299373e

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?