### PR TITLE
Add new field type: `boolean`

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -14,7 +14,7 @@ import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { Site } from '../data/types';
-import type { Operator, ViewTable, ViewGrid, SortDirection } from '@automattic/dataviews';
+import type { Field, Operator, SortDirection, ViewTable, ViewGrid } from '@automattic/dataviews';
 
 const actions = [
 	{
@@ -31,7 +31,7 @@ const actions = [
 	},
 ];
 
-const DEFAULT_FIELDS = [
+const DEFAULT_FIELDS: Field< Site >[] = [
 	{
 		id: 'name',
 		label: __( 'Site' ),

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -59,6 +59,7 @@ const DEFAULT_FIELDS = [
 	},
 	{
 		id: 'backups',
+		type: 'boolean',
 		label: __( 'Backups' ),
 		getValue: ( { item }: { item: Site } ) => !! item.plan?.features?.active?.includes( 'backups' ),
 		elements: [
@@ -74,10 +75,10 @@ const DEFAULT_FIELDS = [
 		filterBy: {
 			operators: [ 'is' as Operator ],
 		},
-		enableSorting: false,
 	},
 	{
 		id: 'protect',
+		type: 'boolean',
 		label: __( 'Protect' ),
 		getValue: ( { item }: { item: Site } ) => !! item.active_modules?.includes( 'protect' ),
 		render: ( { item }: { item: Site } ) =>
@@ -89,7 +90,6 @@ const DEFAULT_FIELDS = [
 		filterBy: {
 			operators: [ 'is' as Operator ],
 		},
-		enableSorting: false,
 	},
 	{
 		id: 'status',
@@ -100,6 +100,7 @@ const DEFAULT_FIELDS = [
 	},
 	{
 		id: 'is_a8c',
+		type: 'boolean',
 		label: __( 'A8C Owned' ),
 		elements: [
 			{ value: true, label: __( 'Yes' ) },
@@ -109,7 +110,6 @@ const DEFAULT_FIELDS = [
 			operators: [ 'is' as Operator ],
 		},
 		render: ( { item }: { item: Site } ) => ( item.is_a8c ? __( 'Yes' ) : __( 'No' ) ),
-		enableSorting: false,
 	},
 	{
 		id: 'preview',

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Add new `boolean` field type and edit control.
+
 ## 0.1.1
 
 - Add support for free composition in the `DataViews` component by exporting subcomponents: `<DataViews.ViewConfig />`, `<DataViews.Search />`, `<DataViews.Pagination />`, `<DataViews.LayoutSwitcher />`, `<DataViews.Layout />`, `<DataViews.FiltersToggle />`, `<DataViews.Filters />`, `<DataViews.BulkActionToolbar />`.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Add new `boolean` field type and edit control.
+- Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 
 ## 0.1.1
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -106,20 +105,7 @@ const fields = [
 	{
 		id: 'sticky',
 		label: 'Sticky',
-		type: 'integer',
-		Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
-			const { id, getValue } = field;
-			return (
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ hideLabelFromVision ? '' : field.label }
-					checked={ getValue( { item: data } ) }
-					onChange={ () =>
-						onChange( { [ id ]: ! getValue( { item: data } ) } )
-					}
-				/>
-			);
-		},
+		type: 'boolean',
 	},
 ] as Field< SamplePost >[];
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -134,11 +134,7 @@ export const Default = ( {
 			fields: [
 				'title',
 				'order',
-				{
-					id: 'sticky',
-					layout: 'regular',
-					labelPosition: 'side',
-				},
+				'sticky',
 				'author',
 				'reviewer',
 				'password',

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -29,6 +29,7 @@ export type SpaceObject = {
 	description: string;
 	image: string;
 	type: string;
+	isPlanet: boolean;
 	categories: string[];
 	satellites: number;
 	date: string;
@@ -41,6 +42,7 @@ export const data: SpaceObject[] = [
 		description: 'Apollo description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Not a planet',
+		isPlanet: false,
 		categories: [ 'Space', 'NASA' ],
 		satellites: 0,
 		date: '2021-01-01T00:00:00Z',
@@ -51,6 +53,7 @@ export const data: SpaceObject[] = [
 		description: 'Space description',
 		image: 'https://live.staticflickr.com/5678/21911065441_92e2d44708_b.jpg',
 		type: 'Not a planet',
+		isPlanet: false,
 		categories: [ 'Space' ],
 		satellites: 0,
 		date: '2019-01-02T00:00:00Z',
@@ -61,6 +64,7 @@ export const data: SpaceObject[] = [
 		description: 'NASA photo',
 		image: 'https://live.staticflickr.com/742/21712365770_8f70a2c91e_b.jpg',
 		type: 'Not a planet',
+		isPlanet: false,
 		categories: [ 'NASA' ],
 		satellites: 0,
 		date: '2025-01-03T00:00:00Z',
@@ -71,6 +75,7 @@ export const data: SpaceObject[] = [
 		description: 'Neptune description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Ice giant',
+		isPlanet: true,
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 14,
 		date: '2020-01-01T00:00:00Z',
@@ -81,6 +86,7 @@ export const data: SpaceObject[] = [
 		description: 'Mercury description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Terrestrial',
+		isPlanet: true,
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
 		date: '2020-01-02T01:00:00Z',
@@ -91,6 +97,7 @@ export const data: SpaceObject[] = [
 		description: 'La planète Vénus',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Terrestrial',
+		isPlanet: true,
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
 		date: '2020-01-02T00:00:00Z',
@@ -101,6 +108,7 @@ export const data: SpaceObject[] = [
 		description: 'Earth description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Terrestrial',
+		isPlanet: true,
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 1,
 		date: '2023-01-03T00:00:00Z',
@@ -111,6 +119,7 @@ export const data: SpaceObject[] = [
 		description: 'Mars description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Terrestrial',
+		isPlanet: true,
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 2,
 		date: '2020-01-01T00:00:00Z',
@@ -121,6 +130,7 @@ export const data: SpaceObject[] = [
 		description: 'Jupiter description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Gas giant',
+		isPlanet: true,
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 95,
 		date: '2017-01-01T00:01:00Z',
@@ -131,6 +141,7 @@ export const data: SpaceObject[] = [
 		description: 'Saturn description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Gas giant',
+		isPlanet: true,
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 146,
 		date: '2020-02-01T00:02:00Z',
@@ -141,6 +152,7 @@ export const data: SpaceObject[] = [
 		description: 'Uranus description',
 		image: 'https://live.staticflickr.com/5725/21726228300_51333bd62c_b.jpg',
 		type: 'Ice giant',
+		isPlanet: true,
 		categories: [ 'Space', 'Ice giant', 'Solar system' ],
 		satellites: 28,
 		date: '2020-03-01T00:00:00Z',
@@ -655,6 +667,14 @@ export const fields: Field< SpaceObject >[] = [
 			{ value: 'Terrestrial', label: 'Terrestrial' },
 			{ value: 'Gas giant', label: 'Gas giant' },
 		],
+	},
+	{
+		id: 'isPlanet',
+		label: 'Is Planet',
+		type: 'boolean',
+		render: ( { item } ) => {
+			return item.isPlanet ? 'Yes' : 'No';
+		},
 	},
 	{
 		label: 'Satellites',

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -672,9 +672,10 @@ export const fields: Field< SpaceObject >[] = [
 		id: 'isPlanet',
 		label: 'Is Planet',
 		type: 'boolean',
-		render: ( { item } ) => {
-			return item.isPlanet ? 'Yes' : 'No';
-		},
+		elements: [
+			{ value: true, label: 'True' },
+			{ value: false, label: 'False' },
+		],
 	},
 	{
 		label: 'Satellites',

--- a/packages/dataviews/src/dataform-controls/boolean.tsx
+++ b/packages/dataviews/src/dataform-controls/boolean.tsx
@@ -14,15 +14,31 @@ export default function Boolean< Item >( {
 	data,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, getValue } = field;
+	const { id, getValue, label } = field;
+	if ( hideLabelFromVision ) {
+		return (
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ '' }
+				checked={ getValue( { item: data } ) }
+				onChange={ () =>
+					onChange( { [ id ]: ! getValue( { item: data } ) } )
+				}
+			/>
+		);
+	}
+
 	return (
-		<ToggleControl
-			__nextHasNoMarginBottom
-			label={ hideLabelFromVision ? '' : field.label }
-			checked={ getValue( { item: data } ) }
-			onChange={ () =>
-				onChange( { [ id ]: ! getValue( { item: data } ) } )
-			}
-		/>
+		<label>
+			{ label }
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ '' }
+				checked={ getValue( { item: data } ) }
+				onChange={ () =>
+					onChange( { [ id ]: ! getValue( { item: data } ) } )
+				}
+			/>
+		</label>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/boolean.tsx
+++ b/packages/dataviews/src/dataform-controls/boolean.tsx
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps } from '../types';
+
+export default function Boolean< Item >( {
+	field,
+	onChange,
+	data,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	const { id, getValue } = field;
+	return (
+		<ToggleControl
+			__nextHasNoMarginBottom
+			label={ hideLabelFromVision ? '' : field.label }
+			checked={ getValue( { item: data } ) }
+			onChange={ () =>
+				onChange( { [ id ]: ! getValue( { item: data } ) } )
+			}
+		/>
+	);
+}

--- a/packages/dataviews/src/dataform-controls/boolean.tsx
+++ b/packages/dataviews/src/dataform-controls/boolean.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToggleControl } from '@wordpress/components';
+import { BaseControl, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,20 +17,21 @@ export default function Boolean< Item >( {
 	const { id, getValue, label } = field;
 	if ( hideLabelFromVision ) {
 		return (
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ '' }
-				checked={ getValue( { item: data } ) }
-				onChange={ () =>
-					onChange( { [ id ]: ! getValue( { item: data } ) } )
-				}
-			/>
+			<BaseControl>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ '' }
+					checked={ getValue( { item: data } ) }
+					onChange={ () =>
+						onChange( { [ id ]: ! getValue( { item: data } ) } )
+					}
+				/>
+			</BaseControl>
 		);
 	}
 
 	return (
-		<label>
-			{ label }
+		<BaseControl label={ label }>
 			<ToggleControl
 				__nextHasNoMarginBottom
 				label={ '' }
@@ -39,6 +40,6 @@ export default function Boolean< Item >( {
 					onChange( { [ id ]: ! getValue( { item: data } ) } )
 				}
 			/>
-		</label>
+		</BaseControl>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -16,12 +16,14 @@ import integer from './integer';
 import radio from './radio';
 import select from './select';
 import text from './text';
+import boolean from './boolean';
 
 interface FormControls {
 	[ key: string ]: ComponentType< DataFormControlProps< any > >;
 }
 
 const FORM_CONTROLS: FormControls = {
+	boolean,
 	datetime,
 	integer,
 	radio,

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -138,7 +138,10 @@ function PanelDropdown< Item >( {
 					) }
 					onClick={ onToggle }
 				>
-					<fieldDefinition.render item={ data } />
+					<fieldDefinition.render
+						item={ data }
+						field={ fieldDefinition }
+					/>
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -78,11 +78,11 @@ function GridItem< Item >( {
 	const instanceId = useInstanceId( GridItem );
 	const isSelected = selection.includes( id );
 	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render item={ item } />
+		<mediaField.render item={ item } field={ mediaField } />
 	) : null;
 	const renderedTitleField =
 		showTitle && titleField?.render ? (
-			<titleField.render item={ item } />
+			<titleField.render item={ item } field={ titleField } />
 		) : null;
 
 	const clickableMediaItemProps = getClickableItemProps( {
@@ -166,7 +166,10 @@ function GridItem< Item >( {
 			</HStack>
 			<VStack spacing={ 1 }>
 				{ showDescription && descriptionField?.render && (
-					<descriptionField.render item={ item } />
+					<descriptionField.render
+						item={ item }
+						field={ descriptionField }
+					/>
 				) }
 				{ !! badgeFields?.length && (
 					<HStack
@@ -182,7 +185,10 @@ function GridItem< Item >( {
 									key={ field.id }
 									className="dataviews-view-grid__field-value"
 								>
-									<field.render item={ item } />
+									<field.render
+										item={ item }
+										field={ field }
+									/>
 								</Badge>
 							);
 						} ) }
@@ -212,7 +218,10 @@ function GridItem< Item >( {
 											className="dataviews-view-grid__field-value"
 											style={ { maxHeight: 'none' } }
 										>
-											<field.render item={ item } />
+											<field.render
+												item={ item }
+												field={ field }
+											/>
 										</FlexItem>
 									</>
 								</Flex>

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -199,13 +199,13 @@ function ListItem< Item >( {
 	const renderedMediaField =
 		showMedia && mediaField?.render ? (
 			<div className="dataviews-view-list__media-wrapper">
-				<mediaField.render item={ item } />
+				<mediaField.render item={ item } field={ mediaField } />
 			</div>
 		) : null;
 
 	const renderedTitleField =
 		showTitle && titleField?.render ? (
-			<titleField.render item={ item } />
+			<titleField.render item={ item } field={ titleField } />
 		) : null;
 
 	const usedActions = eligibleActions?.length > 0 && (
@@ -302,7 +302,10 @@ function ListItem< Item >( {
 						</HStack>
 						{ showDescription && descriptionField?.render && (
 							<div className="dataviews-view-list__field">
-								<descriptionField.render item={ item } />
+								<descriptionField.render
+									item={ item }
+									field={ descriptionField }
+								/>
 							</div>
 						) }
 						<div
@@ -321,7 +324,10 @@ function ListItem< Item >( {
 										{ field.label }
 									</VisuallyHidden>
 									<span className="dataviews-view-list__field-value">
-										<field.render item={ item } />
+										<field.render
+											item={ item }
+											field={ field }
+										/>
 									</span>
 								</div>
 							) ) }

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -40,7 +40,7 @@ function ColumnPrimary< Item >( {
 		<HStack spacing={ 3 } justify="flex-start">
 			{ mediaField && (
 				<div className="dataviews-view-table__cell-content-wrapper dataviews-column-primary__media">
-					<mediaField.render item={ item } />
+					<mediaField.render item={ item } field={ mediaField } />
 				</div>
 			) }
 			<VStack spacing={ 0 }>
@@ -51,11 +51,14 @@ function ColumnPrimary< Item >( {
 								{ '—'.repeat( level ) }&nbsp;
 							</span>
 						) }
-						<titleField.render item={ item } />
+						<titleField.render item={ item } field={ titleField } />
 					</div>
 				) }
 				{ descriptionField && (
-					<descriptionField.render item={ item } />
+					<descriptionField.render
+						item={ item }
+						field={ descriptionField }
+					/>
 				) }
 			</VStack>
 		</HStack>

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -68,7 +68,7 @@ function TableColumnField< Item >( {
 
 	return (
 		<div className="dataviews-view-table__cell-content-wrapper">
-			<field.render { ...{ item } } />
+			<field.render item={ item } field={ field } />
 		</div>
 	);
 }

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import type { SortDirection, ValidationContext } from '../types';
+
+function sort( a: any, b: any, direction: SortDirection ) {
+	const boolA = Boolean( a );
+	const boolB = Boolean( b );
+
+	if ( boolA === boolB ) {
+		return 0;
+	}
+
+	// In ascending order, false comes before true
+	if ( direction === 'asc' ) {
+		return boolA ? 1 : -1;
+	}
+
+	// In descending order, true comes before false
+	return boolA ? -1 : 1;
+}
+
+function isValid( value: any, context?: ValidationContext ) {
+	if ( ! [ true, false, undefined ].includes( value ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+export default {
+	sort,
+	isValid,
+	Edit: () => null,
+};

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import type { SortDirection, ValidationContext } from '../types';
+import type {
+	DataViewRenderFieldProps,
+	SortDirection,
+	ValidationContext,
+} from '../types';
+import { renderFromElements } from '../utils';
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	const boolA = Boolean( a );
@@ -32,4 +37,19 @@ export default {
 	sort,
 	isValid,
 	Edit: 'boolean',
+	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
+		if ( field.elements ) {
+			return renderFromElements( { item, field } );
+		}
+
+		if ( field.getValue( { item } ) === true ) {
+			return 'true';
+		}
+
+		if ( field.getValue( { item } ) === false ) {
+			return 'false';
+		}
+
+		return null;
+	},
 };

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type {
@@ -43,11 +48,11 @@ export default {
 		}
 
 		if ( field.getValue( { item } ) === true ) {
-			return 'true';
+			return __( 'True' );
 		}
 
 		if ( field.getValue( { item } ) === false ) {
-			return 'false';
+			return __( 'False' );
 		}
 
 		return null;

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -31,5 +31,5 @@ function isValid( value: any, context?: ValidationContext ) {
 export default {
 	sort,
 	isValid,
-	Edit: () => null,
+	Edit: 'boolean',
 };

--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import type { SortDirection, ValidationContext } from '../types';
+import type {
+	DataViewRenderFieldProps,
+	SortDirection,
+	ValidationContext,
+} from '../types';
+import { renderFromElements } from '../utils';
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	const timeA = new Date( a ).getTime();
@@ -25,4 +30,9 @@ export default {
 	sort,
 	isValid,
 	Edit: 'datetime',
+	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
+		return field.elements
+			? renderFromElements( { item, field } )
+			: field.getValue( { item } );
+	},
 };

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -1,11 +1,17 @@
 /**
  * Internal dependencies
  */
-import type { FieldType, SortDirection, ValidationContext } from '../types';
+import type {
+	DataViewRenderFieldProps,
+	FieldType,
+	SortDirection,
+	ValidationContext,
+} from '../types';
 import { default as integer } from './integer';
 import { default as text } from './text';
 import { default as datetime } from './datetime';
 import { default as boolean } from './boolean';
+import { renderFromElements } from '../utils';
 
 /**
  *
@@ -13,7 +19,7 @@ import { default as boolean } from './boolean';
  *
  * @return A field type definition.
  */
-export default function getFieldTypeDefinition( type?: FieldType ) {
+export default function getFieldTypeDefinition< Item >( type?: FieldType ) {
 	if ( 'integer' === type ) {
 		return integer;
 	}
@@ -51,5 +57,10 @@ export default function getFieldTypeDefinition( type?: FieldType ) {
 			return true;
 		},
 		Edit: () => null,
+		render: ( { item, field }: DataViewRenderFieldProps< Item > ) => {
+			return field.elements
+				? renderFromElements( { item, field } )
+				: field.getValue( { item } );
+		},
 	};
 }

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -5,6 +5,7 @@ import type { FieldType, SortDirection, ValidationContext } from '../types';
 import { default as integer } from './integer';
 import { default as text } from './text';
 import { default as datetime } from './datetime';
+import { default as boolean } from './boolean';
 
 /**
  *
@@ -23,6 +24,10 @@ export default function getFieldTypeDefinition( type?: FieldType ) {
 
 	if ( 'datetime' === type ) {
 		return datetime;
+	}
+
+	if ( 'boolean' === type ) {
+		return boolean;
 	}
 
 	return {

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import type { SortDirection, ValidationContext } from '../types';
+import type {
+	DataViewRenderFieldProps,
+	SortDirection,
+	ValidationContext,
+} from '../types';
+import { renderFromElements } from '../utils';
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	return direction === 'asc' ? a - b : b - a;
@@ -31,4 +36,9 @@ export default {
 	sort,
 	isValid,
 	Edit: 'integer',
+	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
+		return field.elements
+			? renderFromElements( { item, field } )
+			: field.getValue( { item } );
+	},
 };

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import type { SortDirection, ValidationContext } from '../types';
+import type {
+	DataViewRenderFieldProps,
+	SortDirection,
+	ValidationContext,
+} from '../types';
+import { renderFromElements } from '../utils';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
 	return direction === 'asc'
@@ -24,4 +29,9 @@ export default {
 	sort,
 	isValid,
 	Edit: 'text',
+	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
+		return field.elements
+			? renderFromElements( { item, field } )
+			: field.getValue( { item } );
+	},
 };

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import getFieldTypeDefinition from './field-types';
-import type { Field, NormalizedField } from './types';
+import type { DataViewRenderFieldProps, Field, NormalizedField } from './types';
 import { getControl } from './dataform-controls';
 
 const getValueFromId =
@@ -31,7 +31,9 @@ export function normalizeFields< Item >(
 	fields: Field< Item >[]
 ): NormalizedField< Item >[] {
 	return fields.map( ( field ) => {
-		const fieldTypeDefinition = getFieldTypeDefinition( field.type );
+		const fieldTypeDefinition = getFieldTypeDefinition< Item >(
+			field.type
+		);
 
 		const getValue = field.getValue || getValueFromId( field.id );
 
@@ -56,16 +58,14 @@ export function normalizeFields< Item >(
 
 		const Edit = getControl( field, fieldTypeDefinition );
 
-		const renderFromElements = ( { item }: { item: Item } ) => {
-			const value = getValue( { item } );
-			return (
-				field?.elements?.find( ( element ) => element.value === value )
-					?.label || getValue( { item } )
-			);
-		};
-
 		const render =
-			field.render || ( field.elements ? renderFromElements : getValue );
+			field.render ??
+			function render( {
+				item,
+				field,
+			}: DataViewRenderFieldProps< Item > ) {
+				return fieldTypeDefinition.render( { item, field } );
+			};
 
 		return {
 			...field,

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -71,6 +71,11 @@ export type FieldTypeDefinition< Item > = {
 	 * Callback used to render an edit control for the field or control name.
 	 */
 	Edit: ComponentType< DataFormControlProps< Item > > | string;
+
+	/**
+	 * Callback used to render the field.
+	 */
+	render: ComponentType< DataViewRenderFieldProps< Item > >;
 };
 
 /**
@@ -193,6 +198,7 @@ export type DataFormControlProps< Item > = {
 
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
+	field: NormalizedField< Item >;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -47,7 +47,7 @@ export type Operator =
 	| 'isAll'
 	| 'isNotAll';
 
-export type FieldType = 'text' | 'integer' | 'datetime' | 'media';
+export type FieldType = 'text' | 'integer' | 'datetime' | 'media' | 'boolean';
 
 export type ValidationContext = {
 	elements?: Option[];

--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -8,7 +8,7 @@ import {
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
 } from './constants';
-import type { NormalizedField } from './types';
+import type { DataViewRenderFieldProps, NormalizedField } from './types';
 
 export function sanitizeOperators< Item >( field: NormalizedField< Item > ) {
 	let operators = field.filterBy?.operators;
@@ -35,4 +35,15 @@ export function sanitizeOperators< Item >( field: NormalizedField< Item > ) {
 	}
 
 	return operators;
+}
+
+export function renderFromElements< Item >( {
+	item,
+	field,
+}: DataViewRenderFieldProps< Item > ) {
+	const value = field.getValue( { item } );
+	return (
+		field?.elements?.find( ( element ) => element.value === value )
+			?.label || field.getValue( { item } )
+	);
 }


### PR DESCRIPTION
DOTCOM-12997

Related to https://github.com/Automattic/wp-calypso/pull/103149

## Proposed Changes

This PR adds a new field type and edit control: `boolean`. It also uses the new type in some fields of the new dashboard, so they are sortable (backups, protect, is a8c owned).

https://github.com/user-attachments/assets/8c577b10-cda8-4464-9a28-dc0954140a95


## Why are these changes being made?

To continue expanding the field types. Specifically, this allows sorting by boolean and adds an automatic Edit control for fields of that type.

Sorting booleans works like in JavaScript: in ascending order, false values go first; in descending order, true values go first.

## Testing Instructions

- `yarn workspace @automattic/dataviews storybook:start`.
- Try the new boolean Edit function in the storybook by going to the DataForm story and verify the "Sticky" field still works as before.

https://github.com/user-attachments/assets/1e3102c8-42fa-4fc5-86b2-befc3d74b5e8

- Try the new boolean sort function in the storybook by going to the DataViews story, make the `isPlanet` field visible, and sort.

https://github.com/user-attachments/assets/b88094b7-378b-4218-abf6-06fd590f953b

