### PR TITLE
DataViews: allow external filters to be passed into <Filters /> and <FiltersToggle />

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -71,9 +71,13 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 	}, [ fields, view ] );
 }
 
-export function FiltersToggle() {
+export function FiltersToggle( {
+	extendedFilters = [],
+}: {
+	extendedFilters?: NormalizedFilter[];
+} ) {
 	const {
-		filters,
+		filters: defaultFilters,
 		view,
 		onChangeView,
 		setOpenedFilter,
@@ -89,6 +93,11 @@ export function FiltersToggle() {
 		},
 		[ onChangeView, setIsShowingFilter ]
 	);
+	const filters = useMemo(
+		() => [ ...defaultFilters, ...extendedFilters ],
+		[ defaultFilters, extendedFilters ]
+	);
+
 	const visibleFilters = filters.filter( ( filter ) => filter.isVisible );
 
 	const hasVisibleFilters = !! visibleFilters.length;
@@ -173,11 +182,22 @@ function FilterVisibilityToggle( {
 	);
 }
 
-function Filters( { className }: { className?: string } ) {
+function Filters( {
+	className,
+	extendedFilters = [],
+}: {
+	className?: string;
+	extendedFilters?: NormalizedFilter[];
+} ) {
 	const { fields, view, onChangeView, openedFilter, setOpenedFilter } =
 		useContext( DataViewsContext );
 	const addFilterRef = useRef< HTMLButtonElement >( null );
-	const filters = useFilters( fields, view );
+	const defaultFilters = useFilters( fields, view );
+	const filters = useMemo(
+		() => [ ...defaultFilters, ...extendedFilters ],
+		[ defaultFilters, extendedFilters ]
+	);
+
 	const addFilter = (
 		<AddFilter
 			key="add-filter"

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -28,7 +28,7 @@ import {
 } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
-import type { View } from '../../../types';
+import type { View, NormalizedFilter } from '../../../types';
 
 import './style.css';
 
@@ -128,7 +128,13 @@ export const FieldsNoSortableNoHidable = () => {
 /**
  * Custom composition example
  */
-function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
+function PlanetOverview( {
+	planets,
+	extendedFilters,
+}: {
+	planets: SpaceObject[];
+	extendedFilters: NormalizedFilter[];
+} ) {
 	const moons = planets.reduce( ( sum, item ) => sum + item.satellites, 0 );
 
 	return (
@@ -182,10 +188,12 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 
 				<VStack>
 					<HStack justify="start">
-						<DataViews.FiltersToggle />
+						<DataViews.FiltersToggle
+							extendedFilters={ extendedFilters }
+						/>
 						<DataViews.Search label={ __( 'moons by planet' ) } />
 					</HStack>
-					<DataViews.Filters />
+					<DataViews.Filters extendedFilters={ extendedFilters } />
 				</VStack>
 
 				<VStack>
@@ -235,6 +243,22 @@ export const FreeComposition = () => {
 		item.categories.includes( 'Planet' )
 	);
 
+	const extendedFilters: NormalizedFilter[] = [
+		{
+			field: 'title',
+			name: 'Title',
+			elements: [
+				{ value: 'Earth', label: 'Earth' },
+				{ value: 'Mars', label: 'Mars' },
+			],
+			singleSelection: false,
+			operators: [ 'isAny', 'isNone' ],
+			isVisible:
+				view.filters?.some( ( f ) => f.field === 'title' ) ?? false,
+			isPrimary: false,
+		},
+	];
+
 	return (
 		<DataViews
 			getItemId={ ( item ) => item.id.toString() }
@@ -249,7 +273,10 @@ export const FreeComposition = () => {
 				grid: {},
 			} }
 		>
-			<PlanetOverview planets={ planets } />
+			<PlanetOverview
+				planets={ planets }
+				extendedFilters={ extendedFilters }
+			/>
 		</DataViews>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes WOOA7S-122

## Proposed Changes

* Update <Filters /> and <FiltersToggle /> components so they can accept an optional `extendedFilters` prop. These would be merged with the default filters internally and passed through the regular rendering and toggle logic, without requiring changes to the core view definition.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Right now, the filters used in <Filters /> and <FiltersToggle /> are strictly tied to the fields defined in the current view. There’s no way to inject additional filters that don’t come from that view config.

In some situations, we want to render filters that aren't part of the view’s field list — for example, filters based on external conditions, user metadata, or custom logic outside the current data shape. The current components don't provide a way to do this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dataviews:storybook:start`
* Go to `http://localhost:57863/?path=/story/dataviews-dataviews--free-composition`
* Click on the Filter toggle button
* See that the extended filter for the title field is rendered

<img width="1048" alt="Screenshot 2025-05-06 at 14 43 40" src="https://github.com/user-attachments/assets/7d0c8e2b-7dc2-42ae-85c2-730e1408d0db" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
