### PR TITLE
Update primary buttons on signup

### DIFF
--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -1,15 +1,15 @@
-import { Button, Gridicon, WordPressLogo } from '@automattic/components';
+import { Gridicon, WordPressLogo } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import AutomatticLogo from 'calypso/components/automattic-logo';
-import FormButton from 'calypso/components/forms/form-button';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
+import SignupSubmitButton from './signup-submit-button';
 import SocialSignupForm from './social';
-
 import './crowdsignal.scss';
 
 class CrowdsignalSignupForm extends Component {
@@ -76,9 +76,10 @@ class CrowdsignalSignupForm extends Component {
 							</p>
 
 							<Button
-								primary
+								variant="primary"
 								href={ this.props.loginLink }
 								className="signup-form__crowdsignal-wpcom"
+								__next40pxDefaultSize
 							>
 								<WordPressLogo size={ 20 } />
 								<span>{ translate( 'Sign in with WordPress.com' ) }</span>
@@ -91,8 +92,10 @@ class CrowdsignalSignupForm extends Component {
 								/>
 							) }
 							<Button
+								variant="primary"
 								className="signup-form__crowdsignal-show-form"
 								onClick={ this.showSignupForm }
+								__next40pxDefaultSize
 							>
 								{ translate( 'Create a WordPress.com Account' ) }
 							</Button>
@@ -113,12 +116,12 @@ class CrowdsignalSignupForm extends Component {
 								{ this.props.formFields }
 
 								<LoggedOutFormFooter>
-									<FormButton
+									<SignupSubmitButton
 										className="signup-form__crowdsignal-submit"
-										disabled={ this.props.submitting || this.props.disabled }
+										isDisabled={ this.props.submitting || this.props.disabled }
 									>
 										{ translate( 'Create a WordPress.com Account' ) }
-									</FormButton>
+									</SignupSubmitButton>
 
 									<p className="signup-form__crowdsignal-learn-more">
 										{ translate( 'Why WordPress.com? {{a}}Learn more{{/a}}.', {
@@ -147,13 +150,11 @@ class CrowdsignalSignupForm extends Component {
 					/>
 
 					<Button
-						borderless
-						compact
 						className="signup-form__crowdsignal-prev-button"
 						onClick={ this.hideSignupForm }
 						disabled={ this.props.submitting }
 					>
-						<Gridicon icon="arrow-left" />
+						<Gridicon icon="arrow-left" size={ 18 } />
 						<span>{ translate( 'Back' ) }</span>
 					</Button>
 				</div>

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -47,7 +47,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 .signup-form__crowdsignal {
 	.components-button {
 		width: 100%;
-		justify-content: center;
 
 		&.is-primary:not(.signup-form__crowdsignal-wpcom) {
 			--color-accent: var(--color-primary);

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -113,11 +113,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 			}
 		}
 	}
-
-	.social-buttons__button {
-		height: 44px;
-		border-radius: 2px;
-	}
 }
 
 .signup-form__crowdsignal-submit,

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -1,3 +1,7 @@
+@import "@automattic/typography/styles/fonts";
+@import "@automattic/typography/styles/variables";
+@import "../../assets/stylesheets/shared/mixins/breakpoints";
+
 body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	@include breakpoint-deprecated( ">1040px" ) {
 		margin: 0 auto;
@@ -116,10 +120,13 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.components-button.is-primary {
+.signup-form__crowdsignal-submit,
+.signup-form__crowdsignal-show-form,
+.signup-form__crowdsignal-wpcom {
 	font-size: .875rem;
 	font-weight: 600;
 }
+
 
 .signup-form__crowdsignal-submit,
 .signup-form__crowdsignal-show-form {

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -44,6 +44,18 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
+.signup-form__crowdsignal {
+	.components-button {
+		width: 100%;
+		justify-content: center;
+
+		&.is-primary:not(.signup-form__crowdsignal-wpcom) {
+			--color-accent: var(--color-primary);
+			--color-accent-60: var(--color-primary-dark);
+		}
+	}
+}
+
 .signup-form__crowdsignal-layout {
 	display: flex;
 	flex-direction: column;
@@ -74,11 +86,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	@include breakpoint-deprecated( ">1040px" ) {
 		flex: 1;
 		width: initial;
-	}
-
-	.button,
-	.components-button {
-		width: 100%;
 	}
 
 	.card {
@@ -113,20 +120,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 			}
 		}
 	}
-}
-
-.signup-form__crowdsignal-submit,
-.signup-form__crowdsignal-show-form,
-.signup-form__crowdsignal-wpcom {
-	font-size: .875rem;
-	font-weight: 600;
-}
-
-
-.signup-form__crowdsignal-submit,
-.signup-form__crowdsignal-show-form {
-	--color-accent: var(--color-primary);
-	--color-accent-60: var(--color-primary-dark);
 }
 
 .crowdsignal .auth-form__social {
@@ -165,11 +158,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-// Matches social button layout
+// Matches .social-buttons__button layout
 .signup-form__crowdsignal-wpcom {
 	margin-bottom: 40px;
 	padding-inline: 18px;
-	justify-content: center;
 
 	.wordpress-logo {
 		margin: 0 auto 0 0;
@@ -182,7 +174,6 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal-show-form {
 	margin: 20px 0 0;
-	justify-content: center;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		display: none;

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -72,7 +72,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		width: initial;
 	}
 
-	.button {
+	.button,
+	.components-button {
 		width: 100%;
 	}
 
@@ -115,13 +116,15 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.button.is-primary.signup-form__crowdsignal-submit {
-	background: var(--color-primary);
-	border-color: var(--color-primary-dark);
+.components-button.is-primary {
+	font-size: .875rem;
+	font-weight: 600;
 }
 
-.signup-form__crowdsignal-wpcom .wordpress-logo {
-	margin: 0 15px 0 0;
+.signup-form__crowdsignal-submit,
+.signup-form__crowdsignal-show-form {
+	--color-accent: var(--color-primary);
+	--color-accent-60: var(--color-primary-dark);
 }
 
 .crowdsignal .auth-form__social {
@@ -160,17 +163,24 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.button.signup-form__crowdsignal-wpcom {
-	display: flex;
+// Matches social button layout
+.signup-form__crowdsignal-wpcom {
 	margin-bottom: 40px;
+	padding-inline: 18px;
+	justify-content: center;
+
+	.wordpress-logo {
+		margin: 0 auto 0 0;
+	}
+
+	> span {
+		margin-inline: -20px auto;
+	}
 }
 
-.button.signup-form__crowdsignal-show-form {
-	background-color: var(--color-primary);
-	border-color: var(--color-primary-dark);
-	color: var(--color-text-inverted);
-	text-align: center;
+.signup-form__crowdsignal-show-form {
 	margin: 20px 0 0;
+	justify-content: center;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		display: none;
@@ -250,9 +260,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.button.signup-form__crowdsignal-prev-button {
-	display: inline-block;
-
+.signup-form__crowdsignal-prev-button {
 	.signup-form__crowdsignal-back-button-wrapper.is-first-step & {
 		display: none;
 	}

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -33,7 +33,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
-import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import Notice from 'calypso/components/notice';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -1041,14 +1040,11 @@ class SignupForm extends Component {
 
 		if ( isBlazePro ) {
 			return (
-				<div>
-					<LoggedOutFormLinks>
-						<span>{ this.props.translate( 'Already have an account?' ) }&nbsp;</span>
-						<LoggedOutFormLinkItem href={ this.getLoginLink() }>
-							{ this.props.translate( 'Log in here' ) }
-						</LoggedOutFormLinkItem>
-					</LoggedOutFormLinks>
-				</div>
+				<p className="signup-form__login-link">
+					{ this.props.translate( 'Already have an account? {{link}}Log in here{{/link}}.', {
+						components: { link: <a href={ this.getLoginLink() } /> },
+					} ) }
+				</p>
 			);
 		}
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -27,7 +27,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import ContinueAsUser from 'calypso/blocks/login/continue-as-user';
-import SignupSubmitButton from 'calypso/blocks/signup-form/signup-submit-button';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -61,6 +60,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 import CrowdsignalSignupForm from './crowdsignal';
 import PasswordlessSignupForm from './passwordless';
 import SignupFormSocialFirst from './signup-form-social-first';
+import SignupSubmitButton from './signup-submit-button';
 import SocialSignupForm from './social';
 
 import './style.scss';

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -27,7 +27,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import ContinueAsUser from 'calypso/blocks/login/continue-as-user';
-import FormButton from 'calypso/components/forms/form-button';
+import SignupSubmitButton from 'calypso/blocks/signup-form/signup-submit-button';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -1016,21 +1016,18 @@ class SignupForm extends Component {
 		return (
 			<LoggedOutFormFooter isBlended={ this.props.isSocialSignupEnabled }>
 				{ ! this.props.disableTosText && this.termsOfServiceLink() }
-				<FormButton
-					className={ clsx(
-						'signup-form__submit',
-						variationName && `${ variationName }-signup-form`
-					) }
-					disabled={
+				<SignupSubmitButton
+					isDisabled={
 						this.state.submitting ||
 						this.props.disabled ||
 						this.props.disableSubmitButton ||
 						( this.props.isWoo &&
 							( ! this.hasFilledInputValues() || formState.hasErrors( this.state.form ) ) )
 					}
+					variationName={ variationName }
 				>
 					{ this.props.submitButtonText }
-				</FormButton>
+				</SignupSubmitButton>
 			</LoggedOutFormFooter>
 		);
 	}

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -8,7 +8,6 @@ import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import SignupSubmitButton from 'calypso/blocks/signup-form/signup-submit-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
@@ -21,6 +20,7 @@ import wpcom from 'calypso/lib/wp';
 import ValidationFieldset from 'calypso/signup/validation-fieldset';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
+import SignupSubmitButton from './signup-submit-button';
 
 class PasswordlessSignupForm extends Component {
 	static propTypes = {

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -8,6 +8,7 @@ import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import SignupSubmitButton from 'calypso/blocks/signup-form/signup-submit-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import LoggedOutForm from 'calypso/components/logged-out-form';
 import LoggedOutFormFooter from 'calypso/components/logged-out-form/footer';
@@ -312,14 +313,12 @@ class PasswordlessSignupForm extends Component {
 
 		return (
 			<LoggedOutFormFooter>
-				<Button
-					type="submit"
-					primary
-					busy={ isSubmitting }
-					disabled={ isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton }
+				<SignupSubmitButton
+					isBusy={ isSubmitting }
+					isDisabled={ isSubmitting || !! this.props.disabled || !! this.props.disableSubmitButton }
 				>
 					{ submitButtonText }
-				</Button>
+				</SignupSubmitButton>
 				{ this.props.secondaryFooterButton }
 			</LoggedOutFormFooter>
 		);

--- a/client/blocks/signup-form/signup-submit-button.tsx
+++ b/client/blocks/signup-form/signup-submit-button.tsx
@@ -7,6 +7,7 @@ interface SignupSubmitButtonProps {
 	isDisabled?: boolean;
 	variationName?: string;
 	children: ReactNode;
+	className?: string;
 }
 
 const SignupSubmitButton = ( {
@@ -14,15 +15,20 @@ const SignupSubmitButton = ( {
 	isDisabled = false,
 	variationName,
 	children,
+	className,
 }: SignupSubmitButtonProps ) => {
 	return (
 		<Button
 			variant="primary"
 			type="submit"
-			className={ clsx( 'signup-form__submit', variationName && `${ variationName }-signup-form` ) }
+			className={ clsx(
+				'signup-form__submit',
+				className,
+				variationName && `${ variationName }-signup-form`
+			) }
 			disabled={ isDisabled }
-			__next40pxDefaultSize
 			isBusy={ isBusy }
+			__next40pxDefaultSize
 		>
 			{ children }
 		</Button>

--- a/client/blocks/signup-form/signup-submit-button.tsx
+++ b/client/blocks/signup-form/signup-submit-button.tsx
@@ -3,12 +3,14 @@ import clsx from 'clsx';
 import { ReactNode } from 'react';
 
 interface SignupSubmitButtonProps {
+	isBusy?: boolean;
 	isDisabled?: boolean;
 	variationName?: string;
 	children: ReactNode;
 }
 
 const SignupSubmitButton = ( {
+	isBusy = false,
 	isDisabled = false,
 	variationName,
 	children,
@@ -20,6 +22,7 @@ const SignupSubmitButton = ( {
 			className={ clsx( 'signup-form__submit', variationName && `${ variationName }-signup-form` ) }
 			disabled={ isDisabled }
 			__next40pxDefaultSize
+			isBusy={ isBusy }
 		>
 			{ children }
 		</Button>

--- a/client/blocks/signup-form/signup-submit-button.tsx
+++ b/client/blocks/signup-form/signup-submit-button.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+interface SignupSubmitButtonProps {
+	isDisabled?: boolean;
+	variationName?: string;
+	children: ReactNode;
+}
+
+const SignupSubmitButton = ( {
+	isDisabled = false,
+	variationName,
+	children,
+}: SignupSubmitButtonProps ) => {
+	return (
+		<Button
+			variant="primary"
+			type="submit"
+			className={ clsx( 'signup-form__submit', variationName && `${ variationName }-signup-form` ) }
+			disabled={ isDisabled }
+			__next40pxDefaultSize
+		>
+			{ children }
+		</Button>
+	);
+};
+
+export default SignupSubmitButton;

--- a/client/blocks/signup-form/stories/shared.tsx
+++ b/client/blocks/signup-form/stories/shared.tsx
@@ -24,7 +24,7 @@ export const A4AWrapper = ( Story: StoryFn ) => (
 
 export const AkismetWrapper = ( Story: StoryFn ) => (
 	<div className="layout is-akismet" style={ { maxWidth: '360px', padding: '30px' } }>
-		<div className="signup-form-social-first-email">
+		<div className="signup-form signup-form-social-first">
 			<div className="card logged-out-form__footer">
 				<Story />
 			</div>

--- a/client/blocks/signup-form/stories/shared.tsx
+++ b/client/blocks/signup-form/stories/shared.tsx
@@ -5,7 +5,7 @@ import './style.scss';
 export const submitButtonArgs = {
 	isDisabled: false,
 	isBusy: false,
-	children: 'Create your account',
+	children: 'Continue',
 };
 
 export const SignupFormWrapper = ( Story: StoryFn ) => (

--- a/client/blocks/signup-form/stories/shared.tsx
+++ b/client/blocks/signup-form/stories/shared.tsx
@@ -23,12 +23,8 @@ export const A4AWrapper = ( Story: StoryFn ) => (
 );
 
 export const AkismetWrapper = ( Story: StoryFn ) => (
-	<div className="layout is-akismet" style={ { maxWidth: '360px', padding: '30px' } }>
-		<div className="signup-form signup-form-social-first">
-			<div className="card logged-out-form__footer">
-				<Story />
-			</div>
-		</div>
+	<div className="is-akismet">
+		<Story />
 	</div>
 );
 

--- a/client/blocks/signup-form/stories/shared.tsx
+++ b/client/blocks/signup-form/stories/shared.tsx
@@ -1,0 +1,59 @@
+import SignupSubmitButton from '../signup-submit-button';
+import type { StoryFn, StoryObj } from '@storybook/react';
+import './style.scss';
+
+export const submitButtonArgs = {
+	isDisabled: false,
+	isBusy: false,
+	children: 'Create your account',
+};
+
+export const SignupFormWrapper = ( Story: StoryFn ) => (
+	<div className="signup-form" style={ { maxWidth: '360px', padding: '30px' } }>
+		<div className="card logged-out-form__footer">
+			<Story />
+		</div>
+	</div>
+);
+
+export const A4AWrapper = ( Story: StoryFn ) => (
+	<div className="a8c-for-agencies">
+		<Story />
+	</div>
+);
+
+export const AkismetWrapper = ( Story: StoryFn ) => (
+	<div className="layout is-akismet" style={ { maxWidth: '360px', padding: '30px' } }>
+		<div className="signup-form-social-first-email">
+			<div className="card logged-out-form__footer">
+				<Story />
+			</div>
+		</div>
+	</div>
+);
+
+export const BlazeWrapper = ( Story: StoryFn ) => (
+	<div className="blaze-pro">
+		<Story />
+	</div>
+);
+
+export const CrowdsignalWrapper = ( Story: StoryFn ) => (
+	<div className="crowdsignal">
+		<Story />
+	</div>
+);
+
+export const WooWrapper = ( Story: StoryFn ) => (
+	<div className="woo is-woo-passwordless is-woo-com-oauth">
+		<Story />
+	</div>
+);
+
+export const JetpackWrapper = ( Story: StoryFn ) => (
+	<div className="jetpack-cloud">
+		<Story />
+	</div>
+);
+
+export type SubmitButtonStory = StoryObj< typeof SignupSubmitButton >;

--- a/client/blocks/signup-form/stories/shared.tsx
+++ b/client/blocks/signup-form/stories/shared.tsx
@@ -40,7 +40,11 @@ export const BlazeWrapper = ( Story: StoryFn ) => (
 
 export const CrowdsignalWrapper = ( Story: StoryFn ) => (
 	<div className="crowdsignal">
-		<Story />
+		<div className="signup-form__crowdsignal" style={ { maxWidth: '360px', padding: '30px' } }>
+			<div className="card logged-out-form__footer">
+				<Story />
+			</div>
+		</div>
 	</div>
 );
 

--- a/client/blocks/signup-form/stories/style.scss
+++ b/client/blocks/signup-form/stories/style.scss
@@ -1,0 +1,2 @@
+@import '../style.scss';
+@import 'client/components/logged-out-form/footer.scss';

--- a/client/blocks/signup-form/stories/style.scss
+++ b/client/blocks/signup-form/stories/style.scss
@@ -1,2 +1,2 @@
 @import '../style.scss';
-@import 'client/components/logged-out-form/footer.scss';
+@import '../../../components/logged-out-form/footer.scss';

--- a/client/blocks/signup-form/stories/submit-button/akismet.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/akismet.stories.tsx
@@ -1,20 +1,15 @@
 import SignupSubmitButton from '../../signup-submit-button';
-import {
-	submitButtonArgs,
-	SignupFormWrapper,
-	type SubmitButtonStory,
-	BlazeWrapper,
-} from '../shared';
+import { submitButtonArgs, type SubmitButtonStory, AkismetWrapper } from '../shared';
 import type { Meta } from '@storybook/react';
-import '../../../../layout/masterbar/blaze-pro.scss';
 
 const meta: Meta = {
 	title: 'client/blocks/Signup/Submit Button/Brands',
-	decorators: [ SignupFormWrapper, BlazeWrapper ],
 	component: SignupSubmitButton,
 	args: { ...submitButtonArgs },
 };
 
 export default meta;
 
-export const BlazePro: SubmitButtonStory = {};
+export const Akismet: SubmitButtonStory = {
+	decorators: [ AkismetWrapper ],
+};

--- a/client/blocks/signup-form/stories/submit-button/akismet.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/akismet.stories.tsx
@@ -1,5 +1,10 @@
 import SignupSubmitButton from '../../signup-submit-button';
-import { submitButtonArgs, type SubmitButtonStory, AkismetWrapper } from '../shared';
+import {
+	submitButtonArgs,
+	type SubmitButtonStory,
+	AkismetWrapper,
+	SignupFormWrapper,
+} from '../shared';
 import type { Meta } from '@storybook/react';
 
 const meta: Meta = {
@@ -11,5 +16,5 @@ const meta: Meta = {
 export default meta;
 
 export const Akismet: SubmitButtonStory = {
-	decorators: [ AkismetWrapper ],
+	decorators: [ SignupFormWrapper, AkismetWrapper ],
 };

--- a/client/blocks/signup-form/stories/submit-button/blaze.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/blaze.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
 	title: 'client/blocks/Signup/Submit Button/Brands',
 	decorators: [ SignupFormWrapper, BlazeWrapper ],
 	component: SignupSubmitButton,
-	args: { ...submitButtonArgs },
+	args: { ...submitButtonArgs, children: 'Create your account' },
 };
 
 export default meta;

--- a/client/blocks/signup-form/stories/submit-button/blaze.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/blaze.stories.tsx
@@ -1,0 +1,20 @@
+import SignupSubmitButton from '../../signup-submit-button';
+import {
+	submitButtonArgs,
+	SignupFormWrapper,
+	type SubmitButtonStory,
+	BlazeWrapper,
+} from '../shared';
+import type { Meta } from '@storybook/react';
+import '../../../../layout/masterbar/blaze-pro.scss';
+
+const meta: Meta = {
+	title: 'client/blocks/Signup/Submit Button',
+	decorators: [ SignupFormWrapper, BlazeWrapper ],
+	component: SignupSubmitButton,
+	args: { ...submitButtonArgs },
+};
+
+export default meta;
+
+export const BlazePro: SubmitButtonStory = {};

--- a/client/blocks/signup-form/stories/submit-button/crowdsignal.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/crowdsignal.stories.tsx
@@ -1,0 +1,25 @@
+import SignupSubmitButton from '../../signup-submit-button';
+import {
+	submitButtonArgs,
+	SignupFormWrapper,
+	type SubmitButtonStory,
+	CrowdsignalWrapper,
+} from '../shared';
+import type { Meta } from '@storybook/react';
+import '../../../../layout/masterbar/crowdsignal.scss';
+import '../../../../blocks/signup-form/crowdsignal.scss';
+
+const meta: Meta = {
+	title: 'client/blocks/Signup/Submit Button',
+	decorators: [ SignupFormWrapper, CrowdsignalWrapper ],
+	component: SignupSubmitButton,
+	args: {
+		...submitButtonArgs,
+		className: 'signup-form__crowdsignal-submit',
+		children: 'Create a WordPress.com Account',
+	},
+};
+
+export default meta;
+
+export const Crowdsignal: SubmitButtonStory = {};

--- a/client/blocks/signup-form/stories/submit-button/crowdsignal.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/crowdsignal.stories.tsx
@@ -7,10 +7,10 @@ import {
 } from '../shared';
 import type { Meta } from '@storybook/react';
 import '../../../../layout/masterbar/crowdsignal.scss';
-import '../../../../blocks/signup-form/crowdsignal.scss';
+import '../../crowdsignal.scss';
 
 const meta: Meta = {
-	title: 'client/blocks/Signup/Submit Button',
+	title: 'client/blocks/Signup/Submit Button/Brands',
 	decorators: [ SignupFormWrapper, CrowdsignalWrapper ],
 	component: SignupSubmitButton,
 	args: {

--- a/client/blocks/signup-form/stories/submit-button/crowdsignal.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/crowdsignal.stories.tsx
@@ -1,17 +1,12 @@
 import SignupSubmitButton from '../../signup-submit-button';
-import {
-	submitButtonArgs,
-	SignupFormWrapper,
-	type SubmitButtonStory,
-	CrowdsignalWrapper,
-} from '../shared';
+import { submitButtonArgs, type SubmitButtonStory, CrowdsignalWrapper } from '../shared';
 import type { Meta } from '@storybook/react';
 import '../../../../layout/masterbar/crowdsignal.scss';
 import '../../crowdsignal.scss';
 
 const meta: Meta = {
 	title: 'client/blocks/Signup/Submit Button/Brands',
-	decorators: [ SignupFormWrapper, CrowdsignalWrapper ],
+	decorators: [ CrowdsignalWrapper ],
 	component: SignupSubmitButton,
 	args: {
 		...submitButtonArgs,

--- a/client/blocks/signup-form/stories/submit-button/default.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/default.stories.tsx
@@ -1,0 +1,36 @@
+import SignupSubmitButton from '../../signup-submit-button';
+import {
+	submitButtonArgs,
+	SignupFormWrapper,
+	type SubmitButtonStory,
+	AkismetWrapper,
+} from '../shared';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta = {
+	title: 'client/blocks/Signup/Submit Button',
+	component: SignupSubmitButton,
+	args: { ...submitButtonArgs },
+};
+
+export default meta;
+
+export const Default: SubmitButtonStory = { decorators: [ SignupFormWrapper ] };
+
+export const Disabled: SubmitButtonStory = {
+	args: {
+		isDisabled: true,
+	},
+	decorators: [ SignupFormWrapper ],
+};
+
+export const Busy: SubmitButtonStory = {
+	args: {
+		isBusy: true,
+	},
+	decorators: [ SignupFormWrapper ],
+};
+
+export const Akismet: SubmitButtonStory = {
+	decorators: [ AkismetWrapper ],
+};

--- a/client/blocks/signup-form/stories/submit-button/default.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/default.stories.tsx
@@ -1,10 +1,5 @@
 import SignupSubmitButton from '../../signup-submit-button';
-import {
-	submitButtonArgs,
-	SignupFormWrapper,
-	type SubmitButtonStory,
-	AkismetWrapper,
-} from '../shared';
+import { submitButtonArgs, SignupFormWrapper, type SubmitButtonStory } from '../shared';
 import type { Meta } from '@storybook/react';
 
 const meta: Meta = {
@@ -29,8 +24,4 @@ export const Busy: SubmitButtonStory = {
 		isBusy: true,
 	},
 	decorators: [ SignupFormWrapper ],
-};
-
-export const Akismet: SubmitButtonStory = {
-	decorators: [ AkismetWrapper ],
 };

--- a/client/blocks/signup-form/stories/submit-button/oauth-client.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/oauth-client.stories.tsx
@@ -12,7 +12,7 @@ import {
 import type { Meta } from '@storybook/react';
 
 const meta: Meta = {
-	title: 'client/blocks/Signup/Submit Button',
+	title: 'client/blocks/Signup/Submit Button/Brands',
 	component: SignupSubmitButton,
 	args: { ...submitButtonArgs },
 };

--- a/client/blocks/signup-form/stories/submit-button/oauth-client.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/oauth-client.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta } from '@storybook/react';
 const meta: Meta = {
 	title: 'client/blocks/Signup/Submit Button/Brands',
 	component: SignupSubmitButton,
-	args: { ...submitButtonArgs },
+	args: { ...submitButtonArgs, children: 'Create your account' },
 };
 
 export default meta;

--- a/client/blocks/signup-form/stories/submit-button/oauth-client.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/oauth-client.stories.tsx
@@ -1,0 +1,28 @@
+// These buttons require the oauth-client.scss file to be loaded.
+import '../../../../layout/masterbar/oauth-client.scss';
+
+import SignupSubmitButton from '../../signup-submit-button';
+import {
+	type SubmitButtonStory,
+	A4AWrapper,
+	submitButtonArgs,
+	JetpackWrapper,
+	SignupFormWrapper,
+} from '../shared';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta = {
+	title: 'client/blocks/Signup/Submit Button',
+	component: SignupSubmitButton,
+	args: { ...submitButtonArgs },
+};
+
+export default meta;
+
+export const A4A: SubmitButtonStory = {
+	decorators: [ SignupFormWrapper, A4AWrapper ],
+};
+
+export const JetpackCloud: SubmitButtonStory = {
+	decorators: [ SignupFormWrapper, JetpackWrapper ],
+};

--- a/client/blocks/signup-form/stories/submit-button/woo.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/woo.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta } from '@storybook/react';
 import '../../../../layout/masterbar/woo.scss';
 
 const meta: Meta = {
-	title: 'client/blocks/Signup/Submit Button',
+	title: 'client/blocks/Signup/Submit Button/Brands',
 	decorators: [ SignupFormWrapper, WooWrapper ],
 	component: SignupSubmitButton,
 	args: { ...submitButtonArgs, children: 'Continue' },

--- a/client/blocks/signup-form/stories/submit-button/woo.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/woo.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta = {
 	title: 'client/blocks/Signup/Submit Button/Brands',
 	decorators: [ SignupFormWrapper, WooWrapper ],
 	component: SignupSubmitButton,
-	args: { ...submitButtonArgs, children: 'Continue' },
+	args: { ...submitButtonArgs },
 };
 
 export default meta;

--- a/client/blocks/signup-form/stories/submit-button/woo.stories.tsx
+++ b/client/blocks/signup-form/stories/submit-button/woo.stories.tsx
@@ -1,0 +1,15 @@
+import SignupSubmitButton from '../../signup-submit-button';
+import { submitButtonArgs, SignupFormWrapper, type SubmitButtonStory, WooWrapper } from '../shared';
+import type { Meta } from '@storybook/react';
+import '../../../../layout/masterbar/woo.scss';
+
+const meta: Meta = {
+	title: 'client/blocks/Signup/Submit Button',
+	decorators: [ SignupFormWrapper, WooWrapper ],
+	component: SignupSubmitButton,
+	args: { ...submitButtonArgs, children: 'Continue' },
+};
+
+export default meta;
+
+export const Woo: SubmitButtonStory = {};

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -21,6 +21,18 @@
 	}
 }
 
+.signup-form-social-first-email {
+	/**
+	* Akismet Signup
+	*/
+	@at-root .is-akismet & {
+		.signup-form__submit {
+			--color-accent: var(--color-akismet);
+			--color-accent-60: var(--color-akismet);
+		}
+	}
+}
+
 .signup-form .signup-form__input.form-text-input {
 	margin-bottom: 20px;
 	transition: none;
@@ -281,7 +293,7 @@ body.is-section-accept-invite {
 		}
 	}
 
-}
+	}
 
 .card.auth-form__social.is-signup {
 	background: inherit;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -21,18 +21,6 @@
 	}
 }
 
-.signup-form-social-first-email {
-	/**
-	* Akismet Signup
-	*/
-	@at-root .is-akismet & {
-		.signup-form__submit {
-			--color-accent: var(--color-akismet);
-			--color-accent-60: var(--color-akismet);
-		}
-	}
-}
-
 .signup-form .signup-form__input.form-text-input {
 	margin-bottom: 20px;
 	transition: none;
@@ -292,8 +280,7 @@ body.is-section-accept-invite {
 			}
 		}
 	}
-
-	}
+}
 
 .card.auth-form__social.is-signup {
 	background: inherit;
@@ -384,12 +371,18 @@ body.is-section-accept-invite {
 		}
 	}
 
+
+}
+
+.signup-form.signup-form-social-first,
+.card.auth-form__social.is-signup {
 	/**
 	* Akismet Signup
 	*/
 	@at-root .is-akismet & {
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
+		.components-button {
 			--color-accent: var(--color-akismet);
+			--color-accent-60: var(--color-akismet);
 		}
 	}
 }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/onboarding/styles/mixins";
+@import "../../assets/stylesheets/shared/mixins/breakpoints";
 
 .signup-form-social-first {
 	display: grid;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -370,16 +370,13 @@ body.is-section-accept-invite {
 
 }
 
-.signup-form.signup-form-social-first,
-.card.auth-form__social.is-signup {
-	/**
-	* Akismet Signup
-	*/
-	@at-root .is-akismet & {
-		.components-button {
-			--color-accent: var(--color-akismet);
-			--color-accent-60: var(--color-akismet);
-		}
+/**
+* Akismet Signup
+*/
+.is-akismet .signup-form {
+	.components-button {
+		--color-accent: var(--color-akismet);
+		--color-accent-60: var(--color-akismet);
 	}
 }
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -71,10 +71,6 @@
 	}
 }
 
-.auth-form__social-buttons .social-buttons__button {
-	border-radius: 4px;
-}
-
 .auth-form__social-buttons-tos a {
 	text-decoration: underline;
 }

--- a/client/components/logged-out-form/footer.scss
+++ b/client/components/logged-out-form/footer.scss
@@ -1,3 +1,5 @@
+@import "../../assets/stylesheets/shared/mixins/elevation";
+
 .card.logged-out-form__footer {
 	box-shadow: none;
 	background: none;
@@ -10,7 +12,14 @@
 		padding-top: 0;
 	}
 
-	.signup-form__submit {
+	.button.is-primary {
+		float: none;
+		margin: 0;
+		width: 100%;
+		@include elevation( 1dp );
+	}
+
+	.components-button.is-primary {
 		width: 100%;
 		justify-content: center;
 	}

--- a/client/components/logged-out-form/footer.scss
+++ b/client/components/logged-out-form/footer.scss
@@ -21,6 +21,5 @@
 
 	.components-button.is-primary {
 		width: 100%;
-		justify-content: center;
 	}
 }

--- a/client/components/logged-out-form/footer.scss
+++ b/client/components/logged-out-form/footer.scss
@@ -10,10 +10,8 @@
 		padding-top: 0;
 	}
 
-	.button.is-primary {
-		float: none;
-		margin: 0;
+	.signup-form__submit {
 		width: 100%;
-		@include elevation( 1dp );
+		justify-content: center;
 	}
 }

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -213,8 +213,7 @@ exports[`JetpackSignup should render 1`] = `
                 .
               </p>
               <button
-                class="button signup-form__submit form-button is-primary"
-                locale="en"
+                class="components-button signup-form__submit is-next-40px-default-size is-primary"
                 type="submit"
               >
                 Create your account
@@ -500,8 +499,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
                 .
               </p>
               <button
-                class="button signup-form__submit form-button is-primary"
-                locale="en"
+                class="components-button signup-form__submit is-next-40px-default-size is-primary"
                 type="submit"
               >
                 Create your account

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -51,6 +51,9 @@ body.is-section-signup {
 	--color-gray: #50575e;
 	--color-orange: #ff6433;
 
+	--color-link: var(--color-orange);
+	--color-link-dark: var(--color-orange);
+
 	background: var(--color-white);
 	min-height: 100%;
 
@@ -279,17 +282,12 @@ body.is-section-signup {
 		}
 
 		.continue-as-user__change-user-link {
-			color: var(--color-orange);
 			font-family: $inter;
 			font-size: 0.875rem;
 			font-style: normal;
 			font-weight: 500;
 			line-height: 20px;
 			text-decoration: none;
-
-			&:hover {
-				color: var(--color-orange);
-			}
 		}
 
 		.continue-as-user__continue-button {
@@ -427,7 +425,6 @@ body.is-section-signup {
 
 		a.logged-out-form__link-item,
 		a {
-			color: var(--color-orange);
 			padding: 0;
 			text-decoration: none;
 		}
@@ -512,11 +509,6 @@ body.is-section-signup {
 		font-size: rem(18px);
 		font-weight: 500;
 		line-height: 25px;
-
-		a,
-		a:visited {
-			color: var(--color-orange);
-		}
 	}
 
 	.login__lostpassword-subtitle {
@@ -592,7 +584,6 @@ body.is-section-signup {
 		}
 
 		.login__lost-password-link {
-			color: var(--color-orange);
 			font-family: $sfProText;
 			font-size: rem(18px);
 			font-weight: 500;

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -426,7 +426,7 @@ body.is-section-signup {
 		a.logged-out-form__link-item,
 		a {
 			padding: 0;
-			text-decoration: none;
+			text-decoration: underline;
 		}
 
 		a.logged-out-form__link-item,
@@ -436,6 +436,14 @@ body.is-section-signup {
 			font-weight: 500;
 			line-height: 25px;
 		}
+	}
+
+	.signup-form__login-link {
+		color: var(--studio-gray-60);
+		font-size: rem(18px);
+		font-weight: 500;
+		line-height: 25px;
+		text-align: center;
 	}
 
 	.login__lost-password-footer {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -156,7 +156,7 @@ $breakpoint-mobile: 660px;
 	a:not(.social-buttons__button),
 	.wp-login__links a,
 	.wp-login__links button,
-	.button:not(.social-buttons__button),
+	.button,
 	.magic-login__footer a {
 		color: $gray-50;
 		text-decoration: underline;
@@ -171,7 +171,7 @@ $breakpoint-mobile: 660px;
 		}
 	}
 
-	.button:not(.social-buttons__button) {
+	.button {
 		border-radius: 8px; /* stylelint-disable-line scales/radii */
 		border: 2px solid var(--woo-purple-60);
 		text-decoration: none;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -279,6 +279,8 @@ export class UserStep extends Component {
 							components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
 						}
 					);
+				} else if ( isBlazeProOAuth2Client( oauth2Client ) ) {
+					subHeaderText = translate( 'First, create your WordPress.com account.' );
 				} else {
 					subHeaderText = translate(
 						'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -5,7 +5,7 @@ body.is-section-signup .signup {
 		.auth-form__social p,
 		.signup-form__recaptcha-tos,
 		.logged-out-form__links .logged-out-form__link-item {
-			color: var(--studio-gray-40);
+			color: var(--studio-gray-60);
 			font-weight: normal;
 		}
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -307,9 +307,9 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) {
 
 	.signup__step.is-user,
 	.signup__step.is-user-social {
-		button.signup-form__submit[disabled],
-		button.signup-form__submit:disabled,
-		button.signup-form__submit.disabled {
+		.button.signup-form__submit[disabled],
+		.button.signup-form__submit:disabled,
+		.button.signup-form__submit.disabled {
 			background-color: var(--studio-gray-20);
 			color: var(--color-surface);
 		}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -314,7 +314,7 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) {
 			color: var(--color-surface);
 		}
 
-		button.signup-form__submit {
+		.button.signup-form__submit {
 			border-radius: 4px;
 			max-width: 408px;
 			height: 44px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://linear.app/a8c/issue/DSGCOM-93/update-primary-buttons-on-signup

## Proposed Changes

Update the signup forms:

- Replace the signup A8C primary button with a core button to fix accessibility issues and bring consistency with login buttons (replaced in https://github.com/Automattic/wp-calypso/pull/102639) and social buttons (replaced in https://github.com/Automattic/wp-calypso/pull/100807)
- Standardize the height (40px) and border radius (2px) of text inputs and buttons, unless the brand has specific styling (like Woo)
- Add stories for each product to help in checking for regressions, eg. when upgrading core components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

These signup screens have inconsistent buttons heights and border radii, missing or incorrectly applied brand colors, and some have no visible focus styles for the primary button.

- Focus styles are necessary for accessibility
- Consistent button styles and behaviours form a more high quality experience

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Storybook
1. Run `yarn storybook: start` and the storybook should open in your browser.
2. Browse the sign up submit button stories at http://localhost:6006/?path=/story/client-blocks-signup-submit-button--default
3. Test using prop toggles, hover and focus states, and brands

![Screenshot 2025-05-08 at 2 24 28 PM](https://github.com/user-attachments/assets/17b0f2ec-6b2a-4508-b17f-514503338fa4)

### Product

1. Open the signup screen for each product (see links below)
2. Check the interactive states for each primary button (particularly hover and focus) - hover background should generally use a darker product accent color (some don't have this, eg. Akismet, Blaze), and the focus ring color should use the accent color. Compare with other buttons, eg social. Focus ring should be the same, but background change should be different.
3. Tab through the form to ensure the buttons are focusable
4. Activate the buttons to ensure the actions still fire
5. Check for responsiveness - mobile and ipad size (Crowdsignal in particular has quite a different responsive layout)

#### Signup links

[WordPress.com](http://calypso.localhost:3000/start/account/user-social) -> 'Continue with email' button
[Akismet](http://calypso.localhost:3000/start/account/user-social?redirect_to=https%3A%2F%2Fr-login.wordpress.com%2Fremote-login.php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F) -> 'Continue with email' button
[Woo](http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=50916&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab60ee71bbedf5004689c43f491b%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1)
[Blaze Pro](http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=99370&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a219e9db95944038cb9%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1)
[Jetpack Cloud](http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=69040&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1)
A4A - Can't link due to GitHub OSS scan rules: go to automatt_c.com/for-agencies/ and click 'Log in', then 'Create an Account'. Edit the URL and change the host to calypso.localhost:3000
[VIP](http://calypso.localhost:3000/start/wpcc/oauth2-user?oauth2_client_id=76596&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fstate%3D2e373ba7d0b99c5b66af232a2cd4a90f3af2aeafbb0326604917c9333ac1%26scope%3Dauth%26response_type%3Dcode%26approval_prompt%3Dauto%26redirect_uri%3Dhttps%253A%252F%252Fid.wpvip.com%252Fwp-json%252Foauth%252Fv1%252Fcallback%252Fwpcom%26client_id%3D76596%26from-calypso%3D1)
[Crowdsignal](http://calypso.localhost:3000/start/crowdsignal/oauth2-name?oauth2_client_id=978&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D0eb3f4fa8a636f73b34f4c325da1691565e50548192a021d9614ebfe92669886%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
Partner Portal - Can't link due to GitHub OSS scan rules: go to hosts.automatt_c.com and you should be redirected to log in, then click 'Create an account'. Edit the URL and change the host to calypso.localhost:3000
WP.Cloud - Can't link due to GitHub OSS scan rules: go to [wp.cloud](https://wp.cloud/) and click 'start here', then 'Create an account'. Edit the URL and change the host to calypso.localhost:3000

### Screenshots (showing primary buttons focused)

| Brand | Before | After |
|-|-|-|
| WordPress.com | ![wordpress com_start_account_redirect_to=%2Fsites(5 1440x900)](https://github.com/user-attachments/assets/f09b6138-f2df-4004-a2b2-1168d9e7cb52) | ![calypso localhost_3000_start_account_user-social(5 1440x900)](https://github.com/user-attachments/assets/ca2bde21-6cfc-4c85-8c34-47b32ea19a58) |
| Blaze Pro | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=99370 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a2 (2)](https://github.com/user-attachments/assets/4f8ddbdd-b855-483f-9ff4-579a65e65fa5) | ![calypso localhost_3000_start_wpcc_oauth2_client_id=99370 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a219e9db9](https://github.com/user-attachments/assets/bc9e5b25-3ad6-44f3-83cd-37652f0b2211) |
| Jetpack Cloud | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=69040 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud jetpack com%2 (1)](https://github.com/user-attachments/assets/3615cb7c-5d4d-489c-9643-43d6ec98a9d0) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=69040 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud jetpack](https://github.com/user-attachments/assets/940119ed-2c71-4501-b326-533579681290) |
| Akismet | ![wordpress com_start_account_user-social_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F(5 1440x900) (1)](https://github.com/user-attachments/assets/ef6fa0df-adde-4f28-aab0-de746ee9cbe4) | ![calypso localhost_3000_start_account_user-social_redirect_to=https%3A%2F%2Fr-login wordpress com%2Fremote-login php%3Faction%3Dlink%26back%3Dhttps%253A%252F%252Fakismet com%252Faccount%252F(5 1440x900)](https://github.com/user-attachments/assets/18506b08-6514-4920-9482-4de1471c6924) |
| Woo | ![wordpress com_start_wpcc_oauth2_client_id=50916 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976](https://github.com/user-attachments/assets/f11578c0-b5d7-4e9a-81ea-d88e0f6c7537) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=50916 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D36e78dc55c52c1680dc1b15a5e019bddb1baab6](https://github.com/user-attachments/assets/fe411a03-34e0-40bd-96d0-564c723d6c9c) |
| VIP | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=76596 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fstate%3D2e373ba7d0b99c5b66af232a2cd4a90f3af2aeafbb0326604917c9333ac1%26scope%3Dauth%26response_type%3D](https://github.com/user-attachments/assets/a04d37f4-62fc-46c8-94d8-30177640798d) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=76596 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fstate%3D2e373ba7d0b99c5b66af232a2cd4a90f3af2aeafbb0326604917c9333ac1%26scope%3Dauth%26res (1)](https://github.com/user-attachments/assets/dfed4850-064f-4bfe-878f-9d68268f91c9) |
| A4A | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=95931 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies automattic (1)](https://github.com/user-attachments/assets/0307c639-ae41-465e-8781-81e24def49f5) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=95931 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D95931%26redirect_uri%3Dhttps%253A%252F%252Fagencies autom](https://github.com/user-attachments/assets/4140c098-9066-46ee-94ef-0477dec02fdd) |
| WP Cloud | ![wordpress com_start_wpcc_oauth2-user_oauth2_client_id=103914 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D103914%26redirect_uri%3Dhttps%253A%252F%252Fhostpartnerportal wor](https://github.com/user-attachments/assets/de3ace43-ba7c-4a8f-8de6-d6ce47d18a41) | ![calypso localhost_3000_start_wpcc_oauth2-user_oauth2_client_id=103914 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D103914%26redirect_uri%3Dhttps%253A%252F%252Fhostpartnerp](https://github.com/user-attachments/assets/95ff4ce5-eeaf-462d-9747-af7091f32e21) |
| Crowdsignal desktop | ![wordpress com_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d83e8088443caf5ec4ff3581e3973 (1)](https://github.com/user-attachments/assets/573c9f80-2620-42c7-b630-38ee4af3bcc2) | ![calypso localhost_3000_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D0eb3f4fa8a636f73b34f4c325](https://github.com/user-attachments/assets/614dae7f-4dd4-4d88-8b6b-9153d09d7284) |
| Crowdsignal mobile | ![wordpress com_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D4d83e8088443caf5ec4ff3581e3973 (2)](https://github.com/user-attachments/assets/1c3d9a37-9f61-427e-a89f-dd306e8e0e63) | ![calypso localhost_3000_start_crowdsignal_oauth2-name_oauth2_client_id=978 oauth2_redirect=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D0eb3f4fa8a636f73b34f4 (1)](https://github.com/user-attachments/assets/782cce80-f656-4739-96f7-d27b933b84e7) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
