### PR TITLE
Mobile E2E Tests: Fix onboarding through LOHP

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/playwright-config.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/playwright-config.ts
@@ -44,6 +44,7 @@ const launchOptions: LaunchOptions = {
 const contextOptions: BrowserContextOptions = {
 	...targetDeviceOptions,
 	userAgent: `${ targetDeviceOptions.userAgent } wp-e2e-tests`,
+	locale: envVariables.TEST_LOCALES[ 0 ],
 };
 
 export default Object.freeze( {

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -38,6 +38,8 @@ export * from './blaze-campaign-page';
 export * from './feedback-inbox-page';
 export * from './subscribers-page';
 export * from './subscription-management-page';
+export * from './logged-out-home-page';
+export * from './logged-out-themes-page';
 
 export * from './external';
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
@@ -1,0 +1,65 @@
+import { Page } from 'playwright';
+import { DataHelper } from '../..';
+
+/**
+ * Represents the WPCOM LOHP.
+ */
+export class LoggedOutHomePage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the LOHP.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Selects the first visible theme on the LOHP.
+	 */
+	async selectFirstTheme() {
+		// Hovering over the container to stop the carousel scrolling
+		// The force is necessary as the container is not considered stable due to the scrolling
+		const themeContainer = this.page.locator( '.lp-content.lp-content-area--scrolling' ).first();
+		await themeContainer.hover( { force: true } );
+
+		// Hovering over the theme card is necessary to make the "Start with this theme" button visible.
+		const themeCard = themeContainer.locator( '.lp-image-top-row' ).last();
+		await themeCard.hover();
+
+		const themeButton = themeCard.getByText( 'Start with this theme' );
+		const calypsoUrl = new URL( DataHelper.getCalypsoURL() );
+		const themeButtonUrl = new URL( ( await themeButton.getAttribute( 'href' ) ) || '' );
+
+		if ( calypsoUrl.hostname !== 'wordpress.com' ) {
+			// Reroute the click to the current Calypso URL.
+			await this.page.route( themeButtonUrl.href, async ( route ) => {
+				themeButtonUrl.host = calypsoUrl.host;
+				themeButtonUrl.protocol = calypsoUrl.protocol;
+
+				await route.abort();
+				await this.page.unrouteAll( { behavior: 'ignoreErrors' } );
+				await this.page.goto( themeButtonUrl.href, { waitUntil: 'load' } );
+			} );
+		}
+		// Get theme slug
+		const pageMatch = new URL( themeButtonUrl.href ).search.match( 'theme=([a-z]*)?&' );
+		const themeSlug = pageMatch?.[ 1 ] || null;
+
+		// Hover, otherwise the element isn't considered stable, and is out of the viewport.
+		await themeCard.hover( { force: true } );
+		await themeCard.getByText( 'Start with this theme' ).click( { force: true } );
+
+		return themeSlug;
+	}
+
+	/**
+	 * Clicks the "Explore themes" button.
+	 */
+	async clickExploreThemes() {
+		return Promise.all( [
+			this.page.waitForNavigation( { waitUntil: 'load' } ),
+			this.page.getByRole( 'link', { name: 'Explore themes' } ).click(),
+		] );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -1,0 +1,35 @@
+import { Page } from 'playwright';
+
+/**
+ * Represents the logged-out themes showcase page.
+ */
+export class LoggedOutThemesPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the logged-out themes showcase page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Filters the themes by the given filter.
+	 *
+	 * @param {string} filter - The filter to apply.
+	 */
+	async filterBy( filter: string ) {
+		await this.page.getByRole( 'button', { name: 'View: All' } ).click();
+		await this.page.getByRole( 'menuitem', { name: filter } ).click();
+	}
+
+	/**
+	 * Selects the first theme on the page.
+	 */
+	async clickFirstTheme() {
+		await Promise.all( [
+			this.page.locator( '[data-e2e-theme]' ).first().click(),
+			this.page.waitForNavigation( { waitUntil: 'load' } ),
+		] );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -59,9 +59,30 @@ export class ThemesDetailPage {
 
 	/**
 	 * Click on the Activate button displayed in Logged out theme details.
+	 *
+	 * @returns {Promise<string>} The slug of the selected theme.
 	 */
-	async pickThisDesign(): Promise< void > {
-		await this.page.getByRole( 'link', { name: 'Get started' } ).click();
+	async pickThisDesign(): Promise< string > {
+		const getStartedButton = this.page.getByRole( 'link', { name: 'Get started' } );
+
+		await getStartedButton.waitFor();
+
+		const destinationUrl = await getStartedButton.getAttribute( 'href' );
+
+		if ( ! destinationUrl ) {
+			throw new Error( 'Destination URL not found' );
+		}
+
+		const baseUrl = new URL( this.page.url() );
+		const themeSlug = new URL( destinationUrl, baseUrl ).searchParams.get( 'theme' );
+
+		if ( ! themeSlug ) {
+			throw new Error( 'Theme slug not found' );
+		}
+
+		await getStartedButton.click();
+
+		return themeSlug;
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -19,9 +19,11 @@ import {
 	NoticeComponent,
 	PurchasesPage,
 	envVariables,
+	LoggedOutHomePage,
+	LoggedOutThemesPage,
+	ThemesDetailPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipItIf } from '../../jest-helpers';
 import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
@@ -59,68 +61,24 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 			await page.goto( 'https://WordPress.com' );
 		} );
 
-		skipItIf( envVariables.VIEWPORT_NAME === 'mobile' )(
-			'Select a theme on desktop',
-			async function () {
-				// Hovering over the container to stop the carousel scrolling
-				// The force is necessary as the container is not considered stable due to the scrolling
-				const themeContainer = page.locator( '.lp-content.lp-content-area--scrolling' ).first();
-				await themeContainer.hover( { force: true } );
+		it( 'Select a theme', async function () {
+			const lohp = new LoggedOutHomePage( page );
 
-				// Hovering over the theme card is necessary to make the "Start with this theme" button visible.
-				const themeCard = themeContainer.locator( '.lp-image-top-row' ).last();
-				await themeCard.hover();
-
-				const themeButton = themeCard.getByText( 'Start with this theme' );
-				const calypsoUrl = new URL( DataHelper.getCalypsoURL() );
-				const themeButtonUrl = new URL( ( await themeButton.getAttribute( 'href' ) ) || '' );
-
-				if ( calypsoUrl.hostname !== 'wordpress.com' ) {
-					// Reroute the click to the current Calypso URL.
-					await page.route( themeButtonUrl.href, async ( route ) => {
-						themeButtonUrl.host = calypsoUrl.host;
-						themeButtonUrl.protocol = calypsoUrl.protocol;
-
-						await route.abort();
-						await page.unrouteAll( { behavior: 'ignoreErrors' } );
-						await page.goto( themeButtonUrl.href, { waitUntil: 'load' } );
-					} );
-				}
-				// Get theme slug
-				const pageMatch = new URL( themeButtonUrl.href ).search.match( 'theme=([a-z]*)?&' );
-				console.log( 'pm', pageMatch );
-				themeSlug = pageMatch?.[ 1 ] || null;
-
-				// Hover, otherwise the element isn't considered stable, and is out of the viewport.
-				await themeCard.hover( { force: true } );
-				await themeCard.getByText( 'Start with this theme' ).click( { force: true } );
+			if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
+				themeSlug = await lohp.selectFirstTheme();
+				return;
 			}
-		);
 
-		skipItIf( envVariables.VIEWPORT_NAME !== 'mobile' )(
-			'Select a theme on mobile',
-			async function () {
-				await Promise.all( [
-					page.waitForNavigation( { waitUntil: 'load' } ),
-					page.getByRole( 'link', { name: 'Explore themes' } ).click(),
-				] );
+			await lohp.clickExploreThemes();
 
-				await page.getByRole( 'button', { name: 'View: All' } ).click();
-				await page.getByRole( 'menuitem', { name: 'Free' } ).click();
+			const themeShowcase = new LoggedOutThemesPage( page );
 
-				const firstTheme = page.locator( '[data-e2e-theme]' ).first();
-				await firstTheme.waitFor( { state: 'visible' } );
+			await themeShowcase.filterBy( 'Free' );
+			await themeShowcase.clickFirstTheme();
 
-				themeSlug = await firstTheme.getAttribute( 'data-e2e-theme' );
-
-				await firstTheme.click();
-
-				await Promise.all( [
-					page.waitForNavigation( { waitUntil: 'load' } ),
-					page.getByRole( 'link', { name: 'Get started' } ).click(),
-				] );
-			}
-		);
+			const themeDetails = new ThemesDetailPage( page );
+			themeSlug = await themeDetails.pickThisDesign();
+		} );
 
 		it( 'Sign up as new user', async function () {
 			const userSignupPage = new UserSignupPage( page );

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -18,8 +18,10 @@ import {
 	cancelPurchaseFlow,
 	NoticeComponent,
 	PurchasesPage,
+	envVariables,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { skipItIf } from '../../jest-helpers';
 import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
@@ -57,39 +59,68 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 			await page.goto( 'https://WordPress.com' );
 		} );
 
-		it( 'Selects a theme', async function () {
-			// Hovering over the container to stop the carousel scrolling
-			// The force is necessary as the container is not considered stable due to the scrolling
-			const themeContainer = page.locator( '.lp-content.lp-content-area--scrolling' ).first();
-			await themeContainer.hover( { force: true } );
+		skipItIf( envVariables.VIEWPORT_NAME === 'mobile' )(
+			'Select a theme on desktop',
+			async function () {
+				// Hovering over the container to stop the carousel scrolling
+				// The force is necessary as the container is not considered stable due to the scrolling
+				const themeContainer = page.locator( '.lp-content.lp-content-area--scrolling' ).first();
+				await themeContainer.hover( { force: true } );
 
-			// Hovering over the theme card is necessary to make the "Start with this theme" button visible.
-			const themeCard = themeContainer.locator( '.lp-image-top-row' ).last();
-			await themeCard.hover();
+				// Hovering over the theme card is necessary to make the "Start with this theme" button visible.
+				const themeCard = themeContainer.locator( '.lp-image-top-row' ).last();
+				await themeCard.hover();
 
-			const themeButton = themeCard.getByText( 'Start with this theme' );
-			const calypsoUrl = new URL( DataHelper.getCalypsoURL() );
-			const themeButtonUrl = new URL( ( await themeButton.getAttribute( 'href' ) ) || '' );
+				const themeButton = themeCard.getByText( 'Start with this theme' );
+				const calypsoUrl = new URL( DataHelper.getCalypsoURL() );
+				const themeButtonUrl = new URL( ( await themeButton.getAttribute( 'href' ) ) || '' );
 
-			if ( calypsoUrl.hostname !== 'wordpress.com' ) {
-				// Reroute the click to the current Calypso URL.
-				await page.route( themeButtonUrl.href, async ( route ) => {
-					themeButtonUrl.host = calypsoUrl.host;
-					themeButtonUrl.protocol = calypsoUrl.protocol;
+				if ( calypsoUrl.hostname !== 'wordpress.com' ) {
+					// Reroute the click to the current Calypso URL.
+					await page.route( themeButtonUrl.href, async ( route ) => {
+						themeButtonUrl.host = calypsoUrl.host;
+						themeButtonUrl.protocol = calypsoUrl.protocol;
 
-					await route.abort();
-					await page.unrouteAll( { behavior: 'ignoreErrors' } );
-					await page.goto( themeButtonUrl.href, { waitUntil: 'load' } );
-				} );
+						await route.abort();
+						await page.unrouteAll( { behavior: 'ignoreErrors' } );
+						await page.goto( themeButtonUrl.href, { waitUntil: 'load' } );
+					} );
+				}
+				// Get theme slug
+				const pageMatch = new URL( themeButtonUrl.href ).search.match( 'theme=([a-z]*)?&' );
+				console.log( 'pm', pageMatch );
+				themeSlug = pageMatch?.[ 1 ] || null;
+
+				// Hover, otherwise the element isn't considered stable, and is out of the viewport.
+				await themeCard.hover( { force: true } );
+				await themeCard.getByText( 'Start with this theme' ).click( { force: true } );
 			}
-			// Get theme slug
-			const pageMatch = new URL( themeButtonUrl.href ).search.match( 'theme=([a-z]*)?&' );
-			themeSlug = pageMatch?.[ 1 ] || null;
+		);
 
-			// Hover, otherwise the element isn't considered stable, and is out of the viewport.
-			await themeCard.hover( { force: true } );
-			await themeCard.getByText( 'Start with this theme' ).click( { force: true } );
-		} );
+		skipItIf( envVariables.VIEWPORT_NAME !== 'mobile' )(
+			'Select a theme on mobile',
+			async function () {
+				await Promise.all( [
+					page.waitForNavigation( { waitUntil: 'load' } ),
+					page.getByRole( 'link', { name: 'Explore themes' } ).click(),
+				] );
+
+				await page.getByRole( 'button', { name: 'View: All' } ).click();
+				await page.getByRole( 'menuitem', { name: 'Free' } ).click();
+
+				const firstTheme = page.locator( '[data-e2e-theme]' ).first();
+				await firstTheme.waitFor( { state: 'visible' } );
+
+				themeSlug = await firstTheme.getAttribute( 'data-e2e-theme' );
+
+				await firstTheme.click();
+
+				await Promise.all( [
+					page.waitForNavigation( { waitUntil: 'load' } ),
+					page.getByRole( 'link', { name: 'Get started' } ).click(),
+				] );
+			}
+		);
 
 		it( 'Sign up as new user', async function () {
 			const userSignupPage = new UserSignupPage( page );
@@ -151,6 +182,7 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 			await mePage.visit();
 
 			const meSidebarComponent = new MeSidebarComponent( page );
+			await meSidebarComponent.openMobileMenu();
 			await meSidebarComponent.navigate( 'Purchases' );
 		} );
 


### PR DESCRIPTION
Related to DOTCOM-10588.

## Proposed Changes

The `signup__with-theme-LOHP` E2E test failed on mobile due to differences in how the page behaves depending on the viewport.

Since there are no hover events on mobile, the theme showcase carousel never displays the "Start with this time" overlay. So we need to go through the theme showcase page (the "Explore themes" button).

## Testing Instructions

Verify that all pre-release E2E tests are passing, excluding the muted and authentication ones.