### PR TITLE
Account: Clarifying the primary site dropdown

### DIFF
--- a/client/me/account/hooks/use-get-default-interface.ts
+++ b/client/me/account/hooks/use-get-default-interface.ts
@@ -1,0 +1,32 @@
+import { DefaultInterface } from 'calypso/me/account/types';
+import { useSelector } from 'calypso/state';
+import {
+	getPreference,
+	isFetchingPreferences,
+	isSavingPreference,
+} from 'calypso/state/preferences/selectors';
+
+export default function useGetDefaultInterface() {
+	const isReady = useSelector(
+		( state ) => ! isSavingPreference( state ) && ! isFetchingPreferences( state )
+	);
+
+	const { sitesAsLandingPage, readerAsLandingPage } = useSelector( ( state ) => ( {
+		sitesAsLandingPage: getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage,
+		readerAsLandingPage: getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage,
+	} ) );
+
+	if ( ! isReady ) {
+		return null;
+	}
+
+	if ( readerAsLandingPage ) {
+		return DefaultInterface.READER;
+	}
+
+	if ( sitesAsLandingPage ) {
+		return DefaultInterface.SITES;
+	}
+
+	return DefaultInterface.PRIMARY_SITE;
+}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -32,6 +32,8 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { clearStore } from 'calypso/lib/user/store';
 import wpcom from 'calypso/lib/wp';
 import AccountEmailField from 'calypso/me/account/account-email-field';
+import { DefaultInterface } from 'calypso/me/account/types';
+import { withDefaultInterface } from 'calypso/me/account/with-default-interface';
 import EmailVerificationBanner from 'calypso/me/email-verification-banner';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -656,10 +658,15 @@ class Account extends Component {
 					userSettings={ this.props.userSettings }
 				/>
 
-				<FormFieldset>
-					<FormLabel htmlFor="primary_site_ID">{ translate( 'Primary site' ) }</FormLabel>
-					{ this.renderPrimarySite() }
-				</FormFieldset>
+				{ this.props.defaultInterface === DefaultInterface.PRIMARY_SITE && (
+					<FormFieldset>
+						<FormLabel htmlFor="primary_site_ID">{ translate( 'Primary site' ) }</FormLabel>
+						<FormSettingExplanation>
+							{ translate( "Select the site whose dashboard you'll see first when logging in." ) }
+						</FormSettingExplanation>
+						{ this.renderPrimarySite() }
+					</FormFieldset>
+				) }
 
 				<FormButton
 					isSubmitting={ this.isSubmittingForm( ACCOUNT_FORM_NAME ) }
@@ -972,7 +979,7 @@ class Account extends Component {
 							<FormLabel id="account__default_landing_page">
 								{ translate( 'Default landing page' ) }
 							</FormLabel>
-							<ToggleLandingPageSettings />
+							<ToggleLandingPageSettings defaultInterface={ this.props.defaultInterface } />
 							<FormSettingExplanation>
 								{ fixMe( {
 									text: "Select what you'll see by default when visiting WordPress.com",
@@ -1010,6 +1017,7 @@ export default compose(
 	withLocalizedMoment,
 	withGeoLocation,
 	protectForm,
+	withDefaultInterface,
 	connect(
 		( state ) => ( {
 			canDisplayCommunityTranslator: canDisplayCommunityTranslator( state ),

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -662,7 +662,7 @@ class Account extends Component {
 					<FormFieldset>
 						<FormLabel htmlFor="primary_site_ID">{ translate( 'Primary site' ) }</FormLabel>
 						<FormSettingExplanation>
-							{ translate( "Select the site whose dashboard you'll see first when logging in." ) }
+							{ translate( "Choose the default site dashboard you'll see at login." ) }
 						</FormSettingExplanation>
 						{ this.renderPrimarySite() }
 					</FormFieldset>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -661,10 +661,10 @@ class Account extends Component {
 				{ this.props.defaultInterface === DefaultInterface.PRIMARY_SITE && (
 					<FormFieldset>
 						<FormLabel htmlFor="primary_site_ID">{ translate( 'Primary site' ) }</FormLabel>
+						{ this.renderPrimarySite() }
 						<FormSettingExplanation>
 							{ translate( "Choose the default site dashboard you'll see at login." ) }
 						</FormSettingExplanation>
-						{ this.renderPrimarySite() }
 					</FormFieldset>
 				) }
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -32,7 +32,6 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import { clearStore } from 'calypso/lib/user/store';
 import wpcom from 'calypso/lib/wp';
 import AccountEmailField from 'calypso/me/account/account-email-field';
-import { DefaultInterface } from 'calypso/me/account/types';
 import { withDefaultInterface } from 'calypso/me/account/with-default-interface';
 import EmailVerificationBanner from 'calypso/me/email-verification-banner';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -658,15 +657,13 @@ class Account extends Component {
 					userSettings={ this.props.userSettings }
 				/>
 
-				{ this.props.defaultInterface === DefaultInterface.PRIMARY_SITE && (
-					<FormFieldset>
-						<FormLabel htmlFor="primary_site_ID">{ translate( 'Primary site' ) }</FormLabel>
-						{ this.renderPrimarySite() }
-						<FormSettingExplanation>
-							{ translate( "Choose the default site dashboard you'll see at login." ) }
-						</FormSettingExplanation>
-					</FormFieldset>
-				) }
+				<FormFieldset>
+					<FormLabel htmlFor="primary_site_ID">{ translate( 'Primary site' ) }</FormLabel>
+					{ this.renderPrimarySite() }
+					<FormSettingExplanation>
+						{ translate( "Choose the default site dashboard you'll see at login." ) }
+					</FormSettingExplanation>
+				</FormFieldset>
 
 				<FormButton
 					isSubmitting={ this.isSubmittingForm( ACCOUNT_FORM_NAME ) }

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -97,3 +97,7 @@ main.account {
 		}
 	}
 }
+
+.sites-dropdown {
+	padding-top: 15px;
+}

--- a/client/me/account/types.ts
+++ b/client/me/account/types.ts
@@ -1,0 +1,5 @@
+export enum DefaultInterface {
+	PRIMARY_SITE = 'primary-site',
+	READER = 'reader',
+	SITES = 'my-sites',
+}

--- a/client/me/account/with-default-interface.tsx
+++ b/client/me/account/with-default-interface.tsx
@@ -1,0 +1,10 @@
+import { createHigherOrderComponent } from '@wordpress/compose';
+import useGetDefaultInterface from 'calypso/me/account/hooks/use-get-default-interface';
+
+export const withDefaultInterface = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const defaultInterface = useGetDefaultInterface();
+		return <Wrapped { ...props } defaultInterface={ defaultInterface } />;
+	},
+	'withGeoLocation'
+);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/issues/100330
- DOTCOM-12871

## Proposed Changes

* Added a descriptive message about what the primary site dropdown does.
* We now hide the dropdown if having a primary site doesn't not apply to the selected default interface.

![Screenshot 2025-05-07 at 13 44 36](https://github.com/user-attachments/assets/b7ca5f22-fdf7-4167-83f8-e26cbac7d20e)


https://github.com/user-attachments/assets/50a793dd-1dd5-4c4c-9272-fa3d281e037b



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* It isn't clear what the primary site selector does or is needed for.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to: {container}/me/account
* The Primary site dropdown should have a descriptive message.
* When toggling the default interface options, the primary site dropdown must be hidden if it doesn't apply.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
