### PR TITLE
Documentation: Refresh the Calypso Technology page

### DIFF
--- a/docs/guide/tech-behind-calypso.md
+++ b/docs/guide/tech-behind-calypso.md
@@ -2,69 +2,21 @@
 
 Understanding the technologies and abstractions on which Calypso is built can make for a much better learning and building experience. Even if you are a student of the “learning by doing” school, we would still encourage you spend some time with the resources in this document.
 
-## No Big Famous Framework
+## Based on React
 
-Calypso is using neither Angular nor Ember; because we are building Calypso for the long haul, updating and improving a home-grown framework is a better long-term approach for us. Currently, we're using React and Flux/Redux; they're great, but knowing we have the control to use better technologies as they come along makes us feel more confident in our future. Calypso isn't a small startup project; we know it will need to scale and our technology will need to scale with it.
+Calypso is composed of multiple applications that are all built using React. [React](http://facebook.github.io/react/) is a library by Facebook that implements a virtual DOM. Instead of carefully changing the DOM, we can just re-render whole components when the data changes. React radically simplified our code and allowed for an awesome composition of reusable components.
 
-## Modern Modular JavaScript
+- [Official documentation](https://react.dev/learn)
 
-Instead of a named framework, we decided to assemble our own out of small, focused JavaScript modules.
+## Important libraries used in Calypso
 
-In the recent years, JavaScript went a long way from the language hidden behind jQuery selectors to the engine behind huge single-page applications and fast node.js async server-side daemons. ES6 is a confirmation the language is going in the right direction.
+As Calypso evolved over time, we tried several approaches to both routing and data layers on top of React. These are some of the libraries commonly used in Calypso:
 
-Here are few resources to get up to speed with “modern” JavaScript and ES6:
+- [Redux](http://redux.js.org/) – a predictable state container for JavaScript apps. Perfect fit for complex centralized state management. It powers the data layer of most of the calypso sections, but in new calypso applications, we're moving towards lighter approaches.
+- [TanStack Query](https://tanstack.com/query) – a powerful data-fetching library for React. It provides a simple API for fetching, caching, and synchronizing server state in your React applications. It is used as the main data layer of new Calypso sections (like the hosting dashboard) but is also commonly used in other parts of Calypso.
+- [TanStack Router](https://tanstack.com/router) – a powerful routing library for React. It provides a simple API for managing routes and navigation in your React applications. It is used as the main routing layer of new Calypso sections (like the hosting dashboard).
 
-- [JavaScript Allongé, the "Six" Edition](https://leanpub.com/javascriptallongesix/read)
-- [Exploring ES6](http://exploringjs.com/es6/)
-- [The Modern JavaScript Tutorial](https://javascript.info/)
-- [What the heck is the event loop anyway?](https://www.youtube.com/watch?v=8aGhZQkoFbQ) – short presentation that sheds some light on how asynchronous operations are executed in JavaScript
-
-Key concepts checklist:
-
-- [Module pattern with CommonJS](http://darrenderidder.github.io/talks/ModulePatterns/) and [npm](https://docs.npmjs.com)
-- [Scope](You-Dont-Know-JS/tree/2nd-ed/scope-closures), context, and [function binding](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/this%20&%20object%20prototypes/README.md#you-dont-know-js-this--object-prototypes)
-- [Basic prototypes – creating new objects, inheritance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)
-- Higher-level functions – [`map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), [`reduce`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce)
-- Async primitives – [callbacks](https://docs.nodejitsu.com/articles/getting-started/control-flow/what-are-callbacks), [promises](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-
-_Do you know any good videos and presentations on the subject? If yes, please send a pull request to add them here._
-
-## React
-
-[React](http://facebook.github.io/react/) is a library by Facebook that implements a virtual DOM. Instead of carefully changing the DOM, we can just re-render whole components when the data changes. React radically simplified our code and allowed for an awesome composition of reusable components.
-
-Here are some great React resources:
-
-- [Official documentation](http://facebook.github.io/react/docs/getting-started.html)
-- [Tutorial at Scotch.io](https://scotch.io/tutorials/learning-react-getting-started-and-concepts)
-- [ReactJS For Stupid People](http://blog.andrewray.me/reactjs-for-stupid-people/)
-- [Thinking in React](http://facebook.github.io/react/docs/thinking-in-react.html)
-- [Official Tutorial](http://facebook.github.io/react/docs/tutorial.html)
-- Presentation: [Rethinking Best Practices](https://www.youtube.com/watch?v=x7cQ3mrcKaY)
-- Presentation: [Be Predictable, Not Correct](https://www.youtube.com/watch?v=h3KksH8gfcQ)
-- Presentation: [Why does React Scale?](https://www.youtube.com/watch?v=D-ioDiacTm8)
-
-Key concepts checklist:
-
-- What is mounting of components?
-- When are components rendered?
-- What happens on render?
-- [Differences between props and state](http://facebook.github.io/react/docs/interactivity-and-dynamic-uis.html)
-- [Component lifecycle methods](http://facebook.github.io/react/docs/component-specs.html)
-- [Mixins](http://facebook.github.io/react/docs/reusable-components.html#mixins)
-- [Why shouldn’t we touch the DOM the old way](http://facebook.github.io/react/docs/working-with-the-browser.html)
-
-## Redux
-
-All new code uses [Redux](http://redux.js.org/) to manage state in Calypso – making sure all components work with and react to the same data, living in a single place, instead of scattered between components’ state. Older code uses various [Flux](https://facebook.github.io/flux/) implementations or other data components.
-
-Few, but solid Redux resources:
-
-- [The official website](http://redux.js.org)
-- Probably the best way to learn Redux is via the Egghead [Get Started with Redux](https://egghead.io/courses/getting-started-with-redux) video course
-- When good with the basics, the [Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux) video course is also super useful (though we do few things differently in Calypso, like routing)
-- The [Ecosystem](http://redux.js.org/docs/introduction/Ecosystem.html) page on the official site has a lot of links to tutorials and examples
-- For more Calypso-specific details, see the [Our Approach to Data](../our-approach-to-data.md) document
+For more Calypso-specific details, see the [Our Approach to Data](../our-approach-to-data.md) document
 
 ## Git
 
@@ -96,7 +48,7 @@ The way we use Git with Calypso is described in the [Git Workflow document](../g
 
 ## Other technologies used in Calypso, worth checking out
 
-- [page.js](http://visionmedia.github.io/page.js/) – router
+- [page.js](http://visionmedia.github.io/page.js/) – router used in most sections of Calypso. New sections are using other libraries like TanStack Router.
 - [express.js](http://expressjs.com) – light server-side framework we use to serve the initial page
 - [webpack](http://webpack.github.io) – building a JavaScript bundle of all of our modules and making sure loading them works just fine
 - [Babel](https://babeljs.io) – for transpiling ES2015+ and JSX

--- a/docs/yarn-start.md
+++ b/docs/yarn-start.md
@@ -1,4 +1,4 @@
-# Commands executed with yarn start
+# Understanding `yarn start`
 
 <!--
 


### PR DESCRIPTION
Part of ARC-165

## Proposed Changes

The "Technology behind Calypso" page is largely outdated. This PR removes a lot of part of it, and tries to bring it up to date. There are linked pages that are still outdated but these will be updated separately.