### PR TITLE
A4A: Update the default 'Schedule a call' link to use HubSpot meeting.

### DIFF
--- a/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/index.tsx
@@ -30,7 +30,7 @@ export default function OverviewSidebarGrowthAccelerator() {
 			window.open(
 				result.data
 					? result.data
-					: 'https://savvycal.com/automattic-for-agencies/agency-success?utm_campaign=overview',
+					: 'https://meetings.hubspot.com/automattic-for-agencies/discovery-meeting',
 				'_blank'
 			);
 		} );


### PR DESCRIPTION
This PR updates the 'Schedule a call' link to use the HubSpot meeting by default if none is set for the current agency.

<img width="525" alt="Screenshot 2025-05-12 at 1 10 59 PM" src="https://github.com/user-attachments/assets/c22caa33-2893-4978-9615-ed12b74cd515" />


Closes https://linear.app/a8c/issue/A4A-844/update-booking-links-in-dashboard-cta

## Proposed Changes

* Update the default link for the 'Schedule a call' CTA link to point to https://meetings.hubspot.com/automattic-for-agencies/discovery-meeting

## Why are these changes being made?

* We no longer use Savvy call for our PM calendar, so we need to update our link to use the new one, which is HubSpot meeting.

## Testing Instructions
* Ensure that the agency you are currently logged into does not have a success link set in the HubSpot record.
* Use the A4A live link to navigate to the `/overview` page.
* Click the 'Schedule a call'
* Confirm you are redirected to the HubSpot meeting.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
