### PR TITLE
DataViews: Add headerStickyOffset property to ViewTable component

### DIFF
--- a/packages/dataviews/.storybook/style.scss
+++ b/packages/dataviews/.storybook/style.scss
@@ -5,6 +5,7 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/z-index";
 @import "@wordpress/components/build-style/style";
 
 @import "../src/style.scss";

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import type { Meta } from '@storybook/react';
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useRef } from '@wordpress/element';
 import { createInterpolateElement } from '@wordpress/element';
 import {
 	Card,
@@ -133,18 +133,15 @@ function PlanetOverview( { planets }: { planets: SpaceObject[] } ) {
 
 	return (
 		<>
+			<Heading className="free-composition-heading" level={ 2 }>
+				{ __( 'Solar System numbers' ) }
+			</Heading>
 			<Grid
 				templateColumns="repeat(auto-fit, minmax(330px, 1fr))"
 				align="flex-start"
 				className="free-composition-header"
 			>
 				<Card variant="secondary">
-					<CardHeader>
-						<Heading level={ 2 }>
-							{ __( 'Solar System numbers' ) }
-						</Heading>
-					</CardHeader>
-
 					<CardBody>
 						<VStack>
 							<Text size={ 18 } as="p">
@@ -225,6 +222,9 @@ export const FreeComposition = () => {
 		titleField: 'title',
 		descriptionField: 'description',
 		mediaField: 'image',
+		layout: {
+			headerStickyOffset: 67,
+		},
 	} );
 
 	const { data: processedData, paginationInfo } = useMemo( () => {
@@ -236,20 +236,22 @@ export const FreeComposition = () => {
 	);
 
 	return (
-		<DataViews
-			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ paginationInfo }
-			data={ processedData }
-			view={ view }
-			fields={ fields }
-			actions={ actions }
-			onChangeView={ setView }
-			defaultLayouts={ {
-				table: {},
-				grid: {},
-			} }
-		>
-			<PlanetOverview planets={ planets } />
-		</DataViews>
+		<div className="free-composition">
+			<DataViews
+				getItemId={ ( item ) => item.id.toString() }
+				paginationInfo={ paginationInfo }
+				data={ processedData }
+				view={ view }
+				fields={ fields }
+				actions={ actions }
+				onChangeView={ setView }
+				defaultLayouts={ {
+					table: {},
+					grid: {},
+				} }
+			>
+				<PlanetOverview planets={ planets } />
+			</DataViews>
+		</div>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/style.css
+++ b/packages/dataviews/src/components/dataviews/stories/style.css
@@ -3,6 +3,19 @@
     text-wrap: pretty;
 }
 
+.free-composition {
+	height: 600px;
+	overflow: auto;
+}
+
+.free-composition-heading,
 .free-composition-header {
     padding: 16px 48px;
+}
+
+.free-composition-heading {
+	position: sticky;
+	top: 0;
+	z-index: 2;
+	background-color: white;
 }

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -277,6 +277,11 @@ function ViewTable< Item >( {
 				headerMenuRefs.current.delete( column );
 			}
 		};
+	const headerStyle = view.layout?.headerStickyOffset
+		? {
+				insetBlockStart: view.layout.headerStickyOffset,
+		  }
+		: {};
 
 	return (
 		<>
@@ -291,7 +296,7 @@ function ViewTable< Item >( {
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
 			>
-				<thead>
+				<thead style={ headerStyle }>
 					<tr className="dataviews-view-table__row">
 						{ hasBulkActions && (
 							<th

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -366,6 +366,11 @@ export interface ViewTable extends ViewBase {
 		 * The density of the view.
 		 */
 		density?: Density;
+
+		/**
+		 * The offset of the table header.
+		 */
+		headerStickyOffset?: number;
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes WOOA7S-120

## Proposed Changes

* Introduced headerStickyOffset to allow customization of the table header offset.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


We recently tackled an issue in which the DataViews table header is covered by a sticky page header when filters are shown (see PR https://github.com/woocommerce/woocommerce-analytics/pull/921). The issue was because two sticky elements were interfering with each other: the page header and the table header when they both under the same parent element.

We’re relying on internal classnames from DataViews (`.dataviews-view-table thead`) to apply a workaround via `inset-block-start`. This PR introduces a new prop `headerStickyOffset` to allow customization of the table header offset.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dataviews:storybook:start`
* Go to `http://localhost:57863/?path=/story/dataviews-dataviews--free-composition`
* Scroll down and see that both the page header and the table header are sticky and don't overlap.

https://github.com/user-attachments/assets/22c7f6d7-6fe3-4ec8-ad46-049e1b1c7a9b


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
