### PR TITLE
Stats: New header emails summary page

### DIFF
--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -7,6 +7,7 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Main from 'calypso/my-sites/stats/components/stats-main';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import PageHeader from '../components/headers/page-header';
 import {
 	TooltipWrapper,
 	OpensTooltipContent,
@@ -17,7 +18,6 @@ import PageViewTracker from '../stats-page-view-tracker';
 import statsStringsFactory from '../stats-strings';
 import '../summary/style.scss';
 import '../stats-module/summary-nav.scss';
-import PageHeader from '../components/headers/page-header';
 
 const StatsStrings = statsStringsFactory();
 

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -66,7 +66,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 				) }
 
 				{ ! isStatsNavigationImprovementEnabled && (
-					<NavigationHeader navigationItems={ navigationItems } />
+					<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
 				) }
 
 				<div id="my-stats-content" className="stats stats-summary-view stats-summary__positioned">

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -86,7 +86,7 @@ const StatsEmailSummary = ( { period, query } ) => {
 					<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
 				) }
 
-				<div id="my-stats-content" className="stats stats-summary-view stats-summary__positioned">
+				<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
 					<div className="stats-summary-nav">
 						<div className="stats-summary-nav__header">
 							<div>

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -48,13 +48,12 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
 	return (
-		<Main className="has-fixed-nav" wideLayout>
+		<Main className="has-fixed-nav" fullWidthLayout>
 			<PageViewTracker
 				path={ `/stats/${ module }/:site` }
 				title={ `Stats > ${ titlecase( module ) }` }
 			/>
-
-			<div id="my-stats-content" className="stats stats-summary-view stats-summary__positioned">
+			<div className="stats stats-summary-view">
 				{ isStatsNavigationImprovementEnabled && (
 					<PageHeader
 						className="stats__section-header modernized-header"
@@ -67,82 +66,84 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 				) }
 
 				{ ! isStatsNavigationImprovementEnabled && (
-					<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
+					<NavigationHeader navigationItems={ navigationItems } />
 				) }
 
-				<div className="stats-summary-nav">
-					<div className="stats-summary-nav__header">
-						<div>
-							<div className="stats-section-title">
-								<h3>{ translate( 'Stats for Emails' ) }</h3>
+				<div id="my-stats-content" className="stats stats-summary-view stats-summary__positioned">
+					<div className="stats-summary-nav">
+						<div className="stats-summary-nav__header">
+							<div>
+								<div className="stats-section-title">
+									<h3>{ translate( 'Stats for Emails' ) }</h3>
+								</div>
 							</div>
 						</div>
 					</div>
-				</div>
 
-				<StatsModule
-					additionalColumns={ {
-						header: (
-							<>
-								<span>{ translate( 'Opens' ) }</span>
-							</>
-						),
-						body: ( item ) => {
-							const opensUnique = parseInt( item.unique_opens, 10 );
-							const opens = parseInt( item.opens, 10 );
-							const hasUniquesData = opensUnique > 0 || opens === 0;
-							return (
-								<TooltipWrapper
-									value={
-										hasUniquesData
-											? `${ formatNumber( item.opens_rate, {
-													numberFormatOptions: {
-														maximumFractionDigits: 2,
-													},
-											  } ) }%`
-											: '—'
-									}
-									item={ item }
-									TooltipContent={ OpensTooltipContent }
-								/>
-							);
-						},
-					} }
-					path="emails"
-					moduleStrings={ { ...StatsStrings.emails, title: '' } }
-					period={ period }
-					query={ query }
-					statType="statsEmailsSummary"
-					mainItemLabel={ translate( 'Latest Emails' ) }
-					hideSummaryLink
-					metricLabel={ translate( 'Clicks' ) }
-					valueField="clicks_rate"
-					formatValue={ ( value, item ) => {
-						if ( item?.clicks !== undefined ) {
-							const clicksUnique = parseInt( item.unique_clicks, 10 );
-							const clicks = parseInt( item.clicks, 10 );
-							const hasUniquesData = clicksUnique > 0 || clicks === 0;
-							return (
-								<TooltipWrapper
-									value={
-										hasUniquesData
-											? `${ formatNumber( item.clicks_rate, {
-													numberFormatOptions: {
-														maximumFractionDigits: 2,
-													},
-											  } ) }%`
-											: '—'
-									}
-									item={ item }
-									TooltipContent={ ClicksTooltipContent }
-								/>
-							);
-						}
-						return <span>{ value }</span>;
-					} }
-					listItemClassName="stats__summary--narrow-mobile"
-				/>
-				<JetpackColophon />
+					<StatsModule
+						additionalColumns={ {
+							header: (
+								<>
+									<span>{ translate( 'Opens' ) }</span>
+								</>
+							),
+							body: ( item ) => {
+								const opensUnique = parseInt( item.unique_opens, 10 );
+								const opens = parseInt( item.opens, 10 );
+								const hasUniquesData = opensUnique > 0 || opens === 0;
+								return (
+									<TooltipWrapper
+										value={
+											hasUniquesData
+												? `${ formatNumber( item.opens_rate, {
+														numberFormatOptions: {
+															maximumFractionDigits: 2,
+														},
+												  } ) }%`
+												: '—'
+										}
+										item={ item }
+										TooltipContent={ OpensTooltipContent }
+									/>
+								);
+							},
+						} }
+						path="emails"
+						moduleStrings={ { ...StatsStrings.emails, title: '' } }
+						period={ period }
+						query={ query }
+						statType="statsEmailsSummary"
+						mainItemLabel={ translate( 'Latest Emails' ) }
+						hideSummaryLink
+						metricLabel={ translate( 'Clicks' ) }
+						valueField="clicks_rate"
+						formatValue={ ( value, item ) => {
+							if ( item?.clicks !== undefined ) {
+								const clicksUnique = parseInt( item.unique_clicks, 10 );
+								const clicks = parseInt( item.clicks, 10 );
+								const hasUniquesData = clicksUnique > 0 || clicks === 0;
+								return (
+									<TooltipWrapper
+										value={
+											hasUniquesData
+												? `${ formatNumber( item.clicks_rate, {
+														numberFormatOptions: {
+															maximumFractionDigits: 2,
+														},
+												  } ) }%`
+												: '—'
+										}
+										item={ item }
+										TooltipContent={ ClicksTooltipContent }
+									/>
+								);
+							}
+							return <span>{ value }</span>;
+						} }
+						listItemClassName="stats__summary--narrow-mobile"
+					/>
+					<JetpackColophon />
+				</div>
 			</div>
 		</Main>
 	);

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -60,21 +60,25 @@ const StatsEmailSummary = ( { period, query } ) => {
 
 	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
 
+	const backLinkProps = {
+		text: navigationItems[ 0 ].label,
+		url: navigationItems[ 0 ].href,
+	};
+	const titleProps = {
+		title: navigationItems[ 1 ].label,
+		// Remove the default logo for Odyssey stats.
+		titleLogo: null,
+	};
+
 	return (
 		<Main className="has-fixed-nav" fullWidthLayout>
-			<PageViewTracker
-				path={ `/stats/${ module }/:site` }
-				title={ `Stats > ${ titlecase( module ) }` }
-			/>
+			<PageViewTracker path="/stats/emails/:site" title="Stats > Emails" />
 			<div className="stats stats-summary-view">
 				{ isStatsNavigationImprovementEnabled && (
 					<PageHeader
 						className="stats__section-header modernized-header"
-						titleProps={ { title, titleLogo: null } }
-						backLinkProps={ {
-							url: backLink,
-							text: backLabel,
-						} }
+						titleProps={ titleProps }
+						backLinkProps={ backLinkProps }
 					/>
 				) }
 

--- a/client/my-sites/stats/stats-email-summary/index.jsx
+++ b/client/my-sites/stats/stats-email-summary/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { formatNumber } from '@automattic/number-formatters';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -16,6 +17,7 @@ import PageViewTracker from '../stats-page-view-tracker';
 import statsStringsFactory from '../stats-strings';
 import '../summary/style.scss';
 import '../stats-module/summary-nav.scss';
+import PageHeader from '../components/headers/page-header';
 
 const StatsStrings = statsStringsFactory();
 
@@ -43,14 +45,31 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 	}
 	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
 
+	const isStatsNavigationImprovementEnabled = config.isEnabled( 'stats/navigation-improvement' );
+
 	return (
 		<Main className="has-fixed-nav" wideLayout>
 			<PageViewTracker
 				path={ `/stats/${ module }/:site` }
 				title={ `Stats > ${ titlecase( module ) }` }
 			/>
-			<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
-			<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
+
+			<div id="my-stats-content" className="stats stats-summary-view stats-summary__positioned">
+				{ isStatsNavigationImprovementEnabled && (
+					<PageHeader
+						className="stats__section-header modernized-header"
+						titleProps={ { title, titleLogo: null } }
+						backLinkProps={ {
+							url: backLink,
+							text: backLabel,
+						} }
+					/>
+				) }
+
+				{ ! isStatsNavigationImprovementEnabled && (
+					<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
+				) }
+
 				<div className="stats-summary-nav">
 					<div className="stats-summary-nav__header">
 						<div>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes STATS-62

## Proposed Changes

* Email summary is a separate page 😢 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Add in new header behind feature flag

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click 'View details' of the Emails module from Subscribers page locally
* Ensure you can see the new header

<img width="1397" alt="image" src="https://github.com/user-attachments/assets/58920605-7d92-4330-8ea7-49733a8577a6" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
