### PR TITLE
Experiment streamlining the plans grid + checkout: Implement the plan interval radio button component

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -1,5 +1,9 @@
 import { isWpComPlan } from '@automattic/calypso-products';
 import { FunctionComponent } from 'react';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceRadioTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { ItemVariationDropDown } from './item-variation-dropdown';
 import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
@@ -10,12 +14,21 @@ import type { ItemVariationPickerProps } from './types';
  */
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
 	const { selectedItem } = props;
+	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
+		useStreamlinedPriceExperiment();
 
-	if ( isWpComPlan( selectedItem.product_slug ) ) {
+	if ( isStreamlinedPriceExperimentLoading ) {
+		return null;
+	}
+
+	if (
+		isWpComPlan( selectedItem.product_slug ) &&
+		isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment )
+	) {
 		return <ItemVariationRadioButtons { ...props } />;
 	}
 
-	// Placeholder for other plan types (e.g., dropdown for non-WPCOM plans)
+	// Placeholder for other plan types (e.g., dropdown for non-WPCOM plans or if experiment not assigned)
 	return <ItemVariationDropDown { ...props } />;
 };
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -1,5 +1,7 @@
+import { isWpComPlan } from '@automattic/calypso-products';
 import { FunctionComponent } from 'react';
 import { ItemVariationDropDown } from './item-variation-dropdown';
+import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
 
 /**
@@ -7,6 +9,13 @@ import type { ItemVariationPickerProps } from './types';
  * radio buttons vs. dropdown).
  */
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
+	const { selectedItem } = props;
+
+	if ( isWpComPlan( selectedItem.product_slug ) ) {
+		return <ItemVariationRadioButtons { ...props } />;
+	}
+
+	// Placeholder for other plan types (e.g., dropdown for non-WPCOM plans)
 	return <ItemVariationDropDown { ...props } />;
 };
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,0 +1,97 @@
+import RadioButton from '@automattic/composite-checkout/src/components/radio-button';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { ItemVariantRadioPrice } from './variant-radio-price';
+import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+import type { FunctionComponent } from 'react';
+
+const TermOptions = styled.ul`
+	flex-basis: 100%;
+	margin: 20px 0;
+	padding: 0;
+`;
+
+const TermOptionsItem = styled.li`
+	margin: 8px 0 0;
+	padding: 0;
+	list-style: none;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+interface ProductVariantProps {
+	radioButtonGroup: string;
+	productVariant: WPCOMProductVariant;
+	selectedItem: ResponseCartProduct;
+	onChangeItemVariant: OnChangeItemVariant;
+	isDisabled: boolean;
+	compareTo?: WPCOMProductVariant;
+}
+
+const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
+	radioButtonGroup,
+	productVariant,
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	compareTo,
+} ) => {
+	const { variantLabel, productSlug, productId } = productVariant;
+	const selectedProductSlug = selectedItem.product_slug;
+	const isChecked = productSlug === selectedProductSlug;
+
+	return (
+		<TermOptionsItem>
+			<RadioButton
+				name={ radioButtonGroup }
+				id={ productSlug + variantLabel }
+				value={ productSlug }
+				data-product-slug={ productSlug }
+				checked={ isChecked }
+				disabled={ isDisabled }
+				onChange={ () => {
+					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
+				} }
+				label={ <ItemVariantRadioPrice variant={ productVariant } compareTo={ compareTo } /> }
+				isStreamlinedPriceStyle
+			/>
+		</TermOptionsItem>
+	);
+};
+
+export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerProps > = ( {
+	selectedItem,
+	onChangeItemVariant,
+	isDisabled,
+	variants,
+} ) => {
+	const translate = useTranslate();
+	if ( variants.length < 2 ) {
+		return null;
+	}
+
+	const compareTo = variants[ 0 ];
+
+	return (
+		<TermOptions
+			role="radiogroup"
+			aria-label={ translate( 'Pick a product term' ) }
+			className="item-variation-picker"
+		>
+			{ variants.map( ( productVariant: WPCOMProductVariant ) => (
+				<ProductVariant
+					radioButtonGroup={ `item-variation-picker ${ selectedItem.product_name } ${ selectedItem.uuid }` }
+					key={ productVariant.productSlug + productVariant.variantLabel }
+					selectedItem={ selectedItem }
+					onChangeItemVariant={ onChangeItemVariant }
+					isDisabled={ isDisabled }
+					productVariant={ productVariant }
+					compareTo={ compareTo }
+				/>
+			) ) }
+		</TermOptions>
+	);
+};

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -56,7 +56,7 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
 				} }
 				label={ <ItemVariantRadioPrice variant={ productVariant } compareTo={ compareTo } /> }
-				isStreamlinedPriceStyle
+				isStreamlinedPrice
 			/>
 		</TermOptionsItem>
 	);

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -56,7 +56,8 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 					! isDisabled && onChangeItemVariant( selectedItem.uuid, productSlug, productId );
 				} }
 				label={ <ItemVariantRadioPrice variant={ productVariant } compareTo={ compareTo } /> }
-				isStreamlinedPrice
+				highlighted
+				compact
 			/>
 		</TermOptionsItem>
 	);

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,10 +1,10 @@
 import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState, type FunctionComponent } from 'react';
 import { ItemVariantRadioPrice } from './variant-radio-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
-import type { FunctionComponent } from 'react';
 
 const TermOptions = styled.ul`
 	flex-basis: 100%;
