### PR TITLE
Theme Showcase: Switch to use core Dropdown component

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -2,7 +2,8 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { SelectDropdown } from '@automattic/components';
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
@@ -709,17 +710,40 @@ class ThemeShowcase extends Component {
 											) }
 										</div>
 										{ tabFilters && premiumThemesEnabled && ! isMultisite && (
-											<>
-												<SelectDropdown
-													className="section-nav-tabs__dropdown"
-													onSelect={ this.onTierSelectFilter }
-													selectedText={ translate( 'View: %s', {
-														args: getOptionLabel( tiers, tier ) || '',
-													} ) }
-													options={ tiers }
-													initialSelected={ tier }
-												></SelectDropdown>
-											</>
+											<Dropdown
+												className="section-nav-tabs__dropdown"
+												renderToggle={ ( { isOpen, onToggle } ) => (
+													<Button
+														size="compact"
+														variant="secondary"
+														icon={ chevronDown }
+														iconPosition="right"
+														aria-expanded={ isOpen }
+														onClick={ onToggle }
+													>
+														{ translate( 'View: %s', {
+															args: getOptionLabel( tiers, tier ) || '',
+														} ) }
+													</Button>
+												) }
+												renderContent={ ( { onClose } ) => (
+													<MenuGroup>
+														{ tiers.map( ( item ) => (
+															<MenuItem
+																key={ item.value }
+																role="menuitemradio"
+																isSelected={ item.value === tier }
+																onClick={ () => {
+																	this.onTierSelectFilter( item );
+																	onClose();
+																} }
+															>
+																{ item.label }
+															</MenuItem>
+														) ) }
+													</MenuGroup>
+												) }
+											/>
 										) }
 									</div>
 								</div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -2,8 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
-import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
@@ -58,6 +56,7 @@ import ThemeErrors from './theme-errors';
 import ThemePreview from './theme-preview';
 import ThemeShowcaseHeader from './theme-showcase-header';
 import ThemesSelection from './themes-selection';
+import ThemesTiersDropdown from './themes-tiers-dropdown';
 import ThemesToolbarGroup from './themes-toolbar-group';
 import './theme-showcase.scss';
 
@@ -546,6 +545,29 @@ class ThemeShowcase extends Component {
 		}
 	};
 
+	renderThemesTiersDropdown = () => {
+		const { isMultisite, premiumThemesEnabled, tier = 'all', translate } = this.props;
+		const tabFilters = this.getTabFilters();
+		const tiers = this.getTiers();
+
+		if ( isMultisite || ! premiumThemesEnabled || ! tabFilters ) {
+			return null;
+		}
+
+		return (
+			<ThemesTiersDropdown
+				tiers={ tiers }
+				selectedTier={ tier }
+				buttonText={ translate( 'View: %s', {
+					args: getOptionLabel( tiers, tier ) || '',
+				} ) }
+				onSelect={ ( item ) => {
+					this.onTierSelectFilter( item );
+				} }
+			/>
+		);
+	};
+
 	getScreenshotUrl = ( theme, themeOptions ) => {
 		const { getScreenshotOption, locale, isLoggedIn } = this.props;
 
@@ -595,16 +617,12 @@ class ThemeShowcase extends Component {
 			featureStringFilter,
 			filterString,
 			isJetpackSite,
-			isMultisite,
-			premiumThemesEnabled,
 			isSiteECommerceFreeTrial,
 			isSiteWooExpressOrEcomFreeTrial,
 			isSiteWooExpress,
 			isCollectionView,
 			lastNonEditorRoute,
-			translate,
 		} = this.props;
-		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
 		const staticFilters = this.getStaticFilters();
 
@@ -637,8 +655,6 @@ class ThemeShowcase extends Component {
 		};
 
 		const tabFilters = this.getTabFilters();
-		const tiers = this.getTiers();
-
 		const classnames = clsx( 'theme-showcase', {
 			'is-collection-view': isCollectionView,
 		} );
@@ -709,42 +725,7 @@ class ThemeShowcase extends Component {
 												/>
 											) }
 										</div>
