### PR TITLE
Playground Intent Calculation: Show that we only suggest applicable plans as per their Playground

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -1,22 +1,15 @@
 import { Blueprint } from '@wp-playground/blueprints';
+import { StepDefinition } from '@wp-playground/client';
 import { resolveBlueprintFromURL } from './resolve-blueprint-from-url';
 
 const BLUEPRINT_LIB_HOST = 'blueprintlibrary.wordpress.com';
 const FALLBACK_PHP_VERSION = '8.3';
-const DEFAULT_BLUEPRINT: Blueprint = {
-	preferredVersions: {
-		php: FALLBACK_PHP_VERSION,
-		wp: 'latest',
-	},
-	features: {
-		networking: true,
-	},
-	login: true,
-	steps: [
-		{
-			step: 'writeFile',
-			path: '/wordpress/wp-content/mu-plugins/playground-intent-calculation.php',
-			data: `<?php add_action( 'wp_ajax_pg_intent', function() {
+
+export const DEFAULT_BLUEPRINT_STEPS: StepDefinition[] = [
+	{
+		step: 'writeFile',
+		path: '/wordpress/wp-content/mu-plugins/playground-intent-calculation.php',
+		data: `<?php add_action( 'wp_ajax_pg_intent', function() {
 				$active_plugins = array_diff( get_option( 'active_plugins' ), array( 'hello.php', 'akismet/akismet.php' ) );
 				if ( in_array( 'woocommerce/woocommerce.php', $active_plugins ) ) {
 					return 'woocommerce';
@@ -33,8 +26,19 @@ const DEFAULT_BLUEPRINT: Blueprint = {
 
 				return $has_user_global_styles ? 'global-styles' : 'simple';
 			} );`,
-		},
-	],
+	},
+];
+
+export const DEFAULT_BLUEPRINT: Blueprint = {
+	preferredVersions: {
+		php: FALLBACK_PHP_VERSION,
+		wp: 'latest',
+	},
+	features: {
+		networking: true,
+	},
+	login: true,
+	steps: DEFAULT_BLUEPRINT_STEPS,
 };
 
 const PREDEFINED_BLUEPRINTS: Record< string, Blueprint > = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/blueprint.ts
@@ -12,6 +12,29 @@ const DEFAULT_BLUEPRINT: Blueprint = {
 		networking: true,
 	},
 	login: true,
+	steps: [
+		{
+			step: 'writeFile',
+			path: '/wordpress/wp-content/mu-plugins/playground-intent-calculation.php',
+			data: `<?php add_action( 'wp_ajax_pg_intent', function() {
+				$active_plugins = array_diff( get_option( 'active_plugins' ), array( 'hello.php', 'akismet/akismet.php' ) );
+				if ( in_array( 'woocommerce/woocommerce.php', $active_plugins ) ) {
+					return 'woocommerce';
+				}
+				if ( count( $active_plugins ) > 0 ) {
+					return 'business';
+				}
+
+				$has_user_global_styles = count( get_posts( array(
+					'post_type' => 'wp_global_styles',
+					'post_status' => 'publish',
+					'posts_per_page' => 1,
+				) ) ) > 0;
+
+				return $has_user_global_styles ? 'global-styles' : 'simple';
+			} );`,
+		},
+	],
 };
 
 const PREDEFINED_BLUEPRINTS: Record< string, Blueprint > = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/test/blueprint.tsx
@@ -2,18 +2,7 @@
  * @jest-environment jsdom
  */
 // @ts-nocheck - TODO: Fix TypeScript issues
-import { getBlueprint } from '../lib/blueprint';
-
-const DEFAULT_BLUEPRINT = {
-	preferredVersions: {
-		php: '8.3',
-		wp: 'latest',
-	},
-	features: {
-		networking: true,
-	},
-	login: true,
-};
+import { getBlueprint, DEFAULT_BLUEPRINT, DEFAULT_BLUEPRINT_STEPS } from '../lib/blueprint';
 
 const BLUEPRINT_IN_URL_HASH = '#' + JSON.stringify( { landingPage: '/hash' } );
 const HASH_BLUEPRINT = {
@@ -27,6 +16,10 @@ const HASH_BLUEPRINT = {
 	login: true,
 	landingPage: '/hash',
 	steps: [],
+};
+const HASH_BLUEPRINT_EXPECTED = {
+	...HASH_BLUEPRINT,
+	steps: DEFAULT_BLUEPRINT_STEPS, // overwrite is fine since HASH_BLUEPRINT doesn't have steps of its own
 };
 
 const WOOCOMMERCE_PREDEFINED_BLUEPRINT = {
@@ -72,6 +65,10 @@ const REMOTE_BLUEPRINT = {
 	landingPage: '/remote-blueprint',
 	steps: [],
 };
+const REMOTE_BLUEPRINT_EXPECTED = {
+	...REMOTE_BLUEPRINT,
+	steps: DEFAULT_BLUEPRINT_STEPS, // overwrite is fine since REMOTE_BLUEPRINT doesn't have steps of its own
+};
 
 describe( 'getBlueprint', () => {
 	beforeEach( () => {
@@ -110,7 +107,7 @@ describe( 'getBlueprint', () => {
 		} ) );
 
 		const blueprint = await getBlueprint( false, '8.2' );
-		expect( blueprint ).toEqual( HASH_BLUEPRINT );
+		expect( blueprint ).toEqual( HASH_BLUEPRINT_EXPECTED );
 	} );
 
 	describe.each( [
@@ -233,7 +230,7 @@ describe( 'getBlueprint', () => {
 				expect( global.fetch ).toHaveBeenCalledWith( 'https://example.com/blueprint.json', {
 					credentials: 'omit',
 				} );
-				expect( blueprint ).toEqual( REMOTE_BLUEPRINT );
+				expect( blueprint ).toEqual( REMOTE_BLUEPRINT_EXPECTED );
 			} );
 		}
 	);


### PR DESCRIPTION
🚧 WIP

https://linear.app/a8c/issue/DOTOBRD-132/wpcom-pricing-intent-calculation-logic


## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
