### PR TITLE
Application Passwords: Section Redesign

### DIFF
--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, CompactCard, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -26,25 +26,27 @@ function ApplicationPasswordsItem( { password } ) {
 	} );
 
 	return (
-		<li className="application-password-item">
-			<div className="application-password-item__details">
-				<h2 className="application-password-item__name">{ password.name }</h2>
-				<p className="application-password-item__generated">
-					{ translate( 'Generated on %s', {
-						args: moment( password.generated ).format( 'lll' ),
-					} ) }
-				</p>
-			</div>
-			<Button
-				borderless
-				className="application-password-item__revoke"
-				onClick={ () => {
-					dispatch( recordGoogleEvent( 'Me', 'Clicked on Remove Application Password Button' ) );
-					deleteAppPassword( password.ID );
-				} }
-			>
-				<Gridicon icon="cross" />
-			</Button>
+		<li>
+			<CompactCard className="application-password-item">
+				<div className="application-password-item__details">
+					<h2 className="application-password-item__name">{ password.name }</h2>
+					<p className="application-password-item__generated">
+						{ translate( 'Generated on %s', {
+							args: moment( password.generated ).format( 'lll' ),
+						} ) }
+					</p>
+				</div>
+				<Button
+					compact
+					className="application-password-item__revoke"
+					onClick={ () => {
+						dispatch( recordGoogleEvent( 'Me', 'Clicked on Remove Application Password Button' ) );
+						deleteAppPassword( password.ID );
+					} }
+				>
+					<Gridicon icon="trash" />
+				</Button>
+			</CompactCard>
 		</li>
 	);
 }

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useDeleteAppPasswordMutation from 'calypso/data/application-passwords/use-delete-app-password-mutation';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import './style.scss';
 
 function ApplicationPasswordsItem( { password } ) {
@@ -13,6 +13,13 @@ function ApplicationPasswordsItem( { password } ) {
 	const translate = useTranslate();
 
 	const { deleteAppPassword } = useDeleteAppPasswordMutation( {
+		onSuccess() {
+			dispatch(
+				successNotice( translate( 'Application password successfully deleted.' ), {
+					duration: 2000,
+				} )
+			);
+		},
 		onError() {
 			dispatch(
 				errorNotice(

--- a/client/me/application-password-item/style.scss
+++ b/client/me/application-password-item/style.scss
@@ -1,16 +1,20 @@
 .application-password-item {
-	overflow: auto;
+	display: flex;
 }
 
 .application-password-item__details {
-	float: left;
+	flex-grow: 1;
+	flex-shrink: 0;
 }
 
 .application-password-item__generated {
 	color: var(--color-neutral-40);
 	font-size: 0.9em;
+	margin: 0;
 }
 
 .application-password-item__revoke {
-	float: right;
+	align-self: center;
+	flex-grow: 0;
+	flex-shrink: 0;
 }

--- a/client/me/application-password-item/style.scss
+++ b/client/me/application-password-item/style.scss
@@ -4,7 +4,7 @@
 
 .application-password-item__details {
 	flex-grow: 1;
-	flex-shrink: 0;
+	flex-shrink: 1;
 }
 
 .application-password-item__generated {

--- a/client/me/application-passwords/form.jsx
+++ b/client/me/application-passwords/form.jsx
@@ -1,4 +1,4 @@
-import { Card, FormLabel } from '@automattic/components';
+import { FormLabel } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -10,7 +10,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 export default function NewAppPasswordForm( {
-	appPasswords = [],
 	isSubmitting,
 	addingPassword,
 	onSubmit,
@@ -26,7 +25,7 @@ export default function NewAppPasswordForm( {
 	} );
 
 	return (
-		<Card className={ cardClasses }>
+		<div className={ cardClasses }>
 			<form
 				id="add-application-password"
 				className="application-passwords__add-new"
@@ -56,13 +55,11 @@ export default function NewAppPasswordForm( {
 							? translate( 'Generating Password…' )
 							: translate( 'Generate Password' ) }
 					</FormButton>
-					{ appPasswords.length ? (
-						<FormButton isPrimary={ false } type="button" onClick={ onClickCancel }>
-							{ translate( 'Cancel' ) }
-						</FormButton>
-					) : null }
+					<FormButton isPrimary={ false } type="button" onClick={ onClickCancel }>
+						{ translate( 'Cancel' ) }
+					</FormButton>
 				</FormButtonsBar>
 			</form>
-		</Card>
+		</div>
 	);
 }

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,7 +1,7 @@
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment, useState } from 'react';
+import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -49,7 +49,7 @@ function ApplicationPasswords() {
 	};
 
 	return (
-		<Fragment>
+		<div className="application-passwords">
 			<SectionHeader label={ translate( 'Application passwords' ) }>
 				{ ! newAppPassword && (
 					<Button
@@ -115,7 +115,7 @@ function ApplicationPasswords() {
 			{ ! showAddPasswordForm && ! newAppPassword && (
 				<AppPasswordsList appPasswords={ appPasswords } />
 			) }
-		</Fragment>
+		</div>
 	);
 }
 

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState } from 'react';
@@ -64,7 +64,7 @@ function ApplicationPasswords() {
 					</Button>
 				) }
 			</SectionHeader>
-			<Card>
+			<div>
 				{ newAppPassword ? (
 					<NewAppPassword
 						newAppPassword={ newAppPassword }
@@ -110,7 +110,7 @@ function ApplicationPasswords() {
 				</p>
 
 				<AppPasswordsList appPasswords={ appPasswords } />
-			</Card>
+			</div>
 		</Fragment>
 	);
 }

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,5 +1,6 @@
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -21,6 +22,8 @@ function ApplicationPasswords() {
 
 	const [ applicationName, setApplicationName ] = useState( '' );
 	const [ showAddPasswordForm, setShowAddPasswordForm ] = useState( false );
+
+	const isMobile = useMobileBreakpoint();
 
 	const { data: appPasswords } = useAppPasswordsQuery();
 	const {
@@ -61,7 +64,9 @@ function ApplicationPasswords() {
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						<Gridicon icon="plus-small" size={ 16 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-						{ translate( 'Add new application password' ) }
+						{ isMobile
+							? translate( 'Add New', { context: 'application password' } )
+							: translate( 'Add new application password' ) }
 					</Button>
 				) }
 			</SectionHeader>

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,8 +1,9 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, CompactCard, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import SectionHeader from 'calypso/components/section-header';
 import useAppPasswordsQuery from 'calypso/data/application-passwords/use-app-passwords-query';
@@ -64,7 +65,7 @@ function ApplicationPasswords() {
 					</Button>
 				) }
 			</SectionHeader>
-			<div>
+			<CompactCard>
 				{ newAppPassword ? (
 					<NewAppPassword
 						newAppPassword={ newAppPassword }
@@ -77,7 +78,6 @@ function ApplicationPasswords() {
 					/>
 				) : (
 					<NewAppPasswordForm
-						appPasswords={ appPasswords }
 						isSubmitting={ isCreatingAppPassword }
 						addingPassword={ showAddPasswordForm }
 						onSubmit={ ( appName ) => {
@@ -92,25 +92,29 @@ function ApplicationPasswords() {
 					/>
 				) }
 
-				<p className="application-passwords__nobot">
-					<>
-						{ translate(
-							'With Two-Step Authentication active, you can generate a custom password for ' +
-								'each third-party application you authorize to use your WordPress.com account. ' +
-								'You can revoke access for an individual application here if you ever need to.'
-						) }{ ' ' }
-						<InlineSupportLink
-							supportPostId={ 263616 }
-							showIcon={ false }
-							supportLink={ localizeUrl(
-								'https://wordpress.com/support/security/two-step-authentication/application-specific-passwords'
-							) }
-						/>
-					</>
-				</p>
+				{ ! newAppPassword && (
+					<FormSettingExplanation className="application-passwords__explanation">
+						<>
+							{ translate(
+								'With Two-Step Authentication active, you can generate a custom password for ' +
+									'each third-party application you authorize to use your WordPress.com account. ' +
+									'You can revoke access for an individual application here if you ever need to.'
+							) }{ ' ' }
+							<InlineSupportLink
+								supportPostId={ 263616 }
+								showIcon={ false }
+								supportLink={ localizeUrl(
+									'https://wordpress.com/support/security/two-step-authentication/application-specific-passwords'
+								) }
+							/>
+						</>
+					</FormSettingExplanation>
+				) }
+			</CompactCard>
 
+			{ ! showAddPasswordForm && ! newAppPassword && (
 				<AppPasswordsList appPasswords={ appPasswords } />
-			</div>
+			) }
 		</Fragment>
 	);
 }

--- a/client/me/application-passwords/list.jsx
+++ b/client/me/application-passwords/list.jsx
@@ -1,17 +1,12 @@
-import { useTranslate } from 'i18n-calypso';
-import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import AppPasswordItem from 'calypso/me/application-password-item';
 
 export default function AppPasswordsList( { appPasswords = [] } ) {
-	const translate = useTranslate();
-
 	if ( ! appPasswords.length ) {
 		return null;
 	}
 
 	return (
 		<div className="application-passwords__active">
-			<FormSectionHeading>{ translate( 'Active Passwords' ) }</FormSectionHeading>
 			<ul className="application-passwords__list">
 				{ appPasswords.map( ( password ) => (
 					<AppPasswordItem password={ password } key={ password.ID } />

--- a/client/me/application-passwords/new-password.jsx
+++ b/client/me/application-passwords/new-password.jsx
@@ -1,13 +1,54 @@
+import { Button } from '@automattic/components';
+import { Icon, check, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 export default function NewAppPassword( { appName, newAppPassword, onClickDone } ) {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const [ copyStatus, setCopyStatus ] = useState( '' );
+
+	const handleCopyStatus = ( status ) => {
+		setCopyStatus( status );
+		setTimeout( () => {
+			setCopyStatus( '' );
+		}, 2000 );
+	};
+
+	const copyToClipboard = () => {
+		navigator.clipboard
+			.writeText( newAppPassword )
+			.then( () => {
+				handleCopyStatus( 'success' );
+				dispatch(
+					successNotice( translate( 'Application password copied to clipboard.' ), {
+						duration: 2000,
+					} )
+				);
+			} )
+			.catch( () => {
+				handleCopyStatus( 'error' );
+				dispatch(
+					errorNotice( translate( 'There was a problem copying the password.' ), {
+						duration: 2000,
+					} )
+				);
+			} );
+	};
 
 	return (
 		<div className="application-passwords__new-password">
-			<p className="application-passwords__new-password-display">{ newAppPassword }</p>
+			<p className="application-passwords__new-password-display">
+				<>{ newAppPassword }</>
+				<Button compact onClick={ copyToClipboard }>
+					<Icon icon={ 'success' === copyStatus ? check : copy } />
+				</Button>
+			</p>
 
 			<p className="application-passwords__new-password-help">
 				{ translate(

--- a/client/me/application-passwords/new-password.jsx
+++ b/client/me/application-passwords/new-password.jsx
@@ -1,5 +1,5 @@
-import { Button } from '@automattic/components';
-import { Icon, check, copy } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { check, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import FormButton from 'calypso/components/forms/form-button';
@@ -43,12 +43,15 @@ export default function NewAppPassword( { appName, newAppPassword, onClickDone }
 
 	return (
 		<div className="application-passwords__new-password">
-			<p className="application-passwords__new-password-display">
-				<>{ newAppPassword }</>
-				<Button compact onClick={ copyToClipboard }>
-					<Icon icon={ 'success' === copyStatus ? check : copy } />
-				</Button>
-			</p>
+			<div className="application-passwords__new-password-display">
+				<div className="application-passwords__new-password-content">{ newAppPassword }</div>
+				<Button
+					className="application-passwords__new-password-copy"
+					icon={ 'success' === copyStatus ? check : copy }
+					label={ 'success' === copyStatus ? translate( 'Copied!' ) : translate( 'Copy' ) }
+					onClick={ copyToClipboard }
+				/>
+			</div>
 
 			<p className="application-passwords__new-password-help">
 				{ translate(

--- a/client/me/application-passwords/new-password.jsx
+++ b/client/me/application-passwords/new-password.jsx
@@ -1,4 +1,3 @@
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
@@ -7,7 +6,7 @@ export default function NewAppPassword( { appName, newAppPassword, onClickDone }
 	const translate = useTranslate();
 
 	return (
-		<Card className="application-passwords__new-password">
+		<div className="application-passwords__new-password">
 			<p className="application-passwords__new-password-display">{ newAppPassword }</p>
 
 			<p className="application-passwords__new-password-help">
@@ -23,6 +22,6 @@ export default function NewAppPassword( { appName, newAppPassword, onClickDone }
 			<FormButtonsBar>
 				<FormButton onClick={ onClickDone }>{ translate( 'Done' ) }</FormButton>
 			</FormButtonsBar>
-		</Card>
+		</div>
 	);
 }

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -1,3 +1,7 @@
+.application-passwords {
+	margin-bottom: 16px;
+}
+
 .application-passwords__list {
 	list-style-type: none;
 	margin: 0;

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -40,6 +40,6 @@
 	text-align: center;
 }
 
-.application-passwords__nobot {
-	margin-bottom: 0;
+.application-passwords__explanation {
+	margin: 0;
 }

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -27,26 +27,27 @@
 }
 
 .application-passwords__new-password-display {
+	align-items: center;
 	background: var(--color-neutral-0);
 	border: 1px solid var(--color-border-subtle);
+	display: flex;
 	font-size: 200%;
 	font-weight: 600;
-	width: 70%;
-	display: block;
-	text-align: center;
+	justify-content: space-between;
+	letter-spacing: 2px;
 	margin: 10px auto;
 	padding: 5px;
-	letter-spacing: 2px;
-	position: relative;
+	text-align: center;
+	max-width: 70%;
 
-	.button {
-		position: absolute;
-		right: 12px;
-		top: 12px;
-		svg {
-			height: 18px;
-			width: 18px;
-		}
+	.application-passwords__new-password-content {
+		flex-grow: 1;
+		flex-shrink: 1;
+	}
+
+	.application-passwords__new-password-copy {
+		flex-grow: 0;
+		flex-shrink: 0;
 	}
 }
 

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -16,6 +16,10 @@
 
 .application-passwords__new-password {
 	margin-bottom: 1em;
+
+	.form-buttons-bar {
+		text-align: right;
+	}
 }
 
 .application-passwords__new-password-display {
@@ -29,6 +33,17 @@
 	margin: 10px auto;
 	padding: 5px;
 	letter-spacing: 2px;
+	position: relative;
+
+	.button {
+		position: absolute;
+		right: 12px;
+		top: 12px;
+		svg {
+			height: 18px;
+			width: 18px;
+		}
+	}
 }
 
 .application-passwords__new-password-message {

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .application-passwords {
 	margin-bottom: 16px;
 }
@@ -31,7 +34,7 @@
 	background: var(--color-neutral-0);
 	border: 1px solid var(--color-border-subtle);
 	display: flex;
-	font-size: 200%;
+	font-size: 150%;
 	font-weight: 600;
 	justify-content: space-between;
 	letter-spacing: 2px;
@@ -39,6 +42,10 @@
 	padding: 5px;
 	text-align: center;
 	max-width: 70%;
+
+	@include break-mobile {
+		font-size: 200%;
+	}
 
 	.application-passwords__new-password-content {
 		flex-grow: 1;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-12880

## Proposed Changes

Redesign the Application Password section in the Security settings, as suggested by design.

In detail:

* Update the explanation for consistency with other form explanations (smaller text, italic, lighter color). It's now hidden when the new password screen is displayed.
* Remove the existing passwords list header and wrap items in `CompactCard` containers, for consistency with the Security Key section in the same page. Also hide the list when adding a new password.
* Replace the `cross` delete icon with `trash` as appropriate. Also add a success notice when deleting a password.
* Remove the unnecessary card-in-a-card for the form and new password containers.
* Add a copy button to the new password. The icon turns into a checkmark on click. The action also displays a success or error notice.
* Align the "Done" button to the right to avoid double-clicks on "Generate Password" accidentally dismissing the new password screen.

| Before | After |
|--------|--------|
| ![01_before](https://github.com/user-attachments/assets/64474717-44d0-4557-9651-e249245f3987) | ![01_after](https://github.com/user-attachments/assets/4873b996-0759-480d-85f4-a4b4b38cacf2) |
| ![02_before](https://github.com/user-attachments/assets/be40eaf6-9af4-4d53-939d-7b4a842e7975) | ![02_after](https://github.com/user-attachments/assets/499c71d2-840a-463b-9b8d-309692e143d5) |
| ![03_before](https://github.com/user-attachments/assets/b1beb4be-fd1d-4fa6-8a86-d4f129e15087) | ![03_after_updated](https://github.com/user-attachments/assets/111fefda-5e68-4a0a-9f1a-a864b313d6a3) |
| ![04_before](https://github.com/user-attachments/assets/9e62e0ce-cc13-4e56-bf0c-f07cc027cd81) | ![04_after](https://github.com/user-attachments/assets/00167936-3d5d-4a74-8229-e84322ff7f40) |
| ![05_before](https://github.com/user-attachments/assets/cdaad571-764b-453f-8c07-589e656e14dd) | ![05_after](https://github.com/user-attachments/assets/a2692c9e-a1bf-4a25-9d26-d6fb7c6ea9df) | 

## Additional Notes for Design

@matt-west @fditrapani

The new password element is a regular `p`, not an input field. For this reason I've added the Copy button as an absolutely positioned element on top of if.

I'm not convinced this is the right thing to do, as on smaller screen the button would cover the password.

I wonder if I should entirely replace the element with a `InputControl` as recommended originally. It would need to be disabled, which I think carries its own a11y concerns. 🤔 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enter My Profile (`/me`).
* Navigate to Security -> Two-Step Authentication.
* Scroll to the bottom to find the Application Passwords section.
* Play around with it and confirm it looks as advertised and feels good to use.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
