### PR TITLE
refreshCountryCodeCookieGdpr: don't set country/region cookies if /geo request failed

### DIFF
--- a/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
+++ b/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
@@ -20,35 +20,34 @@ export default async function refreshCountryCodeCookieGdpr( signal = undefined )
 	}
 
 	if ( refreshRequest === null ) {
-		refreshRequest = requestGeoData( signal ).then( ( { countryCode, region } ) => {
-			setCountryCodeCookie( countryCode );
-			setRegionCookie( region );
-		} );
+		refreshRequest = requestGeoData( signal )
+			.then( ( { country_short, region } ) => {
+				setCountryCodeCookie( country_short );
+				// For some IP ranges we don't detect the region and the value returned by the `/geo` endpoint is `"-"`.
+				// In that case set the cookie to `unknown` This cannot happen for `country_short` because the `/geo`
+				// endpoint returns a 404 HTTP status when not even the country can be detected.
+				setRegionCookie( region === '-' ? 'unknown' : region );
+			} )
+			.catch( ( err ) => {
+				debug( 'refreshCountryCodeCookieGdpr: error: ', err );
+			} )
+			.finally( () => {
+				refreshRequest = null;
+			} );
 	}
 
 	await refreshRequest;
-	refreshRequest = null;
 }
 
 function requestGeoData( signal = undefined ) {
 	// cache buster
 	const v = new Date().getTime();
-	return fetch( 'https://public-api.wordpress.com/geo/?v=' + v, { signal } )
-		.then( ( res ) => {
-			if ( ! res.ok ) {
-				return res.body().then( ( body ) => {
-					throw new Error( body );
-				} );
-			}
-			return res.json();
-		} )
-		.then( ( json ) => {
-			return { countryCode: json.country_short, region: json.region };
-		} )
-		.catch( ( err ) => {
-			debug( 'refreshCountryCodeCookieGdpr: error: ', err );
-			return { countryCode: 'unknown', region: 'unknown' };
-		} );
+	return fetch( 'https://public-api.wordpress.com/geo/?v=' + v, { signal } ).then( ( res ) => {
+		if ( ! res.ok ) {
+			return res.body().then( ( body ) => Promise.reject( new Error( body ) ) );
+		}
+		return res.json();
+	} );
 }
 
 function setCountryCodeCookie( countryCode ) {

--- a/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
+++ b/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
@@ -30,6 +30,14 @@ export default async function refreshCountryCodeCookieGdpr( signal = undefined )
 			} )
 			.catch( ( err ) => {
 				debug( 'refreshCountryCodeCookieGdpr: error: ', err );
+				// Set the cookies to `unknown` to signal that the `/geo` request already failed and there's no point
+				// sending it again. But set them only if they don't already exist, don't overwrite valid values!
+				if ( ! cookies.country_code ) {
+					setCountryCodeCookie( 'unknown' );
+				}
+				if ( ! cookies.region ) {
+					setRegionCookie( 'unknown' );
+				}
 			} )
 			.finally( () => {
 				refreshRequest = null;
@@ -39,15 +47,14 @@ export default async function refreshCountryCodeCookieGdpr( signal = undefined )
 	await refreshRequest;
 }
 
-function requestGeoData( signal = undefined ) {
+async function requestGeoData( signal = undefined ) {
 	// cache buster
 	const v = new Date().getTime();
-	return fetch( 'https://public-api.wordpress.com/geo/?v=' + v, { signal } ).then( ( res ) => {
-		if ( ! res.ok ) {
-			return res.body().then( ( body ) => Promise.reject( new Error( body ) ) );
-		}
-		return res.json();
-	} );
+	const res = await fetch( 'https://public-api.wordpress.com/geo/?v=' + v, { signal } );
+	if ( ! res.ok ) {
+		throw new Error( `The /geo endpoint returned an error: ${ res.status } ${ res.statusText }` );
+	}
+	return await res.json();
 }
 
 function setCountryCodeCookie( countryCode ) {

--- a/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
+++ b/client/lib/analytics/utils/refresh-country-code-cookie-gdpr.js
@@ -22,21 +22,21 @@ export default async function refreshCountryCodeCookieGdpr( signal = undefined )
 	if ( refreshRequest === null ) {
 		refreshRequest = requestGeoData( signal )
 			.then( ( { country_short, region } ) => {
-				setCountryCodeCookie( country_short );
+				setCookie( 'country_code', country_short );
 				// For some IP ranges we don't detect the region and the value returned by the `/geo` endpoint is `"-"`.
 				// In that case set the cookie to `unknown` This cannot happen for `country_short` because the `/geo`
 				// endpoint returns a 404 HTTP status when not even the country can be detected.
-				setRegionCookie( region === '-' ? 'unknown' : region );
+				setCookie( 'region', region === '-' ? 'unknown' : region );
 			} )
 			.catch( ( err ) => {
 				debug( 'refreshCountryCodeCookieGdpr: error: ', err );
 				// Set the cookies to `unknown` to signal that the `/geo` request already failed and there's no point
 				// sending it again. But set them only if they don't already exist, don't overwrite valid values!
 				if ( ! cookies.country_code ) {
-					setCountryCodeCookie( 'unknown' );
+					setCookie( 'country_code', 'unknown' );
 				}
 				if ( ! cookies.region ) {
-					setRegionCookie( 'unknown' );
+					setCookie( 'region', 'unknown' );
 				}
 			} )
 			.finally( () => {
@@ -57,14 +57,8 @@ async function requestGeoData( signal = undefined ) {
 	return await res.json();
 }
 
-function setCountryCodeCookie( countryCode ) {
+function setCookie( name, value ) {
 	const maxAge = 6 * 60 * 60; // 6 hours in seconds
-	document.cookie = cookie.serialize( 'country_code', countryCode, { path: '/', maxAge } );
-	debug( 'refreshCountryCodeCookieGdpr: country_code cookie set to %s', countryCode );
-}
-
-function setRegionCookie( region ) {
-	const maxAge = 6 * 60 * 60;
-	document.cookie = cookie.serialize( 'region', region, { path: '/', maxAge } );
-	debug( 'refreshRegionCookieCcpa: region cookie set to %s', region );
+	document.cookie = cookie.serialize( name, value, { path: '/', maxAge } );
+	debug( 'refreshCountryCodeCookieGdpr: %s cookie set to %s', name, value );
 }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -115,12 +115,16 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 		request.cookies.sensitive_pixel_option
 	);
 
+	const countryCodeCookie = request.cookies.country_code;
+	const validCountryCodeCookie =
+		countryCodeCookie && countryCodeCookie !== 'unknown' ? countryCodeCookie : undefined;
+
 	const showGdprBanner = shouldSeeCookieBanner(
-		request.cookies.country_code || geoIPCountryCode,
+		validCountryCodeCookie || geoIPCountryCode,
 		trackingPrefs
 	);
 
-	if ( ! request.cookies.country_code && geoIPCountryCode ) {
+	if ( ! validCountryCodeCookie && geoIPCountryCode ) {
 		response.cookie( 'country_code', geoIPCountryCode );
 	}
 

--- a/packages/calypso-analytics/src/utils/is-country-in-gdpr-zone.ts
+++ b/packages/calypso-analytics/src/utils/is-country-in-gdpr-zone.ts
@@ -41,9 +41,9 @@ const GDPR_COUNTRIES = [
  * @returns Whether the country is in the GDPR zone
  */
 export default function isCountryInGdprZone( countryCode: string | undefined ): boolean {
-	if ( 'unknown' === countryCode ) {
+	if ( 'unknown' === countryCode || undefined === countryCode ) {
 		// Fail safe: if we don't know the countryCode, assume it's in the Gdpr zone.
 		return true;
 	}
-	return countryCode !== undefined && GDPR_COUNTRIES.includes( countryCode );
+	return GDPR_COUNTRIES.includes( countryCode );
 }

--- a/packages/calypso-analytics/src/utils/is-region-in-ccpa-zone.ts
+++ b/packages/calypso-analytics/src/utils/is-region-in-ccpa-zone.ts
@@ -20,14 +20,17 @@ const CCPA_US_REGIONS = [
  * @param region The region to look for.
  * @returns Whether the region is in the GDPR zone
  */
-export default function isRegionInCcpaZone( countryCode?: string, region?: string ): boolean {
+export default function isRegionInCcpaZone(
+	countryCode: string | undefined,
+	region: string | undefined
+): boolean {
 	if ( 'US' !== countryCode ) {
 		return false;
 	}
-	if ( 'unknown' === region ) {
+	if ( 'unknown' === region || undefined === region ) {
 		// Fail safe: if we don't know the region, assume it's in the CCPA zone.
 		return true;
 	}
 
-	return region !== undefined && CCPA_US_REGIONS.includes( region.toLowerCase() );
+	return CCPA_US_REGIONS.includes( region.toLowerCase() );
 }

--- a/packages/calypso-analytics/src/utils/is-region-in-sts-zone.ts
+++ b/packages/calypso-analytics/src/utils/is-region-in-sts-zone.ts
@@ -16,14 +16,17 @@ const STS_US_REGIONS = [
  * @returns Whether the region is in the STS zone
  */
 
-export default function isRegionInStsZone( countryCode?: string, region?: string ): boolean {
+export default function isRegionInStsZone(
+	countryCode: string | undefined,
+	region: string | undefined
+): boolean {
 	if ( 'US' !== countryCode ) {
 		return false;
 	}
-	if ( 'unknown' === region ) {
+	if ( 'unknown' === region || undefined === region ) {
 		// If we don't know the region, assume it's not in an STS zone.
 		return true;
 	}
 
-	return region !== undefined && STS_US_REGIONS.includes( region.toLowerCase() );
+	return STS_US_REGIONS.includes( region.toLowerCase() );
 }


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/102862#pullrequestreview-2817511866 @chriskmnds identified a bug where the `country_code` cookie gets overwritten from a valid country value (e.g., `US`) to an `unknown` value. That can happen when:
- you have a `country_code` cookie but don't have the `region` cookie. That can happen very easily because the Calypso server sets only the `country_code` cookie.
- the `refreshCountryCodeCookieGdpr` function is called, which happens for example in the `recordPageView` analytics function that's called every time you load a Calypso page.
- this function will check if _both_ `country_code` and `region` cookies are present, and if one is missing, will issue the `/geo` request and set the cookies according to the response.
- if the `/geo` request fails, it will set both cookies to `unknown`. That means that a perfectly good `country_code` value is overwritten with `unknown` just because i) the `region` cookie was missing && ii) the `/geo` request failed (e.g., blocked by ad-blocker)

This PR fixes that: if the `/geo` request fails, don't touch the cookies and leave them as they are.

There are a few related refactorings that I'm explaining in comments.

## Testing instructions:
- sandbox `public-api.wordpress.com` and modify the `public.api/geo.php` function on WP.com to make it fail (return 404)
- in local Calypso, delete the `country_code` and `region` cookies and then load any page (like `/home`)
- the page load will call `recordPageView` and in turn `refreshCountryCodeCookieGdpr`. Verify that the failed request doesn't lead to setting `unknown` cookies.
- in the `geo.php` endpoint, hardcode a `31.57.141.255` IP address. And make Calypso call the patched `/geo` endpoint. The response should be `{ country_short: "CZ", region: "-" }`. Verify that we set the `region` cookie to `-` in this case. We must set the `region` value to something because otherwise the very next `refreshCountryCodeCookieGdpr` call would detect a missing `region` and would call the `/geo` endpoint again and again.

This PR changes some high-stakes behavior because it's used to determine if we're in a GDPR-like area and whether we should send analytics. Look for example at #56525 and see how the country code affects Google analytics. Someone knowledgeable should review this. Unfortunately neither Caleb nor Renzo (co-authors of that PR) no longer work with us.
