### PR TITLE
Notification settings: move jabber setup section to bottom group of toggles

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -187,6 +187,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/invite-people/',
 		post_id: 1221,
 	},
+	'jabber-subscription-updates': {
+		link: 'https://wordpress.com/support/jabber',
+		post_id: 3228,
+	},
 	'manage-profile': {
 		link: 'https://wordpress.com/support/manage-my-profile/',
 		post_id: 19775,

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -156,23 +156,6 @@ class NotificationSubscriptions extends Component {
 						</FormFieldset>
 
 						<FormFieldset>
-							<FormLegend>{ this.props.translate( 'Jabber subscription delivery' ) }</FormLegend>
-							<FormLabel>
-								<FormCheckbox
-									checked={ this.props.getSetting( 'subscription_delivery_jabber_default' ) }
-									disabled={ this.props.getDisabledState() }
-									id="subscription_delivery_jabber_default"
-									name="subscription_delivery_jabber_default"
-									onChange={ this.props.toggleSetting }
-									onClick={ this.handleCheckboxEvent( 'Notification delivery by Jabber' ) }
-								/>
-								<span>
-									{ this.props.translate( 'Default delivery via Jabber instant message' ) }
-								</span>
-							</FormLabel>
-						</FormFieldset>
-
-						<FormFieldset>
 							<FormLabel htmlFor="subscription_delivery_mail_option">
 								{ this.props.translate( 'Email delivery format' ) }
 							</FormLabel>
@@ -238,6 +221,23 @@ class NotificationSubscriptions extends Component {
 									'When choosing daily or weekly email delivery, which time of day would you prefer?'
 								) }
 							</FormSettingExplanation>
+						</FormFieldset>
+
+						<FormFieldset>
+							<FormLegend>{ this.props.translate( 'Jabber subscription delivery' ) }</FormLegend>
+							<FormLabel>
+								<FormCheckbox
+									checked={ this.props.getSetting( 'subscription_delivery_jabber_default' ) }
+									disabled={ this.props.getDisabledState() }
+									id="subscription_delivery_jabber_default"
+									name="subscription_delivery_jabber_default"
+									onChange={ this.props.toggleSetting }
+									onClick={ this.handleCheckboxEvent( 'Notification delivery by Jabber' ) }
+								/>
+								<span>
+									{ this.props.translate( 'Default delivery via Jabber instant message' ) }
+								</span>
+							</FormLabel>
 						</FormFieldset>
 
 						<FormFieldset>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -11,6 +11,7 @@ import FormLegend from 'calypso/components/forms/form-legend';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -235,7 +236,11 @@ class NotificationSubscriptions extends Component {
 									onClick={ this.handleCheckboxEvent( 'Notification delivery by Jabber' ) }
 								/>
 								<span>
-									{ this.props.translate( 'Default delivery via Jabber instant message' ) }
+									{ this.props.translate( 'Receive subscription updates via instant message.' ) }{ ' ' }
+									<InlineSupportLink
+										supportContext="jabber-subscription-updates"
+										showIcon={ false }
+									/>
 								</span>
 							</FormLabel>
 						</FormFieldset>


### PR DESCRIPTION


Part of DOTCOM-13035

## Proposed Changes
This PR moves the Jabber notification setting/toggle down, on top of "Pause emails" toggle.

## Why are these changes being made?
Because of a design review: DOTCOM-12890

## Testing Instructions

Visit the Notification Settings, navigate to Email Subscriptions tab. See the Jabber checkbox should be on top of "Pause emails" setting.
<img width="690" alt="image" src="https://github.com/user-attachments/assets/6d538f79-a367-4f45-9e34-1f266d2b48a6" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
