### PR TITLE
Stats: track last viewed tab

### DIFF
--- a/client/my-sites/stats/pages/insights/index.jsx
+++ b/client/my-sites/stats/pages/insights/index.jsx
@@ -53,9 +53,12 @@ function StatsInsights() {
 	const shouldRendeUpsell = config.isEnabled( 'stats/paid-wpcom-v3' ) && shouldGateInsights;
 	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
-	// Track the last viewed tab.
-	// Necessary to properly configure the fixed navigation headers.
-	sessionStorage.setItem( 'jp-stats-last-tab', 'insights' );
+	useEffect(
+		() =>
+			// Necessary to properly configure the fixed navigation headers.
+			sessionStorage.setItem( 'jp-stats-last-tab', 'insights' ),
+		[]
+	); // Track the last viewed tab.
 
 	const isWPAdmin = config.isEnabled( 'is_odyssey' );
 	const insightsPageClasses = clsx( 'stats', { 'is-odyssey-stats': isWPAdmin } );

--- a/client/my-sites/stats/pages/realtime/index.jsx
+++ b/client/my-sites/stats/pages/realtime/index.jsx
@@ -94,9 +94,12 @@ function StatsRealtime() {
 		return () => clearInterval( intervalId );
 	}, [ dispatch, siteId, query ] );
 
-	// Track the last viewed tab.
-	// Necessary to properly configure the fixed navigation headers.
-	sessionStorage.setItem( 'jp-stats-last-tab', 'realtime' );
+	useEffect(
+		() =>
+			// Necessary to properly configure the fixed navigation headers.
+			sessionStorage.setItem( 'jp-stats-last-tab', 'realtime' ),
+		[]
+	); // Track the last viewed tab.
 
 	// TODO: should be refactored into separate components
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -91,9 +92,12 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 		( subscribersTotals?.total === 1 && subscribersTotals?.is_owner_subscribed );
 	const showLaunchpad = ! isLoading && hasNoSubscriberOtherThanAdmin;
 
