### PR TITLE
Remove subscriber: check that both email and wpcom removals are done

### DIFF
--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -120,8 +120,8 @@ const useSubscriberRemoveMutation = (
 				// Consider removal successful if:
 				// 1. We removed the email subscription (if it existed)
 				// 2. We removed the wpcom following (if it existed)
-				const emailSuccess = ! emailSubscriptionId || emailRemoved;
-				const wpcomSuccess = ! isNaN( numericUserId ) ? wpcomRemoved : true;
+				const emailSuccess = emailSubscriptionId ? emailRemoved : true;
+				const wpcomSuccess = isNaN( numericUserId ) ? true : wpcomRemoved;
 
 				return emailSuccess && wpcomSuccess;
 			} );

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -83,14 +83,15 @@ const useSubscriberRemoveMutation = (
 					await Promise.all( promises );
 				}
 
-				let wasRemoved = false;
+				let emailRemoved = false;
+				let wpcomRemoved = false;
 
 				// Remove the subscriber from the followers if they have a numeric user_id
 				const numericUserId = Number( subscriber.user_id );
 				if ( ! isNaN( numericUserId ) ) {
 					try {
 						await wpcom.req.post( `/sites/${ siteId }/followers/${ numericUserId }/delete` );
-						wasRemoved = true;
+						wpcomRemoved = true;
 					} catch ( e ) {
 						// Only throw if they don't have an email subscription ID to try next
 						const emailSubscriptionId = getEmailSubscriptionId( subscriber );
@@ -107,16 +108,22 @@ const useSubscriberRemoveMutation = (
 						await wpcom.req.post(
 							`/sites/${ siteId }/email-followers/${ emailSubscriptionId }/delete`
 						);
-						wasRemoved = true;
+						emailRemoved = true;
 					} catch ( e ) {
 						// Only throw if we haven't successfully removed them through any other method.
-						if ( ! wasRemoved ) {
+						if ( ! wpcomRemoved ) {
 							throw new Error( ( e as ApiResponseError )?.message );
 						}
 					}
 				}
 
-				return wasRemoved;
+				// Consider removal successful if:
+				// 1. We removed the email subscription (if it existed)
+				// 2. We removed the wpcom following (if it existed)
+				const emailSuccess = ! emailSubscriptionId || emailRemoved;
+				const wpcomSuccess = ! isNaN( numericUserId ) ? wpcomRemoved : true;
+
+				return emailSuccess && wpcomSuccess;
 			} );
 			const promiseResults = await Promise.allSettled( subscriberPromises );
 			if (

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -17,7 +17,7 @@ type ApiResponseError = {
 
 const useNewHelper = config.isEnabled( 'subscribers-helper-library' );
 
-const getEmailSubscriptionId: ( subscriber: Subscriber ) => number = ( subscriber ) => {
+const getEmailSubscriptionId = ( subscriber: Subscriber ): number => {
 	if ( useNewHelper ) {
 		return subscriber.email_subscription_id || 0;
 	}

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -17,7 +17,7 @@ type ApiResponseError = {
 
 const useNewHelper = config.isEnabled( 'subscribers-helper-library' );
 
-const getEmailSubscriptionId = ( subscriber: Subscriber ): number => {
+const getEmailSubscriptionId: ( subscriber: Subscriber ) => number = ( subscriber ) => {
 	if ( useNewHelper ) {
 		return subscriber.email_subscription_id || 0;
 	}
@@ -86,15 +86,18 @@ const useSubscriberRemoveMutation = (
 				let emailRemoved = false;
 				let wpcomRemoved = false;
 
-				// Remove the subscriber from the followers if they have a numeric user_id
 				const numericUserId = Number( subscriber.user_id );
+				const emailSubscriptionId = getEmailSubscriptionId( subscriber );
+
+				// Remove the subscriber from the followers if they have a numeric user_id
 				if ( ! isNaN( numericUserId ) ) {
 					try {
-						await wpcom.req.post( `/sites/${ siteId }/followers/${ numericUserId }/delete` );
-						wpcomRemoved = true;
+						const response = await wpcom.req.post(
+							`/sites/${ siteId }/followers/${ numericUserId }/delete`
+						);
+						wpcomRemoved = response?.deleted === true;
 					} catch ( e ) {
 						// Only throw if they don't have an email subscription ID to try next
-						const emailSubscriptionId = getEmailSubscriptionId( subscriber );
 						if ( ( e as ApiResponseError )?.error === 'not_found' && ! emailSubscriptionId ) {
 							throw new Error( ( e as ApiResponseError )?.message );
 						}
@@ -102,13 +105,13 @@ const useSubscriberRemoveMutation = (
 				}
 
 				// Try to remove as email follower if they have an email subscription ID
-				const emailSubscriptionId = getEmailSubscriptionId( subscriber );
 				if ( emailSubscriptionId ) {
 					try {
-						await wpcom.req.post(
+						const response = await wpcom.req.post(
 							`/sites/${ siteId }/email-followers/${ emailSubscriptionId }/delete`
 						);
-						emailRemoved = true;
+						// Verify the response indicates successful deletion
+						emailRemoved = response?.deleted === true;
 					} catch ( e ) {
 						// Only throw if we haven't successfully removed them through any other method.
 						if ( ! wpcomRemoved ) {
@@ -118,12 +121,17 @@ const useSubscriberRemoveMutation = (
 				}
 
 				// Consider removal successful if:
-				// 1. We removed the email subscription (if it existed)
-				// 2. We removed the wpcom following (if it existed)
-				const emailSuccess = emailSubscriptionId ? emailRemoved : true;
-				const wpcomSuccess = isNaN( numericUserId ) ? true : wpcomRemoved;
+				// 1. Email subscription was either:
+				//    - Successfully removed (if it existed)
+				//    - Did not exist (no removal needed)
+				// 2. WPCOM following was either:
+				//    - Successfully removed (if it existed)
+				//    - Did not exist (no removal needed)
+				const isFullyRemoved =
+					( emailSubscriptionId ? emailRemoved : true ) &&
+					( ! isNaN( numericUserId ) ? wpcomRemoved : true );
 
-				return emailSuccess && wpcomSuccess;
+				return isFullyRemoved;
 			} );
 			const promiseResults = await Promise.allSettled( subscriberPromises );
 			if (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Check that both wpcom and email removals have completed if needed, instead of either.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Attempt to fix flaky removal tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /subscribers
* Remove an email-only subscriber
* Remove a Dotcom subscriber
* Sign up as a subscriber, confirm your email, and then remove the subscriber
* In all cases the subscriber should be completely removed.
* Check out this branch and run the test:

```
export CALYPSO_BASE_URL=http://calypso.localhost:3000

yarn workspace wp-e2e-tests build && VIEWPORT_NAME="desktop" ATOMIC_VARIATION="default" TEST_ON_ATOMIC="true" yarn workspace wp-e2e-tests test test/e2e/specs/users/newsletter__subscribe-remove.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
