### PR TITLE
Checkout: vertically align payment method logos

### DIFF
--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -52,7 +52,7 @@ const RadioButtonWrapper = styled.div<
 		display: none;
 
 		@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
-			display: block;
+			display: flex;
 			filter: grayscale( ${ getGrayscaleValue } );
 		}
 	}


### PR DESCRIPTION
This vertically aligns the payment method logos in Checkout with their labels. Mostly, it seems to apply to PayPal and Google Pay.

Fixes: #100359

| Before      | After |
| ----------- | ----------- |
| ![Screenshot 2025-05-06 at 6 52 36 PM](https://github.com/user-attachments/assets/15b4aefd-1635-43c5-94d2-4b6c92d5415c) | ![Screenshot 2025-05-06 at 6 52 02 PM](https://github.com/user-attachments/assets/1a9392c1-d71e-4345-8512-388432638da7) |

**To test:**
- Add a product to your cart and visit Checkout
- Verify that the payment method logos are vertically aligned with their labels