### PR TITLE
A4A > Licenses: Update the `partner_not_connected_to_site` error message

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -66,13 +66,12 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 				dispatch(
 					errorNotice(
 						translate(
-							'You must have your {{b}}%(username)s{{/b}} WordPress.com user connected to the site as an administrator. {{a}}Learn more {{/a}}↗',
+							'Connect your WordPress.com user (%(username)s) as a site admin to continue. {{a}}How to connect {{/a}}↗',
 							{
 								args: {
 									username: user?.display_name ?? '',
 								},
 								components: {
-									b: <b />,
 									a: (
 										<a
 											href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#limitations-for-the-team-member-role"

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -31,6 +31,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { resetSite, setPurchasedLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { DEFAULT_SORT_DIRECTION, DEFAULT_SORT_FIELD } from '../../sites/constants';
@@ -50,6 +51,8 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const user = useSelector( getCurrentUser );
+
 	const { isFeedbackShown } = useShowFeedback( FeedbackType.PurchaseCompleted );
 
 	const [ selectedSite, setSelectedSite ] = useState( { ID: 0, domain: '' } );
@@ -58,7 +61,33 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 	const [ totalSites, setTotalSites ] = useState< number >( 0 );
 
 	const { assignLicensesToSite, isReady } = useAssignLicensesToSite( selectedSite, {
-		onError: ( error: Error ) => {
+		onError: ( error: any ) => {
+			if ( error.code === 'partner_not_connected_to_site' ) {
+				dispatch(
+					errorNotice(
+						translate(
+							'You must have your {{b}}%(username)s{{/b}} WordPress.com user connected to the site as an administrator. {{a}}Learn more {{/a}}↗',
+							{
+								args: {
+									username: user?.display_name ?? '',
+								},
+								components: {
+									b: <b />,
+									a: (
+										<a
+											href="https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#limitations-for-the-team-member-role"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						),
+						{ isPersistent: true }
+					)
+				);
+				return;
+			}
 			dispatch( errorNotice( error.message, { isPersistent: true } ) );
 		},
 	} );


### PR DESCRIPTION
Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/1935

## Proposed Changes

This PR updates the error message when an agency tries to assign a license to a site where they are not connected to the site as an admin. 

## Testing Instructions

* Open the A4A live link
* Assign a license to a site where you are not an admin. You can remove yourself from a site to test this scenario.
* Verify you get an error message as shown below. The link `How to connect ↗` should redirect you to https://agencieshelp.automattic.com/knowledge-base/invite-and-manage-team-members/#limitations-for-the-team-member-role

<img width="730" alt="Screenshot 2025-05-16 at 1 49 56 PM" src="https://github.com/user-attachments/assets/1df26da2-6b67-48f0-810b-23a1b0c92f1d" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
