### PR TITLE
Update page layout spacing to match designs.

### DIFF
--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -30,7 +30,7 @@ function PageLayout( {
 } ) {
 	return (
 		<VStack spacing={ 8 } className="dashboard-page-layout" style={ sizes[ size ] }>
-			<VStack spacing={ 4 }>
+			<VStack>
 				<HStack justify="space-between" alignment="center">
 					<Heading level={ 1 } style={ { flexShrink: 0 } }>
 						{ title }


### PR DESCRIPTION
## Proposed Changes

This PR updates the PageLayout spacing so the description is `8px` below the title to match the designs:

The `<VStack>` spacing default is `2`.


| Before calc(4px * 4) | After calc(4px * 2) | Designs |
|--------|--------|--------|
| <img width="451" alt="Screenshot 2025-05-07 at 11 19 52 AM" src="https://github.com/user-attachments/assets/14cae812-5321-480d-acbb-b894f825f618" /> | <img width="395" alt="Screenshot 2025-05-07 at 11 20 53 AM" src="https://github.com/user-attachments/assets/26d33ea0-1493-487f-a489-98613722bec5" /> | <img width="384" alt="Screenshot 2025-05-07 at 11 22 51 AM" src="https://github.com/user-attachments/assets/4fbeaee6-991c-42ab-87c1-4c0be95d572b" /> | 

QOBjujZah0UlGDDdLKZhzi-fi-1_48321.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?