### PR TITLE
DOTCON-34: Stop redirecting to import flow when clicking the back button

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -530,7 +530,7 @@ const siteSetupFlow: Flow = {
 						return window.location.assign( `${ adminUrl }import.php` );
 					}
 
-					return exitFlow( `/setup/site-migration?siteSlug=${ siteSlug }` );
+					return goToFlow( `site-migration?siteSlug=${ siteSlug }` );
 				}
 
 				case 'importerBlogger':
@@ -550,7 +550,7 @@ const siteSetupFlow: Flow = {
 						return navigate( `importList?siteSlug=${ siteSlug }` );
 					}
 
-					return exitFlow( `/setup/site-migration?siteSlug=${ siteSlug }` );
+					return goToFlow( `site-migration?siteSlug=${ siteSlug }` );
 				case 'importerWix':
 				case 'importReady':
 				case 'importReadyNot':

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -530,7 +530,7 @@ const siteSetupFlow: Flow = {
 						return window.location.assign( `${ adminUrl }import.php` );
 					}
 
-					return navigate( `import?siteSlug=${ siteSlug }` );
+					return exitFlow( `/setup/site-migration?siteSlug=${ siteSlug }` );
 				}
 
 				case 'importerBlogger':
@@ -550,8 +550,7 @@ const siteSetupFlow: Flow = {
 						return navigate( `importList?siteSlug=${ siteSlug }` );
 					}
 
-					// Ensure we override the from param, as we end up in a loop if we don't.
-					return navigate( `import?siteSlug=${ siteSlug }&from` );
+					return exitFlow( `/setup/site-migration?siteSlug=${ siteSlug }` );
 				case 'importerWix':
 				case 'importReady':
 				case 'importReadyNot':

--- a/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
@@ -5,7 +5,7 @@
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import siteSetupFlow from '../flows/site-setup-flow/site-setup-flow';
 import { STEPS } from '../internals/steps';
-import { getFlowLocation, renderFlow } from './helpers';
+import { renderFlow } from './helpers';
 // we need to save the original object for later to not affect tests from other files
 const originalLocation = window.location;
 
@@ -84,17 +84,16 @@ describe( 'Site Setup Flow', () => {
 	} );
 
 	describe( 'goBack', () => {
-		it( 'redirects the user to preview STEP using the regular flow', () => {
+		it( 'redirects the user to site-migration flow when clicking back on importList step without backToFlow', () => {
 			const { runUseStepNavigationGoBack } = renderFlow( siteSetupFlow );
 
 			runUseStepNavigationGoBack( {
 				currentStep: STEPS.IMPORT_LIST.slug,
 			} );
 
-			expect( getFlowLocation() ).toEqual( {
-				path: '/import?siteSlug=example.wordpress.com',
-				state: null,
-			} );
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				expect.stringContaining( '/setup/site-migration' )
+			);
 		} );
 
 		it( 'redirects the users to previous FLOW when backToFlow is defined', () => {

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -79,6 +79,13 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the URL capture page.
+	 */
+	async validateURLMigrationFlow(): Promise< void > {
+		await this.page.waitForURL( /.*setup\/site-migration.*/ );
+	}
+
+	/**
 	 * Validates that we've landed on the URL capture page with 'typo' error.
 	 */
 	async validateErrorCapturePage( error: string ): Promise< void > {

--- a/test/e2e/specs/importer/importer__site-setup.ts
+++ b/test/e2e/specs/importer/importer__site-setup.ts
@@ -44,7 +44,7 @@ describe( DataHelper.createSuiteTitle( 'Importer: Site Setup' ), () => {
 
 		it( 'Back shows the URL capture form', async () => {
 			await startImportFlow.clickBack();
-			await startImportFlow.validateURLCapturePage();
+			await startImportFlow.validateURLMigrationFlow();
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCON-34

## Proposed Changes

Stop navigating back from importList and importerWordpress to `site-setup/import`. Instead, navigate to the new `/setup/migration-flow`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

While I don't know how this code path is being hit, an inspection of tracks events shows that we are hitting the `/site-setup/import` step from the `importList` and the `importerWordpress` steps.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the calypso.live link below
* Navigate to the /start, pick a free site and choose `Import or migrate an existing site`
* Click `pick your current platform from a list`
* Remove `&backToFlow=%2Fsite-migration%2Fsite-migration-identify` from the URL and reload
* Verify that clicking `< Back` takes you to `/setup/site-migration/site-migration-identify`
* Now, click  `pick your current platform from a list` again
* Select WordPress
* Select Import content only
* Remove `&backToFlow=%2Fsite-migration%2Fsite-migration-import-or-migrate` from the URL and reload
* Verify that clicking `< Back` takes you to `/setup/site-migration/site-migration-identify`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
