### PR TITLE
Fix a11y and branding issues with buttons in magic login

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -6,6 +6,10 @@
 }
 
 /* @wordpress/components Button overrides */
+.components-button {
+	justify-content: center;
+}
+
 .components-button.is-primary:not(.is-destructive) {
 	// Background color, focus ring color
 	--wp-components-color-accent: var(--color-accent);

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -56,7 +56,8 @@ form {
 }
 
 .layout.is-white-login .login.is-akismet .login__form,
-.layout.is-white-login .login.is-akismet .continue-as-user {
+.layout.is-white-login .login.is-akismet .continue-as-user,
+.layout.is-white-login.is-akismet .magic-login__form-action {
 	.button.is-primary {
 		background-color: var(--color-akismet);
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -236,7 +236,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 .login__form-action {
 	button {
 		width: 100%;
-		justify-content: center;
 	}
 }
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -267,25 +267,9 @@
 		}
 
 		.magic-login form {
-
-			input[type="text"],
-			input[type="email"],
-			input[type="password"] {
-				padding: 10px 20px;
-			}
-
 			label {
 				color: var(--color-text);
 				font-weight: 400;
-			}
-		}
-
-		.magic-login .button {
-			margin: 0;
-
-			&:disabled {
-				background-color: var(--color-neutral-5);
-				color: var(--color-text-inverted);
 			}
 		}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1308,13 +1308,30 @@ $breakpoint-mobile: 660px;
 				height: 48px;
 
 				&:focus:not(:disabled) {
+					--color-accent: var(--woo-purple-60);
+				}
+			}
+
+			&.social-buttons__button {
+				&:focus:not(:disabled) {
 					box-shadow: inset 0 0 0 1px var(--wp-components-color-background, #fff), 0 0 0 2px var(--wp-components-color-accent);
+				}
+			}
+
+			&.is-primary {
+				&:focus:not(:disabled) {
+					box-shadow: 0 0 0 2px var(--wp-components-color-accent);
+				}
+
+				&:disabled {
+					--color-accent: var(--studio-gray-5);
+
+					color: var(--studio-gray-50);
 				}
 
 				.components-spinner {
 					margin-top: 0;
 				}
-
 			}
 		}
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,9 +1,9 @@
 import { FormLabel } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
-import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
@@ -282,9 +282,15 @@ class RequestLoginEmailForm extends Component {
 							/>
 						) }
 						<div className="magic-login__form-action">
-							<FormButton primary disabled={ ! submitEnabled } busy={ isSubmitButtonBusy }>
+							<Button
+								variant="primary"
+								disabled={ ! submitEnabled }
+								isBusy={ isSubmitButtonBusy }
+								type="submit"
+								__next40pxDefaultSize
+							>
 								{ submitButtonLabel || buttonLabel }
-							</FormButton>
+							</Button>
 						</div>
 					</FormFieldset>
 				</LoggedOutForm>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -245,7 +245,6 @@
 
 	button {
 		width: 100%;
-		justify-content: center;
 	}
 
 	.form-button:last-child {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -47,12 +47,12 @@
 				.button.is-primary {
 					background-color: var(--studio-jetpack-green-50);
 					border-color: var(--studio-jetpack-green-50);
-		
+
 					&:hover,
 					&:focus {
 						background-color: var(--studio-jetpack-green-60);
 					}
-		
+
 					.accessible-focus &:focus {
 						box-shadow: 0 0 0 2px var(--studio-jetpack-green-30);
 					}
@@ -95,7 +95,7 @@
 			transform: translateX(-50%);
 			width: 48px;
 		}
-	}	
+	}
 }
 .magic-login__successfully-jetpack-actions {
 	color: var(--studio-jetpack-grey-50, #646970 );
@@ -242,10 +242,10 @@
 
 .magic-login__form-action {
 	margin-top: 20px;
-	overflow: auto;
 
 	button {
 		width: 100%;
+		justify-content: center;
 	}
 
 	.form-button:last-child {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -538,11 +538,6 @@
 			color: #1d4fc4;
 			text-decoration: underline;
 		}
-
-		button:disabled {
-			opacity: 0.3;
-			cursor: not-allowed;
-		}
 	}
 
 	.grav-powered-magic-login__header,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -782,7 +782,7 @@ $image-height: 47px;
 		}
 	}
 
