### PR TITLE
Follow up of 102998

### DIFF
--- a/packages/components/src/breadcrumbs/index.tsx
+++ b/packages/components/src/breadcrumbs/index.tsx
@@ -20,7 +20,7 @@ function BreadcrumbsMenu( { items }: { items: BreadcrumbItemProps[] } ) {
 				<Menu.TriggerButton
 					className="a8c-components-breadcrumbs__item"
 					render={
-						<Button size="compact" text="__( … )" label={ __( 'More breadcrumb items' ) } />
+						<Button size="compact" text={ __( '…' ) } label={ __( 'More breadcrumb items' ) } />
 					}
 				/>
 				<Menu.Popover>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Small follow up of https://github.com/Automattic/wp-calypso/pull/102998 (addition of Breadcrumbs component).
We missed the proper localization of the dropdown trigger button.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* in storybook `yarn components:storybook:start` the trigger button should display just the `…` character.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
