### PR TITLE
Onboarding: Use new PoweredBy component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/test/index.tsx
@@ -47,7 +47,7 @@ describe( 'Onboarding Free Flow - FreeSetup', () => {
 				expect( screen.getByText( 'Personalize your Site' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Site name' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Brief description' ) ).toBeInTheDocument();
-				expect( screen.getByText( 'Jetpack powered' ) ).toBeInTheDocument();
+				expect( screen.getByText( 'Powered by' ) ).toBeInTheDocument();
 				expect( screen.getByText( 'Add a site icon' ) ).toBeInTheDocument();
 			} );
 		} );

--- a/packages/components/src/powered-by/README.md
+++ b/packages/components/src/powered-by/README.md
@@ -24,4 +24,5 @@ export default function Example() {
 
 - `brand` : (string, required) One of `'jetpack'`, `'woocommerce'`, `'wpcom'`
 - `colorVariant` : (string) One of `'color'`, `'black'`, `'white'`. Default is `'color'`
+- `height`: (number) The height of the brand logo. The width is calculated automatically as needed. Default is `25`
 - `className` : (string) Additional CSS class names

--- a/packages/components/src/powered-by/index.tsx
+++ b/packages/components/src/powered-by/index.tsx
@@ -20,6 +20,7 @@ export type PoweredByVariant = 'color' | 'black' | 'white';
 interface PoweredByProps {
 	brand: PoweredByBrand;
 	colorVariant?: PoweredByVariant;
+	height?: number;
 	className?: string;
 }
 
@@ -45,21 +46,25 @@ const getWordPressWordmarkColor = ( colorVariant: PoweredByVariant ) => {
 	}
 };
 
-const PoweredBy = ( { brand, colorVariant = 'color', className }: PoweredByProps ) => {
+const PoweredBy = ( { brand, colorVariant = 'color', height = 25, className }: PoweredByProps ) => {
 	let LogoComponent: React.ReactNode = null;
 
 	switch ( brand ) {
 		case 'jetpack':
-			LogoComponent = <JetpackLogo colorVariant={ colorVariant } size={ 25 } full />;
+			LogoComponent = <JetpackLogo colorVariant={ colorVariant } size={ height } full />;
 			break;
-		case 'woocommerce':
-			LogoComponent = <WooLogo colorVariant={ colorVariant } height={ 25 } width={ 66 } />;
+		case 'woocommerce': {
+			const wooLogoWidth = ( 66 / 25 ) * height;
+			LogoComponent = (
+				<WooLogo colorVariant={ colorVariant } height={ height } width={ wooLogoWidth } />
+			);
 			break;
+		}
 		case 'wpcom':
 			LogoComponent = (
 				<WordPressWordmark
 					color={ getWordPressWordmarkColor( colorVariant ) }
-					size={ { height: 25, width: 'auto' } }
+					size={ { height: height, width: 'auto' } }
 				/>
 			);
 			break;

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -1,4 +1,4 @@
-import { JetpackLogo, WooCommerceWooLogo } from '@automattic/components';
+import { PoweredBy } from '@automattic/components';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ReactElement } from 'react';
@@ -198,7 +198,7 @@ const StepContainer: React.FC< Props > = ( {
 					{ headerButton && <div className="step-container__header-button">{ headerButton }</div> }
 					{ showHeaderJetpackPowered && (
 						<div className="step-container__header-jetpack-powered">
-							<JetpackLogo monochrome size={ 18 } /> <span>{ translate( 'Jetpack powered' ) }</span>
+							<PoweredBy brand="jetpack" />
 						</div>
 					) }
 				</div>
@@ -214,13 +214,13 @@ const StepContainer: React.FC< Props > = ( {
 			) }
 			{ showJetpackPowered && (
 				<div className="step-container__jetpack-powered">
-					<JetpackLogo monochrome size={ 18 } /> <span>{ translate( 'Jetpack powered' ) }</span>
+					<PoweredBy brand="jetpack" colorVariant="black" height={ 18 } />
 				</div>
 			) }
 
 			{ showFooterWooCommercePowered && (
 				<div className="step-container__woocommerce-powered">
-					<WooCommerceWooLogo /> <span>{ translate( 'WooCommerce powered' ) }</span>
+					<PoweredBy brand="woocommerce" colorVariant="black" height={ 18 } />
 				</div>
 			) }
 		</div>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DS-172

## Proposed Changes

 * Replaces manual uses of 'Powered by {logo}' or '{logo} powered' in the onboarding step-container.
 * Also adds a size prop to PoweredBy to retain visual compatibility with the previous manual use.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To improve consistency everywhere we use 'Powered by {logo}' or '{logo} powered'

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Use the Calypso live link to go to /setup/newsletter/newsletterSetup?ref=newsletter-lp
 2. Look at the 'Powered by' logo at the bottom of the page

Before | After
-------|------
<img width="576" alt="Screenshot 2025-05-08 at 15 23 49" src="https://github.com/user-attachments/assets/ded63da6-3c37-4c0a-b60c-58586660c77e" /> | <img width="576" alt="Screenshot 2025-05-08 at 15 23 56" src="https://github.com/user-attachments/assets/e6d8322a-f173-4a4c-be55-49bcb9225271" />


## Pre-merge Checklist

<!--


Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
