### PR TITLE
Tag Stream: Fix WordPress capitalization

### DIFF
--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -11,6 +11,7 @@ import {
 } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getReaderTagBySlug from 'calypso/state/reader/tags/selectors/get-reader-tag-by-slug';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import renderHeaderSection from '../lib/header-section';
@@ -23,8 +24,9 @@ export const tagListing = ( context, next ) => {
 	const tagSlug = decodeURIComponent(
 		trim( context.params.tag ).toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' )
 	);
-	const tagTitle = titlecase( trim( context.params.tag ) ).replace( /[-_]/g, ' ' );
 	const state = context.store.getState();
+	const tag = getReaderTagBySlug( state, tagSlug );
+	const tagTitle = tag?.title || titlecase( trim( context.params.tag ) ).replace( /[-_]/g, ' ' );
 
 	const encodedTag = encodeURIComponent( tagSlug ).toLowerCase();
 
@@ -64,6 +66,7 @@ export const tagListing = ( context, next ) => {
 				streamKey={ streamKey }
 				encodedTagSlug={ encodedTag }
 				decodedTagSlug={ tagSlug }
+				initialTitle={ tagTitle }
 				sort={ context.query.sort }
 				trackScrollPage={ trackScrollPage.bind(
 					// eslint-disable-line

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -99,15 +99,17 @@ class TagStream extends Component {
 
 	render() {
 		const emptyContent = () => <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
-		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
-		const titleText = titleCase( title.replace( /-/g, ' ' ) );
+		const titleText =
+			tag?.title ||
+			this.props.initialTitle ||
+			titleCase( this.props.decodedTagSlug.replace( /-/g, ' ' ) );
 
 		let encodedTagSlug = this.props.encodedTagSlug;
 
 		// If the tag contains emoji, convert to text equivalent
 		if ( this.state.emojiText && this.state.isEmojiTitle ) {
-			encodedTagSlug = this.state.emojiText.convert( title, {
+			encodedTagSlug = this.state.emojiText.convert( this.props.decodedTagSlug, {
 				delimiter: '',
 			} );
 		}
@@ -119,7 +121,7 @@ class TagStream extends Component {
 					<QueryReaderTag tag={ this.props.decodedTagSlug } />
 					<ReaderBackButton />
 					<TagStreamHeader
-						title={ title }
+						title={ titleText }
 						encodedTagSlug={ encodedTagSlug }
 						// This shouldn not be necessary as user should not have been able to
 						// subscribe to an error tag. Nevertheless, we should give them a route to
@@ -161,7 +163,7 @@ class TagStream extends Component {
 			<Stream
 				{ ...this.props }
 				className="tag-stream__main"
-				listName={ title }
+				listName={ titleText }
 				emptyContent={ emptyContentWithHeader }
 				showFollowInHeader
 				forcePlaceholders={ ! tag } // if tag has not loaded yet, then make everything a placeholder

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -3,7 +3,6 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import { createRef } from 'react';
-import titlecase from 'to-title-case';
 import StickyPanel from 'calypso/components/sticky-panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
@@ -37,7 +36,7 @@ const TagsColumn = ( props: TagsColProps ) => {
 	return (
 		<div key={ props.slug }>
 			<a href={ path } onClick={ trackTagClick.bind( null, props.slug ) }>
-				<span className="alphabetic-tags__title">{ titlecase( props.title ) }</span>
+				<span className="alphabetic-tags__title">{ props.title }</span>
 			</a>
 		</div>
 	);

--- a/client/state/data-layer/wpcom/read/tags/test/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/test/utils.js
@@ -25,14 +25,14 @@ const normalizedFollowedTagsResponse = deepFreeze( [
 		id: '307',
 		slug: 'chickens',
 		title: 'Chickens',
-		displayName: 'chickens',
+		displayName: 'Chickens',
 		url: '/tag/chickens',
 	},
 	{
 		id: '148',
 		slug: 'design',
 		title: 'Design',
-		displayName: 'design',
+		displayName: 'Design',
 		url: '/tag/design',
 	},
 ] );
@@ -52,7 +52,7 @@ const normalizedSuccessfulSingleTagResponse = deepFreeze( [
 		id: '307',
 		slug: 'chickens',
 		title: 'Chickens',
-		displayName: 'chickens',
+		displayName: 'Chickens',
 		url: '/tag/chickens',
 	},
 ] );

--- a/client/state/data-layer/wpcom/read/tags/test/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/test/utils.js
@@ -57,6 +57,26 @@ const normalizedSuccessfulSingleTagResponse = deepFreeze( [
 	},
 ] );
 
+const wordPressTagResponse = deepFreeze( {
+	tag: {
+		ID: '33',
+		slug: 'wordpress',
+		title: 'WordPress',
+		display_name: 'wordpress',
+		URL: 'https://public-api.wordpress.com/rest/v1.2/read/tags/wordpress/posts',
+	},
+} );
+
+const normalizedWordPressTagResponse = deepFreeze( [
+	{
+		id: '33',
+		slug: 'wordpress',
+		title: 'WordPress',
+		displayName: 'WordPress',
+		url: '/tag/wordpress',
+	},
+] );
+
 describe( 'wpcom-api: read/tags utils', () => {
 	describe( '#fromApi', () => {
 		test( 'should properly normalize many tags', () => {
@@ -67,6 +87,11 @@ describe( 'wpcom-api: read/tags utils', () => {
 		test( 'should properly normalize a single tag', () => {
 			const transformedResponse = fromApi( successfulSingleTagResponse );
 			expect( transformedResponse ).toEqual( normalizedSuccessfulSingleTagResponse );
+		} );
+
+		test( 'should properly handle WordPress tag capitalization', () => {
+			const transformedResponse = fromApi( wordPressTagResponse );
+			expect( transformedResponse ).toEqual( normalizedWordPressTagResponse );
 		} );
 
 		test( 'should blow up when given wrong keys', () => {

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -26,7 +26,7 @@ export function fromApi( apiResponse ) {
 	return tags.map( ( tag ) => ( {
 		id: tag.ID,
 		description: decodeEntities( tag.description ),
-		displayName: decodeEntities( tag.display_name ),
+		displayName: decodeEntities( tag.title || tag.display_name ),
 		url: `/tag/${ tag.slug }`,
 		title: decodeEntities( tag.title ),
 		slug: tag.slug.toLowerCase(),


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Use the tag title from the API endpoint and fall back to the slug. Previously we were displaying the slug and capitalizing it, which led to incorrect capitalization of WordPress.
* Also remove incorrect titlecasing from the alphabetical listing of tags.

| Before | After |
|--------|--------|
<img width="642" alt="Screenshot 2025-05-09 at 2 05 14 PM" src="https://github.com/user-attachments/assets/a7552461-3276-4032-b99b-5757f5dc4490" /> | <img width="324" alt="Screenshot 2025-05-09 at 2 05 25 PM" src="https://github.com/user-attachments/assets/263e7b4c-9f66-4cd6-94e2-cb2fc57e60f6" />
<img width="955" alt="Screenshot 2025-05-09 at 1 31 46 PM" src="https://github.com/user-attachments/assets/b8af742f-0f22-4333-a60e-3181292d7772" /> | <img width="960" alt="Screenshot 2025-05-09 at 2 14 29 PM" src="https://github.com/user-attachments/assets/273f5759-e214-4a4d-8d6f-f457b45df58a" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* WordPress was incorrectly capitalized.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /tag/wordpress
* Verify that WordPress is correctly capitalized.
* Regression test other tags to make sure their titles load.
* Go to /tags
* Verify that WordPress is correctly capitalized and one word.
* Check that other tag titles look correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
