### PR TITLE
ContinueAsUser: remove the notYouText customization

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -38,7 +38,6 @@ export default function ContinueAsUser( {
 	redirectPath,
 	isWoo,
 	isBlazePro,
-	notYouText,
 } ) {
 	const translate = useTranslate();
 
@@ -51,23 +50,21 @@ export default function ContinueAsUser( {
 	// like that, but it is better than the alternative, and in practice it should happen quicker than
 	// the user can notice.
 
-	const notYouDisplayedText = notYouText
-		? notYouText
-		: translate( 'Not you?{{br/}}Log in with {{link}}another account{{/link}}', {
-				components: {
-					br: <br />,
-					link: (
-						<button
-							type="button"
-							id="loginAsAnotherUser"
-							className="continue-as-user__change-user-link"
-							onClick={ onChangeAccount }
-						/>
-					),
-				},
-				args: { userName },
-				comment: 'Link to continue login as different user',
-		  } );
+	const notYouText = translate( 'Not you?{{br/}}Log in with {{link}}another account{{/link}}', {
+		components: {
+			br: <br />,
+			link: (
+				<button
+					type="button"
+					id="loginAsAnotherUser"
+					className="continue-as-user__change-user-link"
+					onClick={ onChangeAccount }
+				/>
+			),
+		},
+		args: { userName },
+		comment: 'Link to continue login as different user',
+	} );
 
 	const gravatarLink = (
 		<div className="continue-as-user__gravatar-content">
@@ -149,7 +146,7 @@ export default function ContinueAsUser( {
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>
-			<div className="continue-as-user__not-you">{ notYouDisplayedText }</div>
+			<div className="continue-as-user__not-you">{ notYouText }</div>
 		</div>
 	);
 }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -105,7 +105,6 @@ class SignupForm extends Component {
 		isSocialFirst: PropTypes.bool,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
-		notYouText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 		positionInFlow: PropTypes.number,
 		redirectToAfterLoginUrl: PropTypes.string,
 		save: PropTypes.func,
@@ -1125,29 +1124,6 @@ class SignupForm extends Component {
 					redirectPath={ this.props.redirectToAfterLoginUrl }
 					isWoo={ this.props.isWoo }
 					isBlazePro={ this.props.isBlazePro }
-					notYouText={
-						this.props.notYouText ||
-						this.props.translate(
-							'Not you?{{br/}} Sign out or log in with {{link}}another account{{/link}}',
-							{
-								components: {
-									br: <br />,
-									link: (
-										<button
-											type="button"
-											id="loginAsAnotherUser"
-											className="continue-as-user__change-user-link"
-											onClick={ this.handleOnChangeAccount }
-										/>
-									),
-								},
-								args: {
-									userName: this.props.currentUser.display_name || this.props.currentUser.username,
-								},
-								comment: 'Link to continue login as different user',
-							}
-						)
-					}
 				/>
 			);
 		}


### PR DESCRIPTION
Our login components have many customizations and slight variations that make them very difficult to maintain and change. This PR removes one such customization prop: `notYouText`. It's been used to display either a "Log in with another account" message or, in another flow, a "Sign out or log in with another account" message. This is a trivial difference which we can remove.

The customization was introduced in #92259 and at the time there were three variations: the third is "Sign out and subscribe with {email}". That third variation disappeared together with the `subscribe-email` flow.

## Testing instructions:
Go to `/log-in` while logged in. You should see a page like this, with the affected label at the bottom:

<img width="489" alt="Screenshot 2025-05-08 at 8 51 41" src="https://github.com/user-attachments/assets/068f6ebc-67ce-43e7-bb47-e4a8727f0bb0" />
