### PR TITLE
Breadcrumbs: Add `renderItemLink ` prop

### DIFF
--- a/packages/components/src/breadcrumbs/index.stories.tsx
+++ b/packages/components/src/breadcrumbs/index.stories.tsx
@@ -66,7 +66,8 @@ export const WithCustomItem: Story = {
 			const onClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
 				props.onClick?.( event );
 				event.preventDefault();
-				alert( `Router navigation to ${ href }` );
+				// eslint-disable-next-line no-console
+				console.log( `Router navigation to ${ label }` );
 			};
 
 			return (

--- a/packages/components/src/breadcrumbs/index.stories.tsx
+++ b/packages/components/src/breadcrumbs/index.stories.tsx
@@ -7,7 +7,16 @@ const meta: Meta< typeof Breadcrumbs > = {
 	tags: [ 'autodocs' ],
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
+		// Prevent flickering + automatic menu closing in compact mode.
+		layout: 'fullscreen',
 	},
+	decorators: [
+		( Story ) => (
+			<div style={ { paddingInlineStart: '1rem', paddingBlockStart: '1rem' } }>
+				<Story />
+			</div>
+		),
+	],
 };
 
 export default meta;

--- a/packages/components/src/breadcrumbs/index.stories.tsx
+++ b/packages/components/src/breadcrumbs/index.stories.tsx
@@ -1,4 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { Button, IconType } from '@wordpress/components';
+import { backup, envelope } from '@wordpress/icons';
+import { BreadcrumbItemProps } from './types';
 import { Breadcrumbs } from './';
 
 const meta: Meta< typeof Breadcrumbs > = {
@@ -47,5 +50,23 @@ export const WithLongPath: Story = {
 				href: 'javascript:void(0)',
 			},
 		],
+	},
+};
+
+const iconByLabel: Record< string, IconType > = { Home: backup, Products: envelope };
+
+export const WithRenderLink: Story = {
+	args: {
+		...Default.args,
+		items: [
+			{ label: 'Home', href: 'javascript:void(0)' },
+			{ label: 'Products', href: 'javascript:void(0)' },
+			{ label: 'Electronics', href: 'javascript:void(0)' },
+		],
+		renderLink: ( props: BreadcrumbItemProps ) => (
+			<Button href={ props.href } icon={ iconByLabel[ props.label ] }>
+				{ props.label }
+			</Button>
+		),
 	},
 };

