### PR TITLE
CI: require changelog entry for any DataViews changes

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -18,7 +18,6 @@ object WebApp : Project({
 
 	buildType(RunAllUnitTests)
 	buildType(CheckCodeStyleBranch)
-	buildType(DataViewsChangelogCheck)
 	buildType(Translate)
 	buildType(BuildDockerImage)
 	buildType(playwrightPrBuildType("desktop", "23cc069f-59e5-4a63-a131-539fb55264e7"))
@@ -454,6 +453,23 @@ object RunAllUnitTests : BuildType({
 
 				prevent_uncommitted_changes & prevent_duplicated_packages
 				wait
+			""".trimIndent()
+		}
+		bashNodeScript {
+			name = "Check DataViews changelog"
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -e
+
+				CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
+
+				if grep -q ^packages/dataviews/ <<< "${'$'}CHANGES"; then
+					if ! grep -q ^packages/dataviews/CHANGELOG.automattic.md <<< "${'$'}CHANGES"; then
+						echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."
+						echo "Please document your changes in 'packages/dataviews/CHANGELOG.automattic.md'."
+						exit 1
+					fi
+				fi
 			""".trimIndent()
 		}
 		bashNodeScript {
@@ -1199,71 +1215,3 @@ object QuarantinedE2ETests: E2EBuildType(
 	buildTriggers = {
 	}
 )
-
-object DataViewsChangelogCheck : BuildType({
-	id("calypso_WebApp_DataViews_Changelog_Check")
-	uuid = "c494fae3-e0e1-49e2-9219-ea59cc17c499"
-	name = "DataViews Changelog Check"
-	description = "Ensures that changes to the packages/dataviews fork are accompanied by changes to its changelog"
-
-	vcs {
-		root(Settings.WpCalypso)
-		cleanCheckout = true
-	}
-
-	steps {
-		bashNodeScript {
-			name = "Check DataViews changelog"
-			scriptContent = """
-				#!/usr/bin/env bash
-				set -e
-
-				CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
-
-				if grep -q ^packages/dataviews/ <<< "${'$'}CHANGES"; then
-					if ! grep -q ^packages/dataviews/CHANGELOG.automattic.md <<< "${'$'}CHANGES"; then
-						echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."
-						echo "Please document your changes in 'packages/dataviews/CHANGELOG.automattic.md'."
-						exit 1
-					fi
-				fi
-			"""
-		}
-	}
-
-	triggers {
-		vcs {
-			branchFilter = """
-				+:*
-				-:trunk
-				-:pull*
-			""".trimIndent()
-			triggerRules = """
-				+:packages/dataviews/**
-			""".trimIndent()
-		}
-	}
-
-	features {
-		perfmon {
-		}
-		pullRequests {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			provider = github {
-				authType = token {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
-				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
-			}
-		}
-		commitStatusPublisher {
-			vcsRootExtId = "${Settings.WpCalypso.id}"
-			publisher = github {
-				githubUrl = "https://api.github.com"
-				authType = personalToken {
-					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-				}
-			}
-		}
-	}
-})

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1218,24 +1218,14 @@ object DataViewsChangelogCheck : BuildType({
 				#!/usr/bin/env bash
 				set -e
 
-				# Check if there are any changes to packages/dataviews
-				DATAVIEWS_CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD \
-					| grep -c ^packages/dataviews/ \
-					|| true)
+				CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
 
-				if [ "${'$'}DATAVIEWS_CHANGES" -eq 0 ]; then
-					exit 0
-				fi
-
-				# Check if the changelog file was modified
-				CHANGELOG_MODIFIED=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD \
-					| grep -c '^packages/dataviews/CHANGELOG.automattic.md${'$'}' \
-					|| true)
-
-				if [ "${'$'}CHANGELOG_MODIFIED" -eq 0 ]; then
-					echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."
-					echo "Please document your changes in 'packages/dataviews/CHANGELOG.automattic.md'."
-					exit 1
+				if grep -q ^packages/dataviews/ <<< "${'$'}CHANGES"; then
+					if ! grep -q ^packages/dataviews/CHANGELOG.automattic.md <<< "${'$'}CHANGES"; then
+						echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."
+						echo "Please document your changes in 'packages/dataviews/CHANGELOG.automattic.md'."
+						exit 1
+					fi
 				fi
 			"""
 		}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -461,8 +461,11 @@ object RunAllUnitTests : BuildType({
 				#!/usr/bin/env bash
 				set -e
 
+				# List files affected by the branch's commits
 				CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
 
+				# If there are changes within the DataViews package, ensure
+				# CHANGELOG.automattic.md has been updated too.
 				if grep -q ^packages/dataviews/ <<< "${'$'}CHANGES"; then
 					if ! grep -q ^packages/dataviews/CHANGELOG.automattic.md <<< "${'$'}CHANGES"; then
 						echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -18,6 +18,7 @@ object WebApp : Project({
 
 	buildType(RunAllUnitTests)
 	buildType(CheckCodeStyleBranch)
+	buildType(DataViewsChangelogCheck)
 	buildType(Translate)
 	buildType(BuildDockerImage)
 	buildType(playwrightPrBuildType("desktop", "23cc069f-59e5-4a63-a131-539fb55264e7"))
@@ -1198,3 +1199,81 @@ object QuarantinedE2ETests: E2EBuildType(
 	buildTriggers = {
 	}
 )
+
+object DataViewsChangelogCheck : BuildType({
+	id("calypso_WebApp_DataViews_Changelog_Check")
+	uuid = "c494fae3-e0e1-49e2-9219-ea59cc17c499"
+	name = "DataViews Changelog Check"
+	description = "Ensures that changes to the packages/dataviews fork are accompanied by changes to its changelog"
+
+	vcs {
+		root(Settings.WpCalypso)
+		cleanCheckout = true
+	}
+
+	steps {
+		bashNodeScript {
+			name = "Check DataViews changelog"
+			scriptContent = """
+				#!/usr/bin/env bash
+				set -e
+
+				# Check if there are any changes to packages/dataviews
+				DATAVIEWS_CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD \
+					| grep -c ^packages/dataviews/ \
+					|| true)
+
+				if [ "${'$'}DATAVIEWS_CHANGES" -eq 0 ]; then
+					exit 0
+				fi
+
+				# Check if the changelog file was modified
+				CHANGELOG_MODIFIED=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD \
+					| grep -c '^packages/dataviews/CHANGELOG.automattic.md${'$'}' \
+					|| true)
+
+				if [ "${'$'}CHANGELOG_MODIFIED" -eq 0 ]; then
+					echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."
+					echo "Please document your changes in 'packages/dataviews/CHANGELOG.automattic.md'."
+					exit 1
+				fi
+			"""
+		}
+	}
+
+	triggers {
+		vcs {
+			branchFilter = """
+				+:*
+				-:trunk
+				-:pull*
+			""".trimIndent()
+			triggerRules = """
+				+:packages/dataviews/**
+			""".trimIndent()
+		}
+	}
+
+	features {
+		perfmon {
+		}
+		pullRequests {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			provider = github {
+				authType = token {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+				filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+			}
+		}
+		commitStatusPublisher {
+			vcsRootExtId = "${Settings.WpCalypso.id}"
+			publisher = github {
+				githubUrl = "https://api.github.com"
+				authType = personalToken {
+					token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
+				}
+			}
+		}
+	}
+})

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -32,8 +32,11 @@ require( './validate-config-keys' );
 function parseGitDiffToPathArray( command ) {
 	return execSync( command, { encoding: 'utf8' } )
 		.split( '\n' )
-		.map( ( name ) => name.trim() )
-		.filter( ( name ) => /(?:\.json|\.[jt]sx?|\.scss|\.php)$/.test( name ) );
+		.map( ( name ) => name.trim() );
+}
+
+function isSourceCode( pathname ) {
+	return /(?:\.json|\.[jt]sx?|\.scss|\.php)$/.test( pathname );
 }
 
 function getPathForCommand( command ) {
@@ -78,12 +81,37 @@ function phpcsInstalled() {
 const phpcs = phpcsInstalled();
 
 // grab a list of all the files staged to commit
-const files = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
+const allFiles = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
 
-// grab a list of all the files with changes in the working copy.
+// we'll mostly only care about source code for the remainder of the script
+const files = allFiles.filter( isSourceCode );
+
+// grab a list of all the source code files with changes in the working copy.
+//
 // This list may have overlaps with the staged list if files are
 // partially staged...
-const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );
+const dirtyFiles = new Set(
+	parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ).filter( isSourceCode )
+);
+
+const hasChangesInDataViews = files.some( ( pathname ) =>
+	pathname.startsWith( 'packages/dataviews/' )
+);
+if ( hasChangesInDataViews ) {
+	// be sure to check in `allFiles` rather than `files`, since the target is a .md file
+	const hasChangelogEntry = allFiles.includes( 'packages/dataviews/CHANGELOG.automattic.md' );
+
+	if ( ! hasChangelogEntry ) {
+		console.log(
+			chalk.red( 'COMMIT ABORTED:' ),
+			'You are attempting to commit changes within `packages/dataviews/` ' +
+				'without an accompanying entry in ' +
+				'`packages/dataviews/CHANGELOG.automattic.md`. Please document your ' +
+				'changes in the changelog.'
+		);
+		process.exit( 1 );
+	}
+}
 
 // we don't want to format any files that are partially staged or unstaged
 dirtyFiles.forEach( ( file ) =>

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -32,11 +32,8 @@ require( './validate-config-keys' );
 function parseGitDiffToPathArray( command ) {
 	return execSync( command, { encoding: 'utf8' } )
 		.split( '\n' )
-		.map( ( name ) => name.trim() );
-}
-
-function isSourceCode( pathname ) {
-	return /(?:\.json|\.[jt]sx?|\.scss|\.php)$/.test( pathname );
+		.map( ( name ) => name.trim() )
+		.filter( ( name ) => /(?:\.json|\.[jt]sx?|\.scss|\.php)$/.test( name ) );
 }
 
 function getPathForCommand( command ) {
@@ -81,37 +78,12 @@ function phpcsInstalled() {
 const phpcs = phpcsInstalled();
 
 // grab a list of all the files staged to commit
-const allFiles = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
+const files = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
 
-// we'll mostly only care about source code for the remainder of the script
-const files = allFiles.filter( isSourceCode );
-
-// grab a list of all the source code files with changes in the working copy.
-//
+// grab a list of all the files with changes in the working copy.
 // This list may have overlaps with the staged list if files are
 // partially staged...
-const dirtyFiles = new Set(
-	parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ).filter( isSourceCode )
-);
-
-const hasChangesInDataViews = files.some( ( pathname ) =>
-	pathname.startsWith( 'packages/dataviews/' )
-);
-if ( hasChangesInDataViews ) {
-	// be sure to check in `allFiles` rather than `files`, since the target is a .md file
-	const hasChangelogEntry = allFiles.includes( 'packages/dataviews/CHANGELOG.automattic.md' );
-
-	if ( ! hasChangelogEntry ) {
-		console.log(
-			chalk.red( 'COMMIT ABORTED:' ),
-			'You are attempting to commit changes within `packages/dataviews/` ' +
-				'without an accompanying entry in ' +
-				'`packages/dataviews/CHANGELOG.automattic.md`. Please document your ' +
-				'changes in the changelog.'
-		);
-		process.exit( 1 );
-	}
-}
+const dirtyFiles = new Set( parseGitDiffToPathArray( 'git diff --name-only --diff-filter=ACM' ) );
 
 // we don't want to format any files that are partially staged or unstaged
 dirtyFiles.forEach( ( file ) =>


### PR DESCRIPTION
Fixes DOTDEV-122

## Proposed Changes

* ~Use Git's pre-commit hook~ Add a check in TeamCity to detect whether a ~commit~ pull request includes changes to the DataViews package (`packages/dataviews`) and, if so, require that changes to the fork's changelog (`packages/dataviews/CHANGELOG.automattic.md`) also be staged for commit.

## Why are these changes being made?

* Any changes to the DataViews fork should come with an accompanying entry in its changelog, per our new process.

## Testing Instructions

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
