### PR TITLE
Plugins: Replace Search input with SearchControl component

### DIFF
--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
-import { isDesktop } from '@automattic/viewport';
 import { SearchControl } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
@@ -24,6 +24,7 @@ const SearchBoxHeader = ( props ) => {
 		searchTerms,
 	} = props;
 
+	const isDesktop = useViewportMatch( 'large' );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const selectedSite = useSelector( getSelectedSite );
@@ -49,7 +50,7 @@ const SearchBoxHeader = ( props ) => {
 					__nextHasNoMarginBottom
 					value={ searchTerm }
 					className={ clsx( 'search-box-header__searchbox', {
-						'components-search-control--mobile': ! isDesktop(),
+						'components-search-control--mobile': ! isDesktop,
 					} ) }
 					placeholder={ translate( 'Try searching "%(searchTermSuggestion)s"', {
 						args: { searchTermSuggestion: useTermsSuggestions( searchTerms ) || 'ecommerce' },

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -1,7 +1,8 @@
 import page from '@automattic/calypso-router';
-import Search from '@automattic/search';
+import { isDesktop } from '@automattic/viewport';
+import { SearchControl } from '@wordpress/components';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import scrollTo from 'calypso/lib/scroll-to';
@@ -11,66 +12,6 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { useTermsSuggestions } from '../use-terms-suggestions';
 import './style.scss';
 
-const SearchBox = ( {
-	isMobile,
-	searchTerm,
-	searchBoxRef,
-	categoriesRef,
-	isSearching,
-	searchTerms,
-} ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite );
-	const { localizePath } = useLocalizedPlugins();
-
-	const searchTermSuggestion = useTermsSuggestions( searchTerms ) || 'ecommerce';
-
-	const pageToSearch = useCallback(
-		( search ) => {
-			page.show( localizePath( `/plugins/${ selectedSite?.slug || '' }` ) ); // Ensures location.href is on the main Plugins page before setQueryArgs uses it to construct the redirect.
-			setQueryArgs( '' !== search ? { s: search } : {} );
-
-			if ( search ) {
-				searchBoxRef.current.blur();
-				scrollTo( {
-					x: 0,
-					y:
-						categoriesRef.current?.getBoundingClientRect().y - // Get to the top of categories
-						categoriesRef.current?.getBoundingClientRect().height, // But don't show the categories
-					duration: 300,
-				} );
-			}
-		},
-		[ searchBoxRef, categoriesRef, selectedSite, localizePath ]
-	);
-
-	const recordSearchEvent = ( eventName ) =>
-		dispatch( recordGoogleEvent( 'PluginsBrowser', eventName ) );
-
-	return (
-		<div className="search-box-header__searchbox">
-			<Search
-				ref={ searchBoxRef }
-				pinned={ isMobile }
-				fitsContainer={ isMobile }
-				onSearch={ pageToSearch }
-				defaultValue={ searchTerm }
-				searchMode="on-enter"
-				placeholder={ translate( 'Try searching "%(searchTermSuggestion)s"', {
-					args: { searchTermSuggestion },
-				} ) }
-				delaySearch={ false }
-				recordEvent={ recordSearchEvent }
-				searching={ isSearching }
-				submitOnOpenIconClick
-				openIconSide="right"
-				displayOpenAndCloseIcons
-			/>
-		</div>
-	);
-};
-
 const SearchBoxHeader = ( props ) => {
 	const {
 		searchTerm,
@@ -78,20 +19,19 @@ const SearchBoxHeader = ( props ) => {
 		subtitle,
 		isSticky,
 		stickySearchBoxRef,
-		isSearching,
-		searchRef,
 		categoriesRef,
 		renderTitleInH1,
 		searchTerms,
 	} = props;
 
-	// Update the search box with the value from the url everytime it changes
-	// This allows the component to be refilled with a keyword
-	// when navigating back to a page via breadcrumb,
-	// and get empty when the user accesses a non-search page
-	useEffect( () => {
-		searchRef?.current?.setKeyword( searchTerm ?? '' );
-	}, [ searchRef, searchTerm ] );
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const selectedSite = useSelector( getSelectedSite );
+	const { localizePath } = useLocalizedPlugins();
+
+	const recordSearchEvent = ( eventName ) => {
+		dispatch( recordGoogleEvent( 'PluginsBrowser', eventName ) );
+	};
 
 	const classNames = [ 'search-box-header' ];
 
@@ -100,17 +40,48 @@ const SearchBoxHeader = ( props ) => {
 	}
 
 	return (
-		<div className={ classNames.join( ' ' ) }>
+		<div className={ clsx( classNames ) }>
 			{ renderTitleInH1 && <h1 className="search-box-header__header">{ title }</h1> }
 			{ ! renderTitleInH1 && <div className="search-box-header__header">{ title }</div> }
 			{ subtitle && <p className="search-box-header__subtitle">{ subtitle }</p> }
 			<div className="search-box-header__search">
-				<SearchBox
-					searchTerm={ searchTerm }
-					searchBoxRef={ searchRef }
-					isSearching={ isSearching }
-					categoriesRef={ categoriesRef }
-					searchTerms={ searchTerms }
+				<SearchControl
+					__nextHasNoMarginBottom
+					value={ searchTerm }
+					className={ clsx( 'search-box-header__searchbox', {
+						'components-search-control--mobile': ! isDesktop(),
+					} ) }
+					placeholder={ translate( 'Try searching "%(searchTermSuggestion)s"', {
+						args: { searchTermSuggestion: useTermsSuggestions( searchTerms ) || 'ecommerce' },
+						textOnly: true,
+					} ) }
+					onChange={ ( newValue ) => {
+						// Only update URL on clear
+						if ( newValue === '' ) {
+							recordSearchEvent( 'SearchCleared' );
+							page.show( localizePath( `/plugins/${ selectedSite?.slug || '' }` ) );
+							setQueryArgs( {} );
+						}
+					} }
+					onKeyDown={ ( event ) => {
+						if ( event.key === 'Enter' && event.target ) {
+							event.preventDefault();
+							const value = event.target.value;
+							recordSearchEvent( 'SearchInitiated' );
+							page.show( localizePath( `/plugins/${ selectedSite?.slug || '' }` ) );
+							setQueryArgs( value ? { s: value } : {} );
+
+							if ( value && categoriesRef?.current ) {
+								scrollTo( {
+									x: 0,
+									y:
+										categoriesRef.current.getBoundingClientRect().y - // Get to the top of categories
+										categoriesRef.current.getBoundingClientRect().height, // But don't show the categories
+									duration: 300,
+								} );
+							}
+						}
+					} }
 				/>
 			</div>
 			<div className="search-box-header__sticky-ref" ref={ stickySearchBoxRef }></div>

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -14,6 +14,16 @@
 		width: 100%;
 		justify-content: center;
 
+		.components-search-control {
+			.components-input-base {
+				height: 55px;
+			}
+
+			.components-input-control__container {
+				background-color: var(--studio-white);
+			}
+		}
+
 		.search-box-header__searchbox {
 			max-width: 504px;
 			width: 100%;

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -10,64 +10,12 @@ $search-categories-padding-top: 16px;
 	padding-inline: 0;
 	padding-top: $search-categories-padding-top;
 
-	.search-categories__searchbox {
-		max-width: 265px;
+	.components-search-control {
 		width: 100%;
-		height: 36px;
-		z-index: 0;
-		margin: 0;
-		border-radius: 4px;
+		max-width: 265px;
 
-		&.search-categories__searchbox--mobile {
-			max-width: none;
-		}
-
-		box-shadow: 0 0 0 1px var(--studio-gray-10);
-
-		.search-component__icon-navigation:focus {
-			box-shadow: none;
-		}
-
-		.search-component__open-icon,
-		.search-component__close-icon {
-			color: var(--studio-gray-30);
-
-			&:hover {
-				color: var(--studio-gray-60);
-			}
-		}
-
-		.search-component__icon-navigation {
-			margin-right: 2px;
-		}
-
-		.search-component__icon-navigation-separator {
-			user-select: none;
-			color: var(--studio-gray-5);
-			margin-bottom: 3px;
-		}
-
-		&.is-searching {
-			.components-spinner {
-				margin: 5px -9px 5px 0;
-				width: 50px;
-			}
-		}
-
-		.search-component__input-fade {
-			font-size: $font-body-small !important;
-			padding-left: 8px !important;
-		}
-
-		.search-component__open-icon {
-			height: 24px;
-			margin-right: -9px;
-		}
-
-		.search-component__close-icon {
-			height: 20px;
-			margin-left: -9px;
-			margin-right: -10px;
+		&.components-search-control--mobile {
+			width: none;
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -24,8 +24,7 @@ const selectors = {
 	annualPricing: '.plugins-browser-item__period:text("per year")',
 
 	// Search
-	searchIcon: '.search-component__open-icon',
-	searchInput: 'input.search-component__input',
+	searchInput: '.components-search-control .components-input-control__input',
 	searchResult: ( text: string ) => `.plugins-browser-item__title:text("${ text }")`,
 	// eslint-disable-next-line no-useless-escape
 	searchResultTitle: ( text: string ) => `:text('plugins for "${ text }"')`,
@@ -248,11 +247,6 @@ export class PluginsPage {
 	 * @param {string} query String to search for.
 	 */
 	async search( query: string ): Promise< void > {
-		// On mobile viewports the Loupe icon must be
-		// clicked to activate the search field.
-		const searchInputIconLocator = this.page.locator( selectors.searchIcon );
-		await searchInputIconLocator.click();
-
 		await this.page.fill( selectors.searchInput, query );
 		await this.page.press( selectors.searchInput, 'Enter' );
 		await this.page.waitForSelector( selectors.searchResultTitle( query ) );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/100450

## Proposed Changes

* Replace Search component with SearchControl

## Why are these changes being made?

https://github.com/Automattic/wp-calypso/issues/100450

## Testing Instructions

* Go to `/plugins`
* Search by term and check if it acts the same as before (compare with the production version)

**Before:**
<img width="1199" alt="Screenshot 2025-05-06 at 17 04 10" src="https://github.com/user-attachments/assets/6389615d-3071-4328-a8d9-6392b3d4b257" />

**After:**
<img width="1201" alt="Screenshot 2025-05-06 at 17 03 59" src="https://github.com/user-attachments/assets/40d1dca2-8a09-4323-8bda-202d2141380c" />

* Log out
* Go to `/plugins`
* Search by term and check if it acts the same as before (compare with the production version)

**Before:**
<img width="1367" alt="Screenshot 2025-05-06 at 17 05 45" src="https://github.com/user-attachments/assets/0ac596b4-2707-4348-9d3d-9b0873540f9e" />

**After:**
<img width="1368" alt="Screenshot 2025-05-06 at 17 05 56" src="https://github.com/user-attachments/assets/8c1561f8-4a36-491c-9e50-df737ad8d5bf" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
