### PR TITLE
E2E Tests: Fix plans__upgrade

### DIFF
--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -74,7 +74,11 @@ export class SidebarComponent {
 
 		// Top level menu item selector.
 		const itemSelector = `${ selectors.sidebar } :text-is("${ item }"):visible`;
-		await this.page.dispatchEvent( itemSelector, 'click' );
+
+		await Promise.all( [
+			subitem ? Promise.resolve() : this.page.waitForNavigation( { timeout: 30 * 1000 } ),
+			this.page.dispatchEvent( itemSelector, 'click' ),
+		] );
 
 		// Sub-level menu item selector.
 		if ( subitem ) {

--- a/packages/calypso-e2e/src/lib/pages/checkout-thank-you-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/checkout-thank-you-page.ts
@@ -28,4 +28,11 @@ export class CheckoutThankYouPage {
 
 		await locator.click();
 	}
+
+	/**
+	 * Clicks on the "Back to dashboard" button.
+	 */
+	async backToDashboard() {
+		await this.clickButton( 'Back to dashboard' );
+	}
 }

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -38,6 +38,7 @@ export * from './blaze-campaign-page';
 export * from './feedback-inbox-page';
 export * from './subscribers-page';
 export * from './subscription-management-page';
+export * from './wp-admin-media-page';
 
 export * from './external';
 export * from './me';

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -155,7 +155,10 @@ export class PlansPage {
 	 * @throws If the expected plan title is not found in the timeout period.
 	 */
 	async validateActivePlan( expectedPlan: Plans ): Promise< void > {
-		await this.page.locator( selectors.spotlightPlan ).getByText( expectedPlan ).waitFor();
+		await this.page
+			.locator( selectors.spotlightPlan )
+			.getByRole( 'heading', { name: expectedPlan } )
+			.waitFor();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/wp-admin-media-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin-media-page.ts
@@ -1,0 +1,62 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	items: '.attachments',
+};
+
+/**
+ * Represents an instance of the WPCOM Media library page.
+ */
+export class WPAdminMediaPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Given either a 1-indexed number `n` or the file name, click and select the item.
+	 *
+	 * Note that if an index is passed and the media gallery has been
+	 * filtered (eg. Images only), this method will select the `nth`
+	 * item in the filtered gallery as shown.
+	 *
+	 * @param param0 Keyed object parameter.
+	 * @param {number} param0.index 1-indexed value denoting the nth media gallery item to be selected.
+	 * @param {string} param0.name Filename of the media gallery item to be selected.
+	 * @throws {Error} If requested item could not be located in the gallery, or if the click action failed to select the gallery item.
+	 */
+	async selectItem( { index, name }: { index?: number; name?: string } = {} ) {
+		if ( ! index && ! name ) {
+			throw new Error( 'Specify either index or name.' );
+		}
+
+		if ( index ) {
+			const elementHandle = await this.page.waitForSelector(
+				`:nth-match(${ selectors.items }, ${ index })`
+			);
+			await elementHandle.click();
+			await this.page.waitForFunction(
+				( element: SVGElement | HTMLElement ) => element.classList.contains( 'is-selected' ),
+				elementHandle
+			);
+		}
+		if ( name ) {
+			const locator = this.page.locator( selectors.items ).getByLabel( name );
+			await locator.click();
+
+			const selectedItemName = await this.page
+				.getByRole( 'textbox', { name: 'Title' } )
+				.getAttribute( 'value' );
+
+			if ( selectedItemName !== name ) {
+				throw new Error( `Expected title to be "${ name }", but got "${ selectedItemName }".` );
+			}
+		}
+	}
+}

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1,5 +1,4 @@
-import fs from 'fs';
-import FormData from 'form-data';
+import fs from 'fs/promises';
 import { SecretsManager } from './secrets';
 import {
 	BearerTokenErrorResponse,
@@ -861,16 +860,17 @@ export class RestAPIClient {
 
 		if ( media ) {
 			const data = new FormData();
-			data.append( 'media[]', fs.createReadStream( media.fullpath ) );
+			const fileBuffer = await fs.readFile( media.fullpath );
+			const blob = new Blob( [ fileBuffer ] );
+			data.append( 'media[]', blob, media.basename );
 
 			params = {
 				method: 'post',
 				headers: {
 					// Important: include the boundary
 					Authorization: await this.getAuthorizationHeader( 'bearer' ),
-					...data.getHeaders(),
 				},
-				body: data.getBuffer(),
+				body: data,
 			};
 		}
 		if ( mediaURL ) {

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -14,12 +14,12 @@ import {
 	NewSiteResponse,
 	PostResponse,
 	PublishedPostPage,
-	NavbarComponent,
 	MediaHelper,
 	TestFile,
-	MediaPage,
+	CheckoutThankYouPage,
+	WPAdminMediaPage,
 } from '@automattic/calypso-e2e';
-import { Page, Browser } from 'playwright';
+import { Page, Browser, BrowserContext } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 import { apiDeleteSite } from '../shared';
 
@@ -39,6 +39,7 @@ describe(
 		let newSiteDetails: NewSiteResponse;
 		let restAPIClient: RestAPIClient;
 		let page: Page;
+		let context: BrowserContext;
 
 		beforeAll( async function () {
 			// Set up the test site programmatically against simpleSiteFreePlanUser.
@@ -70,7 +71,8 @@ describe(
 			} );
 
 			// Launch browser.
-			page = await browser.newPage();
+			context = await browser.newContext();
+			page = await context.newPage();
 
 			// Authenticate as simpleSiteFreePlanUser.
 			const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
@@ -105,24 +107,19 @@ describe(
 			} );
 
 			it( 'Make purchase', async function () {
-				try {
-					await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
-				} catch {
-					// Work around an issue where purchase flow does not
-					// complete and redirect the user to the next screen
-					// beyond the timeout.
-					// See: https://github.com/Automattic/wp-calypso/issues/75867
-					await page.goto(
-						DataHelper.getCalypsoURL(
-							`checkout/thank-you/${ newSiteDetails.blog_details.site_slug }`
-						)
-					);
-				}
+				await Promise.all( [
+					page.waitForNavigation( {
+						url: '**/checkout/thank-you/**',
+						// Sometimes the testing domain third party system is really slow. It's better to wait a while than to throw a false positive.
+						timeout: 90 * 1000,
+					} ),
+					cartCheckoutPage.purchase( { timeout: 120 * 1000 } ),
+				] );
 			} );
 
 			it( 'Return to My Home dashboard', async function () {
-				const navbarComponent = new NavbarComponent( page );
-				await navbarComponent.clickMySites();
+				const thankYouPage = new CheckoutThankYouPage( page );
+				await thankYouPage.backToDashboard();
 			} );
 		} );
 
@@ -144,7 +141,7 @@ describe(
 			let testPage: Page;
 
 			beforeAll( async function () {
-				testPage = await browser.newPage();
+				testPage = await context.newPage();
 			} );
 
 			it.each( postTitles )( 'Post %s is preserved', async function ( postTitle: string ) {
@@ -158,9 +155,11 @@ describe(
 			} );
 
 			it( 'Uploaded media is preserved', async function () {
-				const mediaPage = new MediaPage( page );
-				await mediaPage.visit( newSiteDetails.blog_details.site_slug );
-				await mediaPage.selectItem( { name: testMediaFile.basename } );
+				const sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.navigate( 'Media' );
+
+				const mediaPage = new WPAdminMediaPage( page );
+				await mediaPage.selectItem( { name: testMediaFile.filename } );
 			} );
 		} );
 


### PR DESCRIPTION
Related to DOTCOM-10629.

## Proposed Changes

This fixes the remaining muted pre-release tests besides the authentication ones. It is not in a mergeable state. We can unmute this test file once this PR gets merged.

We need a new E2E simple user because the existing one got blocked. @lancewillett, do you know the context behind the blockage, and is it a good idea to keep following that strategy? Maybe the user got blocked due to the number of sites?

An alternative approach is to create a new user and a site and upload the media as part of the test preparation—not programmatically, but as an actual pre-test setup.

EDIT: I spoke with Lance today and the conclusion we arrived is that a better strategy is indeed to create a new user, site, and content every time during set up, and delete it as part of teardown. Let's go with that.

## Testing Instructions

The tests for this file should pass locally if you modify `packages/calypso-e2e/src/secrets/decrypted-secrets.json`. Look for `simpleSiteFreePlanUser` and change its username (not email) and password. 

Once we get a new user and rotate the secrets (assuming we'll keep the strategy), then the test should pass in TeamCity.
