### PR TITLE
CI: require changelog entry for any dataviews changes but package.json

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -464,12 +464,9 @@ object RunAllUnitTests : BuildType({
 				# List files affected by the branch's commits
 				CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
 
-				# Check if there are changes within the DataViews package (excluding package.json)
-				DATAVIEWS_CHANGES=${'$'}(grep ^packages/dataviews/ <<< "${'$'}CHANGES" | grep -v ^packages/dataviews/package.json || true)
-
 				# If there are changes within the DataViews package (excluding package.json),
 				# ensure CHANGELOG.automattic.md has been updated too.
-				if [ -n "${'$'}DATAVIEWS_CHANGES" ]; then
+				if grep ^packages/dataviews/ <<< "${'$'}CHANGES" | grep -vq ^packages/dataviews/package.json; then
 					if ! grep -q ^packages/dataviews/CHANGELOG.automattic.md <<< "${'$'}CHANGES"; then
 						echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."
 						echo "Please document your changes in 'packages/dataviews/CHANGELOG.automattic.md'."

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -464,9 +464,12 @@ object RunAllUnitTests : BuildType({
 				# List files affected by the branch's commits
 				CHANGES=${'$'}(git diff --name-only refs/remotes/origin/trunk...HEAD)
 
-				# If there are changes within the DataViews package, ensure
-				# CHANGELOG.automattic.md has been updated too.
-				if grep -q ^packages/dataviews/ <<< "${'$'}CHANGES"; then
+				# Check if there are changes within the DataViews package (excluding package.json)
+				DATAVIEWS_CHANGES=${'$'}(grep ^packages/dataviews/ <<< "${'$'}CHANGES" | grep -v ^packages/dataviews/package.json || true)
+
+				# If there are changes within the DataViews package (excluding package.json),
+				# ensure CHANGELOG.automattic.md has been updated too.
+				if [ -n "${'$'}DATAVIEWS_CHANGES" ]; then
 					if ! grep -q ^packages/dataviews/CHANGELOG.automattic.md <<< "${'$'}CHANGES"; then
 						echo "ERROR: Changes to 'packages/dataviews' detected with no accompanying changelog entry."
 						echo "Please document your changes in 'packages/dataviews/CHANGELOG.automattic.md'."


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/103074

## Proposed Changes

This follows up on the work done at https://github.com/Automattic/wp-calypso/pull/103074 by excluding `packages/dataviews/package.json`. If there are only changes to that file, the job won't report any errors.

## Why are these changes being made?

Isolated changes to `packages/dataviews/package.json` are common: prepare a new npm package release, update a dep. Those changes don't necessary require updating the changelog.

## Testing Instructions

- https://github.com/Automattic/wp-calypso/pull/103190 should succeed.
- https://github.com/Automattic/wp-calypso/pull/103191 should fail.