### PR TITLE
Unify the background color across the onboarding and dashboard screens

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -46,12 +46,7 @@ body,
 }
 
 body {
-	background: var(--color-surface-backdrop);
-
-	&:has(.step-container-v2) {
-		background: #fdfdfd;
-	}
-
+	background: var( --color-main-background, #fcfcfc );
 	color: var(--color-text);
 	font-size: $font-body;
 	line-height: 1.5;

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,4 +1,5 @@
 import { useBreakpoint } from '@automattic/viewport-react';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useLoadScheduleFromId } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id';
@@ -47,7 +48,11 @@ export const PluginsScheduledUpdatesMultisite = ( {
 
 	return (
 		<MultisitePluginUpdateManagerContextProvider>
-			<Layout title={ title } wide>
+			<Layout
+				className={ clsx( 'sites-dashboard', 'sites-dashboard__layout' ) }
+				title={ title }
+				wide
+			>
 				{ context === 'create' || context === 'edit' ? (
 					<LayoutColumn className="scheduled-updates-list-compact">
 						<ScheduleList

--- a/client/blocks/plugins-scheduled-updates-multisite/index.tsx
+++ b/client/blocks/plugins-scheduled-updates-multisite/index.tsx
@@ -1,5 +1,4 @@
 import { useBreakpoint } from '@automattic/viewport-react';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useLoadScheduleFromId } from 'calypso/blocks/plugins-scheduled-updates-multisite/hooks/use-load-schedule-from-id';
@@ -48,11 +47,7 @@ export const PluginsScheduledUpdatesMultisite = ( {
 
 	return (
 		<MultisitePluginUpdateManagerContextProvider>
-			<Layout
-				className={ clsx( 'sites-dashboard', 'sites-dashboard__layout' ) }
-				title={ title }
-				wide
-			>
+			<Layout title={ title } wide>
 				{ context === 'create' || context === 'edit' ? (
 					<LayoutColumn className="scheduled-updates-list-compact">
 						<ScheduleList

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -12,14 +12,6 @@
  */
 @import "calypso/blocks/import/style/base";
 
-/**
- * General onboarding styling
- */
-body {
-	--color-body-background: #fdfdfd;
-	background-color: var(--color-body-background);
-}
-
 body,
 button {
 	font-family: $sans;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/styles.scss
@@ -2,7 +2,7 @@
 
 .celebration-step {
 	.step-container {
-		background: #fdfdfd;
+		background: var( --color-main-background, #fcfcfc );
 		padding: 0;
 		margin: 0;
 		max-width: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -12,7 +12,7 @@
 	}
 
 	.step-container {
-		background: #fdfdfd;
+		background: var( --color-main-background, #fcfcfc );
 		padding: 0 0 60px;
 		margin: 0;
 		max-width: none;

--- a/client/layout/hosting-dashboard/style.scss
+++ b/client/layout/hosting-dashboard/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .main.hosting-dashboard-layout-column,
 .main.hosting-dashboard-layout {
@@ -43,6 +44,12 @@
 
 .hosting-dashboard-layout-column {
 	flex: 1;
+
+	&:not(:only-child) .hosting-dashboard-layout-column__container {
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+		border: 1px solid $gray-200;
+		overflow: hidden;
+	}
 }
 
 .hosting-dashboard-layout__body {

--- a/client/layout/hosting-dashboard/style.scss
+++ b/client/layout/hosting-dashboard/style.scss
@@ -44,11 +44,17 @@
 
 .hosting-dashboard-layout-column {
 	flex: 1;
+}
 
-	&:not(:only-child) .hosting-dashboard-layout-column__container {
-		border-radius: 8px; /* stylelint-disable-line scales/radii */
+.hosting-dashboard-layout-column__container {
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	overflow: hidden;
+
+	@include break-small {
+		height: 100%;
+		padding-block-start: 1px;
 		border: 1px solid $gray-200;
-		overflow: hidden;
+		box-sizing: border-box;
 	}
 }
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -305,7 +305,7 @@ $image-height: 47px;
 }
 
 .layout.is-white-login {
-	background-color: #fdfdfd;
+	background-color: var( --color-main-background, #fcfcfc );
 
 	// Specificity bump.
 	.layout__content.layout__content {

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -3,7 +3,7 @@
 
 body.is-group-me.is-section-help,
 body.is-section-me {
-	background: var(--studio-gray-0);
+	background: var(--color-main-background);
 
 	&.rtl .layout__content {
 		padding: calc(var(--masterbar-height) + var(--content-padding-top)) calc(var(--sidebar-width-max)) var(--content-padding-bottom) 16px;

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 body.is-group-me.is-section-help,
 body.is-section-me {
@@ -47,10 +48,9 @@ body.is-section-me {
 		.layout__primary {
 			.main {
 				padding: 24px;
-				border-block-end: 1px solid var(--studio-gray-0);
 				background: var(--color-surface);
 				border-radius: 8px; /* stylelint-disable-line scales/radii */
-				box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+				border: 1px solid $gray-200;
 				overflow-y: auto;
 				overflow-x: hidden;
 				max-width: none;

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -50,7 +50,6 @@ body.is-section-me {
 				padding: 24px;
 				background: var(--color-surface);
 				border-radius: 8px; /* stylelint-disable-line scales/radii */
-				border: 1px solid $gray-200;
 				overflow-y: auto;
 				overflow-x: hidden;
 				max-width: none;
@@ -58,6 +57,10 @@ body.is-section-me {
 					max-width: 1040px;
 					margin-left: auto;
 					margin-right: auto;
+				}
+
+				@include break-small {
+					border: 1px solid $gray-200;
 				}
 			}
 		}

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -39,8 +39,8 @@ const sitesDashboardGlobalStyles = css`
 			.is-global-sidebar-visible {
 				.layout__primary > main {
 					background: var( --color-surface );
+					border: 1px solid #e0e0e0;
 					border-radius: 8px;
-					box-shadow: 0px 0px 17.4px 0px rgba( 0, 0, 0, 0.05 );
 					overflow: hidden;
 					max-width: none;
 				}

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -39,7 +39,6 @@ const sitesDashboardGlobalStyles = css`
 			.is-global-sidebar-visible {
 				.layout__primary > main {
 					background: var( --color-surface );
-					border: 1px solid #e0e0e0;
 					border-radius: 8px;
 					overflow: hidden;
 					max-width: none;

--- a/client/my-sites/domains/domain-management/dataviews/style.scss
+++ b/client/my-sites/domains/domain-management/dataviews/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 @import "@wordpress/dataviews/build-style/style.css";
 
 body.is-section-domains.is-bulk-all-domains-page {

--- a/client/my-sites/domains/domain-management/dataviews/style.scss
+++ b/client/my-sites/domains/domain-management/dataviews/style.scss
@@ -152,5 +152,12 @@ body.is-section-domains.is-bulk-all-domains-page {
 			}
 		}
 	}
+
+	@include break-small {
+		.layout__primary > main.dataviews {
+			border: 1px solid $gray-200;
+			border-radius: 8px; /* stylelint-disable-line scales/radii */
+		}
+	}
 }
 

--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -43,7 +43,7 @@ interface BulkAllDomainsProps {
 
 const domainsDataViewsGlobalStyles = css`
 	body.is-bulk-all-domains-page {
-		background: var( --studio-gray-0 );
+		background: var( --color-main-background );
 
 		header.navigation-header {
 			border-block-end: 1px solid var( --color-neutral-5 );
@@ -80,7 +80,7 @@ const domainsDashboardGlobalStyles = css`
 		overflow-y: auto;
 	}
 	body.is-bulk-all-domains-page {
-		background: var( --studio-gray-0 );
+		background: var( --color-main-background );
 
 		&.rtl .layout__content {
 			padding: 16px calc( var( --sidebar-width-max ) ) 16px 16px;

--- a/client/my-sites/plugins/plugins-dashboard/style.scss
+++ b/client/my-sites/plugins/plugins-dashboard/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
 
 :root {
 	--color-light-backdrop: var( --studio-white );
@@ -376,7 +377,7 @@
 body.is-section-plugins .hosting-dashboard-layout,
 .is-section-jetpack-cloud-plugin-management .hosting-dashboard-layout {
 	.hosting-dashboard-layout-with-columns__container {
-		background-color: var( --studio-gray-0 );
+		background-color: var( --color-main-background );
 	}
 	.dataviews-wrapper {
 		margin: auto;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 @import "./woocommerce-box";
 
 .is-section-plugins .main {
@@ -53,7 +54,7 @@ body.is-section-plugins {
 		.layout__primary > * {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			overflow-y: auto;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -99,6 +99,7 @@ body.is-section-plugins {
 	}
 
 	.hosting-dashboard-layout-column {
+		height: 100%;
 		overflow: auto;
 	}
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -54,10 +54,15 @@ body.is-section-plugins {
 		.layout__primary > * {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			overflow-y: auto;
+
+			&:not(:has(.hosting-dashboard-layout-column__container)) {
+				@include break-small {
+					border: 1px solid $gray-200;
+				}
+			}
 		}
 
 		.plugins-browser,
@@ -154,12 +159,12 @@ body.is-section-plugins {
 		}
 	}
 
-	.hosting-dashboard-layout-column.scheduled-updates-edit,
-	.hosting-dashboard-layout-column.scheduled-updates-create {
+	.hosting-dashboard-layout-column.scheduled-updates-edit .hosting-dashboard-layout-column__container,
+	.hosting-dashboard-layout-column.scheduled-updates-create .hosting-dashboard-layout-column__container {
 		padding: 3rem;
 
 		@include breakpoint-deprecated( "<660px" ) {
-			padding: 0.5rem;
+			padding: 1rem;
 		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -46,8 +46,6 @@
 
 body.is-section-plugins {
 	.is-section-plugins.is-global-sidebar-visible {
-		background: var(--studio-gray-0);
-
 		.layout__content {
 			min-height: 100vh;
 		}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -16,7 +16,7 @@ $brand-text: "SF Pro Text", $sans;
 		--sidebar-width-max: 295px;
 		--sidebar-width-min: 295px;
 
-		--color-sidebar-background: var(--studio-gray-0);
+		--color-sidebar-background: var(--color-main-background);
 		// Resetting these colors to prevent bleeding from dashboard color schemes
 		--color-sidebar-text: var(--studio-gray-80);
 		--color-sidebar-text-alternative: var(--studio-gray-40);

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 // The following changes should be merged in their respective files before nav unification goes to production
 @import url( //s0.wp.com/wp-includes/css/dashicons.min.css?v=20250127 );
 @import "@automattic/typography/styles/variables";

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -4,7 +4,6 @@
 @import "@automattic/components/src/highlight-cards/variables";
 @import "@wordpress/base-styles/breakpoints";
 
-$stats-background-color: #fdfdfd;
 $stats-sections-max-width: 1224px;
 $stats-layout-contnet-padding-top: 79px;
 $sidebar-appearance-break-point: $break-medium;
@@ -18,7 +17,7 @@ $sidebar-appearance-break-point: $break-medium;
 
 // Main layout content
 .stats {
-	background-color: $stats-background-color;
+	background-color: var( --color-main-background, #fcfcfc );
 
 	// Ensures vertical padding for certain sections.
 	> .highlight-cards,

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -13,10 +13,6 @@ $button-border: 4px;
 		z-index: 100201;
 	}
 
-	&.theme-default.color-scheme {
-		--color-surface-backdrop: var(--studio-white);
-	}
-
 	.layout.is-logged-in .layout__content {
 		overflow: clip;
 		padding-top: 47px;
@@ -40,8 +36,6 @@ $button-border: 4px;
 	}
 
 	&.is-global-sidebar-visible {
-		background: var(--studio-gray-0);
-
 		&.layout.is-logged-in .layout__content {
 			min-height: 100vh;
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 $theme-sheet-content-max-width: 1462px;
 $theme-sheet-content-padding-x: 20px;
@@ -47,7 +48,7 @@ $button-border: 4px;
 		.layout__primary > * {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			overflow-y: auto;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
+@import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
 $theme-sheet-content-max-width: 1462px;
@@ -48,11 +49,14 @@ $button-border: 4px;
 		.layout__primary > * {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			overflow-y: auto;
 			padding-bottom: 0;
+
+			@include break-small {
+				border: 1px solid $gray-200;
+			}
 		}
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -4,13 +4,7 @@
 
 
 .is-section-themes {
-	&.theme-default.color-scheme {
-		--color-surface-backdrop: var(--studio-white);
-	}
-
 	&.is-global-sidebar-visible {
-		background: var(--studio-gray-0);
-
 		.layout__content {
 			min-height: 100vh;
 			@media screen and (min-width: 782px) {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -1,7 +1,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
-
+@import "@wordpress/base-styles/variables";
 
 .is-section-themes {
 	&.is-global-sidebar-visible {
@@ -15,7 +15,7 @@
 		.layout__primary > * {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			padding-bottom: 0;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -15,10 +15,14 @@
 		.layout__primary > * {
 			background-color: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			max-width: none;
 			padding-bottom: 0;
+
+			@include break-small {
+				border: 1px solid $gray-200;
+			}
+
 			@media (max-width: $break-mobile), (max-height: $break-mobile) {
 				overflow-y: auto;
 				overflow-x: hidden;

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -64,8 +64,6 @@ body.is-reader-page,
 }
 
 body.is-section-reader {
-	background: var(--studio-gray-0);
-
 	&.rtl .layout__content {
 		padding: calc(var(--masterbar-height) + var(--content-padding-top)) calc(var(--sidebar-width-max)) var(--content-padding-bottom) 16px;
 	}

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -86,9 +86,12 @@ body.is-section-reader {
 		.layout__primary > div:not(:has(.recent-feed)) {
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			overflow: hidden;
+
+			@include break-small {
+				border: 1px solid $gray-200;
+			}
 		}
 		.layout__primary > div > div:not(.tags__header):not(.reader-notifications__3pc-notice) {
 			height: 100%;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 body.is-section-reader {
 	div.layout.is-global-sidebar-visible {
@@ -85,7 +86,7 @@ body.is-section-reader {
 		.layout__primary > div:not(:has(.recent-feed)) {
 			background: var(--color-surface);
 			border-radius: 8px; /* stylelint-disable-line scales/radii */
-			box-shadow: 0 0 17.4px 0 rgba(0, 0, 0, 0.05);
+			border: 1px solid $gray-200;
 			height: calc(100vh - var(--masterbar-height) - var(--content-padding-top) - var(--content-padding-bottom));
 			overflow: hidden;
 		}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -3,7 +3,7 @@
 @import "@wordpress/base-styles/mixins";
 
 body.is-section-signup {
-	background: #fdfdfd;
+	background: var( --color-main-background, #fcfcfc );
 
 	.layout:not(.dops) .wpcom-site__logo {
 		/* fill: var(--color-neutral-10); */

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -59,7 +59,7 @@ export function sanitizeQueryParameters( context: PageJSContext, next: () => voi
 export function sitesDashboard( context: Context, next: () => void ) {
 	const sitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
-			background: var( --studio-gray-0 );
+			background: var( --color-main-background, #fcfcfc );
 
 			.layout__content {
 				// Add border around everything

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -94,7 +94,7 @@ export function sitesDashboard( context: Context, next: () => void ) {
 				.layout__primary > main {
 					background: var( --color-surface );
 					border-radius: 8px;
-					box-shadow: 0px 0px 17.4px 0px rgba( 0, 0, 0, 0.05 );
+					border: 1px solid rgba( 0, 0, 0, 0.1 );
 					height: calc( 100vh - 32px );
 					overflow: auto;
 				}

--- a/client/sites/controller.tsx
+++ b/client/sites/controller.tsx
@@ -94,7 +94,6 @@ export function sitesDashboard( context: Context, next: () => void ) {
 				.layout__primary > main {
 					background: var( --color-surface );
 					border-radius: 8px;
-					border: 1px solid rgba( 0, 0, 0, 0.1 );
 					height: calc( 100vh - 32px );
 					overflow: auto;
 				}

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -147,6 +147,7 @@
 	--color-sidebar-menu-hover-background: #1a1e23;/* theme-default */
 	--color-sidebar-menu-hover-text: #00b9eb; /* theme-default */
 
+	--color-main-background: #fcfcfc;
 
 	--color-jetpack-onboarding-text: var(--studio-white);
 	--color-jetpack-onboarding-background: var(--studio-blue-100);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/issues/101133

## Proposed Changes

* Unify the background color across the onboarding and dashboard screens. Now the background color across the screens should be `#fcfcfc`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Unify the background color across the onboarding and dashboard screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites, /p2s, /domains/manage, /themes, /plugins, /me, /reader
* Ensure the background color is `#fcfcfc`
* Go to create a new site
* Ensure the background color is `#fcfcfc`
* Go to /stats/day/:site
* Ensure the background color below the stats header is `#fcfcfc`
* Open the Incognito window
* Go to /log-in
* Ensure the background color is `#fcfcfc`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
