### PR TITLE
Stats: New tabs styling for Odyssey

### DIFF
--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -124,10 +124,7 @@
 		padding: 7px;
 	}
 
-	.stats-navigation.stats-navigation--improved  {
-		&.stats-page-navigation .stats-navigation__tabs {
-			margin-left: -12px;
-		}
+	.stats-navigation.stats-navigation--improved .stats-navigation__tabs {
 		.components-tab-panel__tabs-item::after {
 			background-color: var(--color-primary-50);
 		}

--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -123,6 +123,14 @@
 		line-height: 1;
 		padding: 7px;
 	}
+
+	.stats-navigation.stats-navigation--improved .stats-navigation__tabs {
+		// Jetpack log has a small padding that needs the offest to align.
+		margin-left: -12px;
+		.components-tab-panel__tabs-item::after {
+			background-color: var(--color-primary-50);
+		}
+	}
 }
 
 .inner-notice-container .card.banner.is-jetpack {

--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -124,9 +124,10 @@
 		padding: 7px;
 	}
 
-	.stats-navigation.stats-navigation--improved .stats-navigation__tabs {
-		// Jetpack log has a small padding that needs the offest to align.
-		margin-left: -12px;
+	.stats-navigation.stats-navigation--improved  {
+		&.stats-page-navigation .stats-navigation__tabs {
+			margin-left: -12px;
+		}
 		.components-tab-panel__tabs-item::after {
 			background-color: var(--color-primary-50);
 		}

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -164,7 +164,7 @@ class StatsNavigation extends Component {
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
 
-		const wrapperClass = clsx( 'stats-navigation', 'stats-page-navigation', {
+		const wrapperClass = clsx( 'stats-navigation', {
 			'stats-navigation--modernized': ! isLegacy,
 			'stats-navigation--improved': isStatsNavigationImprovementEnabled,
 		} );

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -164,7 +164,7 @@ class StatsNavigation extends Component {
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
 
-		const wrapperClass = clsx( 'stats-navigation', {
+		const wrapperClass = clsx( 'stats-navigation', 'stats-page-navigation', {
 			'stats-navigation--modernized': ! isLegacy,
 			'stats-navigation--improved': isStatsNavigationImprovementEnabled,
 		} );

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -66,7 +66,7 @@
 		color: var(--wp-components-color-gray-900, $gray-900);
 		display: flex;
 		align-items: center;
-		gap: 10px;
+		gap: 12px;
 		line-height: 1;
 		height: 32px;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STATS-47

## Proposed Changes

* Change active tab background to `--color-primary-50` to match design


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Match Odyssey Stats design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Option 1 PCYsg-Pp7-p2
* Open `https://x.xx.ngrok.io/wp-admin/admin.php?page=stats#!/stats/subscribers/xx.x.ngrok.io?page=stats`
* Ensure active tab is in Jetpack Green 50%
* Ensure the first tab is aligned with logo
* Open post details page
* Ensure the tabs work as before
* Open location summary page
* Ensure the tabs work as before

<img width="347" alt="image" src="https://github.com/user-attachments/assets/b37f4c82-5b02-4fc6-ac19-e7dd515ccc43" />




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?