-										{ tabFilters && premiumThemesEnabled && ! isMultisite && (
-											<Dropdown
-												className="section-nav-tabs__dropdown"
-												renderToggle={ ( { isOpen, onToggle } ) => (
-													<Button
-														size="compact"
-														variant="secondary"
-														icon={ chevronDown }
-														iconPosition="right"
-														aria-expanded={ isOpen }
-														onClick={ onToggle }
-													>
-														{ translate( 'View: %s', {
-															args: getOptionLabel( tiers, tier ) || '',
-														} ) }
-													</Button>
-												) }
-												renderContent={ ( { onClose } ) => (
-													<MenuGroup>
-														{ tiers.map( ( item ) => (
-															<MenuItem
-																key={ item.value }
-																role="menuitemradio"
-																isSelected={ item.value === tier }
-																onClick={ () => {
-																	this.onTierSelectFilter( item );
-																	onClose();
-																} }
-															>
-																{ item.label }
-															</MenuItem>
-														) ) }
-													</MenuGroup>
-												) }
-											/>
-										) }
+										{ this.renderThemesTiersDropdown() }
 									</div>
 								</div>
 								<div

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -261,31 +261,6 @@
 		@include break-xlarge {
 			width: 50%;
 		}
-
-		.section-nav-tabs__dropdown {
-			align-self: flex-start;
-			box-shadow:
-				0 0 0 0 rgba(38, 19, 19, 0.03),
-				0 1px 2px 0 rgba(38, 19, 19, 0.03),
-				0 4px 4px 0 rgba(38, 19, 19, 0.03),
-				0 9px 5px 0 rgba(38, 19, 19, 0.02),
-				0 16px 6px 0 rgba(38, 19, 19, 0),
-				0 25px 7px 0 rgba(38, 19, 19, 0);
-			width: auto;
-
-			button {
-				background-color: var(--color-surface);
-				border-width: 0;
-				height: 55px;
-				line-height: 1.5px;
-
-				&:hover,
-				&:focus {
-					background-color: var(--color-surface);
-					border-width: 0;
-				}
-			}
-		}
 	}
 
 	.themes__filters {
@@ -334,32 +309,6 @@
 
 			@include break-mobile {
 				padding: 0 10px 0 0;
-			}
-		}
-
-		.section-nav-tabs__dropdown {
-			width: 100%;
-			flex-shrink: 0;
-
-			@include break-mobile {
-				width: auto;
-			}
-
-			button {
-				border: 1px solid var(--color-neutral-10);
-				box-shadow: none;
-				color: var(--color-neutral-70);
-				font-size: $font-body-small;
-				height: 42px;
-				padding: 8px 14px;
-
-				&:hover,
-				&:focus{
-					background-color: transparent;
-					border: 1px solid var(--color-neutral-20);
-					box-shadow: none;
-					color: var(--color-neutral-70);
-				}
 			}
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -241,7 +241,7 @@
 		}
 	}
 
-	.theme__search {
+	.theme-showcase .theme__search {
 		@include break-mobile {
 			width: 100%;
 		}
@@ -263,8 +263,7 @@
 		}
 
 		.section-nav-tabs__dropdown {
-			min-width: 140px;
-
+			align-self: flex-start;
 			box-shadow:
 				0 0 0 0 rgba(38, 19, 19, 0.03),
 				0 1px 2px 0 rgba(38, 19, 19, 0.03),
@@ -272,37 +271,19 @@
 				0 9px 5px 0 rgba(38, 19, 19, 0.02),
 				0 16px 6px 0 rgba(38, 19, 19, 0),
 				0 25px 7px 0 rgba(38, 19, 19, 0);
+			width: auto;
 
-			&.select-dropdown {
-				border-radius: 4px;
-				height: 55px;
-			}
-
-			&.is-open {
-				.select-dropdown__header {
-					border-radius: 4px;
-				}
-			}
-
-			.select-dropdown__header {
+			button {
+				background-color: var(--color-surface);
 				border-width: 0;
-				color: #575d63;
 				height: 55px;
-				line-height: 1.5;
-			}
+				line-height: 1.5px;
 
-			.is-selected {
-				color: var(--color-text-inverted);
-				background-color: var(--color-neutral-80);
-			}
-
-			.select-dropdown__option:hover {
-				background: var(--studio-gray-0);
-			}
-
-			.select-dropdown__item:not(.is-selected):hover {
-				color: var(--studio-blue-90);
-				background-color: color-mix(in srgb, var(--studio-blue) 10%, transparent);
+				&:hover,
+				&:focus {
+					background-color: var(--color-surface);
+					border-width: 0;
+				}
 			}
 		}
 	}
@@ -324,7 +305,7 @@
 
 .search-themes-card {
 	.search {
-		height: 43px;
+		height: 42px;
 		border-radius: 2px;
 	}
 }
@@ -347,23 +328,6 @@
 			flex-direction: row;
 		}
 
