### PR TITLE
Tracks event label: for blueprintlibrary.wordpress.com url for blueprint, use its id

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/index.tsx
@@ -7,7 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useIsPlaygroundEligible } from '../../../../hooks/use-is-playground-eligible';
 import { PlaygroundIframe } from './components/playground-iframe';
-import { getBlueprintName } from './lib/blueprint';
+import { getBlueprintLabelForTracking } from './lib/blueprint';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -32,12 +32,10 @@ export const PlaygroundStep: StepType = ( { navigation, flow } ) => {
 			return;
 		}
 
-		const blueprintName = getBlueprintName( query.get( 'blueprint' ) );
-
 		recordTracksEvent( 'calypso_playground_launch_site', {
 			flow,
 			step: 'playground',
-			blueprint: blueprintName ?? 'unknown',
+			blueprint: getBlueprintLabelForTracking( query ),
 		} );
 
 		submit();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -105,12 +105,33 @@ function getDefaultBlueprint( recommendedPhpVersion: string ): Blueprint {
 	};
 }
 
-export function getBlueprintName( name: string | null ): string | null {
+function getBlueprintName( name: string | null ): string | null {
 	if ( name && name in PREDEFINED_BLUEPRINTS ) {
 		return name;
 	}
 
 	return null;
+}
+
+// Used in sending the Tracks event
+export function getBlueprintLabelForTracking( query: URLSearchParams ): string {
+	const name = query.get( 'blueprint' );
+
+	if ( name && name in PREDEFINED_BLUEPRINTS ) {
+		return name;
+	}
+
+	// If its a blueprintlibrary.wordpress.com url for blueprint, use its id to construct the label
+	const blueprintUrl = query.get( 'blueprint-url' );
+	if ( blueprintUrl ) {
+		const src = new URL( blueprintUrl );
+		if ( src.host === 'blueprintlibrary.wordpress.com' ) {
+			const id = src.searchParams.get( 'blueprint' );
+			return 'bpl-' + id;
+		}
+	}
+
+	return 'unknown';
 }
 
 async function getBlueprintFromUrl( recommendedPhpVersion: string ): Blueprint {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -121,7 +121,7 @@ export function getBlueprintLabelForTracking( query: URLSearchParams ): string {
 		return name;
 	}
 
-	// If its a blueprintlibrary.wordpress.com url for blueprint, use its id to construct the label
+	// If it's a blueprintlibrary.wordpress.com url for blueprint, use it's id to construct the label
 	const blueprintUrl = query.get( 'blueprint-url' );
 	if ( blueprintUrl ) {
 		const src = new URL( blueprintUrl );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -1,6 +1,7 @@
 import { Blueprint } from '@wp-playground/blueprints';
 import { resolveBlueprintFromURL } from './resolve-blueprint-from-url';
 
+const BLUEPRINT_LIB_HOST = 'blueprintlibrary.wordpress.com';
 const FALLBACK_PHP_VERSION = '8.3';
 const DEFAULT_BLUEPRINT: Blueprint = {
 	preferredVersions: {
@@ -125,7 +126,7 @@ export function getBlueprintLabelForTracking( query: URLSearchParams ): string {
 	const blueprintUrl = query.get( 'blueprint-url' );
 	if ( blueprintUrl ) {
 		const src = new URL( blueprintUrl );
-		if ( src.host === 'blueprintlibrary.wordpress.com' ) {
+		if ( src.host === BLUEPRINT_LIB_HOST ) {
 			const id = src.searchParams.get( 'blueprint' );
 			return 'bpl-' + id;
 		}


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/PLAYGRD-69/for-blueprint-url-parameters-from-blueprintlibrarywordpresscom

## Proposed Changes

* Construct a label using the post id of `blueprintlibrary.wordpress.com` like `bpl-6`

## Why are these changes being made?

* To recognize events where blueprint is being sourced from `blueprintlibrary.wordpress.com`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
