### PR TITLE
LOHP: Logged-out reader pages use same nav header as LOHP

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,6 +1,5 @@
 import config, { isEnabled } from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import { removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
 import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -89,7 +88,6 @@ const LayoutLoggedOut = ( {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const currentRoute = useSelector( getCurrentRoute );
 	const loggedInAction = useSelector( getLastActionRequiresLogin );
-	const pathNameWithoutLocale = currentRoute && removeLocaleFromPathLocaleInFront( currentRoute );
 
 	const isCheckout = sectionName === 'checkout';
 	const isCheckoutPending = sectionName === 'checkout-pending';
@@ -101,16 +99,7 @@ const LayoutLoggedOut = ( {
 	const isJetpackThankYou =
 		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack/thank-you' );
 
-	const isReaderTagPage =
-		sectionName === 'reader' &&
-		( pathNameWithoutLocale.startsWith( '/tag/' ) || pathNameWithoutLocale.startsWith( '/tags' ) );
 	const isReaderTagEmbed = typeof window !== 'undefined' && isReaderTagEmbedPage( window.location );
-
-	const isReaderDiscoverPage =
-		sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/discover' );
-
-	const isReaderSearchPage =
-		sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/reader/search' );
 
 	// It's used to add a class name for the login-related pages, except for `/log-in/link/use`.
 	const hasGravPoweredClientClass =
@@ -200,10 +189,7 @@ const LayoutLoggedOut = ( {
 			'subscriptions',
 			'theme',
 			'themes',
-		].includes( sectionName ) &&
-		! isReaderTagPage &&
-		! isReaderSearchPage &&
-		! isReaderDiscoverPage
+		].includes( sectionName )
 	) {
 		const nonMonochromeSections = [ 'plugins', 'themes', 'theme' ];
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/103269

## Proposed Changes

* Logged-out reader uses the same header as WordPress.com landing pages

**The LOHP Nav Bar**

![CleanShot 2025-05-09 at 18 12 03](https://github.com/user-attachments/assets/51bf2caf-dfb8-4a2d-8c86-0fb7c29097b5)


**Before**

![CleanShot 2025-05-09 at 18 11 19](https://github.com/user-attachments/assets/2a90ea2e-1ba4-4b6a-ac73-c4eb18539744)


**After**

![CleanShot 2025-05-09 at 18 10 52](https://github.com/user-attachments/assets/40322619-df23-40f8-ab6b-2b9fe58b19d4)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This was raised during the code blue audit. We are reducing inconsistencies in terms of the different blues used, in terms of the logos used, and so we should also use consistent navigation on the logged-out WordPress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

These pages are served by Calypso

* Open incognito tab
* `calypso.localhost:3000/tags` (or `/discover`, or `/reader/search`)
* Test RTL pages with `/ar/tags`
* All logged-out reader pages linked to by the nav bar should use the consistent nav bar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
