### PR TITLE
Show placeholder while loading domain settings page

### DIFF
--- a/client/components/domains/layout/style.scss
+++ b/client/components/domains/layout/style.scss
@@ -3,13 +3,13 @@
 
 .two-columns-layout {
 	@include break-xlarge {
-		display: grid;
-		grid-template-columns: minmax(0, 1fr) 315px;
-		column-gap: 48px;
+		display: flex;
+		flex-direction: row;
 	}
 
 	&__content {
-		grid-column: 1 / 2;
+		flex: 1 1 0;
+		min-width: 0;
 		padding-bottom: 1px;
 		@include break-xlarge {
 			padding-bottom: 0;
@@ -17,6 +17,13 @@
 	}
 
 	&__sidebar {
-		grid-column: 2 / 3;
+		@include break-xlarge {
+			width: 315px;
+			flex: 0 0 315px;
+			margin-left: 48px;
+		}
+		&:empty {
+			display: none;
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -1,19 +1,12 @@
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { transferStatus, type as domainType } from 'calypso/lib/domains/constants';
 import { isCancelable, isRemovable } from 'calypso/lib/purchases';
 import { cancelPurchase } from 'calypso/me/purchases/paths';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import { getCancelPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
-import {
-	getByPurchaseId,
-	hasLoadedSitePurchasesFromServer,
-	isFetchingSitePurchases,
-} from 'calypso/state/purchases/selectors';
-import { IAppState } from 'calypso/state/types';
 import DomainInfoCard from '..';
-import type { DomainDeleteInfoCardProps, DomainInfoCardProps } from '../types';
+import type { DomainDeleteInfoCardProps } from '../types';
 
 const DomainDeleteInfoCard = ( {
 	domain,
@@ -97,11 +90,4 @@ const DomainDeleteInfoCard = ( {
 	);
 };
 
-export default connect( ( state: IAppState, ownProps: DomainInfoCardProps ) => {
-	const { subscriptionId } = ownProps.domain;
-	return {
-		purchase: getByPurchaseId( state, Number( subscriptionId ) ),
-		isLoadingPurchase:
-			isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
-	};
-} )( DomainDeleteInfoCard );
+export default DomainDeleteInfoCard;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -45,7 +45,6 @@ export type DomainInfoCardProps = {
 	selectedSite: SiteDetails;
 };
 export type DomainDeleteInfoCardProps = DomainInfoCardProps & {
-	selectedSite: SiteDetails;
 	purchase?: Purchase | null;
 	isLoadingPurchase: boolean;
 };

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -779,8 +779,13 @@ const Settings = ( {
 				{ ! domain.isHundredYearDomain && (
 					<DomainTransferInfoCard selectedSite={ selectedSite } domain={ domain } />
 				) }
-				{ ! domain.isHundredYearDomain && (
-					<DomainDeleteInfoCard selectedSite={ selectedSite } domain={ domain } />
+				{ ! domain.isHundredYearDomain && ! isLoadingPurchase && (
+					<DomainDeleteInfoCard
+						selectedSite={ selectedSite }
+						domain={ domain }
+						purchase={ purchase }
+						isLoadingPurchase={ isLoadingPurchase }
+					/>
 				) }
 				<DomainDisconnectCard selectedSite={ selectedSite } domain={ domain } />
 			</>

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -787,15 +787,19 @@ const Settings = ( {
 		);
 	};
 
-	if ( ! domain ) {
+	if ( ! domain || isLoadingPurchase ) {
 		// TODO: Update this placeholder
-		return <DomainMainPlaceholder breadcrumbs={ renderHeader } />;
+		return (
+			<>
+				<DomainMainPlaceholder breadcrumbs={ renderHeader } />
+				{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
+			</>
+		);
 	}
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="domain-settings-page">
-			{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderHeader() }
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -794,17 +794,13 @@ const Settings = ( {
 
 	if ( ! domain || isLoadingPurchase ) {
 		// TODO: Update this placeholder
-		return (
-			<>
-				<DomainMainPlaceholder breadcrumbs={ renderHeader } />
-				{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
-			</>
-		);
+		return <DomainMainPlaceholder breadcrumbs={ renderHeader } />;
 	}
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="domain-settings-page">
+			{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderHeader() }
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -792,7 +792,7 @@ const Settings = ( {
 		);
 	};
 
-	if ( ! domain || isLoadingPurchase ) {
+	if ( ! domain ) {
 		// TODO: Update this placeholder
 		return <DomainMainPlaceholder breadcrumbs={ renderHeader } />;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/NOMADO-149/cancel-transfer-ui-briefly-appears-then-disappears-after-domain

## Proposed Changes
This PR introduces a placeholder component on the domain management page that is shown while domain and purchase data are loading.

Originally, this was intended to fix a temporary glitch in the sidebar (as reported in the Linear linked issue). Since the issue couldn't be consistently reproduced, the placeholder was added instead to improve loading behavior and reduce flickering in domain cards during data fetches.

Additionally, the `TwoColumnsLayout` component was updated to:
- Hide the sidebar when it has no content.
- Allow the main content column to expand to full width when the sidebar is hidden.

![Screenshot 2025-05-06 alle 13 10 55](https://github.com/user-attachments/assets/df98b9e1-f144-49c3-949a-a51fa241889f)

## Why Are These Changes Being Made?
These changes aim to improve the user experience by:
- Avoiding UI glitches or layout shifts while data loads.
- Ensuring the page layout adapts gracefully when the sidebar is not needed.

Testing Instructions
To test these changes, apply this PR locally or use the Calypso live build:
- Visit the domain management page.
- Verify that a placeholder component appears until all data is loaded.
- Confirm that the sidebar is hidden when it has no content (to simulate this, you can visit the settings page for a pending transfer-in domain or manually clear the sidebar content using Chrome DevTools)
- Ensure that the content column takes full width when the sidebar is hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
