### PR TITLE
Add filter by date

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -55,6 +55,7 @@ export { default as PlanPrice } from './plan-price';
 export { default as ExternalLink } from './external-link';
 export * from './theme-type-badge';
 export { default as FlowQuestion } from './flow-question';
+export { Calendar } from './calendar';
 
 // Logos
 export { JetpackLogo } from './logos/jetpack-logo';

--- a/packages/dataviews/src/components/dataviews-filters/filter-summary.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter-summary.tsx
@@ -241,6 +241,21 @@ export default function FilterSummary( {
 		}
 		return filterInView?.value?.includes( element.value );
 	} );
+	if (
+		activeElements.length === 0 &&
+		filter.type === 'datetime' &&
+		filterInView?.value !== undefined
+	) {
+		// The date widget enables users to select a day from the calendar.
+		// They are not defined in the field's elements,
+		// and so won't be picked up in the check before.
+		activeElements.push( {
+			value: filterInView.value,
+			label: filterInView.value,
+		} );
+	}
+
+	console.log( activeElements, filter, filterInView );
 	const isPrimary = filter.isPrimary;
 	const hasValues = filterInView?.value !== undefined;
 	const canResetOrRemove = ! isPrimary || hasValues;

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -41,6 +41,7 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 			filters.push( {
 				field: field.id,
 				name: field.label,
+				type: field.type,
 				elements: field.elements,
 				singleSelection: operators.some( ( op ) =>
 					[ OPERATOR_IS, OPERATOR_IS_NOT ].includes( op )

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -4,6 +4,7 @@
 // eslint-disable-next-line no-restricted-imports
 import * as Ariakit from '@ariakit/react';
 import removeAccents from 'remove-accents';
+import { Calendar } from '@automattic/components';
 
 /**
  * WordPress dependencies
@@ -329,96 +330,118 @@ function DateWidget( { view, filter, onChangeView }: SearchWidgetProps ) {
 		( f ) => f.field === filter.field
 	);
 	const currentValue = getCurrentValue( filter, currentFilter );
+	const getNewFilters = ( value: any ) => {
+		// TODO: need to convert the preset into a datetime.
+		const newFilters = currentFilter
+			? [
+					...( view.filters ?? [] ).map( ( _filter ) => {
+						if ( _filter.field === filter.field ) {
+							return {
+								..._filter,
+								operator:
+									currentFilter.operator ||
+									filter.operators[ 0 ],
+								value: getNewValue(
+									filter,
+									currentFilter,
+									value
+								),
+							};
+						}
+						return _filter;
+					} ),
+			  ]
+			: [
+					...( view.filters ?? [] ),
+					{
+						field: filter.field,
+						operator: filter.operators[ 0 ],
+						value: getNewValue( filter, currentFilter, value ),
+					},
+			  ];
+
+		return newFilters;
+	};
+
 	return (
 		<div
 			className="dataviews-filters__datetime-widget"
 			style={ {
 				display: 'flex',
-				flexWrap: 'wrap',
+				flexDirection: 'column',
 				gap: '8px',
 				marginBottom: '8px',
 			} }
 		>
-			{ filter.elements.map( ( element, index ) => {
-				let isActive = false;
-				if (
-					filter.singleSelection &&
-					currentValue === element.value
-				) {
-					isActive = true;
-				} else if (
-					! filter.singleSelection &&
-					currentValue.includes( element.value )
-				) {
-					isActive = true;
-				}
-				return (
-					<button
-						key={ index }
-						style={ {
-							backgroundColor: isActive
-								? 'var(--wp-admin-theme-color)'
-								: '#f0f0f0',
-							color: isActive ? 'white' : 'black',
-							border: '1px solid #ddd',
-							borderRadius: '16px',
-							padding: '6px 12px',
-							fontSize: '14px',
-							cursor: 'pointer',
-							transition: 'background-color 0.2s',
-							boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
-						} }
-						onClick={ () => {
-							// TODO: need to convert the preset into a datetime.
-							const newFilters = currentFilter
-								? [
-										...( view.filters ?? [] ).map(
-											( _filter ) => {
-												if (
-													_filter.field ===
-													filter.field
-												) {
-													return {
-														..._filter,
-														operator:
-															currentFilter.operator ||
-															filter
-																.operators[ 0 ],
-														value: getNewValue(
-															filter,
-															currentFilter,
-															element.value
-														),
-													};
-												}
-												return _filter;
-											}
-										),
-								  ]
-								: [
-										...( view.filters ?? [] ),
-										{
-											field: filter.field,
-											operator: filter.operators[ 0 ],
-											value: getNewValue(
-												filter,
-												currentFilter,
-												element.value
-											),
-										},
-								  ];
-							const newView = {
-								...view,
-								page: 1,
-								filters: newFilters,
-							};
-							onChangeView( newView );
-						} }
-					>
-						{ element.label }
-					</button>
-				);
-			} ) }
+			<div
+				style={ {
+					display: 'flex',
+					flexWrap: 'wrap',
+					gap: '8px',
+				} }
+			>
+				{ filter.elements.map( ( element, index ) => {
+					let isActive = false;
+					if (
+						filter.singleSelection &&
+						currentValue === element.value
+					) {
+						isActive = true;
+					} else if (
+						! filter.singleSelection &&
+						currentValue.includes( element.value )
+					) {
+						isActive = true;
+					}
+					return (
+						<button
+							key={ index }
+							style={ {
+								backgroundColor: isActive
+									? 'var(--wp-admin-theme-color)'
+									: '#f0f0f0',
+								color: isActive ? 'white' : 'black',
+								border: '1px solid #ddd',
+								borderRadius: '16px',
+								padding: '6px 12px',
+								fontSize: '14px',
+								cursor: 'pointer',
+								transition: 'background-color 0.2s',
+								boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
+							} }
+							onClick={ () => {
+								const newView = {
+									...view,
+									page: 1,
+									filters: getNewFilters( element.value ),
+								};
+								onChangeView( newView );
+							} }
+						>
+							{ element.label }
+						</button>
+					);
+				} ) }
+			</div>
+			<div
+				style={ {
+					width: '100%',
+					maxWidth: '100%',
+					overflow: 'hidden',
+				} }
+			>
+				<Calendar
+					currentDate={ new Date() }
+					onChange={ ( newDate: string ) => {
+						const newView = {
+							...view,
+							page: 1,
+							filters: getNewFilters( newDate ),
+						};
+						onChangeView( newView );
+					} }
+				/>
+			</div>
 		</div>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -11,7 +11,13 @@ import removeAccents from 'remove-accents';
 import { useInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo, useDeferredValue } from '@wordpress/element';
-import { VisuallyHidden, Icon, Composite } from '@wordpress/components';
+import {
+	VisuallyHidden,
+	Icon,
+	Composite,
+	__experimentalGrid as Grid,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { search, check } from '@wordpress/icons';
 import { SVG, Circle } from '@wordpress/primitives';
 
@@ -318,7 +324,110 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 	);
 }
 
+function DateWidget( { view, filter, onChangeView }: SearchWidgetProps ) {
+	const currentFilter = view.filters?.find(
+		( f ) => f.field === filter.field
+	);
+	const currentValue = getCurrentValue( filter, currentFilter );
+	return (
+		<div
+			className="dataviews-filters__datetime-widget"
+			style={ {
+				display: 'flex',
+				flexWrap: 'wrap',
+				gap: '8px',
+				marginBottom: '8px',
+			} }
+		>
+			{ filter.elements.map( ( element, index ) => {
+				let isActive = false;
+				if (
+					filter.singleSelection &&
+					currentValue === element.value
+				) {
+					isActive = true;
+				} else if (
+					! filter.singleSelection &&
+					currentValue.includes( element.value )
+				) {
+					isActive = true;
+				}
+				return (
+					<button
+						key={ index }
+						style={ {
+							backgroundColor: isActive
+								? 'var(--wp-admin-theme-color)'
+								: '#f0f0f0',
+							color: isActive ? 'white' : 'black',
+							border: '1px solid #ddd',
+							borderRadius: '16px',
+							padding: '6px 12px',
+							fontSize: '14px',
+							cursor: 'pointer',
+							transition: 'background-color 0.2s',
+							boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
+						} }
+						onClick={ () => {
+							// TODO: need to convert the preset into a datetime.
+							const newFilters = currentFilter
+								? [
+										...( view.filters ?? [] ).map(
+											( _filter ) => {
+												if (
+													_filter.field ===
+													filter.field
+												) {
+													return {
+														..._filter,
+														operator:
+															currentFilter.operator ||
+															filter
+																.operators[ 0 ],
+														value: getNewValue(
+															filter,
+															currentFilter,
+															element.value
+														),
+													};
+												}
+												return _filter;
+											}
+										),
+								  ]
+								: [
+										...( view.filters ?? [] ),
+										{
+											field: filter.field,
+											operator: filter.operators[ 0 ],
+											value: getNewValue(
+												filter,
+												currentFilter,
+												element.value
+											),
+										},
+								  ];
+							const newView = {
+								...view,
+								page: 1,
+								filters: newFilters,
+							};
+							onChangeView( newView );
+						} }
+					>
+						{ element.label }
+					</button>
+				);
+			} ) }
+		</div>
+	);
+}
+
 export default function SearchWidget( props: SearchWidgetProps ) {
+	if ( props.filter.type === 'datetime' ) {
+		return <DateWidget { ...props } />;
+	}
+
 	const Widget = props.filter.elements.length > 10 ? ComboboxList : ListBox;
 	return <Widget { ...props } />;
 }

--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -36,7 +36,9 @@
 .dataviews-filters__summary-operators-container {
 	padding: $grid-unit-10 $grid-unit-10 0;
 
-	&:has(+ .dataviews-filters__search-widget-listbox) {
+	&:has(+ .dataviews-filters__search-widget-listbox),
+	&:has(+ .dataviews-filters__datetime-widget)
+	{
 		border-bottom: 1px solid $gray-200;
 		padding-bottom: $grid-unit-10;
 	}
@@ -159,7 +161,8 @@
 	}
 }
 
-.dataviews-filters__search-widget-listbox {
+.dataviews-filters__search-widget-listbox,
+.dataviews-filters__datetime-widget {
 	padding: $grid-unit-05;
 	overflow: auto;
 }

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -644,6 +644,17 @@ export const fields: Field< SpaceObject >[] = [
 		id: 'date',
 		label: 'Date',
 		type: 'datetime',
+		elements: [
+			{ value: 'today', label: 'Today' },
+			{ value: 'past-week', label: 'Past week' },
+			{ value: 'past-month', label: 'Past month' },
+		],
+		filterBy: {
+			// TODO:
+			// - define before/after operators
+			// - filters for datetime types should be single value by default (is, isNot)?
+			operators: [ 'is', 'isNot' ],
+		},
 	},
 	{
 		label: 'Type',

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -650,9 +650,6 @@ export const fields: Field< SpaceObject >[] = [
 			{ value: 'past-month', label: 'Past month' },
 		],
 		filterBy: {
-			// TODO:
-			// - define before/after operators
-			// - filters for datetime types should be single value by default (is, isNot)?
 			operators: [ 'is', 'isNot' ],
 		},
 	},

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -227,6 +227,11 @@ export interface NormalizedFilter {
 	name: string;
 
 	/**
+	 * The field type.
+	 */
+	type?: FieldType;
+
+	/**
 	 * The list of options to pick from when using the field as a filter.
 	 */
 	elements: Option[];

--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -13,6 +13,15 @@ import type { NormalizedField } from './types';
 export function sanitizeOperators< Item >( field: NormalizedField< Item > ) {
 	let operators = field.filterBy?.operators;
 
+	// TODO: explore moving this logic to the field type.
+	if ( field.type === 'datetime' ) {
+		return (
+			operators?.filter( ( operator ) =>
+				[ OPERATOR_IS, OPERATOR_IS_NOT ].includes( operator )
+			) || []
+		);
+	}
+
 	// Assign default values.
 	if ( ! operators || ! Array.isArray( operators ) ) {
 		operators = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];


### PR DESCRIPTION
DOTCOM-10618

Related: new calendar component at https://github.com/Automattic/wp-calypso/pull/102989

## What

This is an early exploration to add a datetime filter.

https://github.com/user-attachments/assets/c2bfafa3-6bc8-485f-9843-47f1543a5e7d

## Why

It's been one of the most requested features and there are some projects in production that would have used it, should it exist (e.g., hosting logs).

## TODO

- Presets:
  - transform them to dates.
  - allow date filters that don't define presets.
  - auto-select "custom" preset when the user picks a day via the calendar
- Calendar
  - Test https://github.com/Automattic/wp-calypso/pull/102989

## Follow-ups

- Date ranges and before operators. This PR is focused on getting the basics going.
 
## Testing Instructions

TBD