### PR TITLE
DS: Fix build output dir

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -126,7 +126,7 @@ object CalypsoApps: BuildType({
 		apps/happy-blocks/release-files => happy-blocks.zip
 		apps/command-palette-wp-admin/dist => command-palette-wp-admin.zip
 		apps/help-center/dist => help-center.zip
-		apps/design-system-docs/build => design-system-docs.zip
+		apps/design-system-docs/dist => design-system-docs.zip
 	""".trimIndent()
 
 	steps {

--- a/apps/design-system-docs/README.md
+++ b/apps/design-system-docs/README.md
@@ -26,4 +26,4 @@ This command starts a local development server and opens up a browser window. Mo
 $ yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `dist` directory and can be served using any static contents hosting service.

--- a/apps/design-system-docs/package.json
+++ b/apps/design-system-docs/package.json
@@ -14,7 +14,7 @@
 	"scripts": {
 		"docusaurus": "docusaurus",
 		"start": "docusaurus start -p 42987",
-		"build": "docusaurus build",
+		"build": "docusaurus build --out-dir dist",
 		"deploy": "docusaurus deploy",
 		"clear": "docusaurus clear",
 		"serve": "docusaurus serve -p 42987",

--- a/apps/design-system-docs/tsconfig.json
+++ b/apps/design-system-docs/tsconfig.json
@@ -4,5 +4,5 @@
 	"compilerOptions": {
 		"baseUrl": "."
 	},
-	"exclude": [ ".docusaurus", "build" ]
+	"exclude": [ ".docusaurus", "dist" ]
 }


### PR DESCRIPTION
## Proposed Changes

Change DS app output dir to `dist`

## Why are these changes being made?

Because our CI expects `dist` and not the default `build`.
