### PR TITLE
Update theme upload screen to same content width as plugin upload screen

### DIFF
--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -326,7 +326,7 @@ class Upload extends Component {
 		}
 
 		return (
-			<Main className="theme-upload" wideLayout>
+			<Main className="theme-upload">
 				<PageViewTracker path="/themes/upload/:site" title="Themes > Install" />
 				<DocumentHead title={ translate( 'Install Theme' ) } />
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Tiny follow-up from #102439: updates theme upload content width to match plugin upload.

Current:

<img width="1402" alt="Screenshot 2025-05-05 at 4 47 32 pm" src="https://github.com/user-attachments/assets/a1c0152f-8b21-41d4-9b5d-6a5035454aee" />


With this PR:

<img width="1407" alt="Screenshot 2025-05-05 at 4 48 26 pm" src="https://github.com/user-attachments/assets/675fdf47-7f2d-42e0-a69c-bfd453825a4f" />

<img width="1404" alt="Screenshot 2025-05-05 at 4 48 34 pm" src="https://github.com/user-attachments/assets/a6f1355b-be78-4870-818b-c0737a4bdeb4" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Appearance -> Themes -> Upload theme (button on top right)
* Check everything looks in order.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
