### PR TITLE
Domain Search: fix Duplicate "domains are not available for registration" message

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -410,17 +410,6 @@ function getAvailabilityNotice(
 				message = translate( 'Sorry, WordPress.com does not support the %(tld)s TLD.', {
 					args: { tld },
 				} );
-			} else {
-				/* translators: %s: TLD (eg .com, .pl) */
-				message = translate(
-					'{{strong}}.%(tld)s{{/strong}} domains are not available for registration on WordPress.com.',
-					{
-						args: { tld },
-						components: {
-							strong: <strong />,
-						},
-					}
-				);
 			}
 			break;
 		case domainAvailability.UNKNOWN:

--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -54,13 +54,7 @@ describe( 'getAvailabilityNotice()', () => {
 		} );
 	} );
 
-	test( 'Should return default message if TLD is unsupported', () => {
-		expect(
-			getAvailabilityNotice( 'test-domain.se', domainAvailability.TLD_NOT_SUPPORTED, null )
-		).toEqual( { message: 'default', severity: 'error' } );
-	} );
-
-	test( 'Should return no message when domain unavailable, unmappable, unknown, tld not supported, or search results are empty', () => {
+	test( 'Should return no message when domain unavailable, unmappable, unknown or search results are empty', () => {
 		// These are special cases where the error notice should not be handled by client/components/domains/register-domain-step/index.jsx
 		// but in client/components/domains/domain-search-results/index.jsx
 		[


### PR DESCRIPTION
Linear https://linear.app/a8c/issue/NOMADO-157/domain-search-duplicate-domains-are-not-available-for-registration

## Proposed Changes
This PR fixes a regression where duplicate availability notices were being shown when users searched for unsupported TLDs in the domain search interface. The issue was introduced in a [previous PR](https://github.com/Automattic/wp-calypso/pull/94913) that modified the availability message handling logic.

| Before (domain-only) | After (domain-only) |
|--------|--------|
| ![Screenshot 2025-05-09 alle 10 17 57](https://github.com/user-attachments/assets/fde041be-a72d-4fc4-a86f-ba54dc368cf7) | ![Screenshot 2025-05-09 alle 10 18 22](https://github.com/user-attachments/assets/1f08b0ea-eb8b-4e0c-801e-66e4e6aeed73) |

| Before (onboarding) | After (onboarding) |
|--------|--------|
| ![Screenshot 2025-05-09 alle 11 17 51](https://github.com/user-attachments/assets/b40246da-99e4-4054-9351-9c7cda797cb3) | ![Screenshot 2025-05-09 alle 10 19 52](https://github.com/user-attachments/assets/8df6b9c2-d03d-4f23-8e44-6ca879b819cc) |

| Before (add to site) | After (add to site) |
|--------|--------|
| ![Screenshot 2025-05-09 alle 10 56 12](https://github.com/user-attachments/assets/8b3391e3-d28d-4dbb-b08d-c49443d493e2) | ![Screenshot 2025-05-09 alle 10 55 10](https://github.com/user-attachments/assets/0be1639b-66de-4535-83f6-eae21da9ce88) |

## Why are these changes being made?
When searching for a domain with an unsupported TLD (e.g., `.pt`) in the onboarding flow, in the domain-only flow or in the add-domain flow, two identical error messages would appear.

This created a confusing user experience with redundant information.

The fix reverts the changes that caused this regression by:
1. Ensuring that availability notices for unsupported TLDs are only shown once
2. Maintaining the correct message flow between domain availability checks and suggestion results
3. Preserving the proper error handling for unsupported TLDs while eliminating the duplicate messages

## Testing Instructions
Apply this PR and try to search for an usupported tld in each of these flows:
- domain-only (`start/domain`)
- onboarding (`/setup/onboarding/domains`)
- add-domain (`/domains/add/:site`)

Verify that a single error is displayed.
> [!NOTE]  
> It seems that the `connect it` link showed in the message is not working (at least in the onboarding). And the layout is broken as well. I'll create separate tasks to fix those issues. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
