### PR TITLE
Dsgcom 94 update primary buttons on magic login

### DIFF
--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -56,7 +56,8 @@ form {
 }
 
 .layout.is-white-login .login.is-akismet .login__form,
-.layout.is-white-login .login.is-akismet .continue-as-user {
+.layout.is-white-login .login.is-akismet .continue-as-user,
+.layout.is-white-login.is-akismet .magic-login__form-action {
 	.button.is-primary {
 		background-color: var(--color-akismet);
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -267,25 +267,9 @@
 		}
 
 		.magic-login form {
-
-			input[type="text"],
-			input[type="email"],
-			input[type="password"] {
-				padding: 10px 20px;
-			}
-
 			label {
 				color: var(--color-text);
 				font-weight: 400;
-			}
-		}
-
-		.magic-login .button {
-			margin: 0;
-
-			&:disabled {
-				background-color: var(--color-neutral-5);
-				color: var(--color-text-inverted);
 			}
 		}
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,9 +1,9 @@
 import { FormLabel } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
-import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
@@ -282,9 +282,15 @@ class RequestLoginEmailForm extends Component {
 							/>
 						) }
 						<div className="magic-login__form-action">
-							<FormButton primary disabled={ ! submitEnabled } busy={ isSubmitButtonBusy }>
+							<Button
+								variant="primary"
+								disabled={ ! submitEnabled }
+								isBusy={ isSubmitButtonBusy }
+								type="submit"
+								__next40pxDefaultSize
+							>
 								{ submitButtonLabel || buttonLabel }
-							</FormButton>
+							</Button>
 						</div>
 					</FormFieldset>
 				</LoggedOutForm>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -47,12 +47,12 @@
 				.button.is-primary {
 					background-color: var(--studio-jetpack-green-50);
 					border-color: var(--studio-jetpack-green-50);
-		
+
 					&:hover,
 					&:focus {
 						background-color: var(--studio-jetpack-green-60);
 					}
-		
+
 					.accessible-focus &:focus {
 						box-shadow: 0 0 0 2px var(--studio-jetpack-green-30);
 					}
@@ -95,7 +95,7 @@
 			transform: translateX(-50%);
 			width: 48px;
 		}
-	}	
+	}
 }
 .magic-login__successfully-jetpack-actions {
 	color: var(--studio-jetpack-grey-50, #646970 );
@@ -242,10 +242,10 @@
 
 .magic-login__form-action {
 	margin-top: 20px;
-	overflow: auto;
 
 	button {
 		width: 100%;
+		justify-content: center;
 	}
 
 	.form-button:last-child {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -538,11 +538,6 @@
 			color: #1d4fc4;
 			text-decoration: underline;
 		}
-
-		button:disabled {
-			opacity: 0.3;
-			cursor: not-allowed;
-		}
 	}
 
 	.grav-powered-magic-login__header,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -782,7 +782,7 @@ $image-height: 47px;
 		}
 	}
 
-	.login__form-action .components-button.is-primary {
+	.components-button.is-primary {
 		min-height: 56px;
 		margin-top: 16px;
 		font-size: 16px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DSGCOM-94/update-primary-buttons-on-magic-login

## Proposed Changes

Replace primary buttons in magic login with core buttons for accessibility and consistency. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These screens have no visible focus styles for the primary button, and some have no branding.

- Focus styles are necessary for accessibility reasons
- Consistent button styles and behaviours lead to a more high quality experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Screenshots

| Before | Before focus | After | After focus |
|-|-|-|-|
| ![wordpress com_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop)](https://github.com/user-attachments/assets/5466338a-7f89-4a15-a3a5-39a0b9f4827f) | ![wordpress com_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop) (1)](https://github.com/user-attachments/assets/5c6a954c-4fc1-4dbb-bf47-6983aba9dd31) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop)](https://github.com/user-attachments/assets/84a14d85-f136-4e47-96c8-32cb43e3c9c1) | ![calypso localhost_3000_log-in_redirect_to=%2Fsetup%2Fonboarding%2Fdomains signup_url=%2Fsetup%2Fonboarding%2Fuser(Desktop) (1)](https://github.com/user-attachments/assets/c2ecb4c4-7b12-437d-9357-bdbd7f6ff891) |
| ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253A%25](https://github.com/user-attachments/assets/05ad3954-0c2b-4295-9ad2-0affde1edae3) | ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttps%253 (1)](https://github.com/user-attachments/assets/d9ffca35-8f43-4acb-8e6a-20c9d99d79f4) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3Dhttp](https://github.com/user-attachments/assets/7cfb813a-8904-4fd2-bf1f-e5496c44abbd) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F signup_url=%2Fstart%2Faccount%2Fuser-social%3Fredirect_to%3D (1)](https://github.com/user-attachments/assets/53ae7390-21e9-4492-ad21-94349825c419) |
| ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_uri%3Dhttp](https://github.com/user-attachments/assets/550a10dd-91be-4e87-a4de-ea0ed121f8f1) | ![wordpress com_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_uri%3D (1)](https://github.com/user-attachments/assets/08f49603-839c-45c4-b84a-95d13e6d1949) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_u](https://github.com/user-attachments/assets/4c5aba3d-2617-4b33-915c-8352bc249ed7) | ![calypso localhost_3000_log-in_link_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redire (1)](https://github.com/user-attachments/assets/27eefe6e-f0a5-48df-8818-4ec774c4eeb7) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
