### PR TITLE
StepContainerV2: Add FixedColumnOnTheLeftLayout

### DIFF
--- a/packages/onboarding/src/step-container-v2/components/ContentRow/ContentRow.tsx
+++ b/packages/onboarding/src/step-container-v2/components/ContentRow/ContentRow.tsx
@@ -7,14 +7,18 @@ export const ContentRow = ( {
 	children,
 	columns = 12,
 	className,
+	stretched,
 }: {
 	children: ReactNode;
 	columns?: number;
 	className?: string;
+	stretched?: boolean;
 } ) => {
 	return (
 		<div
-			className={ clsx( 'step-container-v2__content-row', className ) }
+			className={ clsx( 'step-container-v2__content-row', className, {
+				stretched,
+			} ) }
 			style={ { '--columns': columns } as CSSProperties }
 		>
 			{ children }

--- a/packages/onboarding/src/step-container-v2/components/ContentRow/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentRow/style.scss
@@ -15,4 +15,8 @@
 
 		max-width: calc( var( --total-gap-width ) + var( --total-column-width ) );
 	}
+
+	&.stretched {
+		align-self: stretch;
+	}
 }

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/ContentWrapper.tsx
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/ContentWrapper.tsx
@@ -6,14 +6,19 @@ import './style.scss';
 export const ContentWrapper = ( {
 	children,
 	centerAligned,
+	axisDirection = 'vertical',
+	noTopPadding = false,
 }: {
 	children: ReactNode;
 	centerAligned?: boolean;
+	axisDirection?: 'vertical' | 'horizontal';
+	noTopPadding?: boolean;
 } ) => {
 	return (
 		<div
-			className={ clsx( 'step-container-v2__content-wrapper', {
+			className={ clsx( 'step-container-v2__content-wrapper', `axis-${ axisDirection }`, {
 				'center-aligned': centerAligned,
+				'no-top-padding': noTopPadding,
 			} ) }
 		>
 			{ children }

--- a/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/ContentWrapper/style.scss
@@ -3,15 +3,26 @@
 
 .step-container-v2__content-wrapper {
 	display: flex;
-	flex-direction: column;
 	align-items: center;
 	gap: 3rem;
 	width: 100%;
 	box-sizing: border-box;
 	flex: 1;
 
+	&.axis-vertical {
+		flex-direction: column;
+	}
+
+	&.axis-horizontal {
+		flex-direction: row;
+	}
+
 	padding: var( --step-container-v2-content-block-padding )
 		var( --step-container-v2-content-inline-padding );
+
+	&.no-top-padding {
+		padding-top: 0;
+	}
 
 	--step-container-v2-content-max-width: 1344px;
 

--- a/packages/onboarding/src/step-container-v2/helpers/wireframe-placeholder.tsx
+++ b/packages/onboarding/src/step-container-v2/helpers/wireframe-placeholder.tsx
@@ -2,10 +2,12 @@ export function WireframePlaceholder( {
 	height,
 	children,
 	className,
+	style: additionalStyle,
 }: {
 	height?: React.CSSProperties[ 'height' ];
 	children?: React.ReactNode;
 	className?: string;
+	style?: React.CSSProperties;
 } ) {
 	const style = {
 		background: '#ff80ff',
@@ -15,6 +17,7 @@ export function WireframePlaceholder( {
 		alignItems: 'center',
 		justifyContent: 'center',
 		...( height && { height } ),
+		...additionalStyle,
 	} as const;
 
 	return (

--- a/packages/onboarding/src/step-container-v2/index.tsx
+++ b/packages/onboarding/src/step-container-v2/index.tsx
@@ -20,3 +20,4 @@ export { TwoColumnLayout } from './wireframes/TwoColumnLayout/TwoColumnLayout';
 export { WideLayout } from './wireframes/WideLayout/WideLayout';
 export { Loading } from './wireframes/Loading/Loading';
 export { PlaygroundLayout } from './wireframes/PlaygroundLayout/PlaygroundLayout';
+export { FixedColumnOnTheLeftLayout } from './wireframes/FixedColumnOnTheLeftLayout/FixedColumnOnTheLeftLayout';

--- a/packages/onboarding/src/step-container-v2/wireframes/FixedColumnOnTheLeftLayout/FixedColumnOnTheLeftLayout.stories.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/FixedColumnOnTheLeftLayout/FixedColumnOnTheLeftLayout.stories.tsx
@@ -1,0 +1,51 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { TopBar, BackButton, PrimaryButton, StickyBottomBar, LinkButton } from '../..';
+import { WireframePlaceholder } from '../../helpers/wireframe-placeholder';
+import { withStepContainerV2ContextDecorator } from '../../helpers/withStepContainerV2ContextDecorator';
+import { FixedColumnOnTheLeftLayout } from './FixedColumnOnTheLeftLayout';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta< typeof FixedColumnOnTheLeftLayout > = {
+	title: 'Onboarding/StepWireframes/FixedColumnOnTheLeftLayout',
+	component: FixedColumnOnTheLeftLayout,
+	decorators: [ withStepContainerV2ContextDecorator ],
+};
+
+export default meta;
+
+export const ThreeColumnsOnTheLeft = () => (
+	<FixedColumnOnTheLeftLayout
+		fixedColumnWidth={ 3 }
+		topBar={
+			<TopBar
+				leftElement={ <BackButton /> }
+				rightElement={
+					<span>
+						Need help? <LinkButton>Contact us</LinkButton>
+					</span>
+				}
+			/>
+		}
+		heading={
+			<FixedColumnOnTheLeftLayout.Heading
+				text="Fixed Column on the Left"
+				subText={ createInterpolateElement(
+					'An example of the <code>FixedColumnOnTheLeftLayout</code> wireframe layout.',
+					{
+						code: <code />,
+					}
+				) }
+			/>
+		}
+		stickyBottomBar={ ( context ) => {
+			if ( context.isLargeViewport ) {
+				return null;
+			}
+
+			return <StickyBottomBar rightElement={ <PrimaryButton /> } />;
+		} }
+	>
+		<WireframePlaceholder style={ { flex: 1 } }>Sidebar</WireframePlaceholder>
+		<WireframePlaceholder height="100%">Main</WireframePlaceholder>
+	</FixedColumnOnTheLeftLayout>
+);

--- a/packages/onboarding/src/step-container-v2/wireframes/FixedColumnOnTheLeftLayout/FixedColumnOnTheLeftLayout.tsx
+++ b/packages/onboarding/src/step-container-v2/wireframes/FixedColumnOnTheLeftLayout/FixedColumnOnTheLeftLayout.tsx
@@ -1,0 +1,69 @@
+import { ComponentProps, ReactNode } from 'react';
+import { ContentRow } from '../../components/ContentRow/ContentRow';
+import { ContentWrapper } from '../../components/ContentWrapper/ContentWrapper';
+import { Heading } from '../../components/Heading/Heading';
+import { StepContainerV2 } from '../../components/StepContainerV2/StepContainerV2';
+import { ContentProp } from '../../components/StepContainerV2/context';
+import { StickyBottomBarRenderer } from '../../components/StickyBottomBar/StickyBottomBarRenderer';
+import { TopBarRenderer } from '../../components/TopBar/TopBarRenderer';
+import './style.scss';
+
+interface FixedColumnOnTheLeftLayoutProps {
+	topBar?: ContentProp;
+	heading?: ReactNode;
+	footer?: ReactNode;
+	children: [ ContentProp, ContentProp ];
+	stickyBottomBar?: ContentProp;
+	fixedColumnWidth: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+}
+
+const FixedColumnOnTheLeftLayout = ( {
+	fixedColumnWidth,
+	children,
+	topBar,
+	heading,
+	footer,
+	stickyBottomBar,
+}: FixedColumnOnTheLeftLayoutProps ) => {
+	return (
+		<StepContainerV2>
+			{ ( context ) => {
+				const [ fixedColumn, secondColumn ] = children.map( ( child ) => {
+					if ( typeof child === 'function' ) {
+						return child( context );
+					}
+					return child;
+				} );
+
+				return (
+					<>
+						<TopBarRenderer topBar={ topBar } />
+						<ContentWrapper
+							axisDirection={ context.isLargeViewport ? 'horizontal' : 'vertical' }
+							noTopPadding={ context.isLargeViewport }
+						>
+							<ContentRow
+								columns={ context.isLargeViewport ? fixedColumnWidth : undefined }
+								stretched
+								className="step-container-v2--fixed-column-on-the-left-layout__fixed-column"
+							>
+								{ heading }
+								{ fixedColumn }
+								{ footer }
+							</ContentRow>
+							<ContentRow stretched>{ secondColumn }</ContentRow>
+						</ContentWrapper>
+						<StickyBottomBarRenderer stickyBottomBar={ stickyBottomBar } />
+					</>
+				);
+			} }
+		</StepContainerV2>
+	);
+};
+
+// eslint-disable-next-line react/display-name
+FixedColumnOnTheLeftLayout.Heading = ( props: ComponentProps< typeof Heading > ) => (
+	<Heading { ...props } align="left" size="small" />
+);
+
+export { FixedColumnOnTheLeftLayout };

--- a/packages/onboarding/src/step-container-v2/wireframes/FixedColumnOnTheLeftLayout/style.scss
+++ b/packages/onboarding/src/step-container-v2/wireframes/FixedColumnOnTheLeftLayout/style.scss
@@ -1,0 +1,14 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+.step-container-v2--fixed-column-on-the-left-layout {
+	&__fixed-column {
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+
+		@include break-large {
+			padding-top: 1.5rem;
+		}
+	}
+}


### PR DESCRIPTION
Part of DOTOBRD-64.

## Proposed Changes

Adds the wireframe, which can be used in the Design Preview, as well as Migration Instructions (purpose of this PR.)

Later on, we can refactor the design picker so it uses this wireframe instead of `WideLayout`.

https://github.com/user-attachments/assets/51cb0b79-d024-42a3-8300-fd1b85da1741

## Testing Instructions

Run `yarn workspace @automattic/onboarding storybook:start` to see the wireframe in action.

