### PR TITLE
ESLint: apply `react/display-name` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -425,6 +425,7 @@ module.exports = {
 		'no-unused-expressions': 'off',
 
 		'react/forbid-foreign-prop-types': 'error',
+		'react/display-name': 'error',
 		'react/jsx-curly-brace-presence': [ 'error', { props: 'never', children: 'never' } ],
 		'react/jsx-boolean-value': 'error',
 		// enforce our classname namespacing rules


### PR DESCRIPTION
Related to #103075

## Proposed Changes

* Enforces named components. Initially proposed by @aduth in
https://github.com/Automattic/wp-calypso/pull/103075


## Why are these changes being made?

See [react/display-name](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md)

* DisplayName is used by React in debugging messages and is visible in other debugging contexts (e.g. React Developer Tools' inspector), helping developers identify components.
* Enforcing this rules also increases the likehood that component definitions are easier to search in the codebase. See https://github.com/Automattic/wp-calypso/pull/103075 for a concrete example.

## Testing Instructions

* Test the rule by attempting to export an anonymous function as a component, for example.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
