### PR TITLE
Plan cancellation: Fix incorrect math when the domain transfer is taxable

### DIFF
--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -119,12 +119,10 @@ const CancelPurchaseDomainOptions = ( {
 		<div>
 			<p>
 				{ translate(
-					'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					'This plan includes a domain transfer, %(domain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
 					{
 						args: {
 							domain: includedDomainTransfer.meta,
-							domainCost: includedDomainTransfer.priceText,
 						},
 					}
 				) }
@@ -135,7 +133,7 @@ const CancelPurchaseDomainOptions = ( {
 						'minus %(domainCost)s for the domain.',
 					{
 						args: {
-							domainCost: includedDomainTransfer.priceText,
+							domainCost: includedDomainTransfer.costToUnbundleText,
 							planCost: planCostText,
 							refundAmount: purchase.refundText,
 						},


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-735/plan-cancellation-fix-incorrect-math-when-the-domain-transfer-is

## Proposed Changes

This is essentially the same fix as https://github.com/Automattic/wp-calypso/pull/103047, but applied to domain transfers also (now that https://github.com/Automattic/wp-calypso/pull/102997 is in).

### Before

![before](https://github.com/user-attachments/assets/32cf26e1-ef0d-4f37-9284-9b49c7b0e65f)

### After

![after](https://github.com/user-attachments/assets/ef49ee1d-5e03-4619-a960-bd05fff2fa0c)

## Testing Instructions

1. Purchase a plan and domain transfer (free with the plan), using a postal code where taxes are charged on domains (United States postal code 98101 works). To buy a domain transfer in store sandbox mode you can use PCYsg-IA-p2#testing-domain-transfers
2. Go to cancel the plan, and compare your results with the above screenshots.  With the pull request applied the math will be correct, whereas previously it wouldn't be.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?