### PR TITLE
Remove the border around the Use a domain I own card to be consistent with the rest of the screens

### DIFF
--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -8,8 +8,10 @@
 	align-items: center;
 	flex-direction: column;
 	padding: 36px 24px;
-	box-shadow: none;
 	background-color: inherit;
+	& .card {
+		box-shadow: none;
+	}
 
 	& &__page-heading {
 		.formatted-header__title {


### PR DESCRIPTION
There was a border around the "Use a domain I own" card in the onboarding. We should remove it to be consistent with the rest of the onboarding flow


| Before | After |
|--------|--------|
| <img width="1511" alt="Screenshot 2025-05-02 at 16 40 57" src="https://github.com/user-attachments/assets/97aeaa47-ba8e-45c1-b1b3-d023db94e546" /> | <img width="1512" alt="Screenshot 2025-05-02 at 16 46 17" src="https://github.com/user-attachments/assets/bfd847bf-319d-45bf-9eae-925ea4ccd5f4" /> |


## Proposed Changes

* Turned out that the `box-shadow: none` was already in the css but the priority was not nigh enough so I moved it inside `& .card`

## Why are these changes being made?

* To make the design of the onboarding flow consistent

## Testing Instructions

* Go to /setup and in the domains step click on "Use a domain I own" link in the right column. You should see the input form without a border around it

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
