### PR TITLE
Updating UI text for user connection page

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -7,7 +7,7 @@ import {
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button, Card, FormLabel, Gridicon, Spinner } from '@automattic/components';
 import { Spinner as WPSpinner, Modal } from '@wordpress/components';
-import { Icon, chartBar, cloudUpload, next } from '@wordpress/icons';
+import { Icon, chartBar, next, share } from '@wordpress/icons';
 import clsx from 'clsx';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -1119,10 +1119,10 @@ export class JetpackAuthorize extends Component {
 							</li>
 							<li>
 								<span>
-									<Icon icon={ cloudUpload } size={ 24 } />
+									<Icon icon={ share } size={ 24 } />
 								</span>
 								<span>
-									{ translate( 'Save full site backups in the cloud, so nothing gets lost.' ) }
+									{ translate( 'Automatically share your site’s posts on social media.' ) }
 								</span>
 							</li>
 						</ul>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to MYJP-113

## Proposed Changes

* update benefit description to reflect the current offering

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* to avoid confusion based on incorrect information

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* create new JN site and go through the new onboarding, when you are redirected to wordpress.com replace the domain with the live branch domain
* apply feature flag to the URL `flags=jetpack/onboarding-user-connection-redesign`
* verify that the page looks like on the screenshot

<img width="555" alt="SCR-20250505-kkpv" src="https://github.com/user-attachments/assets/522dafea-ed2f-4323-ab53-f0607c0b5b6a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
