### PR TITLE
HAPD-904 - Update SEO course link

### DIFF
--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
@@ -20,7 +21,7 @@ export default function () {
 	} );
 
 	page( '/marketing/ultimate-traffic-guide*', function redirectToWPCoursesPage() {
-		window.location.replace( 'https://wordpress.com/learn/courses/intro-to-seo/' );
+		window.location.replace( localizeUrl( 'https://wordpress.com/support/courses/seo/' ) );
 	} );
 
 	const paths = [

--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -103,6 +103,7 @@ export const getMarketingFeaturesData = (
 			imageAlt: translate( 'A rocketship' ),
 			buttonText: translate( 'Register now' ),
 			buttonHref: localizeUrl( 'https://wordpress.com/support/courses/seo/' ),
+			buttonTarget: '_blank',
 			onClick: () => {
 				recordTracksEvent( 'calypso_marketing_tools_seo_course_button_click' );
 			},

--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -102,8 +102,7 @@ export const getMarketingFeaturesData = (
 			imagePath: rocket,
 			imageAlt: translate( 'A rocketship' ),
 			buttonText: translate( 'Register now' ),
-			buttonHref: 'https://wordpress.com/learn/courses/intro-to-seo/',
-			buttonTarget: '_blank',
+			buttonHref: localizeUrl( 'https://wordpress.com/support/courses/seo/' ),
 			onClick: () => {
 				recordTracksEvent( 'calypso_marketing_tools_seo_course_button_click' );
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Related to HAPD-904

## Proposed Changes

* Updates the link for the SEO course to point directly to https://wordpress.com/support/courses/seo/
* Updates the previous redirect for the Ultimate Traffic Guide to point directly to https://wordpress.com/support/courses/seo/

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Updating the links to point directly to https://wordpress.com/support/courses/seo/ avoids an unnecessary redirect in both cases. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Select a site from http://calypso.localhost:3000/marketing/tools
* Go to Tools > Marketing
* Verify that the link for the SEO course has been updated to https://wordpress.com/support/courses/seo/
<img width="1378" alt="Screenshot 2025-05-06 at 12 38 00 PM" src="https://github.com/user-attachments/assets/321b284a-0369-4142-8ecb-bbe218920d52" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