-		.select-dropdown__header {
-			font-weight: 400;
-		}
-
-		.select-dropdown__options {
-			position: absolute;
-			width: 100%;
-
-			@include break-mobile {
-				position: inherit;
-			}
-		}
-
-		.section-nav-tabs__dropdown .select-dropdown__container {
-			width: 100%;
-		}
-
 		.theme__search-input {
 			width: 100%;
 			padding: 0 0 10px 0;
@@ -381,8 +345,21 @@
 				width: auto;
 			}
 
-			.is-selected {
-				background-color: var(--studio-blue-50);
+			button {
+				border: 1px solid var(--color-neutral-10);
+				box-shadow: none;
+				color: var(--color-neutral-70);
+				font-size: $font-body-small;
+				height: 42px;
+				padding: 8px 14px;
+
+				&:hover,
+				&:focus{
+					background-color: transparent;
+					border: 1px solid var(--color-neutral-20);
+					box-shadow: none;
+					color: var(--color-neutral-70);
+				}
 			}
 		}
 	}
@@ -413,24 +390,6 @@
 			line-height: 20px;
 			padding: 8px 16px;
 			white-space: nowrap;
-		}
-	}
-}
-
-.themes:not(.is-logged-out) {
-	.theme-showcase {
-		.theme__search {
-			.section-nav-tabs__dropdown {
-				.is-selected {
-					color: var(--color-text-inverted);
-					background-color: var(--color-neutral-80);
-				}
-
-				.select-dropdown__item:not(.is-selected):hover {
-					color: var(--color-neutral-60);
-					background-color: var(--studio-gray-0);
-				}
-			}
 		}
 	}
 }

