### PR TITLE
Hosting Dashboard: Introduce I18nProvider and abstract i18n implementation (Alternative)

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -6,8 +6,8 @@ import {
 	getLanguageSlugs,
 } from '@automattic/i18n-utils';
 import { setLocale as setLocaleNumberFormatters } from '@automattic/number-formatters';
-import i18n from 'i18n-calypso';
 import { initLanguageEmpathyMode } from 'calypso/lib/i18n-utils/empathy-mode';
+import { getI18n } from 'calypso/lib/i18n-utils/i18n';
 import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-locale';
 import { LOCALE_SET } from 'calypso/state/action-types';
 import { setLocale } from 'calypso/state/ui/language/actions';
@@ -26,7 +26,7 @@ export function getLocaleFromQueryParam() {
 	return query.get( 'locale' );
 }
 
-export const setupLocale = ( currentUser, reduxStore ) => {
+export const setupLocale = ( currentUser, reduxStore = null ) => {
 	if ( config.isEnabled( 'i18n/empathy-mode' ) && currentUser.i18n_empathy_mode ) {
 		initLanguageEmpathyMode();
 	}
@@ -46,37 +46,52 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		// Use the locale translation data that were bootstrapped by the server
 		const localeData = JSON.parse( window.i18nLocaleStrings );
 
-		i18n.setLocale( localeData );
-		const localeSlug = i18n.getLocaleSlug();
-		const localeVariant = i18n.getLocaleVariant();
-		reduxStore.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
+		getI18n().setLocale( localeData );
+		const localeSlug = getI18n().getLocaleSlug();
+		const localeVariant = getI18n().getLocaleVariant();
+		reduxStore?.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
 		// Propagate the locale to @automattic/number-formatters
 		setLocaleNumberFormatters( localeVariant || localeSlug );
 
 		if ( localeSlug ) {
 			loadUserUndeployedTranslations( localeSlug );
 		}
-	} else if ( currentUser && currentUser.localeSlug ) {
+		return localeVariant || localeSlug;
+	}
+
+	if ( currentUser && currentUser.localeSlug ) {
 		if ( shouldUseFallbackLocale ) {
 			// Use user locale fallback slug
-			reduxStore.dispatch( setLocale( userLocaleSlug ) );
-		} else {
-			// Use the current user's and load traslation data with a fetch request
-			reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
+			reduxStore?.dispatch( setLocale( userLocaleSlug ) );
+			return userLocaleSlug;
 		}
-	} else if ( bootstrappedLocaleSlug ) {
+
+		// Use the current user's and load translation data with a fetch request
+		reduxStore?.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
+		return currentUser.localeVariant || currentUser.localeSlug;
+	}
+
+	if ( bootstrappedLocaleSlug ) {
 		// Use locale slug from bootstrapped language manifest object
-		reduxStore.dispatch( setLocale( bootstrappedLocaleSlug ) );
-	} else if ( getLocaleFromQueryParam() ) {
+		reduxStore?.dispatch( setLocale( bootstrappedLocaleSlug ) );
+		return bootstrappedLocaleSlug;
+	}
+
+	if ( getLocaleFromQueryParam() ) {
 		// For logged out Calypso pages, set the locale from query param
 		const pathLocaleSlug = getLocaleFromQueryParam();
-		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
-	} else if ( ! window.hasOwnProperty( 'localeFromRoute' ) ) {
+		pathLocaleSlug && reduxStore?.dispatch( setLocale( pathLocaleSlug, '' ) );
+		return pathLocaleSlug;
+	}
+
+	if ( ! window.hasOwnProperty( 'localeFromRoute' ) ) {
 		// For logged out Calypso pages, set the locale from path if we cannot get the locale from the route on the server side
 		const pathLocaleSlug = getLocaleFromPathname();
-		pathLocaleSlug && reduxStore.dispatch( setLocale( pathLocaleSlug, '' ) );
+		pathLocaleSlug && reduxStore?.dispatch( setLocale( pathLocaleSlug, '' ) );
 		recordTracksEvent( 'calypso_locale_set', { path: window.location.pathname } );
+		return pathLocaleSlug;
 	}
 
 	// If user is logged out and translations are not bootstrapped, we assume default locale
+	return '';
 };

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -7,10 +7,23 @@ module.exports = {
 					{
 						group: [
 							'calypso/*',
+							// Allowed: calypso/boot/locale
+							'!calypso/boot',
+							'calypso/boot/*',
+							'!calypso/boot/locale',
 							// Allowed: calypso/lib/wp
 							'!calypso/lib',
 							'calypso/lib/*',
 							'!calypso/lib/wp',
+							// Allowed: calypso/lib/i18n-utils
+							'!calypso/lib/i18n-utils',
+							'calypso/lib/i18n-utils/*',
+							'!calypso/lib/i18n-utils/i18n',
+							'!calypso/lib/i18n-utils/switch-locale',
+							// Allowed: calypso/lib/user/shared-utils
+							'!calypso/lib/user',
+							'calypso/lib/user/*',
+							'!calypso/lib/user/shared-utils',
 							'!calypso/components',
 							'calypso/components/*',
 							// Allowed: calypso/assets/icons

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react';
 import { fetchUser } from '../../data';
 import type { User } from '../../data/types';
 
-export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
+export const AUTH_QUERY_KEY = [ 'auth', 'user', 'filtered' ];
 export const TWO_STEP_QUERY_KEY = [ 'me', 'two-step' ];
 
 interface AuthContextType {

--- a/client/dashboard/app/i18n/index.tsx
+++ b/client/dashboard/app/i18n/index.tsx
@@ -1,0 +1,27 @@
+import { defaultI18n } from '@wordpress/i18n';
+import { I18nProvider as WPI18nProvider } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import { setupLocale } from 'calypso/boot/locale';
+import switchLocale from 'calypso/lib/i18n-utils/switch-locale';
+import { useAuth } from '../auth';
+import './init';
+
+export function I18nProvider( { children }: { children: React.ReactNode } ) {
+	const { user } = useAuth();
+
+	useEffect( () => {
+		if ( ! user.localeSlug && ! user.localeVariant ) {
+			return;
+		}
+
+		const locale = setupLocale( user );
+
+		// The `switchLocale` function is normally called within the `setLocale` action. However,
+		// since we don't have access to the Redux store in this context, we need to call it manually.
+		if ( locale ) {
+			switchLocale( locale );
+		}
+	}, [ user.localeSlug, user.localeVariant ] );
+
+	return <WPI18nProvider i18n={ defaultI18n }>{ children }</WPI18nProvider>;
+}

--- a/client/dashboard/app/i18n/init.ts
+++ b/client/dashboard/app/i18n/init.ts
@@ -1,0 +1,34 @@
+import { getLocaleData, hasTranslation, setLocaleData, subscribe } from '@wordpress/i18n';
+import { setI18n } from 'calypso/lib/i18n-utils/i18n';
+
+const noop = () => {};
+
+const unsubscribes = new Map< () => unknown, () => unknown >();
+
+const i18n = {
+	addTranslations: ( localeData: Record< string, unknown > ) => {
+		setLocaleData( localeData );
+	},
+	configure: noop,
+	emit: noop,
+	getLocaleSlug: () => getLocaleData()?.[ '' ]?.localeSlug,
+	getLocaleVariant: () => getLocaleData()?.[ '' ]?.localeVariant,
+	hasTranslation,
+	off: ( callback: () => void ) => {
+		const unsubscribe = unsubscribes.get( callback );
+		if ( unsubscribe ) {
+			unsubscribe();
+			unsubscribes.delete( callback );
+		}
+	},
+	on: ( callback: () => void ) => {
+		unsubscribes.set( callback, subscribe( callback ) );
+	},
+	registerTranslateHook: noop,
+	reRenderTranslations: noop,
+	setLocale: ( localeData: Record< string, unknown > ) => {
+		setLocaleData( localeData );
+	},
+};
+
+setI18n( i18n );

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from '@tanstack/react-router';
 import { useMemo } from 'react';
 import { AuthProvider, useAuth } from './auth';
 import { AppProvider, type AppConfig } from './context';
+import { I18nProvider } from './i18n';
 import { queryClient } from './query-client';
 import { getRouter } from './router';
 
@@ -17,7 +18,9 @@ function Layout( { config }: { config: AppConfig } ) {
 		<AppProvider config={ config }>
 			<QueryClientProvider client={ queryClient }>
 				<AuthProvider>
-					<RouterProviderWithAuth config={ config } />
+					<I18nProvider>
+						<RouterProviderWithAuth config={ config } />
+					</I18nProvider>
 				</AuthProvider>
 			</QueryClientProvider>
 		</AppProvider>

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -1,3 +1,4 @@
+import { filterUserObject } from 'calypso/lib/user/shared-utils';
 import wpcom from 'calypso/lib/wp';
 import type {
 	Domain,
@@ -288,7 +289,8 @@ export const fetchEmail = ( id: string ): Promise< Email | undefined > => {
 };
 
 export const fetchUser = async (): Promise< User > => {
-	return wpcom.req.get( '/me' );
+	const user = await wpcom.req.get( '/me' );
+	return filterUserObject( user );
 };
 
 export const fetchTwoStep = async (): Promise< TwoStep > => {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -12,6 +12,14 @@ export interface User {
 	username: string;
 	display_name: string;
 	avatar_URL?: string;
+
+	/**
+	 * Computed attributes
+	 * See client/lib/user/shared-utils/get-computed-attributes.js
+	 */
+	primarySiteSlug: string;
+	localeSlug: string;
+	localeVariant: string;
 }
 
 export interface SiteDomain {

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -1,3 +1,3 @@
-import i18n from 'i18n-calypso';
+import { getI18n } from './i18n';
 
-export const getLocaleSlug = () => i18n.getLocaleSlug();
+export const getLocaleSlug = () => getI18n().getLocaleSlug();

--- a/client/lib/i18n-utils/empathy-mode.js
+++ b/client/lib/i18n-utils/empathy-mode.js
@@ -1,9 +1,10 @@
-import i18n, { I18N, translate } from 'i18n-calypso';
+import { I18N, translate } from 'i18n-calypso';
+import { getI18n } from './i18n';
 
 let defaultUntranslatedPlacehoder = translate( "I don't understand" );
 
 // keep `defaultUntranslatedPlacehoder` in sync with i18n changes
-i18n.on( 'change', () => {
+getI18n().on( 'change', () => {
 	defaultUntranslatedPlacehoder = translate( "I don't understand" );
 } );
 
@@ -27,7 +28,7 @@ export function toggleLanguageEmpathyMode( state ) {
 		initLanguageEmpathyMode();
 	}
 
-	i18n.reRenderTranslations();
+	getI18n().reRenderTranslations();
 }
 
 export function getLanguageEmpathyModeActive() {
@@ -40,20 +41,20 @@ export function initLanguageEmpathyMode() {
 	const i18nEmpathyRegisterHook = i18nEmpathy.registerTranslateHook.bind( i18nEmpathy );
 	const availableEmpathyTranslations = [ defaultUntranslatedPlacehoder ];
 
-	i18n.translateHooks.forEach( i18nEmpathyRegisterHook );
+	getI18n().translateHooks.forEach( i18nEmpathyRegisterHook );
 
 	// wrap translations from i18n
-	i18n.registerTranslateHook( ( translation, options ) => {
-		const locale = i18n.getLocaleSlug();
+	getI18n().registerTranslateHook( ( translation, options ) => {
+		const locale = getI18n().getLocaleSlug();
 		if (
 			! isActive ||
-			locale === i18n.defaultLocaleSlug ||
+			locale === getI18n().defaultLocaleSlug ||
 			availableEmpathyTranslations.includes( options.original )
 		) {
 			return translation;
 		}
 
-		if ( i18n.hasTranslation( options ) ) {
+		if ( getI18n().hasTranslation( options ) ) {
 			return i18nEmpathyTranslate( options );
 		}
 		return '👉 ' + encodeUntranslatedString( options.original );

--- a/client/lib/i18n-utils/i18n.js
+++ b/client/lib/i18n-utils/i18n.js
@@ -1,0 +1,9 @@
+import i18nCalypso from 'i18n-calypso';
+
+let i18n = i18nCalypso;
+
+export const setI18n = ( currentI18n ) => {
+	i18n = currentI18n;
+};
+
+export const getI18n = () => i18n;

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,12 +3,21 @@ import { captureException } from '@automattic/calypso-sentry';
 import { getUrlFromParts, getUrlParts } from '@automattic/calypso-url';
 import { isDefaultLocale, getLanguage } from '@automattic/i18n-utils';
 import { setLocale as setLocaleNumberFormatters } from '@automattic/number-formatters';
+import { isRTL, __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
-import i18n from 'i18n-calypso';
 import { forEach, throttle } from 'lodash';
+import { getI18n } from './i18n';
 const debug = debugFactory( 'calypso:i18n' );
 
 const getPromises = {};
+
+export function getLocaleSlug() {
+	return getI18n().getLocaleSlug();
+}
+
+export function getLocaleVariant() {
+	return getI18n().getLocaleVariant();
+}
 
 /**
  * De-duplicates repeated GET fetches of the same URL while one is taking place.
@@ -69,13 +78,13 @@ export function getLanguageFileUrl( localeSlug, fileType = 'json', languageRevis
 
 function getHtmlLangAttribute() {
 	// translation of this string contains the desired HTML attribute value
-	const slug = i18n.translate( 'html_lang_attribute' );
+	const slug = __( 'html_lang_attribute' );
 
 	// Hasn't been translated? Some languages don't have the translation for this string,
 	// or maybe we are dealing with the default `en` locale. Return the general purpose locale slug
 	// -- there's no special one available for `<html lang>`.
 	if ( slug === 'html_lang_attribute' ) {
-		return i18n.getLocaleSlug();
+		return getLocaleSlug();
 	}
 
 	return slug;
@@ -83,12 +92,12 @@ function getHtmlLangAttribute() {
 
 function setLocaleInDOM() {
 	const htmlLangAttribute = getHtmlLangAttribute();
-	const isRTL = i18n.isRtl();
+	const isRtl = isRTL();
 	document.documentElement.lang = htmlLangAttribute;
-	document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
-	document.body.classList[ isRTL ? 'add' : 'remove' ]( 'rtl' );
+	document.documentElement.dir = isRtl ? 'rtl' : 'ltr';
+	document.body.classList[ isRtl ? 'add' : 'remove' ]( 'rtl' );
 
-	switchWebpackCSS( isRTL );
+	switchWebpackCSS( isRtl );
 }
 
 export async function getFile( url ) {
@@ -282,7 +291,7 @@ let lastRequireChunkTranslationsHandler = null;
  * @param {Array}  options.translatedChunks Array of chunk ids that have available translation for the given locale
  * @param {Object} options.userTranslations User translations data that will override chunk translations
  */
-function addRequireChunkTranslationsHandler( localeSlug = i18n.getLocaleSlug(), options = {} ) {
+function addRequireChunkTranslationsHandler( localeSlug = getLocaleSlug(), options = {} ) {
 	const { translatedChunks = [], userTranslations = {} } = options;
 	const loadedTranslationChunks = {};
 
@@ -347,12 +356,12 @@ export default async function switchLocale( localeSlug ) {
 		getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
 
 	if ( isDefaultLocale( localeSlug ) ) {
-		i18n.configure( { defaultLocaleSlug: localeSlug } );
+		getI18n().configure( { defaultLocaleSlug: localeSlug } );
 		setLocaleInDOM();
 	} else if ( useTranslationChunks ) {
 		// If requested locale is same as current locale, we don't need to
 		// re-fetch the manifest and translation chunks.
-		if ( localeSlug === i18n.getLocaleSlug() ) {
+		if ( localeSlug === getLocaleSlug() ) {
 			setLocaleInDOM();
 			return;
 		}
@@ -369,7 +378,7 @@ export default async function switchLocale( localeSlug ) {
 				return;
 			}
 
-			i18n.setLocale( locale );
+			getI18n().setLocale( locale );
 			setLocaleInDOM();
 			removeRequireChunkTranslationsHandler();
 			addRequireChunkTranslationsHandler( localeSlug, { translatedChunks } );
@@ -433,7 +442,7 @@ export default async function switchLocale( localeSlug ) {
 						return;
 					}
 
-					i18n.setLocale( body );
+					getI18n().setLocale( body );
 					setLocaleInDOM();
 					loadUserUndeployedTranslations( localeSlug );
 				}
@@ -514,11 +523,11 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 
 /*
  * CSS links come in two flavors: either RTL stylesheets with `.rtl.css` suffix, or LTR ones
- * with `.css` suffix. This function sets a desired `isRTL` flag on the supplied URL, i.e., it
+ * with `.css` suffix. This function sets a desired `isRtl` flag on the supplied URL, i.e., it
  * changes the extension if necessary.
  */
-function setRTLFlagOnCSSLink( url, isRTL ) {
-	if ( isRTL ) {
+function setRTLFlagOnCSSLink( url, isRtl ) {
+	if ( isRtl ) {
 		return url.endsWith( '.rtl.css' ) ? url : url.replace( /\.css$/, '.rtl.css' );
 	}
 
@@ -527,14 +536,14 @@ function setRTLFlagOnCSSLink( url, isRTL ) {
 
 /**
  * Switch the Calypso CSS between RTL and LTR versions.
- * @param {boolean} isRTL True to use RTL css.
+ * @param {boolean} isRtl True to use RTL css.
  */
-export function switchWebpackCSS( isRTL ) {
+export function switchWebpackCSS( isRtl ) {
 	const currentLinks = document.querySelectorAll( 'link[rel="stylesheet"][data-webpack]' );
 
 	forEach( currentLinks, async ( currentLink ) => {
 		const currentHref = currentLink.getAttribute( 'href' );
-		const newHref = setRTLFlagOnCSSLink( currentHref, isRTL );
+		const newHref = setRTLFlagOnCSSLink( currentHref, isRtl );
 		const isNewHrefAdded = currentLink.parentElement?.querySelector( `[href = '${ newHref }']` );
 
 		if ( currentHref === newHref || isNewHrefAdded ) {
@@ -560,10 +569,10 @@ function loadCSS( cssUrl, currentLink ) {
 	return new Promise( ( resolve ) => {
 		// While looping the current links the RTL state might have changed
 		// This is a double-check to ensure the value of isRTL
-		const isRTL = i18n.isRtl();
-		const isRTLHref = currentLink.getAttribute( 'href' ).endsWith( '.rtl.css' );
+		const isRtl = isRTL();
+		const isRtlHref = currentLink.getAttribute( 'href' ).endsWith( '.rtl.css' );
 
-		if ( isRTL === isRTLHref ) {
+		if ( isRtl === isRtlHref ) {
 			return resolve( null );
 		}
 
@@ -602,7 +611,9 @@ const _translationsBatch = [];
  */
 const _addTranslationsBatch = throttle( function ( userTranslations ) {
 	window.performance?.mark?.( 'add_translations_start' );
-	i18n.addTranslations( Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations ) );
+	getI18n().addTranslations(
+		Object.assign( {}, ..._translationsBatch.splice( 0 ), userTranslations )
+	);
 	window.performance?.measure?.( 'add_translations', 'add_translations_start' );
 	window.performance?.clearMarks?.( 'add_translations_start' );
 }, 50 );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-10589

## Proposed Changes

* This is an alternative to [#103299](https://github.com/Automattic/wp-calypso/pull/103299), aiming to simplify the approach by abstracting the i18n implementation instead of relying on both `CalypsoI18nProvider` and `i18n-calypso` in the v2 dashboard

> Both [setupLocale](https://github.com/Automattic/wp-calypso/blob/bf667901c61984a0daaba61ddb70b59dfd2f4743/client/boot/locale.js#L29) and [switchLocale](https://github.com/Automattic/wp-calypso/blob/bf667901c61984a0daaba61ddb70b59dfd2f4743/client/lib/i18n-utils/switch-locale.js#L326) functions are tightly coupled with i18n-calypso. If we don't want to use i18n-calypso, we need to decouple the logic that fetches the locale data (enabled or disabled translation chunks) and then initial the locale data by @wordpress/i18n on v2 dashboard.

As referenced in [#103299](https://github.com/Automattic/wp-calypso/pull/103299), the goal of this abstraction is to provide a simpler way to decouple the logic responsible for fetching locale data. While the abstraction may still need refinement, it should help us assess whether this is the right direction to take.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix the translation on Hosting Dashboard V2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your account language to any locale other than English
* Go to /v2
* Ensure the translation works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
