### PR TITLE
JETCRM-6 Release of Jetpack CRM downloads component

### DIFF
--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -37,7 +37,8 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": false,
-		"a4a-client-checkout-v2": true
+		"a4a-client-checkout-v2": true,
+		"jetpack/crm-downloads": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -38,7 +38,7 @@
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": false,
 		"a4a-client-checkout-v2": false,
-		"jetpack/crm-downloads": false
+		"jetpack/crm-downloads": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -63,6 +63,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/crm-downloads": true,
 		"jitms": true,
 		"lasagna": true,
 		"launchpad-updates": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -74,7 +74,8 @@
 		"upgrades/redirect-payments": true,
 		"jetpack/pricing-page-cart": true,
 		"yolo/command-palette": false,
-		"importers/newsletter": true
+		"importers/newsletter": true,
+		"jetpack/crm-downloads": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -63,7 +63,7 @@
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/streamline-license-purchases": false,
-		"jetpack/crm-downloads": false,
+		"jetpack/crm-downloads": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/production.json
+++ b/config/production.json
@@ -79,7 +79,7 @@
 		"jetpack/social-plans-v1": true,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
-		"jetpack/crm-downloads": false,
+		"jetpack/crm-downloads": true,
 		"jitms": true,
 		"lasagna": true,
 		"launchpad-updates": false,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*Turns on the feature flags to release the Jetpack CRM Downloads component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to cloud.jetpack.com/purchases
* Click on a Jetpack Complete purchase
* It should show a "CRM Downloads" card at the details

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
