### PR TITLE
STATS-48: Fix period navigation controls misplaced in mobile.

### DIFF
--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -36,11 +36,6 @@
 				margin: 0;
 			}
 
-			@media (max-width: $break-medium) {
-				padding: 0;
-				justify-content: flex-end;
-			}
-
 			@media (max-width: 660px) {
 				margin-bottom: 24px;
 			}

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -5,6 +5,7 @@
 	display: flex;
 	flex-flow: row wrap;
 	justify-content: space-between;
+	gap: 8px 20px;
 	align-items: center;
 	margin: 1.5em 0;
 	padding: 0 20px;
@@ -12,7 +13,6 @@
 	&.stats-period-navigation__is-with-new-date-control {
 		padding: 0;
 		align-items: flex-start;
-		row-gap: 8px;
 	
 		.stats-navigation-arrows {
 			justify-content: flex-end;
@@ -22,6 +22,10 @@
 			display:flex;
 			flex-direction: row;
 			gap: 20px;
+
+			@media (max-width: $break-mobile) {
+				flex-grow: 1;
+			}
 		}
 	}
 

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -12,7 +12,7 @@
 
 	&.stats-period-navigation__is-with-new-date-control {
 		padding: 0;
-	  align-items: flex-start;
+		align-items: flex-start;
 	
 		.stats-period-navigation__date-range-control {
 			margin-left: auto;

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -12,15 +12,12 @@
 
 	&.stats-period-navigation__is-with-new-date-control {
 		padding: 0;
-		align-items: flex-start;
-	
-		.stats-navigation-arrows {
-			justify-content: flex-end;
-		}
+	  align-items: flex-start;
 	
 		.stats-period-navigation__date-range-control {
+			margin-left: auto;
+
 			display:flex;
-			flex-direction: row;
 			gap: 20px;
 
 			@media (max-width: $break-mobile) {


### PR DESCRIPTION
Fixes [STATS-48](https://linear.app/a8c/issue/STATS-48/period-navigation-controls-misplaced-in-mobile)

## Proposed Changes

* On mobile, align the navigation control and date to opposite ends.
* Align navigation date control using margin-auto instead of flex-end.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
![image](https://github.com/user-attachments/assets/0c23bfaa-a3e9-416e-af7c-dc3f2f696d8b)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Traffic page
* Reduce screen width or switch to mobile view
* Look at the navigation controls

https://github.com/user-attachments/assets/4d5a6518-8029-4200-b3c9-186411aac7c3

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
