### PR TITLE
Adding small disclaimer to Tumblr reply count in Blaze campaign detail

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -783,7 +783,7 @@ export default function CampaignItemDetails( props: Props ) {
 			</div>
 			<div className="campaign-item-details__main-stats-row ">
 				<div>
-					<span className="campaign-item-details__label">{ translate( 'Replies' ) }</span>
+					<span className="campaign-item-details__label">{ translate( 'Replies' ) } &#42;</span>
 					<span className="campaign-item-details__text">
 						<span className="wp-brand-font">
 							{ ! isLoading ? repliesFormatted : <FlexibleSkeleton /> }
@@ -822,6 +822,24 @@ export default function CampaignItemDetails( props: Props ) {
 								{ showAllReplies ? __( 'Show Less' ) : __( 'Show More' ) }
 							</button>
 						) }
+
+						<div className="campaign-items-details__reply-disclaimer">
+							&#42;&nbsp;
+							{ translate(
+								'Some replies may have been hidden, blocked, or removed due to {{tumblrGuideline}}Tumblr guidelines{{/tumblrGuideline}} violation.',
+								{
+									components: {
+										tumblrGuideline: (
+											<a
+												href="https://www.tumblr.com/policy/en/user-guidelines"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
+						</div>
 					</div>
 				) }
 			</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -826,7 +826,7 @@ export default function CampaignItemDetails( props: Props ) {
 						<div className="campaign-items-details__reply-disclaimer">
 							&#42;&nbsp;
 							{ translate(
-								'Some replies may have been hidden, blocked, or removed due to {{tumblrGuideline}}Tumblr guidelines{{/tumblrGuideline}} violation.',
+								'Some replies may have been hidden, blocked, or removed due to {{tumblrGuideline}}Tumblr guidelines {{externalIcon/}}{{/tumblrGuideline}} violation',
 								{
 									components: {
 										tumblrGuideline: (
@@ -836,6 +836,7 @@ export default function CampaignItemDetails( props: Props ) {
 												rel="noopener noreferrer"
 											/>
 										),
+										externalIcon: <Gridicon icon="external" size={ 16 } />,
 									},
 								}
 							) }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -362,6 +362,9 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				text-align: left;
 				cursor: pointer;
 			}
+			.campaign-items-details__reply-disclaimer {
+				margin-top: 10px;
+			}
 		}
 		.campaign-item-details__graph-stats-row {
 			grid-template-columns: 1fr;


### PR DESCRIPTION
https://github.tumblr.net/Tumblr/a8c-dsp/issues/3257

## Proposed Changes

* Adding a small disclaimer below reply count to indicate that the reply count might not match the number of replies because some of them might be hidden.

![image](https://github.com/user-attachments/assets/549d6713-41de-42e5-8199-8ca5cd440ad2)


## Why are these changes being made?
* Users might get confused as to why the reply count shown doesn't match the number of replies.

## Testing Instructions
* Visit the detail page of a completed super-native tumblr blaze campaign.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
