### PR TITLE
Try: make the "primary colum" clickable

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,7 +1,7 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
@@ -41,11 +41,7 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		id: 'URL',
 		label: __( 'URL' ),
 		enableGlobalSearch: true,
-		render: ( { item }: { item: Site } ) => (
-			<ExternalLink href={ item.URL } style={ { overflowWrap: 'anywhere' } }>
-				{ new URL( item.URL ).hostname }
-			</ExternalLink>
-		),
+		getValue: ( { item } ) => new URL( item.URL ).hostname,
 	},
 	{
 		id: 'icon.ico',

--- a/client/dashboard/sites/site-icon/style.scss
+++ b/client/dashboard/sites/site-icon/style.scss
@@ -8,7 +8,6 @@
     background-color: #f5f7f7;
     border: 1px solid #eee;
     color: var(--wp-admin-theme-color);
-    cursor: default;
     display: flex;
     flex-shrink: 0;
     font-size: 24px;

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -88,11 +88,15 @@
 	}
 }
 
-.dataviews-title-field--clickable {
+.dataviews-column-primary--clickable {
 	cursor: pointer;
-	color: $gray-800;
+	.dataviews-title-field {
+		color: $gray-800;
+	}
 	&:hover {
-		color: var(--wp-admin-theme-color);
+		.dataviews-title-field {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 	@include link-reset();
 }

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -33,11 +33,10 @@ function ColumnPrimary< Item >( {
 		item,
 		isItemClickable,
 		onClickItem,
-		className:
-			'dataviews-view-table__cell-content-wrapper dataviews-title-field',
+		className: 'dataviews-column-primary',
 	} );
 	return (
-		<HStack spacing={ 3 } justify="flex-start">
+		<HStack spacing={ 3 } justify="flex-start" { ...clickableProps }>
 			{ mediaField && (
 				<div className="dataviews-view-table__cell-content-wrapper dataviews-column-primary__media">
 					<mediaField.render item={ item } field={ mediaField } />
@@ -45,7 +44,7 @@ function ColumnPrimary< Item >( {
 			) }
 			<VStack spacing={ 0 }>
 				{ titleField && (
-					<div { ...clickableProps }>
+					<div className="dataviews-view-table__cell-content-wrapper dataviews-title-field">
 						{ level !== undefined && (
 							<span className="dataviews-view-table__level">
 								{ '—'.repeat( level ) }&nbsp;


### PR DESCRIPTION
Related conversations:

- figma QOBjujZah0UlGDDdLKZhzi-fi-1059_63137#1247411599
- slack p1746786699361669-slack-C05QAFZSFTL

## Proposed Changes

This PR makes the primary column of the DataViews table clickable and removes the other clickable target in the same cell (external link to site).

Before:

https://github.com/user-attachments/assets/66559a3d-e6f7-49c6-baec-db147cd7326f


After:

https://github.com/user-attachments/assets/698dbdc5-c9fd-4111-8ca5-ad2e97c1e8f0


## Why are these changes being made?

Having two clickable targets is the same cell is prone to errors — they are small targets. Additionally, it was brought up in a few places that the "clicking the title field" to trigger an action was not very discoverable. This PR addresses it by making the whole cell clickable, without changing anything else.

## TODO

Test/Verify other flows (layouts, with/without title field, etc.).

## Testing Instructions

In the v2 dashboard, go to sites and click on the "primary column".