### PR TITLE
Improves the design for the Migration Requested page

### DIFF
--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -46,7 +46,7 @@ export const MigrationStartedDIFM = ( { site }: { site: SiteDetails } ) => {
 	return (
 		<Container>
 			<Header title={ title } subTitle={ subTitle } />
-			<div className="card hosting-card hosting-features__card migration-started-difm">
+			<div className="migration-started-difm">
 				<h2 className="migration-started-difm__title">{ translate( 'What to expect' ) }</h2>
 				<MigrationStartedList>
 					<MigrationStartedItem

--- a/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
+++ b/client/sites/overview/components/migration-overview/components/migration-started-difm.tsx
@@ -46,7 +46,7 @@ export const MigrationStartedDIFM = ( { site }: { site: SiteDetails } ) => {
 	return (
 		<Container>
 			<Header title={ title } subTitle={ subTitle } />
-			<div className="migration-started-difm">
+			<div className="card hosting-card hosting-features__card migration-started-difm">
 				<h2 className="migration-started-difm__title">{ translate( 'What to expect' ) }</h2>
 				<MigrationStartedList>
 					<MigrationStartedItem

--- a/client/sites/overview/components/migration-overview/style.scss
+++ b/client/sites/overview/components/migration-overview/style.scss
@@ -37,13 +37,12 @@
 	.migration-started-difm {
 		display: flex;
 		flex-direction: column;
-		gap: 1rem;
 		margin: 0 auto;
-		padding-bottom: 2rem;
-		max-width: 720px;
+		max-width: 500px;
 		.migration-started-difm__title {
 			font-size: 1rem;
 			font-weight: 600;
+			margin-bottom: 1rem;
 		}
 
 		.migration-started-difm__list {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR addresses the misalignment of the features in relation with the title.

#### Before

![Captura de Tela 2025-05-06 às 12 26 20](https://github.com/user-attachments/assets/60a5e562-15fa-42e0-ba9f-7e93b7b2dda3)

#### After


![Captura de Tela 2025-05-12 às 14 51 27](https://github.com/user-attachments/assets/6c0e2c5c-4a37-474f-9444-57fe19b273e8)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* For a while, the "We've received your migration request" feels off in my larger screen. The features under seems to be misaligned if you take in consideration the title and the subtitle.
* The whole content still feels off, as the right side is considerable larger than the left side. But centralizing it also makes it feel off in relation with the tabs and the header. So, I'd like to invite @fditrapani for any thoughts on that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below
* Go through the Assisted Migration flow(DIFM)
* Once you complete the migration, you should be redirected to the `/overview/:siteSlug?ref=site-migration&`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
