### PR TITLE
Experiment streamlining the plans grid + checkout: Checkout adjustments

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -64,7 +64,10 @@ import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
 import useOneDollarOfferTrack from 'calypso/my-sites/plans/hooks/use-onedollar-offer-track';
-import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceCheckoutTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -304,7 +307,9 @@ function CheckoutSidebarNudge( {
 	if ( isDIFMInCart ) {
 		return (
 			<CheckoutSidebarNudgeWrapper
-				isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+				isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+					streamlinedPriceExperimentAssignment
+				) }
 			>
 				<CheckoutNextSteps responseCart={ responseCart } />
 			</CheckoutSidebarNudgeWrapper>
@@ -318,7 +323,9 @@ function CheckoutSidebarNudge( {
 
 	return (
 		<CheckoutSidebarNudgeWrapper
-			isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+				streamlinedPriceExperimentAssignment
+			) }
 		>
 			{ ! ( productsWithVariants.length > 1 ) && (
 				<>
@@ -635,7 +642,8 @@ export default function CheckoutMainContent( {
 								siteId={ siteId }
 								onChangeSelection={ changeSelection }
 								showFeaturesList={
-									! isStreamlinedPriceExperimentLoading && ! streamlinedPriceExperimentAssignment
+									! isStreamlinedPriceExperimentLoading &&
+									! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
 								}
 							/>
 							<CheckoutSidebarNudge
@@ -860,7 +868,9 @@ export default function CheckoutMainContent( {
 			<WPCheckoutWrapper
 				className="checkout-wrapper"
 				isLargeViewport={ isLargeViewport }
-				isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+				isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+					streamlinedPriceExperimentAssignment
+				) }
 			>
 				{ checkoutSummary }
 				{ checkoutMainContent }
@@ -871,7 +881,9 @@ export default function CheckoutMainContent( {
 	return (
 		<StepContainerV2CheckoutFixer
 			isLargeViewport={ isLargeViewport }
-			isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+				streamlinedPriceExperimentAssignment
+			) }
 		>
 			<Step.TwoColumnLayout
 				firstColumnWidth={ 8 }

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -9,7 +9,10 @@ import debugFactory from 'debug';
 import PromoCard from 'calypso/components/promo-section/promo-card';
 import PromoCardCTA from 'calypso/components/promo-section/promo-card/cta';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceCheckoutTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
@@ -206,13 +209,15 @@ export function CheckoutSidebarPlanUpsell() {
 
 	const checkoutSidebarPlanUpsellClassName =
 		'checkout-sidebar-plan-upsell' +
-		( streamlinedPriceExperimentAssignment ? ' checkout-sidebar-plan-upsell-streamlined' : '' );
+		( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment )
+			? ' checkout-sidebar-plan-upsell-streamlined'
+			: '' );
 
 	return (
 		<>
 			<PromoCard title={ cardTitle } className={ checkoutSidebarPlanUpsellClassName }>
 				<div className="checkout-sidebar-plan-upsell__plan-grid">
-					{ ! streamlinedPriceExperimentAssignment && (
+					{ ! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
 						<>
 							<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 								<strong>{ __( 'Plan' ) }</strong>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -25,7 +25,10 @@ import {
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceCheckoutTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { useSelector } from 'calypso/state';
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import useCartKey from '../../use-cart-key';
@@ -263,7 +266,7 @@ function LineItemCostOverride( {
 			</span>
 			<span className="cost-overrides-list-item__discount">
 				{ costOverride.discountAmount &&
-					! streamlinedPriceExperimentAssignment &&
+					! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
 					formatCurrency( -costOverride.discountAmount, product.currency, {
 						isSmallestUnit: true,
 						signForPositive: true, // TODO clk numberFormatCurrency signForPositive only usage
@@ -397,7 +400,7 @@ function SingleProductAndCostOverridesList( { product }: { product: ResponseCart
 		}
 	);
 	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
-	if ( streamlinedPriceExperimentAssignment ) {
+	if ( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ) {
 		let streamlinedActualAmountDisplay;
 
 		// logic taken from packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -469,8 +472,14 @@ export function CouponCostOverride( {
 	const label = isOnboardingAffiliateFlow ? getAffiliateCouponLabel() : couponLabel;
 
 	return (
-		<CostOverridesListStyle isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }>
-			{ streamlinedPriceExperimentAssignment && <WPCheckoutCheckIcon /> }
+		<CostOverridesListStyle
+			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+				streamlinedPriceExperimentAssignment
+			) }
+		>
+			{ isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
+				<WPCheckoutCheckIcon />
+			) }
 			<div className="cost-overrides-list-item cost-overrides-list-item--coupon">
 				<span className="cost-overrides-list-item__reason cost-overrides-list-item__reason--is-discount">
 					{ label }

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -13,7 +13,10 @@ import {
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceCheckoutTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import CheckoutTerms from '../components/checkout-terms';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
 
@@ -128,26 +131,27 @@ export default function BeforeSubmitCheckoutHeader() {
 			<CheckoutTermsWrapper>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsWrapper>
-			{ ! isStreamlinedPriceExperimentLoading && ! streamlinedPriceExperimentAssignment && (
-				<WPOrderReviewSection>
-					<NonTotalPrices>
-						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-						{ totalAdjustments !== 0 && (
-							<NonProductLineItem subtotal lineItem={ adjustmentLineItem } />
-						) }
-						{ taxLineItems.map( ( taxLineItem ) => (
-							<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
-						) ) }
-						{ creditsLineItem && responseCart.sub_total_integer > 0 && (
-							<NonProductLineItem subtotal lineItem={ creditsLineItem } />
-						) }
-					</NonTotalPrices>
-					<TotalPrice>
-						<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
-					</TotalPrice>
-					{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
-				</WPOrderReviewSection>
-			) }
+			{ ! isStreamlinedPriceExperimentLoading &&
+				! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
+					<WPOrderReviewSection>
+						<NonTotalPrices>
+							<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
+							{ totalAdjustments !== 0 && (
+								<NonProductLineItem subtotal lineItem={ adjustmentLineItem } />
+							) }
+							{ taxLineItems.map( ( taxLineItem ) => (
+								<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
+							) ) }
+							{ creditsLineItem && responseCart.sub_total_integer > 0 && (
+								<NonProductLineItem subtotal lineItem={ creditsLineItem } />
+							) }
+						</NonTotalPrices>
+						<TotalPrice>
+							<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
+						</TotalPrice>
+						{ isBillingInfoEmpty( responseCart ) && <TaxNotCalculatedLineItem /> }
+					</WPOrderReviewSection>
+				) }
 		</>
 	);
 }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -45,7 +45,10 @@ import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { useStreamlinedPriceExperiment } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceCheckoutTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -100,7 +103,9 @@ export function WPCheckoutOrderSummary( {
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
-			isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+				streamlinedPriceExperimentAssignment
+			) }
 		>
 			{ showFeaturesList && (
 				<CheckoutSummaryFeaturedList
@@ -194,7 +199,7 @@ function CheckoutSummaryPriceList() {
 
 	let subtotalBeforeDiscounts = 0;
 	let totalDiscount = 0;
-	if ( streamlinedPriceExperimentAssignment ) {
+	if ( isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) ) {
 		for ( const product of responseCart.products ) {
 			// In specific cases (e.g. premium domains) the original price (renewal) is lower than the due price.
 			subtotalBeforeDiscounts += Math.max(
@@ -207,17 +212,19 @@ function CheckoutSummaryPriceList() {
 
 	return (
 		<>
-			{ streamlinedPriceExperimentAssignment && (
+			{ isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
 				<CheckoutSummaryTitle>
 					<span>{ translate( 'Your order' ) }</span>
 				</CheckoutSummaryTitle>
 			) }
 			<ProductsAndCostOverridesList responseCart={ responseCart } />
 			<CheckoutSummaryAmountWrapper
-				isStreamlinedPrice={ streamlinedPriceExperimentAssignment !== null }
+				isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+					streamlinedPriceExperimentAssignment
+				) }
 			>
 				<CheckoutSubtotalSection>
-					{ streamlinedPriceExperimentAssignment && (
+					{ isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
 						<CheckoutSummarySubtotal key="checkout-summary-line-item-subtotal">
 							<span>{ translate( 'Subtotal' ) }</span>
 							<span className="wp-checkout-order-summary__subtotal-price">
@@ -238,19 +245,20 @@ function CheckoutSummaryPriceList() {
 							</span>
 						</CheckoutSummarySubtotal>
 					) }
-					{ streamlinedPriceExperimentAssignment && totalDiscount > 0 && (
-						<CheckoutSummaryTotalDiscount>
-							<span>{ translate( 'Discount' ) }</span>
-							<span className="wp-checkout-order-summary__subtotal-discount">
-								{ formatCurrency( totalDiscount, responseCart.currency, {
-									isSmallestUnit: true,
-									stripZeros: true,
-								} ) }
-							</span>
-						</CheckoutSummaryTotalDiscount>
-					) }
+					{ isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
+						totalDiscount > 0 && (
+							<CheckoutSummaryTotalDiscount>
+								<span>{ translate( 'Discount' ) }</span>
+								<span className="wp-checkout-order-summary__subtotal-discount">
+									{ formatCurrency( totalDiscount, responseCart.currency, {
+										isSmallestUnit: true,
+										stripZeros: true,
+									} ) }
+								</span>
+							</CheckoutSummaryTotalDiscount>
+						) }
 
-					{ ! streamlinedPriceExperimentAssignment && (
+					{ ! isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) && (
 						<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
 							<span>{ translate( 'Subtotal' ) }</span>
 							<span>

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -1,20 +1,25 @@
 import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 
 const STREAMLINED_PRICE_EXPERIMENT_NAME = 'calypso_streamlined_plans_checkout';
 
 export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
+	const [ isLoadingExperiment, assignment ] = useExperiment( STREAMLINED_PRICE_EXPERIMENT_NAME, {
+		isEligible: isEligibleForExperiment(),
+	} );
+
+	return [ isLoadingExperiment, assignment?.variationName ?? null ];
+}
+
+function isEligibleForExperiment(): boolean {
 	const flowFromStorage = getSignupCompleteFlowName(); // The flow for the Checkout page
 	const flowFromURL = getFlowFromURL(); // The flow for the Plans step
 	const flow = flowFromStorage || flowFromURL;
-
-	const [ isLoadingExperiment, assignment ] = useExperiment(
-		STREAMLINED_PRICE_EXPERIMENT_NAME,
-		{ isEligible: flow === 'onboarding' } // Only onboarding flow is eligible for streamlined pricing
-	);
-
-	return [ isLoadingExperiment, assignment?.variationName ?? null ];
+	// Only onboarding flow is eligible for streamlined pricing. Akismet/Jetpack checkouts are excluded as well.
+	return flow === 'onboarding' && ! isAkismetCheckout() && ! isJetpackCheckout();
 }
 
 export async function isStreamlinedPriceExperiment() {
@@ -34,4 +39,11 @@ export function isStreamlinedPriceRadioTreatment( variationName?: string | null 
 		return false;
 	}
 	return variationName.includes( 'checkout_radio' );
+}
+
+export function isStreamlinedPriceCheckoutTreatment( variationName?: string | null ) {
+	if ( ! variationName ) {
+		return false;
+	}
+	return ! variationName.includes( 'checkout_control' );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p58i-kUT-p2#comment-68347

## Proposed Changes

* Limit the new checkout style for the experiment to not be shown for Jetpack/Akismet checkouts and the `plans_1y_checkout_control` variation.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* `plans_1y_checkout_control` variation is used to only apply the changes to the plans page, but not the checkout.
* We have decided to only limit the new style to WPCom checkout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add some products (plan, domain) and navigate to the checkout page.
* Assign yourself to `plans_1y_checkout_control` variation and confirm that the old checkout style is shown on the checkout page.
* Switch to any other variation and confirm that the new style is being shown.
* Go to https://akismet.com/pricing/, click on "Get Pro" and confirm that the checkout page is using the old style.
* Go to https://jetpack.com/upgrade/backup/, click on "Get VaultPress Backup" and confirm that the checkout page is using the old style.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