-	.login__form-action .components-button.is-primary {
+	.components-button.is-primary {
 		min-height: 56px;
 		margin-top: 16px;
 		font-size: 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DSGCOM-94/update-primary-buttons-on-magic-login

## Proposed Changes

* Replace the primary button in the magic login form with a core button, and apply theming for the brands which use the screen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These screens mostly have no visible focus styles for the primary button, and some have no branding applied.

- Focus styles are necessary for accessibility reasons
- Consistent button styles and behaviours lead to a more high quality experience

## Testing

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Screenshots

| Before | Before focus | After | After focus |
|-|-|-|-|
| ![wordpress com_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop)](https://github.com/user-attachments/assets/5466338a-7f89-4a15-a3a5-39a0b9f4827f) | ![wordpress com_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop) (1)](https://github.com/user-attachments/assets/5c6a954c-4fc1-4dbb-bf47-6983aba9dd31) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop)](https://github.com/user-attachments/assets/84a14d85-f136-4e47-96c8-32cb43e3c9c1) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop) (1)](https://github.com/user-attachments/assets/c2ecb4c4-7b12-437d-9357-bdbd7f6ff891) |
| ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%25](https://github.com/user-attachments/assets/05ad3954-0c2b-4295-9ad2-0affde1edae3) | ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253 (1)](https://github.com/user-attachments/assets/d9ffca35-8f43-4acb-8e6a-20c9d99d79f4) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttp](https://github.com/user-attachments/assets/7cfb813a-8904-4fd2-bf1f-e5496c44abbd) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3D (1)](https://github.com/user-attachments/assets/53ae7390-21e9-4492-ad21-94349825c419) |
| ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_uri%3Dhttp](https://github.com/user-attachments/assets/550a10dd-91be-4e87-a4de-ea0ed121f8f1) | ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_uri%3D (1)](https://github.com/user-attachments/assets/08f49603-839c-45c4-b84a-95d13e6d1949) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_u](https://github.com/user-attachments/assets/4c5aba3d-2617-4b33-915c-8352bc249ed7) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redire (1)](https://github.com/user-attachments/assets/27eefe6e-f0a5-48df-8818-4ec774c4eeb7) |
| ![wordpress com_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D6bea3deab28c39e8ad169d31602b95ca7382c3918ebc70cb622a40b2855a56f8%26redirect_u (2)](https://github.com/user-attachments/assets/d785ea3c-65ff-438a-8ac1-de6856fb0175) | ![wordpress com_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D6bea3deab28c39e8ad169d31602b95ca7382c3918ebc70cb622a40b2855a56f8%26redirect_u (3)](https://github.com/user-attachments/assets/854f9ad0-96cf-4896-99d7-9a36b6608f38) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D6bea3deab28c39e8ad169d31602b95ca7382c3918ebc70cb622a40b2855a56f8%26](https://github.com/user-attachments/assets/afda58f3-612e-4c49-92d2-40eddb85e516) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D6bea3deab28c39e8ad169d31602b95ca7382c3918ebc70cb622a40b2855a56f (1)](https://github.com/user-attachments/assets/9f0b5098-d42e-4034-a172-bd0d3743d833) |
| ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redi (1)](https://github.com/user-attachments/assets/28813c06-cf77-4989-964f-80fa6771e73d) | ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redi (2)](https://github.com/user-attachments/assets/22843e62-1a44-4091-bfbe-09bfa120d9b5) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%2](https://github.com/user-attachments/assets/1eaca36b-b8e9-44fd-ac30-3cbc0799bed6) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50I (1)](https://github.com/user-attachments/assets/a4199319-5c02-4954-adf5-193e1c9ff2af) |
| ![wordpress com_log-in_link_client_id=978 signup_url=%2Fstart%2Fcrowdsignal%2Foauth2-name%3Foauth2_client_id%3D978%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api wordpress com%252Foauth2%252Fauthorize%253Fclient_id%253D978%2526response_ty](https://github.com/user-attachments/assets/db2af19a-5322-486b-a664-ae77200dae22) | ![wordpress com_log-in_link_client_id=978 signup_url=%2Fstart%2Fcrowdsignal%2Foauth2-name%3Foauth2_client_id%3D978%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api wordpress com%252Foauth2%252Fauthorize%253Fclient_id%253D978%2526respons (1)](https://github.com/user-attachments/assets/6f431746-f139-4fb6-ada3-93da57833e78) | ![calypso localhost_3000_log-in_link_client_id=978 signup_url=%2Fstart%2Fcrowdsignal%2Foauth2-name%3Foauth2_client_id%3D978%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api wordpress com%252Foauth2%252Fauthorize%253Fclient_id%253D978%2526re](https://github.com/user-attachments/assets/f1c0cdda-2858-4fe0-b538-d1de5d278f7e) | ![calypso localhost_3000_log-in_link_client_id=978 signup_url=%2Fstart%2Fcrowdsignal%2Foauth2-name%3Foauth2_client_id%3D978%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api wordpress com%252Foauth2%252Fauthorize%253Fclient_id%253D978%25 (1)](https://github.com/user-attachments/assets/5065084e-1761-4a42-904f-4080fa98dd1c) |

### Instructions

1. Ensure you are logged out of WordPress.com
2. Click each of the links below to access the brand's magic login screen
3. Check that the email field and primary button are the same height with the same border radius
4. The button should be visibly disabled until the email field is filled
5. Enter text in the email field and button should become enabled
6. Focus the field and check the hover and focus styles; they should be exactly the same as the primary button on the `/log-in` page. You can use storybook to check the login button styles by running `yarn storybook:start` and opening http://localhost:6006/?path=/story/client-blocks-login-submit-button--default
7. Submit the form to check it still works

#### Magic login links:

[WordPress.com](http://calypso.localhost:3000/log-in/link?redirect_to=%2Fsetup%2Fonboarding%2Fdomains&signup_url=%2Fsetup%2Fonboarding%2Fuser)
[Woo](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916&signup_url=%2Fstart%2Fwpcc%2Foauth2-user%3Foauth2_client_id%3D50916%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%252F%253Fresponse_type%253Dcode%2526client_id%253D50916%2526state%253D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%2526redirect_uri%253Dhttps%25253A%25252F%25252Fwoocommerce.com%25252Fwc-api%25252Fwpcom-signin%25253Fnext%25253D%2525252F%2526blog_id%253D0%2526wpcom_connect%253D1%2526wccom-from%2526calypso_env%253Dproduction%2526from-calypso%253D1)
[Akismet](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F&signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%252F%252Fr-login.wordpress.com%252Fremote-login.php%253Faction%253Dlink%2526back%253Dhttps%25253A%25252F%25252Fakismet.com%25252Faccount%25252F)
[Gravatar](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D6bea3deab28c39e8ad169d31602b95ca7382c3918ebc70cb622a40b2855a56f8%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854)
[WP Job Manager](http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D90057%26response_type%3Dcode%26state%3DeyJyZWRpcmVjdF90byI6Imh0dHBzOlwvXC93cGpvYm1hbmFnZXIuY29tXC9teS1hY2NvdW50In0%26redirect_uri%3Dhttps%253A%252F%252Fwpjobmanager.com%252Fwp-json%252Fwpjmcom-auth%252Fv1%252Fcallback%26blog_id%3D0%26from-calypso%3D1&client_id=90057)
[Crowdsignal](http://calypso.localhost:3000/log-in/link?client_id=978&signup_url=%2Fstart%2Fcrowdsignal%2Foauth2-name%3Foauth2_client_id%3D978%26oauth2_redirect%3Dhttps%253A%252F%252Fpublic-api.wordpress.com%252Foauth2%252Fauthorize%253Fclient_id%253D978%2526response_type%253Dcode%2526blog_id%253D0%2526state%253D0eb3f4fa8a636f73b34f4c325da1691565e50548192a021d9614ebfe92669886%2526redirect_uri%253Dhttps%25253A%25252F%25252Fapp.crowdsignal.com%25252Fconnect%25253Fsource%25253Dlogin%252526action%25253Drequest_access_token%2526wpcom_connect%253D1%2526from-calypso%253D1)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
