### PR TITLE
Add doc link to substack import error

### DIFF
--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -68,12 +68,29 @@ class ImporterError extends PureComponent {
 		);
 		const { description = '' } = this.props;
 
+		const helpButton = (
+			<Button className="importer__error-pane is-link" onClick={ this.contactSupport } />
+		);
+
+		const generalMessage = this.props.translate(
+			'%(errorDescription)s{{br/}}Make sure you are using a valid export file in XML or ZIP format. {{cs}}Still need help{{/cs}}?',
+			{
+				args: {
+					errorDescription: description.length ? description : defaultError,
+				},
+				components: {
+					br: <br />,
+					cs: helpButton,
+				},
+			}
+		);
+
 		if ( isEnabled( 'importer/site-backups' ) && this.props.importerEngine === 'wordpress' ) {
 			return this.props.translate(
 				'The file type you uploaded is not supported. Please upload a WordPress export file in XML or ZIP format, or a Playground ZIP file. {{cs}}Still need help{{/cs}}?',
 				{
 					components: {
-						cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
+						cs: helpButton,
 					},
 				}
 			);
@@ -90,9 +107,7 @@ class ImporterError extends PureComponent {
 						},
 						components: {
 							br: <br />,
-							cs: (
-								<Button className="importer__error-pane is-link" onClick={ this.contactSupport } />
-							),
+							cs: helpButton,
 							doc: (
 								<a
 									href={ localizeUrl(
@@ -105,35 +120,11 @@ class ImporterError extends PureComponent {
 						},
 					}
 				),
-				oldCopy: this.props.translate(
-					'%(errorDescription)s{{br/}}Make sure you are using a valid export file in XML or ZIP format. {{cs}}Still need help{{/cs}}?',
-					{
-						args: {
-							errorDescription: description.length ? description : defaultError,
-						},
-						components: {
-							br: <br />,
-							cs: (
-								<Button className="importer__error-pane is-link" onClick={ this.contactSupport } />
-							),
-						},
-					}
-				),
+				oldCopy: generalMessage,
 			} );
 		}
 
-		return this.props.translate(
-			'%(errorDescription)s{{br/}}Make sure you are using a valid export file in XML or ZIP format. {{cs}}Still need help{{/cs}}?',
-			{
-				args: {
-					errorDescription: description.length ? description : defaultError,
-				},
-				components: {
-					br: <br />,
-					cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
-				},
-			}
-		);
+		return generalMessage;
 	};
 
 	getPreUploadError = () => {

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { localize } from 'i18n-calypso';
+import { localize, fixMe } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { WPImportError, FileTooLarge } from 'calypso/blocks/importer/wordpress/types';
@@ -80,27 +80,46 @@ class ImporterError extends PureComponent {
 		}
 
 		if ( this.props.importerEngine === 'substack' ) {
-			return this.props.translate(
-				'%(errorDescription)s{{br/}}Make sure you are using {{doc}}a valid export file{{/doc}} in XML or ZIP format.{{br/}}{{cs}}Still need help{{/cs}}?',
-				{
-					args: {
-						errorDescription: description.length ? description : defaultError,
-					},
-					components: {
-						br: <br />,
-						cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
-						doc: (
-							<a
-								href={ localizeUrl(
-									'https://wordpress.com/support/import-from-substack/import-content/'
-								) }
-								target="_blank"
-								rel="noreferrer"
-							/>
-						),
-					},
-				}
-			);
+			return fixMe( {
+				text: '%(errorDescription)s{{br/}}Make sure you are using {{doc}}a valid export file{{/doc}} in XML or ZIP format.{{br/}}{{cs}}Still need help{{/cs}}?',
+				newCopy: this.props.translate(
+					'%(errorDescription)s{{br/}}Make sure you are using {{doc}}a valid export file{{/doc}} in XML or ZIP format.{{br/}}{{cs}}Still need help{{/cs}}?',
+					{
+						args: {
+							errorDescription: description.length ? description : defaultError,
+						},
+						components: {
+							br: <br />,
+							cs: (
+								<Button className="importer__error-pane is-link" onClick={ this.contactSupport } />
+							),
+							doc: (
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/import-from-substack/import-content/'
+									) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				),
+				oldCopy: this.props.translate(
+					'%(errorDescription)s{{br/}}Make sure you are using a valid export file in XML or ZIP format. {{cs}}Still need help{{/cs}}?',
+					{
+						args: {
+							errorDescription: description.length ? description : defaultError,
+						},
+						components: {
+							br: <br />,
+							cs: (
+								<Button className="importer__error-pane is-link" onClick={ this.contactSupport } />
+							),
+						},
+					}
+				),
+			} );
 		}
 
 		return this.props.translate(

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
@@ -73,6 +74,30 @@ class ImporterError extends PureComponent {
 				{
 					components: {
 						cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
+					},
+				}
+			);
+		}
+
+		if ( this.props.importerEngine === 'substack' ) {
+			return this.props.translate(
+				'%(errorDescription)s{{br/}}Make sure you are using {{doc}}a valid export file{{/doc}} in XML or ZIP format.{{br/}}{{cs}}Still need help{{/cs}}?',
+				{
+					args: {
+						errorDescription: description.length ? description : defaultError,
+					},
+					components: {
+						br: <br />,
+						cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
+						doc: (
+							<a
+								href={ localizeUrl(
+									'https://wordpress.com/support/import-from-substack/import-content/'
+								) }
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
 					},
 				}
 			);

--- a/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
+++ b/client/my-sites/importer/newsletter/content-upload/file-importer.jsx
@@ -75,8 +75,14 @@ class FileImporter extends PureComponent {
 	};
 
 	render() {
-		const { title, overrideDestination, uploadDescription, optionalUrl, acceptedFileTypes } =
-			this.props.importerData;
+		const {
+			engine,
+			title,
+			overrideDestination,
+			uploadDescription,
+			optionalUrl,
+			acceptedFileTypes,
+		} = this.props.importerData;
 		const { importerStatus, site, fromSite, nextStepUrl, skipNextStep, invalidateCardData } =
 			this.props;
 		const { errorData, importerState } = importerStatus;
@@ -115,6 +121,7 @@ class FileImporter extends PureComponent {
 						retryImport={ () => {
 							this.props.cancelImport( site.ID, importerStatus.importerId );
 						} }
+						importerEngine={ engine }
 					/>
 				) }
 				{ includes( importingStates, importerState ) && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/loop/issues/564 / https://linear.app/a8c/issue/CML-281/substack-importer-create-and-link-to-help-article-for-zip-file-errors

## Proposed Changes

* Adds a link to support docs for the substack import error.

BEFORE
![Screenshot 2025-05-06 at 7 06 31 AM](https://github.com/user-attachments/assets/f097c6f3-d027-4c5d-b8a3-e3bb26c38170)

AFTER
![Screenshot 2025-05-06 at 7 05 51 AM](https://github.com/user-attachments/assets/110bcd54-1e90-4272-bb7f-3cfced9e48cf)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To link relevant support docs for users and make them easily accessible in case of problem.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the importer for substack.
* Trigger an upload error - easy way is to use a type of file other than XMP or ZIP (i used csv).
* Verify the error message links to support docs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
