### PR TITLE
Remove unused server analytics properties

### DIFF
--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -73,10 +73,8 @@ const analytics = {
 			this.createPixel( {
 				_en: eventName,
 				_ts: date.getTime(),
-				_tz: date.getTimezoneOffset() / 60,
 				_dl: req.get( 'Referer' ),
 				_lg: acceptLanguageHeader.split( ',' )[ 0 ],
-				_pf: req.useragent.platform,
 				_via_ip: req.get( 'x-forwarded-for' ) || req.connection.remoteAddress,
 				_via_ua: req.useragent.source,
 				...getUserFromRequest( req ),

--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -76,7 +76,7 @@ const analytics = {
 				_dl: req.get( 'Referer' ),
 				_lg: acceptLanguageHeader.split( ',' )[ 0 ],
 				_via_ip: req.get( 'x-forwarded-for' ) || req.connection.remoteAddress,
-				_via_ua: req.useragent.source,
+				_via_ua: req.get( 'user-agent' ),
 				...getUserFromRequest( req ),
 				...eventProperties,
 			} );

--- a/client/server/lib/analytics/index.ts
+++ b/client/server/lib/analytics/index.ts
@@ -1,8 +1,15 @@
 import crypto from 'crypto';
+import { type Request } from 'express';
 import superagent from 'superagent';
 const URL = require( 'url' );
 
-function getUserFromRequest( request ) {
+interface UserParameters {
+	_ul?: string;
+	_ui: string | number;
+	_ut: string;
+}
+
+function getUserFromRequest( request: Request ): UserParameters {
 	// if user has a cookie, lets use that
 	const encodedUserCookie = request?.cookies?.wordpress_logged_in ?? null;
 
@@ -27,8 +34,8 @@ function getUserFromRequest( request ) {
 	// If we have a full identity on query params - use it
 	if ( request?.query?._ut && request?.query?._ui ) {
 		return {
-			_ui: request.query._ui,
-			_ut: request.query._ut,
+			_ui: request.query._ui as string,
+			_ut: request.query._ut as string,
 		};
 	}
 
@@ -41,7 +48,7 @@ function getUserFromRequest( request ) {
 
 const analytics = {
 	tracks: {
-		createPixel: function ( data ) {
+		createPixel: function ( data: Record< string, string | number | undefined > ) {
 			data._rt = new Date().getTime();
 			data._ = '_';
 			const pixelUrl = URL.format( {
@@ -53,7 +60,11 @@ const analytics = {
 			superagent.get( pixelUrl ).end();
 		},
 
-		recordEvent: function ( eventName, eventProperties, req ) {
+		recordEvent: function (
+			eventName: string,
+			eventProperties: Record< string, string | undefined >,
+			req: Request
+		) {
 			eventProperties = eventProperties || {};
 
 			if ( eventName.indexOf( 'calypso_' ) !== 0 ) {

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -1,4 +1,3 @@
-import UserAgent from 'express-useragent';
 import superagent from 'superagent';
 import analytics from '../index';
 
@@ -27,12 +26,11 @@ describe( 'Server-Side Analytics', () => {
 						return 'test';
 					case 'x-forwarded-for':
 						return '1.1.1.1';
+					case 'user-agent':
+						return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0';
 				}
 				throw 'no ' + header;
 			},
-			useragent: UserAgent.parse(
-				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
-			),
 		};
 
 		test( 'sends an HTTP request to the tracks URL', () => {

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -2,15 +2,12 @@ import UserAgent from 'express-useragent';
 import superagent from 'superagent';
 import analytics from '../index';
 
-const mockTimestamp = new Date( '2024-01-01T00:00:00.000Z' ).getTime();
-const mockTimezoneOffset = new Date( '2024-01-01T00:00:00.000Z' ).getTimezoneOffset() / 60;
-
 describe( 'Server-Side Analytics', () => {
 	describe( 'tracks.recordEvent', () => {
 		beforeAll( function () {
 			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } );
 			jest.useFakeTimers();
-			jest.setSystemTime( mockTimestamp );
+			jest.setSystemTime( 1704067200000 );
 		} );
 
 		afterAll( () => {
@@ -46,11 +43,9 @@ describe( 'Server-Side Analytics', () => {
 			expect( url.origin ).toBe( 'http://pixel.wp.com' );
 			expect( url.pathname ).toBe( '/t.gif' );
 			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_test' );
-			expect( url.searchParams.get( '_ts' ) ).toBe( mockTimestamp.toString() );
-			expect( url.searchParams.get( '_tz' ) ).toBe( mockTimezoneOffset.toString() );
+			expect( url.searchParams.get( '_ts' ) ).toBe( '1704067200000' );
 			expect( url.searchParams.get( '_dl' ) ).toBe( 'test' );
 			expect( url.searchParams.get( '_lg' ) ).toBe( 'cs' );
-			expect( url.searchParams.get( '_pf' ) ).toBe( 'Apple Mac' );
 			expect( url.searchParams.get( '_via_ip' ) ).toBe( '1.1.1.1' );
 			expect( url.searchParams.get( '_via_ua' ) ).toBe(
 				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
@@ -58,7 +53,7 @@ describe( 'Server-Side Analytics', () => {
 			// For anonymous user, as req.cookies is not defined in the test setup for this case
 			expect( url.searchParams.get( '_ut' ) ).toBe( 'anon' );
 			expect( url.searchParams.get( '_ui' ) ).toEqual( expect.stringMatching( /^[a-f0-9-]+$/i ) );
-			expect( url.searchParams.get( '_rt' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_rt' ) ).toBe( '1704067200000' );
 			expect( url.searchParams.get( '_' ) ).toBe( '_' );
 			expect( url.searchParams.get( 'a' ) ).toBe( 'foo' );
 		} );
@@ -77,11 +72,9 @@ describe( 'Server-Side Analytics', () => {
 			expect( url.origin ).toBe( 'http://pixel.wp.com' );
 			expect( url.pathname ).toBe( '/t.gif' );
 			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_user_test' );
-			expect( url.searchParams.get( '_ts' ) ).toBe( mockTimestamp.toString() );
-			expect( url.searchParams.get( '_tz' ) ).toBe( mockTimezoneOffset.toString() );
+			expect( url.searchParams.get( '_ts' ) ).toBe( '1704067200000' );
 			expect( url.searchParams.get( '_dl' ) ).toBe( 'test' );
 			expect( url.searchParams.get( '_lg' ) ).toBe( 'cs' );
-			expect( url.searchParams.get( '_pf' ) ).toBe( 'Apple Mac' );
 			expect( url.searchParams.get( '_via_ip' ) ).toBe( '1.1.1.1' );
 			expect( url.searchParams.get( '_via_ua' ) ).toBe(
 				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
@@ -89,7 +82,7 @@ describe( 'Server-Side Analytics', () => {
 			expect( url.searchParams.get( '_ul' ) ).toBe( 'testuser' );
 			expect( url.searchParams.get( '_ui' ) ).toBe( '12345' );
 			expect( url.searchParams.get( '_ut' ) ).toBe( 'wpcom:user_id' );
-			expect( url.searchParams.get( '_rt' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_rt' ) ).toBe( '1704067200000' );
 			expect( url.searchParams.get( '_' ) ).toBe( '_' );
 			expect( url.searchParams.get( 'b' ) ).toBe( 'bar' );
 		} );
@@ -109,18 +102,16 @@ describe( 'Server-Side Analytics', () => {
 			expect( url.origin ).toBe( 'http://pixel.wp.com' );
 			expect( url.pathname ).toBe( '/t.gif' );
 			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_query_test' );
-			expect( url.searchParams.get( '_ts' ) ).toBe( mockTimestamp.toString() );
-			expect( url.searchParams.get( '_tz' ) ).toBe( mockTimezoneOffset.toString() );
+			expect( url.searchParams.get( '_ts' ) ).toBe( '1704067200000' );
 			expect( url.searchParams.get( '_dl' ) ).toBe( 'test' );
 			expect( url.searchParams.get( '_lg' ) ).toBe( 'cs' );
-			expect( url.searchParams.get( '_pf' ) ).toBe( 'Apple Mac' );
 			expect( url.searchParams.get( '_via_ip' ) ).toBe( '1.1.1.1' );
 			expect( url.searchParams.get( '_via_ua' ) ).toBe(
 				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
 			);
 			expect( url.searchParams.get( '_ui' ) ).toBe( 'queryuser' );
 			expect( url.searchParams.get( '_ut' ) ).toBe( 'querytype' );
-			expect( url.searchParams.get( '_rt' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_rt' ) ).toBe( '1704067200000' );
 			expect( url.searchParams.get( '_' ) ).toBe( '_' );
 			expect( url.searchParams.get( 'c' ) ).toBe( 'baz' );
 		} );

--- a/client/server/lib/analytics/test/index.js
+++ b/client/server/lib/analytics/test/index.js
@@ -2,10 +2,19 @@ import UserAgent from 'express-useragent';
 import superagent from 'superagent';
 import analytics from '../index';
 
+const mockTimestamp = new Date( '2024-01-01T00:00:00.000Z' ).getTime();
+const mockTimezoneOffset = new Date( '2024-01-01T00:00:00.000Z' ).getTimezoneOffset() / 60;
+
 describe( 'Server-Side Analytics', () => {
 	describe( 'tracks.recordEvent', () => {
 		beforeAll( function () {
 			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } );
+			jest.useFakeTimers();
+			jest.setSystemTime( mockTimestamp );
+		} );
+
+		afterAll( () => {
+			jest.useRealTimers();
 		} );
 
 		afterEach( () => {
@@ -36,8 +45,84 @@ describe( 'Server-Side Analytics', () => {
 			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
 			expect( url.origin ).toBe( 'http://pixel.wp.com' );
 			expect( url.pathname ).toBe( '/t.gif' );
+			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_test' );
+			expect( url.searchParams.get( '_ts' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_tz' ) ).toBe( mockTimezoneOffset.toString() );
+			expect( url.searchParams.get( '_dl' ) ).toBe( 'test' );
 			expect( url.searchParams.get( '_lg' ) ).toBe( 'cs' );
+			expect( url.searchParams.get( '_pf' ) ).toBe( 'Apple Mac' );
+			expect( url.searchParams.get( '_via_ip' ) ).toBe( '1.1.1.1' );
+			expect( url.searchParams.get( '_via_ua' ) ).toBe(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
+			);
+			// For anonymous user, as req.cookies is not defined in the test setup for this case
+			expect( url.searchParams.get( '_ut' ) ).toBe( 'anon' );
+			expect( url.searchParams.get( '_ui' ) ).toEqual( expect.stringMatching( /^[a-f0-9-]+$/i ) );
+			expect( url.searchParams.get( '_rt' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_' ) ).toBe( '_' );
 			expect( url.searchParams.get( 'a' ) ).toBe( 'foo' );
+		} );
+
+		test( 'sends an HTTP request with user details from cookie', () => {
+			const reqWithCookie = {
+				...req,
+				cookies: {
+					wordpress_logged_in: encodeURIComponent( 'testuser|12345|token' ),
+				},
+			};
+			analytics.tracks.recordEvent( 'calypso_user_test', { b: 'bar' }, reqWithCookie );
+
+			expect( superagent.get ).toHaveBeenCalled();
+			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			expect( url.origin ).toBe( 'http://pixel.wp.com' );
+			expect( url.pathname ).toBe( '/t.gif' );
+			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_user_test' );
+			expect( url.searchParams.get( '_ts' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_tz' ) ).toBe( mockTimezoneOffset.toString() );
+			expect( url.searchParams.get( '_dl' ) ).toBe( 'test' );
+			expect( url.searchParams.get( '_lg' ) ).toBe( 'cs' );
+			expect( url.searchParams.get( '_pf' ) ).toBe( 'Apple Mac' );
+			expect( url.searchParams.get( '_via_ip' ) ).toBe( '1.1.1.1' );
+			expect( url.searchParams.get( '_via_ua' ) ).toBe(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
+			);
+			expect( url.searchParams.get( '_ul' ) ).toBe( 'testuser' );
+			expect( url.searchParams.get( '_ui' ) ).toBe( '12345' );
+			expect( url.searchParams.get( '_ut' ) ).toBe( 'wpcom:user_id' );
+			expect( url.searchParams.get( '_rt' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_' ) ).toBe( '_' );
+			expect( url.searchParams.get( 'b' ) ).toBe( 'bar' );
+		} );
+
+		test( 'sends an HTTP request with user details from query params', () => {
+			const reqWithQuery = {
+				...req,
+				query: {
+					_ui: 'queryuser',
+					_ut: 'querytype',
+				},
+			};
+			analytics.tracks.recordEvent( 'calypso_query_test', { c: 'baz' }, reqWithQuery );
+
+			expect( superagent.get ).toHaveBeenCalled();
+			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			expect( url.origin ).toBe( 'http://pixel.wp.com' );
+			expect( url.pathname ).toBe( '/t.gif' );
+			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_query_test' );
+			expect( url.searchParams.get( '_ts' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_tz' ) ).toBe( mockTimezoneOffset.toString() );
+			expect( url.searchParams.get( '_dl' ) ).toBe( 'test' );
+			expect( url.searchParams.get( '_lg' ) ).toBe( 'cs' );
+			expect( url.searchParams.get( '_pf' ) ).toBe( 'Apple Mac' );
+			expect( url.searchParams.get( '_via_ip' ) ).toBe( '1.1.1.1' );
+			expect( url.searchParams.get( '_via_ua' ) ).toBe(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:93.0) Gecko/20100101 Firefox/93.0'
+			);
+			expect( url.searchParams.get( '_ui' ) ).toBe( 'queryuser' );
+			expect( url.searchParams.get( '_ut' ) ).toBe( 'querytype' );
+			expect( url.searchParams.get( '_rt' ) ).toBe( mockTimestamp.toString() );
+			expect( url.searchParams.get( '_' ) ).toBe( '_' );
+			expect( url.searchParams.get( 'c' ) ).toBe( 'baz' );
 		} );
 
 		test( 'omits an undefined event property', () => {

--- a/client/server/lib/analytics/test/index.ts
+++ b/client/server/lib/analytics/test/index.ts
@@ -1,10 +1,11 @@
-import superagent from 'superagent';
+import { type Request } from 'express';
+import superagent, { type SuperAgentRequest } from 'superagent';
 import analytics from '../index';
 
 describe( 'Server-Side Analytics', () => {
 	describe( 'tracks.recordEvent', () => {
-		beforeAll( function () {
-			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } );
+		beforeAll( () => {
+			jest.spyOn( superagent, 'get' ).mockReturnValue( { end: () => {} } as SuperAgentRequest );
 			jest.useFakeTimers();
 			jest.setSystemTime( 1704067200000 );
 		} );
@@ -14,11 +15,11 @@ describe( 'Server-Side Analytics', () => {
 		} );
 
 		afterEach( () => {
-			superagent.get.mockClear();
+			( superagent.get as jest.Mock ).mockClear();
 		} );
 
 		const req = {
-			get: ( header ) => {
+			get: ( header: string ) => {
 				switch ( header.toLowerCase() ) {
 					case 'accept-language':
 						return 'cs';
@@ -31,13 +32,13 @@ describe( 'Server-Side Analytics', () => {
 				}
 				throw 'no ' + header;
 			},
-		};
+		} as Request;
 
 		test( 'sends an HTTP request to the tracks URL', () => {
 			analytics.tracks.recordEvent( 'calypso_test', { a: 'foo' }, req );
 
 			expect( superagent.get ).toHaveBeenCalled();
-			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			const url = new URL( ( superagent.get as jest.Mock ).mock.calls[ 0 ][ 0 ] );
 			expect( url.origin ).toBe( 'http://pixel.wp.com' );
 			expect( url.pathname ).toBe( '/t.gif' );
 			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_test' );
@@ -62,11 +63,11 @@ describe( 'Server-Side Analytics', () => {
 				cookies: {
 					wordpress_logged_in: encodeURIComponent( 'testuser|12345|token' ),
 				},
-			};
+			} as Request;
 			analytics.tracks.recordEvent( 'calypso_user_test', { b: 'bar' }, reqWithCookie );
 
 			expect( superagent.get ).toHaveBeenCalled();
-			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			const url = new URL( ( superagent.get as jest.Mock ).mock.calls[ 0 ][ 0 ] );
 			expect( url.origin ).toBe( 'http://pixel.wp.com' );
 			expect( url.pathname ).toBe( '/t.gif' );
 			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_user_test' );
@@ -92,11 +93,11 @@ describe( 'Server-Side Analytics', () => {
 					_ui: 'queryuser',
 					_ut: 'querytype',
 				},
-			};
+			} as unknown as Request;
 			analytics.tracks.recordEvent( 'calypso_query_test', { c: 'baz' }, reqWithQuery );
 
 			expect( superagent.get ).toHaveBeenCalled();
-			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			const url = new URL( ( superagent.get as jest.Mock ).mock.calls[ 0 ][ 0 ] );
 			expect( url.origin ).toBe( 'http://pixel.wp.com' );
 			expect( url.pathname ).toBe( '/t.gif' );
 			expect( url.searchParams.get( '_en' ) ).toBe( 'calypso_query_test' );
@@ -118,7 +119,7 @@ describe( 'Server-Side Analytics', () => {
 			analytics.tracks.recordEvent( 'calypso_test', { a: undefined }, req );
 
 			expect( superagent.get ).toHaveBeenCalled();
-			const url = new URL( superagent.get.mock.calls[ 0 ][ 0 ] );
+			const url = new URL( ( superagent.get as jest.Mock ).mock.calls[ 0 ][ 0 ] );
 			expect( url.searchParams.get( 'a' ) ).toBeNull();
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Split from #103023

## Proposed Changes

* Removes unused parameters from server analytics: `_pf` and `_tz` ([related discussion](https://github.com/Automattic/wp-calypso/pull/103023#discussion_r2069357374))

Also includes some light cleanup:

- Expand test coverage for expected parameters to increase confidence in changes
- Port implementation and test script to TypeScript
- Remove dependency on `express-useragent`, to further simplify the tests and effort of #103023

This file could do for some more changes, but intentionally not included here to facilitate code review:

- Replace use of deprecated `url` module, which seems to be [using a CommonJS `require`](https://github.com/Automattic/wp-calypso/blob/d75983217973270c46effea22342ca13854a0e0d/client/server/lib/analytics/index.js#L3) to circumvent [an existing lint rule](https://github.com/Automattic/wp-calypso/blob/d75983217973270c46effea22342ca13854a0e0d/.eslintrc.js#L396-L401)
- Replace `superagent` with native `fetch`
- Replace [runtime event name checks](https://github.com/Automattic/wp-calypso/blob/d75983217973270c46effea22342ca13854a0e0d/client/server/lib/analytics/index.js#L59-L62) with [TypeScript template literal type](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) ([example](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html)) 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simplify effort of #103023

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify Tracks server-side pixel tracking continues to behave as expected:

1. Start server with debugging and unsupported browser feature enabled (unsupported browsers logs a Tracks event)
   - `DEBUG=superagent ENABLE_FEATURES=redirect-fallback-browsers yarn start`
2. Trigger a Tracks event by emulating a request from an unsupported browser:
   - `curl -I -A "Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko" http://calypso.localhost:3000`
3. Observe a `superagent` debugging entry in the server process for `http://pixel.wp.com/t.gif` with expected parameters  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
