### PR TITLE
Help Center: Remove "Contact support" button after clicking

### DIFF
--- a/packages/odie-client/src/components/message/direct-escalation-link.tsx
+++ b/packages/odie-client/src/components/message/direct-escalation-link.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
@@ -11,7 +11,11 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 	const { trackEvent, isUserEligibleForPaidSupport } = useOdieAssistantContext();
 	const navigate = useNavigate();
 
+	const [ newConversationButtonDisabled, setNewConversationButtonDisabled ] =
+		useState( conversationStarted );
+
 	const handleClick = useCallback( () => {
+		setNewConversationButtonDisabled( true );
 		trackEvent( 'chat_message_direct_escalation_link_click', {
 			message_id: messageId,
 			is_user_eligible_for_paid_support: isUserEligibleForPaidSupport,
@@ -34,10 +38,18 @@ export const DirectEscalationLink = ( { messageId }: { messageId: number | undef
 		navigate,
 	] );
 
+	if ( newConversationButtonDisabled ) {
+		return null;
+	}
+
 	return (
 		<div className="disclaimer">
 			{ __( 'Feeling stuck?', __i18n_text_domain__ ) }{ ' ' }
-			<button onClick={ handleClick } className="odie-button-link" disabled={ conversationStarted }>
+			<button
+				onClick={ handleClick }
+				className="odie-button-link"
+				disabled={ newConversationButtonDisabled }
+			>
 				{ isUserEligibleForPaidSupport
 					? __( 'Contact our support team.', __i18n_text_domain__ )
 					: __( 'Ask in our forums.', __i18n_text_domain__ ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DOTSUP-4/investigate-multiple-interactions-and-blank-chats-for-users

## Proposed Changes

After pushing some optimization for chats management in the Help Center, I checked the data and noticed that now, after solving other problems, the main source of duplicate chats is `direct_escalation`, that is the "Contact our support team" that appears after an answer from AI.

![image](https://github.com/user-attachments/assets/69ed10a7-8604-4b11-95d4-3c1ac1e67109)

This PR:
- Removes the button after the user has clicked and started a conversation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Help center and click on "Still need help?"
* Ask something to AI
* Click on "Contact our support team", and try to quickly click multiple times.
* You should have only one chat and the link should be gone.
