### PR TITLE
STATS-60 - Fix: match the Video stats CSV download to the production export

### DIFF
--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -12,6 +12,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	getSiteStatsCSVData,
+	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -125,7 +126,10 @@ const connectComponent = connect(
 		}
 
 		const { statType, query } = ownProps;
-		const data = getSiteStatsCSVData( state, siteId, statType, query );
+		const data =
+			statType === 'statsVideoPlays'
+				? getSiteStatsNormalizedData( state, siteId, statType, query )
+				: getSiteStatsCSVData( state, siteId, statType, query );
 		const isLoading = isRequestingSiteStatsForQuery( state, siteId, statType, query );
 
 		return { data, siteSlug, siteId, isLoading };

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -239,6 +239,7 @@ class StatsSummary extends Component {
 				title = translate( 'Videos' );
 				path = 'videoplays';
 				statType = 'statsVideoPlays';
+				moduleQuery.complete_stats = 1;
 				summaryView = (
 					<Fragment key="videopress-stats-module">
 						{ /* For CSV button to work, video page needs to pass custom data to the button.

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -459,7 +459,8 @@ export const normalizers = {
 	},
 
 	/**
-	 * Returns a normalized statsVideoPlaysCompleteStats array, ready for use in stats-module
+	 * Returns a normalized data for the `stats/video-plays` API request with `complete_stats` query param set to `1`
+	 * This returns more enriched data about the video plays, including impressions, watch time, and retention rate.
 	 * @param   {Object} data    Stats data
 	 * @param   {Object} query   Stats query
 	 * @returns {Array}          Parsed data array
@@ -469,7 +470,13 @@ export const normalizers = {
 			return [];
 		}
 
-		const videoPlaysData = get( data, [ 'days', 'summary', 'data' ], [] );
+		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const videoPlaysData = get(
+			data,
+			query.summarize ? [ 'days', 'summary', 'data' ] : [ 'days', startOf, 'data' ],
+			[]
+		);
+
 		const normalizedData = videoPlaysData.map( ( item ) => {
 			return {
 				post_id: item.post_id,

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -459,6 +459,35 @@ export const normalizers = {
 	},
 
 	/**
+	 * Returns a normalized statsVideoPlaysCompleteStats array, ready for use in stats-module
+	 * @param   {Object} data    Stats data
+	 * @param   {Object} query   Stats query
+	 * @returns {Array}          Parsed data array
+	 */
+	statsVideoPlaysCompleteStats: ( data, query = {} ) => {
+		if ( ! data || ! query.period || ! query.date ) {
+			return [];
+		}
+
+		const videoPlaysData = get( data, [ 'days', 'summary', 'data' ], [] );
+		const normalizedData = videoPlaysData.map( ( item ) => {
+			return {
+				post_id: item.post_id,
+				label: item.title,
+				views: item.views,
+				impressions: item.impressions,
+				watch_time: item.watch_time,
+				retention_rate: item.retention_rate,
+			};
+		} );
+
+		return [
+			[ 'post_id', 'title', 'views', 'impressions', 'watch_time', 'retention_rate' ],
+			...normalizedData,
+		];
+	},
+
+	/**
 	 * Returns a normalized statsVideoPlays array, ready for use in stats-module
 	 * @param   {Object} data    Stats data
 	 * @param   {Object} query   Stats query
@@ -471,6 +500,12 @@ export const normalizers = {
 			return [];
 		}
 		const { startOf } = rangeOfPeriod( query.period, query.date );
+		const isCompleteStats = query.complete_stats;
+
+		if ( isCompleteStats ) {
+			return normalizers.statsVideoPlaysCompleteStats( data, query, siteId, site );
+		}
+
 		const videoPlaysData = get(
 			data,
 			query.summarize ? [ 'days', 'summary', 'plays' ] : [ 'days', startOf, 'plays' ],


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-60

## Proposed Changes

* Introduce a new normalizer `statsVideoPlaysCompleteStats` to normalize the stats from video stats query where `complete_stats=1` is passed
 
## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To match the CSV export in the new header layout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Download the CSV from - http://calypso.localhost:3000/stats/day/videoplays/jetpack.com
* Download the CSV from https://wordpress.com/stats/day/videoplays/jetpack.com
* Both the CSVs should match

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
