### PR TITLE
Apply sentence case on hosting dashboard labels

### DIFF
--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -36,7 +36,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 	const title = {
 		create: translate( 'New schedule' ),
 		edit: translate( 'Edit schedule' ),
-		list: translate( 'Scheduled Updates' ),
+		list: translate( 'Scheduled updates' ),
 	}[ context ];
 
 	useEffect( () => {

--- a/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/schedule-list.tsx
@@ -135,7 +135,7 @@ export const ScheduleList = ( props: Props ) => {
 			<div className="plugins-update-manager-multisite__header">
 				<div className="plugins-update-manager-multisite__header-main">
 					<div className="plugins-update-manager-multisite__header-main-title">
-						<h1>{ translate( 'Scheduled Updates' ) }</h1>
+						<h1>{ translate( 'Scheduled updates' ) }</h1>
 						{ showSubtitle && (
 							<p>
 								{ translate(

--- a/client/blocks/plugins-scheduled-updates/index.tsx
+++ b/client/blocks/plugins-scheduled-updates/index.tsx
@@ -71,7 +71,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 					setNavigationTitle={ setNavigationTitle }
 				/>
 			),
-			title: translate( 'Scheduled Updates Logs' ),
+			title: translate( 'Scheduled updates logs' ),
 		},
 		list: {
 			component: (
@@ -82,7 +82,7 @@ export const PluginsScheduledUpdates = ( props: Props ) => {
 					onShowLogs={ onShowLogs }
 				/>
 			),
-			title: translate( 'Scheduled Updates' ),
+			title: translate( 'Scheduled updates' ),
 		},
 		create: {
 			component: <ScheduleCreate onNavBack={ onNavBack } />,

--- a/client/components/sites-add-new-site/content/index.tsx
+++ b/client/components/sites-add-new-site/content/index.tsx
@@ -80,7 +80,7 @@ export const Content = () => {
 					} }
 				/>
 			</Column>
-			<Column heading={ translate( 'Migrate and Import' ) }>
+			<Column heading={ translate( 'Migrate and import' ) }>
 				<MenuItem
 					icon={ <Icon icon={ reusableBlock } size={ 18 } /> }
 					heading={ translate( 'Migrate' ) }
@@ -109,8 +109,8 @@ export const Content = () => {
 			<Column>
 				<MenuItem
 					isBanner
-					icon={ <img src={ devSiteBanner } alt="Get a Free Domain and Up to 55% off" /> }
-					heading={ translate( 'Get a Free Domain and Up to %(percentage)s off', {
+					icon={ <img src={ devSiteBanner } alt="Get a free domain and up to 55% off" /> }
+					heading={ translate( 'Get a free domain and up to %(percentage)s off', {
 						args: {
 							percentage: formatNumber( 0.55, {
 								numberFormatOptions: { style: 'percent' },
@@ -137,7 +137,7 @@ export const Content = () => {
 				>
 					<div>
 						<div className={ clsx( 'sites-add-new-site-popover__cta' ) }>
-							{ translate( 'Unlock Offer' ) }
+							{ translate( 'Unlock offer' ) }
 						</div>
 					</div>
 				</MenuItem>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -83,7 +83,7 @@ export function JetpackPreviewPane( {
 				setSelectedSiteFeature,
 				<JetpackPluginsPreview
 					link={ '/plugins/manage/' + site.url }
-					linkLabel={ translate( 'Manage Plugins' ) }
+					linkLabel={ translate( 'Manage plugins' ) }
 					featureText={ translate( 'Manage all plugins installed on %(siteUrl)s', {
 						args: { siteUrl: site.url },
 					} ) }

--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -131,7 +131,7 @@ export const MarketplaceFooter = () => {
 					</Button>
 				) }
 				<ThreeColumnContainer>
-					<FeatureItem header={ __( 'Fully Managed' ) }>
+					<FeatureItem header={ __( 'Fully managed' ) }>
 						{ __(
 							'Premium plugins are fully managed by the team at WordPress.com. No security patches. No update nags. It just works.'
 						) }

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -105,7 +105,7 @@ export class PluginsMain extends Component {
 				href: `/plugins/${ selectedSiteSlug || '' }`,
 			},
 			{
-				label: this.props.translate( 'Manage Plugins' ),
+				label: this.props.translate( 'Manage plugins' ),
 				href: `/plugins/manage/${ selectedSiteSlug || '' }`,
 			},
 		] );
@@ -162,7 +162,7 @@ export class PluginsMain extends Component {
 	renderPluginsContent() {
 		return (
 			<PluginsList
-				header={ this.props.translate( 'Manage Plugins' ) }
+				header={ this.props.translate( 'Manage plugins' ) }
 				plugins={ this.getCurrentPlugins() }
 				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
 				isLoading={ this.props.requestingPluginsForSites || this.props.isLoadingSites }
@@ -222,7 +222,7 @@ export class PluginsMain extends Component {
 		if ( isJetpackCloud ) {
 			pageTitle = this.props.translate( 'Plugins', { textOnly: true } );
 		} else {
-			pageTitle = this.props.translate( 'Manage Plugins', { textOnly: true } );
+			pageTitle = this.props.translate( 'Manage plugins', { textOnly: true } );
 		}
 
 		return (

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -65,7 +65,7 @@ export default function PluginsList( {
 					href={ `/plugins/${ plugin.slug }${ selectedSite ? `/${ selectedSite.domain }` : '' }` }
 					onClick={ trackManagePlugin( plugin.slug ) }
 				>
-					{ translate( 'Manage Plugin' ) }
+					{ translate( 'Manage plugin' ) }
 				</PopoverMenuItem>
 				{ selectedSite ? (
 					<RemovePlugin site={ selectedSite } plugin={ plugin } />

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
@@ -51,7 +51,7 @@ const props = {
 	columns: [
 		{
 			key: 'plugin',
-			header: translate( 'Installed Plugins' ),
+			header: translate( 'Installed plugins' ),
 		},
 	],
 	rowFormatter: function ( props ): React.ReactNode {

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
@@ -51,7 +51,7 @@ const props = {
 	columns: [
 		{
 			key: 'plugin',
-			header: translate( 'Installed Plugins' ),
+			header: translate( 'Installed plugins' ),
 		},
 	],
 	rowFormatter: function ( props ): React.ReactNode {

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -321,7 +321,7 @@ const PluginsDashboard = ( {
 
 	const dashboardTitle = selectedPlugin
 		? `Manage ${ selectedPlugin.name } in all sites`
-		: 'Manage Plugins';
+		: 'Manage plugins';
 	return (
 		<Layout
 			className={ clsx(
@@ -333,7 +333,7 @@ const PluginsDashboard = ( {
 			title={ dashboardTitle }
 			sidebarNavigation={
 				isJetpackCloudOrA8CForAgencies && (
-					<SidebarNavigation sectionTitle={ translate( 'Manage Plugins' ) } />
+					<SidebarNavigation sectionTitle={ translate( 'Manage plugins' ) } />
 				)
 			}
 		>
@@ -350,7 +350,7 @@ const PluginsDashboard = ( {
 				<LayoutTop withNavigation={ false }>
 					{ isA8CForAgencies() && ! pluginSlug && <A4APluginsJetpackBanner /> }
 					<LayoutHeader>
-						<Title>{ translate( 'Manage Plugins' ) }</Title>
+						<Title>{ translate( 'Manage plugins' ) }</Title>
 						{ ! pluginSlug && (
 							<Subtitle>{ translate( 'Manage all your plugins in one place' ) }</Subtitle>
 						) }

--- a/client/my-sites/plugins/plugins-list/use-actions.tsx
+++ b/client/my-sites/plugins/plugins-list/use-actions.tsx
@@ -47,7 +47,7 @@ export function useActions(
 				recordIntentionEvent( plugins, 'manage-plugin' );
 				plugins.length && navigate( '/plugins/' + plugins[ 0 ].slug );
 			},
-			label: translate( 'Manage Plugin' ),
+			label: translate( 'Manage plugin' ),
 			isExternalLink: true,
 			isEnabled: true,
 			supportsBulk: false,

--- a/client/my-sites/plugins/plugins-list/use-fields.tsx
+++ b/client/my-sites/plugins/plugins-list/use-fields.tsx
@@ -58,7 +58,7 @@ export function useFields(
 			},
 			{
 				id: 'plugins',
-				label: translate( 'Installed Plugins' ),
+				label: translate( 'Installed plugins' ),
 				getValue: ( { item }: { item: Plugin } ) => item.name,
 				enableGlobalSearch: true,
 				render: ( { item }: { item: Plugin } ) => {

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -76,7 +76,7 @@ const ManageButton = ( {
 
 	return (
 		<Button className="plugins-browser__button" href={ managePluginsDestination }>
-			<span className="plugins-browser__button-text">{ translate( 'Installed Plugins' ) }</span>
+			<span className="plugins-browser__button-text">{ translate( 'Installed plugins' ) }</span>
 		</Button>
 	);
 };

--- a/client/my-sites/plugins/sidebar/index.tsx
+++ b/client/my-sites/plugins/sidebar/index.tsx
@@ -61,8 +61,8 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 				<SidebarItem
 					className="sidebar__menu-item--plugins"
 					link="/plugins/manage/sites"
-					label={ translate( 'Manage Plugins' ) }
-					tooltip={ isCollapsed && translate( 'Manage Plugins' ) }
+					label={ translate( 'Manage plugins' ) }
+					tooltip={ isCollapsed && translate( 'Manage plugins' ) }
 					selected={ isManagedPluginSelected }
 					icon={ settings }
 					onNavigate={ ( _e: SyntheticEvent, link: string ) => setPreviousPath( link ) }
@@ -71,8 +71,8 @@ const PluginsSidebar = ( { path, isCollapsed }: Props ) => {
 				<SidebarItem
 					className="sidebar__menu-item--plugins"
 					link="/plugins/scheduled-updates"
-					label={ translate( 'Scheduled Updates' ) }
-					tooltip={ isCollapsed && translate( 'Scheduled Updates' ) }
+					label={ translate( 'Scheduled updates' ) }
+					tooltip={ isCollapsed && translate( 'Scheduled updates' ) }
 					selected={ path.startsWith( '/plugins/scheduled-updates' ) }
 					customIcon={ <SidebarIconCalendar /> }
 				/>

--- a/client/my-sites/sidebar/static-data/all-sites-menu.js
+++ b/client/my-sites/sidebar/static-data/all-sites-menu.js
@@ -58,7 +58,7 @@ export default function allSitesMenu( { showManagePlugins = false } = {} ) {
 					{
 						parent: 'plugins',
 						slug: 'all-sites-plugins-installed-plugins',
-						title: translate( 'Installed Plugins' ),
+						title: translate( 'Installed plugins' ),
 						type: 'submenu-item',
 						url: '/plugins/manage',
 					},

--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -27,10 +27,10 @@ export const THEME_COLLECTIONS = {
 			tier: 'marketplace',
 		},
 		get title() {
-			return translate( 'Partner Themes' );
+			return translate( 'Partner themes' );
 		},
 		get fullTitle() {
-			return translate( 'Partner Themes' );
+			return translate( 'Partner themes' );
 		},
 		collectionSlug: 'partner-themes',
 		get description() {
@@ -48,10 +48,10 @@ export const THEME_COLLECTIONS = {
 			tier: 'partner',
 		},
 		get title() {
-			return translate( 'Partner Themes' );
+			return translate( 'Partner themes' );
 		},
 		get fullTitle() {
-			return translate( 'Partner Themes' );
+			return translate( 'Partner themes' );
 		},
 		collectionSlug: 'partner-themes',
 		get description() {

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -106,7 +106,7 @@ const DotcomSitesDataViews = ( {
 		const dataViewFields: Field< SiteExcerptData >[] = [
 			{
 				id: 'icon',
-				label: __( 'Site Icon' ),
+				label: __( 'Site icon' ),
 				render: ( { item }: { item: SiteExcerptData } ) => {
 					return (
 						<SiteIcon
@@ -152,7 +152,7 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'last-publish',
-				label: __( 'Last Published' ),
+				label: __( 'Last published' ),
 				render: ( { item }: { item: SiteExcerptData } ) =>
 					item.options?.updated_at ? <TimeSince date={ item.options.updated_at } /> : '',
 				enableHiding: false,
@@ -173,7 +173,7 @@ const DotcomSitesDataViews = ( {
 			},
 			{
 				id: 'last-interacted',
-				label: __( 'Last Interacted' ),
+				label: __( 'Last interacted' ),
 				render: () => null,
 				enableHiding: false,
 				enableSorting: true,

--- a/client/state/plugins/installed/README.md
+++ b/client/state/plugins/installed/README.md
@@ -1,4 +1,4 @@
-# Installed Plugins
+# Installed plugins
 
 A module for managing installed plugins on connected sites.
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to DOTCOM-55

## Proposed Changes

I propose to change wording of different UI controls from Title Case to Sentence case.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To adhere to the new guidelines.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review `sites/` page and subpages to confirm that the case for the most prominent parts of UI has changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
