### PR TITLE
Dashboard V2: Enable link preloading

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -337,6 +337,8 @@ export const getRouter = ( config: AppConfig ) => {
 		basepath: config.basePath,
 		defaultErrorComponent: UnknownError,
 		defaultNotFoundComponent: NotFound,
+		defaultPreload: 'intent',
+		defaultPreloadStaleTime: 0,
 	} );
 };
 


### PR DESCRIPTION
Fixes DOTCOM-13061

## Proposed Changes

Adds preloading to `Link` component. Check [this page](https://tanstack.com/router/latest/docs/framework/react/guide/preloading) for details. The idea is that when a user hovers a link, we preload the loader of the target page before actually navigating to the page.

This works well with regular links, the problem right now is that we can't make the same thing work for DataViews because of how DataViews renders the links, it just uses a regular `onClickHandler` instead of having a way to actually use links or "hook in" the router somehow.


## Testing Instructions

 - Load the "domains" v2 page. (without loading the sites one first, reload the page for instance)
 - Open the dev tools and the network tab
 - Notice that when you hover the "sites" link in the menu, the sites endpoint is preloaded.
 - Clicking the link should be instant.
