### PR TITLE
Use core button component for continue as user screens

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -35,6 +35,11 @@
 	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }
 
+.components-button.is-link:not(.is-destructive) {
+	// Text color, focus ring color
+	--wp-components-color-accent: var(--color-accent);
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import Gravatar from 'calypso/components/gravatar';
@@ -96,10 +96,11 @@ export default function ContinueAsUser( {
 					</div>
 				</div>
 				<Button
-					primary
+					variant="primary"
 					className="continue-as-user__continue-button"
-					busy={ validatingPath }
+					isBusy={ validatingPath }
 					href={ validatedPath || '/' }
+					__next40pxDefaultSize
 				>
 					{ translate( 'Continue' ) }
 				</Button>
@@ -124,10 +125,11 @@ export default function ContinueAsUser( {
 					</div>
 				</div>
 				<Button
-					primary
+					variant="primary"
 					className="continue-as-user__continue-button"
-					busy={ validatingPath }
+					isBusy={ validatingPath }
 					href={ validatedPath || '/' }
+					__next40pxDefaultSize
 				>
 					{ `${ translate( 'Continue as', {
 						context: 'Continue as an existing WordPress.com user',
@@ -142,7 +144,13 @@ export default function ContinueAsUser( {
 		<div className="continue-as-user">
 			<div className="continue-as-user__user-info">
 				{ gravatarLink }
-				<Button primary busy={ validatingPath } href={ validatedPath || '/' }>
+				<Button
+					variant="primary"
+					isBusy={ validatingPath }
+					href={ validatedPath || '/' }
+					__next40pxDefaultSize
+					className="continue-as-user__continue-button"
+				>
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -54,8 +54,8 @@ export default function ContinueAsUser( {
 		components: {
 			br: <br />,
 			link: (
-				<button
-					type="button"
+				<Button
+					variant="link"
 					id="loginAsAnotherUser"
 					className="continue-as-user__change-user-link"
 					onClick={ onChangeAccount }
@@ -85,14 +85,14 @@ export default function ContinueAsUser( {
 				<div className="continue-as-user__user-info">
 					{ gravatarLink }
 					<div className="continue-as-user__not-you">
-						<button
-							type="button"
+						<Button
+							variant="tertiary"
 							id="loginAsAnotherUser"
 							className="continue-as-user__change-user-link"
 							onClick={ onChangeAccount }
 						>
 							{ translate( 'Sign in as a different user' ) }
-						</button>
+						</Button>
 					</div>
 				</div>
 				<Button
@@ -114,14 +114,14 @@ export default function ContinueAsUser( {
 				<div className="continue-as-user__user-info">
 					{ gravatarLink }
 					<div className="continue-as-user__not-you">
-						<button
-							type="button"
+						<Button
+							variant="tertiary"
 							id="loginAsAnotherUser"
 							className="continue-as-user__change-user-link"
 							onClick={ onChangeAccount }
 						>
 							{ translate( 'Sign in as a different user' ) }
-						</button>
+						</Button>
 					</div>
 				</div>
 				<Button

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -47,6 +47,12 @@
 		}
 	}
 
+	.continue-as-user__continue-button {
+		justify-content: center;
+		min-width: 100%;
+		margin-block: 13px;
+	}
+
 	.continue-as-user__not-you {
 		display: block;
 		bottom: 0;

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -2,7 +2,8 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .continue-as-user {
-	display: block;
+	display: flex;
+	flex-direction: column;
 	animation: 1s appear 0s ease-in;
 	color: var(--color-text-subtle);
 	font-size: $font-body-small;
@@ -23,11 +24,6 @@
 		margin: 0 auto;
 		display: flex;
 		flex-direction: column;
-
-		& > a.button {
-			margin: 0 20px;
-			border-radius: 4px;
-		}
 	}
 
 	.continue-as-user__gravatar {
@@ -36,7 +32,6 @@
 	}
 
 	.continue-as-user__continue-button {
-		justify-content: center;
 		min-width: 100%;
 		margin-block: 13px;
 	}

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -35,18 +35,6 @@
 		border: 1px solid #a7aaad;
 	}
 
-	.continue-as-user__change-user-link {
-		color: var(--color-link);
-		cursor: pointer;
-		margin: auto;
-
-		&:hover,
-		&:focus,
-		&:active {
-			color: var(--color-link-dark);
-		}
-	}
-
 	.continue-as-user__continue-button {
 		justify-content: center;
 		min-width: 100%;

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -64,15 +64,6 @@ form {
 .layout.is-white-login .login.is-akismet .login__form,
 .layout.is-white-login .login.is-akismet .continue-as-user,
 .layout.is-white-login.is-akismet .magic-login__form-action {
-	.button.is-primary {
-		background-color: var(--color-akismet);
-
-		&:hover,
-		&:focus {
-			background-color: var(--color-akismet);
-		}
-	}
-
 	.components-button.is-primary {
 		--color-accent: var(--color-akismet);
 		--color-accent-60: var(--color-akismet);

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -54,20 +54,21 @@ form {
 			}
 		}
 	}
+
+	&.is-akismet {
+		.login,
+		.magic-login {
+			.components-button {
+				--color-accent: var(--color-akismet);
+				--color-accent-60: var(--color-akismet);
+			}
+		}
+	}
 }
 
 .is-jetpack .login__form-account-tip {
 	margin-block-start: -8px;
 	font-size: 0.75rem;
-}
-
-.layout.is-white-login .login.is-akismet .login__form,
-.layout.is-white-login .login.is-akismet .continue-as-user,
-.layout.is-white-login.is-akismet .magic-login__form-action {
-	.components-button.is-primary {
-		--color-accent: var(--color-akismet);
-		--color-accent-60: var(--color-akismet);
-	}
 }
 
 .login__form-jetpack {

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -44,10 +44,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.signup-form__crowdsignal {
+.signup.is-crowdsignal {
 	.components-button {
-		width: 100%;
-
 		&.is-primary:not(.signup-form__crowdsignal-wpcom) {
 			--color-accent: var(--color-primary);
 			--color-accent-60: var(--color-primary-dark);
@@ -143,6 +141,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	margin: 0 auto;
 	max-width: 320px;
 	width: 100%;
+
+	.components-button {
+		width: 100%;
+	}
 }
 
 .signup-form__crowdsignal-card-subheader {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1088,6 +1088,18 @@ class SignupForm extends Component {
 			return null;
 		}
 
+		if ( this.props.currentUser && ! this.props.disableContinueAsUser ) {
+			return (
+				<ContinueAsUser
+					currentUser={ this.props.currentUser }
+					onChangeAccount={ this.handleOnChangeAccount }
+					redirectPath={ this.props.redirectToAfterLoginUrl }
+					isWoo={ this.props.isWoo }
+					isBlazePro={ this.props.isBlazePro }
+				/>
+			);
+		}
+
 		if ( isCrowdsignalOAuth2Client( this.props.oauth2Client ) ) {
 			const socialProps = pick( this.props, [
 				'isSocialSignupEnabled',
@@ -1105,18 +1117,6 @@ class SignupForm extends Component {
 					recordBackLinkClick={ this.recordBackLinkClick }
 					submitting={ this.props.submitting }
 					{ ...socialProps }
-				/>
-			);
-		}
-
-		if ( this.props.currentUser && ! this.props.disableContinueAsUser ) {
-			return (
-				<ContinueAsUser
-					currentUser={ this.props.currentUser }
-					onChangeAccount={ this.handleOnChangeAccount }
-					redirectPath={ this.props.redirectToAfterLoginUrl }
-					isWoo={ this.props.isWoo }
-					isBlazePro={ this.props.isBlazePro }
 				/>
 			);
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -29,6 +29,7 @@ import {
 	isWooOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
+	isCrowdsignalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
@@ -198,6 +199,7 @@ class Layout extends Component {
 			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
 			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
 			'a8c-for-agencies': isA4AOAuth2Client( this.props.oauth2Client ),
+			crowdsignal: isCrowdsignalOAuth2Client( this.props.oauth2Client ),
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
 			'has-no-masterbar': this.props.masterbarIsHidden,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -25,7 +25,7 @@ import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
-import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isWooOAuth2Client, isJetpackCloudOAuth2Client } from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
@@ -209,6 +209,7 @@ class Layout extends Component {
 			'is-unified-site-sidebar-visible': this.props.isUnifiedSiteSidebarVisible,
 			'is-blaze-pro': this.props.isBlazePro,
 			'is-woo-com-oauth': isWooOAuth2Client( this.props.oauth2Client ),
+			'jetpack-cloud': isJetpackCloudOAuth2Client( this.props.oauth2Client ),
 			'feature-flag-woocommerce-core-profiler-passwordless-auth': true,
 		} );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -25,7 +25,11 @@ import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
-import { isWooOAuth2Client, isJetpackCloudOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isWooOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isA4AOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
@@ -193,6 +197,7 @@ class Layout extends Component {
 		const sectionClass = clsx( 'layout', `focus-${ this.props.currentLayoutFocus }`, {
 			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
 			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
+			'a8c-for-agencies': isA4AOAuth2Client( this.props.oauth2Client ),
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
 			'has-no-masterbar': this.props.masterbarIsHidden,

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -224,7 +224,7 @@ body.is-section-signup {
 			align-items: center;
 			align-self: stretch;
 			border: 1px solid #ccc;
-			height: 221px;
+			width: 100%;
 			box-sizing: border-box;
 			padding: 32px 24px 16px 24px;
 			position: relative;

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -282,23 +282,14 @@ body.is-section-signup {
 		}
 
 		.continue-as-user__change-user-link {
-			font-family: $inter;
 			font-size: 0.875rem;
-			font-style: normal;
 			font-weight: 500;
-			line-height: 20px;
-			text-decoration: none;
 		}
 
 		.continue-as-user__continue-button {
-			background: var(--color-orange);
-			border-color: var(--color-orange);
-			font-family: $inter;
 			font-size: rem(13px);
 			font-weight: 600;
-			line-height: 14px;
 			margin-top: 24px;
-			padding: 12px 16px;
 			width: 326px;
 		}
 	}

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -100,6 +100,7 @@ body.is-section-signup {
 
 		@media (max-width: $break-mobile) {
 			display: flex;
+			padding-inline: 24px;
 		}
 
 		.masterbar__login-back-link {
@@ -126,6 +127,7 @@ body.is-section-signup {
 			margin: 0;
 			list-style-type: none;
 			width: 100%;
+			gap: 12px;
 
 			.masterbar__login-back-link {
 				// margin-top: -10px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -678,6 +678,9 @@
 }
 
 .a8c-for-agencies {
+	--color-link: var(--color-primary-40);
+	--color-link-dark: var(--color-primary-60);
+
 	input:focus:hover[type],
 	input:focus[type] {
 		box-shadow: 0 0 0 2px var(--color-primary-10);
@@ -741,8 +744,6 @@
 		--color-accent-60: var(--color-primary-60);
 	}
 
-	a,
-	a:visited,
 	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--color-primary-40);

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -600,6 +600,9 @@
 }
 
 .jetpack-cloud {
+	--color-link: var(--studio-jetpack-green-40);
+	--color-link-dark: var(--studio-jetpack-green-60);
+
 	input:focus:hover[type],
 	input:focus[type] {
 		box-shadow: 0 0 0 2px var(--color-primary-10);
@@ -663,8 +666,6 @@
 		--color-accent-60: var(--studio-jetpack-green-30);
 	}
 
-	a,
-	a:visited,
 	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--studio-jetpack-green-40);

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1669,7 +1669,7 @@ $breakpoint-mobile: 660px;
 				align-self: stretch;
 				border-radius: 8px; // stylelint-disable-line scales/radii
 				border: 1px solid #dcdcde;
-				height: 221px;
+				width: 100%;
 				box-sizing: border-box;
 				padding: 32px 24px 16px 24px;
 			}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1722,7 +1722,6 @@ $breakpoint-mobile: 660px;
 			}
 
 			.continue-as-user__change-user-link {
-				text-decoration: none;
 				font-size: 0.875rem;
 				font-weight: 500;
 			}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -653,12 +653,6 @@ $breakpoint-mobile: 660px;
 			margin-bottom: 32px;
 			position: initial;
 		}
-
-		.continue-as-user__change-user-link {
-			color: $gray-60;
-			font-weight: 400;
-			text-decoration: underline;
-		}
 	}
 
 	.logged-out-form {
@@ -1729,15 +1723,8 @@ $breakpoint-mobile: 660px;
 
 			.continue-as-user__change-user-link {
 				text-decoration: none;
-				color: var(--woo-purple-50);
 				font-size: 0.875rem;
-				font-style: normal;
 				font-weight: 500;
-				line-height: 21px;
-
-				&:hover {
-					color: var(--woo-purple-70);
-				}
 			}
 
 			.continue-as-user__continue-button {
@@ -2311,11 +2298,6 @@ $breakpoint-mobile: 660px;
 	.login__header-subtitle a {
 		@include link-woo;
 		font-weight: 500;
-	}
-
-	.continue-as-user__change-user-link {
-		@include button-tertiary;
-		@include button-size-small;
 	}
 
 	.magic-login__footer a {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -153,7 +153,7 @@ $breakpoint-mobile: 660px;
 		letter-spacing: 0;
 	}
 
-	a:not(.social-buttons__button),
+	a:not(.components-button),
 	.wp-login__links a,
 	.wp-login__links button,
 	.button,

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -328,6 +328,7 @@ $breakpoint-mobile: 660px;
 
 		@media (max-width: $break-mobile) {
 			display: flex;
+			padding-inline: 24px;
 		}
 
 		.masterbar__login-back-link {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -568,12 +568,6 @@ $image-height: 47px;
 	.two-factor-authentication__actions.card {
 		padding-top: 0;
 	}
-
-	.continue-as-user__not-you {
-		> button {
-			text-decoration: underline;
-		}
-	}
 }
 
 /* stylelint-disable scales/font-weights, scales/radii */

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -568,6 +568,12 @@ $image-height: 47px;
 	.two-factor-authentication__actions.card {
 		padding-top: 0;
 	}
+
+	.continue-as-user__not-you {
+		> button {
+			text-decoration: underline;
+		}
+	}
 }
 
 /* stylelint-disable scales/font-weights, scales/radii */

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -66,8 +66,9 @@
 	}
 
 	&-right-element {
+		--color-accent: var( --color-neutral-100 );
+
 		margin-left: auto;
-		--wp-components-color-accent: var( --color-neutral-100 );
 		font-size: 0.875rem;
 		line-height: 1;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [DSGCOM-92: Update primary buttons on 'Continue as user'](https://linear.app/a8c/issue/DSGCOM-92/update-primary-buttons-on-continue-as-user)

## Proposed Changes

* Replace all buttons in the 'Continue as user' screens with core buttons
* Apply branding to buttons where applicable
* Fix the layout of the oauth client version of the screen and bring it more inline with the 'white login' version
* Fix the Crowdsignal screen, which currently renders the signup form instead

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These buttons have no visible focus styles, and are inconsistent with the buttons on the login, magic login and signup screens, which have all been replaced.

- Focus styles are necessary for accessibility
- Consistent button styles and behaviours form a more high quality experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Instructions
1. Ensure you are logged in already
2. For each brand, visit the login page using the links below. Some products will show the 'Continue as user' screen on load, others (A4A, VIP, WP Cloud, Jetpack Cloud, Crowdsignal) will not (this should likely be made consistent, but is out of scope for this PR), and you will need to click 'Create account' to see it.
3. Check that all buttons are branded correctly. They should match buttons on the login and signup screens
4. Check button hover styles with mouse
5. Tab through the screen with your keyboard to check buttons are accessible and have focus styles
6. Check that the Continue as User screen is displayed when creating an account for Crowdsignal
7. Check mobile layout
8. If it exists, check that the 'Create account' link in the top right of the screen is grey and not the brand accent color

#### Login links

[WordPress.com](http://calypso.localhost:3000/log-in)
[Crowdsignal](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
[Jetpack Cloud](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1&client_id=69040&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D69040%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dtoken%2526client_id%253D69040%2526redirect_uri%253Dhttps%25253A%25252F%25252Fcloud.jetpack.com%25252Fconnect%25252Foauth%25252Ftoken%25253Fnext%25253D%2525252F%2526scope%253Dglobal%2526blog_id%253D0%2526from-calypso%253D1)
[Woo](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253Db30d4e6a81f72b803c873f517f4189601c46a1bc8b9bfdb9ed27cf3d17ad5601%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1)
[Blaze Pro](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D99370%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fresponse_type%253Dcode%2526client_id%253D99370%2526state%253D0f0d1f16975b65cf8e9e924461b7c892f78eabeeb190dc03654cef0465786da0%2526redirect_uri%253Dhttps%25253A%25252F%25252Fblazepro.tumblr.com%25252Fauth%25252Fconnected%2526blog_id%253D0%2526wpcom_connect%253D1%2526calypso_env%253Dproduction%2526scope%253Dglobal%2526from-calypso%253D1)
[Akismet](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F)
A4A - Can't link due to GitHub OSS scan rules: go to automatt_c.com/for-agencies/ and click 'Log in'. Edit the URL and change the host to calypso.localhost:3000
[VIP](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fstate%3Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%26scope%3Dauth%26response_type%3Dcode%26approval_prompt%3Dauto%26redirect_uri%3Dhttps%253A%252F%252Fid.wpvip.com%252Fwp-json%252Foauth%252Fv1%252Fcallback%252Fwpcom%26client_id%3D76596%26from-calypso%3D1&client_id=76596&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D76596%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fstate%253Dd01a004590fc4017316cef309b1e213de0cf6c1fd4b68d3152d9f9acbf9c%2526scope%253Dauth%2526response_type%253Dcode%2526approval_prompt%253Dauto%2526redirect_uri%253Dhttps%25253A%25252F%25252Fid.wpvip.com%25252Fwp-json%25252Foauth%25252Fv1%25252Fcallback%25252Fwpcom%2526client_id%253D76596%2526from-calypso%253D1)
Partner Portal - Can't link due to GitHub OSS scan rules: go to hosts.automatt_c.com and you should be redirected to log in. Edit the URL and change the host to calypso.localhost:3000
WP.Cloud - Can't link due to GitHub OSS scan rules: go to [wp.cloud](https://wp.cloud) and click 'start here'. Edit the URL and change the host to calypso.localhost:3000

### Screenshots (showing buttons focused on desktop)

| Brand | Desktop Before | Desktop After | Mobile |
|-|-|-|-|
| WordPress.com | ![wordpress com_log-in(Desktop) (4)](https://github.com/user-attachments/assets/6a34e186-5c92-49e9-a164-cda3c523964a) | ![calypso localhost_3000_log-in_signup_url=%2Fstart%2Faccount%2Fuser-social(Desktop) (1)](https://github.com/user-attachments/assets/2247d5f0-ae60-4897-9316-9fefbec10117) | ![calypso localhost_3000_log-in_signup_url=%2Fstart%2Faccount%2Fuser-social(iPhone 12 Pro)](https://github.com/user-attachments/assets/c3344d74-c2e2-45d2-92df-c5eac698827c) |
| Woo | ![wordpress com_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirect_uri%3Dhttps%253](https://github.com/user-attachments/assets/d6f656c5-d0bc-41fa-bae9-0b8cd74a0659) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirect_ur (1)](https://github.com/user-attachments/assets/dbd73983-099a-4e9a-9af8-25a87213bcd1) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirect_ur (2)](https://github.com/user-attachments/assets/327e6540-2e35-4ea6-a8a6-2e0ce925c223) |
| Akismet | ![wordpress com_log-in_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F(Desktop)](https://github.com/user-attachments/assets/2721650f-5bb8-4306-a0ba-306bc89440ef) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps (2)](https://github.com/user-attachments/assets/c3647f87-d75f-45ed-8e22-2494bc516b1f) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps (1)](https://github.com/user-attachments/assets/66543864-0aad-4396-a0c1-2102b4df952b) |
| Blaze Pro | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=99370 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a2 (3)](https://github.com/user-attachments/assets/a7d37ddd-360c-43a7-a2d1-e2f24a54fad2) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=99370 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae82 (3)](https://github.com/user-attachments/assets/4ff47da7-8d83-4a2a-9e4a-400d299f288a) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=99370 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae82 (2)](https://github.com/user-attachments/assets/0fa277f2-86b7-4ea5-995c-4196cd1d0a0f) |
| Crowdsignal | ![wordpress com_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d83e8088443caf5ec4ff3581e3973 (3)](https://github.com/user-attachments/assets/941b1bc4-332b-4577-b0da-9f983a374d7c) | ![calypso localhost_3000_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d83e8088443caf5ec4ff (2)](https://github.com/user-attachments/assets/52e2c251-0db7-4682-94aa-e838cb93a3f7) | ![calypso localhost_3000_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d83e8088443caf5ec4ff (3)](https://github.com/user-attachments/assets/3a5a7e26-4e89-475a-8f6e-340531af7c2c) |
| Jetpack Cloud | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=69040 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud jetpack com%2 (2)](https://github.com/user-attachments/assets/a2979d01-061f-4dd6-8078-f0d652a222d3) | ![calypso localhost_3000_start_wpcc_oauth2_client_id=69040 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud jetpack com%252Fconn](https://github.com/user-attachments/assets/3f7d4cb0-3c35-4c54-8776-13dacd7ef799) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=69040 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud jetp (1)](https://github.com/user-attachments/assets/bc83c489-0ed1-49d9-92ce-f4dbe6d2effa) |
| A4A | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=69040 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud jetpack com%2 (2)](https://github.com/user-attachments/assets/00895e4f-5f54-4679-88d9-699412aec792) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=95931 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies a (5)](https://github.com/user-attachments/assets/7ef46b44-7ae8-4216-8964-acf1e73e2da6) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=95931 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies a (4)](https://github.com/user-attachments/assets/dc65aae9-f5fb-49a4-bd11-295ce1fffbfc) |
| VIP, WP Cloud, Partner Portal | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=76596 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fstate%3D2e373ba7d0b99c5b66af232a2cd4a90f3af2aeafbb0326604917c9333ac1%26scope%3Dauth%26response_typ (1)](https://github.com/user-attachments/assets/99374a6a-40b7-48e6-b8b7-77cd1a16839f) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=95931 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies a (2)](https://github.com/user-attachments/assets/3ade2f6d-3f45-4a20-a53c-02b31af310bd) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=95931 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies a (3)](https://github.com/user-attachments/assets/416d2f15-6942-4928-aecb-40ef18447bed) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
