### PR TITLE
Gutenberg editor: Replace `post` with `redirectPostEditor`

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,8 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { makeLayout, render } from 'calypso/controller';
-import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { addQueryArgs, getSiteFragment } from 'calypso/lib/route';
-import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { getAdminMenu, getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -21,7 +19,6 @@ import {
 	getSiteAdminUrl,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import CalypsoifyIframe from './calypsoify-iframe';
 import { Placeholder } from './placeholder';
 
 const noop = () => {};
@@ -223,68 +220,6 @@ export const redirect = async ( context, next ) => {
 		// pass along parameters, for example press-this
 		return window.location.replace( addQueryArgs( context.query, url ) );
 	}
-	return next();
-};
-
-function getPressThisData( query ) {
-	const { url, text, title, comment_content, comment_author } = query;
-
-	return url ? { url, text, title, comment_content, comment_author } : null;
-}
-
-function getBloggingPromptData( query ) {
-	const { answer_prompt } = query;
-	return answer_prompt ? { answer_prompt } : null;
-}
-
-function getSessionStorageOneTimeValue( key ) {
-	const value = window.sessionStorage.getItem( key );
-	window.sessionStorage.removeItem( key );
-	return value;
-}
-
-export const post = ( context, next ) => {
-	recordPageView( context.path, 'iFramed Editor', {
-		iframedEditor: true,
-		previousPath: context.previousPath,
-	} );
-
-	const postId = getPostID( context );
-	const postType = determinePostType( context );
-	const jetpackCopy = parseInt( context.query[ 'jetpack-copy' ] );
-
-	// Check if this value is an integer.
-	const duplicatePostId = Number.isInteger( jetpackCopy ) ? jetpackCopy : null;
-
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	const pressThisData = getPressThisData( context.query );
-	const bloggingPromptData = getBloggingPromptData( context.query );
-	const parentPostId = parseInt( context.query.parent_post, 10 ) || null;
-
-	// Set postId on state.editor.postId, so components like editor revisions can read from it.
-	context.store.dispatch( { type: EDITOR_START, siteId, postId } );
-
-	// Set post type on state.posts.[ id ].type, so components like document head can read from it.
-	context.store.dispatch( { type: POST_EDIT, post: { type: postType }, siteId, postId } );
-
-	context.primary = (
-		<CalypsoifyIframe
-			key={ postId }
-			postId={ postId }
-			postType={ postType }
-			duplicatePostId={ duplicatePostId }
-			pressThisData={ pressThisData }
-			bloggingPromptData={ bloggingPromptData }
-			parentPostId={ parentPostId }
-			creatingNewHomepage={ postType === 'page' && context.query.hasOwnProperty( 'new-homepage' ) }
-			stripeConnectSuccess={ context.query.stripe_connect_success ?? null }
-			showDraftPostModal={ getSessionStorageOneTimeValue(
-				'wpcom_signup_complete_show_draft_post_modal'
-			) }
-		/>
-	);
-
 	return next();
 };
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -297,6 +297,14 @@ export const exitPost = ( context, next ) => {
 	next();
 };
 
+export const redirectPostEditor = async ( context ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+
+	return window.location.replace( addQueryArgs( context.query, `${ siteAdminUrl }post-new.php` ) );
+};
+
 /**
  * Redirects to the un-iframed Site Editor if the config is enabled.
  * @param {Object} context Shared context in the route.

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -20,9 +20,7 @@ export default function () {
 		siteSelection,
 		redirect,
 		authenticate,
-		redirectPostEditor,
-		makeLayout,
-		clientRender
+		redirectPostEditor
 	);
 	page.exit( '/post/:site?/:post?', exitPost );
 	page( '/post/:site?', redirectLoggedOut, siteSelection, redirect, makeLayout, clientRender );
@@ -35,9 +33,7 @@ export default function () {
 		siteSelection,
 		redirect,
 		authenticate,
-		redirectPostEditor,
-		makeLayout,
-		clientRender
+		redirectPostEditor
 	);
 	page.exit( '/page/:site?/:post?', exitPost );
 	page( '/page/:site?', redirectLoggedOut, siteSelection, redirect, makeLayout, clientRender );
@@ -56,9 +52,7 @@ export default function () {
 		siteSelection,
 		redirect,
 		authenticate,
-		redirectPostEditor,
-		makeLayout,
-		clientRender
+		redirectPostEditor
 	);
 	page(
 		'/edit/:customPostType/:site?',

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -3,11 +3,11 @@ import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/c
 import { siteSelection, sites } from 'calypso/my-sites/controller';
 import {
 	authenticate,
-	post,
 	redirect,
 	exitPost,
 	redirectSiteEditor,
 	redirectToPermalinkIfLoggedOut,
+	redirectPostEditor,
 } from './controller';
 
 export default function () {
@@ -20,7 +20,7 @@ export default function () {
 		siteSelection,
 		redirect,
 		authenticate,
-		post,
+		redirectPostEditor,
 		makeLayout,
 		clientRender
 	);
@@ -35,7 +35,7 @@ export default function () {
 		siteSelection,
 		redirect,
 		authenticate,
-		post,
+		redirectPostEditor,
 		makeLayout,
 		clientRender
 	);
@@ -56,7 +56,7 @@ export default function () {
 		siteSelection,
 		redirect,
 		authenticate,
-		post,
+		redirectPostEditor,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
Related to DOTCOM-12994

## Proposed Changes

* There are some scenarios where the iframed editor is still reachable through the `post` route. Adding a redirection to the wp-admin post editor in our routing makes sure that doesn't happen.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As part of the RDV effort, we are getting rid of the iframed editor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `reader/feeds/149760554`
* On the first post, click on `Repost` and then choose a simple site
* Check that you are redirect to the wp-admin post editor (look for `/wp-admin/post-new.php` on the URL)

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/3c5ffd73-143c-4feb-97d9-e4ac5e97c0d3)|![image](https://github.com/user-attachments/assets/fd7b1af3-f901-411c-b2c5-e3114bac61d7)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
