### PR TITLE
Dashboard v2: add skeleton Settings tab

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -105,6 +105,17 @@ const sitePerformanceRoute = createRoute( {
 	)
 );
 
+const siteSettingsRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings',
+} ).lazy( () =>
+	import( '../site-settings' ).then( ( d ) =>
+		createLazyRoute( 'site-settings' )( {
+			component: d.default,
+		} )
+	)
+);
+
 const domainsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains',
@@ -263,7 +274,12 @@ const createRouteTree = ( config: AppConfig ) => {
 	if ( config.supports.sites ) {
 		children.push(
 			sitesRoute,
-			siteRoute.addChildren( [ siteOverviewRoute, siteDeploymentsRoute, sitePerformanceRoute ] )
+			siteRoute.addChildren( [
+				siteOverviewRoute,
+				siteDeploymentsRoute,
+				sitePerformanceRoute,
+				siteSettingsRoute,
+			] )
 		);
 	}
 
@@ -313,6 +329,7 @@ export {
 	siteOverviewRoute,
 	siteDeploymentsRoute,
 	sitePerformanceRoute,
+	siteSettingsRoute,
 	domainsRoute,
 	emailsRoute,
 	meRoute,

--- a/client/dashboard/site-menu/index.tsx
+++ b/client/dashboard/site-menu/index.tsx
@@ -11,6 +11,9 @@ const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
 				{ __( 'Performance' ) }
 			</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
+				{ __( 'Settings' ) }
+			</ResponsiveMenu.Item>
 		</ResponsiveMenu>
 	);
 };

--- a/client/dashboard/site-settings/index.tsx
+++ b/client/dashboard/site-settings/index.tsx
@@ -1,0 +1,6 @@
+import { __ } from '@wordpress/i18n';
+import PageLayout from '../page-layout';
+
+export default function SiteSettings() {
+	return <PageLayout title={ __( 'Settings' ) } />;
+}


### PR DESCRIPTION

Related to DOTCOM-12978

## Proposed Changes

This PR adds an empty Site -> Settings tab to the hosting dashboard v2.

<img width="666" alt="image" src="https://github.com/user-attachments/assets/8deaf2b0-8623-4d97-b3d5-26e036c90804" />


## Testing Instructions

1. Go to `/v2/sites`
2. Click any site
3. Click Settings tab
4. Verify it loads an empty page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
