### PR TITLE
Dashboard v2: refactor to avoid anonymous components

### DIFF
--- a/client/dashboard/router-link-button/index.tsx
+++ b/client/dashboard/router-link-button/index.tsx
@@ -3,8 +3,8 @@ import { Button } from '@wordpress/components';
 import { ButtonProps } from '@wordpress/components/build-types/button/types';
 import { forwardRef } from 'react';
 
-export default createLink(
-	forwardRef( ( props: ButtonProps, ref: React.Ref< HTMLAnchorElement > ) => (
-		<Button ref={ ref } { ...props } />
-	) )
-);
+function RouterLinkButton( props: ButtonProps, ref: React.Ref< HTMLAnchorElement > ) {
+	return <Button ref={ ref } { ...props } />;
+}
+
+export default createLink( forwardRef( RouterLinkButton ) );

--- a/client/dashboard/router-link-menu-item/index.tsx
+++ b/client/dashboard/router-link-menu-item/index.tsx
@@ -4,12 +4,12 @@ import { WordPressComponentProps } from '@wordpress/components/build-types/conte
 import { MenuItemProps } from '@wordpress/components/build-types/menu-item/types';
 import { forwardRef } from 'react';
 
-export default createLink(
-	forwardRef(
-		(
-			props: WordPressComponentProps< MenuItemProps, 'button', false >,
-			// To do: Fix MenuItemProps so that it allows HTMLAnchorElement.
-			ref: React.Ref< HTMLButtonElement >
-		) => <MenuItem ref={ ref } { ...props } />
-	)
-);
+function RouterLinkMenuItem(
+	props: WordPressComponentProps< MenuItemProps, 'button', false >,
+	// To do: Fix MenuItemProps so that it allows HTMLAnchorElement.
+	ref: React.Ref< HTMLButtonElement >
+) {
+	return <MenuItem ref={ ref } { ...props } />;
+}
+
+export default createLink( forwardRef( RouterLinkMenuItem ) );


### PR DESCRIPTION
## Proposed Changes

* Minor refactoring with no observable changes. Please see diff.

## Why are these changes being made?

* The goal is not only to ensure that the wrapped functional component has a name (`Function#name`), but to improve the searchability of these definitions. Without this change, searching for `RouterLinkButton` can never point to the definition.

## Testing Instructions

* No changes should be observed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
