### PR TITLE
Prevent merging PRs that sync from upstream

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -473,6 +473,15 @@ object RunAllUnitTests : BuildType({
 						exit 1
 					fi
 				fi
+
+				# If there are changes on the CHANGELOG.md prevent the PR from merging.
+				# In this case, we want to merge via specific instructions on the CLI.
+				if grep -q ^packages/dataviews/CHANGELOG.md <<< "${'$'}CHANGES"; then
+					echo "ERROR: changes to 'packages/dataviews/CHANGELOG.md detected'."
+					echo "PRs that sync changes from upstream cannot be merged via GitHub UI."
+					echo "Please, check packages/dataviews/SYNC.md to merge via the CLI commands."
+					exit 1
+				fi
 			""".trimIndent()
 		}
 		bashNodeScript {


### PR DESCRIPTION
DOTDEV-130
Related https://github.com/Automattic/wp-calypso/pull/103247

## Proposed Changes

This PR adds a TeamCity check so that if there are changes to the `packages/dataviews/CHANGELOG.md` the job fails.

## Why are these changes being made?

PRs that change `packages/dataviews/CHANGELOG.md` can only be PRs that sync changes from upstream Gutenberg. We don't want to merge these PRs via the GitHub UI merge button, but rather via the CLI command described at `packages/dataviews/SYNC.md`.

## Testing Instructions

- https://github.com/Automattic/wp-calypso/pull/103297 should fail.
- https://github.com/Automattic/wp-calypso/pull/103295 should succeed.
