### PR TITLE
[DataViews]: clarify filters toggle and filters usage for accessibility

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -427,7 +427,7 @@ The following components are available directly under `DataViews`:
 * `DataViews.BulkActionToolbar`
 * `DataViews.ViewConfig`
 
-### example
+#### example
 
 ```jsx
 import DataViews from '@automattic/dataviews';

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -396,6 +396,80 @@ A callback function that is triggered when a user clicks on a media field or pri
 
 React component to be rendered next to the view config button.
 
+### Composition modes
+
+The `DataViews` component supports two composition modes:
+
+* **Controlled**: This is the default usage mode. `DataViews` renders a full layout out-of-the-box — including search, filters, view switcher, layout grid or table, actions, and pagination. It’s the simplest way to get started and requires minimal setup.
+
+* **Free composition**: This mode gives developers full control over the layout. You can compose your own UI using internal components — placing them exactly where they’re needed in your interface. This is useful for more advanced or custom layouts, while still relying on the same shared context for user interactions.
+
+The component automatically detects the mode based on the `children` prop. If no `children` are passed, `DataViews` renders its internal layout (controlled mode). If `children` are provided, the component switches to free composition mode, skipping the default layout entirely.
+
+In both modes, user interactions update the same `view` object and share the same behavior. Free composition components rely on context state and don’t require additional props to work, making them safe to use without extra boilerplate.
+
+### Free composition
+
+When you pass the `children` prop to the `DataViews` component, it enters free composition mode. In this mode, `DataViews` no longer renders its built-in layout — instead, it acts as a wrapper that provides access to internal state and shared behavior through context.
+
+This allows you to build your own layout from scratch using the subcomponents exposed by `DataViews`. Each subcomponent automatically connects to the shared context, so you don't need to wire props manually. You can arrange these components however you want and combine them with your own custom elements.
+
+This pattern enables full layout flexibility while keeping the data logic centralized.
+
+The following components are available directly under `DataViews`:
+
+* `DataViews.Search`
+* `DataViews.FiltersToggle`
+* `DataViews.Filters`
+* `DataViews.Layout`
+* `DataViews.LayoutSwitcher`
+* `DataViews.Pagination`
+* `DataViews.BulkActionToolbar`
+* `DataViews.ViewConfig`
+
+### example
+
+```jsx
+import DataViews from '@automattic/dataviews';
+import { __ } from '@wordpress/i18n';
+
+const CustomLayout = () => {
+	// Declare data, fields, etc.
+
+	return (
+		<>
+			<h1>{ __( 'Free composition', 'dataviews' ) }</h1>
+			<DataViews
+    			data={ data }
+    			fields={ fields }
+    			view={ view }
+    			onChangeView={ onChangeView }
+    			paginationInfo={ paginationInfo }
+    			defaultLayouts={ { table: {} } }
+    		>
+    			<DataViews.Search />
+    			<DataViews.FiltersToggle />
+    			<DataViews.Filters />
+    			<DataViews.Layout />
+    			<DataViews.Pagination />
+    		</DataViews>
+		</>
+	);
+};
+```
+
+> You can render only the pieces you need, rearrange them freely, or combine them with custom components.
+
+### Accessibility considerations
+
+All `DataViews` subcomponents are designed with accessibility in mind — including keyboard interactions, focus management, and semantic roles. Components like `Search`, `Pagination`, `FiltersToggle`, and `Filters` already handle these responsibilities internally and can be safely used in custom layouts.
+
+When using free composition, developers are responsible for the outer structure of the layout.
+
+Developers don't need to worry about the internal accessibility logic for individual features. The core behaviors — like search semantics, filter toggles, or pagination focus — are encapsulated.
+
+`FiltersToggle` controls the visibility of the filters panel, and `Filters` renders the actual filters inside it. They work together and should always be used as a pair. While their internal behavior is accessible by default, how they’re positioned and grouped in custom layouts may affect the overall experience — especially for assistive technologies. Extra care is recommended.
+
 ## `DataForm`
 
 <div class="callout callout-info">At <a href="https://wordpress.github.io/gutenberg/">WordPress Gutenberg's Storybook</a> there's and <a href="https://wordpress.github.io/gutenberg/?path=/docs/dataviews-dataform--docs">example implementation of the DataForm component</a>.</div>

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -437,23 +437,21 @@ const CustomLayout = () => {
 	// Declare data, fields, etc.
 
 	return (
-		<>
-			<h1>{ __( 'Free composition', 'dataviews' ) }</h1>
-			<DataViews
-    			data={ data }
-    			fields={ fields }
-    			view={ view }
-    			onChangeView={ onChangeView }
-    			paginationInfo={ paginationInfo }
-    			defaultLayouts={ { table: {} } }
-    		>
-    			<DataViews.Search />
-    			<DataViews.FiltersToggle />
-    			<DataViews.Filters />
-    			<DataViews.Layout />
-    			<DataViews.Pagination />
-    		</DataViews>
-		</>
+		<DataViews
+			data={ data }
+			fields={ fields }
+			view={ view }
+			onChangeView={ onChangeView }
+			paginationInfo={ paginationInfo }
+			defaultLayouts={ { table: {} } }
+		>
+			<h1>{ __( 'Free composition' ) }</h1>
+			<DataViews.Search />
+			<DataViews.FiltersToggle />
+			<DataViews.Filters />
+			<DataViews.Layout />
+			<DataViews.Pagination />
+		</DataViews>
 	);
 };
 ```


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close ARC-163
Related to #

## Proposed Changes

Clarified in the Accessibility section that `FiltersToggle` and `Filters` are designed to be used together. Rewrote the paragraph to reflect their distinct roles (toggling visibility and rendering filters) and the importance of preserving their relationship when building custom layouts using free composition.

## Why are these changes being made?

The previous version of the documentation didn’t clearly explain that `FiltersToggle` and `Filters` are meant to be used as a pair. This PR improves guidance for developers working with free composition mode and highlights the accessibility implications of custom layouts that use these components.

## Testing Instructions

- Read through the updated `Composition modes` and `Accessibility considerations` sections in the README.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
