### PR TITLE
E2E: Fix form responses tests

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -104,7 +104,7 @@ export class FeedbackInboxPage {
 			.fill( search );
 		await responseRequestPromise;
 		// And wait for the UI re-render by waiting until the tabs are re-enabled.
-		await this.page.getByRole( 'tab', { name: 'Inbox', exact: false, disabled: false } ).waitFor();
+		await this.page.getByRole( 'radio', { name: /^Inbox\s*\(\d+\)$/ } ).waitFor();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -103,8 +103,10 @@ export class FeedbackInboxPage {
 			.or( this.page.getByRole( 'textbox', { name: 'Search responses' } ) )
 			.fill( search );
 		await responseRequestPromise;
-		// And wait for the UI re-render by waiting until the tabs are re-enabled.
-		await this.page.getByRole( 'radio', { name: /^Inbox\s*\(\d+\)$/ } ).waitFor();
+		await this.page
+			.getByRole( 'tab', { name: 'Inbox', exact: false, disabled: false } )
+			.or( this.page.getByRole( 'radio', { name: /^Inbox\s*\(\d+\)$/ } ) )
+			.waitFor();
 	}
 
 	/**

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -144,7 +144,9 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 			const searchAndClickFolderWithResult = async () => {
 				await feedbackInboxPage.clearSearch();
 				await feedbackInboxPage.searchResponses( formData.email );
-				await page.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } ).click( { timeout: 4 * 1000 } );
+				await page
+					.getByRole( 'radio', { name: /(Inbox|Spam) \(1\)/ } )
+					.click( { timeout: 4 * 1000 } );
 			};
 
 			const MAX_ATTEMPTS = 3;

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -145,8 +145,9 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 				await feedbackInboxPage.clearSearch();
 				await feedbackInboxPage.searchResponses( formData.email );
 				await page
-					.getByRole( 'radio', { name: /(Inbox|Spam) \(1\)/ } )
-					.click( { timeout: 4 * 1000 } );
+					.getByRole( 'tab', { name: /(Inbox|Spam) 1/ } )
+					.or( page.getByRole( 'radio', { name: /(Inbox|Spam)\s*\(\s*1\s*\)/ } ) )
+					.click( { timeout: 4000 } );
 			};
 
 			const MAX_ATTEMPTS = 3;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

A recent Jetpack PR updated the forms responses page, and broke related E2E tests in Calypso. We muted those tests at the time to proceed with deploying the Jetpack changes. This PR is a follow up to fix the tests. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To fix broken E2E tests, after which we can unmute those test during WordPress.com deployments. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll need to set up your environment to run Calypso E2E testing locally. You can follow the instructions [here](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#quick-start). But assuming you have all the usually dependencies on your machine to do Calypso development, you'll then need to do this:
- Obtain the secrets decryption key from the MC Secret Store
- Export the decryption key as an environment variable: `export E2E_SECRETS_KEY=secret-from-secret-store`
- Navigate to `test/e2e`
- Decrypt the secrets file: `yarn decrypt-secrets` (from e2e dir)
- Run `yarn build --watch` to build the tests (from e2e dir)
- Run the tests with `yarn jest specs/published-content/forms__submissions.ts` (from e2e dir)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- NA Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - NA For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
