### PR TITLE
Remove lower-tier plans in Playground signup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/plans.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/plans.ts
@@ -1,0 +1,5 @@
+import { PlansIntent } from '@automattic/plans-grid-next';
+
+export function playgroundPlansIntent(): PlansIntent | null {
+	return 'plans-plugins';
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/plans.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/plans.ts
@@ -1,5 +1,5 @@
 import { PlansIntent } from '@automattic/plans-grid-next';
 
 export function playgroundPlansIntent(): PlansIntent | null {
-	return 'plans-plugins';
+	return 'plans-playground';
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -4,6 +4,7 @@ import {
 	EXAMPLE_FLOW,
 	NEW_HOSTED_SITE_FLOW,
 	NEWSLETTER_FLOW,
+	ONBOARDING_FLOW,
 	START_WRITING_FLOW,
 	Step,
 	useStepPersistedState,
@@ -22,6 +23,7 @@ import { useSelector } from 'calypso/state';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getTheme, getThemeType } from 'calypso/state/themes/selectors';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { playgroundPlansIntent } from '../playground/lib/plans';
 import UnifiedPlansStep from './unified-plans-step';
 import { getIntervalType } from './util';
 import type { Step as StepType } from '../../types';
@@ -32,7 +34,12 @@ import './style.scss';
 /**
  * Copied from steps-repository/plans (which should be removed)
  */
-function getPlansIntent( flowName: string | null, isWordCampPromo?: boolean ): PlansIntent | null {
+/**
+ * Copied from steps-repository/plans (which should be removed)
+ */
+function getPlansIntent( flowName: string | null ): PlansIntent | null {
+	const search = new URLSearchParams( location.search );
+
 	switch ( flowName ) {
 		case START_WRITING_FLOW:
 			return 'plans-blog-onboarding';
@@ -40,12 +47,20 @@ function getPlansIntent( flowName: string | null, isWordCampPromo?: boolean ): P
 		case EXAMPLE_FLOW:
 			return 'plans-newsletter';
 		case NEW_HOSTED_SITE_FLOW:
-			if ( isWordCampPromo ) {
+			/**
+			 * isWordCampPromo is temporary
+			 */
+			if ( search.has( 'utm_source', 'wordcamp' ) ) {
 				return 'plans-new-hosted-site-business-only';
 			}
+
 			return 'plans-new-hosted-site';
 		case AI_SITE_BUILDER_FLOW:
 			return 'plans-ai-assembler-free-trial';
+		case ONBOARDING_FLOW:
+			if ( search.has( 'playground' ) ) {
+				return playgroundPlansIntent();
+			}
 		default:
 			return null;
 	}
@@ -113,11 +128,7 @@ const PlansStepAdaptor: StepType< {
 
 	useQueryTheme( 'wpcom', selectedDesign?.slug );
 
-	/**
-	 * isWordCampPromo is temporary
-	 */
-	const isWordCampPromo = new URLSearchParams( location.search ).has( 'utm_source', 'wordcamp' );
-	const plansIntent = getPlansIntent( props.flow, isWordCampPromo );
+	const plansIntent = getPlansIntent( props.flow );
 
 	/**
 	 * The plans step has a quirk where it calls `submitSignupStep` then synchronously calls `goToNextStep` after it.

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -207,6 +207,9 @@ export const usePlanTypesWithIntent = ( {
 		case 'plans-site-selected-legacy':
 			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
+		case 'plans-playground':
+			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			break;
 		default:
 			planTypes = availablePlanTypes;
 	}

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -75,6 +75,7 @@ export type PlansIntent =
 	| 'plans-guided-segment-nonprofit'
 	| 'plans-guided-segment-consumer-or-business'
 	| 'plans-site-selected-legacy'
+	| 'plans-playground'
 	| 'default';
 
 export interface PlanActionOverrides {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTOBRD-109/limit-plan-selection-according-to-blueprint-requirements

## Proposed Changes

* Add a Playground plans intent similar to the `plans-plugins` intent
* Force Playground flow to only use the plans that let you install plugins

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add a new intent
* Add a Playground check when the flow is `ONBOARDING_FLOW` with default `null` as before

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/onboarding/playground and click "Launch on WordPress.com"
* Choose a random domain
* Be sure there are only two plans available
* Try other flows, be sure nothing has changed

<img width="732" alt="image" src="https://github.com/user-attachments/assets/42d30caa-11a0-4608-b044-8f0748208c91" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