@@ -29,6 +29,7 @@ interface ProductVariantProps {
 	onChangeItemVariant: OnChangeItemVariant;
 	isDisabled: boolean;
 	compareTo?: WPCOMProductVariant;
+	selectedProductSlug: string;
 }
 
 const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
@@ -38,9 +39,9 @@ const ProductVariant: FunctionComponent< ProductVariantProps > = ( {
 	onChangeItemVariant,
 	isDisabled,
 	compareTo,
+	selectedProductSlug,
 } ) => {
 	const { variantLabel, productSlug, productId } = productVariant;
-	const selectedProductSlug = selectedItem.product_slug;
 	const isChecked = productSlug === selectedProductSlug;
 
 	return (
@@ -70,11 +71,24 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 	variants,
 } ) => {
 	const translate = useTranslate();
+	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState(
+		selectedItem.product_slug
+	);
+
+	useEffect( () => {
+		setOptimisticSelectedItem( selectedItem.product_slug );
+	}, [ selectedItem ] );
+
 	if ( variants.length < 2 ) {
 		return null;
 	}
 
 	const compareTo = variants[ 0 ];
+
+	const onChangeItemVariantCallback = ( uuid: string, productSlug: string, productId: number ) => {
+		setOptimisticSelectedItem( productSlug );
+		onChangeItemVariant( uuid, productSlug, productId );
+	};
 
 	return (
 		<TermOptions
@@ -87,10 +101,11 @@ export const ItemVariationRadioButtons: FunctionComponent< ItemVariationPickerPr
 					radioButtonGroup={ `item-variation-picker ${ selectedItem.product_name } ${ selectedItem.uuid }` }
 					key={ productVariant.productSlug + productVariant.variantLabel }
 					selectedItem={ selectedItem }
-					onChangeItemVariant={ onChangeItemVariant }
+					onChangeItemVariant={ onChangeItemVariantCallback }
 					isDisabled={ isDisabled }
 					productVariant={ productVariant }
 					compareTo={ compareTo }
+					selectedProductSlug={ optimisticSelectedItem }
 				/>
 			) ) }
 		</TermOptions>

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-radio-buttons.tsx
@@ -1,4 +1,4 @@
-import RadioButton from '@automattic/composite-checkout/src/components/radio-button';
+import { RadioButton } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { ItemVariantRadioPrice } from './variant-radio-price';

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -1,3 +1,4 @@
+import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -7,10 +8,10 @@ import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
 	text-align: center;
-	color: var( --studio-green-80, rgba( 0, 69, 12, 1 ) );
+	color: ${ colorStudio.colors[ 'Green 80' ] };
 
 	display: block;
-	background-color: #b8e6bf;
+	background-color: ${ colorStudio.colors[ 'Green 5' ] };
 	padding: 0 10px;
 	border-radius: 4px;
 	font-size: 12px;

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -1,4 +1,4 @@
-import { getCurrencyObject } from '@automattic/number-formatters';
+import { formatCurrency } from '@automattic/number-formatters';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -7,11 +7,14 @@ import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
 	text-align: center;
-	color: #234929;
+	color: var( --studio-green-80, rgba( 0, 69, 12, 1 ) );
+
 	display: block;
 	background-color: #b8e6bf;
-	padding: 0 1em;
+	padding: 0 10px;
 	border-radius: 4px;
