### PR TITLE
DIFM: Update page copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -71,7 +71,7 @@ const DIFMStartingPoint: StepType< {
 									/>
 								) : (
 									<Step.SkipButton onClick={ goNext }>
-										{ translate( 'No Thanks, I’ll Build It' ) }
+										{ translate( 'No thanks, I’ll build it' ) }
 									</Step.SkipButton>
 								)
 							}
@@ -99,7 +99,7 @@ const DIFMStartingPoint: StepType< {
 				isWideLayout
 				isLargeSkipLayout={ false }
 				skipLabelText={
-					shouldRenderHelpCenter ? undefined : translate( 'No Thanks, I’ll Build It' )
+					shouldRenderHelpCenter ? undefined : translate( 'No thanks, I’ll build it' )
 				}
 				hideSkip={ shouldRenderHelpCenter }
 				customizedActionButtons={

--- a/client/my-sites/marketing/do-it-for-me/service-description.tsx
+++ b/client/my-sites/marketing/do-it-for-me/service-description.tsx
@@ -99,7 +99,7 @@ export const DIFMServiceDescription = ( { isStoreFlow }: { isStoreFlow: boolean 
 			<VerticalStepProgress>
 				<Step
 					index={ translate( '1' ) }
-					title={ translate( 'Submit your business information' ) }
+					title={ translate( 'Submit your information' ) }
 					description={ translate( 'Optionally provide your profiles to be found on social.' ) }
 				/>
 

--- a/client/my-sites/marketing/do-it-for-me/service-description.tsx
+++ b/client/my-sites/marketing/do-it-for-me/service-description.tsx
@@ -130,13 +130,6 @@ export const DIFMServiceDescription = ( { isStoreFlow }: { isStoreFlow: boolean 
 					}
 				/>
 			</VerticalStepProgress>
-			<p css={ { fontSize: '0.875rem', lineHeight: 1.5, color: 'var( --color-text )' } }>
-				{ translate( 'Share your finished site with the world in %(days)d business days or less!', {
-					args: {
-						days: 4,
-					},
-				} ) }
-			</p>
 		</ServiceDescription>
 	);
 };

--- a/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
+++ b/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
@@ -39,7 +39,6 @@ export const useDIFMHeading = ( {
 	const headerTextTranslateArgs = {
 		components: {
 			PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
-			sup: <sup />,
 		},
 		args: {
 			displayCost,
@@ -64,9 +63,6 @@ export const useDIFMHeading = ( {
 					args: {
 						freePages: 5,
 					},
-					components: {
-						sup: <sup />,
-					},
 				}
 		  )
 		: translate(
@@ -75,9 +71,6 @@ export const useDIFMHeading = ( {
 					args: {
 						plan: planTitle ?? '',
 						freePages: 5,
-					},
-					components: {
-						sup: <sup />,
 					},
 				}
 		  );

--- a/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
+++ b/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
@@ -59,7 +59,7 @@ export const useDIFMHeading = ( {
 
 	const subHeaderText = hasCurrentPlanOrHigherPlan
 		? translate(
-				'{{sup}}*{{/sup}}One time fee. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				'One time fee. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
 				{
 					args: {
 						freePages: 5,
@@ -70,7 +70,7 @@ export const useDIFMHeading = ( {
 				}
 		  )
 		: translate(
-				'{{sup}}*{{/sup}}One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				'One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
 				{
 					args: {
 						plan: planTitle ?? '',

--- a/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
+++ b/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
@@ -49,11 +49,11 @@ export const useDIFMHeading = ( {
 
 	const headerText = isStoreFlow
 		? translate(
-				'Let us build your store in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+				'Let us build your store in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}',
 				headerTextTranslateArgs
 		  )
 		: translate(
-				'Let us build your site in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+				'Let us build your site in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}',
 				headerTextTranslateArgs
 		  );
 

--- a/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
+++ b/client/my-sites/marketing/do-it-for-me/use-difm-heading.tsx
@@ -58,7 +58,7 @@ export const useDIFMHeading = ( {
 
 	const subHeaderText = hasCurrentPlanOrHigherPlan
 		? translate(
-				'One time fee. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				"It's a one time fee. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:",
 				{
 					args: {
 						freePages: 5,
@@ -66,7 +66,7 @@ export const useDIFMHeading = ( {
 				}
 		  )
 		: translate(
-				'One time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:',
+				"It's a one time fee, plus an additional purchase of the %(plan)s plan. A WordPress.com professional will create layouts for up to %(freePages)d pages of your site. It only takes 4 simple steps:",
 				{
 					args: {
 						plan: planTitle ?? '',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/101979

## Proposed Changes

This is a minor update with improvements to the language on the DIFM page:

* Remove the asterisks
* Remove the "Share your finished site" paragraph
* "Submit your business information" -> "Submit your information"
* "No Thanks, I’ll Build It" -> "No thanks, I'll build it"

> If I have a premium plan or higher, there's no need to mention it in the subtitle.

This change was skipped. More about that [here](https://github.com/Automattic/wp-calypso/issues/101979#issuecomment-2866906889).

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/5edf85c8-6612-44c5-9673-6fac55cf30ac" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of https://github.com/Automattic/wp-calypso/issues/100580.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup/difmStartingPoint?siteSlug=m1r0premium.wordpress.com` and compare with the requirements from the [related task](https://github.com/Automattic/wp-calypso/issues/101979).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
