### PR TITLE
Revert "JETCRM-11 Fix Bug: CRM Downloads on Calypso does not work with user licenses just with partner licenses"

### DIFF
--- a/client/components/crm-downloads/crm-downloads.tsx
+++ b/client/components/crm-downloads/crm-downloads.tsx
@@ -23,7 +23,7 @@ const LoadingSkeleton = () => (
 );
 
 interface CrmDownloadsProps {
-	licenseKey?: string;
+	licenseKey: string;
 	isLoading?: boolean;
 }
 
@@ -160,7 +160,7 @@ export function CrmDownloadsContent( { licenseKey, isLoading }: CrmDownloadsProp
 									<div className="manage-purchase__license-clipboard">
 										<code className="manage-purchase__license-clipboard-code">{ licenseKey }</code>
 										<ClipboardButton
-											text={ licenseKey || null }
+											text={ licenseKey }
 											className="manage-purchase__license-clipboard-icon"
 											borderless
 											compact

--- a/client/components/crm-downloads/is-jetpack-crm-product.ts
+++ b/client/components/crm-downloads/is-jetpack-crm-product.ts
@@ -3,11 +3,7 @@
  * @param keyOrSlug string
  * @returns boolean Returns true if keyOrSlug looks like a Jetpack CRM product license key or slug, false if not
  */
-export default function isJetpackCrmProduct( keyOrSlug?: string ) {
-	if ( ! keyOrSlug ) {
-		return false;
-	}
-
+export default function isJetpackCrmProduct( keyOrSlug: string ) {
 	return (
 		keyOrSlug.startsWith( 'jetpack-complete' ) ||
 		keyOrSlug.startsWith( 'jetpack_complete' ) ||

--- a/client/data/jetpack-crm/use-handle-extensions-download-mutation.ts
+++ b/client/data/jetpack-crm/use-handle-extensions-download-mutation.ts
@@ -5,7 +5,7 @@ const BASE_CRM_APP_URL =
 		? 'https://devapp.jetpackcrm.com'
 		: 'https://app.jetpackcrm.com';
 
-async function fetchExtensionDownloads( extensionSlug: string, licenseKey?: string ) {
+async function fetchExtensionDownloads( licenseKey: string, extensionSlug: string ) {
 	// API URL for downloads
 	const apiUrl = `${ BASE_CRM_APP_URL }/api/downloads/jetpack-complete`;
 
@@ -48,9 +48,9 @@ async function fetchExtensionDownloads( extensionSlug: string, licenseKey?: stri
 	return data;
 }
 
-export default function useHandleExtensionsDownloadMutation( licenseKey?: string ) {
+export default function useHandleExtensionsDownloadMutation( licenseKey: string ) {
 	return useMutation( {
 		mutationKey: [ 'use-handle-jetpack-crm-extensions-download', licenseKey ],
-		mutationFn: ( extensionSlug: string ) => fetchExtensionDownloads( extensionSlug, licenseKey ),
+		mutationFn: ( extensionSlug: string ) => fetchExtensionDownloads( licenseKey, extensionSlug ),
 	} );
 }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -35,7 +35,7 @@ import titles from './titles';
 import VatInfoPage from './vat-info';
 import useVatDetails from './vat-info/use-vat-details';
 
-const useDataViewPurchasesList = ! config.isEnabled( 'purchases/purchase-list-dataview' );
+const useDataViewPurchasesList = config.isEnabled( 'purchases/purchase-list-dataview' );
 
 function useLogPurchasesError( message ) {
 	return useCallback(
@@ -277,6 +277,6 @@ export function changePaymentMethod( context, next ) {
 }
 
 export function crmDownloads( context, next ) {
-	context.primary = <CrmDownloads subscription={ context.params.subscription } />;
+	context.primary = <CrmDownloads licenseKey={ context.params.licenseKey } />;
 	next();
 }

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -51,7 +51,7 @@ export default ( router ) => {
 	);
 
 	router(
-		paths.purchasesRoot + '/crm-downloads/:subscription',
+		paths.purchasesRoot + '/crm-downloads/:licenseKey',
 		sidebar,
 		controller.crmDownloads,
 		makeLayout,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -669,21 +669,27 @@ class ManagePurchase extends Component<
 	}
 
 	renderCrmDownloadsNavItem() {
-		const { purchase, translate } = this.props;
+		const { site, translate } = this.props;
+
+		if ( ! site?.plan ) {
+			return null;
+		}
 
 		// Only show for Jetpack CRM Products
-		if ( ! isJetpackCrmProduct( purchase?.productSlug ) ) {
+		if ( ! isJetpackCrmProduct( site.plan.license_key || '' ) ) {
 			return null;
 		}
 
 		const handleCrmDownloadsClick = () => {
 			recordTracksEvent( 'calypso_purchases_crm_downloads_click', {
-				product_slug: purchase?.productSlug || '',
+				product_slug: site?.plan?.license_key || 'no_key',
 			} );
 		};
 
 		// We'll pass the purchase ID in the URL, and the CRM Downloads component will fetch the actual license key
-		const path = `/purchases/crm-downloads/${ purchase?.id }`;
+		const path = isJetpackCloud()
+			? `/purchases/crm-downloads/${ site.plan.license_key }`
+			: `/me/purchases/crm-downloads/${ site.plan.license_key }`;
 
 		return (
 			<CompactCard href={ path } onClick={ handleCrmDownloadsClick }>

--- a/client/my-sites/purchases/controller.js
+++ b/client/my-sites/purchases/controller.js
@@ -105,6 +105,6 @@ export const receiptView = ( context, next ) => {
 };
 
 export const crmDownloads = ( context, next ) => {
-	context.primary = <CrmDownloads subscription={ context.params.subscription } />;
+	context.primary = <CrmDownloads licenseKey={ context.params.licenseKey } />;
 	next();
 };

--- a/client/my-sites/purchases/crm-downloads/index.tsx
+++ b/client/my-sites/purchases/crm-downloads/index.tsx
@@ -1,18 +1,13 @@
 import { useTranslate } from 'i18n-calypso';
-import {
-	CrmDownloadsError,
-	CrmDownloadsContent,
-} from 'calypso/components/crm-downloads/crm-downloads';
+import { CrmDownloadsContent } from 'calypso/components/crm-downloads/crm-downloads';
 import DocumentHead from 'calypso/components/data/document-head';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import useUserLicenseBySubscriptionQuery from 'calypso/data/jetpack-licensing/use-user-license-by-subscription-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import './style.scss';
 
-export function CrmDownloads( { subscription }: { subscription: number } ) {
+export function CrmDownloads( { licenseKey }: { licenseKey: string } ) {
 	const translate = useTranslate();
-	const { data, isError, isLoading } = useUserLicenseBySubscriptionQuery( subscription );
 
 	return (
 		<Main className="crm-downloads" wideLayout>
@@ -20,11 +15,7 @@ export function CrmDownloads( { subscription }: { subscription: number } ) {
 			<DocumentHead title={ translate( 'CRM Downloads' ) } />
 			<HeaderCake backHref="/purchases/subscriptions/">{ translate( 'CRM Downloads' ) }</HeaderCake>
 
-			{ isError ? (
-				<CrmDownloadsError />
-			) : (
-				<CrmDownloadsContent licenseKey={ data?.licenseKey } isLoading={ isLoading } />
-			) }
+			<CrmDownloadsContent licenseKey={ licenseKey } />
 		</Main>
 	);
 }

--- a/client/my-sites/purchases/index.js
+++ b/client/my-sites/purchases/index.js
@@ -73,14 +73,6 @@ export default ( router ) => {
 	);
 
 	page(
-		'/purchases/crm-downloads/:subscription',
-		navigation,
-		crmDownloads,
-		makeLayout,
-		clientRender
-	);
-
-	page(
 		'/purchases/subscriptions/:site/:purchaseId/payment-method/change/:cardId',
 		...commonHandlers,
 		purchaseChangePaymentMethod,
@@ -116,6 +108,14 @@ export default ( router ) => {
 		'/purchases/payment-methods/:site',
 		...commonHandlers,
 		paymentMethods,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/purchases/crm-downloads/:licenseKey',
+		...commonHandlers,
+		crmDownloads,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103058