### PR TITLE
Update text fields on login

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -35,6 +35,11 @@
 	--wp-components-color-accent-darker-20: var(--color-accent-60);
 }
 
+.components-button.is-link:not(.is-destructive) {
+	// Text color, focus ring color
+	--wp-components-color-accent: var(--color-accent);
+}
+
 /* @wordpress/components ButtonGroup overrides */
 .components-button-group {
 	.components-button {

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -63,6 +63,15 @@
 	}
 }
 
+/* @wordpress/components InputControl overrides */
+.components-input-control {
+	--wp-components-color-accent: var(--color-accent);
+
+	&.is-error {
+		--wp-components-color-accent: var(--color-error);
+	}
+}
+
 .components-external-link__contents {
 	text-decoration: none;
 

--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -65,9 +65,15 @@
 
 /* @wordpress/components InputControl overrides */
 .components-input-control {
+	// Input focus ring color
 	--wp-components-color-accent: var(--color-accent);
+	// Label text color
+	--wp-components-color-foreground: var(--studio-gray-100);
+	// Input border color
+	--wp-components-color-gray-600: var(--studio-gray-10);
 
 	&.is-error {
+		// Error state focus ring color
 		--wp-components-color-accent: var(--color-error);
 	}
 }

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import Gravatar from 'calypso/components/gravatar';
@@ -96,10 +96,11 @@ export default function ContinueAsUser( {
 					</div>
 				</div>
 				<Button
-					primary
+					variant="primary"
 					className="continue-as-user__continue-button"
-					busy={ validatingPath }
+					isBusy={ validatingPath }
 					href={ validatedPath || '/' }
+					__next40pxDefaultSize
 				>
 					{ translate( 'Continue' ) }
 				</Button>
@@ -124,10 +125,11 @@ export default function ContinueAsUser( {
 					</div>
 				</div>
 				<Button
-					primary
+					variant="primary"
 					className="continue-as-user__continue-button"
-					busy={ validatingPath }
+					isBusy={ validatingPath }
 					href={ validatedPath || '/' }
+					__next40pxDefaultSize
 				>
 					{ `${ translate( 'Continue as', {
 						context: 'Continue as an existing WordPress.com user',
@@ -142,7 +144,13 @@ export default function ContinueAsUser( {
 		<div className="continue-as-user">
 			<div className="continue-as-user__user-info">
 				{ gravatarLink }
-				<Button primary busy={ validatingPath } href={ validatedPath || '/' }>
+				<Button
+					variant="primary"
+					isBusy={ validatingPath }
+					href={ validatedPath || '/' }
+					__next40pxDefaultSize
+					className="continue-as-user__continue-button"
+				>
 					{ translate( 'Continue' ) }
 				</Button>
 			</div>

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -54,8 +54,8 @@ export default function ContinueAsUser( {
 		components: {
 			br: <br />,
 			link: (
-				<button
-					type="button"
+				<Button
+					variant="link"
 					id="loginAsAnotherUser"
 					className="continue-as-user__change-user-link"
 					onClick={ onChangeAccount }
@@ -85,14 +85,14 @@ export default function ContinueAsUser( {
 				<div className="continue-as-user__user-info">
 					{ gravatarLink }
 					<div className="continue-as-user__not-you">
-						<button
-							type="button"
+						<Button
+							variant="tertiary"
 							id="loginAsAnotherUser"
 							className="continue-as-user__change-user-link"
 							onClick={ onChangeAccount }
 						>
 							{ translate( 'Sign in as a different user' ) }
-						</button>
+						</Button>
 					</div>
 				</div>
 				<Button
@@ -114,14 +114,14 @@ export default function ContinueAsUser( {
 				<div className="continue-as-user__user-info">
 					{ gravatarLink }
 					<div className="continue-as-user__not-you">
-						<button
-							type="button"
+						<Button
+							variant="tertiary"
 							id="loginAsAnotherUser"
 							className="continue-as-user__change-user-link"
 							onClick={ onChangeAccount }
 						>
 							{ translate( 'Sign in as a different user' ) }
-						</button>
+						</Button>
 					</div>
 				</div>
 				<Button

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -47,6 +47,12 @@
 		}
 	}
 
+	.continue-as-user__continue-button {
+		justify-content: center;
+		min-width: 100%;
+		margin-block: 13px;
+	}
+
 	.continue-as-user__not-you {
 		display: block;
 		bottom: 0;

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -2,7 +2,8 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .continue-as-user {
-	display: block;
+	display: flex;
+	flex-direction: column;
 	animation: 1s appear 0s ease-in;
 	color: var(--color-text-subtle);
 	font-size: $font-body-small;
@@ -23,11 +24,6 @@
 		margin: 0 auto;
 		display: flex;
 		flex-direction: column;
-
-		& > a.button {
-			margin: 0 20px;
-			border-radius: 4px;
-		}
 	}
 
 	.continue-as-user__gravatar {
@@ -36,7 +32,6 @@
 	}
 
 	.continue-as-user__continue-button {
-		justify-content: center;
 		min-width: 100%;
 		margin-block: 13px;
 	}

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -35,18 +35,6 @@
 		border: 1px solid #a7aaad;
 	}
 
-	.continue-as-user__change-user-link {
-		color: var(--color-link);
-		cursor: pointer;
-		margin: auto;
-
-		&:hover,
-		&:focus,
-		&:active {
-			color: var(--color-link-dark);
-		}
-	}
-
 	.continue-as-user__continue-button {
 		justify-content: center;
 		min-width: 100%;

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -457,7 +457,7 @@ export class LoginForm extends Component {
 							autoCapitalize="off"
 							autoCorrect="off"
 							spellCheck="false"
-							label={ this.props.translate( 'Email Address or Username' ) }
+							label={ this.props.translate( 'Email address or username' ) }
 							disabled={ isFormDisabled || this.isPasswordView() }
 							id="usernameOrEmail"
 							name="usernameOrEmail"
@@ -569,10 +569,10 @@ export class LoginForm extends Component {
 			// text above the form. We therefore need to clarity the must use WordPress.com credentials.
 			<>
 				<span className="screen-reader-text">
-					{ this.props.translate( 'WordPress.com Email Address or Username' ) }
+					{ this.props.translate( 'WordPress.com email address or username' ) }
 				</span>
 				{ ! this.props.isJetpack && (
-					<span aria-hidden="true">{ this.props.translate( 'Email Address or Username' ) }</span>
+					<span aria-hidden="true">{ this.props.translate( 'Email address or username' ) }</span>
 				) }
 			</>
 		);

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -880,7 +880,7 @@ export class LoginForm extends Component {
 								autoCorrect="off"
 								spellCheck="false"
 								autoComplete="username"
-								className={ clsx( {
+								className={ clsx( 'login__form-userdata-input', {
 									'is-error': requestError && requestError.field === 'usernameOrEmail',
 									'is-label-hidden': this.isPasswordView(),
 								} ) }
@@ -985,7 +985,7 @@ export class LoginForm extends Component {
 									label={ this.props.translate( 'Password' ) }
 									autoCapitalize="off"
 									autoComplete="current-password"
-									className={ clsx( {
+									className={ clsx( 'login__form-userdata-input', {
 										'is-error': requestError && requestError.field === 'password',
 									} ) }
 									onChange={ ( value ) => this.onChangeField( { name: 'password', value } ) }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -535,17 +535,6 @@ export class LoginForm extends Component {
 		);
 	}
 
-	renderChangeUsername() {
-		return (
-			<Button className="login__form-change-username" onClick={ this.resetView } variant="link">
-				<Gridicon icon="arrow-left" size={ 18 } />
-				{ includes( this.state.usernameOrEmail, '@' )
-					? this.props.translate( 'Change Email Address' )
-					: this.props.translate( 'Change Username' ) }
-			</Button>
-		);
-	}
-
 	renderUsernameorEmailLabel() {
 		if ( this.props.isWoo ) {
 			return this.props.translate( 'Your email or username' );
@@ -773,10 +762,11 @@ export class LoginForm extends Component {
 			isJetpack,
 		} = this.props;
 
-		const isPasswordFieldHidden = this.isUsernameOrEmailView();
+		const isUsernameOrEmailView = this.isUsernameOrEmailView();
+		const isPasswordView = this.isPasswordView();
 		const isOauthLogin = !! oauth2Client;
 		const signupUrl = this.getSignupUrl();
-		const shouldRenderForgotPasswordLink = ! isPasswordFieldHidden && isWoo;
+		const shouldRenderForgotPasswordLink = ! isUsernameOrEmailView && isWoo;
 
 		if ( lastUsedAuthenticationMethod === 'qr-code' ) {
 			loginUrl = this.getQrLoginLink();
@@ -865,9 +855,19 @@ export class LoginForm extends Component {
 								</p>
 							) }
 
-							{ this.isPasswordView() && (
+							{ isPasswordView && (
 								<>
-									{ this.renderChangeUsername() }
+									<Button
+										className="login__form-change-username"
+										onClick={ this.resetView }
+										variant="link"
+									>
+										<Gridicon icon="arrow-left" size={ 18 } />
+										{ includes( this.state.usernameOrEmail, '@' )
+											? this.props.translate( 'Change Email Address' )
+											: this.props.translate( 'Change Username' ) }
+									</Button>
+
 									<label htmlFor="usernameOrEmail" className="screen-reader-text">
 										{ this.renderUsernameorEmailLabel() }
 									</label>
@@ -875,21 +875,20 @@ export class LoginForm extends Component {
 							) }
 
 							<InputControl
-								label={ ! this.isPasswordView() && this.renderUsernameorEmailLabel() }
+								label={ isPasswordView ? null : this.renderUsernameorEmailLabel() }
 								autoCapitalize="off"
 								autoCorrect="off"
 								spellCheck="false"
 								autoComplete="username"
 								className={ clsx( 'login__form-userdata-input', {
 									'is-error': requestError && requestError.field === 'usernameOrEmail',
-									'is-label-hidden': this.isPasswordView(),
 								} ) }
 								onChange={ this.onChangeUsernameOrEmailField }
 								id="usernameOrEmail"
 								name="usernameOrEmail"
 								ref={ this.saveUsernameOrEmailRef }
 								value={ this.state.usernameOrEmail }
-								disabled={ isFormDisabled || this.isPasswordView() }
+								disabled={ isFormDisabled || isPasswordView }
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
 							/>
@@ -976,9 +975,9 @@ export class LoginForm extends Component {
 
 							<div
 								className={ clsx( 'login__form-password', {
-									'is-hidden': isPasswordFieldHidden,
+									'is-hidden': isUsernameOrEmailView,
 								} ) }
-								aria-hidden={ isPasswordFieldHidden }
+								aria-hidden={ isUsernameOrEmailView }
 							>
 								<InputControl
 									type={ isPasswordPlainText ? 'text' : 'password' }
@@ -994,7 +993,7 @@ export class LoginForm extends Component {
 									ref={ this.savePasswordRef }
 									value={ this.state.password }
 									disabled={ isFormDisabled }
-									tabIndex={ isPasswordFieldHidden ? -1 : undefined /* not tabbable when hidden */ }
+									tabIndex={ isUsernameOrEmailView ? -1 : undefined /* not tabbable when hidden */ }
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									suffix={
@@ -1010,8 +1009,8 @@ export class LoginForm extends Component {
 														? this.props.translate( 'Hide password' )
 														: this.props.translate( 'Show password' )
 												}
-												aria-hidden={ isPasswordFieldHidden }
-												tabIndex={ isPasswordFieldHidden ? -1 : undefined }
+												aria-hidden={ isUsernameOrEmailView }
+												tabIndex={ isUsernameOrEmailView ? -1 : undefined }
 											/>
 										</InputControlSuffixWrapper>
 									}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1,11 +1,22 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button, Card, FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
+import {
+	Button as A8CButton,
+	Card,
+	FormInputValidation,
+	FormLabel,
+	Gridicon,
+} from '@automattic/components';
 import { alert } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { suggestEmailCorrection } from '@automattic/onboarding';
-import { TextControl } from '@wordpress/components';
-import { Icon } from '@wordpress/icons';
+import {
+	Button,
+	TextControl,
+	__experimentalInputControl as InputControl,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+} from '@wordpress/components';
+import { Icon, seen, unseen } from '@wordpress/icons';
 import clsx from 'clsx';
 import cookie from 'cookie';
 import emailValidator from 'email-validator';
@@ -18,8 +29,6 @@ import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
 import LoginSubmitButton from 'calypso/blocks/login/login-submit-button';
-import FormPasswordInput from 'calypso/components/forms/form-password-input';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import Notice from 'calypso/components/notice';
 import { LastUsedSocialButton } from 'calypso/components/social-buttons';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
@@ -114,6 +123,7 @@ export class LoginForm extends Component {
 		emailSuggestionError: false,
 		password: '',
 		lastUsedAuthenticationMethod: this.getLastUsedAuthenticationMethod(),
+		isPasswordPlainText: false,
 	};
 
 	componentDidMount() {
@@ -210,20 +220,20 @@ export class LoginForm extends Component {
 		}
 	}, 500 );
 
-	onChangeUsernameOrEmailField = ( event ) => {
+	onChangeUsernameOrEmailField = ( value ) => {
 		this.setState( {
 			emailSuggestionError: false,
 			emailSuggestion: '',
 		} );
-		this.onChangeField( event );
-		this.debouncedEmailSuggestion( event.target.value );
+		this.onChangeField( { name: 'usernameOrEmail', value } );
+		this.debouncedEmailSuggestion( value );
 	};
 
-	onChangeField = ( event ) => {
+	onChangeField = ( { name, value } ) => {
 		this.props.formUpdate();
 
 		this.setState( {
-			[ event.target.name ]: event.target.value,
+			[ name ]: value,
 		} );
 	};
 
@@ -429,7 +439,7 @@ export class LoginForm extends Component {
 
 						<FormLabel htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
-								<Button
+								<A8CButton
 									borderless
 									className="login__form-change-username"
 									onClick={ this.resetView }
@@ -439,7 +449,7 @@ export class LoginForm extends Component {
 									{ includes( this.state.usernameOrEmail, '@' )
 										? this.props.translate( 'Change Email Address' )
 										: this.props.translate( 'Change Username' ) }
-								</Button>
+								</A8CButton>
 							) : null }
 						</FormLabel>
 
@@ -497,14 +507,14 @@ export class LoginForm extends Component {
 					<div className="login__form-footer">
 						<p className="login__social-tos">{ socialToS }</p>
 						<div className="login__form-action">
-							<Button
+							<A8CButton
 								primary
 								disabled={ isFormDisabled }
 								onClick={ this.handleWooCommerceSubmit }
 								type="submit"
 							>
 								{ this.getLoginButtonText() }
-							</Button>
+							</A8CButton>
 						</div>
 
 						{ config.isEnabled( 'signup/social' ) && showSocialLogin && (
@@ -527,12 +537,12 @@ export class LoginForm extends Component {
 
 	renderChangeUsername() {
 		return (
-			<button type="button" className="login__form-change-username" onClick={ this.resetView }>
+			<Button className="login__form-change-username" onClick={ this.resetView } variant="link">
 				<Gridicon icon="arrow-left" size={ 18 } />
 				{ includes( this.state.usernameOrEmail, '@' )
 					? this.props.translate( 'Change Email Address' )
 					: this.props.translate( 'Change Username' ) }
-			</button>
+			</Button>
 		);
 	}
 
@@ -553,9 +563,7 @@ export class LoginForm extends Component {
 			return this.props.translate( 'Your username' );
 		}
 
-		return this.isPasswordView() ? (
-			this.renderChangeUsername()
-		) : (
+		return (
 			// Since the input receives focus on page load, screen reader users don't have any context
 			// for what credentials to use. Unlike other users, they won't have seen the informative
 			// text above the form. We therefore need to clarity the must use WordPress.com credentials.
@@ -748,7 +756,7 @@ export class LoginForm extends Component {
 	};
 
 	renderLoginCard() {
-		const { lastUsedAuthenticationMethod } = this.state;
+		const { lastUsedAuthenticationMethod, isPasswordPlainText } = this.state;
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 		const isSubmitButtonDisabled = isFormDisabled;
 		let loginUrl;
@@ -765,10 +773,10 @@ export class LoginForm extends Component {
 			isJetpack,
 		} = this.props;
 
-		const isPasswordHidden = this.isUsernameOrEmailView();
+		const isPasswordFieldHidden = this.isUsernameOrEmailView();
 		const isOauthLogin = !! oauth2Client;
 		const signupUrl = this.getSignupUrl();
-		const shouldRenderForgotPasswordLink = ! isPasswordHidden && isWoo;
+		const shouldRenderForgotPasswordLink = ! isPasswordFieldHidden && isWoo;
 
 		if ( lastUsedAuthenticationMethod === 'qr-code' ) {
 			loginUrl = this.getQrLoginLink();
@@ -857,15 +865,24 @@ export class LoginForm extends Component {
 								</p>
 							) }
 
-							<FormLabel htmlFor="usernameOrEmail">{ this.renderUsernameorEmailLabel() }</FormLabel>
+							{ this.isPasswordView() && (
+								<>
+									{ this.renderChangeUsername() }
+									<label htmlFor="usernameOrEmail" className="screen-reader-text">
+										{ this.renderUsernameorEmailLabel() }
+									</label>
+								</>
+							) }
 
-							<FormTextInput
+							<InputControl
+								label={ ! this.isPasswordView() && this.renderUsernameorEmailLabel() }
 								autoCapitalize="off"
 								autoCorrect="off"
 								spellCheck="false"
 								autoComplete="username"
 								className={ clsx( {
 									'is-error': requestError && requestError.field === 'usernameOrEmail',
+									'is-label-hidden': this.isPasswordView(),
 								} ) }
 								onChange={ this.onChangeUsernameOrEmailField }
 								id="usernameOrEmail"
@@ -873,6 +890,8 @@ export class LoginForm extends Component {
 								ref={ this.saveUsernameOrEmailRef }
 								value={ this.state.usernameOrEmail }
 								disabled={ isFormDisabled || this.isPasswordView() }
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
 							/>
 
 							{ requestError && requestError.field === 'usernameOrEmail' && (
@@ -957,25 +976,45 @@ export class LoginForm extends Component {
 
 							<div
 								className={ clsx( 'login__form-password', {
-									'is-hidden': isPasswordHidden,
+									'is-hidden': isPasswordFieldHidden,
 								} ) }
-								aria-hidden={ isPasswordHidden }
+								aria-hidden={ isPasswordFieldHidden }
 							>
-								<FormLabel htmlFor="password">{ this.props.translate( 'Password' ) }</FormLabel>
-
-								<FormPasswordInput
+								<InputControl
+									type={ isPasswordPlainText ? 'text' : 'password' }
+									label={ this.props.translate( 'Password' ) }
 									autoCapitalize="off"
 									autoComplete="current-password"
 									className={ clsx( {
 										'is-error': requestError && requestError.field === 'password',
 									} ) }
-									onChange={ this.onChangeField }
+									onChange={ ( value ) => this.onChangeField( { name: 'password', value } ) }
 									id="password"
 									name="password"
 									ref={ this.savePasswordRef }
 									value={ this.state.password }
 									disabled={ isFormDisabled }
-									tabIndex={ isPasswordHidden ? -1 : undefined /* not tabbable when hidden */ }
+									tabIndex={ isPasswordFieldHidden ? -1 : undefined /* not tabbable when hidden */ }
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									suffix={
+										<InputControlSuffixWrapper variant="control">
+											<Button
+												size="small"
+												icon={ isPasswordPlainText ? unseen : seen }
+												onClick={ () => {
+													this.setState( { isPasswordPlainText: ! isPasswordPlainText } );
+												} }
+												label={
+													isPasswordPlainText
+														? this.props.translate( 'Hide password' )
+														: this.props.translate( 'Show password' )
+												}
+												aria-hidden={ isPasswordFieldHidden }
+												tabIndex={ isPasswordFieldHidden ? -1 : undefined }
+											/>
+										</InputControlSuffixWrapper>
+									}
 								/>
 
 								{ requestError && requestError.field === 'password' && (

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -64,15 +64,6 @@ form {
 .layout.is-white-login .login.is-akismet .login__form,
 .layout.is-white-login .login.is-akismet .continue-as-user,
 .layout.is-white-login.is-akismet .magic-login__form-action {
-	.button.is-primary {
-		background-color: var(--color-akismet);
-
-		&:hover,
-		&:focus {
-			background-color: var(--color-akismet);
-		}
-	}
-
 	.components-button.is-primary {
 		--color-accent: var(--color-akismet);
 		--color-accent-60: var(--color-akismet);

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -54,20 +54,21 @@ form {
 			}
 		}
 	}
+
+	&.is-akismet {
+		.login,
+		.magic-login {
+			.components-button {
+				--color-accent: var(--color-akismet);
+				--color-accent-60: var(--color-akismet);
+			}
+		}
+	}
 }
 
 .is-jetpack .login__form-account-tip {
 	margin-block-start: -8px;
 	font-size: 0.75rem;
-}
-
-.layout.is-white-login .login.is-akismet .login__form,
-.layout.is-white-login .login.is-akismet .continue-as-user,
-.layout.is-white-login.is-akismet .magic-login__form-action {
-	.components-button.is-primary {
-		--color-accent: var(--color-akismet);
-		--color-accent-60: var(--color-akismet);
-	}
 }
 
 .login__form-jetpack {

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -58,8 +58,12 @@ form {
 	&.is-akismet {
 		.login,
 		.magic-login {
-			.components-button {
+			.components-button,
+			.components-input-control {
 				--color-accent: var(--color-akismet);
+			}
+
+			.components-button {
 				--color-accent-60: var(--color-akismet);
 			}
 		}

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -121,13 +121,4 @@
 			padding: 24px;
 		}
 	}
-
-	/**
-	* Akismet Login
-	*/
-	@at-root .is-akismet & {
-		.auth-form__social-buttons .auth-form__social-buttons-container .social-buttons__button {
-			--color-accent: var(--color-akismet);
-		}
-	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -230,23 +230,11 @@ $breakpoint-mobile: 782px; //Mobile size.
 }
 
 .login__form-change-username {
-	color: var(--color-link);
 	font-weight: inherit;
-	cursor: pointer;
-
-	&:hover,
-	&:focus,
-	&:active {
-		color: var(--color-link-dark);
-	}
 
 	.gridicon {
 		margin-right: 3px;
 		vertical-align: text-bottom;
-	}
-
-	&.button.is-borderless .gridicon {
-		top: 3px;
 	}
 }
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -204,6 +204,10 @@ $breakpoint-mobile: 782px; //Mobile size.
 			margin-bottom: 0;
 		}
 
+		input {
+			font-size: $font-body-small;
+		}
+
 		label {
 			font-size: $font-body-small;
 			color: var(--studio-gray-100);

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -197,6 +197,27 @@ $breakpoint-mobile: 782px; //Mobile size.
 		}
 	}
 
+	.login__form-userdata-input {
+		margin-bottom: 16px;
+
+		&.is-error {
+			margin-bottom: 0;
+		}
+
+		label {
+			font-size: $font-body-small;
+			color: var(--studio-gray-100);
+			text-transform: initial;
+			font-weight: 500;
+			margin-bottom: unset;
+		}
+	}
+
+	.login__form-change-username {
+		margin-bottom: 8px;
+		font-size: $font-body;
+	}
+
 	.login__form-suggested-email {
 		color: var(--color-link);
 		cursor: pointer;

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -17,7 +17,7 @@ describe( 'LoginForm', () => {
 		const username = screen.getByLabelText( /username/i );
 		expect( username ).toBeInTheDocument();
 
-		const password = screen.getByLabelText( /password/i );
+		const password = screen.getByLabelText( /^password$/i );
 		expect( password ).toBeInTheDocument();
 
 		const btn = screen.getByRole( 'button', { name: /continue$/i } );

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -44,10 +44,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 }
 
-.signup-form__crowdsignal {
+.signup.is-crowdsignal {
 	.components-button {
-		width: 100%;
-
 		&.is-primary:not(.signup-form__crowdsignal-wpcom) {
 			--color-accent: var(--color-primary);
 			--color-accent-60: var(--color-primary-dark);
@@ -143,6 +141,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	margin: 0 auto;
 	max-width: 320px;
 	width: 100%;
+
+	.components-button {
+		width: 100%;
+	}
 }
 
 .signup-form__crowdsignal-card-subheader {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1088,6 +1088,18 @@ class SignupForm extends Component {
 			return null;
 		}
 
+		if ( this.props.currentUser && ! this.props.disableContinueAsUser ) {
+			return (
+				<ContinueAsUser
+					currentUser={ this.props.currentUser }
+					onChangeAccount={ this.handleOnChangeAccount }
+					redirectPath={ this.props.redirectToAfterLoginUrl }
+					isWoo={ this.props.isWoo }
+					isBlazePro={ this.props.isBlazePro }
+				/>
+			);
+		}
+
 		if ( isCrowdsignalOAuth2Client( this.props.oauth2Client ) ) {
 			const socialProps = pick( this.props, [
 				'isSocialSignupEnabled',
@@ -1105,18 +1117,6 @@ class SignupForm extends Component {
 					recordBackLinkClick={ this.recordBackLinkClick }
 					submitting={ this.props.submitting }
 					{ ...socialProps }
-				/>
-			);
-		}
-
-		if ( this.props.currentUser && ! this.props.disableContinueAsUser ) {
-			return (
-				<ContinueAsUser
-					currentUser={ this.props.currentUser }
-					onChangeAccount={ this.handleOnChangeAccount }
-					redirectPath={ this.props.redirectToAfterLoginUrl }
-					isWoo={ this.props.isWoo }
-					isBlazePro={ this.props.isBlazePro }
 				/>
 			);
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -29,6 +29,7 @@ import {
 	isWooOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
+	isCrowdsignalOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
@@ -198,6 +199,7 @@ class Layout extends Component {
 			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
 			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
 			'a8c-for-agencies': isA4AOAuth2Client( this.props.oauth2Client ),
+			crowdsignal: isCrowdsignalOAuth2Client( this.props.oauth2Client ),
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
 			'has-no-masterbar': this.props.masterbarIsHidden,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -25,7 +25,7 @@ import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
-import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isWooOAuth2Client, isJetpackCloudOAuth2Client } from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
@@ -209,6 +209,7 @@ class Layout extends Component {
 			'is-unified-site-sidebar-visible': this.props.isUnifiedSiteSidebarVisible,
 			'is-blaze-pro': this.props.isBlazePro,
 			'is-woo-com-oauth': isWooOAuth2Client( this.props.oauth2Client ),
+			'jetpack-cloud': isJetpackCloudOAuth2Client( this.props.oauth2Client ),
 			'feature-flag-woocommerce-core-profiler-passwordless-auth': true,
 		} );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -25,7 +25,11 @@ import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
-import { isWooOAuth2Client, isJetpackCloudOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isWooOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isA4AOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
@@ -193,6 +197,7 @@ class Layout extends Component {
 		const sectionClass = clsx( 'layout', `focus-${ this.props.currentLayoutFocus }`, {
 			[ 'is-group-' + this.props.sectionGroup ]: this.props.sectionGroup,
 			[ 'is-section-' + this.props.sectionName ]: this.props.sectionName,
+			'a8c-for-agencies': isA4AOAuth2Client( this.props.oauth2Client ),
 			'is-support-session': this.props.isSupportSession,
 			'has-no-sidebar': this.props.sidebarIsHidden,
 			'has-no-masterbar': this.props.masterbarIsHidden,

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -59,8 +59,12 @@ body.is-section-signup {
 
 	$login-form-max-width: 327px;
 
-	.components-button {
+	.components-button,
+	.components-input-control {
 		--color-accent: var(--color-orange);
+	}
+
+	.components-button {
 		--color-accent-60: var(--color-orange);
 
 		font-weight: 600;

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -224,7 +224,7 @@ body.is-section-signup {
 			align-items: center;
 			align-self: stretch;
 			border: 1px solid #ccc;
-			height: 221px;
+			width: 100%;
 			box-sizing: border-box;
 			padding: 32px 24px 16px 24px;
 			position: relative;

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -282,23 +282,14 @@ body.is-section-signup {
 		}
 
 		.continue-as-user__change-user-link {
-			font-family: $inter;
 			font-size: 0.875rem;
-			font-style: normal;
 			font-weight: 500;
-			line-height: 20px;
-			text-decoration: none;
 		}
 
 		.continue-as-user__continue-button {
-			background: var(--color-orange);
-			border-color: var(--color-orange);
-			font-family: $inter;
 			font-size: rem(13px);
 			font-weight: 600;
-			line-height: 14px;
 			margin-top: 24px;
-			padding: 12px 16px;
 			width: 326px;
 		}
 	}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -739,12 +739,15 @@
 		}
 	}
 
-	.components-button {
+	.components-button,
+	.components-input-control {
 		--color-accent: var(--color-primary-40);
+	}
+
+	.components-button {
 		--color-accent-60: var(--color-primary-60);
 	}
 
-	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--color-primary-40);
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -661,12 +661,15 @@
 		}
 	}
 
-	.components-button {
+	.components-button,
+	.components-input-control {
 		--color-accent: var(--studio-jetpack-green-40);
+	}
+
+	.components-button {
 		--color-accent-60: var(--studio-jetpack-green-30);
 	}
 
-	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--studio-jetpack-green-40);
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -477,6 +477,10 @@
 		font-weight: 400;
 	}
 
+	.login__form .login__form-userdata .login__form-userdata-input input {
+		font-size: $font-body;
+	}
+
 	.login__form-action button {
 		font-size: $font-body;
 		line-height: 23px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -678,6 +678,9 @@
 }
 
 .a8c-for-agencies {
+	--color-link: var(--color-primary-40);
+	--color-link-dark: var(--color-primary-60);
+
 	input:focus:hover[type],
 	input:focus[type] {
 		box-shadow: 0 0 0 2px var(--color-primary-10);
@@ -741,8 +744,6 @@
 		--color-accent-60: var(--color-primary-60);
 	}
 
-	a,
-	a:visited,
 	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--color-primary-40);

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -600,6 +600,9 @@
 }
 
 .jetpack-cloud {
+	--color-link: var(--studio-jetpack-green-40);
+	--color-link-dark: var(--studio-jetpack-green-60);
+
 	input:focus:hover[type],
 	input:focus[type] {
 		box-shadow: 0 0 0 2px var(--color-primary-10);
@@ -663,8 +666,6 @@
 		--color-accent-60: var(--studio-jetpack-green-30);
 	}
 
-	a,
-	a:visited,
 	.login__form-change-username,
 	.wp-login__links button {
 		color: var(--studio-jetpack-green-40);

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1669,7 +1669,7 @@ $breakpoint-mobile: 660px;
 				align-self: stretch;
 				border-radius: 8px; // stylelint-disable-line scales/radii
 				border: 1px solid #dcdcde;
-				height: 221px;
+				width: 100%;
 				box-sizing: border-box;
 				padding: 32px 24px 16px 24px;
 			}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1722,7 +1722,6 @@ $breakpoint-mobile: 660px;
 			}
 
 			.continue-as-user__change-user-link {
-				text-decoration: none;
 				font-size: 0.875rem;
 				font-weight: 500;
 			}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -804,7 +804,6 @@ $breakpoint-mobile: 660px;
 		color: $gray-50;
 		margin-bottom: 32px;
 		font-weight: 400;
-		margin-top: -14px;
 	}
 
 	.logged-out-form__footer {
@@ -1290,8 +1289,12 @@ $breakpoint-mobile: 660px;
 			}
 		}
 
-		.components-button {
+		.components-button,
+		.components-input-control {
 			--color-accent: var(--woo-purple-40);
+		}
+
+		.components-button {
 			--color-accent-60: var(--woo-purple-60);
 
 			&.is-primary,
@@ -1325,6 +1328,38 @@ $breakpoint-mobile: 660px;
 
 				.components-spinner {
 					margin-top: 0;
+				}
+			}
+		}
+
+		.components-input-control {
+			--wp-components-color-gray-600: var(--studio-gray-30);
+
+			.components-input-control__label {
+				font-size: $woo-font-size-input;
+				font-weight: 600;
+				line-height: 24px;
+			}
+
+			.components-input-control__container,
+			.components-input-control__input,
+			.components-input-control__backdrop {
+				border-radius: $woo-radius-input;
+			}
+
+			.components-input-control__input,
+			.components-input-control__backdrop {
+				height: 48px;
+			}
+
+			.components-input-control__input {
+				padding: 8px 16px;
+				font-size: $woo-font-size-input;
+			}
+
+			&:has(.components-input-control__input:focus) {
+				.components-input-control__backdrop.components-input-control__backdrop {
+					box-shadow: 0 0 0 1px var(--wp-components-color-accent);
 				}
 			}
 		}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -653,12 +653,6 @@ $breakpoint-mobile: 660px;
 			margin-bottom: 32px;
 			position: initial;
 		}
-
-		.continue-as-user__change-user-link {
-			color: $gray-60;
-			font-weight: 400;
-			text-decoration: underline;
-		}
 	}
 
 	.logged-out-form {
@@ -1729,15 +1723,8 @@ $breakpoint-mobile: 660px;
 
 			.continue-as-user__change-user-link {
 				text-decoration: none;
-				color: var(--woo-purple-50);
 				font-size: 0.875rem;
-				font-style: normal;
 				font-weight: 500;
-				line-height: 21px;
-
-				&:hover {
-					color: var(--woo-purple-70);
-				}
 			}
 
 			.continue-as-user__continue-button {
@@ -2311,11 +2298,6 @@ $breakpoint-mobile: 660px;
 	.login__header-subtitle a {
 		@include link-woo;
 		font-weight: 500;
-	}
-
-	.continue-as-user__change-user-link {
-		@include button-tertiary;
-		@include button-size-small;
 	}
 
 	.magic-login__footer a {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -153,7 +153,7 @@ $breakpoint-mobile: 660px;
 		letter-spacing: 0;
 	}
 
-	a:not(.social-buttons__button),
+	a:not(.components-button),
 	.wp-login__links a,
 	.wp-login__links button,
 	.button,

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -209,7 +209,7 @@ class RequestLoginEmailForm extends Component {
 
 		const formLabel = customFormLabel
 			? this.props.translate( 'Email address or username' )
-			: this.props.translate( 'Email Address or Username' );
+			: this.props.translate( 'Email address or username' );
 
 		const onSubmit = onSubmitEmail
 			? ( e ) => onSubmitEmail( this.getUsernameOrEmailFromState(), e )

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -691,8 +691,11 @@ $image-height: 47px;
 		height: auto;
 	}
 
-	.form-password-input__toggle {
-		top: 14px;
+	.login__form-userdata-input input {
+		padding: 16px;
+		font-size: 16px;
+		height: auto;
+		line-height: 1.5;
 	}
 
 	.form-input-validation {
@@ -793,8 +796,12 @@ $image-height: 47px;
 		clip-path: unset;
 	}
 
-	.components-button {
+	.components-button,
+	.components-input-control {
 		--color-accent: var(--color-gravatar);
+	}
+
+	.components-button {
 		--color-accent-60: color-mix(in srgb, var(--color-gravatar), #000 13%);
 	}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -568,12 +568,6 @@ $image-height: 47px;
 	.two-factor-authentication__actions.card {
 		padding-top: 0;
 	}
-
-	.continue-as-user__not-you {
-		> button {
-			text-decoration: underline;
-		}
-	}
 }
 
 /* stylelint-disable scales/font-weights, scales/radii */

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -155,8 +155,12 @@ $image-height: 47px;
 .layout.is-jetpack-login:not(.is-wccom-oauth-flow):not(.is-woocommerce-core-profiler-flow) {
 	@include jetpack-connect-colors();
 
-	.components-button {
+	.components-button,
+	.components-input-control {
 		--color-accent: var(--studio-jetpack-green-50);
+	}
+
+	.components-button {
 		--color-accent-60: var(--studio-jetpack-green-60);
 	}
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -568,6 +568,12 @@ $image-height: 47px;
 	.two-factor-authentication__actions.card {
 		padding-top: 0;
 	}
+
+	.continue-as-user__not-you {
+		> button {
+			text-decoration: underline;
+		}
+	}
 }
 
 /* stylelint-disable scales/font-weights, scales/radii */

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -19,7 +19,7 @@ $image-height: 47px;
 		padding-bottom: $image-height;
 		min-height: calc(100% - #{$image-height});
 	}
-	
+
 	.layout__content {
 		position: static;
 	}
@@ -352,7 +352,7 @@ $image-height: 47px;
 	}
 
 	.login__form-action .components-button.is-primary {
-		margin: 6px auto 13px;
+		margin: 0 auto 13px;
 	}
 
 	.login form {
@@ -361,7 +361,7 @@ $image-height: 47px;
 		// an exception to opt-out from some style overrides. Ideally, all
 		// input instances would come from `@wordpress/components` and the
 		// following overrides could be safely deleted.
-		input:not(.components-text-control__input),
+		input:not(.components-text-control__input, .components-input-control__input),
 		button:not(.components-button) {
 			/* Note: Same as `button.signup-form__submit, .signup-form__input.form-text-input` */
 			height: 40px; // Matches .components-button height __next40pxDefaultSize
@@ -375,22 +375,49 @@ $image-height: 47px;
 			}
 		}
 
-		.login__form-userdata input {
-			margin: 0 0 20px;
-		}
-
-		.login__form-userdata input:last-of-type {
-			/* Note: reduces space between terms and last input box */
-			margin: 0 0 10px;
-		}
-
 		.login__form-userdata {
-			button {
+			label {
+				color: var(--studio-gray-100);
+			}
+
+			button:not(.components-button) {
 				min-width: 194px;
 				height: unset;
 				border: 0;
 				text-align: start;
 			}
+
+			input:not(.components-input-control__input) {
+				margin: 0 0 20px;
+
+				&:last-of-type {
+						/* Note: reduces space between terms and last input box */
+						margin: 0 0 10px;
+				}
+			}
+
+			.login__form-change-username {
+				margin-bottom: 8px;
+				font-size: $font-body;
+			}
+
+			.components-input-control {
+				margin-bottom: 16px;
+
+				&.is-error {
+					margin-bottom: 0;
+				}
+
+				label {
+					font-size: $font-body-small;
+					color: var(--studio-gray-100);
+					text-transform: initial;
+					font-weight: 500;
+					margin-bottom: unset;
+				}
+			}
+
+
 		}
 	}
 
@@ -528,10 +555,6 @@ $image-height: 47px;
 
 	.two-factor-authentication__verification-code-form > p {
 		text-align: left;
-	}
-
-	.login__form .login__form-userdata label {
-		color: var(--studio-gray-60);
 	}
 
 	.login__form-terms {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -580,8 +580,12 @@ $image-height: 47px;
 			}
 		}
 
-		.components-button {
+		.components-button,
+		.components-input-control {
 			--color-accent: var(--color-wp-job-manager);
+		}
+
+		.components-button {
 			--color-accent-60: color-mix(in srgb, var(--color-wp-job-manager), #000 10%);
 		}
 	}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -374,51 +374,6 @@ $image-height: 47px;
 				background-color: #fdfdfd;
 			}
 		}
-
-		.login__form-userdata {
-			label {
-				color: var(--studio-gray-100);
-			}
-
-			button:not(.components-button) {
-				min-width: 194px;
-				height: unset;
-				border: 0;
-				text-align: start;
-			}
-
-			input:not(.components-input-control__input) {
-				margin: 0 0 20px;
-
-				&:last-of-type {
-						/* Note: reduces space between terms and last input box */
-						margin: 0 0 10px;
-				}
-			}
-
-			.login__form-change-username {
-				margin-bottom: 8px;
-				font-size: $font-body;
-			}
-
-			.components-input-control {
-				margin-bottom: 16px;
-
-				&.is-error {
-					margin-bottom: 0;
-				}
-
-				label {
-					font-size: $font-body-small;
-					color: var(--studio-gray-100);
-					text-transform: initial;
-					font-weight: 500;
-					margin-bottom: unset;
-				}
-			}
-
-
-		}
 	}
 
 	.wp-login__links > .button,

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -66,8 +66,9 @@
 	}
 
 	&-right-element {
+		--color-accent: var( --color-neutral-100 );
+
 		margin-left: auto;
-		--wp-components-color-accent: var( --color-neutral-100 );
 		font-size: 0.875rem;
 		line-height: 1;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
Related to [DSGCOM-95: Update text fields on login](https://linear.app/a8c/issue/DSGCOM-95/update-text-fields-on-login)

Design YIwc478nGHyjIZ45hQ1hfV-fi-245_1996

Based on https://github.com/Automattic/wp-calypso/pull/103097

## Proposed Changes

* Replace user name and email field, and password field, with core components

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The current focus styles of the fields lack sufficient contrast, and aren't consistent with the core buttons now used on all login screens
* The password field toggle password functionality is not keyboard accessible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?