### PR TITLE
TeamCity: Keep design systems docs build

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -43,6 +43,7 @@ object WPComPlugins : Project({
 					"happy-blocks-release-build",
 					"command-palette-wp-admin-release-build",
 					"help-center-release-build",
+					"design-system-docs-release-build",
 				)
 			}
 			dataToKeep = everything()


### PR DESCRIPTION
## Proposed Changes

Adding the design systems build to the list of release builds to keep.

## Why are these changes being made?

To keep the build so we can compare with them in subsequent PRs.

See #103117 and https://github.com/Automattic/wp-calypso/pull/103065/#issuecomment-2848249211

## Testing Instructions

Not needed. 