### PR TITLE
Hosting Dashboard v2: sites: view state in URL

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -236,7 +236,7 @@ export default function Sites() {
 							if ( view.type === 'list' ) {
 								return;
 							}
-							const _defaultView = { ...defaultView, ...( DEFAULT_LAYOUTS[ view.type ] ?? {} ) };
+							const _defaultView = { ...defaultView, ...DEFAULT_LAYOUTS[ view.type ] };
 							navigate( {
 								search: Object.fromEntries(
 									Object.entries( view ).filter(

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -190,12 +190,14 @@ export default function Sites() {
 				: DEFAULT_VIEW,
 		[ hasA8CSites ]
 	);
-	const search: Partial< ViewTable | ViewGrid > = sitesRoute.useSearch();
+	const search: Partial< ViewTable | ViewGrid > | undefined = sitesRoute.useSearch().view;
 	const view = useMemo(
 		() => ( {
 			...defaultView,
-			...DEFAULT_LAYOUTS[ search.type ?? DEFAULT_VIEW.type ],
-			...Object.fromEntries( Object.entries( search ).filter( ( [ , v ] ) => v !== undefined ) ),
+			...DEFAULT_LAYOUTS[ search?.type ?? DEFAULT_VIEW.type ],
+			...( search
+				? Object.fromEntries( Object.entries( search ).filter( ( [ , v ] ) => v !== undefined ) )
+				: {} ),
 		} ),
 		[ defaultView, search ]
 	);
@@ -238,11 +240,13 @@ export default function Sites() {
 							}
 							const _defaultView = { ...defaultView, ...DEFAULT_LAYOUTS[ view.type ] };
 							navigate( {
-								search: Object.fromEntries(
-									Object.entries( view ).filter( ( [ key, value ] ) => {
-										return value !== _defaultView[ key as keyof typeof _defaultView ];
-									} )
-								),
+								search: {
+									view: Object.fromEntries(
+										Object.entries( view ).filter( ( [ key, value ] ) => {
+											return value !== _defaultView[ key as keyof typeof _defaultView ];
+										} )
+									),
+								},
 							} );
 						} }
 						onClickItem={ onClickItem }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -5,15 +5,16 @@ import { Button, ExternalLink } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { sitesQuery } from '../app/queries';
+import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
 import PageLayout from '../components/page-layout';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { Site } from '../data/types';
-import type { View, Operator } from '@automattic/dataviews';
+import type { View, Operator, ViewTable, ViewGrid } from '@automattic/dataviews';
 
 const actions = [
 	{
@@ -166,25 +167,37 @@ const DEFAULT_VIEW: View = {
 	page: 1,
 	perPage: 10,
 	sort: { field: 'name', direction: 'asc' },
+	search: '',
 };
 
 export default function Sites() {
-	const navigate = useNavigate();
+	const navigate = useNavigate( { from: sitesRoute.fullPath } );
 	const sites = useQuery( sitesQuery() ).data;
 	const hasA8CSites = sites?.some( ( site ) => site.is_a8c );
-	const [ view, setView ] = useState< View >(
-		hasA8CSites
-			? {
-					...DEFAULT_VIEW,
-					filters: [
-						{
-							field: 'is_a8c',
-							operator: 'is',
-							value: false,
-						},
-					],
-			  }
-			: DEFAULT_VIEW
+	const defaultView = useMemo(
+		() =>
+			hasA8CSites
+				? {
+						...DEFAULT_VIEW,
+						filters: [
+							{
+								field: 'is_a8c',
+								operator: 'is' as Operator,
+								value: false,
+							},
+						],
+				  }
+				: DEFAULT_VIEW,
+		[ hasA8CSites ]
+	);
+	const search: Partial< ViewTable | ViewGrid > = sitesRoute.useSearch();
+	const view = useMemo(
+		() => ( {
+			...defaultView,
+			...DEFAULT_LAYOUTS[ search.type ?? 'grid' ],
+			...Object.fromEntries( Object.entries( search ).filter( ( [ , v ] ) => v !== undefined ) ),
+		} ),
+		[ defaultView, search ]
 	);
 	const fields = useMemo(
 		() =>
@@ -219,7 +232,19 @@ export default function Sites() {
 						fields={ fields }
 						actions={ actions }
 						view={ view }
-						onChangeView={ setView }
+						onChangeView={ ( view ) => {
+							if ( view.type === 'list' ) {
+								return;
+							}
+							const _defaultView = { ...defaultView, ...( DEFAULT_LAYOUTS[ view.type ] ?? {} ) };
+							navigate( {
+								search: Object.fromEntries(
+									Object.entries( view ).filter(
+										( [ key, value ] ) => value !== _defaultView[ key as keyof View ]
+									)
+								),
+							} );
+						} }
 						onClickItem={ onClickItem }
 						defaultLayouts={ DEFAULT_LAYOUTS }
 						paginationInfo={ paginationInfo }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -14,7 +14,7 @@ import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { Site } from '../data/types';
-import type { View, Operator, ViewTable, ViewGrid } from '@automattic/dataviews';
+import type { Operator, ViewTable, ViewGrid } from '@automattic/dataviews';
 
 const actions = [
 	{
@@ -161,12 +161,12 @@ const DEFAULT_LAYOUTS = {
 	},
 };
 
-const DEFAULT_VIEW: View = {
+const DEFAULT_VIEW = {
 	...DEFAULT_LAYOUTS.grid,
-	type: 'grid',
+	type: 'grid' as const,
 	page: 1,
 	perPage: 10,
-	sort: { field: 'name', direction: 'asc' },
+	sort: { field: 'name', direction: 'asc' as const },
 	search: '',
 };
 
@@ -194,7 +194,7 @@ export default function Sites() {
 	const view = useMemo(
 		() => ( {
 			...defaultView,
-			...DEFAULT_LAYOUTS[ search.type ?? 'grid' ],
+			...DEFAULT_LAYOUTS[ search.type ?? DEFAULT_VIEW.type ],
 			...Object.fromEntries( Object.entries( search ).filter( ( [ , v ] ) => v !== undefined ) ),
 		} ),
 		[ defaultView, search ]
@@ -239,9 +239,9 @@ export default function Sites() {
 							const _defaultView = { ...defaultView, ...DEFAULT_LAYOUTS[ view.type ] };
 							navigate( {
 								search: Object.fromEntries(
-									Object.entries( view ).filter(
-										( [ key, value ] ) => value !== _defaultView[ key as keyof View ]
-									)
+									Object.entries( view ).filter( ( [ key, value ] ) => {
+										return value !== _defaultView[ key as keyof typeof _defaultView ];
+									} )
 								),
 							} );
 						} }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -14,7 +14,7 @@ import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { Site } from '../data/types';
-import type { Operator, ViewTable, ViewGrid } from '@automattic/dataviews';
+import type { Operator, ViewTable, ViewGrid, SortDirection } from '@automattic/dataviews';
 
 const actions = [
 	{
@@ -166,7 +166,7 @@ const DEFAULT_VIEW = {
 	type: 'grid' as const,
 	page: 1,
 	perPage: 10,
-	sort: { field: 'name', direction: 'asc' as const },
+	sort: { field: 'name', direction: 'asc' as SortDirection },
 	search: '',
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes DOTCOM-12925

## Proposed Changes

Currently when you change views, or search/filter, click a site, and press the back button, the state is lost. Let's store it in the URL instead.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to sites, filter/search/change views, check the URL, refresh and see that it still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
