### PR TITLE
redirect to site-migration/identify after clicking back on wix importer

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -556,7 +556,7 @@ const siteSetupFlow: Flow = {
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
-					return navigate( `import?siteSlug=${ siteSlug }` );
+					return goToFlow( `site-migration?siteSlug=${ siteSlug }` );
 
 				case 'options':
 					return navigate( 'goals' );

--- a/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/flows/site-setup-flow/site-setup-flow.ts
@@ -552,11 +552,12 @@ const siteSetupFlow: Flow = {
 
 					return goToFlow( `site-migration?siteSlug=${ siteSlug }` );
 				case 'importerWix':
+					return goToFlow( `site-migration?siteSlug=${ siteSlug }` );
 				case 'importReady':
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
-					return goToFlow( `site-migration?siteSlug=${ siteSlug }` );
+					return navigate( `import?siteSlug=${ siteSlug }` );
 
 				case 'options':
 					return navigate( 'goals' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCON-34

## Proposed Changes

Stop navigating  to site-setup/import from wix Importer and the intermediate steps in the old capture step. Instead, navigate to the new /setup/migration-flow

This should be merged if we decide to keep the Wix importer as is. More info on the Linear issue

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

After merging [this PR](https://github.com/Automattic/wp-calypso/pull/103179) I found that there was still people seeing the old capture step. I found out that some of them came from the wix importer and that's the reason for this change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the calypso.live link below
* Navigate to the `/start`, pick a free site and choose Import or migrate an existing site
* Enter a wix site in the Identify your site step
* The Wix importer will kick in
* Verify that clicking < Back takes you to **/setup/site-migration/site-migration-identify**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
