### PR TITLE
Scheduled Plugin Updates: Add sensible text wrap to long empty state message 

### DIFF
--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -84,7 +84,7 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		p {
 			color: var(--studio-gray-80);
-			margin: 1.5rem auto;
+			margin-block: 1.5rem;
 		}
 	}
 

--- a/client/blocks/plugin-scheduled-updates-common/styles.scss
+++ b/client/blocks/plugin-scheduled-updates-common/styles.scss
@@ -93,6 +93,7 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		p {
 			text-align: center;
+			margin-inline: auto;
 		}
 
 		button {

--- a/client/blocks/plugins-scheduled-updates-multisite/styles.scss
+++ b/client/blocks/plugins-scheduled-updates-multisite/styles.scss
@@ -94,11 +94,6 @@ $brand-display: "SF Pro Display", sans-serif;
 				justify-content: end;
 			}
 		}
-		@media screen and (max-width: $break-small) {
-			.empty-state {
-				padding-inline: 0 !important;
-			}
-		}
 	}
 
 	.plugins-update-manager-multisite-filters {
@@ -211,6 +206,14 @@ $brand-display: "SF Pro Display", sans-serif;
 
 		.validation-msg {
 			width: 100%;
+		}
+	}
+
+	.empty-state {
+		@include content-padding;
+
+		p {
+			max-width: 720px;
 		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -132,11 +132,6 @@ body.is-section-plugins {
 		@include breakpoint-deprecated( "<960px" ) {
 			display: none;
 		}
-
-		.empty-state {
-			max-width: 100%;
-			padding: 0 1rem;
-		}
 	}
 
 	.hosting-dashboard-layout-column.scheduled-updates-list {
@@ -156,14 +151,6 @@ body.is-section-plugins {
 				margin-bottom: 0;
 				font-size: 0.875rem;
 				color: var(--color-neutral-60);
-			}
-		}
-
-		.empty-state {
-			padding: 0 4rem;
-
-			@include breakpoint-deprecated( "<960px" ) {
-				padding: 0 1rem;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/100468

## Proposed Changes

* Adds a 720px max width to the long "Take control of your site's maintenance ..." message that appears when the user hasn't set up any scheduled plugin updates yet
* Ensures the message padding aligns vertically with the page heading, subheading, search box, etc.

**Before**

![CleanShot 2025-05-06 at 22 05 56@2x](https://github.com/user-attachments/assets/cf0edaf1-0980-4357-9d52-d2b63366fb59)

![CleanShot 2025-05-06 at 22 07 20@2x](https://github.com/user-attachments/assets/de17e1f2-aab6-447e-9d48-11f794a914bd)


**After**

![CleanShot 2025-05-06 at 22 06 23@2x](https://github.com/user-attachments/assets/039cc5c8-2449-4fef-932d-506ca72f6118)

![CleanShot 2025-05-06 at 22 07 02@2x](https://github.com/user-attachments/assets/56d201c3-3a3f-48a1-9680-ebefa3364be1)



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes alignment and legibility.

Discussion in https://github.com/Automattic/wp-calypso/issues/100468 discusses using a shared "token width" that we use on for this sort of paragraph copy. Unfortunately no such token exists yet. I went with 720px because it matches the width of other paragraph-style text in the multisite dashboard. I accept I might not have made the correct decision on that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The multi-site scheduled updates UI is at:
`/plugins/scheduled-updates`
Remove any existing scheduled updates to see the message

There is also a site-specific scheduled updates UI at:
`/plugins/scheduled-updates/{{ atomic site slug }}`

![CleanShot 2025-05-06 at 22 10 34@2x](https://github.com/user-attachments/assets/9ad09645-a18a-4f20-971d-55eb249a94c3)

Do a side-by side comparison to confirm no changes have happened to this interface.

There's another `empty-state` message that appears when your search term doesn't match any of your schedules:

![CleanShot 2025-05-06 at 22 13 15@2x](https://github.com/user-attachments/assets/67256b81-980b-4515-8741-670bbe8c51f4)

It uses the same `empty-state` CSS class, so you should confirm this message is still centred the way it was before.


![CleanShot 2025-05-06 at 22 15 54@2x](https://github.com/user-attachments/assets/2dbe51b8-4adc-4421-9e3d-c667281a9775)

This version with the message in the sidebar isn't pixel perfect to what was there before. The CSS is spread over a number of files so it's not straightforward to get the paddings to align exactly the way I'd expect. But given this text is centred it's not as critical to have the paddings exactly the same IMO.

And of course make sure to test on mobile too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
