### PR TITLE
Hosting Dashboard v2: only iframe https

### DIFF
--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -9,6 +9,13 @@ export default function SitePreview( {
 	width?: number;
 	height?: number;
 } ) {
+	// The /sites endpoint may return non-secure URLs. Often these _can_ be
+	// loaded securely, so it's worth trying to load over https. If it fails,
+	// there would have been an error either way because the dasboard is loaded
+	// over https.
+	// To do: check why the endpoint returns non-secure URLs when it will
+	// redirect to a secure URL.
+	const secureUrl = url.replace( /^http:\/\//, 'https://' );
 	return (
 		<iframe
 			loading="lazy"
@@ -17,7 +24,7 @@ export default function SitePreview( {
 			title="Site Preview"
 			// Hide banners + `preview` hides cookie banners + `iframe` hides
 			// admin bar for atomic sites.
-			src={ `${ url }/?hide_banners=true&preview=true&iframe=true` }
+			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }
 			style={ {
 				display: 'block',
 				border: 'none',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* See inline comment: try always loading sites securely. For those that can't be loaded securely (not sure if this can be the case), there will be an error either way so at least there are less errors.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ask @arthur791004 to be invite you to his site because he has run into an edge case where the `URL` field from the `/sites` endpoint returns a non-secure URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