-	// Track the last viewed tab.
-	// Necessary to properly configure the fixed navigation headers.
-	// sessionStorage.setItem( 'jp-stats-last-tab', 'subscribers' );
+	useEffect(
+		() =>
+			// Necessary to properly configure the fixed navigation headers.
+			sessionStorage.setItem( 'jp-stats-last-tab', 'subscribers' ),
+		[]
+	); // Track the last viewed tab.
 
 	const summaryUrl = `/stats/${ period?.period }/emails/${ siteSlug }?startDate=${ period?.startOf?.format(
 		'YYYY-MM-DD'

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -118,7 +118,7 @@ class StatsEmailDetail extends Component {
 			insights: '/stats/insights/',
 			store: '/stats/store/',
 			ads: '/stats/ads/',
-			subscribers: '/stats/subscribers',
+			subscribers: '/stats/subscribers/',
 		};
 		// We track the parent tab via sessionStorage.
 		const lastClickedTab = sessionStorage.getItem( 'jp-stats-last-tab' );

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -111,12 +111,14 @@ class StatsEmailDetail extends Component {
 			insights: this.props.translate( 'Insights' ),
 			store: this.props.translate( 'Store' ),
 			ads: this.props.translate( 'Ads' ),
+			subscribers: this.props.translate( 'Subscribers' ),
 		};
 		const possibleBackLinks = {
 			traffic: '/stats/day/',
 			insights: '/stats/insights/',
 			store: '/stats/store/',
 			ads: '/stats/ads/',
+			subscribers: '/stats/subscribers',
 		};
 		// We track the parent tab via sessionStorage.
 		const lastClickedTab = sessionStorage.getItem( 'jp-stats-last-tab' );

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -40,7 +40,7 @@ const StatsEmailSummary = ( { period, query } ) => {
 			insights: '/stats/insights/',
 			store: '/stats/store/',
 			ads: '/stats/ads/',
-			subscribers: '/stats/subscribers',
+			subscribers: '/stats/subscribers/',
 		};
 		// We track the parent tab via sessionStorage.
 		const lastClickedTab = sessionStorage.getItem( 'jp-stats-last-tab' );

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,10 +1,10 @@
 import { formatNumber } from '@automattic/number-formatters';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import titlecase from 'to-title-case';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
+import { useSelector } from 'calypso/state';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import {
 	TooltipWrapper,
@@ -19,36 +19,46 @@ import '../stats-module/summary-nav.scss';
 
 const StatsStrings = statsStringsFactory();
 
-const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
-	// Navigation settings. One of the following, depending on the summary view.
-	// Traffic => /stats/day/
-	// Insights => /stats/insights/
-	const localizedTabNames = {
-		traffic: translate( 'Traffic' ),
-		insights: translate( 'Insights' ),
-	};
-	const backLabel = localizedTabNames.traffic;
-	let backLink = `/stats/day/`;
+// TODO: `query` was never passed from outside or defined in scope. Adding it to avoid a lint error.
+const StatsEmailSummary = ( { period, query } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state, siteId ) );
 
-	const query = {
-		period: period,
-		quantity: 30,
-	};
-	const module = 'emails';
-	const title = translate( 'Emails' );
+	// TODO: align with all summary pages.
+	const navigationItems = useMemo( () => {
+		const title = translate( 'Emails' );
+		const localizedTabNames = {
+			traffic: translate( 'Traffic' ),
+			insights: translate( 'Insights' ),
+			store: translate( 'Store' ),
+			ads: translate( 'Ads' ),
+			subscribers: translate( 'Subscribers' ),
+		};
+		const possibleBackLinks = {
+			traffic: '/stats/day/',
+			insights: '/stats/insights/',
+			store: '/stats/store/',
+			ads: '/stats/ads/',
+			subscribers: '/stats/subscribers',
+		};
+		// We track the parent tab via sessionStorage.
+		const lastClickedTab = sessionStorage.getItem( 'jp-stats-last-tab' );
+		const backLabel = localizedTabNames[ lastClickedTab ] || localizedTabNames.traffic;
+		let backLink = possibleBackLinks[ lastClickedTab ] || possibleBackLinks.traffic;
+		// Append the domain as needed.
+		const domain = siteSlug;
+		if ( domain?.length > 0 ) {
+			backLink += domain;
+		}
 
-	const domain = siteSlug;
-	if ( domain?.length > 0 ) {
-		backLink += domain;
-	}
-	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
+		// Wrap it up!
+		return [ { label: backLabel, href: backLink }, { label: title } ];
+	}, [ translate, siteSlug ] );
 
 	return (
 		<Main className="has-fixed-nav" wideLayout>
-			<PageViewTracker
-				path={ `/stats/${ module }/:site` }
-				title={ `Stats > ${ titlecase( module ) }` }
-			/>
+			<PageViewTracker path="/stats/emails/:site" title="Stats > Emails" />
 			<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
 			<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
 				<div className="stats-summary-nav">
@@ -129,10 +139,4 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	);
 };
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	return {
-		siteId: getSelectedSiteId( state ),
-		siteSlug: getSelectedSiteSlug( state, siteId ),
-	};
-} )( localize( StatsEmailSummary ) );
+export default StatsEmailSummary;

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -71,7 +71,7 @@ class StatsPostDetail extends Component {
 			insights: '/stats/insights/',
 			store: '/stats/store/',
 			ads: '/stats/ads/',
-			subscribers: '/stats/subscribers',
+			subscribers: '/stats/subscribers/',
 		};
 		// We track the parent tab via sessionStorage.
 		const lastClickedTab = sessionStorage.getItem( 'jp-stats-last-tab' );

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -64,12 +64,14 @@ class StatsPostDetail extends Component {
 			insights: this.props.translate( 'Insights' ),
 			store: this.props.translate( 'Store' ),
 			ads: this.props.translate( 'Ads' ),
+			subscribers: this.props.translate( 'Subscribers' ),
 		};
 		const possibleBackLinks = {
 			traffic: '/stats/day/',
 			insights: '/stats/insights/',
 			store: '/stats/store/',
 			ads: '/stats/ads/',
+			subscribers: '/stats/subscribers',
 		};
 		// We track the parent tab via sessionStorage.
 		const lastClickedTab = sessionStorage.getItem( 'jp-stats-last-tab' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Update last viewed tab for Subscribers page
* Align the implementation in different places. We could add a custom hook, but i'm not super concerned about it atm.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix back link for old/new headers

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Opne Subscribers page
- Click View details for the Emails module
- Ensure the breadcrumbs are like the screenshot

<img width="735" alt="image" src="https://github.com/user-attachments/assets/a61af475-e1ab-4fe2-8074-95509d57822a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
