### PR TITLE
Dashboard v2: Update docs after removal of maybeAwaitFetch

### DIFF
--- a/client/dashboard/docs/data-library.md
+++ b/client/dashboard/docs/data-library.md
@@ -51,14 +51,14 @@ The dashboard sets uses a combination of route loaders and component-level queri
 
 ### Route Loaders
 
-The primary data fetching pattern uses route loaders to prefetch data before rendering components:
+The primary data-fetching pattern uses route loaders to prefetch data before rendering components:
 
 ```typescript
 const siteRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteId',
 	loader: ( { params: { siteId } } ) =>
-		maybeAwaitFetch( {
+		queryClient.ensureQueryData( {
 			queryKey: [ 'site', siteId ],
 			queryFn: async () => {
 				const [
@@ -78,7 +78,7 @@ const siteRoute = createRoute( {
 } ).lazy( () => import( '../site' ).then( ( d ) => d.Route ) );
 ```
 
-The `maybeAwaitFetch` helper checks if data is already cached before fetching, improving performance by avoiding unnecessary requests.
+The `queryClient.ensureQueryData` helper checks if data is already cached before fetching, improving performance by avoiding unnecessary requests.
 
 ### Component-Level Queries
 
@@ -140,5 +140,5 @@ const { data, isLoading, error } = useQuery(newEntityQuery(entityId));
 
 // 5. Use in a route loader
 loader: ({ params: { id } }) =>
-  maybeAwaitFetch(newEntityQuery(id)),
+  queryClient.ensureQueryData(newEntityQuery(id)),
 

--- a/client/dashboard/docs/router.md
+++ b/client/dashboard/docs/router.md
@@ -19,7 +19,7 @@ Routes use loaders to prefetch data before rendering. This ensures that componen
 
 ```typescript
 loader: () =>
-  maybeAwaitFetch(profileQuery()),
+  queryClient.ensureQueryData(profileQuery()),
 ```
 
 later the component can use the `useQuery` hook to access the data:


### PR DESCRIPTION
Follows-up on #103268

## Proposed Changes

* Edit documentation for Dashboard v2 to reflect the removal of custom function `maybeAwaitFetch` in favour of framework-provided `queryClient.ensureQueryData`.

## Why are these changes being made?

* `maybeAwaitFetch` no longer exists, per #103268.

## Testing Instructions

* No testing involved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
