### PR TITLE
Stats: Tweak mobile navigation improvement with the legacy component

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -144,6 +144,91 @@ class StatsNavigation extends Component {
 		this.props.requestModuleToggles( this.props.siteId );
 	}
 
+	renderNavigation( { selectedItem, interval, slugPath, showLock } ) {
+		return (
+			<TabPanel
+				className="stats-navigation__tabs"
+				tabs={ Object.keys( navItems )
+					.filter( this.isValidItem )
+					.map( ( item ) => {
+						const navItem = navItems[ item ];
+						const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
+						const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+						return {
+							name: item,
+							title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
+							className: 'stats-navigation__' + item,
+							path: itemPath,
+						};
+					} ) }
+				initialTabName={ selectedItem }
+			>
+				{ ( tab ) => {
+					if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+						window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
+					} else if ( tab.path ) {
+						page( tab.path );
+					}
+					return <div className="stats-navigation__content" />; // Placeholder div since content is rendered elsewhere
+				} }
+			</TabPanel>
+		);
+	}
+
+	renderLegacyNavigation( {
+		selectedItem,
+		interval,
+		slugPath,
+		showLock,
+		isLegacy,
+		showIntervals,
+		pathTemplate,
+		label,
+	} ) {
+		return (
+			<SectionNav selectedText={ label }>
+				<NavTabs selectedText={ label }>
+					{ Object.keys( navItems )
+						.filter( this.isValidItem )
+						.map( ( item ) => {
+							const navItem = navItems[ item ];
+							const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
+							const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+							const className = 'stats-navigation__' + item;
+							if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+								return (
+									<NavItem
+										className={ className }
+										key={ item }
+										onClick={ () =>
+											( window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview` )
+										}
+										selected={ false }
+									>
+										{ navItem.label }
+									</NavItem>
+								);
+							}
+							return (
+								<NavItem
+									className={ className }
+									key={ item }
+									path={ itemPath }
+									selected={ selectedItem === item }
+								>
+									{ navItem.label }
+									{ navItem.paywall && showLock && ' 🔒' }
+								</NavItem>
+							);
+						} ) }
+				</NavTabs>
+				{ isLegacy && showIntervals && (
+					<Intervals selected={ interval } pathTemplate={ pathTemplate } />
+				) }
+			</SectionNav>
+		);
+	}
+
 	render() {
 		const {
 			slug,
@@ -182,81 +267,6 @@ class StatsNavigation extends Component {
 			! hideModuleSettings &&
 			! gatedTrafficPage;
 
-		const coreNavTabsComponent = (
-			<TabPanel
-				className="stats-navigation__tabs"
-				tabs={ Object.keys( navItems )
-					.filter( this.isValidItem )
-					.map( ( item ) => {
-						const navItem = navItems[ item ];
-						const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
-						const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-						return {
-							name: item,
-							title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
-							className: 'stats-navigation__' + item,
-							path: itemPath,
-						};
-					} ) }
-				initialTabName={ selectedItem }
-			>
-				{ ( tab ) => {
-					if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-						window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
-					} else if ( tab.path ) {
-						page( tab.path );
-					}
-					return <div className="stats-navigation__content" />; // Placeholder div since content is rendered elsewhere
-				} }
-			</TabPanel>
-		);
-
-		const legacyNavTabsComponent = (
-			<SectionNav selectedText={ label }>
-				<NavTabs selectedText={ label }>
-					{ Object.keys( navItems )
-						.filter( this.isValidItem )
-						.map( ( item ) => {
-							const navItem = navItems[ item ];
-							const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
-							const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-							const className = 'stats-navigation__' + item;
-							if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-								return (
-									<NavItem
-										className={ className }
-										key={ item }
-										onClick={ () =>
-											( window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview` )
-										}
-										selected={ false }
-									>
-										{ navItem.label }
-									</NavItem>
-								);
-							}
-							return (
-								<NavItem
-									className={ className }
-									key={ item }
-									path={ itemPath }
-									selected={ selectedItem === item }
-								>
-									{ navItem.label }
-									{ navItem.paywall && showLock && ' 🔒' }
-								</NavItem>
-							);
-						} ) }
-				</NavTabs>
-
-				{ isLegacy && showIntervals && (
-					<Intervals selected={ interval } pathTemplate={ pathTemplate } />
-				) }
-			</SectionNav>
-		);
-
-		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
-
 		return (
 			<div className={ wrapperClass }>
 				{ siteId && <QueryJetpackModules siteId={ siteId } /> }
@@ -264,13 +274,36 @@ class StatsNavigation extends Component {
 					<ComponentSwapper
 						className="stats-navigation__tabs-swapper"
 						breakpoint="<480px"
-						breakpointActiveComponent={ legacyNavTabsComponent }
-						breakpointInactiveComponent={ coreNavTabsComponent }
+						breakpointActiveComponent={ this.renderLegacyNavigation( {
+							selectedItem,
+							interval,
+							slugPath,
+							showLock,
+							isLegacy,
+							showIntervals,
+							pathTemplate,
+							label,
+						} ) }
+						breakpointInactiveComponent={ this.renderNavigation( {
+							selectedItem,
+							interval,
+							slugPath,
+							showLock,
+						} ) }
 					/>
 				) : (
 					//TODO: remove this SectionNav in favour of above TabPanel once Navigation Improvement is fully launched
 					<>
-						{ legacyNavTabsComponent }
+						{ this.renderLegacyNavigation( {
+							selectedItem,
+							interval,
+							slugPath,
+							showLock,
+							isLegacy,
+							showIntervals,
+							pathTemplate,
+							label,
+						} ) }
 						{ isLegacy && showIntervals && (
 							<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
 						) }

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -158,19 +158,18 @@ class StatsNavigation extends Component {
 							name: item,
 							title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
 							className: 'stats-navigation__' + item,
-							path: itemPath,
+							onClick: () => {
+								if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+									window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
+								} else {
+									page( itemPath );
+								}
+							},
 						};
 					} ) }
 				initialTabName={ selectedItem }
 			>
