### PR TITLE
Notifications: improve Email Subscriptions button saving state

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,11 +1,10 @@
 import { Card, FormLabel, Dialog } from '@automattic/components';
-import { CheckboxControl } from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
-import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
@@ -78,6 +77,11 @@ class NotificationSubscriptions extends Component {
 		}
 
 		this.props.submitForm( event );
+	};
+
+	handleSubmitButtonClick = ( event ) => {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on Save Notification Settings Button' );
+		this.handleSubmit( event );
 	};
 
 	handleModalCancel = () => {
@@ -299,15 +303,16 @@ class NotificationSubscriptions extends Component {
 							</FormFieldset>
 						) }
 
-						<FormButton
-							isSubmitting={ this.props.isUpdatingUserSettings }
+						<Button
+							variant="primary"
 							disabled={ this.props.isUpdatingUserSettings || ! this.props.hasUnsavedUserSettings }
-							onClick={ this.handleClickEvent( 'Save Notification Settings Button' ) }
+							isBusy={ this.props.isUpdatingUserSettings }
+							onClick={ this.handleSubmitButtonClick }
 						>
 							{ this.props.isUpdatingUserSettings
 								? this.props.translate( 'Saving…' )
 								: this.props.translate( 'Save notification settings' ) }
-						</FormButton>
+						</Button>
 					</form>
 				</Card>
 

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -309,9 +309,7 @@ class NotificationSubscriptions extends Component {
 							isBusy={ this.props.isUpdatingUserSettings }
 							onClick={ this.handleSubmitButtonClick }
 						>
-							{ this.props.isUpdatingUserSettings
-								? this.props.translate( 'Saving…' )
-								: this.props.translate( 'Save notification settings' ) }
+							{ this.props.translate( 'Save notification settings' ) }
 						</Button>
 					</form>
 				</Card>


### PR DESCRIPTION


Part of DOTCOM-13037

## Proposed Changes
This PR replaces the submit button with WP component/button and addresses the design issues with the button saving states.

## Why are these changes being made?
Because of design review DOTCOM-12890

## Testing Instructions

Go to wordpress.com/me and navigate to the Email Subscriptions tab. See the button is now styled as the buttons on other tabs (or refer to DOTCOM-13037 thread for design references).

https://github.com/user-attachments/assets/ea952389-9360-4cc3-b28f-045e13a636a1


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->



- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
