### PR TITLE
Remove inconsistent white background on 'Use a domain I own' screen

### DIFF
--- a/client/components/domains/use-my-domain/style.scss
+++ b/client/components/domains/use-my-domain/style.scss
@@ -9,6 +9,7 @@
 	flex-direction: column;
 	padding: 36px 24px;
 	box-shadow: none;
+	background-color: inherit;
 
 	& &__page-heading {
 		.formatted-header__title {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/NOMADO-148/inconsistent-white-background-on-use-a-domain-i-own-screen

## Proposed Changes
This change ensures the background color of the "Use a domain I own" flow is consistent with its parent container, preventing unexpected background mismatches and improving visual consistency across different parent backgrounds.

## Why are these changes being made?
The 'Use a domain I own' step in the domain connection flow displays a large white background container, while other pages in the flow use the standard light gray background directly.

## Testing Instructions
Navigate to the "Use a domain I own" flow in the Domains section.
Verify that the background color of the main container now inherits from its parent, and there are no visual regressions.
Test in both light and dark modes, and with different parent backgrounds if possible.

## Pre-merge Checklist
- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
