### PR TITLE
DOTCOM-13001 Remove background for the site information on purchase cancel

### DIFF
--- a/client/me/purchases/purchases-site/header.scss
+++ b/client/me/purchases/purchases-site/header.scss
@@ -21,4 +21,9 @@
 	.site .site__content {
 		padding: 11px 24px;
 	}
+
+	.site > .site__content > .site__info > .site__title::after,
+	.site > .site__content > .site__info > .site__domain::after {
+		background: none;
+	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

When cancelling a plan, the site listed in the right sidebar has a white gradient.
![image](https://github.com/user-attachments/assets/1ebf793f-d708-48c7-bd05-1dfcc1fb59e5)

This component should have a solid gray background with no gradient.

### Result
![image](https://github.com/user-attachments/assets/75d937bd-9830-4a07-ba3f-bf2940a7ab32)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me/purchases`
* Select a purchase
* Click the "Cancel" option

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
