### PR TITLE
Account Deletion: Improve visibility of "Restore Site" option

### DIFF
--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/sites';
 import { useQueryClient } from '@tanstack/react-query';
 import { sprintf } from '@wordpress/i18n';
-import { drawerLeft, external, wordpress } from '@wordpress/icons';
+import { backup, drawerLeft, external, wordpress } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useMemo } from 'react';
@@ -466,6 +466,8 @@ export function useActions( {
 
 			{
 				id: 'restore',
+				isPrimary: true,
+				icon: backup,
 				label: __( 'Restore' ),
 				callback: ( sites ) => {
 					const site = sites[ 0 ];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- DOTCOM-12875
- https://github.com/Automattic/wp-calypso/issues/100342

## Proposed Changes
We've marked the `Restore` action as primary so that when the user hovers over a row with a deleted site, they see the corresponding icon/button to restore the site without needing to click on the actions menu. 

| Header | Header |
|--------|--------|
|![Screenshot 2025-05-08 at 12 57 05](https://github.com/user-attachments/assets/8ba21c41-18e6-42a1-8a92-13f93cb9b40a)|![Screenshot 2025-05-08 at 12 56 57](https://github.com/user-attachments/assets/94ad8ef2-ee2b-4ce1-8ac0-3b432cde9310)| 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to improve the visibility of the Restore action so that users can find it without needing to click on the actions menu.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Log in with a dummy account
* Make sure you have at least one site created
* Delete the account and click on restore account
* On the sites list you should see that deleted sites now show an icon for restoring each deleted site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
