### PR TITLE
Cancel Purchase: Move inline components to prevent redefinitions

### DIFF
--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -8,6 +8,152 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { getName, isRefundable, isSubscription } from 'calypso/lib/purchases';
 
+const NonRefundableDomainMappingMessage = ( { includedDomainPurchase } ) => {
+	const translate = useTranslate();
+	return (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
+						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					{
+						args: {
+							mappedDomain: includedDomainPurchase.meta,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};
+
+const CancelableDomainMappingMessage = ( { includedDomainPurchase, purchase } ) => {
+	const translate = useTranslate();
+	return (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes mapping for the domain %(mappedDomain)s. ' +
+						"Cancelling will remove all the plan's features from your site, including the domain.",
+					{
+						args: {
+							mappedDomain: includedDomainPurchase.meta,
+						},
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
+					{
+						args: {
+							mappedDomain: includedDomainPurchase.meta,
+							wordpressSiteUrl: purchase.domain,
+						},
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
+						'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
+					{
+						args: {
+							mappedDomain: includedDomainPurchase.meta,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};
+
+const NonRefundableDomainPurchaseMessage = ( { includedDomainPurchase } ) => {
+	const translate = useTranslate();
+	return (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					{
+						args: {
+							domain: includedDomainPurchase.meta,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};
+
+const DomainTransferMessage = ( { includedDomainTransfer, planCostText, purchase } ) => {
+	const translate = useTranslate();
+	return (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
+						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					{
+						args: {
+							domain: includedDomainTransfer.meta,
+							domainCost: includedDomainTransfer.priceText,
+						},
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+						'minus %(domainCost)s for the domain.',
+					{
+						args: {
+							domainCost: includedDomainTransfer.priceText,
+							planCost: planCostText,
+							refundAmount: purchase.refundText,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};
+
+const RefundablePurchaseWithNonRefundableDomainMessage = ( {
+	includedDomainPurchase,
+	planCostText,
+	purchase,
+} ) => {
+	const translate = useTranslate();
+	return (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					{
+						args: {
+							domain: includedDomainPurchase.meta,
+						},
+					}
+				) }
+			</p>
+			<p>
+				{ translate(
+					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+						'minus %(domainCost)s for the domain.',
+					{
+						args: {
+							domainCost: includedDomainPurchase.costToUnbundleText,
+							planCost: planCostText,
+							refundAmount: purchase.refundText,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};
+
 const CancelPurchaseDomainOptions = ( {
 	includedDomainPurchase,
 	includedDomainTransfer,
@@ -43,154 +189,18 @@ const CancelPurchaseDomainOptions = ( {
 		[ cancelBundledDomain, onCancelConfirmationStateChange ]
 	);
 
-	const NonRefundableDomainMappingMessage = useCallback(
-		() => (
-			<div>
-				<p>
-					{ translate(
-						'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
-							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-						{
-							args: {
-								mappedDomain: includedDomainPurchase.meta,
-							},
-						}
-					) }
-				</p>
-			</div>
-		),
-		[ includedDomainPurchase, translate ]
-	);
-
-	const CancelableDomainMappingMessage = useCallback(
-		() => (
-			<div>
-				<p>
-					{ translate(
-						'This plan includes mapping for the domain %(mappedDomain)s. ' +
-							"Cancelling will remove all the plan's features from your site, including the domain.",
-						{
-							args: {
-								mappedDomain: includedDomainPurchase.meta,
-							},
-						}
-					) }
-				</p>
-				<p>
-					{ translate(
-						'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
-						{
-							args: {
-								mappedDomain: includedDomainPurchase.meta,
-								wordpressSiteUrl: purchase.domain,
-							},
-						}
-					) }
-				</p>
-				<p>
-					{ translate(
-						'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
-							'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
-						{
-							args: {
-								mappedDomain: includedDomainPurchase.meta,
-							},
-						}
-					) }
-				</p>
-			</div>
-		),
-		[ includedDomainPurchase, purchase, translate ]
-	);
-
-	const NonRefundableDomainPurchaseMessage = useCallback(
-		() => (
-			<div>
-				<p>
-					{ translate(
-						'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-						{
-							args: {
-								domain: includedDomainPurchase.meta,
-							},
-						}
-					) }
-				</p>
-			</div>
-		),
-		[ includedDomainPurchase, translate ]
-	);
-
-	const DomainTransferMessage = useCallback(
-		() => (
-			<div>
-				<p>
-					{ translate(
-						'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
-							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-						{
-							args: {
-								domain: includedDomainTransfer.meta,
-								domainCost: includedDomainTransfer.priceText,
-							},
-						}
-					) }
-				</p>
-				<p>
-					{ translate(
-						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-							'minus %(domainCost)s for the domain.',
-						{
-							args: {
-								domainCost: includedDomainTransfer.priceText,
-								planCost: planCostText,
-								refundAmount: purchase.refundText,
-							},
-						}
-					) }
-				</p>
-			</div>
-		),
-		[ includedDomainTransfer, planCostText, purchase, translate ]
-	);
-
-	const RefundablePurchaseWithNonRefundableDomainMessage = useCallback(
-		() => (
-			<div>
-				<p>
-					{ translate(
-						'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-						{
-							args: {
-								domain: includedDomainPurchase.meta,
-							},
-						}
-					) }
-				</p>
-				<p>
-					{ translate(
-						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-							'minus %(domainCost)s for the domain.',
-						{
-							args: {
-								domainCost: includedDomainPurchase.costToUnbundleText,
-								planCost: planCostText,
-								refundAmount: purchase.refundText,
-							},
-						}
-					) }
-				</p>
-			</div>
-		),
-		[ includedDomainPurchase, planCostText, purchase, translate ]
-	);
-
 	if ( ( ! includedDomainPurchase && ! includedDomainTransfer ) || ! isSubscription( purchase ) ) {
 		return null;
 	}
 
 	if ( includedDomainTransfer ) {
-		return <DomainTransferMessage />;
+		return (
+			<DomainTransferMessage
+				includedDomainTransfer={ includedDomainTransfer }
+				purchase={ purchase }
+				planCostText={ planCostText }
+			/>
+		);
 	}
 
 	if (
@@ -203,19 +213,32 @@ const CancelPurchaseDomainOptions = ( {
 	// Domain mapping.
 	if ( isDomainMapping( includedDomainPurchase ) ) {
 		if ( ! isRefundable( purchase ) ) {
-			return <NonRefundableDomainMappingMessage />;
+			return (
+				<NonRefundableDomainMappingMessage includedDomainPurchase={ includedDomainPurchase } />
+			);
 		}
 
-		return <CancelableDomainMappingMessage />;
+		return (
+			<CancelableDomainMappingMessage
+				includedDomainPurchase={ includedDomainPurchase }
+				purchase={ purchase }
+			/>
+		);
 	}
 
 	// Domain registration.
 	if ( ! isRefundable( purchase ) ) {
-		return <NonRefundableDomainPurchaseMessage />;
+		return <NonRefundableDomainPurchaseMessage includedDomainPurchase={ includedDomainPurchase } />;
 	}
 
 	if ( isRefundable( purchase ) && ! isRefundable( includedDomainPurchase ) ) {
-		return <RefundablePurchaseWithNonRefundableDomainMessage />;
+		return (
+			<RefundablePurchaseWithNonRefundableDomainMessage
+				includedDomainPurchase={ includedDomainPurchase }
+				purchase={ purchase }
+				planCostText={ planCostText }
+			/>
+		);
 	}
 
 	return (

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -18,156 +18,176 @@ const CancelPurchaseDomainOptions = ( {
 	const translate = useTranslate();
 	const [ confirmCancel, setConfirmCancel ] = useState( false );
 
+	const planCostText = purchase.totalRefundText;
+
+	const onCancelBundledDomainChange = useCallback(
+		( event ) => {
+			const newCancelBundledDomainValue = event.currentTarget.value === 'cancel';
+			onCancelConfirmationStateChange( {
+				cancelBundledDomain: newCancelBundledDomainValue,
+				confirmCancelBundledDomain: newCancelBundledDomainValue && confirmCancel,
+			} );
+		},
+		[ confirmCancel, onCancelConfirmationStateChange ]
+	);
+
+	const onConfirmCancelBundledDomainChange = useCallback(
+		( event ) => {
+			const checked = event.target.checked;
+			setConfirmCancel( checked );
+			onCancelConfirmationStateChange( {
+				cancelBundledDomain,
+				confirmCancelBundledDomain: checked,
+			} );
+		},
+		[ cancelBundledDomain, onCancelConfirmationStateChange ]
+	);
+
+	const NonRefundableDomainMappingMessage = useCallback(
+		() => (
+			<div>
+				<p>
+					{ translate(
+						'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
+							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+						{
+							args: {
+								mappedDomain: includedDomainPurchase.meta,
+							},
+						}
+					) }
+				</p>
+			</div>
+		),
+		[ includedDomainPurchase, translate ]
+	);
+
+	const CancelableDomainMappingMessage = useCallback(
+		() => (
+			<div>
+				<p>
+					{ translate(
+						'This plan includes mapping for the domain %(mappedDomain)s. ' +
+							"Cancelling will remove all the plan's features from your site, including the domain.",
+						{
+							args: {
+								mappedDomain: includedDomainPurchase.meta,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate(
+						'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
+						{
+							args: {
+								mappedDomain: includedDomainPurchase.meta,
+								wordpressSiteUrl: purchase.domain,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate(
+						'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
+							'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
+						{
+							args: {
+								mappedDomain: includedDomainPurchase.meta,
+							},
+						}
+					) }
+				</p>
+			</div>
+		),
+		[ includedDomainPurchase, purchase, translate ]
+	);
+
+	const NonRefundableDomainPurchaseMessage = useCallback(
+		() => (
+			<div>
+				<p>
+					{ translate(
+						'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+						{
+							args: {
+								domain: includedDomainPurchase.meta,
+							},
+						}
+					) }
+				</p>
+			</div>
+		),
+		[ includedDomainPurchase, translate ]
+	);
+
+	const DomainTransferMessage = useCallback(
+		() => (
+			<div>
+				<p>
+					{ translate(
+						'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
+							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+						{
+							args: {
+								domain: includedDomainTransfer.meta,
+								domainCost: includedDomainTransfer.priceText,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate(
+						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+							'minus %(domainCost)s for the domain.',
+						{
+							args: {
+								domainCost: includedDomainTransfer.priceText,
+								planCost: planCostText,
+								refundAmount: purchase.refundText,
+							},
+						}
+					) }
+				</p>
+			</div>
+		),
+		[ includedDomainTransfer, planCostText, purchase, translate ]
+	);
+
+	const RefundablePurchaseWithNonRefundableDomainMessage = useCallback(
+		() => (
+			<div>
+				<p>
+					{ translate(
+						'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+						{
+							args: {
+								domain: includedDomainPurchase.meta,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate(
+						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
+							'minus %(domainCost)s for the domain.',
+						{
+							args: {
+								domainCost: includedDomainPurchase.costToUnbundleText,
+								planCost: planCostText,
+								refundAmount: purchase.refundText,
+							},
+						}
+					) }
+				</p>
+			</div>
+		),
+		[ includedDomainPurchase, planCostText, purchase, translate ]
+	);
 
 	if ( ( ! includedDomainPurchase && ! includedDomainTransfer ) || ! isSubscription( purchase ) ) {
 		return null;
 	}
-
-	const onCancelBundledDomainChange = ( event ) => {
-		const newCancelBundledDomainValue = event.currentTarget.value === 'cancel';
-		onCancelConfirmationStateChange( {
-			cancelBundledDomain: newCancelBundledDomainValue,
-			confirmCancelBundledDomain: newCancelBundledDomainValue && confirmCancel,
-		} );
-	};
-
-	const onConfirmCancelBundledDomainChange = ( event ) => {
-		const checked = event.target.checked;
-		setConfirmCancel( checked );
-		onCancelConfirmationStateChange( {
-			cancelBundledDomain,
-			confirmCancelBundledDomain: checked,
-		} );
-	};
-
-	const planCostText = purchase.totalRefundText;
-
-	const NonRefundableDomainMappingMessage = () => (
-		<div>
-			<p>
-				{ translate(
-					'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-					{
-						args: {
-							mappedDomain: includedDomainPurchase.meta,
-						},
-					}
-				) }
-			</p>
-		</div>
-	);
-
-	const CancelableDomainMappingMessage = () => (
-		<div>
-			<p>
-				{ translate(
-					'This plan includes mapping for the domain %(mappedDomain)s. ' +
-						"Cancelling will remove all the plan's features from your site, including the domain.",
-					{
-						args: {
-							mappedDomain: includedDomainPurchase.meta,
-						},
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
-					{
-						args: {
-							mappedDomain: includedDomainPurchase.meta,
-							wordpressSiteUrl: purchase.domain,
-						},
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
-						'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
-					{
-						args: {
-							mappedDomain: includedDomainPurchase.meta,
-						},
-					}
-				) }
-			</p>
-		</div>
-	);
-
-	const NonRefundableDomainPurchaseMessage = () => (
-		<div>
-			<p>
-				{ translate(
-					'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-					{
-						args: {
-							domain: includedDomainPurchase.meta,
-						},
-					}
-				) }
-			</p>
-		</div>
-	);
-
-	const DomainTransferMessage = () => (
-		<div>
-			<p>
-				{ translate(
-					'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-					{
-						args: {
-							domain: includedDomainTransfer.meta,
-							domainCost: includedDomainTransfer.priceText,
-						},
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-						'minus %(domainCost)s for the domain.',
-					{
-						args: {
-							domainCost: includedDomainTransfer.priceText,
-							planCost: planCostText,
-							refundAmount: purchase.refundText,
-						},
-					}
-				) }
-			</p>
-		</div>
-	);
-
-	const RefundablePurchaseWithNonRefundableDomainMessage = () => (
-		<div>
-			<p>
-				{ translate(
-					'This plan includes the custom domain, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
-					{
-						args: {
-							domain: includedDomainPurchase.meta,
-						},
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-						'minus %(domainCost)s for the domain.',
-					{
-						args: {
-							domainCost: includedDomainPurchase.costToUnbundleText,
-							planCost: planCostText,
-							refundAmount: purchase.refundText,
-						},
-					}
-				) }
-			</p>
-		</div>
-	);
 
 	if ( includedDomainTransfer ) {
 		return <DomainTransferMessage />;

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -3,7 +3,7 @@ import { CompactCard, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { UPDATE_NAMESERVERS } from '@automattic/urls';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { getName, isRefundable, isSubscription } from 'calypso/lib/purchases';
@@ -12,16 +12,12 @@ const CancelPurchaseDomainOptions = ( {
 	includedDomainPurchase,
 	includedDomainTransfer,
 	cancelBundledDomain,
-	confirmCancelBundledDomain = false,
 	purchase,
 	onCancelConfirmationStateChange,
 } ) => {
 	const translate = useTranslate();
-	const [ confirmCancel, setConfirmCancel ] = useState( confirmCancelBundledDomain );
+	const [ confirmCancel, setConfirmCancel ] = useState( false );
 
-	useEffect( () => {
-		setConfirmCancel( confirmCancelBundledDomain );
-	}, [ confirmCancelBundledDomain ] );
 
 	if ( ( ! includedDomainPurchase && ! includedDomainTransfer ) || ! isSubscription( purchase ) ) {
 		return null;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/CHE-17/the-cancelpurchasedomainoptions-component-defines-all-its

## Proposed Changes

* Remove unecessary useEffect and unused parameter
* Use callbacks for inline components as the components are not reused anywhere else. It removes complexity of adding new components. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Clean up and small optimization impact

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test everything is displayed as expecting when cancelling a domain purchase or transfer
<img width="300" alt="Screenshot 2025-05-07 at 19 15 18" src="https://github.com/user-attachments/assets/75651ec5-c967-46e1-a1e3-8748fd16df26" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
