### PR TITLE
A4A: Add loading indicator when removing site.

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
@@ -5,88 +5,99 @@ import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
-const createRemoveSiteActionModal =
-	( {
-		onRefetchSite,
-		recordTracksEventRemoveSite,
-	}: {
-		onRefetchSite?: () => Promise< unknown >;
-		recordTracksEventRemoveSite: () => void;
-	} ) =>
-	( {
-		items,
-		closeModal,
-		onActionPerformed,
-	}: {
-		items: SiteData[];
-		closeModal: () => void;
-		onActionPerformed?: () => void;
-	} ) => {
-		const translate = useTranslate();
-		const dispatch = useDispatch();
-		const { mutate: removeSite } = useRemoveSiteMutation();
+type ActionProps = {
+	onRefetchSite?: () => Promise< unknown >;
+	recordTracksEventRemoveSite: () => void;
+};
 
-		recordTracksEventRemoveSite();
+type ModalProps = {
+	items: SiteData[];
+	closeModal: () => void;
+	onActionPerformed?: () => void;
+};
 
-		const item = items[ 0 ];
-		const siteName = item.site.value.url;
-		const siteId = item.site.value.a4a_site_id;
+type Props = ActionProps & ModalProps;
 
-		const onRemoveSite = () => {
-			if ( ! siteId ) {
-				return;
-			}
+function RemoveSiteActionModal( {
+	items,
+	closeModal,
+	onActionPerformed,
+	onRefetchSite,
+	recordTracksEventRemoveSite,
+}: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { mutate: removeSite } = useRemoveSiteMutation();
 
-			removeSite(
-				{ siteId },
-				{
-					onSuccess: () => {
-						// Add 1 second delay to refetch sites to give time for site profile to be reindexed properly.
-						setTimeout( () => {
-							onRefetchSite?.()?.then( () => {
-								closeModal?.();
-								onActionPerformed?.();
-								dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
-							} );
-						}, 1000 );
-					},
-				}
-			);
-		};
+	recordTracksEventRemoveSite();
 
-		const onSubmit = ( event: React.FormEvent ) => {
-			event.preventDefault();
-			onRemoveSite();
-		};
+	const item = items[ 0 ];
+	const siteName = item.site.value.url;
+	const siteId = item.site.value.a4a_site_id;
 
-		return (
-			<form onSubmit={ onSubmit }>
-				{ translate(
-					'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
-					{
-						args: { siteName },
-						components: {
-							b: <b />,
-						},
-						comment: '%(siteName)s is the site name',
-					}
-				) }
-				<HStack justify="right">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ () => {
+	const onRemoveSite = () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		removeSite(
+			{ siteId },
+			{
+				onSuccess: () => {
+					// Add 1 second delay to refetch sites to give time for site profile to be reindexed properly.
+					setTimeout( () => {
+						onRefetchSite?.()?.then( () => {
 							closeModal?.();
-						} }
-					>
-						{ translate( 'Cancel' ) }
-					</Button>
-					<Button __next40pxDefaultSize variant="primary" type="submit" isDestructive>
-						{ translate( 'Remove site' ) }
-					</Button>
-				</HStack>
-			</form>
+							onActionPerformed?.();
+							dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
+						} );
+					}, 1000 );
+				},
+			}
 		);
 	};
 
-export default createRemoveSiteActionModal;
+	const onSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		onRemoveSite();
+	};
+
+	return (
+		<form onSubmit={ onSubmit }>
+			{ translate(
+				'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
+				{
+					args: { siteName },
+					components: {
+						b: <b />,
+					},
+					comment: '%(siteName)s is the site name',
+				}
+			) }
+			<HStack justify="right">
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ () => {
+						closeModal?.();
+					} }
+				>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button __next40pxDefaultSize variant="primary" type="submit" isDestructive>
+					{ translate( 'Remove site' ) }
+				</Button>
+			</HStack>
+		</form>
+	);
+}
+
+export default function createRemoveSiteActionModal( actionProps: ActionProps ) {
+	const RemoveSiteActionModalWrapper = ( modalProps: ModalProps ) => {
+		return <RemoveSiteActionModal { ...actionProps } { ...modalProps } />;
+	};
+
+	RemoveSiteActionModalWrapper.displayName = 'RemoveSiteActionModalWrapper';
+
+	return RemoveSiteActionModalWrapper;
+}

