### PR TITLE
add tests for playground error component's behavior

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -46,7 +46,13 @@ export function PlaygroundIframe( {
 					setPlaygroundError( 'UNKNOWN_ERROR' );
 				}
 			} );
-	}, [ playgroundError ] );
+	}, [
+		playgroundClient,
+		playgroundError,
+		recommendedPHPVersion,
+		setPlaygroundClient,
+		setSearchParams,
+	] );
 
 	if ( playgroundError === 'PLAYGROUND_NOT_FOUND' ) {
 		return <PlaygroundError createNewPlayground={ createNewPlayground } />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -46,13 +46,8 @@ export function PlaygroundIframe( {
 					setPlaygroundError( 'UNKNOWN_ERROR' );
 				}
 			} );
-	}, [
-		playgroundClient,
-		playgroundError,
-		recommendedPHPVersion,
-		setPlaygroundClient,
-		setSearchParams,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ playgroundError ] );
 
 	if ( playgroundError === 'PLAYGROUND_NOT_FOUND' ) {
 		return <PlaygroundError createNewPlayground={ createNewPlayground } />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
@@ -3,7 +3,7 @@
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PlaygroundStep from '..';
 import { StepProps } from '../../../types';
@@ -12,6 +12,17 @@ import { renderStep, mockStepProps, RenderStepOptions } from '../../test/helpers
 // Be sure to mock this hook to return true so that the step is rendered.
 jest.mock( 'calypso/landing/stepper/hooks/use-is-playground-eligible', () => ( {
 	useIsPlaygroundEligible: () => true,
+} ) );
+
+// Mock the initializeWordPressPlayground function to cause an error
+jest.mock( '../lib/initialize-playground', () => ( {
+	initializeWordPressPlayground: () =>
+		Promise.reject( new Error( 'WordPress installation has failed.' ) ),
+} ) );
+
+// Mock the PlaygroundError component to simplify testing
+jest.mock( '../components/playground-error', () => ( {
+	PlaygroundError: () => <div data-testid="playground-error">Playground Error Component</div>,
 } ) );
 
 const renderPlaygroundStep = (
@@ -40,6 +51,17 @@ describe( 'Playground', () => {
 
 			await userEvent.click( getLaunchButton() );
 			expect( submit ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'PlaygroundIframe error handling', () => {
+		it( 'should render PlaygroundError when initialization fails', async () => {
+			renderPlaygroundStep();
+
+			// Verify the error component is displayed
+			await waitFor( () => {
+				expect( screen.getByTestId( 'playground-error' ) ).toBeVisible();
+			} );
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/index.tsx
@@ -3,11 +3,12 @@
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
 
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PlaygroundStep from '..';
 import { StepProps } from '../../../types';
 import { renderStep, mockStepProps, RenderStepOptions } from '../../test/helpers';
+import { initializeWordPressPlayground } from '../lib/initialize-playground';
 
 // Be sure to mock this hook to return true so that the step is rendered.
 jest.mock( 'calypso/landing/stepper/hooks/use-is-playground-eligible', () => ( {
@@ -15,10 +16,7 @@ jest.mock( 'calypso/landing/stepper/hooks/use-is-playground-eligible', () => ( {
 } ) );
 
 // Mock the initializeWordPressPlayground function to cause an error
-jest.mock( '../lib/initialize-playground', () => ( {
-	initializeWordPressPlayground: () =>
-		Promise.reject( new Error( 'WordPress installation has failed.' ) ),
-} ) );
+jest.mock( '../lib/initialize-playground' );
 
 // Mock the PlaygroundError component to simplify testing
 jest.mock( '../components/playground-error', () => ( {
@@ -37,9 +35,19 @@ const renderPlaygroundStep = (
 const getLaunchButton = () => screen.getByRole( 'button', { name: 'Launch on WordPress.com' } );
 
 describe( 'Playground', () => {
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
 	describe( 'step', () => {
-		it( 'should render the iframe and the launch button', () => {
-			const { container } = renderPlaygroundStep();
+		it( 'should render the iframe and the launch button', async () => {
+			let container;
+			initializeWordPressPlayground.mockReturnValue( Promise.resolve( {} ) );
+
+			await act( async () => {
+				const result = renderPlaygroundStep();
+				container = result.container;
+			} );
 
 			expect( getLaunchButton() ).toBeVisible();
 			expect( container.querySelector( 'iframe' ) ).toBeVisible();
@@ -47,7 +55,11 @@ describe( 'Playground', () => {
 
 		it( 'should change page when the user clicks the launch button', async () => {
 			const submit = jest.fn();
-			renderPlaygroundStep( { navigation: { submit } } );
+			initializeWordPressPlayground.mockReturnValue( Promise.resolve( {} ) );
+
+			await act( async () => {
+				renderPlaygroundStep( { navigation: { submit } } );
+			} );
 
 			await userEvent.click( getLaunchButton() );
 			expect( submit ).toHaveBeenCalled();
@@ -56,7 +68,11 @@ describe( 'Playground', () => {
 
 	describe( 'PlaygroundIframe error handling', () => {
 		it( 'should render PlaygroundError when initialization fails', async () => {
-			renderPlaygroundStep();
+			initializeWordPressPlayground.mockRejectedValue(
+				new Error( 'WordPress installation has failed.' )
+			);
+
+			await act( async () => renderPlaygroundStep() );
 
 			// Verify the error component is displayed
 			await waitFor( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/playground-error.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/playground-error.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - TODO: Fix TypeScript issues
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { PlaygroundError } from '../components/playground-error';
+
+// Mock the React Router hooks
+const mockSearchParams = {
+	get: jest.fn().mockReturnValue( 'invalid-id' ),
+};
+
+jest.mock( 'react-router-dom', () => ( {
+	useSearchParams: () => [ mockSearchParams ],
+} ) );
+
+// Mock the useEffect and setTimeout
+const originalSetTimeout = global.setTimeout;
+global.setTimeout = jest.fn().mockImplementation( ( cb ) => {
+	// Execute the callback immediately for testing purposes
+	return originalSetTimeout( cb, 0 );
+} );
+
+// Restore original setTimeout after tests
+afterAll( () => {
+	global.setTimeout = originalSetTimeout;
+} );
+
+describe( 'PlaygroundError', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should display error message with the invalid playground ID', () => {
+		const mockCreateNewPlayground = jest.fn();
+		render( <PlaygroundError createNewPlayground={ mockCreateNewPlayground } /> );
+
+		// Verify the error message is shown with the invalid ID
+		expect( screen.getByText( 'Playground Not Found' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( /The playground you are trying to access \(ID: invalid-id\)/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should display countdown message', () => {
+		const mockCreateNewPlayground = jest.fn();
+		render( <PlaygroundError createNewPlayground={ mockCreateNewPlayground } /> );
+
+		// Verify countdown message is displayed
+		expect( screen.getByText( /Creating new playground/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'should call createNewPlayground when countdown reaches zero', () => {
+		// Create a special version of setTimeout that triggers the callback immediately
+		const mockCreateNewPlayground = jest.fn();
+
+		// Mock the setState to immediately set countdown to 0
+		jest.spyOn( React, 'useState' ).mockImplementation( ( initialState ) => {
+			if ( initialState === 5 ) {
+				// When countdown is initialized, immediately return 0 to trigger the effect
+				return [ 0, jest.fn() ];
+			}
+			return [ initialState, jest.fn() ];
+		} );
+
+		render( <PlaygroundError createNewPlayground={ mockCreateNewPlayground } /> );
+
+		// The effect should have called createNewPlayground when countdown became 0
+		expect( mockCreateNewPlayground ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/DOTOBRD-116/add-new-tests-for-invalid-playground-id-page

## Proposed Changes

* Add tests

## Testing Instructions

`yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/playground`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
