### PR TITLE
Themes: Replace search and dropdown with the components from the @wordpress package

### DIFF
--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -1,7 +1,7 @@
 import { SearchControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
 import './style.scss';
 
@@ -14,6 +14,21 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	const translate = useTranslate();
 	const [ searchInput, setSearchInput ] = useState( query );
 
+	const onClearSearch = useCallback( () => {
+		onSearch( '' );
+		recordTracksEvent && recordTracksEvent( 'search_clear_icon_click' );
+	}, [ onSearch, recordTracksEvent ] );
+
+	const onChange = useCallback(
+		( value: string ) => {
+			setSearchInput( value );
+			if ( value === '' && query !== '' ) {
+				onClearSearch();
+			}
+		},
+		[ query, onClearSearch ]
+	);
+
 	const onKeyDown = useCallback(
 		( event: React.KeyboardEvent< HTMLInputElement > ) => {
 			if ( event.key === 'Enter' ) {
@@ -22,17 +37,6 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 		},
 		[ onSearch, searchInput ]
 	);
-
-	const onClearSearch = useCallback( () => {
-		onSearch( '' );
-		recordTracksEvent && recordTracksEvent( 'search_clear_icon_click' );
-	}, [ onSearch, recordTracksEvent ] );
-
-	useEffect( () => {
-		if ( searchInput === '' && query !== '' ) {
-			onClearSearch();
-		}
-	}, [ searchInput, query, onClearSearch ] );
 
 	return (
 		<div>
@@ -45,7 +49,7 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 					__nextHasNoMarginBottom
 					value={ searchInput }
 					placeholder={ translate( 'Search themes…' ) }
-					onChange={ setSearchInput }
+					onChange={ onChange }
 					onKeyDown={ onKeyDown }
 				/>
 			</div>

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -1,78 +1,52 @@
-import { Gridicon } from '@automattic/components';
-import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
+import { SearchControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
 import './style.scss';
+
 interface SearchThemesProps {
 	query: string;
 	onSearch: ( query: string ) => void;
 	recordTracksEvent: ( eventName: string, eventProperties?: object ) => void;
 }
 const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordTracksEvent } ) => {
-	const wrapperRef = useRef< HTMLDivElement | null >( null );
-	const searchRef = useRef< Search | null >( null );
 	const translate = useTranslate();
 	const [ searchInput, setSearchInput ] = useState( query );
-	const [ isApplySearch, setIsApplySearch ] = useState( false );
-	const focusOnInput = () => {
-		searchRef.current?.focus();
-	};
-	const clearSearch = () => {
-		setSearchInput( '' );
-		focusOnInput();
-	};
-	const closeSearch = () => {
-		searchRef.current?.blur();
-	};
-	const onKeyDown = ( event: React.KeyboardEvent< HTMLInputElement > ) => {
-		if ( event.key === 'Enter' ) {
-			searchRef.current?.blur();
-		}
-	};
-	const onClearIconClick = () => {
-		clearSearch();
+
+	const onKeyDown = useCallback(
+		( event: React.KeyboardEvent< HTMLInputElement > ) => {
+			if ( event.key === 'Enter' ) {
+				onSearch( searchInput );
+			}
+		},
+		[ onSearch, searchInput ]
+	);
+
+	const onClearSearch = useCallback( () => {
+		onSearch( '' );
 		recordTracksEvent( 'search_clear_icon_click' );
-	};
+	}, [ onSearch, recordTracksEvent ] );
+
+	useEffect( () => {
+		if ( searchInput === '' && query !== '' ) {
+			onClearSearch();
+		}
+	}, [ searchInput, query, onClearSearch ] );
+
 	return (
-		<div ref={ wrapperRef } { ...useFocusOutside( closeSearch ) }>
+		<div>
 			<div
 				className={ clsx( 'search-themes-card' ) }
 				role="presentation"
 				data-tip-target="search-themes-card"
-				onClick={ focusOnInput }
 			>
-				<Search
-					initialValue={ searchInput }
+				<SearchControl
 					value={ searchInput }
-					ref={ searchRef }
 					placeholder={ translate( 'Search themes…' ) }
-					analyticsGroup="Themes"
-					searchMode={ SEARCH_MODE_ON_ENTER }
-					applySearch={ isApplySearch }
-					hideClose
+					onChange={ setSearchInput }
 					onKeyDown={ onKeyDown }
-					onSearch={ onSearch }
-					onSearchClose={ closeSearch }
-					onSearchChange={ ( inputValue: string ) => {
-						setSearchInput( inputValue );
-						setIsApplySearch( false );
-					} }
-				>
-					{ searchInput !== '' && (
-						<div className="search-themes-card__icon">
-							<Gridicon
-								icon="cross"
-								className="search-themes-card__icon-close"
-								tabIndex={ 0 }
-								aria-controls="search-component-search-themes"
-								aria-label={ translate( 'Clear Search' ) }
-								onClick={ onClearIconClick }
-							/>
-						</div>
-					) }
-				</Search>
+				/>
 			</div>
 		</div>
 	);

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -2,7 +2,6 @@ import { SearchControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
-import Search, { SEARCH_MODE_ON_ENTER } from 'calypso/components/search';
 import './style.scss';
 
 interface SearchThemesProps {
@@ -57,26 +56,4 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	);
 };
 
-interface SearchThemesV2Props {
-	query: string;
-	onSearch: ( query: string ) => void;
-}
-
-const SearchThemesV2: React.FC< SearchThemesV2Props > = ( { query, onSearch } ) => {
-	const translate = useTranslate();
-
-	return (
-		<div className="search-themes-card" role="presentation" data-tip-target="search-themes-card">
-			<Search
-				initialValue={ query }
-				value={ query }
-				placeholder={ translate( 'Search themes…' ) }
-				analyticsGroup="Themes"
-				searchMode={ SEARCH_MODE_ON_ENTER }
-				onSearch={ onSearch }
-			/>
-		</div>
-	);
-};
-
-export { SearchThemes, SearchThemesV2 };
+export { SearchThemes };

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -25,7 +25,7 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 
 	const onClearSearch = useCallback( () => {
 		onSearch( '' );
-		recordTracksEvent( 'search_clear_icon_click' );
+		recordTracksEvent && recordTracksEvent( 'search_clear_icon_click' );
 	}, [ onSearch, recordTracksEvent ] );
 
 	useEffect( () => {

--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -42,6 +42,7 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 				data-tip-target="search-themes-card"
 			>
 				<SearchControl
+					__nextHasNoMarginBottom
 					value={ searchInput }
 					placeholder={ translate( 'Search themes…' ) }
 					onChange={ setSearchInput }

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -32,6 +32,7 @@ export function getProps( context ) {
 		isCollectionView: view === 'collection',
 		pathName: context.pathname,
 		trackScrollPage: boundTrackScrollPage,
+		isServerSide: context.isServerSide,
 	};
 }
 

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -42,6 +42,11 @@ export function loggedOut( context, next ) {
 		return next();
 	}
 
+	// Skip rendering logged-out component for logged-in users
+	if ( context.store?.getState()?.currentUser?.user ) {
+		return next();
+	}
+
 	const props = getProps( context );
 
 	// We need to pass isServerSide to LoggedOutComponent to hide the search bar

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -42,16 +42,9 @@ export function loggedOut( context, next ) {
 		return next();
 	}
 
-	// Skip rendering logged-out component for logged-in users
-	if ( context.store?.getState()?.currentUser?.user ) {
-		return next();
-	}
-
 	const props = getProps( context );
 
-	// We need to pass isServerSide to LoggedOutComponent to hide the search bar
-	// because SearchControl is not server-side renderable
-	context.primary = <LoggedOutComponent { ...props } isServerSide={ context.isServerSide } />;
+	context.primary = <LoggedOutComponent { ...props } />;
 	next();
 }
 

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -32,7 +32,6 @@ export function getProps( context ) {
 		isCollectionView: view === 'collection',
 		pathName: context.pathname,
 		trackScrollPage: boundTrackScrollPage,
-		isServerSide: context.isServerSide,
 	};
 }
 
@@ -45,7 +44,9 @@ export function loggedOut( context, next ) {
 
 	const props = getProps( context );
 
-	context.primary = <LoggedOutComponent { ...props } />;
+	// We need to pass isServerSide to LoggedOutComponent to hide the search bar
+	// because SearchControl is not server-side renderable
+	context.primary = <LoggedOutComponent { ...props } isServerSide={ context.isServerSide } />;
 	next();
 }
 

--- a/client/my-sites/themes/custom-select-wrapper.tsx
+++ b/client/my-sites/themes/custom-select-wrapper.tsx
@@ -1,0 +1,19 @@
+import { CustomSelectControl } from '@wordpress/components';
+import { useState, useLayoutEffect } from 'react';
+import type { ComponentProps } from 'react';
+
+// Wrapper component to handle SSR for CustomSelectControl
+// This is needed because CustomSelectControl is not SSR-compatible
+export const CustomSelectWrapper = ( props: ComponentProps< typeof CustomSelectControl > ) => {
+	const [ isMounted, setIsMounted ] = useState( false );
+
+	useLayoutEffect( () => {
+		setIsMounted( true );
+	}, [] );
+
+	if ( ! isMounted ) {
+		return null;
+	}
+
+	return <CustomSelectControl { ...props } />;
+};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -15,7 +15,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
-import { SearchThemes } from 'calypso/components/search-themes';
+import { SearchThemes, SearchThemesV2 } from 'calypso/components/search-themes';
 import ThemeDesignYourOwnModal from 'calypso/components/theme-design-your-own-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
@@ -697,7 +697,7 @@ class ThemeShowcase extends Component {
 									<div className="theme__search">
 										<div className="theme__search-input">
 											{ isSearchV2 ? (
-												<SearchThemes
+												<SearchThemesV2
 													query={ featureStringFilter + search }
 													onSearch={ this.doSearch }
 												/>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -2,12 +2,11 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { CustomSelectControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
-import { createRef, Component, useLayoutEffect, useState } from 'react';
+import { createRef, Component } from 'react';
 import { InView } from 'react-intersection-observer';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
@@ -44,6 +43,7 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import EligibilityWarningModal from './atomic-transfer-dialog';
+import { CustomSelectWrapper } from './custom-select-wrapper';
 import {
 	addTracking,
 	getSubjectsFromTermTable,
@@ -65,22 +65,6 @@ const optionShape = PropTypes.shape( {
 	getUrl: PropTypes.func,
 	action: PropTypes.func,
 } );
-
-// Wrapper component to handle SSR for CustomSelectControl
-// This is needed because CustomSelectControl is not SSR-compatible
-const CustomSelectWrapper = ( props ) => {
-	const [ isMounted, setIsMounted ] = useState( false );
-
-	useLayoutEffect( () => {
-		setIsMounted( true );
-	}, [] );
-
-	if ( ! isMounted ) {
-		return null;
-	}
-
-	return <CustomSelectControl { ...props } />;
-};
 
 class ThemeShowcase extends Component {
 	state = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -15,7 +15,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
-import { SearchThemes, SearchThemesV2 } from 'calypso/components/search-themes';
+import { SearchThemes } from 'calypso/components/search-themes';
 import ThemeDesignYourOwnModal from 'calypso/components/theme-design-your-own-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
@@ -697,7 +697,7 @@ class ThemeShowcase extends Component {
 									<div className="theme__search">
 										<div className="theme__search-input">
 											{ isSearchV2 ? (
-												<SearchThemesV2
+												<SearchThemes
 													query={ featureStringFilter + search }
 													onSearch={ this.doSearch }
 												/>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -802,7 +802,7 @@ const mapStateToProps = ( state, { siteId, filter } ) => {
 		isSiteWooExpress: isSiteOnWooExpress( state, siteId ),
 		isSiteWooExpressOrEcomFreeTrial:
 			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
-		isSearchV2: ! isUserLoggedIn( state ) && config.isEnabled( 'themes/text-search-lots' ),
+		isSearchV2: ! isUserLoggedIn( state ),
 		lastNonEditorRoute: getLastNonEditorRoute( state ),
 		themeTiers: getThemeTiers( state ),
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -596,6 +596,7 @@ class ThemeShowcase extends Component {
 			filterString,
 			isJetpackSite,
 			isMultisite,
+			isServerSide,
 			premiumThemesEnabled,
 			isSiteECommerceFreeTrial,
 			isSiteWooExpressOrEcomFreeTrial,
@@ -709,25 +710,23 @@ class ThemeShowcase extends Component {
 												/>
 											) }
 										</div>
-										{ tabFilters && premiumThemesEnabled && ! isMultisite && ! isSearchV2 && (
-											<>
-												<CustomSelectControl
-													className="theme__tier-select"
-													label={ translate( 'Filters' ) }
-													hideLabelFromVision
-													__next40pxDefaultSize
-													options={ tiers.map( ( t ) => {
-														return { ...t, className: t.key === tier ? 'is-selected' : '' };
-													} ) }
-													value={ {
-														key: tier,
-														name: translate( 'View: %s', {
-															args: this.getTiers().find( ( t ) => t.key === tier ).name,
-														} ),
-													} }
-													onChange={ this.onTierSelectFilter }
-												/>
-											</>
+										{ tabFilters && premiumThemesEnabled && ! isMultisite && ! isServerSide && (
+											<CustomSelectControl
+												className="theme__tier-select"
+												label={ translate( 'Filters' ) }
+												hideLabelFromVision
+												__next40pxDefaultSize
+												options={ tiers.map( ( t ) => {
+													return { ...t, className: t.key === tier ? 'is-selected' : '' };
+												} ) }
+												value={ {
+													key: tier,
+													name: translate( 'View: %s', {
+														args: this.getTiers().find( ( t ) => t.key === tier ).name,
+													} ),
+												} }
+												onChange={ this.onTierSelectFilter }
+											/>
 										) }
 									</div>
 								</div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -15,7 +15,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
-import { SearchThemes, SearchThemesV2 } from 'calypso/components/search-themes';
+import { SearchThemes } from 'calypso/components/search-themes';
 import ThemeDesignYourOwnModal from 'calypso/components/theme-design-your-own-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
@@ -292,11 +292,11 @@ class ThemeShowcase extends Component {
 
 	doSearch = ( searchBoxContent ) => {
 		const filterRegex = /([\w-]*):([\w-]*)/g;
-		const { filterToTermTable, subjectStringFilter, isSearchV2 } = this.props;
+		const { filterToTermTable, subjectStringFilter, isLoggedIn } = this.props;
 		const staticFilters = this.getStaticFilters();
 
-		const filters =
-			`${ searchBoxContent } ${ isSearchV2 ? subjectStringFilter : '' }`.match( filterRegex ) || [];
+		const searchString = `${ searchBoxContent } ${ ! isLoggedIn ? subjectStringFilter : '' }`;
+		const filters = searchString.match( filterRegex ) || [];
 
 		const validFilters = filters.map( ( filter ) => filterToTermTable[ filter ] );
 		const filterString = compact( validFilters ).join( '+' );
@@ -590,7 +590,6 @@ class ThemeShowcase extends Component {
 			search,
 			filter,
 			isLoggedIn,
-			isSearchV2,
 			pathName,
 			featureStringFilter,
 			filterString,
@@ -697,18 +696,11 @@ class ThemeShowcase extends Component {
 								<div className="theme__search-container">
 									<div className="theme__search">
 										<div className="theme__search-input">
-											{ isSearchV2 ? (
-												<SearchThemesV2
-													query={ featureStringFilter + search }
-													onSearch={ this.doSearch }
-												/>
-											) : (
-												<SearchThemes
-													query={ filterString + search }
-													onSearch={ this.doSearch }
-													recordTracksEvent={ this.recordSearchThemesTracksEvent }
-												/>
-											) }
+											<SearchThemes
+												query={ isLoggedIn ? filterString + search : featureStringFilter + search }
+												onSearch={ this.doSearch }
+												recordTracksEvent={ this.recordSearchThemesTracksEvent }
+											/>
 										</div>
 										{ tabFilters && premiumThemesEnabled && ! isMultisite && ! isServerSide && (
 											<CustomSelectControl
@@ -802,7 +794,6 @@ const mapStateToProps = ( state, { siteId, filter } ) => {
 		isSiteWooExpress: isSiteOnWooExpress( state, siteId ),
 		isSiteWooExpressOrEcomFreeTrial:
 			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
-		isSearchV2: ! isUserLoggedIn( state ),
 		lastNonEditorRoute: getLastNonEditorRoute( state ),
 		themeTiers: getThemeTiers( state ),
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import PropTypes from 'prop-types';
-import { createRef, Component } from 'react';
+import { createRef, Component, useLayoutEffect, useState } from 'react';
 import { InView } from 'react-intersection-observer';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
@@ -66,12 +66,27 @@ const optionShape = PropTypes.shape( {
 	action: PropTypes.func,
 } );
 
+// Wrapper component to handle SSR for CustomSelectControl
+// This is needed because CustomSelectControl is not SSR-compatible
+const CustomSelectWrapper = ( props ) => {
+	const [ isMounted, setIsMounted ] = useState( false );
+
+	useLayoutEffect( () => {
+		setIsMounted( true );
+	}, [] );
+
+	if ( ! isMounted ) {
+		return null;
+	}
+
+	return <CustomSelectControl { ...props } />;
+};
+
 class ThemeShowcase extends Component {
 	state = {
 		isDesignThemeModalVisible: false,
 		isSiteSelectorModalVisible: false,
 		shouldThemeControlsSticky: false,
-		isClientSide: typeof window !== 'undefined',
 	};
 
 	constructor( props ) {
@@ -703,27 +718,24 @@ class ThemeShowcase extends Component {
 												recordTracksEvent={ this.recordSearchThemesTracksEvent }
 											/>
 										</div>
-										{ tabFilters &&
-											premiumThemesEnabled &&
-											! isMultisite &&
-											this.state.isClientSide && (
-												<CustomSelectControl
-													className="theme__tier-select"
-													label={ translate( 'Filters' ) }
-													hideLabelFromVision
-													__next40pxDefaultSize
-													options={ tiers.map( ( t ) => {
-														return { ...t, className: t.key === tier ? 'is-selected' : '' };
-													} ) }
-													value={ {
-														key: tier,
-														name: translate( 'View: %s', {
-															args: this.getTiers().find( ( t ) => t.key === tier ).name,
-														} ),
-													} }
-													onChange={ this.onTierSelectFilter }
-												/>
-											) }
+										{ tabFilters && premiumThemesEnabled && ! isMultisite && (
+											<CustomSelectWrapper
+												className="theme__tier-select"
+												label={ translate( 'Filters' ) }
+												hideLabelFromVision
+												__next40pxDefaultSize
+												options={ tiers.map( ( t ) => {
+													return { ...t, className: t.key === tier ? 'is-selected' : '' };
+												} ) }
+												value={ {
+													key: tier,
+													name: translate( 'View: %s', {
+														args: this.getTiers().find( ( t ) => t.key === tier ).name,
+													} ),
+												} }
+												onChange={ this.onTierSelectFilter }
+											/>
+										) }
 									</div>
 								</div>
 								<div

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { SelectDropdown } from '@automattic/components';
+import { CustomSelectControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
@@ -19,7 +19,6 @@ import { SearchThemes, SearchThemesV2 } from 'calypso/components/search-themes';
 import ThemeDesignYourOwnModal from 'calypso/components/theme-design-your-own-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
-import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
@@ -222,16 +221,16 @@ class ThemeShowcase extends Component {
 			return [
 				...availableTiers,
 				{
-					value: tier,
-					label: THEME_TIERS[ tier ].label,
+					key: tier,
+					name: THEME_TIERS[ tier ].label,
 				},
 			];
 		}, [] );
 
 		return [
 			{
-				value: 'all',
-				get label() {
+				key: 'all',
+				get name() {
 					return translate( 'All' );
 				},
 			},
@@ -341,7 +340,9 @@ class ThemeShowcase extends Component {
 		} );
 	};
 
-	onTierSelectFilter = ( { value: tier } ) => {
+	onTierSelectFilter = ( attrs ) => {
+		const tier = attrs.selectedItem.key;
+
 		recordTracksEvent( 'calypso_themeshowcase_filter_pricing_click', { tier } );
 		trackClick( 'search bar filter', tier );
 
@@ -710,15 +711,20 @@ class ThemeShowcase extends Component {
 										</div>
 										{ tabFilters && premiumThemesEnabled && ! isMultisite && (
 											<>
-												<SelectDropdown
-													className="section-nav-tabs__dropdown"
-													onSelect={ this.onTierSelectFilter }
-													selectedText={ translate( 'View: %s', {
-														args: getOptionLabel( tiers, tier ) || '',
-													} ) }
+												<CustomSelectControl
+													className="theme__tier-select"
+													label={ translate( 'Filters' ) }
+													hideLabelFromVision
+													__next40pxDefaultSize
 													options={ tiers }
-													initialSelected={ tier }
-												></SelectDropdown>
+													value={ {
+														key: tier,
+														name: translate( 'View: %s', {
+															args: this.getTiers().find( ( t ) => t.key === tier ).name,
+														} ),
+													} }
+													onChange={ this.onTierSelectFilter }
+												/>
 											</>
 										) }
 									</div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -71,6 +71,7 @@ class ThemeShowcase extends Component {
 		isDesignThemeModalVisible: false,
 		isSiteSelectorModalVisible: false,
 		shouldThemeControlsSticky: false,
+		isClientSide: typeof window !== 'undefined',
 	};
 
 	constructor( props ) {
@@ -595,7 +596,7 @@ class ThemeShowcase extends Component {
 			filterString,
 			isJetpackSite,
 			isMultisite,
-			isServerSide,
+
 			premiumThemesEnabled,
 			isSiteECommerceFreeTrial,
 			isSiteWooExpressOrEcomFreeTrial,
@@ -702,24 +703,27 @@ class ThemeShowcase extends Component {
 												recordTracksEvent={ this.recordSearchThemesTracksEvent }
 											/>
 										</div>
-										{ tabFilters && premiumThemesEnabled && ! isMultisite && ! isServerSide && (
-											<CustomSelectControl
-												className="theme__tier-select"
-												label={ translate( 'Filters' ) }
-												hideLabelFromVision
-												__next40pxDefaultSize
-												options={ tiers.map( ( t ) => {
-													return { ...t, className: t.key === tier ? 'is-selected' : '' };
-												} ) }
-												value={ {
-													key: tier,
-													name: translate( 'View: %s', {
-														args: this.getTiers().find( ( t ) => t.key === tier ).name,
-													} ),
-												} }
-												onChange={ this.onTierSelectFilter }
-											/>
-										) }
+										{ tabFilters &&
+											premiumThemesEnabled &&
+											! isMultisite &&
+											this.state.isClientSide && (
+												<CustomSelectControl
+													className="theme__tier-select"
+													label={ translate( 'Filters' ) }
+													hideLabelFromVision
+													__next40pxDefaultSize
+													options={ tiers.map( ( t ) => {
+														return { ...t, className: t.key === tier ? 'is-selected' : '' };
+													} ) }
+													value={ {
+														key: tier,
+														name: translate( 'View: %s', {
+															args: this.getTiers().find( ( t ) => t.key === tier ).name,
+														} ),
+													} }
+													onChange={ this.onTierSelectFilter }
+												/>
+											) }
 									</div>
 								</div>
 								<div

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -709,7 +709,7 @@ class ThemeShowcase extends Component {
 												/>
 											) }
 										</div>
-										{ tabFilters && premiumThemesEnabled && ! isMultisite && (
+										{ tabFilters && premiumThemesEnabled && ! isMultisite && ! isSearchV2 && (
 											<>
 												<CustomSelectControl
 													className="theme__tier-select"

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -716,7 +716,9 @@ class ThemeShowcase extends Component {
 													label={ translate( 'Filters' ) }
 													hideLabelFromVision
 													__next40pxDefaultSize
-													options={ tiers }
+													options={ tiers.map( ( t ) => {
+														return { ...t, className: t.key === tier ? 'is-selected' : '' };
+													} ) }
 													value={ {
 														key: tier,
 														name: translate( 'View: %s', {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -415,6 +415,16 @@
 			white-space: nowrap;
 		}
 	}
+
+	.theme__tier-select {
+		min-width: 220px;
+		width: 220px;
+
+		@media ( max-width: $break-small ) {
+			width: 100%;
+			min-width: auto;
+		}
+	}
 }
 
 .themes:not(.is-logged-out) {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -424,6 +424,10 @@
 			width: 100%;
 			min-width: auto;
 		}
+
+		.components-custom-select-control__item.is-selected {
+			background-color: var(--wp-components-color-gray-300, #ddd);
+		}
 	}
 }
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -160,6 +160,24 @@
 				padding: 0 32px;
 			}
 		}
+
+		.theme__search {
+			.theme__search-input {
+				.components-input-control__container {
+					background-color: #fff;
+				}
+
+				.components-input-base {
+					height: 55px;
+				}
+			}
+
+			.theme__tier-select {
+				.components-input-control__container {
+					height: 55px;
+				}
+			}
+		}
 	}
 
 	.search-themes-card {

--- a/config/development.json
+++ b/config/development.json
@@ -199,7 +199,6 @@
 		"themes/discovery": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": true,
-		"themes/text-search-lots": true,
 		"titan/iframe-control-panel": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -134,7 +134,6 @@
 		"themes/discovery": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
-		"themes/text-search-lots": true,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -171,7 +171,6 @@
 		"themes/discovery": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
-		"themes/text-search-lots": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -166,7 +166,6 @@
 		"themes/discovery": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
-		"themes/text-search-lots": true,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -169,7 +169,6 @@
 		"themes/discovery": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
-		"themes/text-search-lots": true,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/packages/calypso-e2e/src/lib/pages/themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-page.ts
@@ -16,7 +16,7 @@ const selectors = {
 	// Search
 	showAllThemesButton: 'text=Show all themes',
 	searchToolbar: '.themes-magic-search',
-	searchInput: '.themes__content input.search__input',
+	searchInput: '.themes__content input.components-input-control__input',
 };
 
 /**


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/100450

## Proposed Changes

* Replace Search component with `SearchControl`
* Replace SelectDropdown component with `CustomSelectControl`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/100450

## Testing Instructions

* Go to `/themes`
* Search by term and check if it acts the same as before
* Change the view control and check if it works in the same way as before this change

| Before | After |
|--------|--------|
| <img width="1242" alt="Screenshot 2025-05-05 at 12 18 34" src="https://github.com/user-attachments/assets/9ec8fb08-bf24-43cb-a419-c79c19393f96" /> | <img width="1238" alt="Screenshot 2025-05-05 at 12 17 31" src="https://github.com/user-attachments/assets/3bd03015-c6a0-46da-8616-0691c99a1454" /> |
| <img width="1238" alt="Screenshot 2025-05-05 at 12 18 51" src="https://github.com/user-attachments/assets/143aed02-3d3e-45f1-a602-c48f561b8cfe" /> | <img width="1237" alt="Screenshot 2025-05-05 at 12 17 48" src="https://github.com/user-attachments/assets/c8bd5b74-fc99-4505-9e05-9c528de6595f" /> | 

**Logged Out case:**
- Make sure you are logged out
- Go to `/themes`
- Check the input search and dropdown filters
- Should work the same as before the change

Before:
<img width="975" alt="Screenshot 2025-05-05 at 14 26 46" src="https://github.com/user-attachments/assets/bcf6a911-dbd5-4edd-b225-0467cbf6cb3b" />

After:
<img width="975" alt="Screenshot 2025-05-05 at 14 26 57" src="https://github.com/user-attachments/assets/60dcc681-4009-4d83-bd07-e99c72352c06" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
