### PR TITLE
Revised the checkbox label for marking a user as an external collaborator

### DIFF
--- a/client/my-sites/people/contractor-select/index.tsx
+++ b/client/my-sites/people/contractor-select/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import InfoPopover from 'calypso/components/info-popover';
 import type { ChangeEventHandler } from 'react';
 
 interface Props {
@@ -27,14 +26,7 @@ const ContractorSelect: FunctionComponent< Props > = ( { id, checked, onChange, 
 					checked={ checked }
 					disabled={ disabled }
 				/>
-				<span>
-					{ translate( 'This user is a contractor, freelancer, consultant, or agency.' ) }
-					<InfoPopover position="top right" screenReaderText={ translate( 'Learn more' ) }>
-						{ translate(
-							'Use this checkbox to flag users who are not a part of your organization.'
-						) }
-					</InfoPopover>
-				</span>
+				<span>{ translate( 'Mark as external collaborator' ) }</span>
 			</FormLabel>
 		</FormFieldset>
 	);


### PR DESCRIPTION
## Proposed Changes

* This PR updates the label on the user form checkbox to designate an external collaborator
* It also removes the redundant tooltip from the label

Fixes: #100410 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the calypso live link or check out this branch locally
* In Calypso, select a simple site and navigate to Users > Add New User
* From the add new user screen, under the email/ username field, confirm that the label next to the checkbox now reads "Mark as external collaborator"

![Screenshot 2025-05-08 at 9 53 04 AM](https://github.com/user-attachments/assets/b17b27e8-8fe4-44ac-8e2d-f3d345506e52)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
