### PR TITLE
[NOX In-Context] Do not show the Jetpack logo when onboarding for Woo accounts

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -635,8 +635,9 @@ class Login extends Component {
 					break;
 				default:
 					headerText = <h3>{ translate( 'Log in to your account' ) }</h3>;
+					// pluginName is already translated with an "in" prefix
 					subtitle = translate(
-						'To access all of the features and functionality in %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
+						'To access all of the features and functionality %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
 						{
 							components: {
 								signupLink,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -635,7 +635,7 @@ class Login extends Component {
 					break;
 				default:
 					headerText = <h3>{ translate( 'Log in to your account' ) }</h3>;
-					// pluginName is already translated with an "in" prefix
+					// pluginName is already translated with an "in" prefix in getPluginTitle.
 					subtitle = translate(
 						'To access all of the features and functionality %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
 						{

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -538,7 +538,12 @@ export class Login extends Component {
 	}
 
 	renderTopBar( isSocialFirst ) {
-		const { isFromAkismet, isJetpack } = this.props;
+		const { isFromAkismet, isJetpack, isWooJPC } = this.props;
+
+		if ( isWooJPC ) {
+			// The Woo flow already displays the Woo logo in the header.
+			return null;
+		}
 
 		const akismetLogo = (
 			<svg


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/57799

## Proposed Changes

This fixes two main problems:

* In the new NOX In-Context flow, and the **Connect to WordPress.com** step specifically, if a user clicks on "Sign in as a different user" the displayed page shows two logos:

![CleanShot 2025-05-07 at 17 16 27@2x](https://github.com/user-attachments/assets/fd655358-2b28-4c28-90b0-35b8cfe63cc0)

* On the same page, there is a small typo in the paragraph (in in):

![CleanShot 2025-05-07 at 17 17 05@2x](https://github.com/user-attachments/assets/6bbd4850-27a9-429d-ae74-cda910a00b94)

This PR fixes both issues.

## Why are these changes being made?

To fix the logo issue (and typo as a bonus)

## Testing Instructions

* Clone and set up this repo locally using the [Getting Started](https://github.com/Automattic/wp-calypso?tab=readme-ov-file#getting-started)
* Start the server locally on `http://calypso.localhost:3000/`
* Create a new JN site from WooCommerce core and use a zip of WooPayments 9.3.0.
* Visit WooCommerce > Settings > Payments and start the NOX
* Once you're redirect to connect WordPress.com, make sure you see both logos (and that there is a typo in the page):

![CleanShot 2025-05-07 at 17 16 27@2x](https://github.com/user-attachments/assets/fd655358-2b28-4c28-90b0-35b8cfe63cc0)

* Replace `https://wordpress.com/` with `http://calypso.localhost:3000/`. You should see the same login page but with one logo only (and a fixed typo):

![CleanShot 2025-05-07 at 17 21 37@2x](https://github.com/user-attachments/assets/540a0b48-a4f5-4a21-add3-fddd347b3525)

* Enjoy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
