### PR TITLE
/me/account: Improve username confirmation validation message

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -813,6 +813,16 @@ class Account extends Component {
 			this.getUserSetting( 'user_login' ) === this.state.userLoginConfirm &&
 			this.state.userLoginConfirm.length > 0;
 
+		const usernameValidationFailureMessage = this.getUsernameValidationFailureMessage();
+		const isError = ! usernameMatch || usernameValidationFailureMessage;
+
+		let validationMessage = translate( 'Please re-enter your new username to confirm it.' );
+		if ( usernameMatch ) {
+			validationMessage = usernameValidationFailureMessage
+				? usernameValidationFailureMessage
+				: translate( 'Thanks for confirming your new username!' );
+		}
+
 		return (
 			<div className="account__username-form" key="usernameForm">
 				<FormFieldset>
@@ -827,13 +837,9 @@ class Account extends Component {
 						value={ this.state.userLoginConfirm ?? '' }
 						onChange={ this.updateUserLoginConfirm }
 						isValid={ usernameMatch }
-						isError={ ! usernameMatch }
+						isError={ isError }
 					/>
-					<FormInputValidation isError={ ! usernameMatch }>
-						{ usernameMatch
-							? translate( 'Thanks for confirming your new username!' )
-							: translate( 'Please re-enter your new username to confirm it.' ) }
-					</FormInputValidation>
+					<FormInputValidation isError={ isError }>{ validationMessage }</FormInputValidation>
 				</FormFieldset>
 
 				{ this.renderBlogActionFields() }


### PR DESCRIPTION
Ref DOTCOM-1817

## Proposed Changes

This PR improves the username confirmation validation message so that if the username is already taken, it won't show a success message if the confirmation username matches the username.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Contributes to the overall WP.com.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /me/account on a non-a11n account.
* Change your username to one that's taken.
* Ensure that when you confirm your username, the validation message says "Sorry, that username already exists!".
* Now try a username that's not taken.
* Ensure that when you confirm your username, the validation message says "Thanks for confirming your new username!".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
