### PR TITLE
Hosting Dashboard v2: sites: add status badges

### DIFF
--- a/client/dashboard/sites/badge.scss
+++ b/client/dashboard/sites/badge.scss
@@ -1,0 +1,12 @@
+.sites-core-badge-custom-icon,
+.sites-core-badge-no-icon {
+	// This is hacky way of hiding the badge icon for now.
+	// We need to handle this in the core Badge component.
+	> svg {
+		display: none;
+	}
+}
+
+.sites-core-badge-no-icon.has-icon {
+	padding-inline-start: 8px;
+}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,3 +1,4 @@
+import CoreBadge from '@automattic/components/src/core-badge';
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -10,11 +11,18 @@ import { sitesQuery } from '../app/queries';
 import { sitesRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
 import PageLayout from '../components/page-layout';
-import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
+import {
+	STATUS_LABELS,
+	getSiteStatus,
+	getSiteStatusLabel,
+	getSiteStatusIntent,
+} from '../utils/site-status';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { Site } from '../data/types';
 import type { Operator, ViewTable, ViewGrid, SortDirection } from '@automattic/dataviews';
+
+import './badge.scss';
 
 const actions = [
 	{
@@ -96,7 +104,13 @@ const DEFAULT_FIELDS = [
 		label: __( 'Status' ),
 		getValue: ( { item }: { item: Site } ) => getSiteStatus( item ),
 		elements: Object.entries( STATUS_LABELS ).map( ( [ value, label ] ) => ( { value, label } ) ),
-		render: ( { item }: { item: Site } ) => getSiteStatusLabel( item ),
+		render: ( { item }: { item: Site } ) => {
+			return (
+				<CoreBadge className="sites-core-badge-no-icon" intent={ getSiteStatusIntent( item ) }>
+					{ getSiteStatusLabel( item ) }
+				</CoreBadge>
+			);
+		},
 	},
 	{
 		id: 'is_a8c',
@@ -155,7 +169,7 @@ const DEFAULT_LAYOUTS = {
 	},
 	grid: {
 		mediaField: 'preview',
-		fields: [],
+		fields: [ 'status' ],
 		titleField: 'name',
 		descriptionField: 'URL',
 	},

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -1,3 +1,4 @@
+import CoreBadge from '@automattic/components/src/core-badge';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -8,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
-import { getSiteStatusLabel } from '../../utils/site-status';
+import { getSiteStatusLabel, getSiteStatusIntent } from '../../utils/site-status';
 import SitePreview from '../site-preview';
 import type { Site, SiteDomain, Plan } from '../../data/types';
 
@@ -67,7 +68,14 @@ export default function SiteCard( {
 						</Field>
 					) }
 					<HStack justify="space-between">
-						<Field title={ __( 'Status' ) }>{ getSiteStatusLabel( site ) }</Field>
+						<Field title={ __( 'Status' ) }>
+							<CoreBadge
+								className="sites-core-badge-no-icon"
+								intent={ getSiteStatusIntent( site ) }
+							>
+								{ getSiteStatusLabel( site ) }
+							</CoreBadge>
+						</Field>
 					</HStack>
 					<HStack justify="space-between">
 						{ options?.software_version && (

--- a/client/dashboard/sites/overview/style.scss
+++ b/client/dashboard/sites/overview/style.scss
@@ -15,12 +15,3 @@
 	text-transform: uppercase;
 	font-size: 12px;
 }
-
-
-.site-overview-card__badge {
-	// This is hacky way of hiding the badge icon for now.
-	// We need to handle this in the core Badge component.
-	> svg {
-		display: none;
-	}
-}

--- a/client/dashboard/sites/overview/trend-comparizon-badge.tsx
+++ b/client/dashboard/sites/overview/trend-comparizon-badge.tsx
@@ -2,6 +2,8 @@ import CoreBadge from '@automattic/components/src/core-badge';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { arrowDown, arrowUp } from '@wordpress/icons';
 
+import '../badge.scss';
+
 interface TrendComparisonBadgeProps {
 	count: number;
 	previousCount: number;
@@ -33,9 +35,7 @@ export default function TrendComparisonBadge( {
 		<CoreBadge
 			intent={ negative ? 'error' : 'success' }
 			style={ { width: 'fit-content' } }
-			className={ `site-overview-card__badge site-overview-card__badge-${
-				negative ? 'negative' : 'positive'
-			}` }
+			className="sites-core-badge-custom-icon"
 		>
 			<HStack spacing={ 0 }>
 				<Icon

--- a/client/dashboard/utils/site-status.ts
+++ b/client/dashboard/utils/site-status.ts
@@ -11,6 +11,16 @@ export const STATUS_LABELS = {
 	migration_started: __( 'Migration Started' ),
 };
 
+const STATUS_INTENTS = {
+	public: 'success' as const,
+	private: 'warning' as const,
+	coming_soon: 'warning' as const,
+	deleted: 'error' as const,
+	redirect: 'success' as const,
+	migration_pending: 'info' as const,
+	migration_started: 'info' as const,
+};
+
 export function getSiteStatus( item: Site ) {
 	if ( item.site_migration?.migration_status.startsWith( 'migration-pending' ) ) {
 		return 'migration_pending';
@@ -41,4 +51,8 @@ export function getSiteStatus( item: Site ) {
 
 export function getSiteStatusLabel( item: Site ) {
 	return STATUS_LABELS[ getSiteStatus( item ) ];
+}
+
+export function getSiteStatusIntent( item: Site ) {
+	return STATUS_INTENTS[ getSiteStatus( item ) ];
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/fa4f561a-3fef-4a95-8893-c9ddcb2bdc34" />

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/49399edf-0599-4e89-b80a-1bf2c36d2db7" />

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/6a319ca3-269e-4c7f-82c9-e03c44db50b3" />


## Proposed Changes

* Adds coloured badges to the status fields to easily see the status at glance.
* Adds the field to the grid by default, as proposed by design.
* The badge is shown both in the table and grid layout, even in the site overview for consistency.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the sites list (grid and table) and site overview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
