### PR TITLE
Shorten the flow for DIFM starting from Tools > Marketing

### DIFF
--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -25,10 +25,9 @@ export const getMarketingFeaturesData = (
 			categories: [ 'design', 'favourite' ],
 			imagePath: wordPressLogo,
 			buttonText: translate( 'Get started' ),
-			buttonHref: localizeUrl( 'https://wordpress.com/website-design-service/?ref=tools-banner' ),
-			buttonTarget: '_blank',
 			onClick: () => {
 				recordTracksEvent( 'calypso_marketing_tools_built_by_wp_button_click' );
+				page( '/start/do-it-for-me/new-or-existing-site' );
 			},
 		},
 		{


### PR DESCRIPTION
This change will skip the intermediate landing page in a new window

Related to DOTCOM-860

## Proposed Changes

* Starting the difm flow instead of going to the landing page. The DIFM flow has site selection.

## Why are these changes being made?

* Requested in DOTCOM-860 and DOTCOM-12915, the goal is to shorten the flow for getting a DIFM upgrade

## Testing Instructions

* With an existing site, go to Tools > Marketing and click the link under "Let our WordPress.com experts build your site!" 
* You should enter the DIFM signup flow

https://github.com/user-attachments/assets/72843bf1-1328-4600-85c8-e65babf96251

CC @mikeicode 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
