### PR TITLE
My Profile: Remove the Extra NavigationHeader Padding

### DIFF
--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -41,11 +41,7 @@
 
 .help__section-title {
 	font-size: $font-title-small;
-	margin: 32px 16px 16px;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		margin: 32px 0 16px;
-	}
+	margin: 32px 0 16px;
 }
 
 .help__support-link .gridicons-external {

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -78,6 +78,9 @@ body.is-section-me {
 	}
 
 	@media only screen and (max-width: 600px) {
+		.navigation-header {
+			padding: 0 0 24px 0;
+		}
 		.navigation-header__main {
 			justify-content: normal;
 			align-items: center;

--- a/client/me/style.scss
+++ b/client/me/style.scss
@@ -78,7 +78,7 @@ body.is-section-me {
 	}
 
 	@media only screen and (max-width: 600px) {
-		.navigation-header {
+		.navigation-header:not(.developer__header) {
 			padding: 0 0 24px 0;
 		}
 		.navigation-header__main {


### PR DESCRIPTION
Fixes DOTCOM-605

## Proposed Changes

* Restore the larger-screens padding to the `NavigationHeader` component when navigating the My Profile section (`/me`) on small screens (<600px).

| Before | After |
|--------|--------|
| ![Screenshot 2025-05-09 at 11 43 34](https://github.com/user-attachments/assets/61852e2e-345e-452a-92f1-fec70f073ea1) | ![Screenshot 2025-05-09 at 11 44 03](https://github.com/user-attachments/assets/9c1aa2d9-249b-4571-acee-ce9cd0db8dbf) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The `NavigationHeader` component has a 16px padding on small screens (<600px) . While this works fine for most screens, it looks out of alignment in the My Profile section (`/me`).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the My Profile section (`/me`) and resize the screen below 600px.
* Confirm the NavigationHeader component doesn't have any unnecessary padding and the title is aligned with the content.
* Check that the changes are applied consistently on all My Profile pages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
