### PR TITLE
Stats: New nav tabs for Locations summary page

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
@@ -1,0 +1,77 @@
+import page from '@automattic/calypso-router';
+import { TabPanel } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import {
+	STATS_FEATURE_LOCATION_REGION_VIEWS,
+	STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
+	STATS_FEATURE_LOCATION_CITY_VIEWS,
+} from '../../../constants';
+
+const OPTION_KEYS = {
+	COUNTRIES: 'countries',
+	REGIONS: 'regions',
+	CITIES: 'cities',
+};
+
+function LocationsNavTabs( { period, query, givenSiteId } ) {
+	const translate = useTranslate();
+	const tabPanelTabs = useMemo( () => {
+		const optionLabels = {
+			[ OPTION_KEYS.COUNTRIES ]: {
+				selectLabel: translate( 'Countries' ),
+				headerLabel: translate( 'Top countries' ),
+				analyticsId: 'countries',
+				feature: STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
+				countryFilterLabel: translate( 'All countries' ),
+			},
+			[ OPTION_KEYS.REGIONS ]: {
+				selectLabel: translate( 'Regions' ),
+				headerLabel: translate( 'Top regions' ),
+				analyticsId: 'regions',
+				feature: STATS_FEATURE_LOCATION_REGION_VIEWS,
+				countryFilterLabel: translate( 'All regions' ),
+			},
+			[ OPTION_KEYS.CITIES ]: {
+				selectLabel: translate( 'Cities' ),
+				headerLabel: translate( 'Top cities' ),
+				analyticsId: 'cities',
+				feature: STATS_FEATURE_LOCATION_CITY_VIEWS,
+				countryFilterLabel: translate( 'All cities' ),
+			},
+		};
+		return Object.entries( optionLabels ).map( ( [ key, item ] ) => {
+			const updateQuery = { ...query, geoMode: key };
+
+			return {
+				name: key,
+				title: item.selectLabel,
+				className: `stats-navigation__${ key }`,
+				path: `/stats/${ period.period || 'day' }/locations/${ givenSiteId }?${ new URLSearchParams(
+					updateQuery
+				).toString() }`,
+			};
+		} );
+	}, [] );
+
+	const selectedTab = query.geoMode || OPTION_KEYS.COUNTRIES;
+
+	return (
+		<TabPanel
+			className="stats-navigation__tabs"
+			tabs={ tabPanelTabs }
+			initialTabName={ selectedTab }
+			onSelect={ ( tabName ) => {
+				// TODO add analytics tracking here.
+				const tab = tabPanelTabs.find( ( tab ) => tab.name === tabName );
+				if ( tab?.path ) {
+					page( tab.path );
+				}
+			} }
+		>
+			{ () => null /* Placeholder div since content is rendered elsewhere */ }
+		</TabPanel>
+	);
+}
+
+export default LocationsNavTabs;

--- a/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
@@ -2,19 +2,16 @@ import page from '@automattic/calypso-router';
 import { TabPanel } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { getPathWithUpdatedQueryString } from 'calypso/my-sites/stats/utils';
 import {
 	STATS_FEATURE_LOCATION_REGION_VIEWS,
 	STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
 	STATS_FEATURE_LOCATION_CITY_VIEWS,
 } from '../../../constants';
+import { StatsQueryType } from '../types';
+import { UrlGeoMode, OPTION_KEYS } from './types';
 
