### PR TITLE
[DataViews]: move default UI into a separate component

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,7 @@
 
 ## Next 
 
+- Extract `<DefaultUI />` as a standalone component to clarify layout logic and prepare for custom UI compositions.
 - Expose `<DataViews.BulkActionToolbar />` component.
 - Expose `<DataViews.Filters />` component.
 - Expose `<DataViews.FiltersToggle />` component.

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -69,7 +69,7 @@ type DefaultUIProps = Pick<
 	isShowingFilter: boolean;
 };
 
-function DefaultLayout( {
+function DefaultUI( {
 	header,
 	search = true,
 	searchLabel = undefined,
@@ -165,9 +165,9 @@ function DataViews< Item >( {
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
-	const defaultLayout = useMemo(
+	const defaultUI = useMemo(
 		() => (
-			<DefaultLayout
+			<DefaultUI
 				header={ header }
 				search={ search }
 				searchLabel={ searchLabel }
@@ -203,7 +203,7 @@ function DataViews< Item >( {
 			} }
 		>
 			<div className="dataviews-wrapper" ref={ containerRef }>
-				{ children || defaultLayout }
+				{ children || defaultUI }
 			</div>
 		</DataViewsContext.Provider>
 	);

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -165,18 +165,6 @@ function DataViews< Item >( {
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
-	const defaultUI = useMemo(
-		() => (
-			<DefaultUI
-				header={ header }
-				search={ search }
-				searchLabel={ searchLabel }
-				isShowingFilter={ isShowingFilter }
-			/>
-		),
-		[ header, search, searchLabel, isShowingFilter ]
-	);
-
 	return (
 		<DataViewsContext.Provider
 			value={ {
@@ -203,7 +191,14 @@ function DataViews< Item >( {
 			} }
 		>
 			<div className="dataviews-wrapper" ref={ containerRef }>
-				{ children || defaultUI }
+				{ children ?? (
+					<DefaultUI
+						header={ header }
+						search={ search }
+						searchLabel={ searchLabel }
+						isShowingFilter={ isShowingFilter }
+					/>
+				) }
 			</div>
 		</DataViewsContext.Provider>
 	);

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react';
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useMemo, useState } from '@wordpress/element';
+import { useContext, useMemo, useState } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 
 /**
@@ -65,16 +65,14 @@ const EMPTY_ARRAY: any[] = [];
 type DefaultUIProps = Pick<
 	DataViewsProps< any >,
 	'header' | 'search' | 'searchLabel'
-> & {
-	isShowingFilter: boolean;
-};
+>;
 
 function DefaultUI( {
 	header,
 	search = true,
 	searchLabel = undefined,
-	isShowingFilter,
 }: DefaultUIProps ) {
+	const { isShowingFilter } = useContext( DataViewsContext );
 	return (
 		<>
 			<HStack
@@ -196,7 +194,6 @@ function DataViews< Item >( {
 						header={ header }
 						search={ search }
 						searchLabel={ searchLabel }
-						isShowingFilter={ isShowingFilter }
 					/>
 				) }
 			</div>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -62,6 +62,53 @@ const defaultGetItemId = ( item: ItemWithId ) => item.id;
 const defaultIsItemClickable = () => true;
 const EMPTY_ARRAY: any[] = [];
 
+type DefaultUIProps = Pick<
+	DataViewsProps< any >,
+	'header' | 'search' | 'searchLabel'
+> & {
+	isShowingFilter: boolean;
+};
+
+function DefaultLayout( {
+	header,
+	search = true,
+	searchLabel = undefined,
+	isShowingFilter,
+}: DefaultUIProps ) {
+	return (
+		<>
+			<HStack
+				alignment="top"
+				justify="space-between"
+				className="dataviews__view-actions"
+				spacing={ 1 }
+			>
+				<HStack
+					justify="start"
+					expanded={ false }
+					className="dataviews__search"
+				>
+					{ search && <DataViewsSearch label={ searchLabel } /> }
+					<FiltersToggle />
+				</HStack>
+				<HStack
+					spacing={ 1 }
+					expanded={ false }
+					style={ { flexShrink: 0 } }
+				>
+					<DataViewsViewConfig />
+					{ header }
+				</HStack>
+			</HStack>
+			{ isShowingFilter && (
+				<DataViewsFilters className="dataviews-filters__container" />
+			) }
+			<DataViewsLayout />
+			<DataViewsFooter />
+		</>
+	);
+}
+
 function DataViews< Item >( {
 	view,
 	onChangeView,
@@ -118,39 +165,6 @@ function DataViews< Item >( {
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
-	const defaultUI = (
-		<>
-			<HStack
-				alignment="top"
-				justify="space-between"
-				className="dataviews__view-actions"
-				spacing={ 1 }
-			>
-				<HStack
-					justify="start"
-					expanded={ false }
-					className="dataviews__search"
-				>
-					{ search && <DataViewsSearch label={ searchLabel } /> }
-					<FiltersToggle />
-				</HStack>
-				<HStack
-					spacing={ 1 }
-					expanded={ false }
-					style={ { flexShrink: 0 } }
-				>
-					<DataViewsViewConfig />
-					{ header }
-				</HStack>
-			</HStack>
-			{ isShowingFilter && (
-				<DataViewsFilters className="dataviews-filters__container" />
-			) }
-			<DataViewsLayout />
-			<DataViewsFooter />
-		</>
-	);
-
 	return (
 		<DataViewsContext.Provider
 			value={ {
@@ -177,7 +191,14 @@ function DataViews< Item >( {
 			} }
 		>
 			<div className="dataviews-wrapper" ref={ containerRef }>
-				{ children || defaultUI }
+				{ children || (
+					<DefaultLayout
+						header={ header }
+						search={ search }
+						searchLabel={ searchLabel }
+						isShowingFilter={ isShowingFilter }
+					/>
+				) }
 			</div>
 		</DataViewsContext.Provider>
 	);

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -165,6 +165,18 @@ function DataViews< Item >( {
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
 
+	const defaultLayout = useMemo(
+		() => (
+			<DefaultLayout
+				header={ header }
+				search={ search }
+				searchLabel={ searchLabel }
+				isShowingFilter={ isShowingFilter }
+			/>
+		),
+		[ header, search, searchLabel, isShowingFilter ]
+	);
+
 	return (
 		<DataViewsContext.Provider
 			value={ {
@@ -191,14 +203,7 @@ function DataViews< Item >( {
 			} }
 		>
 			<div className="dataviews-wrapper" ref={ containerRef }>
-				{ children || (
-					<DefaultLayout
-						header={ header }
-						search={ search }
-						searchLabel={ searchLabel }
-						isShowingFilter={ isShowingFilter }
-					/>
-				) }
+				{ children || defaultLayout }
 			</div>
 		</DataViewsContext.Provider>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes WOOA7S-129

## Proposed Changes

* Extract the default internal UI of `<DataViews />` into a new `DefaultUI` component.
* Use `useMemo()` to prevent unnecessary re-rendering of `DefaultUI` when `children` are passed.

## Why are these changes being made?

Currently, the JSX for the default layout inside `<DataViews />` is always computed, even if custom `children` are provided. This can introduce avoidable computation costs during render.

By moving the internal UI to a dedicated `DefaultUI` component and wrapping its usage in `useMemo()`, we reduce wasteful renders and make the codebase easier to read and evolve. This aligns with recent performance concerns raised by @mcsf and guidance from @youknowriad.

## Testing Instructions

* Run Storybook with:

```sh
yarn storybook:dataviews:start
```

* Visit the `Default` and `FreeComposition` stories.
* Ensure that:
    * The default UI renders correctly when no `children` are passed.
    * The memoized component is not re-rendered when `children` are present.
    * Behavior and visuals remain consistent with previous behavior.

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/c150f214-f205-417a-8030-c78a66a9fd7b" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
