### PR TITLE
Add feature flag for cancelling difm migrations

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -127,6 +127,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": true,
 		"oauth": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,6 +84,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": true,
 		"onboarding/create-course": false,
 		"onboarding/playground": true,
 		"onboarding/step-container-v2-import-flow": false,

--- a/config/production.json
+++ b/config/production.json
@@ -102,6 +102,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,6 +99,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/test.json
+++ b/config/test.json
@@ -80,6 +80,7 @@
 		"me/account-close": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -102,6 +102,7 @@
 		"me/account/color-scheme-picker": true,
 		"migration-flow/experiment": false,
 		"migration-flow/introductory-offer": true,
+		"migration-flow/cancel-difm": false,
 		"onboarding/create-course": false,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCON-26-linear-issue

## Proposed Changes

This adds a feature flag for the Calypso side of the DIFM cancellation.  We'll hide the cancellations buttons behind this flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `yarn feature-search migration-flow/cancel-difm` and verify it looks like the below:

<img width="571" alt="CleanShot 2025-05-02 at 15 04 31@2x" src="https://github.com/user-attachments/assets/91b6b79c-01c3-43f8-92ef-73d329c563ed" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?