### PR TITLE
SummaryButton: Add focus styles

### DIFF
--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -73,4 +73,8 @@
 			@include body-medium;
 		}
 	}
+
+	&:focus {
+		box-shadow: 0 0 0 1.5px var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+	}
 }

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/variables";
 
 .summary-button.components-button {
-	padding: 24px;
+	padding: $grid-unit-30;
 	display: block;
 	height: auto;
 	transition: none;
@@ -70,7 +70,7 @@
 	}
 
 	&.has-density-medium {
-		padding: 12px;
+		padding: $grid-unit-15;
 		box-shadow: 0 2px 1px -1px $gray-100;
 
 		// TODO: this should be handled better in `SummaryButtonList` component.

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -75,7 +75,7 @@
 
 		// TODO: this should be handled better in `SummaryButtonList` component.
 		// @see: https://github.com/Automattic/wp-calypso/pull/103233#issuecomment-2862541935
-		&:focus-visible {
+		&:focus-visible, &:hover:not(:disabled, [aria-disabled="true"]) {
 			/* stylelint-disable-next-line scales/radii */
 			border-radius: 7px;
 		}

--- a/packages/components/src/summary-button/style.scss
+++ b/packages/components/src/summary-button/style.scss
@@ -21,11 +21,15 @@
 		}
 
 		&.has-density-low {
-			box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
+			&:not(:focus-visible) {
+				box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
+			}
 		}
 
 		&.has-density-medium {
-			box-shadow: 0 2px 1px -1px color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
+			&:not(:focus-visible) {
+				box-shadow: 0 2px 1px -1px color-mix(in srgb, var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9)) 12%, transparent);
+			}
 		}
 	}
 
@@ -69,12 +73,19 @@
 		padding: 12px;
 		box-shadow: 0 2px 1px -1px $gray-100;
 
+		// TODO: this should be handled better in `SummaryButtonList` component.
+		// @see: https://github.com/Automattic/wp-calypso/pull/103233#issuecomment-2862541935
+		&:focus-visible {
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 7px;
+		}
+
 		.summary-button-title {
 			@include body-medium;
 		}
 	}
 
-	&:focus {
-		box-shadow: 0 0 0 1.5px var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+	&:focus-visible {
+		@include button-style__focus();
 	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes: DS-170

`SummaryButton` component needs proper focus styles. Currently they are overridden by specific box-shadow styles per variant.

This highlights an issue though with usages inside `Card` which has `border-radius: 7px`. The focus ring doesn't match for the `medium` density variant. You can see the issue with the `hover` `box-shadow` too in trunk.

In `low` density it matches because we have the `border-radius` rule. @jameskoster what's your suggestion?


## Testing Instructions
1. Storybook: `yarn components:storybook:start`
2. http://calypso.localhost:3000/v2/me/billing 
3. http://calypso.localhost:3000/v2/sites/`${a site here}`/settings ( navigate to the settings of a single site..

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
