### PR TITLE
Failed attempt: sass-embedded

### DIFF
--- a/.storybook/index.scss
+++ b/.storybook/index.scss
@@ -1,4 +1,4 @@
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 
 // Calypso style needs these variables
 @import "@automattic/typography/styles/variables";

--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -1,4 +1,4 @@
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/onboarding/styles/mixins";
 

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -1,4 +1,4 @@
-@import '@automattic/calypso-color-schemes';
+// @import '@automattic/calypso-color-schemes';
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.

--- a/apps/happy-blocks/block-library/universal-header/style.scss
+++ b/apps/happy-blocks/block-library/universal-header/style.scss
@@ -1,4 +1,4 @@
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.

--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,5 +1,5 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 
 h1,
 h2,

--- a/apps/odyssey-stats/src/styles/widget-base.scss
+++ b/apps/odyssey-stats/src/styles/widget-base.scss
@@ -3,7 +3,7 @@
 // External Dependencies
 @import "calypso/assets/stylesheets/vendor";
 // Color Schemes
-@import "@automattic/calypso-color-schemes/src/calypso-color-schemes-root";
+@// import "@automattic/calypso-color-schemes/src/calypso-color-schemes-root";
 @import "./variables";
 @import "calypso/my-sites/stats/modernized-tooltip-styles";
 

--- a/client/a8c-for-agencies/sections/purchases/crm-downloads/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/crm-downloads/style.scss
@@ -1,5 +1,5 @@
 // Import the base component styles
