### PR TITLE
Theme/Plugin Showcase: Use correct button colour for Get Started

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -205,7 +205,7 @@ const LayoutLoggedOut = ( {
 		! isReaderSearchPage &&
 		! isReaderDiscoverPage
 	) {
-		const nonMonochromeSections = [ 'plugins' ];
+		const nonMonochromeSections = [ 'plugins', 'themes', 'theme' ];
 
 		const className = clsx( {
 			'is-style-monochrome':

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -30,6 +30,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@wordpress/url": "^4.22.0",

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -199,7 +199,7 @@ $x-nav-height: $x-nav-padding-top + $x-nav-item-height + $x-nav-item-padding-x-w
 
 	.cta-btn-nav {
 		border-radius: 4px;
-		background: $studio-blue-30 !important;
+		background: $studio-blue-50 !important;
 		margin: 11px 18px 0 9px;
 		padding: 8px 9px !important;
 		text-decoration: none !important;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1,10 +1,11 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/color-studio/dist/color-variables-rgb";
 @import "@automattic/typography/styles/variables";
 
 $lp-font-stack-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $lp-font-stack-default: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif, $lp-font-stack-emoji;
 $x-content-font-stack: $lp-font-stack-default;
 $studio-blue-15: #e5f4ff;
-$studio-blue-30: #0675c4;
 
 .x-hidden {
 	border: 0;
@@ -147,22 +148,12 @@ $x-nav-breakpoint-medium: $lp-breakpoint-M;
 $x-nav-breakpoint-medium-wide: 864px;
 $x-nav-breakpoint-wide: $lp-breakpoint-L;
 
-$studio-pink-50-rgb: 201, 53, 110;
-$studio-white: #fff;
-$studio-gray-100: #101517;
-$studio-gray-5: #dcdcde;
-$studio-blue-60: #055d9c;
-$studio-blue-0: #e9f0f5;
-$studio-blue-5: #bbe0fa;
-$studio-blue-70: #044b7a;
-$studio-blue-90: #01283d;
 $x-color-link-active: var( --studio-wordpress-blue-80 );
 $x-color-link-background-active: var( --studio-wordpress-blue-10 );
 $x-color-link-hover: var( --studio-wordpress-blue-60 );
 $x-color-link-background-hover: var( --studio-wordpress-blue-5 );
 $x-color-link: var( --studio-wordpress-blue-50 );
 $x-color-content-separator: rgba( $studio-gray-5, 0.85 );
-$studio-white-rgb: 255, 255, 255;
 $x-content-min-z-index: 801;
 $lp-font-weight-bold: 600;
 $lp-font-weight-semi-bold: 600;
@@ -541,8 +532,6 @@ $x-dropdown-item-line-height: 19px;
 
 $lp-transition-properties: 0.15s ease-out;
 $lp-chevron-transform-right: translate3d(0.15em, 0, 0);
-$studio-gray-50: #646970;
-$studio-gray-30: #8c8f94;
 $x-color-content-icon: $studio-gray-30;
 $x-color-content-heading: $studio-gray-50;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,6 +2364,7 @@ __metadata:
   resolution: "@automattic/wpcom-template-parts@workspace:packages/wpcom-template-parts"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@wordpress/url": "npm:^4.22.0"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #103197

## Proposed Changes

* The `UniversalNavbarHeader` component now gets its colour values directly from the `color-studio` package
  * This feels like a follow on from #98732
* The "Get Started" button
* Fix a bug in local development so the header style matches how things look in production
  * The presence of the `site-profiler/metrics` feature flag changed the `/themes` and `/theme` landing page style. This was presumably an oversight while working on a different header style for the site profiler.
  * This change doesn't impact production.

The `UniversalNavbarHeader` package is still using a special `$studio-color-15` variable that doesn't actually exist in `color-studio`. This is the custom background colour used above the fold on these landing pages. So I think it should be thought of as a custom colour, not something that needs to align with the studio colours.

**Before**

![CleanShot 2025-05-08 at 11 16 23@2x](https://github.com/user-attachments/assets/462334ea-6896-4deb-aac7-94c221b90c7b)

**After**

![CleanShot 2025-05-08 at 11 17 02@2x](https://github.com/user-attachments/assets/84048be5-719b-47d5-b484-eb864b15d2c2)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can run `yarn why @automattic/color-studio` to confirm that we're all using the same version of the package.

* Open an incognito tab
* Visit `/plugins`
  * Confirm the "Get Started" button in the top-right now uses the same colour as the filter control and WordPress.com logo
  * Navigate into a specific plugin and confirm the "Get Started" button is still the correct colour
* Visit `/themes`
  * Confirm the "Get Started" button in the top-right now uses the same colour as the filter control and WordPress.com logo
  * Navigate into a specific theme and confirm the "Get Started" button is still the correct colour

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