+	font-size: 12px;
+	line-height: 20px;
 
 	.rtl & {
 		margin-right: 0;
@@ -26,10 +29,10 @@ const Price = styled.span`
 const Variant = styled.div`
 	align-items: center;
 	display: flex;
-	font-size: 14px;
+	font-size: 16px;
 	font-weight: 400;
 	justify-content: space-between;
-	line-height: 20px;
+	line-height: 24px;
 	width: 100%;
 `;
 
@@ -44,6 +47,7 @@ const PriceArea = styled.span`
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
+	align-items: flex-end;
 `;
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
@@ -59,64 +63,32 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
-const VariantBillingTotal = styled.div`
-	font-size: small;
-	color: #777;
-`;
-
 export const ItemVariantRadioPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
 	const translate = useTranslate();
 	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
-	const formattedCurrentPrice = getCurrencyObject( variant.priceInteger, variant.currency, {
-		stripZeros: true,
-		isSmallestUnit: true,
-	} );
 
 	const pricePerMonth = Math.round( variant.priceInteger / variant.termIntervalInMonths );
-	const pricePerYear = pricePerMonth * 12;
 
-	const pricePerYearFormatted = getCurrencyObject( pricePerYear, variant.currency, {
-		stripZeros: true,
-		isSmallestUnit: true,
-	} );
-	const pricePerMonthFormatted = getCurrencyObject( pricePerMonth, variant.currency, {
+	const pricePerMonthFormatted = formatCurrency( pricePerMonth, variant.currency, {
 		stripZeros: true,
 		isSmallestUnit: true,
 	} );
 
-	const shouldShowMonthlyPrice =
-		compareTo?.termIntervalInMonths === 1 || variant.termIntervalInMonths === 1;
 	const priceDisplay = ( () => {
-		if ( shouldShowMonthlyPrice ) {
-			return translate( '%(pricePerMonth)s / month', {
-				args: {
-					pricePerMonth: pricePerMonthFormatted.integer,
-				},
-			} );
-		}
-		return translate( '%(pricePerYear)s / year', {
+		return translate( '%(pricePerMonth)s /mo', {
 			args: {
-				pricePerYear: pricePerYearFormatted.integer,
+				pricePerMonth: pricePerMonthFormatted,
 			},
 		} );
 	} )();
-
-	const shouldShowBillingTotal = variant.termIntervalInMonths !== compareTo?.termIntervalInMonths;
-	const billingTotal = translate( 'Billed as one payment of %(totalPrice)s', {
-		args: {
-			totalPrice: formattedCurrentPrice.integer,
-		},
-	} );
-
+	const label =
+		variant.termIntervalInMonths === 1 ? translate( 'Month' ) : variant.variantLabel.noun;
 	return (
 		<Variant>
-			<VariantTermLabel>
-				{ variant.variantLabel.noun }
-				{ shouldShowBillingTotal && <VariantBillingTotal>{ billingTotal }</VariantBillingTotal> }
-			</VariantTermLabel>
+			<VariantTermLabel>{ label }</VariantTermLabel>
 			<PriceArea>
 				<Price>{ priceDisplay }</Price>
 				{ discountPercentage > 0 && <DiscountPercentage percent={ discountPercentage } /> }

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -1,0 +1,126 @@
+import { getCurrencyObject } from '@automattic/number-formatters';
+import { styled } from '@automattic/wpcom-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { getItemVariantDiscountPercentage } from './util';
+import type { WPCOMProductVariant } from './types';
+
+const Discount = styled.span`
+	text-align: center;
+	color: #234929;
+	display: block;
+	background-color: #b8e6bf;
+	padding: 0 1em;
+	border-radius: 4px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+`;
+
+const Price = styled.span`
+	color: #000;
+`;
+
+const Variant = styled.div`
+	align-items: center;
+	display: flex;
+	font-size: 14px;
+	font-weight: 400;
+	justify-content: space-between;
+	line-height: 20px;
+	width: 100%;
+`;
+
+const VariantTermLabel = styled.span`
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+`;
+
+const PriceArea = styled.span`
+	text-align: right;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+`;
+
+const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
+	const translate = useTranslate();
+	return (
+		<Discount>
+			{ translate( 'Save %(percent)s%%', {
+				args: {
+					percent,
+				},
+			} ) }
+		</Discount>
+	);
+};
+
+const VariantBillingTotal = styled.div`
+	font-size: small;
+	color: #777;
+`;
+
+export const ItemVariantRadioPrice: FunctionComponent< {
+	variant: WPCOMProductVariant;
+	compareTo?: WPCOMProductVariant;
+} > = ( { variant, compareTo } ) => {
+	const translate = useTranslate();
+	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
+	const formattedCurrentPrice = getCurrencyObject( variant.priceInteger, variant.currency, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
+	const pricePerMonth = Math.round( variant.priceInteger / variant.termIntervalInMonths );
+	const pricePerYear = pricePerMonth * 12;
+
+	const pricePerYearFormatted = getCurrencyObject( pricePerYear, variant.currency, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+	const pricePerMonthFormatted = getCurrencyObject( pricePerMonth, variant.currency, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
+	const shouldShowMonthlyPrice =
+		compareTo?.termIntervalInMonths === 1 || variant.termIntervalInMonths === 1;
+	const priceDisplay = ( () => {
+		if ( shouldShowMonthlyPrice ) {
+			return translate( '%(pricePerMonth)s / month', {
+				args: {
+					pricePerMonth: pricePerMonthFormatted.integer,
+				},
+			} );
+		}
+		return translate( '%(pricePerYear)s / year', {
+			args: {
+				pricePerYear: pricePerYearFormatted.integer,
+			},
+		} );
+	} )();
+
+	const shouldShowBillingTotal = variant.termIntervalInMonths !== compareTo?.termIntervalInMonths;
+	const billingTotal = translate( 'Billed as one payment of %(totalPrice)s', {
+		args: {
+			totalPrice: formattedCurrentPrice.integer,
+		},
+	} );
+
+	return (
+		<Variant>
+			<VariantTermLabel>
+				{ variant.variantLabel.noun }
+				{ shouldShowBillingTotal && <VariantBillingTotal>{ billingTotal }</VariantBillingTotal> }
+			</VariantTermLabel>
+			<PriceArea>
+				<Price>{ priceDisplay }</Price>
+				{ discountPercentage > 0 && <DiscountPercentage percent={ discountPercentage } /> }
+			</PriceArea>
+		</Variant>
+	);
+};

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -24,7 +24,7 @@ const Discount = styled.span`
 `;
 
 const Price = styled.span`
-	color: #000;
+	color: ${ colorStudio.colors[ 'Black' ] };
 `;
 
 const Variant = styled.div`

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -23,6 +23,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
+import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -377,6 +378,7 @@ function LineItemWrapper( {
 		isJetpackPurchasableItem( product.product_slug )
 	);
 
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
@@ -388,7 +390,7 @@ function LineItemWrapper( {
 		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
 		const isMarketplace = product.extra?.is_marketplace_product;
 
-		if ( isJetpack || isAkismet || isMarketplace ) {
+		if ( isJetpack || isAkismet || isMarketplace || streamlinedPriceExperimentAssignment ) {
 			return true;
 		}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -23,7 +23,10 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
-import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
+import {
+	isStreamlinedPriceRadioTreatment,
+	useStreamlinedPriceExperiment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -378,7 +381,8 @@ function LineItemWrapper( {
 		isJetpackPurchasableItem( product.product_slug )
 	);
 
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
+		useStreamlinedPriceExperiment();
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
@@ -390,7 +394,15 @@ function LineItemWrapper( {
 		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
 		const isMarketplace = product.extra?.is_marketplace_product;
 
-		if ( isJetpack || isAkismet || isMarketplace || streamlinedPriceExperimentAssignment ) {
+		if ( isJetpack || isAkismet || isMarketplace ) {
+			return true;
+		}
+
+		if (
+			isWpComPlan( variant.productSlug ) &&
+			! isStreamlinedPriceExperimentLoading &&
+			isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment )
+		) {
 			return true;
 		}
 

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -18,3 +18,10 @@ export function isStreamlinedPricePlansTreatment( variationName?: string | null 
 	}
 	return ! variationName.includes( 'plans_control' );
 }
+
+export function isStreamlinedPriceRadioTreatment( variationName?: string | null ) {
+	if ( ! variationName ) {
+		return false;
+	}
+	return variationName.includes( 'checkout_radio' );
+}

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -9,7 +9,7 @@ interface RadioButtonWrapperProps {
 	isFocused?: boolean;
 	checked?: boolean;
 	hideRadioButton?: boolean;
-	isStreamlinedPriceStyle?: boolean;
+	isStreamlinedPrice?: boolean;
 }
 
 export const RadioButtonWrapper = styled.div<
@@ -34,14 +34,12 @@ export const RadioButtonWrapper = styled.div<
 			left: 0;
 			content: '';
 			border: ${
-				props.checked || props.isStreamlinedPriceStyle
-					? '1px solid ' + getBorderColor( props )
-					: 'none'
+				props.checked || props.isStreamlinedPrice ? '1px solid ' + getBorderColor( props ) : 'none'
 			};
 			border-bottom: 1px solid ${ getBorderColor( props ) };
 			box-sizing: border-box;
-			border-radius: ${ props.checked || props.isStreamlinedPriceStyle ? '3px' : 0 };
-			border-width: ${ props.checked && props.isStreamlinedPriceStyle ? '2px' : '1px' };
+			border-radius: ${ props.checked || props.isStreamlinedPrice ? '3px' : 0 };
+			border-width: ${ props.checked && props.isStreamlinedPrice ? '2px' : '1px' };
 			.rtl & {
 				right: 0;
 				left: auto;
@@ -50,7 +48,7 @@ export const RadioButtonWrapper = styled.div<
 
 		:hover::before {
 			border: 3px solid ${ props.theme.colors.highlight };
-			border-width: ${ ! props.checked && props.isStreamlinedPriceStyle ? '1px' : '2px' };
+			border-width: ${ ! props.checked && props.isStreamlinedPrice ? '1px' : '2px' };
 			border-radius: 3px;
 		}
 	` }
@@ -114,7 +112,7 @@ interface LabelProps {
 	disabled?: boolean;
 	checked?: boolean;
 	hideRadioButton?: boolean;
-	isStreamlinedPriceStyle?: boolean;
+	isStreamlinedPrice?: boolean;
 }
 
 /**
@@ -124,7 +122,7 @@ interface LabelProps {
 const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelElement > >`
 	position: relative;
 	padding: ${ ( props ) => {
-		if ( props.isStreamlinedPriceStyle ) {
+		if ( props.isStreamlinedPrice ) {
 			return '12px 12px 12px 43px';
 		}
 		return props.hideRadioButton ? '16px 24px' : '16px 14px 16px 56px';
@@ -144,7 +142,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 
 	.rtl & {
 		padding: ${ ( props ) => {
-			if ( props.isStreamlinedPriceStyle ) {
+			if ( props.isStreamlinedPrice ) {
 				return '12px';
 			}
 			return props.hideRadioButton ? '16px 24px' : '16px 56px 16px 14px';
@@ -163,14 +161,14 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
 		top: 40%;
-		left: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '16px' : '24px' ) };
+		left: ${ ( props ) => ( props.isStreamlinedPrice ? '16px' : '24px' ) };
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
 		z-index: 2;
 
 		.rtl & {
-			right: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '8px' : '16px' ) };
+			right: ${ ( props ) => ( props.isStreamlinedPrice ? '8px' : '16px' ) };
 			left: auto;
 		}
 	}
@@ -183,14 +181,14 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		border-radius: 100%;
 		margin-top: 4px;
 		top: 40%;
-		left: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '20px' : '28px' ) };
+		left: ${ ( props ) => ( props.isStreamlinedPrice ? '20px' : '28px' ) };
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;
 		z-index: 3;
 
 		.rtl & {
-			right: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '12px' : '20px' ) };
+			right: ${ ( props ) => ( props.isStreamlinedPrice ? '12px' : '20px' ) };
 			left: auto;
 		}
 	}
@@ -224,7 +222,7 @@ export default function RadioButton( {
 	id,
 	ariaLabel,
 	hideRadioButton,
-	isStreamlinedPriceStyle,
+	isStreamlinedPrice,
 	...otherProps
 }: RadioButtonProps ) {
 	const [ isFocused, changeFocus ] = useState( false );
@@ -236,7 +234,7 @@ export default function RadioButton( {
 			hidden={ hidden }
 			hideRadioButton={ hideRadioButton }
 			className={ `${ checked ? 'is-checked' : '' }` }
-			isStreamlinedPriceStyle={ isStreamlinedPriceStyle }
+			isStreamlinedPrice={ isStreamlinedPrice }
 		>
 			<Radio
 				type="radio"
@@ -261,7 +259,7 @@ export default function RadioButton( {
 				htmlFor={ id }
 				disabled={ disabled }
 				hideRadioButton={ hideRadioButton }
-				isStreamlinedPriceStyle={ isStreamlinedPriceStyle }
+				isStreamlinedPrice={ isStreamlinedPrice }
 			>
 				{ label }
 			</Label>
@@ -282,7 +280,7 @@ interface RadioButtonProps {
 	ariaLabel?: string;
 	children?: React.ReactNode;
 	hideRadioButton?: boolean;
-	isStreamlinedPriceStyle?: boolean;
+	isStreamlinedPrice?: boolean;
 }
 
 RadioButton.propTypes = {

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -41,6 +41,7 @@ export const RadioButtonWrapper = styled.div<
 			border-bottom: 1px solid ${ getBorderColor( props ) };
 			box-sizing: border-box;
 			border-radius: ${ props.checked || props.isStreamlinedPriceStyle ? '3px' : 0 };
+			border-width: ${ props.checked && props.isStreamlinedPriceStyle ? '2px' : '1px' };
 			.rtl & {
 				right: 0;
 				left: auto;
@@ -49,6 +50,7 @@ export const RadioButtonWrapper = styled.div<
 
 		:hover::before {
 			border: 3px solid ${ props.theme.colors.highlight };
+			border-width: ${ ! props.checked && props.isStreamlinedPriceStyle ? '1px' : '2px' };
 			border-radius: 3px;
 		}
 	` }
@@ -112,6 +114,7 @@ interface LabelProps {
 	disabled?: boolean;
 	checked?: boolean;
 	hideRadioButton?: boolean;
+	isStreamlinedPriceStyle?: boolean;
 }
 
 /**
@@ -120,7 +123,12 @@ interface LabelProps {
  */
 const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelElement > >`
 	position: relative;
-	padding: ${ ( props ) => ( props.hideRadioButton ? '16px 24px' : '16px 14px 16px 56px' ) };
+	padding: ${ ( props ) => {
+		if ( props.isStreamlinedPriceStyle ) {
+			return '12px 12px 12px 43px';
+		}
+		return props.hideRadioButton ? '16px 24px' : '16px 14px 16px 56px';
+	} };
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
@@ -135,7 +143,12 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 	min-height: 72px;
 
 	.rtl & {
-		padding: ${ ( props ) => ( props.hideRadioButton ? '16px 24px' : '16px 56px 16px 14px' ) };
+		padding: ${ ( props ) => {
+			if ( props.isStreamlinedPriceStyle ) {
+				return '12px';
+			}
+			return props.hideRadioButton ? '16px 24px' : '16px 56px 16px 14px';
+		} };
 	}
 
 	:hover {
@@ -150,14 +163,14 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
 		top: 40%;
-		left: 24px;
+		left: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '16px' : '24px' ) };
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
 		z-index: 2;
 
 		.rtl & {
-			right: 16px;
+			right: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '8px' : '16px' ) };
 			left: auto;
 		}
 	}
@@ -170,14 +183,14 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		border-radius: 100%;
 		margin-top: 4px;
 		top: 40%;
-		left: 28px;
+		left: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '20px' : '28px' ) };
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;
 		z-index: 3;
 
 		.rtl & {
-			right: 20px;
+			right: ${ ( props ) => ( props.isStreamlinedPriceStyle ? '12px' : '20px' ) };
 			left: auto;
 		}
 	}
@@ -248,6 +261,7 @@ export default function RadioButton( {
 				htmlFor={ id }
 				disabled={ disabled }
 				hideRadioButton={ hideRadioButton }
+				isStreamlinedPriceStyle={ isStreamlinedPriceStyle }
 			>
 				{ label }
 			</Label>

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -9,9 +9,10 @@ interface RadioButtonWrapperProps {
 	isFocused?: boolean;
 	checked?: boolean;
 	hideRadioButton?: boolean;
+	isStreamlinedPriceStyle?: boolean;
 }
 
-const RadioButtonWrapper = styled.div<
+export const RadioButtonWrapper = styled.div<
 	RadioButtonWrapperProps & React.HTMLAttributes< HTMLDivElement >
 >`
 	position: relative;
@@ -32,10 +33,14 @@ const RadioButtonWrapper = styled.div<
 			top: 0;
 			left: 0;
 			content: '';
-			border: ${ props.checked ? '1px solid ' + getBorderColor( props ) : 'none' };
+			border: ${
+				props.checked || props.isStreamlinedPriceStyle
+					? '1px solid ' + getBorderColor( props )
+					: 'none'
+			};
 			border-bottom: 1px solid ${ getBorderColor( props ) };
 			box-sizing: border-box;
-			border-radius: ${ props.checked ? '3px' : 0 };
+			border-radius: ${ props.checked || props.isStreamlinedPriceStyle ? '3px' : 0 };
 			.rtl & {
 				right: 0;
 				left: auto;
@@ -206,6 +211,7 @@ export default function RadioButton( {
 	id,
 	ariaLabel,
 	hideRadioButton,
+	isStreamlinedPriceStyle,
 	...otherProps
 }: RadioButtonProps ) {
 	const [ isFocused, changeFocus ] = useState( false );
@@ -217,6 +223,7 @@ export default function RadioButton( {
 			hidden={ hidden }
 			hideRadioButton={ hideRadioButton }
 			className={ `${ checked ? 'is-checked' : '' }` }
+			isStreamlinedPriceStyle={ isStreamlinedPriceStyle }
 		>
 			<Radio
 				type="radio"
@@ -261,6 +268,7 @@ interface RadioButtonProps {
 	ariaLabel?: string;
 	children?: React.ReactNode;
 	hideRadioButton?: boolean;
+	isStreamlinedPriceStyle?: boolean;
 }
 
 RadioButton.propTypes = {

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -21,6 +21,8 @@ const RadioButtonWrapper = styled.div<
 	box-sizing: border-box;
 	width: 100%;
 	outline: ${ getOutline };
+	opacity: ${ ( props ) => ( props.disabled && props.highlighted ? '0.7' : '1' ) };
+	pointer-events: ${ ( props ) => ( props.disabled && props.highlighted ? 'none' : 'auto' ) };
 
 	${ ( props ) =>
 		! props.hideRadioButton &&

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -9,10 +9,10 @@ interface RadioButtonWrapperProps {
 	isFocused?: boolean;
 	checked?: boolean;
 	hideRadioButton?: boolean;
-	isStreamlinedPrice?: boolean;
+	highlighted?: boolean;
 }
 
-export const RadioButtonWrapper = styled.div<
+const RadioButtonWrapper = styled.div<
 	RadioButtonWrapperProps & React.HTMLAttributes< HTMLDivElement >
 >`
 	position: relative;
@@ -33,13 +33,11 @@ export const RadioButtonWrapper = styled.div<
 			top: 0;
 			left: 0;
 			content: '';
-			border: ${
-				props.checked || props.isStreamlinedPrice ? '1px solid ' + getBorderColor( props ) : 'none'
-			};
+			border: ${ props.checked || props.highlighted ? '1px solid ' + getBorderColor( props ) : 'none' };
 			border-bottom: 1px solid ${ getBorderColor( props ) };
 			box-sizing: border-box;
-			border-radius: ${ props.checked || props.isStreamlinedPrice ? '3px' : 0 };
-			border-width: ${ props.checked && props.isStreamlinedPrice ? '2px' : '1px' };
+			border-radius: ${ props.checked || props.highlighted ? '3px' : 0 };
+			border-width: ${ props.checked && props.highlighted ? '2px' : '1px' };
 			.rtl & {
 				right: 0;
 				left: auto;
@@ -48,7 +46,7 @@ export const RadioButtonWrapper = styled.div<
 
 		:hover::before {
 			border: 3px solid ${ props.theme.colors.highlight };
-			border-width: ${ ! props.checked && props.isStreamlinedPrice ? '1px' : '2px' };
+			border-width: ${ ! props.checked && props.highlighted ? '1px' : '2px' };
 			border-radius: 3px;
 		}
 	` }
@@ -112,7 +110,7 @@ interface LabelProps {
 	disabled?: boolean;
 	checked?: boolean;
 	hideRadioButton?: boolean;
-	isStreamlinedPrice?: boolean;
+	compact?: boolean;
 }
 
 /**
@@ -122,7 +120,7 @@ interface LabelProps {
 const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelElement > >`
 	position: relative;
 	padding: ${ ( props ) => {
-		if ( props.isStreamlinedPrice ) {
+		if ( props.compact ) {
 			return '12px 12px 12px 43px';
 		}
 		return props.hideRadioButton ? '16px 24px' : '16px 14px 16px 56px';
@@ -142,7 +140,7 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 
 	.rtl & {
 		padding: ${ ( props ) => {
-			if ( props.isStreamlinedPrice ) {
+			if ( props.compact ) {
 				return '12px';
 			}
 			return props.hideRadioButton ? '16px 24px' : '16px 56px 16px 14px';
@@ -161,14 +159,14 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
 		top: 40%;
-		left: ${ ( props ) => ( props.isStreamlinedPrice ? '16px' : '24px' ) };
+		left: ${ ( props ) => ( props.compact ? '16px' : '24px' ) };
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
 		z-index: 2;
 
 		.rtl & {
-			right: ${ ( props ) => ( props.isStreamlinedPrice ? '8px' : '16px' ) };
+			right: ${ ( props ) => ( props.compact ? '8px' : '16px' ) };
 			left: auto;
 		}
 	}
@@ -181,14 +179,14 @@ const Label = styled.label< LabelProps & React.LabelHTMLAttributes< HTMLLabelEle
 		border-radius: 100%;
 		margin-top: 4px;
 		top: 40%;
-		left: ${ ( props ) => ( props.isStreamlinedPrice ? '20px' : '28px' ) };
+		left: ${ ( props ) => ( props.compact ? '20px' : '28px' ) };
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;
 		z-index: 3;
 
 		.rtl & {
-			right: ${ ( props ) => ( props.isStreamlinedPrice ? '12px' : '20px' ) };
+			right: ${ ( props ) => ( props.compact ? '12px' : '20px' ) };
 			left: auto;
 		}
 	}
@@ -222,7 +220,8 @@ export default function RadioButton( {
 	id,
 	ariaLabel,
 	hideRadioButton,
-	isStreamlinedPrice,
+	highlighted,
+	compact,
 	...otherProps
 }: RadioButtonProps ) {
 	const [ isFocused, changeFocus ] = useState( false );
@@ -234,7 +233,7 @@ export default function RadioButton( {
 			hidden={ hidden }
 			hideRadioButton={ hideRadioButton }
 			className={ `${ checked ? 'is-checked' : '' }` }
-			isStreamlinedPrice={ isStreamlinedPrice }
+			highlighted={ highlighted }
 		>
 			<Radio
 				type="radio"
@@ -259,7 +258,7 @@ export default function RadioButton( {
 				htmlFor={ id }
 				disabled={ disabled }
 				hideRadioButton={ hideRadioButton }
-				isStreamlinedPrice={ isStreamlinedPrice }
+				compact={ compact }
 			>
 				{ label }
 			</Label>
@@ -280,7 +279,8 @@ interface RadioButtonProps {
 	ariaLabel?: string;
 	children?: React.ReactNode;
 	hideRadioButton?: boolean;
-	isStreamlinedPrice?: boolean;
+	highlighted?: boolean;
+	compact?: boolean;
 }
 
 RadioButton.propTypes = {
@@ -292,6 +292,8 @@ RadioButton.propTypes = {
 	value: PropTypes.string.isRequired,
 	onChange: PropTypes.func,
 	ariaLabel: PropTypes.string,
+	highlighted: PropTypes.bool,
+	compact: PropTypes.bool,
 };
 
 function handleWrapperDisabled( { disabled, checked }: { disabled?: boolean; checked?: boolean } ) {

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -15,6 +15,7 @@ import {
 	useMakeStepActive,
 	createCheckoutStepGroupStore,
 } from './components/checkout-steps';
+import RadioButton from './components/radio-button';
 import useProcessPayment from './components/use-process-payment';
 import { useFormStatus } from './lib/form-status';
 import {
@@ -41,6 +42,7 @@ export type { Theme } from './lib/theme';
 // Re-export the public API
 export {
 	Button,
+	RadioButton,
 	CheckoutErrorBoundary,
 	CheckoutFormSubmit,
 	CheckoutModal,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p58i-kUT-p2

## Proposed Changes

* add checkout radio buttons for WPCOM plans based on a previous implementation -https://github.com/Automattic/wp-calypso/pull/70315
* restyle checkout radio buttons to match the design
<img width="320" alt="Screenshot 2025-05-08 at 13 55 12" src="https://github.com/user-attachments/assets/00640cac-a3a1-440c-9d80-117ff9a81391" />

## Important Considerations / Experiment Notes

*   **Potential Impact on Plan Interval Selection:** The introduction of radio buttons for all plan intervals is a significant UI change. It's important to note that this may influence user behavior, potentially leading to a different distribution of plan interval choices (e.g., an increase in monthly plan selections).
*   **Alignment with Experiment Goals:** This potential shift in user choice will be a key area of focus during the analysis of the `calypso_streamlined_plans_checkout` experiment (pbxNRc-52Y-p2). 


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're experimenting with streamlining the plans and checkout user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to either `plans_3y_checkout_radio` or `plans_control_checkout_radio` of the experiment variations of `calypso_streamlined_plans_checkout`
* Add a WPCOM plan, a domain and a Titan email subscription to the cart
* The radio button component should only be visible for the WPCOM plan

|Before|After|
|------|-----|
|<img width="430" alt="Screenshot 2025-05-08 at 12 16 16" src="https://github.com/user-attachments/assets/8e0ecf1b-d2d0-4ef5-875d-39e1aee33b67" />|<img width="430" alt="Screenshot 2025-05-08 at 13 50 26" src="https://github.com/user-attachments/assets/5f6c6345-af70-4ef7-bfce-b91793b00bf0" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?