### PR TITLE
Assigning users to the experiment only at the plans page

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -9,7 +9,7 @@ import {
 	useIsPlaygroundEligible,
 	isPlaygroundEligible,
 } from 'calypso/landing/stepper/hooks/use-is-playground-eligible';
-import { useMvpOnboardingExperiment } from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
+import { isMvpOnboardingExperiment } from 'calypso/landing/stepper/hooks/use-mvp-onboarding-experiment';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { pathToUrl } from 'calypso/lib/url';
 import {
@@ -70,7 +70,7 @@ const onboarding: FlowV2< typeof initialize > = {
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
 		const isPlaygroundEligible = useIsPlaygroundEligible();
-		const [ , isMvpOnboarding ] = useMvpOnboardingExperiment();
+
 		const {
 			setDomain,
 			setDomainCartItem,
@@ -95,10 +95,10 @@ const onboarding: FlowV2< typeof initialize > = {
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
 		 */
-		const getPostCheckoutDestination = (
+		const getPostCheckoutDestination = async (
 			providedDependencies: ProvidedDependencies,
 			isPlaygroundEligible: boolean
-		): [ string, string | null ] => {
+		): Promise< [ string, string | null ] > => {
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
 				return [ `/home/${ providedDependencies.siteSlug }`, null ];
 			}
@@ -132,7 +132,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				];
 			}
 
-			if ( isMvpOnboarding ) {
+			if ( await isMvpOnboardingExperiment() ) {
 				return [
 					addQueryArgs( `/home/${ providedDependencies.siteSlug }`, { ref: flowName } ),
 					addQueryArgs( withLocale( `/setup/${ flowName }/plans`, locale ), {
@@ -239,7 +239,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				case 'post-checkout-onboarding':
 					return navigate( 'processing' );
 				case 'processing': {
-					const [ destination, backDestination ] = getPostCheckoutDestination(
+					const [ destination, backDestination ] = await getPostCheckoutDestination(
 						providedDependencies,
 						isPlaygroundEligible
 					);

--- a/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/onboarding-flow.tsx
@@ -22,6 +22,10 @@ jest.mock( '../../hooks/use-marketplace-theme-products', () => ( {
 	} ),
 } ) );
 
+jest.mock( '../../hooks/use-mvp-onboarding-experiment', () => ( {
+	isMvpOnboardingExperiment: () => Promise.resolve( false ),
+} ) );
+
 describe( 'Onboarding Flow', () => {
 	beforeAll( () => {
 		Object.defineProperty( window, 'location', {
@@ -55,7 +59,7 @@ describe( 'Onboarding Flow', () => {
 		it( 'should redirect to home when hasPluginByGoal true and hasExternalTheme false', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
 
-			runUseStepNavigationSubmit( {
+			await runUseStepNavigationSubmit( {
 				currentStep: STEPS.PROCESSING.slug,
 				dependencies: {
 					hasExternalTheme: false,
@@ -65,13 +69,16 @@ describe( 'Onboarding Flow', () => {
 				},
 			} );
 
+			// Wait for the next tick to allow async operations to complete
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
 			expect( window.location.replace ).toHaveBeenCalledWith( '/home/test-site.wordpress.com' );
 		} );
 
 		it( 'should redirect to home when hasExternalTheme true', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( onboarding );
 
-			runUseStepNavigationSubmit( {
+			await runUseStepNavigationSubmit( {
 				currentStep: STEPS.PROCESSING.slug,
 				dependencies: {
 					hasExternalTheme: true,
@@ -79,6 +86,9 @@ describe( 'Onboarding Flow', () => {
 					processingResult: ProcessingResult.SUCCESS,
 				},
 			} );
+
+			// Wait for the next tick to allow async operations to complete
+			await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 			expect( window.location.replace ).toHaveBeenCalledWith(
 				addQueryArgs( '/setup/site-setup', {

--- a/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
+++ b/client/landing/stepper/hooks/use-mvp-onboarding-experiment.ts
@@ -2,7 +2,7 @@ import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
 import { useIsPlaygroundEligible, isPlaygroundEligible } from './use-is-playground-eligible';
 import { useQuery } from './use-query';
 
-const HOSTING_ONBOARDING_EXPERIMENT_NAME = 'calypso_signup_onboarding_simplified_hosting_flow_v2';
+const HOSTING_ONBOARDING_EXPERIMENT_NAME = 'calypso_signup_onboarding_simplified_hosting_flow_v3';
 
 export function useMvpOnboardingExperiment() {
 	const isPlaygroundEligible = useIsPlaygroundEligible();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

[Experiment work](https://linear.app/a8c/project/onboarding-simplify-flows-ab-tests-917de0dff4f8/overview).
Part of p1746743916586929/1746050595.866149-slack-C04H4NY6STW

## Proposed Changes

* We're assigning users to the experiment as late as possible to ensure the data we see is accurate.
* We're also assigning code to the experiment `v3`

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Slack thread: p1746743331350849/1746050595.866149-slack-C04H4NY6STW

We’ve been closely tracking the experiment, and the results appear to be quite positive—perhaps too positive. Plan purchase conversions are up by roughly 6% on average.

While this may be accurate, we're concerned due to the treatment group outperforming the control starting as early as the domain submission step. This raises the possibility of unexpected edge cases occurring between group assignment (at the beginning of the funnel) and the divergence of experiences (which happens post-signup).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use the new experiment to test: 22250-explat-experiment
- Follow the test instructions of the CfT post: pdtkmj-3zG-p2
- Make sure you only see the `/wpcom/v2/experiments/0.1.0/assignments/calypso` call at the plans page view (currently is at the beginning of the `/setup/onboarding` flow.
- Make sure you still get the exposure event `calypso_signup_complete ` once you surpass the plans page
- Test both `treatment` and `control` groups to ensure they still work as expected.

https://github.com/user-attachments/assets/eba1524c-39c2-4da6-b4f1-b17139c528ac




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?