### PR TITLE
Update the button for the cancel survey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -60,7 +60,7 @@ function Upsell( { image, ...props }: UpsellProps ) {
 						{ props.acceptButtonText }
 					</Button>
 					<Button
-						variant="primary"
+						variant="secondary"
 						onClick={ () => {
 							setBusyButton( 'decline' );
 							props.onDecline?.();


### PR DESCRIPTION
DOTCOM-1746-linear

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The cancellation survey sometimes offers solutions. For example, if building a site is too difficult, we offer DIFM
* These have two primary buttons
* Per @fditrapani's request, make one primary and one secondary button

## Why are these changes being made?

* UI consistency

## Testing Instructions

* With the store sandbox enabled, buy a plan
* Go to /me/purchases and attempt to cancel the plan
* In the cancellation survey, select various options until you see an upsell (for example, too expensive, or don't have time)

Before:
<img width="45%" alt="Screenshot 2025-05-05 at 14 18 31" src="https://github.com/user-attachments/assets/99294b7d-9557-4d5f-be62-7d7f2059f2c5" /> <img width="45%" alt="Screenshot 2025-05-05 at 14 18 13" src="https://github.com/user-attachments/assets/6c2ab01f-e4ef-42a7-b443-0ac2ef7ff670" />

After:
<img width="45%" alt="Screenshot 2025-05-05 at 14 13 49" src="https://github.com/user-attachments/assets/1bc25889-ef09-4552-82a0-290227838c8e" /> <img width="45%" alt="Screenshot 2025-05-05 at 14 13 16" src="https://github.com/user-attachments/assets/5da7364f-db65-4ff6-8b53-a11b668a9389" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
