### PR TITLE
QrCodeLoginButton: fix Redux selector warning

### DIFF
--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -7,7 +7,6 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { isFormDisabled } from 'calypso/state/login/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
-import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
 import '@automattic/components/styles/wp-button-override.scss';
@@ -17,17 +16,12 @@ type QrCodeLoginButtonProps = {
 	loginUrl: string;
 };
 
-export const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
+export default function QrCodeLoginButton( { loginUrl }: QrCodeLoginButtonProps ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { isDisabled, oauth2Client, isWoo } = useSelector( ( select ) => {
-		return {
-			oauth2Client: getCurrentOAuth2Client( select ) as { id: string },
-			locale: getCurrentLocaleSlug( select ),
-			isWoo: getIsWoo( select ),
-			isDisabled: isFormDisabled( select ),
-		};
-	} );
+	const isDisabled = useSelector( isFormDisabled );
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const isWoo = useSelector( getIsWoo );
 
 	// Is not supported for any oauth 2 client.
 	// n.b this seems to work for woo.com so it's not clear why the above comment is here
@@ -61,6 +55,4 @@ export const QrCodeLoginButton = ( { loginUrl }: QrCodeLoginButtonProps ) => {
 			</span>
 		</Button>
 	);
-};
-
-export default QrCodeLoginButton;
+}

--- a/client/components/social-buttons/stories/shared.tsx
+++ b/client/components/social-buttons/stories/shared.tsx
@@ -4,7 +4,7 @@ import { AppleLoginButton } from '../apple';
 import { GitHubLoginButton } from '../github';
 import { GoogleSocialButton } from '../google';
 import { MagicLoginButton } from '../magic-login';
-import { QrCodeLoginButton } from '../qr-code';
+import QrCodeLoginButton from '../qr-code';
 import { UsernameOrEmailButton } from '../username-or-email';
 import type { StoryFn, StoryObj } from '@storybook/react';
 import './style.scss';


### PR DESCRIPTION
Fixes a Redux selector warning about unstable return values:

<img width="924" alt="Screenshot 2025-05-08 at 19 36 53" src="https://github.com/user-attachments/assets/d8565776-e6da-4b3a-86df-3c3955f1e082" />

The selector code in `QrCodeLoginButton` was a confused mix of Redux and `@wordpress/data`, referencing the `state` as `select`.

I'm also removing double `export` of the same component, keeping only the default export.

## Testing instructions:
Go to `/log-in` and verify the button labeled as "Log in with Jetpack app" is there and that it works--it navigates to the `/log-in/qr` page with a QR code.