### PR TITLE
Hosting Dashboard: Introduce I18nProvider to make translation work correctly

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -26,7 +26,7 @@ export function getLocaleFromQueryParam() {
 	return query.get( 'locale' );
 }
 
-export const setupLocale = ( currentUser, reduxStore ) => {
+export const setupLocale = ( currentUser, reduxStore = null ) => {
 	if ( config.isEnabled( 'i18n/empathy-mode' ) && currentUser.i18n_empathy_mode ) {
 		initLanguageEmpathyMode();
 	}
@@ -49,34 +49,51 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		i18n.setLocale( localeData );
 		const localeSlug = i18n.getLocaleSlug();
 		const localeVariant = i18n.getLocaleVariant();
-		reduxStore.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
+		reduxStore?.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
 		// Propagate the locale to @automattic/number-formatters
 		setLocaleNumberFormatters( localeVariant || localeSlug );
 
 		if ( localeSlug ) {
 			loadUserUndeployedTranslations( localeSlug );
 		}
-	} else if ( currentUser && currentUser.localeSlug ) {
+		return localeVariant || localeSlug;
+	}
+
+	if ( currentUser && ( currentUser.localeSlug || currentUser.language ) ) {
 		if ( shouldUseFallbackLocale ) {
 			// Use user locale fallback slug
-			reduxStore.dispatch( setLocale( userLocaleSlug ) );
-		} else {
-			// Use the current user's and load traslation data with a fetch request
-			reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
+			reduxStore?.dispatch( setLocale( userLocaleSlug ) );
+			return userLocaleSlug;
 		}
-	} else if ( bootstrappedLocaleSlug ) {
+
+		// Use the current user's and load translation data with a fetch request
+		reduxStore?.dispatch(
+			setLocale( currentUser.localeSlug || currentUser.language, currentUser.localeVariant )
+		);
+		return currentUser.localeVariant || currentUser.localeSlug || currentUser.language;
+	}
+
+	if ( bootstrappedLocaleSlug ) {
 		// Use locale slug from bootstrapped language manifest object
-		reduxStore.dispatch( setLocale( bootstrappedLocaleSlug ) );
-	} else if ( getLocaleFromQueryParam() ) {
+		reduxStore?.dispatch( setLocale( bootstrappedLocaleSlug ) );
+		return bootstrappedLocaleSlug;
+	}
+
+	if ( getLocaleFromQueryParam() ) {
 		// For logged out Calypso pages, set the locale from query param
 		const pathLocaleSlug = getLocaleFromQueryParam();
-		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
-	} else if ( ! window.hasOwnProperty( 'localeFromRoute' ) ) {
+		pathLocaleSlug && reduxStore?.dispatch( setLocale( pathLocaleSlug, '' ) );
+		return pathLocaleSlug;
+	}
+
+	if ( ! window.hasOwnProperty( 'localeFromRoute' ) ) {
 		// For logged out Calypso pages, set the locale from path if we cannot get the locale from the route on the server side
 		const pathLocaleSlug = getLocaleFromPathname();
-		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
+		pathLocaleSlug && reduxStore?.dispatch( setLocale( pathLocaleSlug, '' ) );
 		recordTracksEvent( 'calypso_locale_set', { path: window.location.pathname } );
+		return pathLocaleSlug;
 	}
 
 	// If user is logged out and translations are not bootstrapped, we assume default locale
+	return '';
 };

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -7,12 +7,19 @@ module.exports = {
 					{
 						group: [
 							'calypso/*',
+							'!calypso/boot',
+							'calypso/boot/*',
+							'!calypso/boot/locale',
 							// Allowed: calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',
 							'!calypso/lib/wp',
+							'!calypso/lib/i18n-utils',
+							'calypso/lib/i18n-utils/*',
+							'!calypso/lib/i18n-utils/switch-locale',
 							'!calypso/components',
 							'calypso/components/*',
+							'!calypso/components/calypso-i18n-provider',
 							// Allowed: calypso/assets/icons
 							'!calypso/assets',
 							'calypso/assets/*',

--- a/client/dashboard/app/i18n/index.tsx
+++ b/client/dashboard/app/i18n/index.tsx
@@ -1,0 +1,26 @@
+import defaultCalypsoI18n from 'i18n-calypso';
+import { useEffect } from 'react';
+import { setupLocale } from 'calypso/boot/locale';
+import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
+import switchLocale from 'calypso/lib/i18n-utils/switch-locale';
+import { useAuth } from '../auth';
+
+export function I18nProvider( { children }: { children: React.ReactNode } ) {
+	const { user } = useAuth();
+
+	useEffect( () => {
+		if ( ! user.language ) {
+			return;
+		}
+
+		const locale = setupLocale( user );
+
+		// The `switchLocale` function is normally called within the `setLocale` action. However,
+		// since we don't have access to the Redux store in this context, we need to call it manually.
+		if ( locale ) {
+			switchLocale( locale );
+		}
+	}, [ user.language ] );
+
+	return <CalypsoI18nProvider i18n={ defaultCalypsoI18n }>{ children }</CalypsoI18nProvider>;
+}

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from '@tanstack/react-router';
 import { useMemo } from 'react';
 import { AuthProvider, useAuth } from './auth';
 import { AppProvider, type AppConfig } from './context';
+import { I18nProvider } from './i18n';
 import { queryClient } from './query-client';
 import { getRouter } from './router';
 
@@ -17,7 +18,9 @@ function Layout( { config }: { config: AppConfig } ) {
 		<AppProvider config={ config }>
 			<QueryClientProvider client={ queryClient }>
 				<AuthProvider>
-					<RouterProviderWithAuth config={ config } />
+					<I18nProvider>
+						<RouterProviderWithAuth config={ config } />
+					</I18nProvider>
 				</AuthProvider>
 			</QueryClientProvider>
 		</AppProvider>

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -12,6 +12,7 @@ export interface User {
 	username: string;
 	display_name: string;
 	avatar_URL?: string;
+	language: string;
 }
 
 export interface SiteDomain {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-10589

## Proposed Changes

* Introduce the `I18nProvider` under `/dashboard` to setup the locale
* Make the `reduxStore` argument in the `setupLocale` function optional, and have the function return the resolved locale.

Needs to be discussed:

* Whether we want to introduce the `CalypsoI18nProvider`?
* Whether we want to use `i18n-calypso`?

Both [setupLocale](https://github.com/Automattic/wp-calypso/blob/bf667901c61984a0daaba61ddb70b59dfd2f4743/client/boot/locale.js#L29) and [switchLocale](https://github.com/Automattic/wp-calypso/blob/bf667901c61984a0daaba61ddb70b59dfd2f4743/client/lib/i18n-utils/switch-locale.js#L326) functions are tightly coupled with `i18n-calypso`. If we don't want to use `i18n-calypso`, we need to decouple the logic that fetches the locale data (enabled or disabled translation chunks) and then initial the locale data by `@wordpress/i18n` on v2 dashboard.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix the translation on Hosting Dashboard V2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your account language to any locale other than English
* Go to /v2
* Ensure the translation works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
