### PR TITLE
Site Management Panel: Add local CSS override for the PanelSidebar button

### DIFF
--- a/client/sites/components/panel-sidebar/style.scss
+++ b/client/sites/components/panel-sidebar/style.scss
@@ -56,6 +56,7 @@
 	padding: 8px;
 	margin-bottom: 2px;
 	height: 40px;
+	justify-content: flex-start;
 	color: var(--studio-gray-100);
 	white-space: nowrap;
 	font-size: $font-body-small;

--- a/client/sites/settings/database/form.scss
+++ b/client/sites/settings/database/form.scss
@@ -34,6 +34,10 @@
 
 .phpmyadmin-card__questions {
 	margin-bottom: 1.5em;
+
+	button {
+		justify-content: flex-start;
+	}
 }
 
 .phpmyadmin-card__db-warning {

--- a/client/sites/settings/sftp-ssh/sftp-form.scss
+++ b/client/sites/settings/sftp-ssh/sftp-form.scss
@@ -4,6 +4,10 @@
 
 .sftp-card__questions-container {
 	margin-bottom: 1.5em;
+
+	button {
+		justify-content: flex-start;
+	}
 }
 
 .sftp-card__password-explainer {


### PR DESCRIPTION
## Proposed Changes

This PR fixes a regression where the button text is horizontally center aligned. See https://github.com/Automattic/wp-calypso/pull/103142#issuecomment-2871213375.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Bug fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Settings tab.
* Ensure that the button text is flex-start aligned..

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
