### PR TITLE
Remove `Remove from cart` modal

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -336,7 +336,6 @@ export default function CheckoutMainContent( {
 	addItemToCart,
 	changeSelection,
 	countriesList,
-	createUserAndSiteBeforeTransaction,
 	infoMessage,
 	isLoggedOutCart,
 	onPageLoadError,
@@ -359,7 +358,6 @@ export default function CheckoutMainContent( {
 	changeSelection: OnChangeItemVariant;
 	onStepChanged?: StepChangedCallback;
 	countriesList: CountryListItem[];
-	createUserAndSiteBeforeTransaction: boolean;
 	infoMessage?: JSX.Element;
 	isLoggedOutCart: boolean;
 	onPageLoadError: CheckoutPageErrorCallback;
@@ -677,7 +675,6 @@ export default function CheckoutMainContent( {
 							setCouponFieldVisible={ setCouponFieldVisible }
 							onChangeSelection={ changeSelection }
 							siteUrl={ siteUrl }
-							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						/>
 					}
 					formStatus={ formStatus }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -816,7 +816,6 @@ export default function CheckoutMain( {
 					addItemToCart={ addItemAndLog }
 					changeSelection={ changeSelection }
 					countriesList={ countriesList }
-					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 					infoMessage={ <PrePurchaseNotices siteId={ updatedSiteId } isSiteless={ isSiteless } /> }
 					isLoggedOutCart={ !! isLoggedOutCart }
 					onPageLoadError={ onPageLoadError }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -12,8 +12,6 @@ import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
-import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import Coupon from './coupon';
@@ -84,7 +82,6 @@ export default function WPCheckoutOrderReview( {
 	onChangeSelection,
 	siteUrl,
 	isSummary,
-	createUserAndSiteBeforeTransaction,
 }: {
 	className?: string;
 	removeProductFromCart?: RemoveProductFromCart;
@@ -96,16 +93,12 @@ export default function WPCheckoutOrderReview( {
 	setCouponFieldVisible: SetCouponFieldVisible;
 	siteUrl?: string;
 	isSummary?: boolean;
-	createUserAndSiteBeforeTransaction?: boolean;
 } ) {
 	const translate = useTranslate();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 
-	const onRemoveProductCancel = useCallback( () => {
-		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );
-	}, [ reduxDispatch ] );
 	const onRemoveProduct = useCallback(
 		( label: string ) => {
 			reduxDispatch(
@@ -133,11 +126,6 @@ export default function WPCheckoutOrderReview( {
 	const domainUrl = getDomainToDisplayInCheckoutHeader( responseCart, selectedSiteData, siteUrl );
 
 	const planIsP2Plus = hasP2PlusPlan( responseCart );
-
-	const isPwpoUser = useSelector(
-		( state ) =>
-			getCurrentUser( state ) && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
-	);
 
 	return (
 		<>
@@ -167,12 +155,9 @@ export default function WPCheckoutOrderReview( {
 						removeCoupon={ removeCouponAndClearField }
 						onChangeSelection={ onChangeSelection }
 						isSummary={ isSummary }
-						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						responseCart={ responseCart }
-						isPwpoUser={ isPwpoUser ?? false }
 						onRemoveProduct={ onRemoveProduct }
 						onRemoveProductClick={ onRemoveProductClick }
-						onRemoveProductCancel={ onRemoveProductCancel }
 					/>
 				</WPOrderReviewSection>
 			</div>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -70,12 +70,9 @@ export function WPOrderReviewLineItems( {
 	replaceProductInCart,
 	removeCoupon,
 	onChangeSelection,
-	createUserAndSiteBeforeTransaction,
 	responseCart,
-	isPwpoUser,
 	onRemoveProduct,
 	onRemoveProductClick,
-	onRemoveProductCancel,
 }: {
 	className?: string;
 	isSummary?: boolean;
@@ -83,12 +80,9 @@ export function WPOrderReviewLineItems( {
 	replaceProductInCart: ReplaceProductInCart;
 	removeCoupon: RemoveCouponFromCart;
 	onChangeSelection?: OnChangeItemVariant;
-	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
-	isPwpoUser: boolean;
 	onRemoveProduct?: ( label: string ) => void;
 	onRemoveProductClick?: ( label: string ) => void;
-	onRemoveProductCancel?: ( label: string ) => void;
 } ) {
 	const reduxDispatch = useDispatch();
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
@@ -195,12 +189,9 @@ export function WPOrderReviewLineItems( {
 					isSummary={ isSummary }
 					removeProductFromCart={ removeProductFromCart }
 					onChangeSelection={ onChangeSelection }
-					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 					responseCart={ responseCart }
-					isPwpoUser={ isPwpoUser }
 					onRemoveProduct={ onRemoveProduct }
 					onRemoveProductClick={ onRemoveProductClick }
-					onRemoveProductCancel={ onRemoveProductCancel }
 					hasPartnerCoupon={ hasPartnerCoupon }
 					isDisabled={ isDisabled }
 					initialVariantTerm={
@@ -226,19 +217,12 @@ export function WPOrderReviewLineItems( {
 						isSummary={ isSummary }
 						hasDeleteButton={ couponLineItem.hasDeleteButton }
 						removeProductFromCart={ removeCoupon }
-						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-						isPwpoUser={ isPwpoUser }
 						hasPartnerCoupon={ hasPartnerCoupon }
 					/>
 				</WPOrderReviewListItem>
 			) }
 			{ creditsLineItem && responseCart.sub_total_integer > 0 && (
-				<NonProductLineItem
-					subtotal
-					lineItem={ creditsLineItem }
-					isSummary={ isSummary }
-					isPwpoUser={ isPwpoUser }
-				/>
+				<NonProductLineItem subtotal lineItem={ creditsLineItem } isSummary={ isSummary } />
 			) }
 		</WPOrderReviewList>
 	);
@@ -253,12 +237,9 @@ function LineItemWrapper( {
 	isSummary,
 	removeProductFromCart,
 	onChangeSelection,
-	createUserAndSiteBeforeTransaction,
 	responseCart,
-	isPwpoUser,
 	onRemoveProduct,
 	onRemoveProductClick,
-	onRemoveProductCancel,
 	hasPartnerCoupon,
 	isDisabled,
 	initialVariantTerm,
@@ -274,12 +255,9 @@ function LineItemWrapper( {
 	isSummary?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
 	onChangeSelection?: OnChangeItemVariant;
-	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
-	isPwpoUser: boolean;
 	onRemoveProduct?: ( label: string ) => void;
 	onRemoveProductClick?: ( label: string ) => void;
-	onRemoveProductCancel?: ( label: string ) => void;
 	hasPartnerCoupon: boolean;
 	isDisabled: boolean;
 	initialVariantTerm: number | null | undefined;
@@ -407,12 +385,9 @@ function LineItemWrapper( {
 				hasDeleteButton={ isDeletable }
 				removeProductFromCart={ removeProductFromCart }
 				isSummary={ isSummary }
-				createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 				responseCart={ responseCart }
-				isPwpoUser={ isPwpoUser }
 				onRemoveProduct={ onRemoveProduct }
 				onRemoveProductClick={ onRemoveProductClick }
-				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
 			>

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -167,9 +167,7 @@ describe( 'CheckoutMain', () => {
 		const user = userEvent.setup();
 		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 1 );
 		await user.click( removeProductButton );
-		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
-		await user.click( confirmButton );
+
 		await waitFor( async () => {
 			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
 		} );
@@ -190,9 +188,7 @@ describe( 'CheckoutMain', () => {
 		);
 		const user = userEvent.setup();
 		await user.click( removeProductButton );
-		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
-		await user.click( confirmButton );
+
 		await waitFor( () => {
 			expect( navigate ).toHaveBeenCalledWith( '/plans/foo.com' );
 		} );
@@ -213,9 +209,7 @@ describe( 'CheckoutMain', () => {
 		);
 		const user = userEvent.setup();
 		await user.click( removeProductButton );
-		const confirmModal = await screen.findByRole( 'dialog' );
-		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
-		await user.click( confirmButton );
+
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );
 		} );

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -33,12 +33,10 @@ const MiniCartLineItemWrapper = styled.li`
 export function MiniCartLineItems( {
 	removeProductFromCart,
 	removeCoupon,
-	createUserAndSiteBeforeTransaction,
 	responseCart,
 }: {
 	removeProductFromCart: RemoveProductFromCart;
 	removeCoupon: RemoveCouponFromCart;
-	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
 } ) {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
@@ -53,7 +51,6 @@ export function MiniCartLineItems( {
 							product={ product }
 							hasDeleteButton={ canItemBeRemovedFromCart( product, responseCart ) }
 							removeProductFromCart={ removeProductFromCart }
-							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 							responseCart={ responseCart }
 						/>
 					</MiniCartLineItemWrapper>
@@ -64,7 +61,6 @@ export function MiniCartLineItems( {
 					<NonProductLineItem
 						lineItem={ couponLineItem }
 						removeProductFromCart={ removeCoupon }
-						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						hasDeleteButton={ couponLineItem.hasDeleteButton }
 					/>
 				</MiniCartLineItemWrapper>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1,6 +1,5 @@
 import {
 	isAddOn,
-	isDomainRegistration,
 	isPlan,
 	isMonthlyProduct,
 	isYearly,
@@ -403,56 +402,6 @@ function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRe
 interface ModalCopy {
 	title: string;
 	description: string;
-}
-
-function returnModalCopyForProduct(
-	product: ResponseCartProduct,
-	translate: ReturnType< typeof useTranslate >,
-	hasBundledDomainInCart: boolean,
-	hasMarketplaceProductsInCart: boolean,
-	createUserAndSiteBeforeTransaction: boolean,
-	isPwpoUser: boolean
-): ModalCopy {
-	const productType = getProductTypeForModalCopy(
-		product,
-		hasBundledDomainInCart,
-		hasMarketplaceProductsInCart,
-		isPwpoUser
-	);
-	const isRenewal = isWpComProductRenewal( product );
-	return returnModalCopy(
-		productType,
-		translate,
-		createUserAndSiteBeforeTransaction,
-		isRenewal,
-		product
-	);
-}
-
-function getProductTypeForModalCopy(
-	product: ResponseCartProduct,
-	hasBundledDomainInCart: boolean,
-	hasMarketplaceProductsInCart: boolean,
-	isPwpoUser: boolean
-): string {
-	if ( product.is_gift_purchase ) {
-		return 'gift purchase';
-	}
-	if ( isWpComPlan( product.product_slug ) ) {
-		if ( hasMarketplaceProductsInCart ) {
-			return 'plan with marketplace dependencies';
-		}
-		if ( hasBundledDomainInCart && ! isPwpoUser ) {
-			return 'plan with domain dependencies';
-		}
-		return 'plan';
-	}
-
-	if ( isDomainRegistration( product ) ) {
-		return 'domain';
-	}
-
-	return product.product_slug;
 }
 
 function returnModalCopy(
@@ -1186,12 +1135,9 @@ function CheckoutLineItem( {
 	hasDeleteButton,
 	removeProductFromCart,
 	isSummary,
-	createUserAndSiteBeforeTransaction,
 	responseCart,
-	isPwpoUser,
 	onRemoveProduct,
 	onRemoveProductClick,
-	onRemoveProductCancel,
 	isAkPro500Cart,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
@@ -1204,33 +1150,13 @@ function CheckoutLineItem( {
 	isPwpoUser?: boolean;
 	onRemoveProduct?: ( label: string ) => void;
 	onRemoveProductClick?: ( label: string ) => void;
-	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
 	shouldShowBillingInterval?: boolean;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
-	const hasBundledDomainsInCart = responseCart.products.some(
-		( product ) =>
-			( product.is_domain_registration || product.product_slug === 'domain_transfer' ) &&
-			product.is_bundled
-	);
-	const hasMarketplaceProductsInCart = responseCart.products.some(
-		( product ) =>
-			product.extra.is_marketplace_product === true ||
-			product.product_slug.startsWith( 'wp_mp_theme' )
-	);
 	const { formStatus } = useFormStatus();
 	const itemSpanId = `checkout-line-item-${ id }`;
-	const [ isModalVisible, setIsModalVisible ] = useState( false );
-	const modalCopy = returnModalCopyForProduct(
-		product,
-		translate,
-		hasBundledDomainsInCart,
-		hasMarketplaceProductsInCart,
-		createUserAndSiteBeforeTransaction || false,
-		isPwpoUser || false
-	);
 	const isDisabled = formStatus !== FormStatus.READY;
 
 	const isRenewal = isWpComProductRenewal( product );
@@ -1336,49 +1262,31 @@ function CheckoutLineItem( {
 							) }
 							disabled={ isDisabled }
 							onClick={ () => {
-								setIsModalVisible( true );
 								onRemoveProductClick?.( label );
+
+								let product_uuids_to_remove = [ product.uuid ];
+
+								// Gifts need to be all or nothing, to prevent leaving
+								// the site in a state where it requires other purchases
+								// in order to actually work correctly for the period of
+								// the gift (for example, gifting a plan renewal without
+								// a domain renewal would likely lead the site's domain
+								// to expire soon afterwards).
+								if ( product.is_gift_purchase ) {
+									product_uuids_to_remove = responseCart.products
+										.filter( ( cart_product ) => cart_product.is_gift_purchase )
+										.map( ( cart_product ) => cart_product.uuid );
+								}
+
+								Promise.all( product_uuids_to_remove.map( removeProductFromCart ) ).catch( () => {
+									// Nothing needs to be done here. CartMessages will display the error to the user.
+								} );
+								onRemoveProduct?.( label );
 							} }
 						>
 							{ translate( 'Remove from cart' ) }
 						</DeleteButton>
 					</DeleteButtonWrapper>
-
-					<CheckoutModal
-						isVisible={ isModalVisible }
-						closeModal={ () => {
-							setIsModalVisible( false );
-						} }
-						primaryAction={ () => {
-							let product_uuids_to_remove = [ product.uuid ];
-
-							// Gifts need to be all or nothing, to prevent leaving
-							// the site in a state where it requires other purchases
-							// in order to actually work correctly for the period of
-							// the gift (for example, gifting a plan renewal without
-							// a domain renewal would likely lead the site's domain
-							// to expire soon afterwards).
-							if ( product.is_gift_purchase ) {
-								product_uuids_to_remove = responseCart.products
-									.filter( ( cart_product ) => cart_product.is_gift_purchase )
-									.map( ( cart_product ) => cart_product.uuid );
-							}
-
-							Promise.all( product_uuids_to_remove.map( removeProductFromCart ) ).catch( () => {
-								// Nothing needs to be done here. CartMessages will display the error to the user.
-							} );
-							onRemoveProduct?.( label );
-						} }
-						cancelAction={ () => {
-							onRemoveProductCancel?.( label );
-						} }
-						secondaryAction={ () => {
-							onRemoveProductCancel?.( label );
-						} }
-						secondaryButtonCTA={ String( translate( 'Cancel' ) ) }
-						title={ modalCopy.title }
-						copy={ modalCopy.description }
-					/>
 				</>
 			) }
 		</div>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -18,13 +18,7 @@ import {
 	isAkismetProduct,
 } from '@automattic/calypso-products';
 import { Gridicon, Popover } from '@automattic/components';
-import {
-	CheckoutModal,
-	FormStatus,
-	useFormStatus,
-	Button,
-	Theme,
-} from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus, Button, Theme } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/number-formatters';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -216,16 +210,12 @@ function WPNonProductLineItem( {
 	isSummary,
 	hasDeleteButton,
 	removeProductFromCart,
-	createUserAndSiteBeforeTransaction,
-	isPwpoUser,
 }: {
 	lineItem: LineItemType;
 	className?: string | null;
 	isSummary?: boolean;
 	hasDeleteButton?: boolean;
 	removeProductFromCart?: () => void;
-	createUserAndSiteBeforeTransaction?: boolean;
-	isPwpoUser?: boolean;
 } ) {
 	const id = lineItem.id;
 	const itemSpanId = `checkout-line-item-${ id }`;
@@ -233,14 +223,7 @@ function WPNonProductLineItem( {
 	const actualAmountDisplay = lineItem.formattedAmount;
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
-	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const translate = useTranslate();
-	const modalCopy = returnModalCopy(
-		lineItem.type,
-		translate,
-		createUserAndSiteBeforeTransaction || false,
-		isPwpoUser || false
-	);
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -270,28 +253,12 @@ function WPNonProductLineItem( {
 							) }
 							disabled={ isDisabled }
 							onClick={ () => {
-								setIsModalVisible( true );
+								removeProductFromCart();
 							} }
 						>
 							{ translate( 'Remove from cart' ) }
 						</DeleteButton>
 					</DeleteButtonWrapper>
-
-					<CheckoutModal
-						isVisible={ isModalVisible }
-						closeModal={ () => {
-							setIsModalVisible( false );
-						} }
-						secondaryAction={ () => {
-							setIsModalVisible( false );
-						} }
-						primaryAction={ () => {
-							removeProductFromCart();
-						} }
-						secondaryButtonCTA={ String( 'Cancel' ) }
-						title={ modalCopy.title }
-						copy={ modalCopy.description }
-					/>
 				</>
 			) }
 		</div>
@@ -305,8 +272,6 @@ function WPCouponLineItem( {
 	isSummary,
 	hasDeleteButton,
 	removeProductFromCart,
-	createUserAndSiteBeforeTransaction,
-	isPwpoUser,
 	hasPartnerCoupon,
 }: {
 	lineItem: LineItemType;
@@ -328,8 +293,6 @@ function WPCouponLineItem( {
 				isSummary={ isSummary }
 				hasDeleteButton={ hasDeleteButton }
 				removeProductFromCart={ removeProductFromCart }
-				createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-				isPwpoUser={ isPwpoUser }
 			/>
 			{ !! hasPartnerCoupon && <PartnerLogo /> }
 		</div>
@@ -397,160 +360,6 @@ function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRe
 			} ) }
 		</>
 	);
-}
-
-interface ModalCopy {
-	title: string;
-	description: string;
-}
-
-function returnModalCopy(
-	productType: string,
-	translate: ReturnType< typeof useTranslate >,
-	createUserAndSiteBeforeTransaction: boolean,
-	isRenewal = false,
-	product?: ResponseCartProduct
-): ModalCopy {
-	const domainNameString = product ? product.meta : translate( 'your selected domain' );
-
-	switch ( productType ) {
-		case 'gift purchase':
-			return {
-				title: String( translate( 'You are about to remove your gift from the cart' ) ),
-				description: String(
-					translate(
-						'When you press Continue, all gift products in the cart will be removed, and your gift will not be given.'
-					)
-				),
-			};
-		case 'plan with marketplace dependencies':
-			if ( isRenewal ) {
-				return {
-					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
-					description: String(
-						translate(
-							"Some of your other product(s) depend on your plan to be renewed. When you press Continue, the plan renewal will be removed from the cart and your plan will keep its current expiry date. When the plan expires these product(s) will stop working even if they haven't expired yet."
-						)
-					),
-				};
-			}
-
-			return {
-				title: String( translate( 'You are about to remove your plan from the cart' ) ),
-				description: String(
-					translate(
-						'Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, these product(s) along with your new plan will be removed from the cart, and your site will continue to run on its current plan.'
-					)
-				),
-			};
-		case 'plan with domain dependencies': {
-			if ( isRenewal ) {
-				return {
-					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
-					description: String(
-						translate(
-							'When you press Continue, your plan renewal will be removed from the cart and your plan will keep its current expiry date.'
-						)
-					),
-				};
-			}
-			const title = String( translate( 'You are about to remove your plan from the cart' ) );
-			let description = '';
-
-			if ( createUserAndSiteBeforeTransaction ) {
-				description = String(
-					translate(
-						'When you press Continue, your plan will be removed from the cart. Your site will be created with the free plan when you complete payment for the other product(s) in your cart.'
-					)
-				);
-			} else {
-				description = String(
-					translate(
-						'Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, these product(s) will be removed along with your new plan in the cart, and your site will continue to run with its current plan.'
-					)
-				);
-			}
-			return { title, description };
-		}
-		case 'plan':
-			if ( isRenewal ) {
-				return {
-					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
-					description: String(
-						translate(
-							'When you press Continue, your plan renewal will be removed from the cart and your plan will keep its current expiry date.'
-						)
-					),
-				};
-			}
-
-			return {
-				title: String( translate( 'You are about to remove your plan from the cart' ) ),
-				description: String(
-					createUserAndSiteBeforeTransaction
-						? translate( 'When you press Continue, your plan will be removed from the cart.' )
-						: translate(
-								'When you press Continue, your plan will be removed from the cart and your site will continue to run with its current plan.'
-						  )
-				),
-			};
-		case 'domain':
-			if ( isRenewal ) {
-				return {
-					title: String( translate( 'You are about to remove your domain renewal from the cart' ) ),
-					description: String(
-						translate(
-							'When you press Continue, your domain renewal will be removed from the cart and your domain will keep its current expiry date.'
-						)
-					),
-				};
-			}
-
-			return {
-				title: String(
-					translate( 'You are about to remove %(domainName)s from the cart', {
-						args: { domainName: domainNameString },
-					} )
-				),
-				description: String(
-					translate(
-						'When you press Continue, %(domainName)s will be removed from the cart and will become available for anyone to register.',
-						{
-							args: { domainName: domainNameString },
-						}
-					)
-				),
-			};
-		case 'coupon':
-			return {
-				title: String( translate( 'You are about to remove your coupon from the cart' ) ),
-				description: String(
-					translate( 'When you press Continue, you will need to confirm your payment details.' )
-				),
-			};
-		default:
-			if ( isRenewal ) {
-				return {
-					title: String( translate( 'You are about to remove your renewal from the cart' ) ),
-					description: String(
-						translate(
-							'When you press Continue, your renewal will be removed from the cart and your product will keep its current expiry date.'
-						)
-					),
-				};
-			}
-
-			return {
-				title: String( translate( 'You are about to remove your product from the cart' ) ),
-				description: String(
-					createUserAndSiteBeforeTransaction
-						? translate( 'When you press Continue, your product will be removed from the cart.' )
-						: translate(
-								'When you press Continue, your product will be removed from the cart and your site will continue to run without it.'
-						  )
-				),
-			};
-	}
 }
 
 function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ) {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -279,8 +279,6 @@ function WPCouponLineItem( {
 	isSummary?: boolean;
 	hasDeleteButton?: boolean;
 	removeProductFromCart?: () => void;
-	createUserAndSiteBeforeTransaction?: boolean;
-	isPwpoUser?: boolean;
 	hasPartnerCoupon?: boolean;
 } ) {
 	return (
@@ -954,9 +952,7 @@ function CheckoutLineItem( {
 	hasDeleteButton?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
 	isSummary?: boolean;
-	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
-	isPwpoUser?: boolean;
 	onRemoveProduct?: ( label: string ) => void;
 	onRemoveProductClick?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes CHE-29

## Proposed Changes

* When a user attempts to `Remove from cart` an element on the checkout page, we'll skip the dialog that prompted the user to confirm the action.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Removing an item from the cart is an expected action that doesn't require confirmation. This feels unnecessary and alarming as many purchase flows on the web don't have this confirmation dialog.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live preview
* Go to `/add-ons`
* Choose a site
* Click on `Buy add-on`
* On the checkout page, click on `Remove from cart`
* Check that you are redirected to the add-ons page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
