### PR TITLE
Reader repost popover - fix broken looking colors

### DIFF
--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -163,11 +163,21 @@
 }
 
 .reader-popover.reader-share__popover {
+	// Since this is in popover context, it won't inherit variable overrides from the global sidebar
+	// or main reader frame. We set them here, otherwise they inherit the dark theme values used for
+	// the global masterbar.
+	--color-sidebar-submenu-background: var(--studio-gray-0);
+	--color-sidebar-text: var(--studio-gray-80);
 	min-width: 240px;
 
 	.site-selector {
 		height: auto;
 		max-height: 220px;
+		// The long-content-fade mixin applied further below fades to --color-surface, but for
+		// the highlighted item we need to ensure that matches the background.
+		.site.is-highlighted {
+			--color-surface: var(--color-sidebar-submenu-background);
+		}
 	}
 
 	&.is-top .popover__arrow::before,
@@ -198,6 +208,5 @@
 .reader-share__site-selector .site__domain {
 	&::after {
 		@include long-content-fade();
-		border-radius: 50%;
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/CML-452/site-selector-on-the-reader-shows-a-weird-white-ellipse

## Proposed Changes


* Sets some color variables for the popover.  
    * `--color-sidebar-submenu-background` and `--color-sidebar-text`. Generally the reader and global sidebar override color variables for their context, as the main colors set higher on the body are the dark theme used for the global masterbar at the top. Since this is a popover, it is outside the dom context of the general reader and global sidebar so it still inherits the colors that the dark masterbar uses. This sets these values to the same used by the reader and global sidebar, changing the colors of the background and text color for the highlighted item.
    * sets `--color-surface` specifically for the highlighted site item. The mixin used for content fading fades to --color-surface, which is the correct value for non highlighted items but for the highlighted item doesn't match the background. This makes the background of the highlighted item and the color the content fade uses to match.
* Removes the border radius from the after element. This may not be 100% necessary, before I realized the --color-surface above was wrong it was glaring that the fade was not the correct shape and I removed this first fixing its shape. After fixing --color-surface above, the change of border radius really has no effect, but it seems unnecessary now so we can probably remove.

BEFORE
![Screenshot 2025-05-07 at 10 44 50 AM](https://github.com/user-attachments/assets/042db4dd-d9c5-40cd-a2f4-ce480fb57836)

AFTER
![Screenshot 2025-05-07 at 10 44 37 AM](https://github.com/user-attachments/assets/dbf4518f-d008-4169-b5d4-616a69671bd1)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* look bad

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch.
* go to the reader, scroll down to a post card
* click "repost" 
* in the popover, click into the search box
* before typing, move the cursor away from the popover
* type to filter
* verify the style on the first item isn't black with a white ellipse and looks ok now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