--- a/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
@@ -1,5 +1,6 @@
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import useRemoveSiteMutation from 'calypso/a8c-for-agencies/data/sites/use-remove-site';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -29,6 +30,9 @@ function RemoveSiteActionModal( {
 	const dispatch = useDispatch();
 	const { mutate: removeSite } = useRemoveSiteMutation();
 
+	// We won't rely on mutation's isPending state as we have include 1 second delay to refetch sites to give time for site profile to be reindexed properly.
+	const [ isPending, setIsPending ] = useState( false );
+
 	recordTracksEventRemoveSite();
 
 	const item = items[ 0 ];
@@ -40,6 +44,8 @@ function RemoveSiteActionModal( {
 			return;
 		}
 
+		setIsPending( true );
+
 		removeSite(
 			{ siteId },
 			{
@@ -50,8 +56,12 @@ function RemoveSiteActionModal( {
 							closeModal?.();
 							onActionPerformed?.();
 							dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
+							setIsPending( false );
 						} );
 					}, 1000 );
+				},
+				onSettled: () => {
+					setIsPending( false );
 				},
 			}
 		);
@@ -84,7 +94,14 @@ function RemoveSiteActionModal( {
 				>
 					{ translate( 'Cancel' ) }
 				</Button>
-				<Button __next40pxDefaultSize variant="primary" type="submit" isDestructive>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					type="submit"
+					isDestructive
+					isBusy={ isPending }
+					disabled={ isPending }
+				>
 					{ translate( 'Remove site' ) }
 				</Button>
 			</HStack>

--- a/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
+++ b/client/a8c-for-agencies/sections/sites/site-actions/remove-site-action-modal.tsx
@@ -6,6 +6,8 @@ import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import type { SiteData } from '../../../../jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
+import './style.scss';
+
 type ActionProps = {
 	onRefetchSite?: () => Promise< unknown >;
 	recordTracksEventRemoveSite: () => void;
@@ -56,11 +58,10 @@ function RemoveSiteActionModal( {
 							closeModal?.();
 							onActionPerformed?.();
 							dispatch( successNotice( translate( 'The site has been successfully removed.' ) ) );
-							setIsPending( false );
 						} );
 					}, 1000 );
 				},
-				onSettled: () => {
+				onError: () => {
 					setIsPending( false );
 				},
 			}
@@ -73,17 +74,20 @@ function RemoveSiteActionModal( {
 	};
 
 	return (
-		<form onSubmit={ onSubmit }>
-			{ translate(
-				'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
-				{
-					args: { siteName },
-					components: {
-						b: <b />,
-					},
-					comment: '%(siteName)s is the site name',
-				}
-			) }
+		<form className="remove-site-action-form" onSubmit={ onSubmit }>
+			<div className="remove-site-action-form__message">
+				{ translate(
+					'Are you sure you want to remove the site {{b}}%(siteName)s{{/b}} from the dashboard?',
+					{
+						args: { siteName },
+						components: {
+							b: <b />,
+						},
+						comment: '%(siteName)s is the site name',
+					}
+				) }
+			</div>
+
 			<HStack justify="right">
 				<Button
 					__next40pxDefaultSize

--- a/client/a8c-for-agencies/sections/sites/site-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-actions/style.scss
@@ -78,3 +78,9 @@
 		top: unset;
 	}
 }
+
+form.remove-site-action-form {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}


### PR DESCRIPTION
The current 'Remove site' experience is somewhat broken, lacking any indication that the dashboard is processing the request. This PR introduces an `isBusy` state on the button to show that the site is loading.


https://github.com/user-attachments/assets/d6d89c28-606d-4b78-bed7-821a80c5eb95




Closes https://linear.app/a8c/issue/A4A-793/show-a-loading-indicator-when-the-remove-site-request-is-in-progress

## Proposed Changes

* Pass the `isPending` state to the button to display the busy indicator. The isPending state should not depend on the mutation state; instead, it uses a custom state due to a one-second delay for refetching sites after a site has been removed.
* Fix styling so there is proper spacing around the action and message elements.
* **Extra: I refactored the component for better readability, as the double-nested callback can be confusing. This also resolves a linting problem related to the component's display name.**

## Why are these changes being made?

* This improves user experience

## Testing Instructions

* Use the A4A live link and navigate to `/sites`.
* Remove a site.
* Confirm that the modal shows a busy button when the request is being sent.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
