### PR TITLE
A4A: Add 'a4a-signup-v2' feature flag and remove existing WC Asia context.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/controller.tsx
+++ b/client/a8c-for-agencies/sections/signup/controller.tsx
@@ -65,13 +65,7 @@ export const signUpContext: Callback = ( context, next ) => {
 	next();
 };
 
-export const finishSignUpContext: Callback = ( context, next ) => {
-	context.store.dispatch( hideMasterbar() );
-	context.primary = <AgencySignupFinish />;
-	next();
-};
-
-export const wcAsiaSignupContext: Callback = ( context, next ) => {
+export const signupV2Context: Callback = ( context, next ) => {
 	context.store.dispatch( hideMasterbar() );
 	context.primary = (
 		<>
@@ -79,6 +73,12 @@ export const wcAsiaSignupContext: Callback = ( context, next ) => {
 			<AgencySignupV2 />
 		</>
 	);
+	next();
+};
+
+export const finishSignUpContext: Callback = ( context, next ) => {
+	context.store.dispatch( hideMasterbar() );
+	context.primary = <AgencySignupFinish />;
 	next();
 };
 

--- a/client/a8c-for-agencies/sections/signup/index.ts
+++ b/client/a8c-for-agencies/sections/signup/index.ts
@@ -4,10 +4,12 @@ import { makeLayout, render as clientRender } from 'calypso/controller';
 import * as controller from './controller';
 
 export default function () {
-	page( '/signup', controller.signUpContext, makeLayout, clientRender );
+	page(
+		'/signup',
+		isEnabled( 'a4a-signup-v2' ) ? controller.signupV2Context : controller.signUpContext,
+		makeLayout,
+		clientRender
+	);
 	page( '/signup/finish', controller.finishSignUpContext, makeLayout, clientRender );
-	if ( isEnabled( 'a4a-wc-asia-signup-enabled' ) ) {
-		page( '/signup/wc-asia', controller.wcAsiaSignupContext, makeLayout, clientRender );
-	}
 	page( '/signup/oauth/token', controller.tokenRedirect, makeLayout, clientRender );
 }

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -43,7 +43,7 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true,
+		"a4a-signup-v2": true,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -36,7 +36,7 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true,
+		"a4a-signup-v2": false,
 		"a4a-client-checkout-v2": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -36,7 +36,7 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true,
+		"a4a-signup-v2": false,
 		"a4a-client-checkout-v2": false,
 		"jetpack/crm-downloads": false
 	},

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -38,7 +38,7 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-wc-asia-signup-enabled": true,
+		"a4a-signup-v2": false,
 		"a4a-client-checkout-v2": false,
 		"jetpack/crm-downloads": true
 	},


### PR DESCRIPTION
This PR adds the 'a4a-signup-v2' feature flag for the new signup form.


Closes https://linear.app/a8c/issue/A4A-838/frontend-add-feature-flag

## Proposed Changes
* Remove WC Asia specific signup form and routing.
* Add the feature flag and signup v2 route context.

## Why are these changes being made?

* This is part of the A4A Onboarding enhancement project part 1.

## Testing Instructions

* Use the A4A live link and navigate to `/signup?flags=a4a-signup-v2`.
* Confirm you see the new signup form.
   <img width="1726" alt="Screenshot 2025-05-05 at 3 52 19 PM" src="https://github.com/user-attachments/assets/5775f681-1c6e-4a71-8d79-36a6247a8721" />
* Now navigate to `/signup`
* Confirm you see the current signup form.
   <img width="1725" alt="Screenshot 2025-05-05 at 3 52 56 PM" src="https://github.com/user-attachments/assets/d5830a20-0568-4d8f-9504-1820db3e518b" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
