### PR TITLE
STATS-59 - Match filename for the location stats to production

### DIFF
--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -369,7 +369,7 @@ class StatsSummary extends Component {
 		}
 		const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
 		const geoMode = this.props.context.query.geoMode;
-		const geoModeLabel = geoMode && geoMode in GEO_MODES ? GEO_MODES[ geoMode ] : 'country';
+		const geoModeLabel = geoMode && Object.prototype.hasOwnProperty.call(GEO_MODES, geoMode) ? GEO_MODES[ geoMode ] : 'country';
 
 		return (
 			<Main fullWidthLayout>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -23,6 +23,7 @@ import PageHeader from '../components/headers/page-header';
 import { STATS_FEATURE_DOWNLOAD_CSV } from '../constants';
 import StatsModuleLocations from '../features/modules/stats-locations';
 import LocationsNavTabs from '../features/modules/stats-locations/locations-nav-tabs';
+import { GEO_MODES } from '../features/modules/stats-locations/types';
 import StatsModuleUTM from '../features/modules/stats-utm';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import { StatsGlobalValuesContext } from '../pages/providers/global-provider';
@@ -367,6 +368,8 @@ class StatsSummary extends Component {
 			backLink += domain;
 		}
 		const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
+		const geoMode = this.props.context.query.geoMode;
+		const geoModeLabel = geoMode && geoMode in GEO_MODES ? GEO_MODES[ geoMode ] : 'country';
 
 		return (
 			<Main fullWidthLayout>
@@ -391,7 +394,9 @@ class StatsSummary extends Component {
 										<DownloadCsv
 											statType={ statType }
 											query={ moduleQuery }
-											path={ path }
+											path={
+												statType === 'statsCountryViews' ? `${ path }-${ geoModeLabel }` : path
+											}
 											period={ this.props.period }
 											skipQuery={ statType === 'statsUTM' }
 										/>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -369,7 +369,10 @@ class StatsSummary extends Component {
 		}
 		const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
 		const geoMode = this.props.context.query.geoMode;
-		const geoModeLabel = geoMode && Object.prototype.hasOwnProperty.call(GEO_MODES, geoMode) ? GEO_MODES[ geoMode ] : 'country';
+		const geoModeLabel =
+			geoMode && Object.prototype.hasOwnProperty.call( GEO_MODES, geoMode )
+				? GEO_MODES[ geoMode ]
+				: 'country';
 
 		return (
 			<Main fullWidthLayout>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-59

## Proposed Changes

* Match the filename for the location stats to production
* This needed to be changed since - https://github.com/Automattic/wp-calypso/pull/103237
* Note: This still does not fix the date in the filename as that is not a regression and this seems to be happening in production as well - https://github.com/Automattic/wp-calypso/pull/103161#pullrequestreview-2822794815

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
