### PR TITLE
Added tests to ensure blueprints are correctly returned

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -139,7 +139,7 @@ async function getBlueprintFromUrl( recommendedPhpVersion: string ): Blueprint {
 		...DEFAULT_BLUEPRINT,
 		...blueprint,
 		// Ensure steps are combined
-		steps: [ ...( DEFAULT_BLUEPRINT.steps || [] ), ...( blueprint.steps || [] ) ],
+		steps: [ ...( DEFAULT_BLUEPRINT.steps || [] ), ...( blueprint.steps || [] ) ].filter( Boolean ),
 		// Ensure nested objects like preferredVersions are merged properly
 		preferredVersions: {
 			...DEFAULT_BLUEPRINT.preferredVersions,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -131,14 +131,29 @@ async function getBlueprintFromUrl( recommendedPhpVersion: string ): Blueprint {
 
 	const blueprint = await resolveBlueprintFromURL( url );
 
+	// Create a deeply merged blueprint where custom properties override defaults
+	// but nested objects are merged properly
+	// Some properties are always set to an ensured value, like login: true and networking: true
+	// in the end, to ensure any new properties that might be added in the future are handled nicely
 	return {
 		...DEFAULT_BLUEPRINT,
 		...blueprint,
+		// Ensure steps are combined
 		steps: [ ...( DEFAULT_BLUEPRINT.steps || [] ), ...( blueprint.steps || [] ) ],
+		// Ensure nested objects like preferredVersions are merged properly
 		preferredVersions: {
-			wp: 'latest',
-			php: getPHPVersion( recommendedPhpVersion ),
+			...DEFAULT_BLUEPRINT.preferredVersions,
+			...blueprint.preferredVersions,
+			php: getPHPVersion( recommendedPhpVersion ), // Always ensure PHP version is set correctly
+			wp: 'latest', // Always ensure WordPress version is set to latest
 		},
+		// Ensure nested objects like features are merged properly
+		features: {
+			...DEFAULT_BLUEPRINT.features,
+			...blueprint.features,
+			networking: true, // ensure its always true
+		},
+		login: true, // ensure its always true, even though PG code already enforces this
 	};
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/resolve-blueprint-from-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/resolve-blueprint-from-url.ts
@@ -105,11 +105,9 @@ export async function resolveBlueprintFromURL( url: URL ) {
 	blueprint.preferredVersions!.wp =
 		query.get( 'wp' ) || blueprint.preferredVersions!.wp || 'latest';
 
-	// Features, must have networking enabled.
+	// Features
 	if ( ! blueprint.features ) {
-		blueprint.features = {
-			networking: true,
-		};
+		blueprint.features = {};
 	}
 
 	/**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - TODO: Fix TypeScript issues
+import { getBlueprint } from '../lib/blueprint';
+
+const DEFAULT_BLUEPRINT = {
+	preferredVersions: {
+		php: '8.3',
+		wp: 'latest',
+	},
+	features: {
+		networking: true,
+	},
+	login: true,
+};
+
+const BLUEPRINT_IN_URL_HASH = '#' + JSON.stringify( { landingPage: '/hash' } );
+const HASH_BLUEPRINT = {
+	preferredVersions: {
+		php: '8.2',
+		wp: 'latest',
+	},
+	features: {
+		networking: true,
+	},
+	login: true,
+	landingPage: '/hash',
+	steps: [], // @TODO remove this, temporarily added to satisfy tests
+};
+
+const WOOCOMMERCE_PREDEFINED_BLUEPRINT = {
+	preferredVersions: {
+		php: '8.1',
+		wp: 'latest',
+	},
+	features: {
+		networking: true,
+	},
+	login: true,
+	landingPage: '/shop',
+	steps: [
+		{
+			step: 'installPlugin',
+			pluginData: {
+				resource: 'wordpress.org/plugins',
+				slug: 'woocommerce',
+			},
+			options: {
+				activate: true,
+			},
+		},
+		{
+			step: 'importWxr',
+			file: {
+				resource: 'url',
+				url: 'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/sample_products.xml',
+			},
+		},
+	],
+};
+
+const REMOTE_BLUEPRINT = {
+	preferredVersions: {
+		php: '8.4', // Should use the PHP version passed to getBlueprint
+		wp: 'latest',
+	},
+	features: {
+		networking: true,
+	},
+	login: true,
+	landingPage: '/remote-blueprint',
+	steps: [], // @TODO remove this, temporarily added to satisfy tests
+};
+
+describe( 'getBlueprint', () => {
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'returns default blueprint if WordPress is installed', async () => {
+		const blueprint = await getBlueprint( true, '7.4' );
+		expect( blueprint ).toEqual( {
+			...DEFAULT_BLUEPRINT,
+			preferredVersions: {
+				wp: 'latest',
+				php: '7.4',
+			},
+		} );
+	} );
+
+	it( 'returns pre-defined blueprint when its name is specified', async () => {
+		jest.spyOn( global, 'URL' ).mockImplementation( () => ( {
+			searchParams: {
+				get: ( param ) => ( param === 'blueprint' ? 'woocommerce' : null ),
+			},
+		} ) );
+
+		const blueprint = await getBlueprint( false, '8.1' );
+		expect( blueprint ).toEqual( WOOCOMMERCE_PREDEFINED_BLUEPRINT );
+	} );
+
+	it( 'returns blueprint in url hash', async () => {
+		jest.spyOn( global, 'URL' ).mockImplementation( () => ( {
+			searchParams: {
+				get: () => null,
+				has: () => false,
+			},
+			hash: BLUEPRINT_IN_URL_HASH,
+		} ) );
+
+		const blueprint = await getBlueprint( false, '8.2' );
+		expect( blueprint ).toEqual( HASH_BLUEPRINT );
+	} );
+
+	it( 'returns blueprint after fetching from blueprint-url GET param', async () => {
+		// Mock URL to return blueprint-url parameter
+		jest.spyOn( global, 'URL' ).mockImplementation( () => ( {
+			searchParams: {
+				get: ( param ) =>
+					param === 'blueprint-url' ? 'https://example.com/blueprint.json' : null,
+				has: ( param ) => param === 'blueprint-url',
+			},
+		} ) );
+
+		// Mock the fetch function
+		global.fetch = jest.fn().mockImplementation( () =>
+			Promise.resolve( {
+				json: () =>
+					Promise.resolve( {
+						preferredVersions: {
+							php: '8.4',
+							wp: 'latest',
+						},
+						features: {
+							networking: true,
+						},
+						login: true,
+						landingPage: '/remote-blueprint',
+					} ),
+			} )
+		);
+
+		const blueprint = await getBlueprint( false, '8.4' );
+
+		// Verify fetch was called with the right URL
+		expect( global.fetch ).toHaveBeenCalledWith( 'https://example.com/blueprint.json', {
+			credentials: 'omit',
+		} );
+		expect( blueprint ).toEqual( REMOTE_BLUEPRINT );
+	} );
+
+	afterEach( () => {
+		// Restore the original fetch
+		if ( global.fetch && typeof global.fetch === 'function' && global.fetch.mockRestore ) {
+			global.fetch.mockRestore();
+		}
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
@@ -113,42 +113,130 @@ describe( 'getBlueprint', () => {
 		expect( blueprint ).toEqual( HASH_BLUEPRINT );
 	} );
 
-	it( 'returns blueprint after fetching from blueprint-url GET param', async () => {
-		// Mock URL to return blueprint-url parameter
-		jest.spyOn( global, 'URL' ).mockImplementation( () => ( {
-			searchParams: {
-				get: ( param ) =>
-					param === 'blueprint-url' ? 'https://example.com/blueprint.json' : null,
-				has: ( param ) => param === 'blueprint-url',
+	describe.each( [
+		{
+			testName: 'with a standard blueprint',
+			mockResponse: {
+				preferredVersions: {
+					php: '8.4',
+					wp: 'latest',
+				},
+				features: {
+					networking: true,
+				},
+				login: true,
+				landingPage: '/remote-blueprint',
 			},
-		} ) );
+		},
+		{
+			testName: 'when features property is not specified',
+			mockResponse: {
+				preferredVersions: {
+					php: '8.4',
+					wp: 'latest',
+				},
+				login: true,
+				landingPage: '/remote-blueprint',
+			},
+		},
+		{
+			testName: 'when features property is empty',
+			mockResponse: {
+				preferredVersions: {
+					php: '8.4',
+					wp: 'latest',
+				},
+				features: {},
+				login: true,
+				landingPage: '/remote-blueprint',
+			},
+		},
+		{
+			testName: 'with networking turned off',
+			mockResponse: {
+				preferredVersions: {
+					php: '8.4',
+					wp: 'latest',
+				},
+				features: {
+					networking: false,
+				},
+				login: true,
+				landingPage: '/remote-blueprint',
+			},
+		},
+		{
+			testName: 'with login turned off',
+			mockResponse: {
+				preferredVersions: {
+					php: '8.4',
+					wp: 'latest',
+				},
+				features: {
+					networking: true,
+				},
+				login: false,
+				landingPage: '/remote-blueprint',
+			},
+		},
+		{
+			testName: 'with modified PHP version',
+			mockResponse: {
+				preferredVersions: {
+					php: '99',
+					wp: 'latest',
+				},
+				features: {
+					networking: true,
+				},
+				login: true,
+				landingPage: '/remote-blueprint',
+			},
+		},
+		{
+			testName: 'with modified wp value',
+			mockResponse: {
+				preferredVersions: {
+					php: '8.4',
+					wp: '1.0',
+				},
+				features: {
+					networking: true,
+				},
+				login: true,
+				landingPage: '/remote-blueprint',
+			},
+		},
+	] )(
+		'returns blueprint after fetching from blueprint-url GET param $testName',
+		( { mockResponse } ) => {
+			it( 'fetches and returns the expected blueprint', async () => {
+				// Mock URL to return blueprint-url parameter
+				jest.spyOn( global, 'URL' ).mockImplementation( () => ( {
+					searchParams: {
+						get: ( param ) =>
+							param === 'blueprint-url' ? 'https://example.com/blueprint.json' : null,
+						has: ( param ) => param === 'blueprint-url',
+					},
+				} ) );
 
-		// Mock the fetch function
-		global.fetch = jest.fn().mockImplementation( () =>
-			Promise.resolve( {
-				json: () =>
+				// Mock the fetch function
+				global.fetch = jest.fn().mockImplementation( () =>
 					Promise.resolve( {
-						preferredVersions: {
-							php: '8.4',
-							wp: 'latest',
-						},
-						features: {
-							networking: true,
-						},
-						login: true,
-						landingPage: '/remote-blueprint',
-					} ),
-			} )
-		);
+						json: () => Promise.resolve( mockResponse ),
+					} )
+				);
 
-		const blueprint = await getBlueprint( false, '8.4' );
+				const blueprint = await getBlueprint( false, '8.4' );
 
-		// Verify fetch was called with the right URL
-		expect( global.fetch ).toHaveBeenCalledWith( 'https://example.com/blueprint.json', {
-			credentials: 'omit',
-		} );
-		expect( blueprint ).toEqual( REMOTE_BLUEPRINT );
-	} );
+				// Verify fetch was called with the right URL
+				expect( global.fetch ).toHaveBeenCalledWith( 'https://example.com/blueprint.json', {
+					credentials: 'omit',
+				} );
+				expect( blueprint ).toEqual( REMOTE_BLUEPRINT );
+			} );
+		}
+	);
 
 	afterEach( () => {
 		// Restore the original fetch

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
@@ -26,7 +26,7 @@ const HASH_BLUEPRINT = {
 	},
 	login: true,
 	landingPage: '/hash',
-	steps: [], // @TODO remove this, temporarily added to satisfy tests
+	steps: [],
 };
 
 const WOOCOMMERCE_PREDEFINED_BLUEPRINT = {
@@ -70,7 +70,7 @@ const REMOTE_BLUEPRINT = {
 	},
 	login: true,
 	landingPage: '/remote-blueprint',
-	steps: [], // @TODO remove this, temporarily added to satisfy tests
+	steps: [],
 };
 
 describe( 'getBlueprint', () => {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/PLAYGRD-51/networking-isnt-turned-on

## Proposed Changes

* Add tests


## Testing Instructions

`yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/playground/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
