### PR TITLE
Notifications: email subscriptions - show tooltip for disabled save button

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -305,6 +305,8 @@ class NotificationSubscriptions extends Component {
 
 						<Button
 							variant="primary"
+							showTooltip={ ! this.props.hasUnsavedUserSettings }
+							label={ this.props.translate( 'No unsaved changes' ) }
 							disabled={ this.props.isUpdatingUserSettings || ! this.props.hasUnsavedUserSettings }
 							isBusy={ this.props.isUpdatingUserSettings }
 							onClick={ this.handleSubmitButtonClick }

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -304,6 +304,7 @@ class NotificationSubscriptions extends Component {
 						) }
 
 						<Button
+							accessibleWhenDisabled
 							variant="primary"
 							showTooltip={ ! this.props.hasUnsavedUserSettings }
 							label={ this.props.translate( 'No unsaved changes' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/103300 (this PR target that PR's branch)

Part of DOTCOM-13091

## Proposed Changes

* Adds tooltip to "save" button when it's disabled
<img width="523" alt="image" src="https://github.com/user-attachments/assets/87dce6fd-c91f-4423-8a65-88910bb2917f" />


As per settings design system guidelines, we should show tooltip for disabled button:

<img width="1236" alt="Screenshot 2025-05-12 at 14 00 36" src="https://github.com/user-attachments/assets/1829c50e-6683-49e7-a460-416b26a023af" />

Discussed in Slack that it's fine to have tooltip under instead of above (p1747050764116809-slack-C08AQV1NREG)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?