--- a/client/my-sites/themes/themes-tiers-dropdown/index.tsx
+++ b/client/my-sites/themes/themes-tiers-dropdown/index.tsx
@@ -1,0 +1,58 @@
+import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
+import './style.scss';
+
+interface ThemesTiersDropdownProps {
+	tiers: { value: string; label: string }[];
+	selectedTier: string;
+	buttonText: string;
+	onSelect: ( item: { value: string; label: string } ) => void;
+}
+
+const ThemesTiersDropdown = ( {
+	tiers,
+	selectedTier,
+	buttonText,
+	onSelect,
+}: ThemesTiersDropdownProps ) => {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+
+	return (
+		<Dropdown
+			className="section-nav-tabs__dropdown"
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					size="compact"
+					variant="secondary"
+					icon={ chevronDown }
+					iconPosition="right"
+					aria-expanded={ isOpen }
+					onClick={ onToggle }
+				>
+					{ buttonText }
+				</Button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<MenuGroup>
+					{ tiers.map( ( item ) => (
+						<MenuItem
+							key={ item.value }
+							role="menuitemradio"
+							isSelected={ item.value === selectedTier }
+							onClick={ () => {
+								onSelect( item );
+								onClose();
+							} }
+						>
+							{ item.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			) }
+		/>
+	);
+};
+
+export default ThemesTiersDropdown;

--- a/client/my-sites/themes/themes-tiers-dropdown/style.scss
+++ b/client/my-sites/themes/themes-tiers-dropdown/style.scss
@@ -2,34 +2,36 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.section-nav-tabs__dropdown {
-	width: 100%;
-	flex-shrink: 0;
+.theme-showcase {
+    .section-nav-tabs__dropdown {
+    	width: 100%;
+    	flex-shrink: 0;
 
-	@include break-mobile {
-		width: auto;
-	}
+    	@include break-mobile {
+    		width: auto;
+    	}
 
-	button {
-		border: 1px solid var(--color-neutral-10);
-		box-shadow: none;
-		color: var(--color-neutral-70);
-		font-size: $font-body-small;
-		height: 42px;
-		padding: 8px 14px;
+    	.components-button {
+    		border: 1px solid var(--color-neutral-10);
+    		box-shadow: none;
+    		color: var(--color-neutral-70);
+    		font-size: $font-body-small;
+    		height: 42px;
+    		padding: 8px 14px;
 
-		&:hover,
-		&:focus{
-			background-color: transparent;
-			border: 1px solid var(--color-neutral-20);
-			box-shadow: none;
-			color: var(--color-neutral-70);
-		}
-	}
+    		&:hover,
+    		&:focus{
+    			background-color: transparent;
+    			border: 1px solid var(--color-neutral-20);
+    			box-shadow: none;
+    			color: var(--color-neutral-70);
+    		}
+    	}
+    }
 }
 
 .is-logged-out {
-	.section-nav-tabs__dropdown {
+	.theme-showcase .section-nav-tabs__dropdown {
 		align-self: flex-start;
 		box-shadow:
 			0 0 0 0 rgba(38, 19, 19, 0.03),
@@ -40,7 +42,7 @@
 			0 25px 7px 0 rgba(38, 19, 19, 0);
 		width: auto;
 
-		button {
+		.components-button {
 			background-color: var(--color-surface);
 			border-width: 0;
 			height: 55px;

--- a/client/my-sites/themes/themes-tiers-dropdown/style.scss
+++ b/client/my-sites/themes/themes-tiers-dropdown/style.scss
@@ -1,0 +1,56 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.section-nav-tabs__dropdown {
+	width: 100%;
+	flex-shrink: 0;
+
+	@include break-mobile {
+		width: auto;
+	}
+
+	button {
+		border: 1px solid var(--color-neutral-10);
+		box-shadow: none;
+		color: var(--color-neutral-70);
+		font-size: $font-body-small;
+		height: 42px;
+		padding: 8px 14px;
+
+		&:hover,
+		&:focus{
+			background-color: transparent;
+			border: 1px solid var(--color-neutral-20);
+			box-shadow: none;
+			color: var(--color-neutral-70);
+		}
+	}
+}
+
+.is-logged-out {
+	.section-nav-tabs__dropdown {
+		align-self: flex-start;
+		box-shadow:
+			0 0 0 0 rgba(38, 19, 19, 0.03),
+			0 1px 2px 0 rgba(38, 19, 19, 0.03),
+			0 4px 4px 0 rgba(38, 19, 19, 0.03),
+			0 9px 5px 0 rgba(38, 19, 19, 0.02),
+			0 16px 6px 0 rgba(38, 19, 19, 0),
+			0 25px 7px 0 rgba(38, 19, 19, 0);
+		width: auto;
+
+		button {
+			background-color: var(--color-surface);
+			border-width: 0;
+			height: 55px;
+			line-height: 1.5px;
+
+			&:hover,
+			&:focus {
+				background-color: var(--color-surface);
+				border-width: 0;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Ref DOTCOM-557

## Proposed Changes

This PR updates the Theme Showcase tier dropdown to use core Dropdown component instead of Calypso SelectDropdown. See below for differences:

Logged-in Theme Showcase - Desktop
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-07 at 11 53 15 AM](https://github.com/user-attachments/assets/03f90738-0715-44c1-807d-29b23471601d) | ![Screenshot 2025-05-07 at 11 53 33 AM](https://github.com/user-attachments/assets/b9fd0480-a382-4e76-b955-81d6bb29e0ae) |

Logged-in Theme Showcase - Mobile
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-07 at 11 55 58 AM](https://github.com/user-attachments/assets/5754587f-5519-4ee0-8179-bc4b700c6e05) | ![Screenshot 2025-05-07 at 12 11 22 PM](https://github.com/user-attachments/assets/141b08e2-b8dd-4d2a-9624-7fd26a8ab01d) |

Logged-out Theme Showcase - Desktop
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-07 at 11 57 31 AM](https://github.com/user-attachments/assets/93c2b234-5b6c-44b5-927a-759094e74136) | ![Screenshot 2025-05-07 at 12 11 48 PM](https://github.com/user-attachments/assets/15d0967f-0127-490a-8ae3-985384e71ddf) |

Logged-out Theme Showcase - Mobile
| Before | After |
| --- | --- |
| ![Screenshot 2025-05-07 at 11 56 57 AM](https://github.com/user-attachments/assets/40e50a1b-c7bd-4156-9e79-846235c4d803) | ![Screenshot 2025-05-07 at 12 12 04 PM](https://github.com/user-attachments/assets/02518979-dd0f-4bea-9d53-8b5f036428e2) |

>[!NOTE]
>The Dropdown core component breaks on SSR. Thus, we'll skip the rendering of the dropdown on SSR.

## Why are these changes being made?

<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall WP.com polish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the 4 scenarios above and ensure the dropdown work as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
