### PR TITLE
Improve new invite screen

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -1,4 +1,5 @@
-import { Card, Button } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -58,29 +59,14 @@ class InviteAcceptLoggedIn extends Component {
 
 	getJoinAsText = () => {
 		const { user } = this.props;
-		let text = '';
-
-		if ( 'follower' === this.props.invite.role ) {
-			text = this.props.translate( 'Follow as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
-				components: {
-					usernameWrap: <span className="invite-accept-logged-in__join-as-username" />,
-				},
-				args: {
-					username: user && user.display_name,
-				},
-			} );
-		} else {
-			text = this.props.translate( 'Join as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
-				components: {
-					usernameWrap: <span className="invite-accept-logged-in__join-as-username" />,
-				},
-				args: {
-					username: user && user.display_name,
-				},
-			} );
-		}
-
-		return text;
+		const userName = user && user.display_name;
+		const userEmail = user && user.email;
+		return (
+			<>
+				<div className="invite-accept-logged-in__join-as-username">{ userName }</div>
+				<p className="invite-accept-logged-in__join-as-email">{ userEmail }</p>
+			</>
+		);
 	};
 
 	renderMatchEmailError = () => {
@@ -118,18 +104,18 @@ class InviteAcceptLoggedIn extends Component {
 		}
 
 		return (
-			<div>
+			<>
 				<Card>
 					<InviteFormHeader { ...this.props.invite } user={ this.props.user } />
 					<div className="invite-accept-logged-in__join-as">
-						<Gravatar user={ this.props.user } size={ 72 } />
+						<Gravatar user={ this.props.user } size={ 110 } imgSize={ 220 } />
 						{ this.getJoinAsText() }
 					</div>
 					<div className="invite-accept-logged-in__button-bar">
-						<Button onClick={ this.decline } disabled={ this.state.submitting }>
+						<Button variant="secondary" onClick={ this.decline } disabled={ this.state.submitting }>
 							{ this.props.translate( 'Cancel', { context: 'button' } ) }
 						</Button>
-						<Button primary onClick={ this.accept } disabled={ this.state.submitting }>
+						<Button variant="primary" onClick={ this.accept } disabled={ this.state.submitting }>
 							{ this.getButtonText() }
 						</Button>
 					</div>
@@ -137,10 +123,10 @@ class InviteAcceptLoggedIn extends Component {
 
 				<LoggedOutFormLinks>
 					<LoggedOutFormLinkItem onClick={ this.signInLink } href={ this.props.signInLink }>
-						{ this.props.translate( 'Sign in as a different user' ) }
+						{ this.props.translate( 'Log in with another account' ) }
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>
-			</div>
+			</>
 		);
 	};
 

--- a/client/my-sites/invites/invite-accept-logged-in/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-in/style.scss
@@ -1,44 +1,81 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$recoleta-font-family: "Recoleta", sans-serif;
+$font-sf-pro-text: "SF Pro Text", $sans;
+
 .invite-accept-logged-in__join-as {
 	color: var(--color-neutral-60);
 	font-size: $font-title-small;
 	line-height: 24px;
-	margin-bottom: 16px;
 	text-align: center;
 }
 
-.invite-accept-logged-in .card {
-	margin-bottom: 0;
+.invite-accept-logged-in {
+	width: 100%;
+	margin: 0 auto;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	height: 100%;
+	font-family: $font-sf-pro-text;
 
 	.invite-form-header__title {
-		color: var(--color-text);
-		font-size: $font-title-small;
-		line-height: 24px;
-		margin-bottom: 16px;
+		color: var(--studio-gray-100, #2c3338);
+		text-align: center;
+		font-family: $recoleta-font-family;
+		font-size: 2rem;
+		line-height: 1.26;
 	}
 
 	.invite-form-header__explanation {
-		font-size: $font-body-small;
+		color: var(--studio-gray-50, #2c3338);
+		text-align: center;
+		margin-top: 6px;
+		font-size: 14px;
+	}
+
+	.card {
+		box-shadow: none;
+		padding: 0;
+		margin: 0;
+		background: none;
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		max-height: 768px;
 	}
 }
 
 .invite-accept-logged-in__join-as-username {
+	color: var(--studio-gray-100, #2c3338);
 	font-weight: 600;
+	font-size: 16px;
+	line-height: 1.3;
+}
+
+.invite-accept-logged-in__join-as-email {
+	font-size: 12px;
 }
 
 .invite-accept-logged-in__join-as .gravatar {
 	display: block;
-	margin: 0 auto 8px;
+	margin: 2px auto 12px;
+	border: 1px solid var(--studio-gray-5);
 }
 
 .invite-accept-logged-in__button-bar {
 	display: flex;
+	width: 340px;
 }
 
-.invite-accept-logged-in__button-bar .button {
+.invite-accept-logged-in__button-bar .components-button {
 	flex-basis: 0;
 	flex-grow: 1;
-	margin: 0 4px;
-	text-align: center;
+	margin: 4px;
+	justify-content: center;
 
 	&:first-child {
 		margin-left: 0;
@@ -47,4 +84,9 @@
 	&:last-child {
 		margin-right: 0;
 	}
+}
+
+.logged-out-form__link-item {
+	color: var(--color-link);
+	font-size: 12px;
 }

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -11,10 +11,11 @@ body.is-section-accept-invite {
 	}
 	background: #fdfdfd;
 	.invite-accept {
-		margin-top: 50px;
-		@media (min-width: $break-small) {
-			margin-top: 150px;
-		}
+		padding-top: 50px;
+		height: calc(100vh - 100px);
+	}
+	.invite-accept__form {
+		height: 100%;
 	}
 	.layout__content {
 		padding: 24px;
@@ -25,6 +26,7 @@ body.is-section-accept-invite {
 	margin: 0 auto;
 	@media (min-width: $break-small) {
 		width: 372px;
+		margin-top: 100px;
 	}
 	font-family: $font-sf-pro-text;
 
@@ -48,6 +50,8 @@ body.is-section-accept-invite {
 		padding: 0;
 		margin: 0;
 		max-width: 372px;
+		background: none;
+
 		button.is-primary {
 			border-radius: 2px;
 			border: 1px solid var(--studio-wordpress-blue, #3858e9);

--- a/client/my-sites/invites/invite-accept/style.scss
+++ b/client/my-sites/invites/invite-accept/style.scss
@@ -4,7 +4,7 @@
 
 .invite-accept__form {
 	margin: 0 auto;
-	max-width: 400px;
+	max-width: 440px;
 
 	&.is-error {
 		max-width: none;

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -110,67 +110,76 @@ class InviteFormHeader extends Component {
 
 		switch ( role ) {
 			case 'administrator':
-				title = this.props.translate( 'Would you like to start managing {{siteLink/}}?', {
+				title = this.props.translate( 'Start managing{{br/}}{{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
+						br: <br />,
 					},
 				} );
 				break;
 			case 'editor':
-				title = this.props.translate( 'Would you like to start editing {{siteLink/}}?', {
+				title = this.props.translate( 'Start editing{{br/}}{{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
+						br: <br />,
 					},
 				} );
 				break;
 			case 'author':
-				title = this.props.translate( 'Would you like to start writing for {{siteLink/}}?', {
+				title = this.props.translate( 'Start writing for{{br/}}{{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
+						br: <br />,
 					},
 				} );
 				break;
 			case 'contributor':
-				title = this.props.translate( 'Would you like to start contributing to {{siteLink/}}?', {
+				title = this.props.translate( 'Start contributing to{{br/}}{{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
+						br: <br />,
 					},
 				} );
 				break;
 			case 'subscriber':
 				title = this.props.translate(
-					'Would you like to start following {{siteLink/}} in the WordPress.com Reader?',
+					'Start following{{br/}}{{siteLink/}}{{br/}}in the WordPress.com Reader',
 					{
 						components: {
 							siteLink: this.getSiteLink(),
+							br: <br />,
 						},
 					}
 				);
 				break;
 			case 'viewer':
-				title = this.props.translate( 'Would you like to be able to view {{siteLink/}}?', {
+				title = this.props.translate( 'Begin viewing{{br/}}{{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
+						br: <br />,
 					},
 				} );
 				break;
 			case 'follower':
-				title = this.props.translate( 'Would you like to become a follower of {{siteLink/}}?', {
+				title = this.props.translate( 'Start following{{br/}}{{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
+						br: <br />,
 					},
 				} );
 				break;
 			default:
 				title = this.props.translate(
-					'Would you like to join {{siteLink/}} as: {{strong}}%(siteRole)s{{/strong}}?',
+					'Join{{br/}}{{siteLink/}}{{br/}}{{span}}as: {{strong}}%(siteRole)s{{/strong}}{{/span}}',
 					{
 						args: {
 							siteRole: role,
 						},
 						components: {
 							siteLink: this.getSiteLink(),
+							br: <br />,
 							strong: <strong />,
+							span: <span />,
 						},
 					}
 				);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/issues/100416

## Proposed Changes

Updates the layout and copy of the invite screen as per design:

<img width="480px" src="https://github.com/user-attachments/assets/082138ff-5b99-4529-8e99-31c5df41aa1d"/>

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're updating the interface to be more concise and offer more clarity.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Send yourself an invite from the User screen
* Access the emailed link both as a logged-in user and logged-out
* Ensure the logged-out screen is unaffected
<img width="480" alt="Screenshot 2025-05-09 at 16 01 40" src="https://github.com/user-attachments/assets/0fe97b48-fdd3-49ee-b4d0-0138883f44e0" />


* The logged-in screen should match the design
<img width="480" alt="Screenshot 2025-05-09 at 16 00 50" src="https://github.com/user-attachments/assets/33672475-084a-4174-b290-82f2038bcca9" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
