### PR TITLE
Plan cancellation: Fix incorrect message when cancelling a nonrefundable plan that has a domain transfer

### DIFF
--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -218,14 +218,13 @@ const CancelPurchaseDomainOptions = ( {
 	}
 
 	if ( includedDomainTransfer ) {
-
 		if ( ! isRefundable( purchase ) ) {
 			return (
 				<NonRefundablePurchaseWithDomainTransferMessage
-				includedDomainTransfer={ includedDomainTransfer }
-				purchase={ purchase }
-				planCostText={ planCostText }
-			/>
+					includedDomainTransfer={ includedDomainTransfer }
+					purchase={ purchase }
+					planCostText={ planCostText }
+				/>
 			);
 		}
 

--- a/client/me/purchases/cancel-purchase/domain-options.jsx
+++ b/client/me/purchases/cancel-purchase/domain-options.jsx
@@ -86,7 +86,11 @@ const NonRefundableDomainPurchaseMessage = ( { includedDomainPurchase } ) => {
 	);
 };
 
-const DomainTransferMessage = ( { includedDomainTransfer, planCostText, purchase } ) => {
+const RefundablePurchaseWithDomainTransferMessage = ( {
+	includedDomainTransfer,
+	planCostText,
+	purchase,
+} ) => {
 	const translate = useTranslate();
 	return (
 		<div>
@@ -111,6 +115,26 @@ const DomainTransferMessage = ( { includedDomainTransfer, planCostText, purchase
 							domainCost: includedDomainTransfer.priceText,
 							planCost: planCostText,
 							refundAmount: purchase.refundText,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};
+
+const NonRefundablePurchaseWithDomainTransferMessage = ( { includedDomainTransfer } ) => {
+	const translate = useTranslate();
+	return (
+		<div>
+			<p>
+				{ translate(
+					'This plan includes a domain transfer, %(domain)s, normally a %(domainCost)s purchase. ' +
+						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.',
+					{
+						args: {
+							domain: includedDomainTransfer.meta,
+							domainCost: includedDomainTransfer.priceText,
 						},
 					}
 				) }
@@ -194,8 +218,19 @@ const CancelPurchaseDomainOptions = ( {
 	}
 
 	if ( includedDomainTransfer ) {
+
+		if ( ! isRefundable( purchase ) ) {
+			return (
+				<NonRefundablePurchaseWithDomainTransferMessage
+				includedDomainTransfer={ includedDomainTransfer }
+				purchase={ purchase }
+				planCostText={ planCostText }
+			/>
+			);
+		}
+
 		return (
-			<DomainTransferMessage
+			<RefundablePurchaseWithDomainTransferMessage
 				includedDomainTransfer={ includedDomainTransfer }
 				purchase={ purchase }
 				planCostText={ planCostText }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-736/plan-cancellation-fix-incorrect-message-when-cancelling-a

## Proposed Changes

In reviewing https://github.com/Automattic/wp-calypso/pull/102997 (partly done in https://github.com/Automattic/wp-calypso/issues/101341) I made a mistake and led the issue a bit astray.

I correctly noted that the message should not be describing the domain transfer differently based on its refund status.

What I missed is that the code was actually checking the refund status of the **plan**, and that it actually is important to differentiate the text based on that (just not in the way we were doing in that issue).

The end result is a nonsensical message in the case where you have a domain transfer attached to a plan and the plan is outside the refund window and you go to cancel the plan.  This pull request fixes it.

### Before

![before](https://github.com/user-attachments/assets/6326495c-aed3-440f-872c-984a6a6603df)

### After

![after](https://github.com/user-attachments/assets/20127ac4-48e4-4e4f-86c2-4585156c042b)

## Testing Instructions

1. Purchase a plan and domain transfer (free with the plan). To buy a domain transfer in store sandbox mode you can use PCYsg-IA-p2#testing-domain-transfers
2. Wait until the plan is outside the refund window. If you don't want to wait, you can just change the `Store_Subscription::is_refundable()` server-side code on your sandbox to return `false` unconditionally.
3. Go to cancel the plan, and compare your results with the above screenshots.

You can also check that if the plan is still within its refund window, this pull request has no effect.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?