### PR TITLE
Help Center: Fix History not showing for users with only closed interactions

### DIFF
--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -246,21 +246,14 @@ const HelpCenterFooterButton = ( {
 export const HelpCenterContactButton: FC = () => {
 	const { canConnectToZendesk } = useHelpCenterContext();
 	const { __ } = useI18n();
-	const { data: supportInteractionsResolved } = useGetSupportInteractions(
-		'zendesk',
-		1,
-		'resolved'
-	);
-	const { data: supportInteractionsOpen } = useGetSupportInteractions( 'zendesk', 1, 'open' );
-	const { data: supportInteractionsSolved } = useGetSupportInteractions( 'zendesk', 1, 'solved' );
+	const { data: supportInteractionsSolvedOrClosed } = useGetSupportInteractions( 'zendesk', 1, [
+		'solved',
+		'closed',
+	] );
 
-	const supportInteractions = [
-		...( supportInteractionsResolved || [] ),
-		...( supportInteractionsOpen || [] ),
-		...( supportInteractionsSolved || [] ),
-	];
-
-	return canConnectToZendesk && supportInteractions && supportInteractions?.length > 0 ? (
+	return canConnectToZendesk &&
+		supportInteractionsSolvedOrClosed &&
+		supportInteractionsSolvedOrClosed?.length > 0 ? (
 		<>
 			<HelpCenterFooterButton
 				icon={ comment }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -251,7 +251,9 @@ export const HelpCenterContactButton: FC = () => {
 		'closed',
 	] );
 
-	return canConnectToZendesk && supportInteractionsSolvedOrClosed?.length > 0 ? (
+	return canConnectToZendesk &&
+		supportInteractionsSolvedOrClosed &&
+		supportInteractionsSolvedOrClosed.length > 0 ? (
 		<>
 			<HelpCenterFooterButton
 				icon={ comment }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -251,9 +251,7 @@ export const HelpCenterContactButton: FC = () => {
 		'closed',
 	] );
 
-	return canConnectToZendesk &&
-		supportInteractionsSolvedOrClosed &&
-		supportInteractionsSolvedOrClosed?.length > 0 ? (
+	return canConnectToZendesk && supportInteractionsSolvedOrClosed?.length > 0 ? (
 		<>
 			<HelpCenterFooterButton
 				icon={ comment }

--- a/packages/odie-client/src/data/use-get-support-interactions.ts
+++ b/packages/odie-client/src/data/use-get-support-interactions.ts
@@ -9,7 +9,7 @@ import type { SupportProvider } from '../types';
 export const useGetSupportInteractions = (
 	provider: SupportProvider | null = null,
 	per_page = 10,
-	status = 'open',
+	status: string | string[] = 'open',
 	page = 1,
 	enabled = true
 ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1746132352324169-slack-C07D72S1135

## Proposed Changes

*   Modify `useGetSupportInteractions` hook in `@automattic/odie-client` to accept an array of statuses in addition to a single status string.
*   Update `HelpCenterContactButton` in `packages/help-center` to use the updated `useGetSupportInteractions` hook to fetch interactions with 'solved' or 'closed' status in a single call. This simplifies the logic for determining whether to show the "History" button.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*   We were not checking for closed interactions, **so users with all closed interactions were not seeing the History button**.
*   The previous implementation made multiple calls to `useGetSupportInteractions` to check for 'resolved', 'open', and 'solved' statuses separately. This change optimizes the data fetching by allowing multiple statuses in one request.

## Testing Instructions

1.  Have a user with a closed interaction and open the Help Center. (Create a new paid user, start a new conversation with AI and escalate to Happiness Engineer. Then in Zendesk set the chat to solved)
2.  Verify that the "Still need help?" button is displayed.
3.  **If** you have previously closed or solved support interactions (via Zendesk):
    *   Verify that the "History" button is also displayed next to the "Still need help?" button.
    *   Verify clicking the "History" button navigates you to `/chat-history`.
4.  **If** you do **not** have any closed or solved support interactions:
    *   Verify that only the "Still need help?" button is displayed.
5.  Verify clicking the "Still need help?" button navigates you to `/odie`.
6.  Check the browser console for any errors.
