### PR TITLE
Remove calypso-polyfills from Explat tests

### DIFF
--- a/client/lib/explat/internals/test/anon-id.ts
+++ b/client/lib/explat/internals/test/anon-id.ts
@@ -1,6 +1,4 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
-import '@automattic/calypso-polyfills';
-
 import * as AnonId from '../anon-id';
 
 const mockLogError = jest.fn();

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -30,7 +30,6 @@
 		"tslib": ">=2.3.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/react": "^16.3.0",

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -28,7 +28,6 @@
 		"tslib": "^2.3.0"
 	},
 	"devDependencies": {
-		"@automattic/calypso-polyfills": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"jest": "^29.7.0",
 		"typescript": "^5.8.2"

--- a/packages/explat-client/src/internal/test/requests.ts
+++ b/packages/explat-client/src/internal/test/requests.ts
@@ -1,6 +1,3 @@
-// This is required to fix the "regeneratorRuntime is not defined" error
-import '@automattic/calypso-polyfills';
-
 import * as ExperimentAssignments from '../experiment-assignments';
 import localStorage from '../local-storage';
 import * as Requests from '../requests';

--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -1,6 +1,3 @@
-// This is required to fix the "regeneratorRuntime is not defined" error
-import '@automattic/calypso-polyfills';
-
 import { delayedValue } from '../test-common';
 import * as Timing from '../timing';
 

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -1,6 +1,3 @@
-// This is required to fix the "regeneratorRuntime is not defined" error
-import '@automattic/calypso-polyfills';
-
 import { createExPlatClient } from '../create-explat-client';
 import localStorage from '../internal/local-storage';
 import {

--- a/packages/explat-client/src/test/create-ssr-safe-dummy-explat-client.ts
+++ b/packages/explat-client/src/test/create-ssr-safe-dummy-explat-client.ts
@@ -1,6 +1,3 @@
-// This is required to fix the "regeneratorRuntime is not defined" error
-import '@automattic/calypso-polyfills';
-
 import { createSsrSafeDummyExPlatClient } from '../create-explat-client';
 import * as Timing from '../internal/timing';
 import type { Config } from '../types';

--- a/packages/explat-client/src/test/index.ts
+++ b/packages/explat-client/src/test/index.ts
@@ -1,6 +1,3 @@
-// This is required to fix the "regeneratorRuntime is not defined" error
-import '@automattic/calypso-polyfills';
-
 import {
 	createExPlatClient as createBrowserExPlatClient,
 	createSsrSafeDummyExPlatClient,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,7 +1007,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/explat-client-react-helpers@workspace:packages/explat-client-react-helpers"
   dependencies:
-    "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/explat-client": "workspace:^"
     "@testing-library/dom": "npm:^10.4.0"
@@ -1024,7 +1023,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/explat-client@workspace:packages/explat-client"
   dependencies:
-    "@automattic/calypso-polyfills": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     jest: "npm:^29.7.0"
     tslib: "npm:^2.3.0"


### PR DESCRIPTION
Tests for the Explat Client library import `@automattic/calypso-polyfills` at the beginning, and the comments say it's to prevent a `regeneratorRuntime is not defined` error. Probably some issue with Babel transpilation. However, including the `calypso-polyfills` is not likely a right solution.

When I remove these imports, locally nothing happens, the `explat-client` tests succeed. Hard to say what actually happened four years ago, when the fix was added in #49832. Looks like some Babel/Jest misconfiguration.

Let's see what CI says.

The only place where `@automattic/calypso-polyfills` import is justified is a webpack build of some entrypoint: one of the Calypso entrypoint (including the server), widgets like Notifications or Oddyssey.

This PR was inspired by reviewing @aduth's #103087 which touches the polyfills package.

## Testing instructions:
1. Let's see if all unit tests continue passing after this change.
2. Verify that `@automattic/calypso-polyfills` is ever imported in app entrypoints, as described above. There should be no other usages.
