### PR TITLE
Remove uses of `preventWidows` from `client/blocks`

### DIFF
--- a/client/blocks/app-promo/index.tsx
+++ b/client/blocks/app-promo/index.tsx
@@ -6,7 +6,6 @@ import wpToJpImage from 'calypso/assets/images/jetpack/wp-to-jp.svg';
 import QrCode from 'calypso/blocks/app-promo/qr-code';
 import AppsBadge from 'calypso/blocks/get-apps/apps-badge';
 import CardHeading from 'calypso/components/card-heading';
-import { preventWidows } from 'calypso/lib/formatting';
 import userAgent from 'calypso/lib/user-agent';
 import './style.scss';
 
@@ -50,17 +49,13 @@ export const AppPromo = ( {
 				alt="WordPress and Jetpack app"
 			/>
 			<div className="app-promo__title">
-				<CardHeading tagName="h2">
-					{ preventWidows( title || translate( 'Get our mobile app' ) ) }
-				</CardHeading>
-				{ ! showBadge && <h3 className="app-promo__subheader">{ preventWidows( subheader ) }</h3> }
+				<CardHeading tagName="h2">{ title || translate( 'Get our mobile app' ) }</CardHeading>
+				{ ! showBadge && <h3 className="app-promo__subheader">{ subheader }</h3> }
 			</div>
 
 			{ showBadge && (
 				<div className="app-promo__app-badges">
-					{ subheader && (
-						<p className="app-promo__app-badges-text">{ preventWidows( subheader ) }</p>
-					) }
+					{ subheader && <p className="app-promo__app-badges-text">{ subheader }</p> }
 					<AppsBadge
 						storeName={ showIosBadge ? 'ios' : 'android' }
 						utm_campaign={ campaign }

--- a/client/blocks/inline-help/inline-help-compact-results.jsx
+++ b/client/blocks/inline-help/inline-help-compact-results.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { decodeEntities } from 'calypso/lib/formatting';
 
 function InlineHelpCompactResults( { helpLinks, onClick } ) {
 	return (
@@ -12,7 +12,7 @@ function InlineHelpCompactResults( { helpLinks, onClick } ) {
 						onClick={ ( event ) => onClick( event, link ) }
 						tabIndex={ -1 }
 					>
-						{ preventWidows( decodeEntities( link.title ) ) }
+						{ decodeEntities( link.title ) }
 					</a>
 				</li>
 			) ) }

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import { Fragment, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { decodeEntities } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getAdminHelpResults from 'calypso/state/selectors/get-admin-help-results';
 import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
@@ -178,7 +178,7 @@ function HelpSearchResults( {
 							{ /* Old stuff - leaving this incase we need to quick revert
 							{ icon && <Gridicon icon={ icon } size={ 18 } /> } */ }
 							<LinkIcon />
-							<span>{ preventWidows( decodeEntities( title ) ) }</span>
+							<span>{ decodeEntities( title ) }</span>
 						</a>
 					</div>
 				</li>

--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -2,7 +2,6 @@ import { ExternalLink } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC, useCallback, useMemo, useState } from 'react';
 import Notice from 'calypso/components/notice';
-import { preventWidows } from 'calypso/lib/formatting';
 import version_compare from 'calypso/lib/version-compare';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -59,28 +58,26 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 
 	return (
 		<Notice onDismissClick={ dismissClick } status="is-warning">
-			{ preventWidows(
-				translate(
-					'Your Jetpack plugin is out of date. ' +
-						'{{WarningRequirement/}}, {{JetpackUpdateLink}}update Jetpack{{/JetpackUpdateLink}}.',
-					{
-						components: {
-							JetpackUpdateLink: (
-								<ExternalLink
-									href={ pluginUpgradeUrl }
-									onClick={ updatePluginClick }
-									target="_blank"
-								/>
-							),
-							WarningRequirement: (
-								<>
-									{ warningRequirement ??
-										translate( 'To make sure it will work with our recommended plans' ) }
-								</>
-							),
-						},
-					}
-				)
+			{ translate(
+				'Your Jetpack plugin is out of date. ' +
+					'{{WarningRequirement/}}, {{JetpackUpdateLink}}update Jetpack{{/JetpackUpdateLink}}.',
+				{
+					components: {
+						JetpackUpdateLink: (
+							<ExternalLink
+								href={ pluginUpgradeUrl }
+								onClick={ updatePluginClick }
+								target="_blank"
+							/>
+						),
+						WarningRequirement: (
+							<>
+								{ warningRequirement ??
+									translate( 'To make sure it will work with our recommended plans' ) }
+							</>
+						),
+					},
+				}
 			) }
 		</Notice>
 	);

--- a/client/blocks/jetpack-review-prompt/index.tsx
+++ b/client/blocks/jetpack-review-prompt/index.tsx
@@ -2,7 +2,6 @@ import { Button, Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useEffect } from 'react';
 import QueryPreferences from 'calypso/components/data/query-preferences';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { dismiss } from 'calypso/state/jetpack-review-prompt/actions';
@@ -74,10 +73,8 @@ const JetpackReviewPrompt: FunctionComponent< Props > = ( { align = 'center', ty
 			case 'restore':
 				return (
 					<p>
-						{ preventWidows(
-							translate(
-								'Was it easy to restore your site? Leave us a review and help spread the word.'
-							)
+						{ translate(
+							'Was it easy to restore your site? Leave us a review and help spread the word.'
 						) }
 					</p>
 				);
@@ -85,10 +82,8 @@ const JetpackReviewPrompt: FunctionComponent< Props > = ( { align = 'center', ty
 			default:
 				return (
 					<p>
-						{ preventWidows(
-							translate(
-								'Are you happy with Jetpack Scan? Leave us a review and help spread the word.'
-							)
+						{ translate(
+							'Are you happy with Jetpack Scan? Leave us a review and help spread the word.'
 						) }
 					</p>
 				);

--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -1,5 +1,4 @@
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import { preventWidows } from 'calypso/lib/formatting';
 
 import './sidebar-banner.scss';
 
@@ -32,7 +31,7 @@ export default function SidebarBannerTemplate( {
 				href={ CTA.link }
 				onClick={ onClick }
 				onDismissClick={ onDismiss }
-				title={ preventWidows( message ) }
+				title={ message }
 			/>
 			{ trackImpression && trackImpression() }
 		</>

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -12,7 +12,6 @@ import {
 	GithubSocialButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
-import { preventWidows } from 'calypso/lib/formatting';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { recordTracksEvent as recordTracks } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -106,9 +105,7 @@ class SocialSignupForm extends Component {
 				} ) }
 			>
 				{ ! compact && (
-					<p className="auth-form__social-text">
-						{ preventWidows( translate( 'Or create an account using:' ) ) }
-					</p>
+					<p className="auth-form__social-text">{ translate( 'Or create an account using:' ) }</p>
 				) }
 
 				<div className="auth-form__social-buttons">

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
 import Notice, { NoticeStatus } from 'calypso/components/notice';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'calypso/state/preferences/selectors';
@@ -44,17 +43,15 @@ export const TimeMismatchWarning: FC< ExternalProps > = ( {
 
 	return (
 		<Notice status={ status } onDismissClick={ dismissClick }>
-			{ preventWidows(
-				translate(
-					'This page reflects the time zone set on your site. ' +
-						'It looks like that does not match your current time zone. ' +
-						'{{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.',
-					{
-						components: {
-							SiteSettings: <a href={ settingsUrl } />,
-						},
-					}
-				)
+			{ translate(
+				'This page reflects the time zone set on your site. ' +
+					'It looks like that does not match your current time zone. ' +
+					'{{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.',
+				{
+					components: {
+						SiteSettings: <a href={ settingsUrl } />,
+					},
+				}
 			) }
 		</Notice>
 	);

--- a/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
+++ b/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
@@ -31,7 +31,7 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
       <span
         class="calypso-notice__text"
       >
-        This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
+        This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.
       </span>
     </span>
     <button

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -228,7 +228,7 @@ exports[`JetpackSignup should render 1`] = `
           <p
             class="auth-form__social-text"
           >
-            Or create an account using:
+            Or create an account using:
           </p>
           <div
             class="auth-form__social-buttons"
@@ -515,7 +515,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
           <p
             class="auth-form__social-text"
           >
-            Or create an account using:
+            Or create an account using:
           </p>
           <div
             class="auth-form__social-buttons"

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -586,7 +586,6 @@ $font-size: rem(14px);
 
 		.upsell-nudge.banner.card.is-compact .banner__info .banner__title {
 			color: var(--studio-black);
-			text-wrap: wrap;
 		}
 
 		.upsell-nudge.banner.card.is-compact .dismissible-card__close-button .gridicon {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#100475](https://github.com/Automattic/wp-calypso/issues/100475)

## Proposed Changes

* Remove use of `preventWidows()` which is a JS workaround for what `text-wrap: pretty` now does in native CSS. Given `pretty` (and `balance`) now have good browser support, we can start removing the function.
* Scope of this PR: `client/blocks`. I'm separating out parts of the codebase so PRs are easier to review.
* Note that I'm **not** removing the instance in `client/blocks/login` as that's being done in #102811 as part of a larger changeset.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We don't need to run JS all over the place to move words about so sentences are balanced, when CSS can now do this by itself 😊 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See inline comments in code view for detailed instructions. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
