### PR TITLE
Marketplace Thank You: Remove back and contact buttons

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
@@ -1,7 +1,3 @@
-import page from '@automattic/calypso-router';
-import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import MasterbarStyled from '../redesign-v2/masterbar-styled';
 import { hasMultipleProductTypes } from './utils';
 
@@ -10,7 +6,6 @@ export function MarketplaceGoBackSection( {
 	themeSlugs,
 	pluginsGoBackSection,
 	themesGoBackSection,
-	areAllProductsFetched,
 }: {
 	pluginSlugs: string[];
 	themeSlugs: string[];
@@ -21,7 +16,7 @@ export function MarketplaceGoBackSection( {
 	const multipleProductTypes = hasMultipleProductTypes( [ pluginSlugs, themeSlugs ] );
 
 	if ( multipleProductTypes ) {
-		return <DefaultGoBackSection areAllProductsFetched={ areAllProductsFetched } />;
+		return <MasterbarStyled />;
 	}
 
 	if ( pluginSlugs.length > 0 ) {
@@ -33,18 +28,4 @@ export function MarketplaceGoBackSection( {
 	}
 
 	return null;
-}
-
-function DefaultGoBackSection( { areAllProductsFetched }: { areAllProductsFetched: boolean } ) {
-	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
-	return (
-		<MasterbarStyled
-			onClick={ () => page( `/home/${ siteSlug }` ) }
-			backText={ translate( 'Back to dashboard' ) }
-			canGoBack={ areAllProductsFetched }
-			showContact={ areAllProductsFetched }
-		/>
-	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
@@ -4,27 +4,14 @@ import { hasMultipleProductTypes } from './utils';
 export function MarketplaceGoBackSection( {
 	pluginSlugs,
 	themeSlugs,
-	pluginsGoBackSection,
-	themesGoBackSection,
 }: {
 	pluginSlugs: string[];
 	themeSlugs: string[];
-	pluginsGoBackSection: JSX.Element;
-	themesGoBackSection: JSX.Element;
-	areAllProductsFetched: boolean;
 } ): JSX.Element | null {
 	const multipleProductTypes = hasMultipleProductTypes( [ pluginSlugs, themeSlugs ] );
 
-	if ( multipleProductTypes ) {
+	if ( multipleProductTypes || pluginSlugs.length > 0 || themeSlugs.length > 0 ) {
 		return <MasterbarStyled />;
-	}
-
-	if ( pluginSlugs.length > 0 ) {
-		return pluginsGoBackSection;
-	}
-
-	if ( themeSlugs.length > 0 ) {
-		return themesGoBackSection;
 	}
 
 	return null;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -82,7 +82,8 @@ const MarketplaceThankYou = ( {
 		}
 	}, [ dispatch, firstTheme, styleVariationSlug ] );
 
-	const [ hasThemes ] = [ themeSlugs ].map( ( slugs ) => slugs.length !== 0 );
+	const hasPlugins = pluginSlugs.length > 0;
+	const hasThemes = themeSlugs.length > 0;
 
 	const [ title, subtitle ] = usePageTexts( {
 		pluginSlugs,
@@ -102,7 +103,7 @@ const MarketplaceThankYou = ( {
 		allPluginsActivated &&
 		allThemesFetched &&
 		isAtomicTransferCheckComplete &&
-		isLoadedPlugins &&
+		( ! hasPlugins || isLoadedPlugins ) &&
 		( ! hasThemes || isLoadedThemes );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -49,7 +49,6 @@ const MarketplaceThankYou = ( {
 		pluginsSection,
 		allPluginsFetched,
 		allPluginsActivated,
-		pluginsGoBackSection,
 		pluginTitle,
 		pluginSubtitle,
 		pluginsProgressbarSteps,
@@ -61,7 +60,6 @@ const MarketplaceThankYou = ( {
 		firstTheme,
 		themesSection,
 		allThemesFetched,
-		themesGoBackSection,
 		themeTitle,
 		themeSubtitle,
 		themesProgressbarSteps,
@@ -178,13 +176,7 @@ const MarketplaceThankYou = ( {
 					}
 				` }
 			/>
-			<MarketplaceGoBackSection
-				pluginSlugs={ pluginSlugs }
-				pluginsGoBackSection={ pluginsGoBackSection }
-				themeSlugs={ themeSlugs }
-				themesGoBackSection={ themesGoBackSection }
-				areAllProductsFetched={ isPageReady }
-			/>
+			<MarketplaceGoBackSection pluginSlugs={ pluginSlugs } themeSlugs={ themeSlugs } />
 			{ showProgressBar && (
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				<div className="marketplace-plugin-install__root">

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -189,14 +188,7 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		return <ThankYouPluginSection plugin={ plugin } key={ `plugin_${ plugin.slug }` } />;
 	} );
 
-	const goBackSection = (
-		<MasterbarStyled
-			onClick={ () => page( `/plugins/${ siteSlug }` ) }
-			backText={ translate( 'Back to plugins' ) }
-			canGoBack={ allPluginsFetched }
-			showContact={ allPluginsFetched }
-		/>
-	);
+	const goBackSection = <MasterbarStyled />;
 
 	const thankyouSteps = useMemo(
 		() =>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -20,14 +20,12 @@ import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import MasterbarStyled from '../redesign-v2/masterbar-styled';
 import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
 
 type ThankYouData = [
 	React.ReactElement[],
 	boolean,
 	boolean,
-	JSX.Element,
 	string,
 	string,
 	string[],
@@ -188,8 +186,6 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		return <ThankYouPluginSection plugin={ plugin } key={ `plugin_${ plugin.slug }` } />;
 	} );
 
-	const goBackSection = <MasterbarStyled />;
-
 	const thankyouSteps = useMemo(
 		() =>
 			isJetpack
@@ -236,7 +232,6 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		pluginsSection,
 		allPluginsFetched,
 		allPluginsActivated,
-		goBackSection,
 		title,
 		subtitle,
 		thankyouSteps,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -4,7 +4,6 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
@@ -15,7 +14,7 @@ import {
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
-import { getPluginsOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { getPluginsOnSite } from 'calypso/state/plugins/installed/selectors';
 import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg/selectors';
@@ -62,7 +61,6 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		wpComPluginData ? wpComPluginData.software_slug || wpComPluginData.org_slug : pluginSlugs[ i ]
 	);
 
-	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 	const pluginsOnSite: Plugin[] = useSelector( ( state ) =>
 		getPluginsOnSite( state, siteId, softwareSlugs )
 	);
@@ -161,11 +159,23 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 			return;
 		}
 
-		if ( ! isRequestingPlugins ) {
-			waitFor( 1 ).then( () => dispatch( fetchSitePlugins( siteId ) ) );
+		const abortController = new AbortController();
+
+		async function fetchPlugins() {
+			if ( abortController.signal.aborted ) {
+				return;
+			}
+
+			await dispatch( fetchSitePlugins( siteId ) );
+			fetchPlugins();
 		}
+
+		fetchPlugins();
+
+		return () => {
+			abortController.abort();
+		};
 	}, [
-		isRequestingPlugins,
 		dispatch,
 		siteId,
 		transferStatus,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -9,7 +9,7 @@ import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
-import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
 import { clearActivated } from 'calypso/state/themes/actions';
 import {
 	getThemes,
@@ -73,14 +73,6 @@ export function useThemesThankYouData(
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'wpcom_admin_interface' )
-	);
-
-	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
-	const themeUrl =
-		adminInterface === 'wp-admin' ? `${ siteAdminUrl }themes.php` : `/themes/${ siteSlug }`;
-
 	useQueryThemes( 'wpcom', themeSlugs );
 	useQueryThemes( 'wporg', themeSlugs );
 
@@ -96,14 +88,7 @@ export function useThemesThankYouData(
 			);
 		} );
 
-	const goBackSection = (
-		<MasterbarStyled
-			onClick={ () => page( themeUrl ) }
-			backText={ translate( 'Back to dashboard' ) }
-			canGoBack={ allThemesFetched }
-			showContact={ allThemesFetched }
-		/>
-	);
+	const goBackSection = <MasterbarStyled />;
 
 	const thankyouSteps = useMemo(
 		() =>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -18,14 +18,12 @@ import {
 import { hasExternallyManagedThemes as getHasExternallyManagedThemes } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { Theme } from 'calypso/types';
-import MasterbarStyled from '../redesign-v2/masterbar-styled';
 import { ThankYouThemeSection } from './marketplace-thank-you-theme-section';
 
 type ThankYouThemeData = [
 	Theme,
 	React.ReactElement[],
 	boolean,
-	JSX.Element,
 	string,
 	string,
 	string[],
@@ -87,8 +85,6 @@ export function useThemesThankYouData(
 				/>
 			);
 		} );
-
-	const goBackSection = <MasterbarStyled />;
 
 	const thankyouSteps = useMemo(
 		() =>
@@ -178,7 +174,6 @@ export function useThemesThankYouData(
 		firstTheme,
 		themesSection,
 		allThemesFetched,
-		goBackSection,
 		title,
 		subtitle,
 		thankyouSteps,

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
@@ -15,7 +15,7 @@ const MasterbarStyled = ( {
 }: {
 	onClick?: () => void;
 	backText?: string;
-	canGoBack: boolean;
+	canGoBack?: boolean;
 	contact?: JSX.Element | null;
 	showContact?: boolean;
 } ) => (

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -124,7 +124,11 @@ function getPluginsSelector( state, siteIds, pluginFilter ) {
 
 export const getPlugins = createSelector(
 	getPluginsSelector,
-	( state ) => state.plugins.installed.plugins,
+	( state, siteIds ) => [
+		state.plugins.installed.plugins,
+		isRequestingForAllSites( state ),
+		...siteIds.map( ( siteId ) => isRequesting( state, siteId ) ),
+	],
 	( state, siteIds, pluginFilter ) => {
 		return [ siteIds, pluginFilter ].flat().join( '-' );
 	}

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -124,11 +124,7 @@ function getPluginsSelector( state, siteIds, pluginFilter ) {
 
 export const getPlugins = createSelector(
 	getPluginsSelector,
-	( state, siteIds ) => [
-		state.plugins.installed.plugins,
-		isRequestingForAllSites( state ),
-		...siteIds.map( ( siteId ) => isRequesting( state, siteId ) ),
-	],
+	( state ) => state.plugins.installed.plugins,
 	( state, siteIds, pluginFilter ) => {
 		return [ siteIds, pluginFilter ].flat().join( '-' );
 	}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/101591.

## Proposed Changes

The back button blinked because we were firing multiple get plugin requests, which confused the Redux selector.

This PR introduces recursiveness-based plugin fetching instead of an arbitrary interval (which introduced the race condition).

## Testing Instructions

Buy multiple plugins from `/plugins/%s` and verify that you don't see the Back and Contact buttons. Also, verify that you don't get stuck on the white screen.

Test it by:
- purchasing a theme
- purchasing a plugin
- purchasing a plugin and a theme

In all cases, you should be redirected away from the post-checkout installation page.

### Onboarding

Enter `/setup/site-setup?siteSlug=%s` and purchase a partner theme. You should still see the StepContainerV2 top bar in that flow specifically.