-				{ ( tab ) => {
-					if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-						window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
-					} else if ( tab.path ) {
-						page( tab.path );
-					}
-					return <div className="stats-navigation__content" />; // Placeholder div since content is rendered elsewhere
-				} }
+				{ () => <div className="stats-navigation__content" /> }
 			</TabPanel>
 		);
 	}

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
+import { ComponentSwapper } from '@automattic/components';
 import { TabPanel } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -181,83 +182,95 @@ class StatsNavigation extends Component {
 			! hideModuleSettings &&
 			! gatedTrafficPage;
 
+		const coreNavTabsComponent = (
+			<TabPanel
+				className="stats-navigation__tabs"
+				tabs={ Object.keys( navItems )
+					.filter( this.isValidItem )
+					.map( ( item ) => {
+						const navItem = navItems[ item ];
+						const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
+						const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+						return {
+							name: item,
+							title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
+							className: 'stats-navigation__' + item,
+							path: itemPath,
+						};
+					} ) }
+				initialTabName={ selectedItem }
+			>
+				{ ( tab ) => {
+					if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+						window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
+					} else if ( tab.path ) {
+						page( tab.path );
+					}
+					return <div className="stats-navigation__content" />; // Placeholder div since content is rendered elsewhere
+				} }
+			</TabPanel>
+		);
+
+		const legacyNavTabsComponent = (
+			<SectionNav selectedText={ label }>
+				<NavTabs selectedText={ label }>
+					{ Object.keys( navItems )
+						.filter( this.isValidItem )
+						.map( ( item ) => {
+							const navItem = navItems[ item ];
+							const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
+							const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+							const className = 'stats-navigation__' + item;
+							if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+								return (
+									<NavItem
+										className={ className }
+										key={ item }
+										onClick={ () =>
+											( window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview` )
+										}
+										selected={ false }
+									>
+										{ navItem.label }
+									</NavItem>
+								);
+							}
+							return (
+								<NavItem
+									className={ className }
+									key={ item }
+									path={ itemPath }
+									selected={ selectedItem === item }
+								>
+									{ navItem.label }
+									{ navItem.paywall && showLock && ' 🔒' }
+								</NavItem>
+							);
+						} ) }
+				</NavTabs>
+
+				{ isLegacy && showIntervals && (
+					<Intervals selected={ interval } pathTemplate={ pathTemplate } />
+				) }
+			</SectionNav>
+		);
+
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
 		return (
 			<div className={ wrapperClass }>
 				{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 				{ isStatsNavigationImprovementEnabled ? (
-					<TabPanel
-						className="stats-navigation__tabs"
-						tabs={ Object.keys( navItems )
-							.filter( this.isValidItem )
-							.map( ( item ) => {
-								const navItem = navItems[ item ];
-								const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
-								const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-								return {
-									name: item,
-									title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
-									className: 'stats-navigation__' + item,
-									path: itemPath,
-								};
-							} ) }
-						initialTabName={ selectedItem }
-					>
-						{ ( tab ) => {
-							if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-								window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
-							} else if ( tab.path ) {
-								page( tab.path );
-							}
-							return <div className="stats-navigation__content" />; // Placeholder div since content is rendered elsewhere
-						} }
-					</TabPanel>
+					<ComponentSwapper
+						className="stats-navigation__tabs-swapper"
+						breakpoint="<480px"
+						breakpointActiveComponent={ legacyNavTabsComponent }
+						breakpointInactiveComponent={ coreNavTabsComponent }
+					/>
 				) : (
 					//TODO: remove this SectionNav in favour of above TabPanel once Navigation Improvement is fully launched
 					<>
-						<SectionNav selectedText={ label }>
-							<NavTabs selectedText={ label }>
-								{ Object.keys( navItems )
-									.filter( this.isValidItem )
-									.map( ( item ) => {
-										const navItem = navItems[ item ];
-										const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
-										const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-										const className = 'stats-navigation__' + item;
-										if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-											return (
-												<NavItem
-													className={ className }
-													key={ item }
-													onClick={ () =>
-														( window.location.href = `${ this.props.adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview` )
-													}
-													selected={ false }
-												>
-													{ navItem.label }
-												</NavItem>
-											);
-										}
-										return (
-											<NavItem
-												className={ className }
-												key={ item }
-												path={ itemPath }
-												selected={ selectedItem === item }
-											>
-												{ navItem.label }
-												{ navItem.paywall && showLock && ' 🔒' }
-											</NavItem>
-										);
-									} ) }
-							</NavTabs>
-
-							{ isLegacy && showIntervals && (
-								<Intervals selected={ interval } pathTemplate={ pathTemplate } />
-							) }
-						</SectionNav>
-
+						{ legacyNavTabsComponent }
 						{ isLegacy && showIntervals && (
 							<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
 						) }

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -175,6 +175,7 @@ class StatsNavigation extends Component {
 		);
 	}
 
+	// Keep using the previous navigation component until the new one is ready for mobile use.
 	renderLegacyNavigation( {
 		selectedItem,
 		interval,
@@ -274,6 +275,7 @@ class StatsNavigation extends Component {
 					<ComponentSwapper
 						className="stats-navigation__tabs-swapper"
 						breakpoint="<480px"
+						// TODO: Utilize the core TabPanel component once it's ready for mobile.
 						breakpointActiveComponent={ this.renderLegacyNavigation( {
 							selectedItem,
 							interval,

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -49,6 +49,11 @@
 	}
 
 	&.stats-navigation--improved {
+		// To make the component swapper take the full width of the parent.
+		.stats-navigation__tabs-swapper {
+			flex: 1;
+		}
+
 		.stats-navigation__tabs {
 			margin-left: -16px;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
