### PR TITLE
Fix notification settings checkboxes

### DIFF
--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -1,8 +1,8 @@
+import { CheckboxControl } from '@wordpress/components';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import { isFetchingNotificationsSettings } from 'calypso/state/notification-settings/selectors';
 import { NOTIFICATIONS_EXCEPTIONS } from './constants';
 
@@ -35,7 +35,8 @@ class StreamOptions extends PureComponent {
 					return (
 						<li className="notification-settings-form-stream-options__item" key={ index }>
 							{ isException ? null : (
-								<FormCheckbox
+								<CheckboxControl
+									__nextHasNoMarginBottom
 									disabled={ this.props.isFetching }
 									checked={ get( this.props.settings, setting ) }
 									onChange={ () => {

--- a/client/me/notification-settings/settings-form/style.scss
+++ b/client/me/notification-settings/settings-form/style.scss
@@ -83,7 +83,7 @@
 
 .notification-settings-form-stream-options {
 	color: var(--color-neutral-light);
-	margin: 20px 0 10px;
+	margin: 15px 0 10px;
 	display: block;
 }
 
@@ -91,4 +91,10 @@
 	display: flex;
 	height: 40px;
 	justify-content: center;
+	align-items: center;
+
+	// wp component override: margin originally designed for spacing the label to the right of the checkbox
+	& .components-checkbox-control__input-container {
+		margin-right: 0;
+	}
 }

--- a/client/me/notification-settings/wpcom-settings/email-category.jsx
+++ b/client/me/notification-settings/wpcom-settings/email-category.jsx
@@ -1,8 +1,8 @@
 import { FormLabel } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
 import { toggleWPcomEmailSetting } from 'calypso/state/notification-settings/actions';
@@ -24,8 +24,11 @@ class EmailCategory extends Component {
 			<FormFieldset>
 				<FormLegend>{ this.props.title }</FormLegend>
 				<FormLabel>
-					<FormCheckbox checked={ this.props.isEnabled } onChange={ this.toggleSetting } />
-					<span>{ this.props.description }</span>
+					<CheckboxControl
+						checked={ this.props.isEnabled }
+						onChange={ this.toggleSetting }
+						label={ this.props.description }
+					/>
 				</FormLabel>
 			</FormFieldset>
 		);


### PR DESCRIPTION
Part of DOTCOM-13026
Part of DOTCOM-13048

## Proposed Changes
This PR replaces checkboxes on Notification settings with WP component CheckboxControl. It also addresses a minor refactor for the onChange handler as the component doesn't expose the event but a simple "checked" (boolean) value.


## Why are these changes being made?
Because of a design review: DOTCOM-12890

## Testing Instructions
Head to Notification Settings. Navigate tabs there (Notifications, Comments, Updates and Email Susbscriptions). See all checkbox instances are now using WP Component blue checkbox.

Verify functionality is not affected, both on UI as backend responses/settings.

| Before | After |
|--------|--------|
| <img width="683" alt="image" src="https://github.com/user-attachments/assets/3bfa4c10-6f87-4837-b621-5d6bce5ad7ff" /> | <img width="688" alt="image" src="https://github.com/user-attachments/assets/377f042e-d4db-4b74-a480-426dc8183c03" /> |
| <img width="688" alt="image" src="https://github.com/user-attachments/assets/f2818c80-3788-4e83-bf5a-e3cb04a03177" /> | <img width="687" alt="image" src="https://github.com/user-attachments/assets/02054048-0bfd-4177-858e-d8c90bcc4802" /> |
| <img width="677" alt="image" src="https://github.com/user-attachments/assets/559c3c30-4729-4c20-aa5e-1858387cc929" /> | <img width="712" alt="image" src="https://github.com/user-attachments/assets/e8820af6-8765-473b-b68c-6b4b010273eb" /> |
| <img width="701" alt="image" src="https://github.com/user-attachments/assets/03424d33-9d15-45fa-a7e2-7cea14d34b75" /> | <img width="553" alt="image" src="https://github.com/user-attachments/assets/1036d241-4fe4-4899-b337-b15073a6efbe" /> | 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
