### PR TITLE
A4A: Referral checkout v2 - always replace cart items

### DIFF
--- a/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/checkout-v2/index.tsx
@@ -33,7 +33,7 @@ function ClientCheckoutContent() {
 	const { referredProducts } = useProductsById( referral?.products ?? [] );
 
 	// Access the shopping cart API
-	const { addProductsToCart, responseCart } = useShoppingCart( 'no-site' );
+	const { replaceProductsInCart, responseCart } = useShoppingCart( 'no-site' );
 
 	const userEmail = useSelector( ( state ) => getCurrentUser( state )?.email );
 
@@ -69,9 +69,9 @@ function ClientCheckoutContent() {
 
 		debug( '[A4A Checkout] Products to add', productsToAdd );
 
-		// Add products to cart
+		// Replace products in cart
 		if ( productsToAdd.length > 0 ) {
-			addProductsToCart( productsToAdd )
+			replaceProductsInCart( productsToAdd )
 				.then( () => {
 					debug( '[A4A Checkout] Products added to cart successfully' );
 					debug( '[A4A Checkout] Cart', responseCart );
@@ -90,7 +90,7 @@ function ClientCheckoutContent() {
 		error,
 		referredProducts,
 		referral,
-		addProductsToCart,
+		replaceProductsInCart,
 		responseCart,
 		queryArgs.referralId,
 		queryArgs.agencyId,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Linear issue: https://linear.app/a8c/issue/A4A-854/replace-items-in-cart-instead-of-adding

## Proposed Changes

* When visiting a referral link always replace items in the cart instead of adding them on top of any existing items.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create 2 separate referrals, one for wpcom hosting and one for a woo product.
* As the client visit the first referral link (DO NOT CHECKOUT)
* In the URL, change the host to that of the live link (or localhost if you're using it) and change `client/checkout` to `client/checkout/v2`.
* The checkout page should load with the right product in the cart.
* Repeat the process for the second referral in a separate browser tab, you should again see the right product.
* Refresh the tab of the first referral and you should still see the right product for that referral.
* Do not proceed to complete checkout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
