### PR TITLE
Fix button label wraps in 'Paid plan required' modal

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
@@ -37,7 +37,7 @@ export const ButtonContainer = styled.div`
 		margin-top: 24px;
 		button {
 			max-width: 220px;
-			flex-basis: 196px;
+			flex-basis: 220px;
 		}
 	}
 `;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
@@ -36,8 +36,8 @@ export const ButtonContainer = styled.div`
 	@media ( min-width: 780px ) {
 		margin-top: 24px;
 		button {
-			max-width: 220px;
-			flex-basis: 220px;
+			max-width: 240px;
+			flex-basis: 240px;
 		}
 	}
 `;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
@@ -29,8 +29,8 @@ function PlanUpsellButton( {
 			} }
 		>
 			{ ! hidePrice
-				? translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-						comment: 'Eg: Get Personal $4/month',
+				? translate( 'Get %(planTitle)s - %(planPrice)s/mo', {
+						comment: 'Eg: Get Personal $4/mo',
 						args: {
 							planTitle: planUpsellInfo.title,
 							planPrice: planUpsellInfo.formattedPriceMonthly,

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
@@ -29,8 +29,8 @@ function PlanUpsellButton( {
 			} }
 		>
 			{ ! hidePrice
-				? translate( 'Get %(planTitle)s - %(planPrice)s/mo', {
-						comment: 'Eg: Get Personal $4/mo',
+				? translate( 'Get %(planTitle)s - %(planPrice)s/month', {
+						comment: 'Eg: Get Personal $4/month',
 						args: {
 							planTitle: planUpsellInfo.title,
 							planPrice: planUpsellInfo.formattedPriceMonthly,


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/NOMADO-151/button-label-wraps-in-paid-plan-required-modal

## Proposed Changes
- Increased `flex-basis` and `max-width` of plan selection buttons in the **'Paid plan required'** modal to `240px`, ensuring button labels remain on a single line.

## Why are these changes being made?
Previously, in the 'Paid plan required' modal shown during domain transfer, the plan button label (e.g., “Get Premium – A$12/month”) would wrap onto multiple lines on smaller screens or within constrained containers. This reduced visual clarity and made pricing information less scannable at a glance.
By increasing the button width and abbreviating the price label, we ensure that button labels remain on a single line, improving readability and maintaining visual balance across devices.

I tested the PR setting German language on my WordPress.com profile, where I noticed that the "Continue with Free plan" button takes 2 lines. 

| ![Screenshot 2025-05-05 alle 12 54 58](https://github.com/user-attachments/assets/826ebc75-6b80-41c5-b902-b3e250e5dd89) | ![Screenshot 2025-05-05 alle 12 17 44](https://github.com/user-attachments/assets/0cbbf748-36a8-4484-9558-6a57f5464ba6) |
| - | - |
| BEFORE | AFTER |

## Testing Instructions
Steps to reproduce the original issue:
- Start a domain transfer without a paid plan.
- Reach the 'Paid plan required' modal.
- Observe the Premium plan button's label for wrapping.

To test the fix:
- Open the 'Paid plan required' modal in the site management interface.
- Verify that the plan selection buttons labels now fit in a single line .
- Check that button labels remain on a single line in both desktop and mobile views.
- Ensure all buttons remain accessible and functional.

## Pre-merge Checklist
- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?