### PR TITLE
Stepper: Remove hardcoded step types

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
+++ b/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
@@ -1,5 +1,4 @@
-import type { DomainStepResult, PlansStepResult } from './types';
-import type { SiteDetails } from '@automattic/data-stores';
+import type { StepperStepsUnionedType } from '../types';
 import type { createSite } from 'calypso/landing/stepper/hooks/use-create-site-hook';
 
 type CreatedSite = Awaited< ReturnType< typeof createSite > >;
@@ -7,27 +6,11 @@ type CreatedSite = Awaited< ReturnType< typeof createSite > >;
 /**
  * The manifest of the state of all available state fields in Stepper. Feel free to type and add all the fields you need.
  */
-export type FlowStateManifest = Partial< {
-	domains: DomainStepResult;
+export type StepperMiscellaneousFields = Partial< {
 	flow: {
 		entryPoint: string;
 	};
-	plans: PlansStepResult;
-	newsletterSetup: {
-		siteTitle: string;
-		tagline: string;
-	};
-	newsletterGoals: {
-		goals: string[];
-	};
 	site: CreatedSite;
-	siteId: SiteDetails[ 'ID' ];
-	siteSlug: SiteDetails[ 'slug' ];
-	processing: {
-		siteId: number;
-		siteSlug: string;
-		domainItem?: DomainStepResult[ 'domainItem' ];
-		goToCheckout?: true;
-		goToHome?: true;
-	};
 } >;
+
+export type FlowStateManifest = StepperMiscellaneousFields & StepperStepsUnionedType;

--- a/client/landing/stepper/declarative-flow/internals/state-manager/store.ts
+++ b/client/landing/stepper/declarative-flow/internals/state-manager/store.ts
@@ -29,18 +29,18 @@ export function useFlowState() {
 	const flow = getFlowFromURL() || 'flow';
 	const session = getSessionId();
 
-	const { data: state = {} } = useQuery< FlowStateManifest >( {
+	const { data: state } = useQuery< FlowStateManifest >( {
 		queryKey: [ PREFIX, flow, session, VERSION ],
 		...PERSISTENCE_CONFIG,
 	} );
 
 	function get< T extends keyof FlowStateManifest >( key: T ) {
-		return state[ key ];
+		return state?.[ key ];
 	}
 
 	function set< T extends keyof FlowStateManifest >(
 		key: T,
-		value: unknown
+		value: FlowStateManifest[ T ]
 	): FlowStateManifest[ T ] {
 		queryClient.setQueryData( [ PREFIX, flow, session, VERSION ], {
 			...state,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -46,8 +46,10 @@ const DomainsStep: Step< {
 				domainName?: string;
 				productSlug?: string;
 				domainItem?: DomainSuggestion;
+				deferDomainSelection?: true;
+				// Fake type just to make the this step types isomorphic to unified-domains.
+				domainCart?: undefined;
 		  }
-		| { deferDomainSelection: true }
 		| undefined;
 } > = function DomainsStep( { navigation, flow } ) {
 	const { setHideFreePlan, setDomainCartItem, setDomain } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -11,6 +11,8 @@ const plans: Step< {
 	submits: {
 		plan: MinimalRequestCartProduct | null;
 		goToCheckout: boolean;
+		// Fake type just to make the this step types isomorphic to unified-plans.
+		cartItems?: undefined;
 	};
 } > = function Plans( { navigation, flow } ) {
 	const { goBack, submit } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -383,3 +383,18 @@ export interface FailureInfo {
 	code: number | string;
 	error: string;
 }
+
+/**
+ * Below are types used by State management
+ */
+type GroupBySlug< U extends StepperStep > = {
+	[ S in U[ 'slug' ] ]: U extends { slug: S }
+		? Parameters<
+				Parameters<
+					Awaited< ReturnType< U[ 'asyncComponent' ] > >[ 'default' ]
+				>[ 0 ][ 'navigation' ][ 'submit' ]
+		  >[ 0 ]
+		: never;
+};
+
+export type StepperStepsUnionedType = GroupBySlug< AsyncStepperStep >;

--- a/client/landing/stepper/hooks/use-create-site-hook.ts
+++ b/client/landing/stepper/hooks/use-create-site-hook.ts
@@ -189,7 +189,7 @@ export const useCreateSite = () => {
 				username,
 				domainCartItems: mergedDomainCartItems,
 				partnerBundle: null,
-				domainItem: domains?.domainItem,
+				domainItem: domains?.domainItem as DomainSuggestion | undefined,
 				siteIntent,
 				planCartItems,
 			} );


### PR DESCRIPTION
Fixes DOTCOM-12988

## Proposed Changes

Instead of hard-coding arbitrary step types in a manifest, this PR uses the type information taken from the steps themselves to infer the `useFlowState` types.

## Why are these changes being made?
To make the types a function of the real data flow, not separate from it. This means types will match the values in runtime and will remove the need for maintaining a manifest.

## Testing Instructions
1. Green TS.
2. Go to client/landing/stepper/declarative-flow/flows/00-example-flow/example.ts file, change one of the `set` calls and pass incorrect data instead of `providedDepenedancies`. TS should complain.


