### PR TITLE
Remove `preventWidows` from `client/components`

### DIFF
--- a/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
+++ b/client/components/activity-card-list/visible-days-limit-upsell/index.tsx
@@ -3,7 +3,6 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import ActivityCard from 'calypso/components/activity-card';
-import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import ActivityLogItem from 'calypso/my-sites/activity/activity-log-item';
 import { useSelector } from 'calypso/state';
@@ -74,27 +73,23 @@ const VisibleDaysLimitUpsell: React.FC< OwnProps > = ( { cardClassName } ) => {
 			<div className="visible-days-limit-upsell__next-activity">{ card }</div>
 			<div className="visible-days-limit-upsell__call-to-action">
 				<h3 className="visible-days-limit-upsell__call-to-action-header">
-					{ preventWidows(
-						translate(
-							'Restore backups older than %(retentionDays)d day',
-							'Restore backups older than %(retentionDays)d days',
-							{
-								count: visibleDays,
-								args: { retentionDays: visibleDays },
-							}
-						)
+					{ translate(
+						'Restore backups older than %(retentionDays)d day',
+						'Restore backups older than %(retentionDays)d days',
+						{
+							count: visibleDays,
+							args: { retentionDays: visibleDays },
+						}
 					) }
 				</h3>
 				<p className="visible-days-limit-upsell__call-to-action-copy">
-					{ preventWidows(
-						translate(
-							'Your activity log spans more than %(retentionDays)d day. Upgrade your backup storage to access activity older than %(retentionDays)d day.',
-							'Your activity log spans more than %(retentionDays)d days. Upgrade your backup storage to access activity older than %(retentionDays)d days.',
-							{
-								count: visibleDays,
-								args: { retentionDays: visibleDays },
-							}
-						)
+					{ translate(
+						'Your activity log spans more than %(retentionDays)d day. Upgrade your backup storage to access activity older than %(retentionDays)d day.',
+						'Your activity log spans more than %(retentionDays)d days. Upgrade your backup storage to access activity older than %(retentionDays)d days.',
+						{
+							count: visibleDays,
+							args: { retentionDays: visibleDays },
+						}
 					) }
 				</p>
 				<Button

--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -21,7 +21,6 @@ import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import AddNewSiteContext from 'calypso/components/add-new-site/context';
 import AddNewSiteMenuItem from 'calypso/components/add-new-site/menu-item';
 import AddNewSitePopoverColumn from 'calypso/components/add-new-site/popover-column';
-import { preventWidows } from 'calypso/lib/formatting';
 import type { AddNewSiteMenuItemsProps } from 'calypso/components/add-new-site/types';
 
 type PendingSite = { features: { wpcom_atomic: { state: string; license_key: string } } };
@@ -64,9 +63,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 				<AddNewSiteMenuItem
 					icon={ <WordPressLogo /> }
 					heading={ translate( 'Via WordPress.com connection' ) }
-					description={ preventWidows(
-						translate( 'Import connected WordPress.com or Jetpack sites.' )
-					) }
+					description={ translate( 'Import connected WordPress.com or Jetpack sites.' ) }
 					buttonProps={ {
 						onClick: () => {
 							handleOnClick( 'import-from-wpcom' );
@@ -76,9 +73,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 				<AddNewSiteMenuItem
 					icon={ <A4ALogo /> }
 					heading={ translate( 'Via the Automattic plugin' ) }
-					description={ preventWidows(
-						translate( 'Connect with the Automattic for Agencies plugin.' )
-					) }
+					description={ translate( 'Connect with the Automattic for Agencies plugin.' ) }
 					buttonProps={ {
 						onClick: () => {
 							handleOnClick( 'a4a-connection' );
@@ -88,9 +83,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 				<AddNewSiteMenuItem
 					icon={ <JetpackLogo /> }
 					heading={ translate( 'Via the Jetpack plugin' ) }
-					description={ preventWidows(
-						translate( 'Install the Jetpack plugin on an existing site.' )
-					) }
+					description={ translate( 'Install the Jetpack plugin on an existing site.' ) }
 					buttonProps={ {
 						onClick: () => {
 							handleOnClick( 'jetpack-connection' );
@@ -114,9 +107,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 				<AddNewSiteMenuItem
 					icon={ <WordPressLogo /> }
 					heading="WordPress.com"
-					description={ preventWidows(
-						translate( 'Use a backup file to import your content into a new site.' )
-					) }
+					description={ translate( 'Use a backup file to import your content into a new site.' ) }
 					buttonProps={ {
 						href: hasPendingWPCOMSites
 							? A4A_SITES_LINK_NEEDS_SETUP
@@ -142,10 +133,8 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 						isBanner
 						icon={ <img src={ devSiteBanner } alt="Start building for free" /> }
 						heading={ translate( 'Start building for free' ) }
-						description={ preventWidows(
-							translate(
-								'Develop WordPress.com sites for as long as you need, with free development sites. Only pay when you launch!'
-							)
+						description={ translate(
+							'Develop WordPress.com sites for as long as you need, with free development sites. Only pay when you launch!'
 						) }
 						disabled={ ! hasAvailableDevSites }
 						buttonProps={ {

--- a/client/components/add-new-site/style.scss
+++ b/client/components/add-new-site/style.scss
@@ -129,6 +129,7 @@ button, a {
 		.add-new-site__popover-button-heading {
 			font-size: rem(14px);
 			font-weight: 600;
+			text-wrap: pretty;
 		}
 
 		.add-new-site__popover-button-description {
@@ -136,6 +137,7 @@ button, a {
 			font-weight: 400;
 			color: var(--color-text-black);
 			padding-top: 4px;
+			text-wrap: pretty;
 		}
 	}
 }

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -19,7 +19,6 @@ import { connect } from 'react-redux';
 import DismissibleCard from 'calypso/blocks/dismissible-card';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { preventWidows } from 'calypso/lib/formatting';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -308,7 +307,7 @@ export class Banner extends Component {
 								onClick={ this.handleSecondaryClick }
 								primary={ false }
 							>
-								{ preventWidows( secondaryCallToAction ) }
+								{ secondaryCallToAction }
 							</Button>
 						) }
 						{ callToAction &&
@@ -319,7 +318,7 @@ export class Banner extends Component {
 									target={ target }
 									busy={ isBusy }
 								>
-									{ preventWidows( callToAction ) }
+									{ callToAction }
 								</Button>
 							) : (
 								<Button
@@ -330,7 +329,7 @@ export class Banner extends Component {
 									target={ target }
 									busy={ isBusy }
 								>
-									{ preventWidows( callToAction ) }
+									{ callToAction }
 								</Button>
 							) ) }
 					</div>

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement } from 'react';
-import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
@@ -18,7 +17,7 @@ function CardHeading( { tagName = 'h1', size = 20, isBold = false, className, id
 		className && className,
 		classNameObject
 	);
-	return createElement( tagName, { className: classes, id }, preventWidows( children, 2 ) );
+	return createElement( tagName, { className: classes, id }, children );
 }
 
 CardHeading.propTypes = {

--- a/client/components/formatted-header/README.md
+++ b/client/components/formatted-header/README.md
@@ -22,4 +22,3 @@ function render() {
 - `subHeaderText` (`node`) - Sub header text (optional)
 - `compactOnMobile` (`bool`) - Display a compact header on small screens (optional)
 - `isSecondary` (`bool`) - Use the H2 element instead of the H1 (optional)
-- `disablePreventWidows` (`bool`) - Disable the default behavior of inserting non-breaking space to prevent dangling words.

--- a/client/components/formatted-header/index.tsx
+++ b/client/components/formatted-header/index.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import InfoPopover from 'calypso/components/info-popover';
-import { preventWidows } from 'calypso/lib/formatting';
 import type { ElementType, FC, PropsWithChildren, ReactNode } from 'react';
 import './style.scss';
 
@@ -17,7 +16,6 @@ export interface Props extends PropsWithChildren {
 	subHeaderAs?: ElementType;
 	subHeaderText?: ReactNode;
 	tooltipText?: ReactNode;
-	disablePreventWidows?: boolean;
 }
 
 const FormattedHeader: FC< Props > = ( {
@@ -34,7 +32,6 @@ const FormattedHeader: FC< Props > = ( {
 	subHeaderAs: SubHeaderAs = 'p',
 	subHeaderText,
 	tooltipText,
-	disablePreventWidows,
 } ) => {
 	const classes = clsx( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
@@ -51,29 +48,22 @@ const FormattedHeader: FC< Props > = ( {
 		</InfoPopover>
 	);
 
-	const formattedHeaderText = disablePreventWidows ? headerText : preventWidows( headerText, 2 );
-	const formattedSubHeaderText = disablePreventWidows
-		? subHeaderText
-		: preventWidows( subHeaderText, 2 );
-
 	return (
 		<header id={ id } className={ classes }>
 			<div>
 				{ ! isSecondary && (
 					<h1 className={ headerClasses }>
-						{ formattedHeaderText } { tooltip }
+						{ headerText } { tooltip }
 					</h1>
 				) }
 				{ isSecondary && (
 					<h2 className={ headerClasses }>
-						{ formattedHeaderText } { tooltip }
+						{ headerText } { tooltip }
 					</h2>
 				) }
 				{ screenReader && <h2 className="screen-reader-text">{ screenReader }</h2> }
-				{ formattedSubHeaderText && (
-					<SubHeaderAs className="formatted-header__subtitle">
-						{ formattedSubHeaderText }
-					</SubHeaderAs>
+				{ subHeaderText && (
+					<SubHeaderAs className="formatted-header__subtitle">{ subHeaderText }</SubHeaderAs>
 				) }
 			</div>
 			{ children }

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -125,6 +125,7 @@
 	font-size: $font-body-small;
 	padding: 0 20px 24px;
 	margin-top: 8px;
+	text-wrap: pretty; // Subtitle can be configured to any element, so we need to make sure it can wrap properly.
 
 	@include breakpoint-deprecated( ">480px" ) {
 		padding: 0;

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -8,7 +8,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import supportImage from 'calypso/assets/images/illustrations/dotcom-support.svg';
 import SupportButton from 'calypso/components/support-button';
-import { preventWidows } from 'calypso/lib/formatting';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
@@ -44,17 +43,15 @@ export class HappinessSupport extends Component {
 		const components = {
 			strong: <strong />,
 		};
-		return preventWidows(
-			isJetpackFreePlan
-				? translate(
-						'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of WordPress.',
-						{ components }
-				  )
-				: translate(
-						'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.',
-						{ components }
-				  )
-		);
+		return isJetpackFreePlan
+			? translate(
+					'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of WordPress.',
+					{ components }
+			  )
+			: translate(
+					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.',
+					{ components }
+			  );
 	}
 
 	getSupportButtons() {

--- a/client/components/jetpack/backup-getting-started/index.tsx
+++ b/client/components/jetpack/backup-getting-started/index.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import videoThumbnail2x from 'calypso/assets/images/jetpack/getting-started-backup-video-thumbnail-2x.png';
 import videoThumbnail from 'calypso/assets/images/jetpack/getting-started-backup-video-thumbnail.png';
 import DismissibleCard from 'calypso/blocks/dismissible-card';
-import { preventWidows } from 'calypso/lib/formatting';
 import './style.scss';
 import { GETTING_STARTED_WITH_JETPACK_BACKUP_VIDEO_URL } from './consts';
 
@@ -40,14 +39,12 @@ export default function BackupGettingStarted() {
 		<DismissibleCard preferenceName="backup-getting-started" className="backup-getting-started">
 			<VideoPreview { ...videoPreviewProps } hiddenOn="mobile" />
 			<div className="backup-getting-started__content">
-				<div className="backup-getting-started__header">
-					{ preventWidows( translate( 'Getting started with Jetpack VaultPress Backup' ) ) }
-				</div>
+				<h2 className="backup-getting-started__header">
+					{ translate( 'Getting started with Jetpack VaultPress Backup' ) }
+				</h2>
 				<p className="backup-getting-started__text">
-					{ preventWidows(
-						translate(
-							'A short video guide covering the basics of backing up your website and restoring your website from a previous backup.'
-						)
+					{ translate(
+						'A short video guide covering the basics of backing up your website and restoring your website from a previous backup.'
 					) }
 				</p>
 				<VideoPreview { ...videoPreviewProps } hiddenOn="desktop" />

--- a/client/components/jetpack/card/jetpack-product-card/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features-item.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { preventWidows } from 'calypso/lib/formatting';
 import type { ProductCardFeaturesItem } from './types';
 
 interface Props {
@@ -15,7 +14,7 @@ const JetpackProductCardFeaturesItem: React.FC< Props > = ( {
 			'is-differentiator': isDifferentiator,
 		} ) }
 	>
-		{ preventWidows( text ) }
+		{ text }
 	</li>
 );
 

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -3,7 +3,6 @@ import { SVG, Path } from '@wordpress/components';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { createElement, ReactNode, useEffect, useRef } from 'react';
-import { preventWidows } from 'calypso/lib/formatting';
 import DisplayPrice from './display-price';
 import JetpackProductCardFeatures from './features';
 import type {
@@ -198,9 +197,7 @@ const JetpackProductCard: React.FC< OwnProps > = ( {
 					<p className="jetpack-product-card__above-button">{ aboveButtonText }</p>
 				) }
 				{ isDisabled && disabledMessage && (
-					<p className="jetpack-product-card__disabled-message">
-						{ preventWidows( disabledMessage ) }
-					</p>
+					<p className="jetpack-product-card__disabled-message">{ disabledMessage }</p>
 				) }
 				{ buttonURL ? (
 					<Button

--- a/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-in-progress.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import * as React from 'react';
 import { recordLogRocketEvent } from 'calypso/lib/analytics/logrocket';
-import { preventWidows } from 'calypso/lib/formatting';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { backupMainPath } from 'calypso/my-sites/backup/paths';
@@ -50,7 +49,7 @@ const BackupInProgress: React.FC< Props > = ( { percent, inProgressDate, lastBac
 					"We're making a backup of your site from {{strong}}%(inProgressDisplayDate)s{{/strong}}.",
 					{
 						args: {
-							inProgressDisplayDate: preventWidows( inProgressDisplayDate ),
+							inProgressDisplayDate: inProgressDisplayDate,
 						},
 						components: {
 							strong: <strong />,
@@ -63,9 +62,9 @@ const BackupInProgress: React.FC< Props > = ( { percent, inProgressDate, lastBac
 			<ProgressBar value={ percent } total={ 100 } />
 
 			{ siteLastBackupDate && (
-				<div className="status-card__no-backup-last-backup">
+				<p className="status-card__no-backup-last-backup">
 					{ translate( 'Last backup before today: {{link}}%(lastBackupDisplayDate)s{{/link}}', {
-						args: { lastBackupDisplayDate: preventWidows( lastBackupDisplayDate ) },
+						args: { lastBackupDisplayDate: lastBackupDisplayDate || '' },
 						components: {
 							link: (
 								<a
@@ -76,7 +75,7 @@ const BackupInProgress: React.FC< Props > = ( { percent, inProgressDate, lastBac
 							),
 						},
 					} ) }
-				</div>
+				</p>
 			) }
 			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="IN_PROGRESS" /> }
 		</>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-just-completed.tsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-just-completed.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import { Moment } from 'moment';
 import * as React from 'react';
 import { recordLogRocketEvent } from 'calypso/lib/analytics/logrocket';
-import { preventWidows } from 'calypso/lib/formatting';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import { backupMainPath } from 'calypso/my-sites/backup/paths';
@@ -45,9 +44,9 @@ const BackupJustCompleted: React.FC< Props > = ( { justCompletedBackupDate, last
 			</p>
 
 			{ siteLastBackupDate && (
-				<div className="status-card__no-backup-last-backup">
+				<p className="status-card__no-backup-last-backup">
 					{ translate( 'Last backup before today: {{link}}%(lastBackupDisplayDate)s{{/link}}', {
-						args: { lastBackupDisplayDate: preventWidows( lastBackupDisplayDate ) },
+						args: { lastBackupDisplayDate: lastBackupDisplayDate || '' },
 						components: {
 							link: (
 								<a
@@ -58,7 +57,7 @@ const BackupJustCompleted: React.FC< Props > = ( { justCompletedBackupDate, last
 							),
 						},
 					} ) }
-				</div>
+				</p>
 			) }
 
 			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="COMPLETED" /> }

--- a/client/components/jetpack/daily-backup-status/status-card/backup-scheduled.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-scheduled.jsx
@@ -73,7 +73,7 @@ const BackupScheduled = ( { lastBackupDate } ) => {
 					<LoadingPlaceholder height="52px" />
 				) }
 			</div>
-			<div className="status-card__no-backup-last-backup">
+			<p className="status-card__no-backup-last-backup">
 				{ translate( 'Last daily backup: {{link}}%(lastBackupDay)s %(lastBackupTime)s{{/link}}', {
 					args: { lastBackupDay, lastBackupTime },
 					components: {
@@ -86,7 +86,7 @@ const BackupScheduled = ( { lastBackupDate } ) => {
 						),
 					},
 				} ) }
-			</div>
+			</p>
 			<ActionButtons disabled />
 			{ isEnabled( 'jetpack/backup-messaging-i3' ) && <BackupTips location="SCHEDULED" /> }
 		</>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-successful.jsx
@@ -7,7 +7,6 @@ import { default as Toolbar } from 'calypso/components/activity-card/toolbar';
 import BackupWarningRetry from 'calypso/components/jetpack/backup-warnings/backup-warning-retry';
 import NextScheduledBackup from 'calypso/components/jetpack/daily-backup-status/status-card/parts/next-scheduled-backup';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useActionableRewindId } from 'calypso/lib/jetpack/actionable-rewind-id';
 import { getBackupWarnings } from 'calypso/lib/jetpack/backup-utils';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
@@ -101,20 +100,18 @@ const BackupSuccessful = ( {
 			<div className="status-card__meta">{ meta }</div>
 			{ isMultiSite && (
 				<div className="status-card__multisite-warning">
-					<div className="status-card__multisite-warning-title">
-						{ preventWidows( translate( 'This site is a WordPress Multisite installation.' ) ) }
-					</div>
+					<h2 className="status-card__multisite-warning-title">
+						{ translate( 'This site is a WordPress Multisite installation.' ) }
+					</h2>
 					<p className="status-card__multisite-warning-info">
-						{ preventWidows(
-							translate(
-								'Jetpack VaultPress Backup for Multisite installations provides downloadable backups, no one-click restores. ' +
-									'For more information {{ExternalLink}}visit our documentation page{{/ExternalLink}}.',
-								{
-									components: {
-										ExternalLink: <ExternalLink href={ multiSiteInfoLink } target="_blank" icon />,
-									},
-								}
-							)
+						{ translate(
+							'Jetpack VaultPress Backup for Multisite installations provides downloadable backups, no one-click restores. ' +
+								'For more information {{ExternalLink}}visit our documentation page{{/ExternalLink}}.',
+							{
+								components: {
+									ExternalLink: <ExternalLink href={ multiSiteInfoLink } target="_blank" icon />,
+								},
+							}
 						) }
 					</p>
 				</div>

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo } from 'react';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cloud-cart';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
-import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import {
 	GUARANTEE_DAYS,
@@ -79,30 +78,26 @@ const IntroPricingBanner: React.FC = () => {
 				<div className="intro-pricing-banner__content">
 					{ shouldShowNoticeVAT && (
 						<div className="intro-pricing-banner__item is-centered-mobile">
-							<span className="intro-pricing-banner__item-label">
-								{ preventWidows( translate( 'Prices do not include VAT' ) ) }
-							</span>
+							<p className="intro-pricing-banner__item-label">
+								{ translate( 'Prices do not include VAT' ) }
+							</p>
 						</div>
 					) }
 					<div className="intro-pricing-banner__item">
 						<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
-						<span className="intro-pricing-banner__item-label">
-							{ preventWidows(
-								translate( 'Get up to %(percent)d% off your first year', {
-									args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE },
-								} )
-							) }
-						</span>
+						<p className="intro-pricing-banner__item-label">
+							{ translate( 'Get up to %(percent)d% off your first year', {
+								args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE },
+							} ) }
+						</p>
 					</div>
 					<div className="intro-pricing-banner__item">
 						<img className="intro-pricing-banner__item-icon" src={ guaranteeBadge } alt="" />
-						<span className="intro-pricing-banner__item-label">
-							{ preventWidows(
-								translate( '%(days)d day money back guarantee.', {
-									args: { days: GUARANTEE_DAYS },
-								} )
-							) }
-						</span>
+						<p className="intro-pricing-banner__item-label">
+							{ translate( '%(days)d day money back guarantee.', {
+								args: { days: GUARANTEE_DAYS },
+							} ) }
+						</p>
 					</div>
 					{ shouldShowCart && hasCrossed && (
 						<CloudCart cartStyle={ isSmallScreen ? {} : { left: clientRect.left } } />

--- a/client/components/jetpack/intro-pricing-banner/style.scss
+++ b/client/components/jetpack/intro-pricing-banner/style.scss
@@ -63,6 +63,12 @@
 	margin-inline-end: 0.5em;
 }
 
+.intro-pricing-banner__item-label {
+	font-size: 1rem;
+	line-height: 1.5;
+	margin-bottom: 0;
+}
+
 .intro-pricing-banner__item-label.is-link {
 	color: var(--color-primary-100);
 	text-decoration: underline;

--- a/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected-wpcom/index.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import JetpackDisconnected from 'calypso/assets/images/jetpack/disconnected.svg';
 import PromoCard from 'calypso/components/promo-section/promo-card';
-import { preventWidows } from 'calypso/lib/formatting';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -20,27 +19,23 @@ const JetpackDisconnectedWPCOM: FunctionComponent = () => {
 	const onSupportClick = useTrackCallback( undefined, 'calypso_jetpack_backup_support_click' );
 	return (
 		<PromoCard
-			title={ preventWidows( translate( 'Jetpack connection has failed' ) ) }
+			title={ translate( 'Jetpack connection has failed' ) }
 			image={ { path: JetpackDisconnected } }
 			isPrimary
 		>
 			<p>
-				{ preventWidows(
-					translate( 'Jetpack is unable to reach your site {{siteName/}} at this moment.', {
-						components: { siteName: <strong>{ siteName }</strong> },
-					} )
-				) }
+				{ translate( 'Jetpack is unable to reach your site {{siteName/}} at this moment.', {
+					components: { siteName: <strong>{ siteName }</strong> },
+				} ) }
 			</p>
 			<p>
-				{ preventWidows(
-					translate(
-						'Please visit {{siteUrl/}} to ensure your site is loading correctly and reconnect Jetpack if necessary.',
-						{
-							components: {
-								siteUrl: <ExternalLink href={ siteUrl }>{ siteUrl }</ExternalLink>,
-							},
-						}
-					)
+				{ translate(
+					'Please visit {{siteUrl/}} to ensure your site is loading correctly and reconnect Jetpack if necessary.',
+					{
+						components: {
+							siteUrl: <ExternalLink href={ siteUrl }>{ siteUrl }</ExternalLink>,
+						},
+					}
 				) }
 			</p>
 			<div className="jetpack-disconnected-wpcom__ctas">

--- a/client/components/jetpack/jetpack-disconnected/index.tsx
+++ b/client/components/jetpack/jetpack-disconnected/index.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import JetpackDisconnectedSVG from 'calypso/assets/images/jetpack/disconnected-gray.svg';
 import Upsell from 'calypso/components/jetpack/upsell';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -24,22 +23,18 @@ const JetpackDisconnected: FunctionComponent = () => {
 	const reconnectUrl = `https://wordpress.com/settings/disconnect-site/${ siteSlug }?type=down`;
 	const body = [
 		<span className="jetpack-disconnected__paragraph" key="paragraph-1">
-			{ preventWidows(
-				translate( 'Jetpack is unable to reach your site {{siteName/}} at this moment.', {
-					components: { siteName: <strong>{ siteName }</strong> },
-				} )
-			) }
+			{ translate( 'Jetpack is unable to reach your site {{siteName/}} at this moment.', {
+				components: { siteName: <strong>{ siteName }</strong> },
+			} ) }
 		</span>,
 		<span className="jetpack-disconnected__paragraph" key="paragraph-2">
-			{ preventWidows(
-				translate(
-					'Please visit {{siteUrl/}} to ensure your site is loading correctly and reconnect Jetpack if necessary.',
-					{
-						components: {
-							siteUrl: <ExternalLink href={ siteUrl }>{ siteUrl }</ExternalLink>,
-						},
-					}
-				)
+			{ translate(
+				'Please visit {{siteUrl/}} to ensure your site is loading correctly and reconnect Jetpack if necessary.',
+				{
+					components: {
+						siteUrl: <ExternalLink href={ siteUrl }>{ siteUrl }</ExternalLink>,
+					},
+				}
 			) }
 		</span>,
 	];

--- a/client/components/jetpack/licensing-activation/index.tsx
+++ b/client/components/jetpack/licensing-activation/index.tsx
@@ -6,7 +6,6 @@ import footerCardAltBackground from 'calypso/assets/images/jetpack/jp-licensing-
 import footerCardBackground from 'calypso/assets/images/jetpack/jp-licensing-checkout-footer-bg.svg';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import Main from 'calypso/components/main';
-import { preventWidows } from 'calypso/lib/formatting';
 
 import './style.scss';
 
@@ -63,7 +62,7 @@ const LicensingActivation: FC< Props > = ( {
 						) }
 					</div>
 					<h1 className={ clsx( 'licensing-activation__title', { 'is-loading': isLoading } ) }>
-						{ preventWidows( title ) }
+						{ title }
 					</h1>
 					{ children }
 

--- a/client/components/jetpack/licensing-prompt-dialog/index.tsx
+++ b/client/components/jetpack/licensing-prompt-dialog/index.tsx
@@ -2,7 +2,6 @@ import { Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
 import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
@@ -53,16 +52,16 @@ function LicensingPromptDialog( { siteId }: Props ) {
 	if ( ! titleToRender ) {
 		if ( hasOneDetachedLicense ) {
 			titleToRender = detachedUserLicense?.product
-				? preventWidows(
+				? String(
 						translate( 'Activate %(productName)s', {
 							args: {
 								productName: detachedUserLicense.product,
 							},
 						} )
 				  )
-				: preventWidows( translate( 'Your product is pending activation' ) );
+				: translate( 'Your product is pending activation' );
 		} else {
-			titleToRender = preventWidows( translate( 'Activate your new Jetpack features' ) );
+			titleToRender = translate( 'Activate your new Jetpack features' );
 		}
 	}
 

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -2,7 +2,6 @@ import { Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { preventWidows } from 'calypso/lib/formatting';
 import PurchaseButton from './purchase-button';
 import TipInfo from './tip-info';
 
@@ -99,7 +98,7 @@ export default class PurchaseDetail extends PureComponent {
 					<div className="purchase-detail__image">{ this.renderIcon() }</div>
 					<div className="purchase-detail__text">
 						<h3 className="purchase-detail__title">{ title }</h3>
-						<div className="purchase-detail__description">{ preventWidows( description ) }</div>
+						<div className="purchase-detail__description">{ description }</div>
 						{ this.renderBody() }
 					</div>
 				</div>

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -15,7 +15,6 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import FeatureExample from 'calypso/components/feature-example';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { preventWidows } from 'calypso/lib/formatting';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -73,10 +72,8 @@ export const SeoPreviewNudge = ( {
 								className="preview-upgrade-nudge__features-list-item-checkmark"
 								icon="checkmark"
 							/>
-							{ preventWidows(
-								translate(
-									"Preview your site's content as it will appear on Facebook, Twitter, and the WordPress.com Reader."
-								)
+							{ translate(
+								"Preview your site's content as it will appear on Facebook, Twitter, and the WordPress.com Reader."
 							) }
 						</li>
 						<li className="preview-upgrade-nudge__features-list-item">
@@ -84,10 +81,8 @@ export const SeoPreviewNudge = ( {
 								className="preview-upgrade-nudge__features-list-item-checkmark"
 								icon="checkmark"
 							/>
-							{ preventWidows(
-								translate(
-									'Control how page titles will appear on Google search results and social networks.'
-								)
+							{ translate(
+								'Control how page titles will appear on Google search results and social networks.'
 							) }
 						</li>
 						<li className="preview-upgrade-nudge__features-list-item">
@@ -95,10 +90,8 @@ export const SeoPreviewNudge = ( {
 								className="preview-upgrade-nudge__features-list-item-checkmark"
 								icon="checkmark"
 							/>
-							{ preventWidows(
-								translate(
-									'Customize your front page meta data to change how your site appears to search engines.'
-								)
+							{ translate(
+								'Customize your front page meta data to change how your site appears to search engines.'
 							) }
 						</li>
 					</ul>

--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 // TODO: This will need to be updated to use whatever image we decide on.
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
-import { preventWidows } from 'calypso/lib/formatting';
 import { TRACK_SOURCE_NAME } from 'calypso/sites-dashboard/utils';
 import { Column } from './layout/column';
 import { MenuItem } from './layout/menu-item';
@@ -62,9 +61,7 @@ export const Content = () => {
 				<MenuItem
 					icon={ <WordPressLogo /> }
 					heading={ translate( 'WordPress.com' ) }
-					description={ preventWidows(
-						translate( 'Build and grow your site, all in one powerful platform.' )
-					) }
+					description={ translate( 'Build and grow your site, all in one powerful platform.' ) }
 					buttonProps={ {
 						onClick: wordpressClick,
 					} }
@@ -72,9 +69,7 @@ export const Content = () => {
 				<MenuItem
 					icon={ <JetpackLogo /> }
 					heading={ translate( 'Via the Jetpack plugin' ) }
-					description={ preventWidows(
-						translate( 'Install the Jetpack plugin on an existing site.' )
-					) }
+					description={ translate( 'Install the Jetpack plugin on an existing site.' ) }
 					buttonProps={ {
 						onClick: jetpackClick,
 					} }
@@ -84,11 +79,11 @@ export const Content = () => {
 				<MenuItem
 					icon={ <Icon icon={ reusableBlock } size={ 18 } /> }
 					heading={ translate( 'Migrate' ) }
-					description={ preventWidows(
+					description={
 						hasEnTranslation( 'Bring your entire WordPress site to WordPress.com.' )
 							? translate( 'Bring your entire WordPress site to WordPress.com.' )
 							: translate( 'Bring your theme, plugins, and content to WordPress.com.' )
-					) }
+					}
 					buttonProps={ {
 						onClick: migrateClick,
 					} }
@@ -96,11 +91,11 @@ export const Content = () => {
 				<MenuItem
 					icon={ <Icon icon={ download } size={ 18 } /> }
 					heading={ translate( 'Import' ) }
-					description={ preventWidows(
+					description={
 						hasEnTranslation( 'Use a backup to only import content from other platforms.' )
 							? translate( 'Use a backup to only import content from other platforms.' )
 							: translate( 'Use a backup file to import your content into a new site.' )
-					) }
+					}
 					buttonProps={ {
 						onClick: importClick,
 					} }
@@ -118,18 +113,16 @@ export const Content = () => {
 							comment: 'percentage like 55% off',
 						},
 					} ) }
-					description={ preventWidows(
-						translate(
-							'Save up to %(percentage)s on annual plans and get a free custom domain for a year. Your next site is just a step away.',
-							{
-								args: {
-									percentage: formatNumber( 0.55, {
-										numberFormatOptions: { style: 'percent' },
-									} ),
-									comment: 'percentage like 55% off',
-								},
-							}
-						)
+					description={ translate(
+						'Save up to %(percentage)s on annual plans and get a free custom domain for a year. Your next site is just a step away.',
+						{
+							args: {
+								percentage: formatNumber( 0.55, {
+									numberFormatOptions: { style: 'percent' },
+								} ),
+								comment: 'percentage like 55% off',
+							},
+						}
 					) }
 					buttonProps={ {
 						onClick: offerClick,

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -4,7 +4,6 @@ import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { PropsWithChildren, ReactElement, useEffect, useRef, useState } from 'react';
 import { Swiper as SwiperType } from 'swiper/types';
-import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import './style.scss';
@@ -144,7 +143,7 @@ export default function ThemeCollection( {
 			<div className="theme-collection__meta">
 				<div className="theme-collection__headings">
 					<h2 className="theme-collection__title">{ title }</h2>
-					<p className="theme-collection__description">{ preventWidows( description ) }</p>
+					<p className="theme-collection__description">{ description }</p>
 				</div>
 				<div className="theme-collection__carousel-controls">
 					<Button className="theme-collection__see-all" onClick={ onSeeAllAction }>

--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -28,7 +28,6 @@ const Header: React.FC< Props > = ( { title } ) => {
 			<div className={ clsx( 'header', { 'has-sale-banner': hasSaleBanner } ) }>
 				<FormattedHeader
 					className="header__main-title"
-					disablePreventWidows
 					headerText={
 						title ?? translate( 'Security, performance, and marketing tools made for WordPress' )
 					}

--- a/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
@@ -11,13 +11,13 @@ exports[`AuthFormHeader renders as expected 1`] = `
         <h1
           class="formatted-header__title"
         >
-          Create an account to set up Jetpack
+          Create an account to set up Jetpack
            
         </h1>
         <p
           class="formatted-header__subtitle"
         >
-          You are moments away from a better WordPress.
+          You are moments away from a better WordPress.
         </p>
       </div>
     </header>

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -57,13 +57,13 @@ exports[`JetpackAuthorize renders as expected 1`] = `
               <h1
                 class="formatted-header__title"
               >
-                Create an account to set up Jetpack
+                Create an account to set up Jetpack
                  
               </h1>
               <p
                 class="formatted-header__subtitle"
               >
-                You are moments away from a better WordPress.
+                You are moments away from a better WordPress.
               </p>
             </div>
           </header>

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -55,13 +55,13 @@ exports[`JetpackSignup should render 1`] = `
             <h1
               class="formatted-header__title"
             >
-              Create an account to set up Jetpack
+              Create an account to set up Jetpack
                
             </h1>
             <p
               class="formatted-header__subtitle"
             >
-              You are moments away from a better WordPress.
+              You are moments away from a better WordPress.
             </p>
           </div>
         </header>
@@ -342,13 +342,13 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
             <h1
               class="formatted-header__title"
             >
-              Create an account to set up Jetpack
+              Create an account to set up Jetpack
                
             </h1>
             <p
               class="formatted-header__subtitle"
             >
-              You are moments away from a better WordPress.
+              You are moments away from a better WordPress.
             </p>
           </div>
         </header>

--- a/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/subpage-wrapper/test/index.test.tsx
@@ -9,7 +9,11 @@ import configureStore from 'redux-mock-store';
 import SubpageWrapper from '../index';
 import { ADD_FORWARDING_EMAIL, ADD_DNS_RECORD, EDIT_DNS_RECORD } from '../subpages';
 
-jest.mock( 'component-file-picker', () => () => <div>File Picker</div> );
+jest.mock( 'component-file-picker', () => {
+	const MockFilePicker = () => <div>File Picker</div>;
+	MockFilePicker.displayName = 'MockFilePicker';
+	return MockFilePicker;
+} );
 
 const initialState = {
 	sites: {
@@ -64,7 +68,7 @@ describe( 'SubpageWrapper', () => {
 		);
 
 		expect(
-			screen.getByRole( 'heading', { name: 'Add new email forwarding' } )
+			screen.getByRole( 'heading', { name: 'Add new email forwarding' } )
 		).toBeInTheDocument();
 		expect(
 			screen.getByText( 'Seamlessly redirect your messages to where you need them.' )

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -238,7 +238,6 @@ class StepWrapper extends Component {
 								headerText={ this.headerText() }
 								subHeaderText={ this.subHeaderText() }
 								align={ align }
-								disablePreventWidows
 								brandFont
 							/>
 							{ headerImageUrl && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/100475 and  #103147

## Proposed Changes

* Remove use of preventWidows() which is a JS workaround for what text-wrap: pretty now does in native CSS. Given pretty (and balance) now have good browser support, we can start removing the function.
* Scope of this PR: client/components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See inline comments for each component.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
