### PR TITLE
DIFM: FAQ style updates

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/faq.tsx
+++ b/client/my-sites/marketing/do-it-for-me/faq.tsx
@@ -48,7 +48,8 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 		padding: 24px;
 		flex-direction: row-reverse;
 		width: 100%;
-		svg {
+		.gridicon {
+			transform: rotate( 90deg );
 			margin-inline-end: 0;
 			margin-inline-start: auto;
 			flex-shrink: 0;
@@ -62,6 +63,10 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 	&.is-expanded {
 		.foldable-faq__question {
 			padding-bottom: 16px;
+
+			.gridicon {
+				transform: rotate( 270deg );
+			}
 		}
 
 		.foldable-faq__answer {

--- a/client/my-sites/marketing/do-it-for-me/faq.tsx
+++ b/client/my-sites/marketing/do-it-for-me/faq.tsx
@@ -60,8 +60,6 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 		}
 	}
 	&.is-expanded {
-		border: 2px solid var( --studio-wordpress-blue-50 );
-
 		.foldable-faq__question {
 			padding-bottom: 16px;
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/101992

## Proposed Changes

* Remove the blue border when expanded.
* Change the arrow to point up when expanded and down when not.

<img width="730" alt="image" src="https://github.com/user-attachments/assets/882127f4-f398-4187-b645-05260407a2b6" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This is part of https://github.com/Automattic/wp-calypso/issues/100580.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/site-setup/difmStartingPoint?siteSlug=m1r0premium.wordpress.com and compare with the requirements from the https://github.com/Automattic/wp-calypso/issues/101992.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
