### PR TITLE
Browserslist config: update Electron version to match installed one

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 			"last 2 Edge versions",
 			"last 2 Opera versions",
 			"Firefox ESR",
-			"Electron >= 11",
+			"Electron >= 26",
 			"unreleased Chrome versions",
 			"unreleased ChromeAndroid versions",
 			"unreleased Firefox versions",


### PR DESCRIPTION
The Desktop app uses Electron version 26.2.4, that's what is specified in `desktop/package.json`. But the Browserslist config is not up to date, it specifies `Electron >= 11`. That leads to unnecessary polyfilling.

This PR updates the Browserslist config also to v26. That removes some global polyfills, namely `es.regexp.flags` and `es.typed-array.set`.

## Testing instructions:
The easiest way to see the changed polyfills is to:
1. start local dev server at `calypso.localhost:3000`
2. open the local Calypso in browser and then find the `packages/calypso-polyfills/browser.js` module in devtools
3. without this PR, it imports three CoreJS polyfills:
   <img width="1295" alt="Screenshot 2025-05-06 at 12 32 15" src="https://github.com/user-attachments/assets/2d901460-e9ab-4848-b07c-09eb40a06e2c" />
4. after this PR, you'll see only one polyfill remaining, `web.immediate`
