### PR TITLE
Implement field type `media`

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -49,9 +49,9 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	},
 	{
 		id: 'icon.ico',
-		type: 'media',
 		label: __( 'Media' ),
 		render: ( { item }: { item: Site } ) => <SiteIcon site={ item } />,
+		enableSorting: false,
 	},
 	{
 		id: 'subscribers_count',
@@ -113,7 +113,6 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	},
 	{
 		id: 'preview',
-		type: 'media',
 		label: __( 'Preview' ),
 		render: function PreviewRender( { item }: { item: Site } ) {
 			const [ resizeListener, { width } ] = useResizeObserver();
@@ -143,6 +142,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 				</>
 			);
 		},
+		enableSorting: false,
 	},
 ];
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -49,9 +49,9 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	},
 	{
 		id: 'icon.ico',
+		type: 'media',
 		label: __( 'Media' ),
 		render: ( { item }: { item: Site } ) => <SiteIcon site={ item } />,
-		enableSorting: false,
 	},
 	{
 		id: 'subscribers_count',
@@ -113,6 +113,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 	},
 	{
 		id: 'preview',
+		type: 'media',
 		label: __( 'Preview' ),
 		render: function PreviewRender( { item }: { item: Site } ) {
 			const [ resizeListener, { width } ] = useResizeObserver();
@@ -142,7 +143,6 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 				</>
 			);
 		},
-		enableSorting: false,
 	},
 ];
 

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 - Pin the actions column on the table view when the width is insufficient.
 - Bring changes from @wordpress/dataviews 4.19.0 (no updates in this version).

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -633,6 +633,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Image',
 		id: 'image',
+		type: 'media',
 		header: (
 			<HStack spacing={ 1 } justify="start">
 				<Icon icon={ image } />

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -645,7 +645,6 @@ export const fields: Field< SpaceObject >[] = [
 				<img src={ item.image } alt="" style={ { width: '100%' } } />
 			);
 		},
-		enableSorting: false,
 	},
 	{
 		label: 'Title',

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -57,4 +57,5 @@ export default {
 
 		return null;
 	},
+	enableSorting: true,
 };

--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -35,4 +35,5 @@ export default {
 			? renderFromElements( { item, field } )
 			: field.getValue( { item } );
 	},
+	enableSorting: true,
 };

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -11,6 +11,7 @@ import { default as integer } from './integer';
 import { default as text } from './text';
 import { default as datetime } from './datetime';
 import { default as boolean } from './boolean';
+import { default as media } from './media';
 import { renderFromElements } from '../utils';
 
 /**
@@ -36,6 +37,12 @@ export default function getFieldTypeDefinition< Item >( type?: FieldType ) {
 		return boolean;
 	}
 
+	if ( 'media' === type ) {
+		return media;
+	}
+
+	// This is a fallback for fields that don't provide a type.
+	// It can be removed when the field.type is mandatory.
 	return {
 		sort: ( a: any, b: any, direction: SortDirection ) => {
 			if ( typeof a === 'number' && typeof b === 'number' ) {

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -69,5 +69,6 @@ export default function getFieldTypeDefinition< Item >( type?: FieldType ) {
 				? renderFromElements( { item, field } )
 				: field.getValue( { item } );
 		},
+		enableSorting: true,
 	};
 }

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -41,4 +41,5 @@ export default {
 			? renderFromElements( { item, field } )
 			: field.getValue( { item } );
 	},
+	enableSorting: true,
 };

--- a/packages/dataviews/src/field-types/media.tsx
+++ b/packages/dataviews/src/field-types/media.tsx
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import type { SortDirection, ValidationContext } from '../types';
+
+function sort( a: any, b: any, direction: SortDirection ) {
+	return 0;
+}
+
+function isValid( value: any, context?: ValidationContext ) {
+	if ( context?.elements ) {
+		const validValues = context?.elements.map( ( f ) => f.value );
+		if ( ! validValues.includes( value ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+export default {
+	sort,
+	isValid,
+	Edit: 'text',
+	render: () => null,
+};

--- a/packages/dataviews/src/field-types/media.tsx
+++ b/packages/dataviews/src/field-types/media.tsx
@@ -21,6 +21,7 @@ function isValid( value: any, context?: ValidationContext ) {
 export default {
 	sort,
 	isValid,
-	Edit: 'text',
+	Edit: () => null,
 	render: () => null,
+	enableSorting: false,
 };

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -34,4 +34,5 @@ export default {
 			? renderFromElements( { item, field } )
 			: field.getValue( { item } );
 	},
+	enableSorting: true,
 };

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -77,7 +77,10 @@ export function normalizeFields< Item >(
 			isValid,
 			Edit,
 			enableHiding: field.enableHiding ?? true,
-			enableSorting: field.enableSorting ?? true,
+			enableSorting:
+				field.enableSorting ??
+				fieldTypeDefinition.enableSorting ??
+				true,
 		};
 	} );
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -76,6 +76,11 @@ export type FieldTypeDefinition< Item > = {
 	 * Callback used to render the field.
 	 */
 	render: ComponentType< DataViewRenderFieldProps< Item > >;
+
+	/**
+	 * Whether the field is sortable.
+	 */
+	enableSorting: boolean;
 };
 
 /**


### PR DESCRIPTION
Follow-up to https://github.com/wordpress/gutenberg/pull/67278#discussion_r1905408381 and https://github.com/Automattic/wp-calypso/pull/103149#issuecomment-2853850451

## Proposed Changes

Implements the `media` field type.

## Why are these changes being made?

DataViews declares a field type `media`, but there's no implementation for that field type.

So far, the type was used to provide an affordance to switch the media field ([see](https://github.com/wordpress/gutenberg/pull/67278#discussion_r1905408381)). With this PR, fields that set a `media` type would also have sorting disabled by default — though they can override it.

## Testing Instructions

- In the storybook (`yarn workspace @automattic/dataviews storybook:start`):
  - go to the DataViews default story and verify that the "Image" field is not sortable either.
  - in this case, there's only one media type field, so the "media switcher" is not available in the view config. 
