### PR TITLE
Allow user cancellation of DIFM migrations

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/index.tsx
@@ -1,0 +1,103 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Modal, Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { LoadingBar } from 'calypso/components/loading-bar';
+import wp from 'calypso/lib/wp';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+
+const CancelDifmMigrationForm = ( { siteId }: { siteId: number } ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ isOpen, setOpen ] = useState( false );
+	const openModal = () => setOpen( true );
+	const closeModal = () => setOpen( false );
+	const [ cancellationStatus, setCancellationStatus ] = useState<
+		'pending' | 'error' | 'success' | null
+	>( null );
+
+	if ( ! isEnabled( 'migration-flow/cancel-difm' ) ) {
+		return null;
+	}
+
+	const handleSendCancellationRequest = async ( siteId: number ) => {
+		try {
+			return await wp.req.post( {
+				path: `/sites/${ siteId }/automated-migration/cancel-migration`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		} catch ( error ) {
+			return error;
+		}
+	};
+
+	const handleCancelMigration = async ( siteId: number ) => {
+		setCancellationStatus( 'pending' );
+		closeModal();
+		const response = await handleSendCancellationRequest( siteId );
+
+		if ( ! response?.success ) {
+			setCancellationStatus( 'error' );
+			dispatch(
+				errorNotice(
+					translate(
+						"We couldn't cancel your migration. Our support team will reach out to help."
+					),
+					{ duration: 5000 }
+				)
+			);
+			return;
+		}
+
+		setCancellationStatus( 'success' );
+		dispatch(
+			successNotice( translate( 'Migration cancellation request sent.' ), {
+				duration: 5000,
+			} )
+		);
+	};
+
+	return (
+		<div className="migration-started-difm__cancel-form">
+			{ cancellationStatus === 'pending' && (
+				<LoadingBar className="migration-started-difm__cancel-loading-bar" progress={ 0.5 } />
+			) }
+			{ cancellationStatus === null && (
+				<Button
+					variant="link"
+					onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+						e.preventDefault();
+						openModal();
+					} }
+				>
+					{ translate( 'Request cancellation' ) }
+				</Button>
+			) }
+			{ isOpen && (
+				<Modal
+					className="migration-started-difm__cancel-dialog"
+					title={ translate( 'Request migration cancellation' ) }
+					onRequestClose={ closeModal }
+					size="medium"
+				>
+					<p>
+						{ translate(
+							"Since your migration is already underway, you'll need to send us a cancellation request. If you cancel now, you'll lose all your progress."
+						) }
+					</p>
+					<div className="migration-started-difm__cancel-dialog-buttons">
+						<Button key="cancel" variant="secondary" onClick={ () => closeModal() }>
+							{ translate( "Don't cancel migration" ) }
+						</Button>
+						<Button key="send" variant="primary" onClick={ () => handleCancelMigration( siteId ) }>
+							{ translate( 'Send request' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</div>
+	);
+};
+
+export default CancelDifmMigrationForm;

--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import CancelDifmMigrationForm from '../index';
+
+jest.mock( '@automattic/calypso-config', () => {
+	return {
+		__esModule: true,
+		default: jest.fn(), // mock config()
+		isEnabled: jest.fn(),
+	};
+} );
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		post: jest.fn(),
+	},
+} ) );
+
+describe( 'CancelDifmMigrationForm', () => {
+	const siteId = 123;
+	const isEnabled = jest.requireMock( '@automattic/calypso-config' ).isEnabled;
+
+	beforeEach( () => {
+		nock.cleanAll();
+		jest.clearAllMocks();
+		isEnabled.mockReturnValue( true );
+	} );
+
+	it( 'renders nothing if feature flag is disabled', () => {
+		isEnabled.mockReturnValue( false );
+		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+		expect( screen.queryByRole( 'button', { name: /request cancellation/i } ) ).toBeNull();
+	} );
+
+	it( 'opens dialog on button click', async () => {
+		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+		await userEvent.click( screen.getByRole( 'button', { name: /request cancellation/i } ) );
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+		expect( screen.getByText( /request migration cancellation/i ) ).toBeVisible();
+	} );
+
+	it( 'closes dialog on cancel', async () => {
+		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+		await userEvent.click( screen.getByRole( 'button', { name: /request cancellation/i } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /don't cancel migration/i } ) );
+		await waitFor( () => {
+			expect( screen.queryByRole( 'dialog' ) ).toBeNull();
+		} );
+	} );
+} );

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -2,7 +2,9 @@ import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { globe, group, Icon, scheduled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
+import CancelDifmMigrationForm from './cancel-difm-migration';
 import { Container, Header } from './layout';
+import type { SiteDetails } from '@automattic/data-stores';
 
 type MigrationStartedListProps = {
 	children: ReactElement< MigrationStartedItemProps > | ReactElement< MigrationStartedItemProps >[];
@@ -26,7 +28,7 @@ const MigrationStartedItem = ( { icon, text }: MigrationStartedItemProps ) => (
 	</li>
 );
 
-export const MigrationStartedDIFM = () => {
+export const MigrationStartedDIFM = ( { site }: { site: SiteDetails } ) => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 
@@ -66,6 +68,7 @@ export const MigrationStartedDIFM = () => {
 						) }
 					/>
 				</MigrationStartedList>
+				<CancelDifmMigrationForm siteId={ site.ID } />
 			</div>
 		</Container>
 	);

--- a/client/sites/overview/components/migration-overview/index.tsx
+++ b/client/sites/overview/components/migration-overview/index.tsx
@@ -15,7 +15,7 @@ const MigrationOverview = ( { site }: { site: SiteDetails } ) => {
 	}
 
 	if ( migrationType === 'difm' ) {
-		return <MigrationStartedDIFM />;
+		return <MigrationStartedDIFM site={ site } />;
 	}
 
 	if ( migrationType === 'diy' ) {

--- a/client/sites/overview/components/migration-overview/style.scss
+++ b/client/sites/overview/components/migration-overview/style.scss
@@ -71,5 +71,23 @@
 			background-color: #F7F8FE;
 			flex-shrink: 0;
 		}
+
+		.migration-started-difm__cancel-form {
+			display: flex;
+			justify-content: center;
+
+			button {
+				color: var(--studio-gray-80);
+			}
+		}
+	}
+}
+
+.migration-started-difm__cancel-dialog {
+	.migration-started-difm__cancel-dialog-buttons {
+		display: flex;
+		flex-direction: row;
+		gap: 1rem;
+		justify-content: flex-end;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCON-26-linear-issue

## Proposed Changes

This adds a button to the site overview in the case where the user has a DIFM migration started.

Clicking the button displays a dialog which lets the user send a request to cancel the migration. This calls the
/automated-migration/cancel-migration endpoint.

We display a success or error notice depending on the result from the endpoint.

If the request is successful, the user will see the normal site overview on refresh.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso.live url or run this locally. NOTE: If you run it locally, you'll need to share credentials instead of authorizing the application password once you reach that step.
* Go to `/start` and continue to the Goals step.
* Select the 'import or migrate' intent.
* Continue with the migration flow and select a DIFM migration.
* When you reach the site overview, there should be a new 'Request cancellation' button. 
![image](https://github.com/user-attachments/assets/c5a8a8c6-1010-41ab-87ce-47e4365b12ce)
  * If you don't see the button, try enabling the `migration-flow/cancel-difm` flag.
* Clicking the button should display the following dialog.
<img width="542" alt="CleanShot 2025-05-07 at 16 17 51@2x" src="https://github.com/user-attachments/assets/6b5f7df8-1847-4e8f-a28d-6d9a5726e9f1" />

* Clicking 'Send Request' should display a success notice.
 
![image](https://github.com/user-attachments/assets/34319f2f-bee9-497e-b46f-f2ac2f156c60)

* Once the migration has been cancelled, find the Zendesk ticket for the site. The ticket should have a 'The user has requested to cancel the migration.' internal reply.
<img width="433" alt="CleanShot 2025-05-06 at 14 01 28@2x" src="https://github.com/user-attachments/assets/2143bec0-fb15-4a14-bc70-909b7e20753f" />

In the unlikely event of an error, it should display an error notice:
<img width="959" alt="CleanShot 2025-05-08 at 09 52 36@2x" src="https://github.com/user-attachments/assets/7de97867-d542-4031-ae55-c48d34930127" />


You can simulate an error by sandboxing the public api and modifying the cancellation endpoint (site-automated-migration.php#L442) as follows.

You may need to reset the site by removing the `migration-cancelled-difm` sticker and adding the `migration-started-difm` sticker.

You'll want to add the following to your `0-sandbox.php` to direct any Slack error messages to a personal channel.
```
add_filter(
	'wpcom_migration_notification_slack_channel',
	function( $channel ) {
		return 'CHANNEL_ID';
	}
);
```
You can get the channel id (I like to use the Slackbot channel) by clicking on the channel and clicking the `...` in the upper right, then clicking "View full profile".
![image](https://github.com/user-attachments/assets/df80aace-738e-4b57-a1c1-e43b38c21177)


Then click the `...` on the profile and click "Copy member id".
![image](https://github.com/user-attachments/assets/f809e95f-aa6c-4463-b740-d1dfeec8c647)


Then change this code
```
if ( ! $current_site ) {
			self::automated_migration_notification_slack(
				(int) $request->get_param( 'wpcom_site' ) ?? -1,
				wp_get_current_user(),
				$cancellation_error_message,
				array(
					'error' => 'Unable to get blog details',
				)
			);
			return new WP_Error( 'site_not_found', 'Site not found.', array( 'status' => WP_Http::NOT_FOUND ) );
		}
```

to

```
if ( true || ! $current_site ) {
	return new WP_Error( 'site_not_found', 'Site not found.', array( 'status' => WP_Http::NOT_FOUND ) );
}
```


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?