### PR TITLE
Masterbar: Cleanup editor-specific functionality

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { isEcommercePlan } from '@automattic/calypso-products/src';
 import page from '@automattic/calypso-router';
 import { CoreBadge } from '@automattic/components';
-import { isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
@@ -13,7 +12,6 @@ import { connect } from 'react-redux';
 import ReaderIcon from 'calypso/assets/icons/reader/reader-icon';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
-import { getStatsPathForTab } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
@@ -40,7 +38,6 @@ import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { updateSiteMigrationMeta } from 'calypso/state/sites/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
 import { isTrialSite } from 'calypso/state/sites/plans/selectors';
-import { isTrialExpired } from 'calypso/state/sites/plans/selectors/trials/trials-expiration';
 import {
 	getSiteSlug,
 	isJetpackSite,
@@ -53,30 +50,17 @@ import {
 	getSite,
 } from 'calypso/state/sites/selectors';
 import canCurrentUserManageSiteOptions from 'calypso/state/sites/selectors/can-current-user-manage-site-options';
-import canCurrentUserUseCustomerHome from 'calypso/state/sites/selectors/can-current-user-use-customer-home';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import isSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import {
-	getMostRecentlySelectedSiteId,
-	getSectionGroup,
-	getSectionName,
-} from 'calypso/state/ui/selectors';
+import { getMostRecentlySelectedSiteId, getSectionGroup } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
 import Notifications from './masterbar-notifications/notifications-button';
 
-const MOBILE_BREAKPOINT = '<480px';
-const IS_RESPONSIVE_MENU_BREAKPOINT = '<782px';
-
 class MasterbarLoggedIn extends Component {
-	state = {
-		isMobile: isWithinBreakpoint( MOBILE_BREAKPOINT ),
-		isResponsiveMenu: isWithinBreakpoint( IS_RESPONSIVE_MENU_BREAKPOINT ),
-	};
-
 	static propTypes = {
 		user: PropTypes.object.isRequired,
 		domainOnlySite: PropTypes.bool,
@@ -88,21 +72,9 @@ class MasterbarLoggedIn extends Component {
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
 		isCheckoutFailed: PropTypes.bool,
-		isInEditor: PropTypes.bool,
 		loadHelpCenterIcon: PropTypes.bool,
 		isGlobalSidebarVisible: PropTypes.bool,
 	};
-
-	subscribeToViewPortChanges() {
-		this.unsubscribeToViewPortChanges = subscribeIsWithinBreakpoint(
-			MOBILE_BREAKPOINT,
-			( isMobile ) => this.setState( { isMobile } )
-		);
-		this.unsubscribeResponsiveMenuViewPortChanges = subscribeIsWithinBreakpoint(
-			IS_RESPONSIVE_MENU_BREAKPOINT,
-			( isResponsiveMenu ) => this.setState( { isResponsiveMenu } )
-		);
-	}
 
 	handleLayoutFocus = ( currentSection ) => {
 		if ( currentSection !== this.props.section ) {
@@ -122,12 +94,6 @@ class MasterbarLoggedIn extends Component {
 		if ( qryString?.openSidebar === 'true' ) {
 			this.props.setNextLayoutFocus( 'sidebar' );
 		}
-		this.subscribeToViewPortChanges();
-	}
-
-	componentWillUnmount() {
-		this.unsubscribeToViewPortChanges?.();
-		this.unsubscribeResponsiveMenuViewPortChanges?.();
 	}
 
 	handleToggleMobileMenu = () => {
@@ -245,16 +211,6 @@ class MasterbarLoggedIn extends Component {
 				tooltip={ translate( 'Menu' ) }
 			/>
 		);
-	}
-
-	getHomeUrl() {
-		const { hasNoSites, siteSlug, isCustomerHomeEnabled, isSiteTrialExpired } = this.props;
-		// eslint-disable-next-line no-nested-ternary
-		return hasNoSites || isSiteTrialExpired
-			? '/sites'
-			: isCustomerHomeEnabled
-			? `/home/${ siteSlug }`
-			: getStatsPathForTab( 'day', siteSlug );
 	}
 
 	// will render as back button on mobile and in editor
@@ -821,44 +777,12 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
-	renderBackHomeButton() {
-		const { translate } = this.props;
-
-		return (
-			<Item
-				tipTarget="back-home"
-				className="masterbar__item-back"
-				icon="chevron-left"
-				tooltip={ translate( 'Back' ) }
-				url={ this.getHomeUrl() }
-			/>
-		);
-	}
-
 	render() {
-		const { isInEditor, isCheckout, isCheckoutPending, isCheckoutFailed, loadHelpCenterIcon } =
-			this.props;
-		const { isMobile, isResponsiveMenu } = this.state;
+		const { isCheckout, isCheckoutPending, isCheckoutFailed, loadHelpCenterIcon } = this.props;
 
 		// Checkout flow uses it's own version of the masterbar
 		if ( isCheckout || isCheckoutPending || isCheckoutFailed ) {
 			return this.renderCheckout();
-		}
-
-		// Editor specific masterbar, only shows back to home button and help center as these are hidden on mobile views
-		// from the desktop version of the editor.
-		// The desktop version of the editor has no masterbar at all so we only do this for mobile.
-		if ( isInEditor && ( isMobile || isResponsiveMenu ) ) {
-			return (
-				<Masterbar>
-					<div className="masterbar__section masterbar__section--left">
-						{ this.renderBackHomeButton() }
-					</div>
-					<div className="masterbar__section masterbar__section--right">
-						{ loadHelpCenterIcon && this.renderHelpCenter() }
-					</div>
-				</Masterbar>
-			);
 		}
 
 		return (
@@ -901,7 +825,6 @@ export default connect(
 		const isClassicView = site && siteUsesWpAdminInterface( site );
 
 		return {
-			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isManageSiteOptionsEnabled: canCurrentUserManageSiteOptions( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			isEcommerce: isEcommercePlan( sitePlanSlug ),
@@ -920,7 +843,6 @@ export default connect(
 			hasNoSites: siteCount === 0,
 			user: getCurrentUser( state ),
 			isSupportSession: isSupportSession( state ),
-			isInEditor: getSectionName( state ) === 'gutenberg-editor',
 			isMigrationInProgress,
 			migrationStatus: getSiteMigrationStatus( state, siteId ),
 			isClassicView,
@@ -930,7 +852,6 @@ export default connect(
 			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			currentRoute: getCurrentRoute( state ),
-			isSiteTrialExpired: isTrialExpired( state, siteId ),
 			newPostUrl: getEditorUrl( state, siteId, null, 'post' ),
 			newPageUrl: getEditorUrl( state, siteId, null, 'page' ),
 			isUnlaunchedSite: getIsUnlaunchedSite( state, siteId ),


### PR DESCRIPTION
Follow-up to DOTCOM-13017

## Proposed Changes

Removes the old editor-specific masterbar that is no longer in use since #103208.

## Why are these changes being made?

Removing some unused code.

## Testing Instructions

* Verify removed code is not in use. 