### PR TITLE
Hosting Dashboard: Make Overview active only when the URL matches exactly

### DIFF
--- a/client/dashboard/components/menu/index.tsx
+++ b/client/dashboard/components/menu/index.tsx
@@ -1,14 +1,23 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import RouterLinkButton from '../router-link-button';
-
+import type { ActiveOptions } from '@tanstack/react-router';
 import './style.scss';
 
-function MenuItem( { to, children }: { to: string; children: React.ReactNode } ) {
+function MenuItem( {
+	to,
+	children,
+	activeOptions,
+}: {
+	to: string;
+	children: React.ReactNode;
+	activeOptions?: ActiveOptions;
+} ) {
 	return (
 		<RouterLinkButton
 			className="dashboard-menu__item"
 			variant="tertiary"
 			to={ to }
+			activeOptions={ activeOptions }
 			__next40pxDefaultSize
 		>
 			{ children }

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -4,6 +4,7 @@ import { menu } from '@wordpress/icons';
 import React from 'react';
 import Menu from '../menu';
 import RouterLinkMenuItem from '../router-link-menu-item';
+import type { ActiveOptions } from '@tanstack/react-router';
 
 type ResponsiveMenuProps = {
 	children: React.ReactNode;
@@ -65,6 +66,7 @@ ResponsiveMenu.Item = function MenuItem(
 	props: {
 		to: string;
 		children: React.ReactNode;
+		activeOptions?: ActiveOptions;
 	}
 ) {
 	// This is going to be replaced with the right menu item depending on the screen size.

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -4,7 +4,9 @@ import ResponsiveMenu from '../../components/responsive-menu';
 const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
 	return (
 		<ResponsiveMenu label={ __( 'Site Menu' ) }>
-			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` }>{ __( 'Overview' ) }</ResponsiveMenu.Item>
+			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
+				{ __( 'Overview' ) }
+			</ResponsiveMenu.Item>
 			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
 				{ __( 'Deployments' ) }
 			</ResponsiveMenu.Item>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Since the Overview tab links to the top-level URL of the site, it remained active even when navigating to other tabs. This PR proposes a change to make the Overview tab active only when the URL matches exactly.
* Alternatively, we could modify the URL of the Overview tab to include /overview, but I'm not sure what the original intent was.

| Before | After |
| - | - |
| <img width="390" alt="image" src="https://github.com/user-attachments/assets/9493a320-7856-4368-85d8-d563a8265044" /> | <img width="387" alt="image" src="https://github.com/user-attachments/assets/4005565a-eece-424d-8521-b1a14f7e20f3" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any site
* Switch to either Deployments, Performance, or Settings tab
* Ensure the Overview tab is not active

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
