### PR TITLE
Sites Dashboard: Improve logic of whether the site should open on the preview pane or not

### DIFF
--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -135,6 +135,14 @@ export const siteUsesWpAdminInterface = ( site: SiteExcerptNetworkData ) => {
 	return ( site.jetpack && ! site.is_wpcom_atomic ) || getAdminInterface( site ) === 'wp-admin';
 };
 
+export const isSitePreviewPaneEligible = ( site: SiteExcerptData, canManageOptions: boolean ) => {
+	return (
+		! isDisconnectedJetpackAndNotAtomic( site ) &&
+		! isNotAtomicJetpack( site ) &&
+		! isP2Site( site ) &&
+		canManageOptions
+	);
+};
 export interface InterfaceURLFragment {
 	calypso: `/${ string }`;
 	wpAdmin: `/${ string }`;

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -25,6 +25,7 @@ import {
 	isP2Site,
 	isSimpleSite,
 	isStagingSite,
+	isSitePreviewPaneEligible,
 } from 'calypso/sites-dashboard/utils';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -40,13 +41,7 @@ export const isActionEligible = (
 ): ( ( site: SiteExcerptData ) => boolean ) => {
 	const canOpenHosting = ( site: SiteExcerptData ) => {
 		const canManageOptions = capabilities[ site.ID ]?.manage_options;
-		if (
-			site.is_deleted ||
-			! canManageOptions ||
-			isP2Site( site ) ||
-			isNotAtomicJetpack( site ) ||
-			isDisconnectedJetpackAndNotAtomic( site )
-		) {
+		if ( site.is_deleted || ! isSitePreviewPaneEligible( site, canManageOptions ) ) {
 			return false;
 		}
 		return true;

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -7,11 +7,7 @@ import { useQueryReaderTeams } from 'calypso/components/data/query-reader-teams'
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { navigate } from 'calypso/lib/navigate';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
-import {
-	isNotAtomicJetpack,
-	isP2Site,
-	isDisconnectedJetpackAndNotAtomic,
-} from 'calypso/sites-dashboard/utils';
+import { isSitePreviewPaneEligible } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -83,14 +79,8 @@ const DotcomSitesDataViews = ( {
 
 			const site = sites.find( ( s ) => s.ID === Number( selectedSiteIds[ 0 ] ) );
 			if ( site && ! site.is_deleted ) {
-				const isAdmin = canCurrentUser( state, site.ID, 'manage_options' );
-				const shouldOpenSitePreviewPane =
-					! isDisconnectedJetpackAndNotAtomic( site ) &&
-					! isNotAtomicJetpack( site ) &&
-					! isP2Site( site ) &&
-					isAdmin;
-
-				if ( shouldOpenSitePreviewPane ) {
+				const canManageOptions = canCurrentUser( state, site.ID, 'manage_options' );
+				if ( isSitePreviewPaneEligible( site, canManageOptions ) ) {
 					sitePreviewPane.open( site, 'list_row_click' );
 					return;
 				}

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -5,9 +5,16 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo } from 'react';
 import { useQueryReaderTeams } from 'calypso/components/data/query-reader-teams';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import { navigate } from 'calypso/lib/navigate';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
+import {
+	isNotAtomicJetpack,
+	isP2Site,
+	isDisconnectedJetpackAndNotAtomic,
+} from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isA8cTeamMember } from 'calypso/state/teams/selectors';
 import { useActions } from './actions';
 import SiteField from './dataviews-fields/site-field';
@@ -15,7 +22,6 @@ import SiteIcon from './site-icon';
 import { SiteStats } from './sites-site-stats';
 import { SiteStatus } from './sites-site-status';
 import type { View } from '@wordpress/dataviews';
-
 import './style.scss';
 import './dataview-style.scss';
 
@@ -56,6 +62,7 @@ const DotcomSitesDataViews = ( {
 	sitePreviewPane,
 }: Props ) => {
 	const { __ } = useI18n();
+	const state = useSelector( ( state ) => state );
 	const userId = useSelector( getCurrentUserId );
 
 	// By default, DataViews is in an "uncontrolled" mode, meaning the current selection is handled internally.
@@ -70,16 +77,31 @@ const DotcomSitesDataViews = ( {
 			if ( dataViewsState.type !== 'list' ) {
 				return;
 			}
+
 			if ( selectedSiteIds.length === 0 ) {
 				return;
 			}
+
 			const site = sites.find( ( s ) => s.ID === Number( selectedSiteIds[ 0 ] ) );
 			if ( site && ! site.is_deleted ) {
-				sitePreviewPane.open( site, 'list_row_click' );
+				const isAdmin = canCurrentUser( state, site.ID, 'manage_options' );
+				const shouldOpenSitePreviewPane =
+					! isDisconnectedJetpackAndNotAtomic( site ) &&
+					! isNotAtomicJetpack( site ) &&
+					! isP2Site( site ) &&
+					isAdmin;
+
+				if ( shouldOpenSitePreviewPane ) {
+					sitePreviewPane.open( site, 'list_row_click' );
+					return;
+				}
+
+				navigate( site.options?.admin_url || '', true );
 			}
 		},
-		[ dataViewsState.type, sitePreviewPane, sites ]
+		[ dataViewsState.type, sitePreviewPane, sites, state ]
 	);
+
 	const getSelection = useCallback(
 		() => ( selectedItem ? [ selectedItem.ID.toString() ] : undefined ),
 		[ selectedItem ]

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -77,7 +77,6 @@ const DotcomSitesDataViews = ( {
 			if ( dataViewsState.type !== 'list' ) {
 				return;
 			}
-
 			if ( selectedSiteIds.length === 0 ) {
 				return;
 			}
@@ -96,7 +95,7 @@ const DotcomSitesDataViews = ( {
 					return;
 				}
 
-				navigate( site.options?.admin_url || '', true );
+				navigate( site.options?.admin_url || '' );
 			}
 		},
 		[ dataViewsState.type, sitePreviewPane, sites, state ]

--- a/client/sites/components/sites-dataviews/site-icon.tsx
+++ b/client/sites/components/sites-dataviews/site-icon.tsx
@@ -2,13 +2,8 @@ import { translate } from 'i18n-calypso';
 import * as React from 'react';
 import SiteFavicon from 'calypso/blocks/site-favicon';
 import { navigate } from 'calypso/lib/navigate';
-import { isP2Theme } from 'calypso/lib/site/utils';
 import { ThumbnailLink } from 'calypso/sites-dashboard/components/thumbnail-link';
-import {
-	isNotAtomicJetpack,
-	getMigrationStatus,
-	isDisconnectedJetpackAndNotAtomic,
-} from 'calypso/sites-dashboard/utils';
+import { getMigrationStatus, isSitePreviewPaneEligible } from 'calypso/sites-dashboard/utils';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { useSiteAdminInterfaceData } from 'calypso/state/sites/hooks';
@@ -29,22 +24,17 @@ export default function SiteIcon( {
 	disableClick?: boolean;
 } ) {
 	const { adminUrl } = useSiteAdminInterfaceData( site.ID );
-	const isP2Site = site.options?.theme_slug && isP2Theme( site.options?.theme_slug );
-	const isAdmin = useSelector( ( state ) => canCurrentUser( state, site.ID, 'manage_options' ) );
+	const canManageOptions = useSelector( ( state ) =>
+		canCurrentUser( state, site.ID, 'manage_options' )
+	);
 
 	const onClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
-
 		if ( site.is_deleted ) {
 			return;
 		}
 
-		if (
-			isAdmin &&
-			! isP2Site &&
-			! isNotAtomicJetpack( site ) &&
-			! isDisconnectedJetpackAndNotAtomic( site )
-		) {
+		if ( isSitePreviewPaneEligible( site, canManageOptions ) ) {
 			openSitePreviewPane && openSitePreviewPane( site, 'site_field' );
 		} else {
 			navigate( adminUrl );


### PR DESCRIPTION
## Proposed Changes

As reported in p1746124066015959-slack-C014TPFLP4Z, Jetpack-connect sites are not properly handled when click on from the collapsed site list view. The click should behave the same way as in the table view, which is redirecting users to the site wp-admin/

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a Jetpack-connect site (e.g. JN site with Jetpack connection).
* Head to /sites and select a WP.com site.
* In the collapsed site list view, click on the Jetpack-connect site.
* Ensure that you'll be redirected to the Jetpack-connect site wp-admin. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?