### PR TITLE
[Odie] Chat history - remove dupes

### DIFF
--- a/packages/help-center/src/hooks/use-get-history-chats.ts
+++ b/packages/help-center/src/hooks/use-get-history-chats.ts
@@ -10,12 +10,7 @@ import {
 	getZendeskConversations,
 } from '../components/utils';
 import { HELP_CENTER_STORE } from '../stores';
-import type {
-	Conversations,
-	OdieConversation,
-	SupportInteraction,
-	ZendeskConversation,
-} from '@automattic/odie-client';
+import type { Conversations, SupportInteraction } from '@automattic/odie-client';
 
 interface UseGetHistoryChatsResult {
 	conversations: Conversations;
@@ -28,6 +23,8 @@ interface UseGetHistoryChatsResult {
 export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 	const [ conversations, setConversations ] = useState< Conversations >( [] );
 	const [ supportInteractions, setSupportInteractions ] = useState< SupportInteraction[] >( [] );
+	const [ recentConversations, setRecentConversations ] = useState< Conversations >( [] );
+	const [ archivedConversations, setArchivedConversations ] = useState< Conversations >( [] );
 
 	const { data: openSupportInteraction, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk', 10, 'open' );
@@ -38,79 +35,78 @@ export const useGetHistoryChats = (): UseGetHistoryChatsResult => {
 
 	const { isChatLoaded } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
-
-		return {
-			isChatLoaded: store.getIsChatLoaded(),
-		};
+		return { isChatLoaded: store.getIsChatLoaded() };
 	}, [] );
 
 	const isLoadingInteractions =
 		isLoadingOpenInteractions || isLoadingOtherSupportInteractions || isLoadingOdieConversations;
 
 	useEffect( () => {
-		if ( isChatLoaded && getZendeskConversations && ! isLoadingInteractions ) {
-			const allConversations = getZendeskConversations();
-			const allSupportInteractions = [
-				...( openSupportInteraction || [] ),
-				...( otherSupportInteractions || [] ),
-			];
-
-			const conversationsWithUpdatedStatuses = filterAndUpdateConversationsWithStatus(
-				allConversations,
-				allSupportInteractions
-			);
-
-			setConversations( conversationsWithUpdatedStatuses );
-			setSupportInteractions( allSupportInteractions );
-		}
-	}, [ isChatLoaded, isLoadingInteractions, openSupportInteraction, otherSupportInteractions ] );
-
-	// We need to import this function from utils, but for now we'll define it here
-	const getSortedRecentAndArchivedConversations = ( {
-		conversations,
-	}: {
-		conversations: Conversations;
-	} ) => {
-		const recentConversations: Conversations = [];
-		const archivedConversations: Conversations = [];
-
-		if ( Array.isArray( conversations ) ) {
-			const oneYearAgoDate = new Date();
-			oneYearAgoDate.setFullYear( oneYearAgoDate.getFullYear() - 1 );
-			const oneYearAgo = oneYearAgoDate.getTime();
-
-			conversations.forEach( ( conversation: OdieConversation | ZendeskConversation ) => {
-				const createdAt = getConversationCreatedAt( conversation );
-
-				if ( typeof createdAt === 'number' && createdAt < oneYearAgo ) {
-					archivedConversations.push( conversation );
-
-					return;
-				}
-
-				recentConversations.push( conversation );
-			} );
+		if ( ! isChatLoaded || ! getZendeskConversations || isLoadingInteractions ) {
+			return;
 		}
 
-		return {
-			recentConversations,
-			archivedConversations,
-		};
-	};
+		const allConversations = getZendeskConversations();
+		const allSupportInteractions = [
+			...( openSupportInteraction || [] ),
+			...( otherSupportInteractions || [] ),
+		];
 
-	// Merges conversations coming from Zendesk with those coming from Odie, then sort them by most recent first
-	const mergedAndSortedConversations = [ ...conversations, ...( odieConversations ?? [] ) ].sort(
-		( a, b ) => {
+		const conversationsWithUpdatedStatuses = filterAndUpdateConversationsWithStatus(
+			allConversations,
+			allSupportInteractions
+		);
+
+		setConversations( conversationsWithUpdatedStatuses );
+		setSupportInteractions( allSupportInteractions );
+
+		// Filter Odie conversations not already present in support interactions
+		const eventExternalIds = new Set(
+			allSupportInteractions
+				.flatMap( ( interaction ) => interaction.events || [] )
+				.filter( ( event ) => event.event_source === 'odie' )
+				.map( ( event ) => event.event_external_id )
+		);
+
+		const filteredOdieConversations = ( odieConversations || [] ).filter(
+			( conversation ) => ! eventExternalIds.has( conversation.id )
+		);
+
+		const mergedAndSortedConversations = [
+			...conversationsWithUpdatedStatuses,
+			...filteredOdieConversations,
+		].sort( ( a, b ) => {
 			const createdAtA = getConversationCreatedAt( a ) ?? 0;
 			const createdAtB = getConversationCreatedAt( b ) ?? 0;
-
 			return createdAtB - createdAtA;
-		}
-	);
+		} );
 
-	const { recentConversations, archivedConversations } = getSortedRecentAndArchivedConversations( {
-		conversations: mergedAndSortedConversations,
-	} );
+		// Split into recent and archived
+		const oneYearAgoDate = new Date();
+		oneYearAgoDate.setFullYear( oneYearAgoDate.getFullYear() - 1 );
+		const oneYearAgo = oneYearAgoDate.getTime();
+
+		const recent: Conversations = [];
+		const archived: Conversations = [];
+
+		mergedAndSortedConversations.forEach( ( conversation ) => {
+			const createdAt = getConversationCreatedAt( conversation );
+			if ( typeof createdAt === 'number' && createdAt < oneYearAgo ) {
+				archived.push( conversation );
+			} else {
+				recent.push( conversation );
+			}
+		} );
+
+		setRecentConversations( recent );
+		setArchivedConversations( archived );
+	}, [
+		isChatLoaded,
+		isLoadingInteractions,
+		openSupportInteraction,
+		otherSupportInteractions,
+		odieConversations,
+	] );
 
 	return {
 		conversations,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

We are duplicating the conversations that ended up escalated to Zendesk. The chat history should show the latest interaction when escalated, that means, the conversation with the AI should not be present in the chat history if it is escalated.

## Why are these changes being made?

Showing duplicated interactions but with different visualisation on the chat history is quite a lot confusing. Even tho it might serve for choosing to keep talking with the AI instead of the HE, we prefer to show the last interaction in this case.

## Testing Instructions

1. Sandbox your public api
2. Use the calypso live link here in the Pull Request.
3. Start a new conversation with the AI Assistant and ask to escalate (it won't escalate as you are sandboxing your public-api)

Assert the following:
| WITH PATCH | WITHOUT PATCH |
|------------|----------------|
| ![image](https://github.com/user-attachments/assets/1131d149-7b77-4f84-b2a7-f898aa3dcdf0) | ![image](https://github.com/user-attachments/assets/5238cf0e-fed1-49a5-959a-3fa23ea568a3) |


Notice that without the patch, you are seeing the AI Assistant escalating you. We are removing those interactions with this patch


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
