### PR TITLE
DS Docs: Handle build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ cached-requests.json
 
 # Monorepo output
 /apps/*/dist/
+/apps/*/build/
 /apps/*/types/
 /packages/*/dist/
 /build-tools/dist/

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -126,6 +126,7 @@ object CalypsoApps: BuildType({
 		apps/happy-blocks/release-files => happy-blocks.zip
 		apps/command-palette-wp-admin/dist => command-palette-wp-admin.zip
 		apps/help-center/dist => help-center.zip
+		apps/design-system-docs/build => design-system-docs.zip
 	""".trimIndent()
 
 	steps {


### PR DESCRIPTION
Follow-up to #103118

## Proposed Changes

This adds the build artifacts for `design-system-docs` to the gitignore, as well as add handling for it on CI.

## Why are these changes being made?

To complete the full steps required for adding a new app to the repo.

## Testing Instructions

- The build folder emitted by `yarn workspace @automattic/design-system-docs run build` should not be tracked by git.
- You can see a `design-system-docs` zip in the Artifacts page on TeamCity.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