--- a/packages/components/src/breadcrumbs/index.stories.tsx
+++ b/packages/components/src/breadcrumbs/index.stories.tsx
@@ -1,7 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Button, IconType } from '@wordpress/components';
-import { backup, envelope } from '@wordpress/icons';
-import { BreadcrumbItemProps } from './types';
 import { Breadcrumbs } from './';
 
 const meta: Meta< typeof Breadcrumbs > = {
@@ -14,7 +11,7 @@ const meta: Meta< typeof Breadcrumbs > = {
 };
 
 export default meta;
-type Story = StoryObj< typeof meta >;
+type Story = StoryObj< typeof Breadcrumbs >;
 
 export const Default: Story = {
 	args: {
@@ -53,20 +50,21 @@ export const WithLongPath: Story = {
 	},
 };
 
-const iconByLabel: Record< string, IconType > = { Home: backup, Products: envelope };
-
-export const WithRenderLink: Story = {
+export const WithCustomItem: Story = {
 	args: {
 		...Default.args,
-		items: [
-			{ label: 'Home', href: 'javascript:void(0)' },
-			{ label: 'Products', href: 'javascript:void(0)' },
-			{ label: 'Electronics', href: 'javascript:void(0)' },
-		],
-		renderLink: ( props: BreadcrumbItemProps ) => (
-			<Button href={ props.href } icon={ iconByLabel[ props.label ] }>
-				{ props.label }
-			</Button>
-		),
+		renderItemLink: ( { label, href, ...props } ) => {
+			const onClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
+				props.onClick?.( event );
+				event.preventDefault();
+				alert( `Router navigation to ${ href }` );
+			};
+
+			return (
+				<a href={ href } { ...props } onClick={ onClick }>
+					{ label }
+				</a>
+			);
+		},
 	},
 };

--- a/packages/components/src/breadcrumbs/index.tsx
+++ b/packages/components/src/breadcrumbs/index.tsx
@@ -9,10 +9,16 @@ import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import React, { useState, forwardRef, useRef } from 'react';
 import Menu from '../menu';
-import { BreadcrumbProps, BreadcrumbItemProps } from './types';
+import { BreadcrumbProps, BreadcrumbItemProps, RenderLink } from './types';
 import './style.scss';
 
-function BreadcrumbsMenu( { items }: { items: BreadcrumbItemProps[] } ) {
+function BreadcrumbsMenu( {
+	items,
+	renderLink,
+}: {
+	items: BreadcrumbItemProps[];
+	renderLink?: RenderLink;
+} ) {
 	const { __ } = useI18n();
 	return (
 		<li className="a8c-components-breadcrumbs__item-wrapper">
@@ -24,27 +30,34 @@ function BreadcrumbsMenu( { items }: { items: BreadcrumbItemProps[] } ) {
 					}
 				/>
 				<Menu.Popover>
-					{ items.map( ( item, index ) => (
-						<Menu.Item
-							key={ `${ item.label }-${ index }` }
-							onClick={ item.onClick }
-							render={ <a href={ item.href } /> }
-						>
-							<Menu.ItemLabel>{ item.label }</Menu.ItemLabel>
-						</Menu.Item>
-					) ) }
+					{ items.map( ( item, index ) => {
+						const { label, ...linkProps } = item;
+						return (
+							<Menu.Item
+								key={ `${ item.label }-${ index }` }
+								render={ renderLink?.( item ) || <a { ...linkProps } /> }
+							>
+								<Menu.ItemLabel>{ item.label }</Menu.ItemLabel>
+							</Menu.Item>
+						);
+					} ) }
 				</Menu.Popover>
 			</Menu>
 		</li>
 	);
 }
 
-function BreadcrumbItem( { item: { label, href, onClick } }: { item: BreadcrumbItemProps } ) {
+function BreadcrumbItem( {
+	item,
+	renderLink,
+}: {
+	item: BreadcrumbItemProps;
+	renderLink?: RenderLink;
+} ) {
+	const { label, ...linkProps } = item;
 	return (
 		<li className="a8c-components-breadcrumbs__item-wrapper">
-			<a href={ href } onClick={ onClick } className="a8c-components-breadcrumbs__item">
-				{ label }
-			</a>
+			{ renderLink?.( item ) || <a { ...linkProps }>{ item.label }</a> }
 		</li>
 	);
 }
@@ -74,7 +87,7 @@ const BreadcrumbsNav = forwardRef<
 		isOffscreen?: boolean;
 	}
 >( function BreadcrumbsNav(
-	{ isOffscreen, items, showCurrentItem = false, variant = 'default', ...props },
+	{ isOffscreen, items, showCurrentItem = false, variant = 'default', renderLink, ...props },
 	ref
 ) {
 	// Always show the first item. The last item (current page) is rendered
@@ -94,7 +107,6 @@ const BreadcrumbsNav = forwardRef<
 	 * Noting that we prioritize the `isCompact` prop over the `width` checks.
 	 */
 	const isCompact = ! isOffscreen && hasMiddleItems && variant === 'compact';
-
 	return (
 		<nav
 			className={ clsx( 'a8c-components-breadcrumbs', { 'is-offscreen': isOffscreen } ) }
@@ -109,15 +121,19 @@ const BreadcrumbsNav = forwardRef<
 				justify="flex-start"
 				expanded={ false }
 			>
-				<BreadcrumbItem item={ firstItem } />
+				<BreadcrumbItem item={ firstItem } renderLink={ renderLink } />
 				{ isCompact ? (
-					<BreadcrumbsMenu items={ middleItems } />
+					<BreadcrumbsMenu items={ middleItems } renderLink={ renderLink } />
 				) : (
 					middleItems.map( ( item, index ) => (
-						<BreadcrumbItem key={ `${ item.label }-${ index }` } item={ item } />
+						<BreadcrumbItem
+							key={ `${ item.label }-${ index }` }
+							item={ item }
+							renderLink={ renderLink }
+						/>
 					) )
 				) }
-				{ parentItem && <BreadcrumbItem item={ parentItem } /> }
+				{ parentItem && <BreadcrumbItem item={ parentItem } renderLink={ renderLink } /> }
 				<BreadcrumbCurrentItem item={ items[ items.length - 1 ] } visible={ showCurrentItem } />
 			</HStack>
 		</nav>
@@ -125,7 +141,7 @@ const BreadcrumbsNav = forwardRef<
 } );
 
 function UnforwardedBreadcrumbs(
-	{ items, 'aria-label': ariaLabel, ...props }: BreadcrumbProps,
+	{ items, renderLink, 'aria-label': ariaLabel, ...props }: BreadcrumbProps,
 	ref: React.ForwardedRef< HTMLElement >
 ) {
 	const { __ } = useI18n();
@@ -159,6 +175,7 @@ function UnforwardedBreadcrumbs(
 			<BreadcrumbsNav
 				ref={ offScreenRef }
 				items={ items }
+				renderLink={ renderLink }
 				{ ...props }
 				variant={ computedVariant }
 				isOffscreen
@@ -166,6 +183,7 @@ function UnforwardedBreadcrumbs(
 			<BreadcrumbsNav
 				ref={ mergedRefs }
 				items={ items }
+				renderLink={ renderLink }
 				{ ...props }
 				variant={ computedVariant }
 				aria-label={ computedAriaLabel }

--- a/packages/components/src/breadcrumbs/index.tsx
+++ b/packages/components/src/breadcrumbs/index.tsx
@@ -7,19 +7,24 @@ import {
 import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import React, { useState, forwardRef, useRef } from 'react';
+import React, { useState, forwardRef, useRef, useMemo } from 'react';
 import Menu from '../menu';
-import { BreadcrumbProps, BreadcrumbItemProps, RenderLink } from './types';
+import { BreadcrumbProps, BreadcrumbItemProps, Item } from './types';
 import './style.scss';
+
+function defaultRenderItemLink( props: BreadcrumbItemProps ) {
+	return <a { ...props }>{ props.label }</a>;
+}
 
 function BreadcrumbsMenu( {
 	items,
-	renderLink,
+	renderItemLink,
 }: {
 	items: BreadcrumbItemProps[];
-	renderLink?: RenderLink;
+	renderItemLink: NonNullable< BreadcrumbProps[ 'renderItemLink' ] >;
 } ) {
 	const { __ } = useI18n();
+
 	return (
 		<li className="a8c-components-breadcrumbs__item-wrapper">
 			<Menu placement="bottom-start">
@@ -31,12 +36,8 @@ function BreadcrumbsMenu( {
 				/>
 				<Menu.Popover>
 					{ items.map( ( item, index ) => {
-						const { label, ...linkProps } = item;
 						return (
-							<Menu.Item
-								key={ `${ item.label }-${ index }` }
-								render={ renderLink?.( item ) || <a { ...linkProps } /> }
-							>
+							<Menu.Item key={ `${ item.label }-${ index }` } render={ renderItemLink( item ) }>
 								<Menu.ItemLabel>{ item.label }</Menu.ItemLabel>
 							</Menu.Item>
 						);
@@ -49,16 +50,20 @@ function BreadcrumbsMenu( {
 
 function BreadcrumbItem( {
 	item,
-	renderLink,
+	renderItemLink,
 }: {
-	item: BreadcrumbItemProps;
-	renderLink?: RenderLink;
+	item: Item;
+	renderItemLink: NonNullable< BreadcrumbProps[ 'renderItemLink' ] >;
 } ) {
-	const { label, ...linkProps } = item;
+	const itemProps = useMemo(
+		() => ( {
+			...item,
+			className: 'a8c-components-breadcrumbs__item',
+		} ),
+		[ item ]
+	);
 	return (
-		<li className="a8c-components-breadcrumbs__item-wrapper">
-			{ renderLink?.( item ) || <a { ...linkProps }>{ item.label }</a> }
-		</li>
+		<li className="a8c-components-breadcrumbs__item-wrapper">{ renderItemLink( itemProps ) }</li>
 	);
 }
 
@@ -87,7 +92,14 @@ const BreadcrumbsNav = forwardRef<
 		isOffscreen?: boolean;
 	}
 >( function BreadcrumbsNav(
-	{ isOffscreen, items, showCurrentItem = false, variant = 'default', renderLink, ...props },
+	{
+		isOffscreen,
+		items,
+		showCurrentItem = false,
+		variant = 'default',
+		renderItemLink = defaultRenderItemLink,
+		...props
+	},
 	ref
 ) {
 	// Always show the first item. The last item (current page) is rendered
@@ -121,19 +133,19 @@ const BreadcrumbsNav = forwardRef<
 				justify="flex-start"
 				expanded={ false }
 			>
-				<BreadcrumbItem item={ firstItem } renderLink={ renderLink } />
+				<BreadcrumbItem item={ firstItem } renderItemLink={ renderItemLink } />
 				{ isCompact ? (
-					<BreadcrumbsMenu items={ middleItems } renderLink={ renderLink } />
+					<BreadcrumbsMenu items={ middleItems } renderItemLink={ renderItemLink } />
 				) : (
 					middleItems.map( ( item, index ) => (
 						<BreadcrumbItem
 							key={ `${ item.label }-${ index }` }
 							item={ item }
-							renderLink={ renderLink }
+							renderItemLink={ renderItemLink }
 						/>
 					) )
 				) }
-				{ parentItem && <BreadcrumbItem item={ parentItem } renderLink={ renderLink } /> }
+				{ parentItem && <BreadcrumbItem item={ parentItem } renderItemLink={ renderItemLink } /> }
 				<BreadcrumbCurrentItem item={ items[ items.length - 1 ] } visible={ showCurrentItem } />
 			</HStack>
 		</nav>
@@ -141,7 +153,7 @@ const BreadcrumbsNav = forwardRef<
 } );
 
 function UnforwardedBreadcrumbs(
-	{ items, renderLink, 'aria-label': ariaLabel, ...props }: BreadcrumbProps,
+	{ items, renderItemLink, 'aria-label': ariaLabel, ...props }: BreadcrumbProps,
 	ref: React.ForwardedRef< HTMLElement >
 ) {
 	const { __ } = useI18n();
@@ -175,7 +187,7 @@ function UnforwardedBreadcrumbs(
 			<BreadcrumbsNav
 				ref={ offScreenRef }
 				items={ items }
-				renderLink={ renderLink }
+				renderItemLink={ renderItemLink }
 				{ ...props }
 				variant={ computedVariant }
 				isOffscreen
@@ -183,7 +195,7 @@ function UnforwardedBreadcrumbs(
 			<BreadcrumbsNav
 				ref={ mergedRefs }
 				items={ items }
-				renderLink={ renderLink }
+				renderItemLink={ renderItemLink }
 				{ ...props }
 				variant={ computedVariant }
 				aria-label={ computedAriaLabel }

--- a/packages/components/src/breadcrumbs/index.tsx
+++ b/packages/components/src/breadcrumbs/index.tsx
@@ -213,5 +213,9 @@ function UnforwardedBreadcrumbs(
  * For accessibility, **it is important that the current page is included as the
  * final item in the breadcrumb trail**. This ensures screen reader users
  * receive the full navigational context.
+ *
+ * Note: for the Breadcrumbs component to work properly in compact mode, make
+ * sure that the implicit component's width is not affected by changes in the
+ * document's body padding.
  */
 export const Breadcrumbs = forwardRef( UnforwardedBreadcrumbs );

--- a/packages/components/src/breadcrumbs/style.scss
+++ b/packages/components/src/breadcrumbs/style.scss
@@ -28,7 +28,8 @@
 		}
 	}
 
-	.a8c-components-breadcrumbs__item {
+	.a8c-components-breadcrumbs__item,
+	.a8c-components-breadcrumbs__item-wrapper a {
 		color: $gray-700;
 		text-decoration: none;
 		height: auto;

--- a/packages/components/src/breadcrumbs/style.scss
+++ b/packages/components/src/breadcrumbs/style.scss
@@ -28,8 +28,7 @@
 		}
 	}
 
-	.a8c-components-breadcrumbs__item,
-	.a8c-components-breadcrumbs__item-wrapper a {
+	.a8c-components-breadcrumbs__item {
 		color: $gray-700;
 		text-decoration: none;
 		height: auto;

--- a/packages/components/src/breadcrumbs/test/index.tsx
+++ b/packages/components/src/breadcrumbs/test/index.tsx
@@ -109,4 +109,30 @@ describe( 'Breadcrumbs', () => {
 			screen.queryByRole( 'button', { name: 'More breadcrumb items' } )
 		).not.toBeInTheDocument();
 	} );
+
+	it( 'renders a custom item link', async () => {
+		const user = userEvent.setup();
+		const consoleLog = jest.fn();
+		render(
+			<Breadcrumbs
+				items={ THREE_ITEMS }
+				renderItemLink={ ( { label, href, ...props } ) => {
+					const onClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
+						props.onClick?.( event );
+						event.preventDefault();
+						consoleLog( `clicked ${ label }` );
+					};
+					return (
+						<a href={ href } { ...props } onClick={ onClick }>
+							{ label }
+						</a>
+					);
+				} }
+			/>
+		);
+		const secondItemLabel = THREE_ITEMS[ 1 ].label;
+		await user.click( screen.getByRole( 'link', { name: secondItemLabel } ) );
+		expect( consoleLog ).toHaveBeenCalledTimes( 1 );
+		expect( consoleLog ).toHaveBeenCalledWith( `clicked ${ secondItemLabel }` );
+	} );
 } );

--- a/packages/components/src/breadcrumbs/test/index.tsx
+++ b/packages/components/src/breadcrumbs/test/index.tsx
@@ -115,7 +115,7 @@ describe( 'Breadcrumbs', () => {
 		const consoleLog = jest.fn();
 		render(
 			<Breadcrumbs
-				items={ THREE_ITEMS }
+				items={ FIVE_ITEMS }
 				renderItemLink={ ( { label, href, ...props } ) => {
 					const onClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
 						props.onClick?.( event );
@@ -128,11 +128,27 @@ describe( 'Breadcrumbs', () => {
 						</a>
 					);
 				} }
+				variant="compact"
+				showCurrentItem
 			/>
 		);
-		const secondItemLabel = THREE_ITEMS[ 1 ].label;
-		await user.click( screen.getByRole( 'link', { name: secondItemLabel } ) );
+		const firstItemLabel = FIVE_ITEMS[ 0 ].label;
+		await user.click( screen.getByRole( 'link', { name: firstItemLabel } ) );
 		expect( consoleLog ).toHaveBeenCalledTimes( 1 );
+		expect( consoleLog ).toHaveBeenCalledWith( `clicked ${ firstItemLabel }` );
+
+		// The renderProp should not be applied to the current item.
+		// We have two items with the same label due to the internal implementation
+		// for calculating when to render as 'compact'.
+		await user.click( screen.getAllByText( FIVE_ITEMS[ FIVE_ITEMS.length - 1 ].label )[ 1 ] );
+		expect( consoleLog ).toHaveBeenCalledTimes( 1 );
+
+		// Also test the dropdown menu items.
+		const dropdownTrigger = screen.getByRole( 'button', { name: 'More breadcrumb items' } );
+		await user.click( dropdownTrigger );
+		const secondItemLabel = FIVE_ITEMS[ 1 ].label;
+		await user.click( screen.getByRole( 'menuitem', { name: secondItemLabel } ) );
+		expect( consoleLog ).toHaveBeenCalledTimes( 2 );
 		expect( consoleLog ).toHaveBeenCalledWith( `clicked ${ secondItemLabel }` );
 	} );
 } );

--- a/packages/components/src/breadcrumbs/types.ts
+++ b/packages/components/src/breadcrumbs/types.ts
@@ -1,22 +1,22 @@
-export interface BreadcrumbItemProps extends React.AnchorHTMLAttributes< HTMLAnchorElement > {
+export interface Item {
 	/**
 	 * The URL that the breadcrumb item should link to.
 	 */
-	href: string;
+	href: NonNullable< React.AnchorHTMLAttributes< HTMLAnchorElement >[ 'href' ] >;
 	/**
 	 * The label text for the breadcrumb item.
 	 */
 	label: string;
 }
 
-export type RenderLink = ( props: BreadcrumbItemProps ) => React.ReactElement;
+export type BreadcrumbItemProps = React.AnchorHTMLAttributes< HTMLAnchorElement > & Item;
 
 export interface BreadcrumbProps extends React.HTMLAttributes< HTMLElement > {
 	/**
 	 * An array of items to display in the breadcrumb trail.
 	 * The last item is considered the current item.
 	 */
-	items: BreadcrumbItemProps[];
+	items: Item[];
 	/**
 	 * A boolean to show/hide the current item in the trail.
 	 * Note that when `false` the current item is only visually hidden.
@@ -32,18 +32,32 @@ export interface BreadcrumbProps extends React.HTMLAttributes< HTMLElement > {
 	 */
 	variant?: 'default' | 'compact';
 	/**
-	 * An optional function to render a custom link for each breadcrumb item.
-	 * This function receives the breadcrumb item as an argument and should return a React node.
-	 * @param props - The breadcrumb item props.
-	 * @returns A customized ReactElement link.
+	 * Allows each breadcrumb item link to be rendered as a different HTML
+	 * element or React component. The value is a function that takes in the
+	 * original component props and gives back a React element with the props
+	 * merged.
+	 * This render prop will not affect the last (current) item, since it is
+	 * not rendered as an interactive link.
+	 *
+	 * **Note: this render function should only be used to add behaviors to the
+	 * item link (ie. connect it to a routing solution). Do not use this render
+	 * prop to implement custom breadcrumb item designs.**
+	 *
+	 * By default, the item link will be rendered as an `a` element.
 	 * @example
 	 * ```tsx
 	 * <Breadcrumbs
 	 *   items={ items }
-	 *   renderLink={ ( props ) => (
+	 *   renderItemLink={ ( props ) => (
 	 *     <Link to={ props.href }>{ props.label }</Link>
 	 *   ) }
 	 * </Breadcrumbs>
+	 *
+	 * @default ( props ) => <a { ...props }>{ props.label }</a>
 	 */
-	renderLink?: RenderLink;
+	renderItemLink?: (
+		props: BreadcrumbItemProps & {
+			ref?: React.Ref< HTMLAnchorElement >;
+		}
+	) => React.ReactElement;
 }

--- a/packages/components/src/breadcrumbs/types.ts
+++ b/packages/components/src/breadcrumbs/types.ts
@@ -39,9 +39,16 @@ export interface BreadcrumbProps extends React.HTMLAttributes< HTMLElement > {
 	 * This render prop will not affect the last (current) item, since it is
 	 * not rendered as an interactive link.
 	 *
-	 * **Note: this render function should only be used to add behaviors to the
-	 * item link (ie. connect it to a routing solution). Do not use this render
+	 * Note: this render prop should only be used to add behaviors to the
+	 * item link (e.g. to connect it to a routing solution). **Do not use this
 	 * prop to implement custom breadcrumb item designs.**
+	 *
+	 * In order to ensure the correct behavior of the component, make sure that
+	 * the render prop is open for extension:
+	 * - Spread all props onto the underlying element.
+	 * - Forward `ref` prop and merge it with the internal ref, if any.
+	 * - Merge the `style` and `className` props with the internal styles and classes, if any.
+	 * - Chain the event props with the internal event handlers, if any.
 	 *
 	 * By default, the item link will be rendered as an `a` element.
 	 * @example

--- a/packages/components/src/breadcrumbs/types.ts
+++ b/packages/components/src/breadcrumbs/types.ts
@@ -1,17 +1,15 @@
-export interface BreadcrumbItemProps {
-	/**
-	 * The label text for the breadcrumb item.
-	 */
-	label: string;
+export interface BreadcrumbItemProps extends React.AnchorHTMLAttributes< HTMLAnchorElement > {
 	/**
 	 * The URL that the breadcrumb item should link to.
 	 */
 	href: string;
 	/**
-	 * An optional callback to handle clicking on this breadcrumb item.
+	 * The label text for the breadcrumb item.
 	 */
-	onClick?: React.MouseEventHandler;
+	label: string;
 }
+
+export type RenderLink = ( props: BreadcrumbItemProps ) => React.ReactElement;
 
 export interface BreadcrumbProps extends React.HTMLAttributes< HTMLElement > {
 	/**
@@ -33,4 +31,19 @@ export interface BreadcrumbProps extends React.HTMLAttributes< HTMLElement > {
 	 * @default 'default'
 	 */
 	variant?: 'default' | 'compact';
+	/**
+	 * An optional function to render a custom link for each breadcrumb item.
+	 * This function receives the breadcrumb item as an argument and should return a React node.
+	 * @param props - The breadcrumb item props.
+	 * @returns A customized ReactElement link.
+	 * @example
+	 * ```tsx
+	 * <Breadcrumbs
+	 *   items={ items }
+	 *   renderLink={ ( props ) => (
+	 *     <Link to={ props.href }>{ props.label }</Link>
+	 *   ) }
+	 * </Breadcrumbs>
+	 */
+	renderLink?: RenderLink;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up of: https://github.com/Automattic/wp-calypso/pull/102998

After landing v1 of Breadcrumbs, we needed to verify how consumers with a routing system would integrate well. There was an [exploration](https://github.com/Automattic/wp-calypso/pull/103294) and it seems passing `onClick` prop any other isn't enough. 

So we need to support passing a render function for the link. This PR does that with a `renderItemLink ` prop.


## Notes
`renderItemLink ` could also be part of each item to fine grain each link specifically, but not sure it's a better approach.


## Testing Instructions
1. in storybook `yarn components:storybook:start` (WithRenderLink story)
2. in combination with the [dashboard PR
](https://github.com/Automattic/wp-calypso/pull/103294) by also updating the usage with:
```
<BreadcrumbsComponent
	items={ items }
	renderItemLink ={ ( { href, label, ...rest } ) => (
		<Link to={ href } { ...rest }>{ label }</Link>
	) }
/>
```


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
