### PR TITLE
Dashboard v2: implement breadcrumbs

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -30,8 +30,9 @@ module.exports = {
 							'@automattic/components/*',
 							'!@automattic/components/src',
 							'@automattic/components/src/*',
-							'!@automattic/components/src/summary-button',
 							'!@automattic/components/src/core-badge',
+							'!@automattic/components/src/breadcrumbs',
+							'!@automattic/components/src/summary-button',
 							'!@automattic/dataviews',
 							// Please do not add exceptions unless agreed on
 							// with the #architecture group.

--- a/client/dashboard/app/breadcrumbs/index.tsx
+++ b/client/dashboard/app/breadcrumbs/index.tsx
@@ -9,9 +9,10 @@ export default function Breadcrumbs() {
 
 	let hasParent = false;
 	matches.forEach( ( match ) => {
-		if ( match.loaderData?.breadcrumbItemLabel || hasParent ) {
+		const breadcrumbItemLabel = match.staticData?.breadcrumbItemLabel;
+		if ( breadcrumbItemLabel || hasParent ) {
 			items.push( {
-				label: match.loaderData?.breadcrumbItemLabel || '',
+				label: breadcrumbItemLabel?.() || '',
 				href: match.pathname,
 			} );
 			hasParent = true;

--- a/client/dashboard/app/breadcrumbs/index.tsx
+++ b/client/dashboard/app/breadcrumbs/index.tsx
@@ -1,0 +1,22 @@
+import { Breadcrumbs as BreadcrumbsComponent } from '@automattic/components/src/breadcrumbs';
+import { useMatches } from '@tanstack/react-router';
+import type { BreadcrumbItemProps } from '@automattic/components/src/breadcrumbs/types';
+
+export default function Breadcrumbs() {
+	const matches = useMatches();
+
+	const items = [] as BreadcrumbItemProps[];
+
+	let hasParent = false;
+	matches.forEach( ( match ) => {
+		if ( match.loaderData?.breadcrumbItemLabel || hasParent ) {
+			items.push( {
+				label: match.loaderData?.breadcrumbItemLabel || '',
+				href: match.pathname,
+			} );
+			hasParent = true;
+		}
+	} );
+
+	return <BreadcrumbsComponent items={ items } />;
+}

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -23,7 +23,6 @@ import type { AppConfig } from './context';
 
 interface RouteContext {
 	config?: AppConfig;
-	breadcrumbItemLabel?: string;
 }
 
 const rootRoute = createRootRoute( { component: Root } );
@@ -109,11 +108,10 @@ const sitePerformanceRoute = createRoute( {
 const siteSettingsRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings',
-	loader: async ( { params: { siteSlug } } ) => {
-		await queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) );
-		return {
-			breadcrumbItemLabel: __( 'Settings' ),
-		};
+	loader: ( { params: { siteSlug } } ) =>
+		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+	staticData: {
+		breadcrumbItemLabel: () => __( 'Settings' ),
 	},
 } ).lazy( () =>
 	import( '../sites/settings' ).then( ( d ) =>

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -5,6 +5,7 @@ import {
 	redirect,
 	createLazyRoute,
 } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
 import { fetchTwoStep } from '../data';
 import NotFound from './404';
 import UnknownError from './500';
@@ -22,6 +23,7 @@ import type { AppConfig } from './context';
 
 interface RouteContext {
 	config?: AppConfig;
+	breadcrumbItemLabel?: string;
 }
 
 const rootRoute = createRootRoute( { component: Root } );
@@ -107,8 +109,12 @@ const sitePerformanceRoute = createRoute( {
 const siteSettingsRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings',
-	loader: ( { params: { siteSlug } } ) =>
-		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+	loader: async ( { params: { siteSlug } } ) => {
+		await queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) );
+		return {
+			breadcrumbItemLabel: __( 'Settings' ),
+		};
+	},
 } ).lazy( () =>
 	import( '../sites/settings' ).then( ( d ) =>
 		createLazyRoute( 'site-settings' )( {
@@ -118,10 +124,8 @@ const siteSettingsRoute = createRoute( {
 );
 
 const siteSettingsSubscriptionGiftingRoute = createRoute( {
-	getParentRoute: () => siteRoute,
-	path: 'settings/subscription-gifting',
-	loader: ( { params: { siteSlug } } ) =>
-		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+	getParentRoute: () => siteSettingsRoute,
+	path: 'subscription-gifting',
 } ).lazy( () =>
 	import( '../sites/settings-subscription-gifting' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-subscription-gifting' )( {
@@ -292,8 +296,7 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteOverviewRoute,
 				siteDeploymentsRoute,
 				sitePerformanceRoute,
-				siteSettingsRoute,
-				siteSettingsSubscriptionGiftingRoute,
+				siteSettingsRoute.addChildren( [ siteSettingsSubscriptionGiftingRoute ] ),
 			] )
 		);
 	}

--- a/client/dashboard/app/types.d.ts
+++ b/client/dashboard/app/types.d.ts
@@ -1,0 +1,7 @@
+import '@tanstack/react-router';
+
+declare module '@tanstack/react-router' {
+	interface StaticDataRouteOption {
+		breadcrumbItemLabel?: () => string;
+	}
+}

--- a/client/dashboard/components/page-layout/index.tsx
+++ b/client/dashboard/components/page-layout/index.tsx
@@ -4,6 +4,7 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import Breadcrumbs from '../../app/breadcrumbs';
 import './style.scss';
 
 const sizes = {
@@ -31,6 +32,7 @@ function PageLayout( {
 	return (
 		<VStack spacing={ 8 } className="dashboard-page-layout" style={ sizes[ size ] }>
 			<VStack spacing={ 4 }>
+				<Breadcrumbs />
 				<HStack justify="space-between" alignment="center">
 					<Heading level={ 1 } style={ { flexShrink: 0 } }>
 						{ title }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { Outlet, useMatch, useMatches } from '@tanstack/react-router';
 import {
 	__experimentalHeading as Heading,
 	__experimentalVStack as VStack,
@@ -6,17 +7,25 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { siteQuery, siteSettingsQuery } from '../../app/queries';
-import { siteRoute } from '../../app/router';
+import { siteSettingsRoute } from '../../app/router';
 import PageLayout from '../../components/page-layout';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
 
 export default function SiteSettings() {
-	const { siteSlug } = siteRoute.useParams();
+	const { siteSlug } = siteSettingsRoute.useParams();
 	const { data: siteData } = useQuery( siteQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
 
+	const matches = useMatches();
+	const match = useMatch( { from: siteSettingsRoute.id } );
+
 	if ( ! siteData || ! settings ) {
 		return null;
+	}
+
+	const isExactMatch = match.id === matches[ matches.length - 1 ].id;
+	if ( ! isExactMatch ) {
+		return <Outlet />;
 	}
 
 	return (


### PR DESCRIPTION
Part of DOTCOM-13067

## Proposed Changes

This PR implements breadcrumbs and show it on the child pages of Settings as per design (p1746709722501659/1746709518.587029-slack-C08JZTRS6NA)

|Before|After|
|-|-|
|<img width="781" alt="image" src="https://github.com/user-attachments/assets/6c1d707f-79b1-4160-8d50-0a58cbb8a27d" />|<img width="783" alt="image" src="https://github.com/user-attachments/assets/b35a40b4-e63b-4e06-8089-531b54f0938f" />|

## Implementation details

- Added a new optional `breadcrumbItemLabel` prop to the route's context. Any route can append this prop by returning this in its `loader()`.- 
- Make `siteSettingsSubscriptionGiftingRoute` (and future setting routes) as a child of `siteSettingsRoute`.
- Return the breadcrumb item label in `siteSettingsRoute`.
- Show the breadcrumbs inside `<PageLayout />`.
   - Why here, you may ask? Because the breadcrumbs must follow the page's width so that it is aligned with the page's title...

## Open discussions

- Clicking the breadcrumb items will trigger a page reload. This is because it's a regular link, not a router link. I don't have any good idea yet how to solve it. Need help from @Automattic/io.
- For consistency, should I move `<PageLayout />` to `app/` not `components/`? Because it is not a "pure" component anymore; it contains logic (breadcrumbs).

## Testing instructions

1. Go to `/v2/sites`
2. Click any site with paid plan.
3. Go to Settings
4. Go to Accept a gift subscription
5. Verify you see the breadcrumbs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?