-@import '~calypso/components/crm-downloads/style';
+@import 'calypso/components/crm-downloads/style';
 
 // Error state styling
 .crm-downloads-error {

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -2,7 +2,7 @@
 @import "vendor";
 
 // Color Schemes
-@import "@automattic/calypso-color-schemes/src/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes/src/calypso-color-schemes";
 
 // Shared
 @import "shared/reset"; // css reset before the rest of the styles are defined

--- a/client/blocks/jetpack-benefits/style.scss
+++ b/client/blocks/jetpack-benefits/style.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 
 
 .jetpack-benefits__section-header {

--- a/client/blocks/jitm/templates/modal-style.scss
+++ b/client/blocks/jitm/templates/modal-style.scss
@@ -1,6 +1,6 @@
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 
 $wpcom-modal-breakpoint: 600px;
 

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -1,7 +1,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
-@import "jetpack-connect/colors";
+@import "client/sites/deployments/components/repositories/style.scss";
+@import "../../../jetpack-connect/colors";
 
 .is-section-jetpack-connect .licensing-prompt-dialog {
 	@include jetpack-connect-colors();

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -1,7 +1,7 @@
 /*
     Global styles for Stepper framework
 */
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/onboarding/styles/mixins";
 @import "@automattic/onboarding/styles/variables";

--- a/client/landing/subscriptions/styles/styles.scss
+++ b/client/landing/subscriptions/styles/styles.scss
@@ -2,7 +2,7 @@
     Global styles for the subscription manager app
 */
 @import "@wordpress/components/build-style/style.css";
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 @import "@automattic/typography/styles/fonts";
 @import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 @import "@automattic/typography/styles/variables";
 
 @media (max-height: 450px) {

--- a/client/my-sites/email/email-providers-comparison/price-badge/style.scss
+++ b/client/my-sites/email/email-providers-comparison/price-badge/style.scss
@@ -1,4 +1,4 @@
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 @import "@automattic/typography/styles/variables";
 
 .price-badge {

--- a/client/my-sites/purchases/crm-downloads/style.scss
+++ b/client/my-sites/purchases/crm-downloads/style.scss
@@ -1,5 +1,5 @@
 // Import the base component styles
-@import '~calypso/components/crm-downloads/style';
+@import 'calypso/components/crm-downloads/style';
 
 // Error state styling
 .crm-downloads-error {

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -1,5 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
-@import "jetpack-connect/colors";
+@import "../../jetpack-connect/colors";
 
 .is-group-woocommerce-installation.is-section-woocommerce-installation .layout__content {
 	padding-bottom: 0; //removes whitespace in the end

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -116,7 +116,7 @@ body.is-section-signup .layout:not(.dops) {
 }
 
 .layout.is-wccom-oauth-flow {
-	@import "jetpack-connect/colors";
+	@import "../jetpack-connect/colors";
 	@include woocommerce-colors();
 	background-color: var(--color-woocommerce-onboarding-background);
 	height: 100%;

--- a/client/sites/deployments/components/repositories/style.scss
+++ b/client/sites/deployments/components/repositories/style.scss
@@ -1,5 +1,5 @@
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .github-deployments-repositories {
 	display: flex;

--- a/client/sites/deployments/deployment-creation/style.scss
+++ b/client/sites/deployments/deployment-creation/style.scss
@@ -1,5 +1,5 @@
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .repository-selection-dialog {
 	height: 515px;

--- a/client/sites/settings/server/style.scss
+++ b/client/sites/settings/server/style.scss
@@ -1,5 +1,5 @@
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .settings-server {
 	select {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -247,16 +247,10 @@ const webpackConfig = {
 				// Since `prelude` string will be appended to each Sass file
 				// We need to ensure that the import path (inside a sass file) is a posix path, regardless of the OS/platform
 				// Final result should be something like `@use 'client/assets/stylesheets/shared/_utils.scss' as *;`
-				prelude: `@use '${
-					path
-						// Path, relative to Node CWD
-						.relative(
-							process.cwd(),
-							path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' )
-						)
-						.split( path.sep ) // Break any path (posix/win32) by path separator
-						.join( path.posix.sep ) // Convert the path explicitly to posix to ensure imports work fine
-				}' as *;`,
+				prelude: `@use '${ path.resolve(
+					__dirname,
+					'assets/stylesheets/shared/_utils.scss'
+				) }' as *;`,
 			} ),
 			{
 				include: path.join( __dirname, 'sections.js' ),

--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
 		"react-intersection-observer": "^9.4.3",
 		"react-modal": "^3.16.3",
 		"redux": "^5.0.1",
+		"sass-embedded": "^1.87.0",
 		"swiper": "^10.1.0",
 		"wpcom": "workspace:^"
 	},

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -1,3 +1,4 @@
+const path = require( 'path' );
 const WebpackRTLPlugin = require( '@automattic/webpack-rtl-plugin' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const MiniCSSWithRTLPlugin = require( './mini-css-with-rtl' );
@@ -36,10 +37,17 @@ module.exports.loader = ( { includePaths, prelude, postCssOptions } ) => ( {
 		{
 			loader: require.resolve( 'sass-loader' ),
 			options: {
+				implementation: require( 'sass-embedded' ),
+				api: 'modern',
 				additionalData: prelude,
 				sassOptions: {
-					includePaths,
+					loadPaths: [
+						'node_modules',
+						'/Users/omaralshaker/Work.nosync/Automattic/wp-calypso',
+						'/Users/omaralshaker/Work.nosync/Automattic/wp-calypso/packages',
+					],
 					quietDeps: true,
+					verbose: true,
 				},
 				// The warnRuleAsWarning can be removed once sass-loader is updated to v14. It defaults to true in that version.
 				// @see https://github.com/webpack-contrib/sass-loader/tree/v14.0.0?tab=readme-ov-file#warnruleaswarning

--- a/packages/command-palette/src/style.scss
+++ b/packages/command-palette/src/style.scss
@@ -1,6 +1,6 @@
-@import "~@wordpress/base-styles/variables";
-@import "~@wordpress/base-styles/mixins";
-@import "~@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
 
 .commands-command-menu__overlay {
 	z-index: z-index("root", ".commands-commands-menu__overlay");
@@ -23,4 +23,4 @@ div.commands-command-menu {
 	fill: #1e1e1e;
 }
 
-@import '~@wordpress/commands/src/style';
+@import '@wordpress/commands/src/style';

--- a/packages/components/.storybook/style.scss
+++ b/packages/components/.storybook/style.scss
@@ -1,2 +1,2 @@
 @import '@wordpress/components/build-style/style';
-@import '@automattic/calypso-color-schemes';
+//@import '@automattic/calypso-color-schemes';

--- a/packages/onboarding/.storybook/index.scss
+++ b/packages/onboarding/.storybook/index.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable scss/load-no-partial-leading-underscore */
 @import '@wordpress/base-styles/variables';
-@import '@automattic/calypso-color-schemes';
+//@import '@automattic/calypso-color-schemes';
 
 // Calypso style needs these variables
 @import '@automattic/typography/styles/variables';

--- a/packages/plans-grid-next/.storybook/styles.scss
+++ b/packages/plans-grid-next/.storybook/styles.scss
@@ -1,5 +1,5 @@
 @import "@wordpress/base-styles/variables";
-@import "@automattic/calypso-color-schemes";
+// import "@automattic/calypso-color-schemes";
 
 // Calypso style needs these variables
 @import "@automattic/typography/styles/variables";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4140,6 +4140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bufbuild/protobuf@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@bufbuild/protobuf@npm:2.3.0"
+  checksum: ddd628ffa86fa9a64f7a434a13ebb73200a43ecbecc36001d8d73534c281cecaf2b4ec890a12810ac54302ae10a9fee794b438db91af54e268f8d6cdcdb82a49
+  languageName: node
+  linkType: hard
+
 "@bundled-es-modules/cookie@npm:^2.0.0":
   version: 2.0.0
   resolution: "@bundled-es-modules/cookie@npm:2.0.0"
@@ -14119,6 +14126,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-builder@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "buffer-builder@npm:0.2.0"
+  checksum: e50c3a379f4acaea75ade1ee3e8c07ed6d7c5dfc3f98adbcf0159bfe1a4ce8ca1fe3689e861fcdb3fcef0012ebd4345a6112a5b8a1185295452bb66d7b6dc8a1
+  languageName: node
+  linkType: hard
+
 "buffer-crc32@npm:^0.2.1, buffer-crc32@npm:^0.2.13, buffer-crc32@npm:~0.2.3":
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
@@ -15445,6 +15459,13 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
+"colorjs.io@npm:^0.5.0":
+  version: 0.5.2
+  resolution: "colorjs.io@npm:0.5.2"
+  checksum: 2e6ea43629e325e721b92429239de3a6f42fb6d88ba6e4c2aeff0288c196d876f2f7ee82aea95bd40072d5cdc8cb87f042f4d94c134dcabf0e34a717e4caacb9
   languageName: node
   linkType: hard
 
@@ -22050,6 +22071,13 @@ __metadata:
   version: 4.3.7
   resolution: "immutable@npm:4.3.7"
   checksum: 9b099197081b22f6433003e34929da8ecddbbdc1474cdc8aa3b7669dee4adda349c06143de22def36016d1b6de5322b043eccd7a11db1dad2ca85dad4fff5435
+  languageName: node
+  linkType: hard
+
+"immutable@npm:^5.0.2":
+  version: 5.1.2
+  resolution: "immutable@npm:5.1.2"
+  checksum: da5af92d2c70323c1f9a0e418832c9eef441feadaf6a295a4e07764bd2400c85186872e016071d9253549d58d364160d55dca8dcdf59fd4a6a06c6756fe61657
   languageName: node
   linkType: hard
 
@@ -32742,6 +32770,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.4.0":
+  version: 7.8.2
+  resolution: "rxjs@npm:7.8.2"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 1fcd33d2066ada98ba8f21fcbbcaee9f0b271de1d38dc7f4e256bfbc6ffcdde68c8bfb69093de7eeb46f24b1fb820620bf0223706cff26b4ab99a7ff7b2e2c45
+  languageName: node
+  linkType: hard
+
 "rxjs@npm:^7.5.5":
   version: 7.5.7
   resolution: "rxjs@npm:7.5.7"
@@ -32828,6 +32865,225 @@ __metadata:
   dependencies:
     truncate-utf8-bytes: "npm:^1.0.0"
   checksum: 16ff47556a6e54e228c28db096bedd303da67b030d4bea4925fd71324932d6b02c7b0446f00ad33987b25b6414f24ae968e01a1a1679ce599542e82c4b07eb1f
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-arm64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-android-arm64@npm:1.87.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-arm@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-android-arm@npm:1.87.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-ia32@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-android-ia32@npm:1.87.0"
+  conditions: os=android & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-riscv64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-android-riscv64@npm:1.87.0"
+  conditions: os=android & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-x64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-android-x64@npm:1.87.0"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-darwin-arm64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-darwin-arm64@npm:1.87.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-darwin-x64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-darwin-x64@npm:1.87.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-arm64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-arm64@npm:1.87.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-arm@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-arm@npm:1.87.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-ia32@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-ia32@npm:1.87.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-arm64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-musl-arm64@npm:1.87.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-arm@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-musl-arm@npm:1.87.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-ia32@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-musl-ia32@npm:1.87.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-riscv64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-musl-riscv64@npm:1.87.0"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-x64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-musl-x64@npm:1.87.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-riscv64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-riscv64@npm:1.87.0"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-x64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-linux-x64@npm:1.87.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-win32-arm64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-win32-arm64@npm:1.87.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-win32-ia32@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-win32-ia32@npm:1.87.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-win32-x64@npm:1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded-win32-x64@npm:1.87.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded@npm:^1.87.0":
+  version: 1.87.0
+  resolution: "sass-embedded@npm:1.87.0"
+  dependencies:
+    "@bufbuild/protobuf": "npm:^2.0.0"
+    buffer-builder: "npm:^0.2.0"
+    colorjs.io: "npm:^0.5.0"
+    immutable: "npm:^5.0.2"
+    rxjs: "npm:^7.4.0"
+    sass-embedded-android-arm: "npm:1.87.0"
+    sass-embedded-android-arm64: "npm:1.87.0"
+    sass-embedded-android-ia32: "npm:1.87.0"
+    sass-embedded-android-riscv64: "npm:1.87.0"
+    sass-embedded-android-x64: "npm:1.87.0"
+    sass-embedded-darwin-arm64: "npm:1.87.0"
+    sass-embedded-darwin-x64: "npm:1.87.0"
+    sass-embedded-linux-arm: "npm:1.87.0"
+    sass-embedded-linux-arm64: "npm:1.87.0"
+    sass-embedded-linux-ia32: "npm:1.87.0"
+    sass-embedded-linux-musl-arm: "npm:1.87.0"
+    sass-embedded-linux-musl-arm64: "npm:1.87.0"
+    sass-embedded-linux-musl-ia32: "npm:1.87.0"
+    sass-embedded-linux-musl-riscv64: "npm:1.87.0"
+    sass-embedded-linux-musl-x64: "npm:1.87.0"
+    sass-embedded-linux-riscv64: "npm:1.87.0"
+    sass-embedded-linux-x64: "npm:1.87.0"
+    sass-embedded-win32-arm64: "npm:1.87.0"
+    sass-embedded-win32-ia32: "npm:1.87.0"
+    sass-embedded-win32-x64: "npm:1.87.0"
+    supports-color: "npm:^8.1.1"
+    sync-child-process: "npm:^1.0.2"
+    varint: "npm:^6.0.0"
+  dependenciesMeta:
+    sass-embedded-android-arm:
+      optional: true
+    sass-embedded-android-arm64:
+      optional: true
+    sass-embedded-android-ia32:
+      optional: true
+    sass-embedded-android-riscv64:
+      optional: true
+    sass-embedded-android-x64:
+      optional: true
+    sass-embedded-darwin-arm64:
+      optional: true
+    sass-embedded-darwin-x64:
+      optional: true
+    sass-embedded-linux-arm:
+      optional: true
+    sass-embedded-linux-arm64:
+      optional: true
+    sass-embedded-linux-ia32:
+      optional: true
+    sass-embedded-linux-musl-arm:
+      optional: true
+    sass-embedded-linux-musl-arm64:
+      optional: true
+    sass-embedded-linux-musl-ia32:
+      optional: true
+    sass-embedded-linux-musl-riscv64:
+      optional: true
+    sass-embedded-linux-musl-x64:
+      optional: true
+    sass-embedded-linux-riscv64:
+      optional: true
+    sass-embedded-linux-x64:
+      optional: true
+    sass-embedded-win32-arm64:
+      optional: true
+    sass-embedded-win32-ia32:
+      optional: true
+    sass-embedded-win32-x64:
+      optional: true
+  bin:
+    sass: dist/bin/sass.js
+  checksum: 44b6dd76bc14a1d75cfae99cc577ccb3b034325886fe77409a739ea3e789c6c04f712a7b579ab9adbacfd1d8f091035799675419d8ec357642295a7f29f4225f
   languageName: node
   linkType: hard
 
@@ -34533,7 +34789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0":
+"supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -34641,6 +34897,22 @@ __metadata:
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: dfbe201ae09ac6053d163578778c53aa860a784147ecf95705de0cd23f42c851e1be7889241495e95c37cabb058edb1052f141387bef68f705afc8f9dd358509
+  languageName: node
+  linkType: hard
+
+"sync-child-process@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "sync-child-process@npm:1.0.2"
+  dependencies:
+    sync-message-port: "npm:^1.0.0"
+  checksum: f73c87251346fba28da8ac5bc8ed4c9474504a5250ab4bd44582beae8e25c230e0a5b7b16076488fee1aed39a1865de5ed4cec19c6fa4efdbb1081c514615170
+  languageName: node
+  linkType: hard
+
+"sync-message-port@npm:^1.0.0":
+  version: 1.1.3
+  resolution: "sync-message-port@npm:1.1.3"
+  checksum: d259b08ab6da284135ba45bc13724268688b469371259f5978b2905e2c79342032b9240093b2483e83cfeccfd3a5e8300978e67090385f9b6b38941fcce1aec4
   languageName: node
   linkType: hard
 
@@ -36403,6 +36675,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"varint@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "varint@npm:6.0.0"
+  checksum: 737fc37088a62ed3bd21466e318d21ca7ac4991d0f25546f518f017703be4ed0f9df1c5559f1dd533dddba4435a1b758fd9230e4772c1a930ef72b42f5c750fd
+  languageName: node
+  linkType: hard
+
 "vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
@@ -37294,6 +37573,7 @@ __metadata:
     replace: "npm:^1.1.5"
     resize-observer-polyfill: "npm:^1.5.1"
     sass: "npm:1.54.0"
+    sass-embedded: "npm:^1.87.0"
     sass-loader: "npm:^13.3.3"
     source-map: "npm:^0.7.4"
     stackframe: "npm:^1.1.1"


### PR DESCRIPTION
## Proposed Changes

This was a failed attempt at switching from `sass` to `sass-embedded`. The latter is supposed to be at least 2x faster, but for some reason it's running slower for me.

**Note** that his PR has a lot of noise. These are temporary fixes to fix resolution issues and just get to the compile time.

**Only pay attention to packages/calypso-build/webpack/sass.js**

I decided to push a PR for posterity.

## Why are these changes being made?
I discovered that compiling our CSS takes most of the time of `yarn start` and I was trying to speed things up.

## Testing Instructions

1. Check out this branch.
2. Run `yarn`.
3. `time yarn build-client`
4. Compare against trunk.