### PR TITLE
STATS-52: New header for email stats details

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -1,6 +1,9 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Spinner } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Button as CoreButton } from '@wordpress/components';
+import clsx from 'clsx';
 import { localize, translate } from 'i18n-calypso';
 import { find, flowRight } from 'lodash';
 import moment from 'moment';
@@ -19,6 +22,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import memoizeLast from 'calypso/lib/memoize-last';
+import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsEmailModule from 'calypso/my-sites/stats/stats-email-module';
@@ -186,6 +190,7 @@ class StatsEmailDetail extends Component {
 			statType,
 			hasValidDate,
 			showNoDataInfo,
+			showViewLink,
 		} = this.props;
 		const { maxBars } = this.state;
 
@@ -201,6 +206,28 @@ class StatsEmailDetail extends Component {
 		const query = memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ traffic.path }/{{ interval }}/${ postId }${ slugPath }`;
+
+		// TODO: Refactor navigationItems to a single object with backLink and title attributes.
+		const navigationItems = this.getNavigationItemsWithTitle( this.getTitle() );
+
+		const backLinkProps = {
+			text: navigationItems[ 0 ].label,
+			url: navigationItems[ 0 ].href,
+		};
+		const titleProps = {
+			title: navigationItems[ 1 ].label,
+			// Remove the default logo for Odyssey stats.
+			titleLogo: null,
+		};
+
+		let actionLabel;
+		const postType = post && post.type !== null ? post.type : 'post';
+		if ( postType === 'page' ) {
+			actionLabel = translate( 'View Page' );
+		} else {
+			actionLabel = translate( 'View Post' );
+		}
+
 		return (
 			<>
 				<Main className="has-fixed-nav stats__email-detail stats">
@@ -223,9 +250,24 @@ class StatsEmailDetail extends Component {
 						path="/stats/email/:statType/:site/:period/:email_id"
 						title="Stats > Single Email"
 					/>
-					<NavigationHeader
-						navigationItems={ this.getNavigationItemsWithTitle( this.getNavigationTitle() ) }
-					/>
+
+					{ config.isEnabled( 'stats/navigation-improvement' ) ? (
+						<PageHeader
+							backLinkProps={ backLinkProps }
+							titleProps={ titleProps }
+							rightSection={
+								showViewLink && (
+									<CoreButton onClick={ this.openPreview } variant="primary">
+										<span>{ actionLabel }</span>
+									</CoreButton>
+								)
+							}
+						/>
+					) : (
+						<NavigationHeader
+							navigationItems={ this.getNavigationItemsWithTitle( this.getNavigationTitle() ) }
+						/>
+					) }
 
 					{ ! isRequestingStats && ! countViews && post && (
 						<EmptyContent
@@ -242,7 +284,11 @@ class StatsEmailDetail extends Component {
 					) }
 					{ post ? (
 						<>
-							<div className="stats-navigation stats-navigation--modernized">
+							<div
+								className={ clsx( 'stats-navigation', 'stats-navigation--modernized', {
+									'stats-navigation--improved': config.isEnabled( 'stats/navigation-improvement' ),
+								} ) }
+							>
 								<StatsDetailsNavigation
 									postId={ postId }
 									period={ period }

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -29,7 +29,7 @@ import StatsEmailModule from 'calypso/my-sites/stats/stats-email-module';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSitePost } from 'calypso/state/posts/selectors';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
 import { getEmailStat, isRequestingEmailStats } from 'calypso/state/stats/emails/selectors';
 import { getPeriodWithFallback, getCharts } from 'calypso/state/stats/emails/utils';
@@ -405,6 +405,8 @@ const connectComponent = connect(
 	( state, ownProps ) => {
 		const { postId, statType, isValidStartDate } = ownProps;
 		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isPreviewable = isSitePreviewable( state, siteId );
 		const postFallback = getPostStat( state, siteId, postId, 'post' );
 		const post = getSitePost( state, siteId, postId ) ?? {
 			title: postFallback?.post_title,
@@ -443,6 +445,7 @@ const connectComponent = connect(
 			date,
 			hasValidDate,
 			showNoDataInfo,
+			showViewLink: ! isJetpack && isPreviewable,
 		};
 	},
 	{ recordGoogleEvent }

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -208,7 +208,7 @@ class StatsEmailDetail extends Component {
 		const pathTemplate = `${ traffic.path }/{{ interval }}/${ postId }${ slugPath }`;
 
 		// TODO: Refactor navigationItems to a single object with backLink and title attributes.
-		const navigationItems = this.getNavigationItemsWithTitle( this.getTitle() );
+		const navigationItems = this.getNavigationItemsWithTitle( this.getNavigationTitle() );
 
 		const backLinkProps = {
 			text: navigationItems[ 0 ].label,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STATS-52

## Proposed Changes

* Add new headers for Email opens and Email clicks

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the navigation improvements project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Subscribers page `http://calypso.localhost:3000/stats/subscribers/xxx.au.ngrok.io`
* Click on an Email to open Email Opens
* Ensure the header looks okay
* Click Email Clicks
* Ensure the header looks okay
* Disable the feature
* `http://calypso.localhost:3000/stats/subscribers/xxx.au.ngrok.io?flags=-stats/navigation-improvement`
* Ensure things work like they did

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/afacc92a-e644-4ff5-9f6d-b9a1f39a6afd" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
