### PR TITLE
Use common polyfill for server and client, removing isomorphic-fetch

### DIFF
--- a/packages/calypso-polyfills/index.js
+++ b/packages/calypso-polyfills/index.js
@@ -1,5 +1,5 @@
-// Polyfills required for the browser build of Calypso.
-// Note that these polyfills will not necessarily be included in the build,
+// Polyfills required for Calypso.
+// Note that these polyfills will not necessarily be included in the browser build,
 // since Calypso makes use of @babel/preset-env and browserslist configs to
 // avoid including polyfills for features that are supported across all target
 // browsers.

--- a/packages/calypso-polyfills/node.js
+++ b/packages/calypso-polyfills/node.js
@@ -1,3 +1,0 @@
-// Polyfills required for the server build of Calypso.
-require( 'core-js/stable' );
-require( 'isomorphic-fetch' );

--- a/packages/calypso-polyfills/package.json
+++ b/packages/calypso-polyfills/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@automattic/calypso-polyfills",
+	"type": "module",
 	"version": "2.0.0",
 	"description": "Polyfills required for Calypso to work across various browsers and in node.",
 	"main": "index.js",

--- a/packages/calypso-polyfills/package.json
+++ b/packages/calypso-polyfills/package.json
@@ -2,8 +2,7 @@
 	"name": "@automattic/calypso-polyfills",
 	"version": "2.0.0",
 	"description": "Polyfills required for Calypso to work across various browsers and in node.",
-	"browser": "browser.js",
-	"main": "node.js",
+	"main": "index.js",
 	"sideEffects": true,
 	"keywords": [
 		"wordpress"
@@ -22,8 +21,7 @@
 	},
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"dependencies": {
-		"core-js": "^3.6.3",
-		"isomorphic-fetch": "^3.0.0"
+		"core-js": "^3.6.3"
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^"

--- a/packages/calypso-polyfills/package.json
+++ b/packages/calypso-polyfills/package.json
@@ -4,6 +4,7 @@
 	"version": "2.0.0",
 	"description": "Polyfills required for Calypso to work across various browsers and in node.",
 	"main": "index.js",
+	"exports": "./index.js",
 	"sideEffects": true,
 	"keywords": [
 		"wordpress"

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,7 +618,6 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     core-js: "npm:^3.6.3"
-    isomorphic-fetch: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -23075,16 +23074,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isomorphic-fetch@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "isomorphic-fetch@npm:3.0.0"
-  dependencies:
-    node-fetch: "npm:^2.6.1"
-    whatwg-fetch: "npm:^3.4.1"
-  checksum: 511b1135c6d18125a07de661091f5e7403b7640060355d2d704ce081e019bc1862da849482d079ce5e2559b8976d3de7709566063aec1b908369c0b98a2b075b
-  languageName: node
-  linkType: hard
-
 "isomorphic.js@npm:^0.2.4":
   version: 0.2.5
   resolution: "isomorphic.js@npm:0.2.5"
@@ -27016,7 +27005,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.7":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -36732,13 +36721,6 @@ __metadata:
   dependencies:
     iconv-lite: "npm:0.6.3"
   checksum: 91b90a49f312dc751496fd23a7e68981e62f33afe938b97281ad766235c4872fc4e66319f925c5e9001502b3040dd25a33b02a9c693b73a4cbbfdc4ad10c3e3e
-  languageName: node
-  linkType: hard
-
-"whatwg-fetch@npm:^3.4.1":
-  version: 3.6.2
-  resolution: "whatwg-fetch@npm:3.6.2"
-  checksum: cc10f6893fe71839250b6e2fa9bc293bcf0ca5b93129712a7d1097fb7528b3ff617eb065098dc972e74d1455378e514aa34c0901ded41584be16508db63477c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #103054

## Proposed Changes

* Removes another instance of a `fetch` polyfill that can be removed due to [baseline support for `fetch` as of Node.js v21](https://nodejs.org/en/blog/announcements/v21-release-announce#stable-fetchwebstreams)
* Consolidates to a common entrypoint for polyfills, since the polyfill implementation is now identical between server and browser

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Eliminate unnecessary dependencies to reduce maintenance overhead and supply chain attack risk surface area

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I wasn't able to find anywhere where we currently incur a `fetch` through server-side rendering, but I was able to verify with the introduction of a test route:

```diff
diff --git a/client/server/pages/index.js b/client/server/pages/index.js
index c69e132fa83..e1ed7f22e0d 100644
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -999,2 +999,8 @@ export default function pages() {
 
+	app.get( '/test', async ( req, res ) => {
+		const result = await fetch( 'https://public-api.wordpress.com/geo/' );
+		const data = await result.json();
+		res.send( data );
+	} );
+
 	// Redirect legacy `/new` routes to the corresponding `/start`
```

After applied and starting the server, navigate to http://calypso.localhost:3000/test to verify you see the same output as from https://public-api.wordpress.com/geo/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