-const OPTION_KEYS = {
-	COUNTRIES: 'countries',
-	REGIONS: 'regions',
-	CITIES: 'cities',
-};
-
-function LocationsNavTabs( { period, query, givenSiteId } ) {
+function LocationsNavTabs( { query }: { query: StatsQueryType & { geoMode?: UrlGeoMode } } ) {
 	const translate = useTranslate();
 	const tabPanelTabs = useMemo( () => {
 		const optionLabels = {
@@ -41,15 +38,13 @@ function LocationsNavTabs( { period, query, givenSiteId } ) {
 			},
 		};
 		return Object.entries( optionLabels ).map( ( [ key, item ] ) => {
-			const updateQuery = { ...query, geoMode: key };
-
 			return {
 				name: key,
 				title: item.selectLabel,
 				className: `stats-navigation__${ key }`,
-				path: `/stats/${ period.period || 'day' }/locations/${ givenSiteId }?${ new URLSearchParams(
-					updateQuery
-				).toString() }`,
+				path: getPathWithUpdatedQueryString( {
+					geoMode: key,
+				} ),
 			};
 		} );
 	}, [] );

--- a/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
@@ -1,45 +1,17 @@
 import page from '@automattic/calypso-router';
 import { TabPanel } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import {
 	getPathWithUpdatedQueryString,
 	trackStatsAnalyticsEvent,
 } from 'calypso/my-sites/stats/utils';
-import {
-	STATS_FEATURE_LOCATION_REGION_VIEWS,
-	STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
-	STATS_FEATURE_LOCATION_CITY_VIEWS,
-} from '../../../constants';
 import { StatsQueryType } from '../types';
 import { UrlGeoMode, OPTION_KEYS } from './types';
+import useOptionLabels from './use-option-labels';
 
 function LocationsNavTabs( { query }: { query: StatsQueryType & { geoMode?: UrlGeoMode } } ) {
-	const translate = useTranslate();
+	const optionLabels = useOptionLabels();
 	const tabPanelTabs = useMemo( () => {
-		const optionLabels = {
-			[ OPTION_KEYS.COUNTRIES ]: {
-				selectLabel: translate( 'Countries' ),
-				headerLabel: translate( 'Top countries' ),
-				analyticsId: 'countries',
-				feature: STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
-				countryFilterLabel: translate( 'All countries' ),
-			},
-			[ OPTION_KEYS.REGIONS ]: {
-				selectLabel: translate( 'Regions' ),
-				headerLabel: translate( 'Top regions' ),
-				analyticsId: 'regions',
-				feature: STATS_FEATURE_LOCATION_REGION_VIEWS,
-				countryFilterLabel: translate( 'All regions' ),
-			},
-			[ OPTION_KEYS.CITIES ]: {
-				selectLabel: translate( 'Cities' ),
-				headerLabel: translate( 'Top cities' ),
-				analyticsId: 'cities',
-				feature: STATS_FEATURE_LOCATION_CITY_VIEWS,
-				countryFilterLabel: translate( 'All cities' ),
-			},
-		};
 		return Object.entries( optionLabels ).map( ( [ key, item ] ) => {
 			return {
 				name: key,
@@ -51,7 +23,7 @@ function LocationsNavTabs( { query }: { query: StatsQueryType & { geoMode?: UrlG
 				feature: item.feature,
 			};
 		} );
-	}, [ translate ] );
+	}, [ optionLabels ] );
 
 	const selectedTab = query.geoMode || OPTION_KEYS.COUNTRIES;
 

--- a/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/locations-nav-tabs.tsx
@@ -2,7 +2,10 @@ import page from '@automattic/calypso-router';
 import { TabPanel } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { getPathWithUpdatedQueryString } from 'calypso/my-sites/stats/utils';
+import {
+	getPathWithUpdatedQueryString,
+	trackStatsAnalyticsEvent,
+} from 'calypso/my-sites/stats/utils';
 import {
 	STATS_FEATURE_LOCATION_REGION_VIEWS,
 	STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
@@ -45,9 +48,10 @@ function LocationsNavTabs( { query }: { query: StatsQueryType & { geoMode?: UrlG
 				path: getPathWithUpdatedQueryString( {
 					geoMode: key,
 				} ),
+				feature: item.feature,
 			};
 		} );
-	}, [] );
+	}, [ translate ] );
 
 	const selectedTab = query.geoMode || OPTION_KEYS.COUNTRIES;
 
@@ -57,9 +61,11 @@ function LocationsNavTabs( { query }: { query: StatsQueryType & { geoMode?: UrlG
 			tabs={ tabPanelTabs }
 			initialTabName={ selectedTab }
 			onSelect={ ( tabName ) => {
-				// TODO add analytics tracking here.
 				const tab = tabPanelTabs.find( ( tab ) => tab.name === tabName );
 				if ( tab?.path ) {
+					trackStatsAnalyticsEvent( 'stats_locations_module_menu_clicked', {
+						stat_type: tab.feature,
+					} );
 					page( tab.path );
 				}
 			} }

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -20,7 +20,6 @@ import {
 	trackStatsAnalyticsEvent,
 } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -76,33 +75,15 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
-	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const statType = STAT_TYPE_COUNTRY_VIEWS;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const supportUrl = isOdysseyStats
 		? `${ JETPACK_SUPPORT_URL_TRAFFIC }#views-by-locations`
 		: LOCATIONS_SUPPORT_URL;
-
-	const selectedOption = query?.geoMode ?? initialGeoMode ?? OPTION_KEYS.COUNTRIES;
-	const setSelectedOption = useCallback(
-		( newOption: string ) => {
-			const geoModeParam = query.geoMode;
-			const isValidGeoModeParam =
-				geoModeParam && Object.values( OPTION_KEYS ).includes( geoModeParam );
-
-			if ( ! isValidGeoModeParam ) {
-				return;
-			}
-
-			// If URL has valid param and it's different from state, update state
-			if ( geoModeParam !== newOption ) {
-				const updatedQuery = { ...query, geoMode: newOption };
-				const queryString = new URLSearchParams( updatedQuery ).toString();
-				page( `/stats/${ period.period }/locations/${ siteSlug }?${ queryString }` );
-			}
-		},
-		[ query ]
-	);
+	const [ selectedOption, setSelectedOption ] = useState( () => {
+		const urlGeoMode = query.geoMode ?? initialGeoMode;
+		return urlGeoMode && urlGeoMode in GEO_MODES ? urlGeoMode : OPTION_KEYS.COUNTRIES;
+	} );
 
 	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
 

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -43,15 +43,15 @@ import { OPTION_KEYS, UrlGeoMode, GEO_MODES } from './types';
 
 import './style.scss';
 
-interface StatsModuleLocationsProps extends StatsDefaultModuleProps {
-	initialGeoMode?: string;
-	query: StatsQueryType & { geoMode?: UrlGeoMode };
-}
-
 export type SelectOptionType = {
 	label: string;
 	value: string;
 };
+
+interface StatsModuleLocationsProps extends StatsDefaultModuleProps {
+	initialGeoMode?: string;
+	query: StatsQueryType & { geoMode?: UrlGeoMode };
+}
 
 const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	initialGeoMode,

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -4,7 +4,7 @@ import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { mapMarker } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import useLocationViewsQuery, {
 	StatsLocationViewsData,
@@ -39,32 +39,19 @@ import StatsInfoArea from '../shared/stats-info-area';
 import { StatsDefaultModuleProps, StatsQueryType } from '../types';
 import CountryFilter from './country-filter';
 import sampleLocations from './sample-locations';
+import { OPTION_KEYS, UrlGeoMode, GEO_MODES } from './types';
 
 import './style.scss';
 
-const OPTION_KEYS = {
-	COUNTRIES: 'countries',
-	REGIONS: 'regions',
-	CITIES: 'cities',
-};
+interface StatsModuleLocationsProps extends StatsDefaultModuleProps {
+	initialGeoMode?: string;
+	query: StatsQueryType & { geoMode?: UrlGeoMode };
+}
 
-type GeoMode = 'country' | 'region' | 'city';
-
-export const GEO_MODES: Record< string, GeoMode > = {
-	[ OPTION_KEYS.COUNTRIES ]: 'country',
-	[ OPTION_KEYS.REGIONS ]: 'region',
-	[ OPTION_KEYS.CITIES ]: 'city',
-};
-
-type SelectOptionType = {
+export type SelectOptionType = {
 	label: string;
 	value: string;
 };
-
-interface StatsModuleLocationsProps extends StatsDefaultModuleProps {
-	initialGeoMode?: string;
-	query: StatsQueryType & { geoMode?: GeoMode };
-}
 
 const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	initialGeoMode,
@@ -80,23 +67,14 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	const supportUrl = isOdysseyStats
 		? `${ JETPACK_SUPPORT_URL_TRAFFIC }#views-by-locations`
 		: LOCATIONS_SUPPORT_URL;
+
+	// selectOption is in plural form i.e. 'countries'! Possible something to unify in the future.
 	const [ selectedOption, setSelectedOption ] = useState( () => {
 		const urlGeoMode = query.geoMode ?? initialGeoMode;
 		return urlGeoMode && urlGeoMode in GEO_MODES ? urlGeoMode : OPTION_KEYS.COUNTRIES;
 	} );
 
 	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
-
-	useEffect( () => {
-		if ( ! summary ) {
-			return;
-		}
-
-		// If URL has valid param and it's different from state, update state
-		if ( query.geoMode !== selectedOption ) {
-			page( getPathWithUpdatedQueryString( { geoMode: selectedOption } ) );
-		}
-	}, [ query.geoMode, selectedOption, summary ] );
 
 	const optionLabels = {
 		[ OPTION_KEYS.COUNTRIES ]: {
@@ -127,6 +105,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	const shouldGateDownloads = useShouldGateStats( STATS_FEATURE_DOWNLOAD_CSV );
 	const shouldGateTab = useShouldGateStats( optionLabels[ selectedOption ].feature );
 	const shouldGate = shouldGateStatsModule || shouldGateTab;
+	// Mapping plural to singular form where all other places are using.
 	const geoMode = GEO_MODES[ selectedOption ];
 	const title = translate( 'Locations' );
 
@@ -179,6 +158,11 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		} );
 
 		setSelectedOption( filter );
+
+		// If URL has valid param and it's different from state, update URL; only intended for summary page.
+		if ( summary && query.geoMode !== selectedOption ) {
+			page( getPathWithUpdatedQueryString( { geoMode: selectedOption } ) );
+		}
 	};
 
 	const onShowMoreClick = () => {

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -25,13 +25,7 @@ import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors'
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import EmptyModuleCard from '../../../components/empty-module-card/empty-module-card';
 import { LOCATIONS_SUPPORT_URL, JETPACK_SUPPORT_URL_TRAFFIC } from '../../../const';
-import {
-	STAT_TYPE_COUNTRY_VIEWS,
-	STATS_FEATURE_LOCATION_REGION_VIEWS,
-	STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
-	STATS_FEATURE_LOCATION_CITY_VIEWS,
-	STATS_FEATURE_DOWNLOAD_CSV,
-} from '../../../constants';
+import { STAT_TYPE_COUNTRY_VIEWS, STATS_FEATURE_DOWNLOAD_CSV } from '../../../constants';
 import Geochart from '../../../geochart';
 import StatsCardUpdateJetpackVersion from '../../../stats-card-upsell/stats-card-update-jetpack-version';
 import StatsCardSkeleton from '../shared/stats-card-skeleton';
@@ -40,6 +34,7 @@ import { StatsDefaultModuleProps, StatsQueryType } from '../types';
 import CountryFilter from './country-filter';
 import sampleLocations from './sample-locations';
 import { OPTION_KEYS, UrlGeoMode, GEO_MODES } from './types';
+import useOptionLabels from './use-option-labels';
 
 import './style.scss';
 
@@ -89,29 +84,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 
 	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
 
-	const optionLabels = {
-		[ OPTION_KEYS.COUNTRIES ]: {
-			selectLabel: translate( 'Countries' ),
-			headerLabel: translate( 'Top countries' ),
-			analyticsId: 'countries',
-			feature: STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
-			countryFilterLabel: translate( 'All countries' ),
-		},
-		[ OPTION_KEYS.REGIONS ]: {
-			selectLabel: translate( 'Regions' ),
-			headerLabel: translate( 'Top regions' ),
-			analyticsId: 'regions',
-			feature: STATS_FEATURE_LOCATION_REGION_VIEWS,
-			countryFilterLabel: translate( 'All regions' ),
-		},
-		[ OPTION_KEYS.CITIES ]: {
-			selectLabel: translate( 'Cities' ),
-			headerLabel: translate( 'Top cities' ),
-			analyticsId: 'cities',
-			feature: STATS_FEATURE_LOCATION_CITY_VIEWS,
-			countryFilterLabel: translate( 'All cities' ),
-		},
-	};
+	const optionLabels = useOptionLabels();
 
 	// Use StatsModule to display paywall upsell.
 	const shouldGateStatsModule = useShouldGateStats( statType );
@@ -183,7 +156,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		} );
 	};
 
-	const toggleControlComponent = config.isEnabled( 'stats/navigation-improvement' ) && (
+	const toggleControlComponent = ! config.isEnabled( 'stats/navigation-improvement' ) && (
 		<>
 			<SimplifiedSegmentedControl
 				className="stats-module-locations__tabs"

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -4,7 +4,7 @@ import { SimplifiedSegmentedControl, StatsCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { mapMarker } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import useLocationViewsQuery, {
 	StatsLocationViewsData,
@@ -69,10 +69,23 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		: LOCATIONS_SUPPORT_URL;
 
 	// selectOption is in plural form i.e. 'countries'! Possible something to unify in the future.
-	const [ selectedOption, setSelectedOption ] = useState( () => {
+	const appliedGeoModeFromUrl = useMemo( () => {
 		const urlGeoMode = query.geoMode ?? initialGeoMode;
 		return urlGeoMode && urlGeoMode in GEO_MODES ? urlGeoMode : OPTION_KEYS.COUNTRIES;
+	}, [ query.geoMode, initialGeoMode ] );
+
+	// Set the state locally to avoid a page being reloaded by URL changes.
+	const [ selectedLocalOption, setSelectedLocalOption ] = useState( () => {
+		return appliedGeoModeFromUrl;
 	} );
+
+	const selectedOption = useMemo( () => {
+		if ( summary ) {
+			return appliedGeoModeFromUrl;
+		}
+
+		return selectedLocalOption;
+	}, [ summary, appliedGeoModeFromUrl, selectedLocalOption ] );
 
 	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
 
@@ -157,11 +170,10 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 			stat_type: optionLabels[ filter ].feature,
 		} );
 
-		setSelectedOption( filter );
-
-		// If URL has valid param and it's different from state, update URL; only intended for summary page.
-		if ( summary && query.geoMode !== filter ) {
+		if ( summary ) {
 			page( getPathWithUpdatedQueryString( { geoMode: filter } ) );
+		} else {
+			setSelectedLocalOption( filter );
 		}
 	};
 

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -38,7 +38,7 @@ import useOptionLabels from './use-option-labels';
 
 import './style.scss';
 
-export type SelectOptionType = {
+type SelectOptionType = {
 	label: string;
 	value: string;
 };

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -183,7 +183,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		} );
 	};
 
-	const toggleControlComponent = config.isEnabled( 'stats/navigation-improvement' ) ? null : (
+	const toggleControlComponent = config.isEnabled( 'stats/navigation-improvement' ) && (
 		<>
 			<SimplifiedSegmentedControl
 				className="stats-module-locations__tabs"

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -20,6 +20,7 @@ import {
 	trackStatsAnalyticsEvent,
 } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { getSiteStatsNormalizedData } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -75,15 +76,33 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const statType = STAT_TYPE_COUNTRY_VIEWS;
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const supportUrl = isOdysseyStats
 		? `${ JETPACK_SUPPORT_URL_TRAFFIC }#views-by-locations`
 		: LOCATIONS_SUPPORT_URL;
-	const [ selectedOption, setSelectedOption ] = useState( () => {
-		const urlGeoMode = query.geoMode ?? initialGeoMode;
-		return urlGeoMode && urlGeoMode in GEO_MODES ? urlGeoMode : OPTION_KEYS.COUNTRIES;
-	} );
+
+	const selectedOption = query?.geoMode ?? initialGeoMode ?? OPTION_KEYS.COUNTRIES;
+	const setSelectedOption = useCallback(
+		( newOption: string ) => {
+			const geoModeParam = query.geoMode;
+			const isValidGeoModeParam =
+				geoModeParam && Object.values( OPTION_KEYS ).includes( geoModeParam );
+
+			if ( ! isValidGeoModeParam ) {
+				return;
+			}
+
+			// If URL has valid param and it's different from state, update state
+			if ( geoModeParam !== newOption ) {
+				const updatedQuery = { ...query, geoMode: newOption };
+				const queryString = new URLSearchParams( updatedQuery ).toString();
+				page( `/stats/${ period.period }/locations/${ siteSlug }?${ queryString }` );
+			}
+		},
+		[ query ]
+	);
 
 	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
 

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -156,7 +156,9 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		} );
 	};
 
-	const toggleControlComponent = ! config.isEnabled( 'stats/navigation-improvement' ) && (
+	// Need to keep the old tabs on Traffic page.
+	const toggleControlComponent = ( ! summary ||
+		! config.isEnabled( 'stats/navigation-improvement' ) ) && (
 		<>
 			<SimplifiedSegmentedControl
 				className="stats-module-locations__tabs"

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -160,8 +160,8 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		setSelectedOption( filter );
 
 		// If URL has valid param and it's different from state, update URL; only intended for summary page.
-		if ( summary && query.geoMode !== selectedOption ) {
-			page( getPathWithUpdatedQueryString( { geoMode: selectedOption } ) );
+		if ( summary && query.geoMode !== filter ) {
+			page( getPathWithUpdatedQueryString( { geoMode: filter } ) );
 		}
 	};
 

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -187,7 +187,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		} );
 	};
 
-	const toggleControlComponent = (
+	const toggleControlComponent = config.isEnabled( 'stats/navigation-improvement' ) ? null : (
 		<>
 			<SimplifiedSegmentedControl
 				className="stats-module-locations__tabs"

--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -69,6 +69,8 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		return urlGeoMode && urlGeoMode in GEO_MODES ? urlGeoMode : OPTION_KEYS.COUNTRIES;
 	}, [ query.geoMode, initialGeoMode ] );
 
+	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
+
 	// Set the state locally to avoid a page being reloaded by URL changes.
 	const [ selectedLocalOption, setSelectedLocalOption ] = useState( () => {
 		return appliedGeoModeFromUrl;
@@ -81,8 +83,6 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 
 		return selectedLocalOption;
 	}, [ summary, appliedGeoModeFromUrl, selectedLocalOption ] );
-
-	const [ countryFilter, setCountryFilter ] = useState< string | null >( null );
 
 	const optionLabels = useOptionLabels();
 

--- a/client/my-sites/stats/features/modules/stats-locations/types.ts
+++ b/client/my-sites/stats/features/modules/stats-locations/types.ts
@@ -1,0 +1,14 @@
+export const OPTION_KEYS = {
+	COUNTRIES: 'countries',
+	REGIONS: 'regions',
+	CITIES: 'cities',
+};
+
+export type GeoMode = 'country' | 'region' | 'city';
+export type UrlGeoMode = ( typeof OPTION_KEYS )[ keyof typeof OPTION_KEYS ];
+
+export const GEO_MODES: Record< UrlGeoMode, GeoMode > = {
+	[ OPTION_KEYS.COUNTRIES ]: 'country',
+	[ OPTION_KEYS.REGIONS ]: 'region',
+	[ OPTION_KEYS.CITIES ]: 'city',
+};

--- a/client/my-sites/stats/features/modules/stats-locations/use-option-labels.ts
+++ b/client/my-sites/stats/features/modules/stats-locations/use-option-labels.ts
@@ -1,0 +1,34 @@
+import { useTranslate } from 'i18n-calypso';
+import {
+	STATS_FEATURE_LOCATION_REGION_VIEWS,
+	STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
+	STATS_FEATURE_LOCATION_CITY_VIEWS,
+} from '../../../constants';
+import { OPTION_KEYS } from './types';
+
+export default function useOptionLabels() {
+	const translate = useTranslate();
+	return {
+		[ OPTION_KEYS.COUNTRIES ]: {
+			selectLabel: translate( 'Countries' ),
+			headerLabel: translate( 'Top countries' ),
+			analyticsId: 'countries',
+			feature: STATS_FEATURE_LOCATION_COUNTRY_VIEWS,
+			countryFilterLabel: translate( 'All countries' ),
+		},
+		[ OPTION_KEYS.REGIONS ]: {
+			selectLabel: translate( 'Regions' ),
+			headerLabel: translate( 'Top regions' ),
+			analyticsId: 'regions',
+			feature: STATS_FEATURE_LOCATION_REGION_VIEWS,
+			countryFilterLabel: translate( 'All regions' ),
+		},
+		[ OPTION_KEYS.CITIES ]: {
+			selectLabel: translate( 'Cities' ),
+			headerLabel: translate( 'Top cities' ),
+			analyticsId: 'cities',
+			feature: STATS_FEATURE_LOCATION_CITY_VIEWS,
+			countryFilterLabel: translate( 'All cities' ),
+		},
+	};
+}

--- a/client/my-sites/stats/features/modules/types.d.ts
+++ b/client/my-sites/stats/features/modules/types.d.ts
@@ -59,6 +59,7 @@ type StatsPeriodType = {
 type StatsQueryType = {
 	date: string;
 	period: StatsPeriodGrainType;
+	geoMode?: 'country' | 'region' | 'city';
 };
 
 type StatsPeriodGrainType = 'day' | 'week' | 'month' | 'year';

--- a/client/my-sites/stats/features/modules/types.d.ts
+++ b/client/my-sites/stats/features/modules/types.d.ts
@@ -59,7 +59,6 @@ type StatsPeriodType = {
 type StatsQueryType = {
 	date: string;
 	period: StatsPeriodGrainType;
-	geoMode?: 'country' | 'region' | 'city';
 };
 
 type StatsPeriodGrainType = 'day' | 'week' | 'month' | 'year';

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -21,6 +21,7 @@ import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-e
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PageHeader from '../components/headers/page-header';
 import StatsModuleLocations from '../features/modules/stats-locations';
+import LocationsTabNav from '../features/modules/stats-locations/locations-nav-tabs';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
 import DownloadCsv from '../stats-download-csv';
@@ -393,6 +394,15 @@ class StatsSummary extends Component {
 					{ ! isStatsNavigationImprovementEnabled && (
 						<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
 					) }
+
+					{ isStatsNavigationImprovementEnabled &&
+						this.props.context.params.module === 'locations' && (
+							<LocationsTabNav
+								period={ this.props.period }
+								query={ moduleQuery }
+								givenSiteId={ siteId }
+							/>
+						) }
 
 					<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
 						{ this.props.context.params.module === 'utm' ? (

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -397,11 +397,13 @@ class StatsSummary extends Component {
 
 					{ isStatsNavigationImprovementEnabled &&
 						this.props.context.params.module === 'locations' && (
-							<LocationsTabNav
-								period={ this.props.period }
-								query={ moduleQuery }
-								givenSiteId={ siteId }
-							/>
+							<div className="stats-navigation stats-navigation--improved">
+								<LocationsTabNav
+									period={ this.props.period }
+									query={ moduleQuery }
+									givenSiteId={ siteId }
+								/>
+							</div>
 						) }
 
 					<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -21,7 +21,7 @@ import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-e
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import PageHeader from '../components/headers/page-header';
 import StatsModuleLocations from '../features/modules/stats-locations';
-import LocationsTabNav from '../features/modules/stats-locations/locations-nav-tabs';
+import LocationsNavTabs from '../features/modules/stats-locations/locations-nav-tabs';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
 import DownloadCsv from '../stats-download-csv';
@@ -398,7 +398,7 @@ class StatsSummary extends Component {
 					{ isStatsNavigationImprovementEnabled &&
 						this.props.context.params.module === 'locations' && (
 							<div className="stats-navigation stats-navigation--improved">
-								<LocationsTabNav
+								<LocationsNavTabs
 									period={ this.props.period }
 									query={ moduleQuery }
 									givenSiteId={ siteId }

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -55,3 +55,22 @@
 		}
 	}
 }
+
+.stats-navigation.stats-navigation--improved {
+	.stats-navigation__tabs {
+		margin-left: -16px;
+
+		.components-tab-panel__tabs {
+			padding-left: 0;
+		}
+
+		@media (max-width: $break-small) {
+			margin-left: 0;
+
+			.components-tab-panel__tabs {
+				padding-left: 16px;
+				padding-right: 16px;
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STATS-8

## Proposed Changes

* Included change from p1746693569061979/1746687024.440609-slack-C82FZ5T4G by @dognose24 
* Replaced segment control with tabs to choose location types
* Minor refactoring for sharing code

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Replace segment control with tabs on the top

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `http://calypso.localhost:3000/stats/day/xx.com`
* Find the Locations module
* Ensure you can switch among Countries/Regions/Cities
* Click `View all` for the locations module
* Ensure tabs work as expected for Countries/Regions/Cities
* Remove the feature flag by  `http://calypso.localhost:3000/stats/day/xx.com?flags=-stats/navigation-improvement`
* Repeat the test instructions above


<img width="1360" alt="image" src="https://github.com/user-attachments/assets/dcb19ee8-cd66-4c90-91b9-4dd970d6166a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?