### PR TITLE
Notifications: localise start of the week

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -112,10 +112,56 @@ class NotificationSubscriptions extends Component {
 		} );
 	}
 
+	renderLocalizedWeekdayOptions() {
+		const { translate, locale } = this.props;
+		const startOfWeek = getNumericFirstDayOfWeek( locale );
+
+		switch ( startOfWeek ) {
+			// Monday
+			case 1:
+				return (
+					<>
+						<option value="1">{ translate( 'Monday' ) }</option>
+						<option value="2">{ translate( 'Tuesday' ) }</option>
+						<option value="3">{ translate( 'Wednesday' ) }</option>
+						<option value="4">{ translate( 'Thursday' ) }</option>
+						<option value="5">{ translate( 'Friday' ) }</option>
+						<option value="6">{ translate( 'Saturday' ) }</option>
+						<option value="7">{ translate( 'Sunday' ) }</option>
+					</>
+				);
+			// Saturday
+			case 6:
+				return (
+					<>
+						<option value="6">{ translate( 'Saturday' ) }</option>
+						<option value="7">{ translate( 'Sunday' ) }</option>
+						<option value="1">{ translate( 'Monday' ) }</option>
+						<option value="2">{ translate( 'Tuesday' ) }</option>
+						<option value="3">{ translate( 'Wednesday' ) }</option>
+						<option value="4">{ translate( 'Thursday' ) }</option>
+						<option value="5">{ translate( 'Friday' ) }</option>
+					</>
+				);
+			// Sunday
+			case 7:
+				return (
+					<>
+						<option value="7">{ translate( 'Sunday' ) }</option>
+						<option value="1">{ translate( 'Monday' ) }</option>
+						<option value="2">{ translate( 'Tuesday' ) }</option>
+						<option value="3">{ translate( 'Wednesday' ) }</option>
+						<option value="4">{ translate( 'Thursday' ) }</option>
+						<option value="5">{ translate( 'Friday' ) }</option>
+						<option value="6">{ translate( 'Saturday' ) }</option>
+					</>
+				);
+		}
+	}
+
 	render() {
-		const { locale, teams } = this.props;
+		const { teams } = this.props;
 		const isAutomattician = isAutomatticTeamMember( teams );
-		const startOfWeek = getNumericFirstDayOfWeek( locale ); // 1 being Monday and 7 being Sunday.
 
 		return (
 			<Main wideLayout className="reader-subscriptions__notifications-settings">
@@ -212,18 +258,7 @@ class NotificationSubscriptions extends Component {
 								onFocus={ this.handleFocusEvent( 'Email delivery window day' ) }
 								value={ this.props.getSetting( 'subscription_delivery_day' ) }
 							>
-								{ startOfWeek === 7 && (
-									<option value="0">{ this.props.translate( 'Sunday' ) }</option>
-								) }
-								<option value="1">{ this.props.translate( 'Monday' ) }</option>
-								<option value="2">{ this.props.translate( 'Tuesday' ) }</option>
-								<option value="3">{ this.props.translate( 'Wednesday' ) }</option>
-								<option value="4">{ this.props.translate( 'Thursday' ) }</option>
-								<option value="5">{ this.props.translate( 'Friday' ) }</option>
-								<option value="6">{ this.props.translate( 'Saturday' ) }</option>
-								{ startOfWeek === 1 && (
-									<option value="0">{ this.props.translate( 'Sunday' ) }</option>
-								) }
+								{ this.renderLocalizedWeekdayOptions() }
 							</FormSelect>
 
 							<FormSelect

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,4 +1,5 @@
 import { Card, FormLabel, Dialog } from '@automattic/components';
+import { getNumericFirstDayOfWeek, withLocale } from '@automattic/i18n-utils';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
@@ -112,8 +113,9 @@ class NotificationSubscriptions extends Component {
 	}
 
 	render() {
-		const { teams } = this.props;
+		const { locale, teams } = this.props;
 		const isAutomattician = isAutomatticTeamMember( teams );
+		const startOfWeek = getNumericFirstDayOfWeek( locale ); // 1 being Monday and 7 being Sunday.
 
 		return (
 			<Main wideLayout className="reader-subscriptions__notifications-settings">
@@ -210,13 +212,18 @@ class NotificationSubscriptions extends Component {
 								onFocus={ this.handleFocusEvent( 'Email delivery window day' ) }
 								value={ this.props.getSetting( 'subscription_delivery_day' ) }
 							>
+								{ startOfWeek === 7 && (
+									<option value="0">{ this.props.translate( 'Sunday' ) }</option>
+								) }
 								<option value="1">{ this.props.translate( 'Monday' ) }</option>
 								<option value="2">{ this.props.translate( 'Tuesday' ) }</option>
 								<option value="3">{ this.props.translate( 'Wednesday' ) }</option>
 								<option value="4">{ this.props.translate( 'Thursday' ) }</option>
 								<option value="5">{ this.props.translate( 'Friday' ) }</option>
 								<option value="6">{ this.props.translate( 'Saturday' ) }</option>
-								<option value="0">{ this.props.translate( 'Sunday' ) }</option>
+								{ startOfWeek === 1 && (
+									<option value="0">{ this.props.translate( 'Sunday' ) }</option>
+								) }
 							</FormSelect>
 
 							<FormSelect
@@ -366,6 +373,7 @@ export default compose(
 	connect( mapStateToProps, mapDispatchToProps ),
 	localize,
 	protectForm,
+	withLocale,
 	withLocalizedMoment,
 	withFormBase
 )( NotificationSubscriptionsWithHooks );

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -116,47 +116,31 @@ class NotificationSubscriptions extends Component {
 		const { translate, locale } = this.props;
 		const startOfWeek = getNumericFirstDayOfWeek( locale );
 
-		switch ( startOfWeek ) {
-			// Monday
-			case 1:
-				return (
-					<>
-						<option value="1">{ translate( 'Monday' ) }</option>
-						<option value="2">{ translate( 'Tuesday' ) }</option>
-						<option value="3">{ translate( 'Wednesday' ) }</option>
-						<option value="4">{ translate( 'Thursday' ) }</option>
-						<option value="5">{ translate( 'Friday' ) }</option>
-						<option value="6">{ translate( 'Saturday' ) }</option>
-						<option value="7">{ translate( 'Sunday' ) }</option>
-					</>
-				);
-			// Saturday
-			case 6:
-				return (
-					<>
-						<option value="6">{ translate( 'Saturday' ) }</option>
-						<option value="7">{ translate( 'Sunday' ) }</option>
-						<option value="1">{ translate( 'Monday' ) }</option>
-						<option value="2">{ translate( 'Tuesday' ) }</option>
-						<option value="3">{ translate( 'Wednesday' ) }</option>
-						<option value="4">{ translate( 'Thursday' ) }</option>
-						<option value="5">{ translate( 'Friday' ) }</option>
-					</>
-				);
-			// Sunday
-			case 7:
-				return (
-					<>
-						<option value="7">{ translate( 'Sunday' ) }</option>
-						<option value="1">{ translate( 'Monday' ) }</option>
-						<option value="2">{ translate( 'Tuesday' ) }</option>
-						<option value="3">{ translate( 'Wednesday' ) }</option>
-						<option value="4">{ translate( 'Thursday' ) }</option>
-						<option value="5">{ translate( 'Friday' ) }</option>
-						<option value="6">{ translate( 'Saturday' ) }</option>
-					</>
-				);
-		}
+		const weekDays = [
+			{ value: '1', label: translate( 'Monday' ) },
+			{ value: '2', label: translate( 'Tuesday' ) },
+			{ value: '3', label: translate( 'Wednesday' ) },
+			{ value: '4', label: translate( 'Thursday' ) },
+			{ value: '5', label: translate( 'Friday' ) },
+			{ value: '6', label: translate( 'Saturday' ) },
+			{ value: '7', label: translate( 'Sunday' ) },
+		];
+
+		// Rotate the array based on startOfWeek
+		const rotatedWeekdays = [
+			...weekDays.slice( startOfWeek - 1 ),
+			...weekDays.slice( 0, startOfWeek - 1 ),
+		];
+
+		return (
+			<>
+				{ rotatedWeekdays.map( ( { value, label } ) => (
+					<option key={ value } value={ value }>
+						{ label }
+					</option>
+				) ) }
+			</>
+		);
 	}
 
 	render() {

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -193,7 +193,7 @@ class NotificationSubscriptions extends Component {
 								value={ this.props.getSetting( 'subscription_delivery_mail_option' ) }
 							>
 								<option value="html">{ this.props.translate( 'HTML' ) }</option>
-								<option value="text">{ this.props.translate( 'Plain Text' ) }</option>
+								<option value="text">{ this.props.translate( 'Plain text' ) }</option>
 							</FormSelect>
 						</FormFieldset>
 
@@ -210,13 +210,13 @@ class NotificationSubscriptions extends Component {
 								onFocus={ this.handleFocusEvent( 'Email delivery window day' ) }
 								value={ this.props.getSetting( 'subscription_delivery_day' ) }
 							>
-								<option value="0">{ this.props.translate( 'Sunday' ) }</option>
 								<option value="1">{ this.props.translate( 'Monday' ) }</option>
 								<option value="2">{ this.props.translate( 'Tuesday' ) }</option>
 								<option value="3">{ this.props.translate( 'Wednesday' ) }</option>
 								<option value="4">{ this.props.translate( 'Thursday' ) }</option>
 								<option value="5">{ this.props.translate( 'Friday' ) }</option>
 								<option value="6">{ this.props.translate( 'Saturday' ) }</option>
+								<option value="0">{ this.props.translate( 'Sunday' ) }</option>
 							</FormSelect>
 
 							<FormSelect

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -240,7 +240,7 @@ class NotificationSubscriptions extends Component {
 								onFocus={ this.handleFocusEvent( 'Email delivery format' ) }
 								value={ this.props.getSetting( 'subscription_delivery_mail_option' ) }
 							>
-								<option value="html">{ this.props.translate( 'HTML' ) }</option>
+								<option value="html">{ this.props.translate( 'Visual (HTML)' ) }</option>
 								<option value="text">{ this.props.translate( 'Plain text' ) }</option>
 							</FormSelect>
 						</FormFieldset>

--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-Add `getNumericFirstDayOfWeek` method as a wrapper for native (but not yet fully supported) `new Intl.Locale( locale ).getWeekInfo()
+Add `getNumericFirstDayOfWeek` method as a wrapper for native (but not yet fully supported) `new Intl.Locale( locale ).getWeekInfo()`
 
 ## 1.2.3
 

--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+Add `getNumericFirstDayOfWeek` method as a wrapper for native (but not yet fully supported) `new Intl.Locale( locale ).getWeekInfo()
+
 ## 1.2.3
 
 Get rid of i18n-calypso dependency

--- a/packages/i18n-utils/src/date-utils.ts
+++ b/packages/i18n-utils/src/date-utils.ts
@@ -125,3 +125,37 @@ export const getNumericDateTimeString = ( timestamp: number, locale = 'en' ) => 
 		return getISODateString( timestamp );
 	}
 };
+
+/**
+ * Get localized first day of week 1–7, 1 being Monday and 7 being Sunday.
+ * Uses vanilla API for retrieving value from `Locale.prototype.getWeekInfo()`,
+ * or the currently more supported `Locale.prototype.weekInfo`.
+ * As of 05/2025, Firefox does not support either.
+ *
+ * If you need full support across browsers, you could load a polyfill first:
+ * https://github.com/bart-krakowski/get-week-info-polyfill
+ * @param {string} locale Locale slug
+ * @param {number} defaultFirstDayOfWeek Default first day of week if browser API is not available or locale is incorrect.
+ * @returns {number} First day of week 1–7, 1 being Monday and 7 being Sunday.
+ */
+export const getNumericFirstDayOfWeek = ( locale: string, defaultFirstDayOfWeek: number = 1 ) => {
+	try {
+		let weekInfo;
+		// New API
+		if ( typeof Intl.Locale.prototype.getWeekInfo === 'function' ) {
+			// @ts-ignore Native browser API not available in all browsers
+			weekInfo = new Intl.Locale( locale ).getWeekInfo();
+		}
+		// "Old" API
+		else if ( 'weekInfo' in Intl.Locale.prototype ) {
+			// @ts-ignore Native browser API not available in all browsers
+			weekInfo = new Intl.Locale( locale ).weekInfo;
+		} else {
+			return defaultFirstDayOfWeek;
+		}
+
+		return weekInfo.firstDay;
+	} catch ( error ) {
+		return defaultFirstDayOfWeek;
+	}
+};

--- a/packages/i18n-utils/src/date-utils.ts
+++ b/packages/i18n-utils/src/date-utils.ts
@@ -127,7 +127,7 @@ export const getNumericDateTimeString = ( timestamp: number, locale = 'en' ) => 
 };
 
 /**
- * Get localized first day of week 1–7, 1 being Monday and 7 being Sunday.
+ * Get localized first day of week 1–7, 1 being Monday, 6 being Saturday, and 7 being Sunday.
  * Uses vanilla API for retrieving value from `Locale.prototype.getWeekInfo()`,
  * or the currently more supported `Locale.prototype.weekInfo`.
  * As of 05/2025, Firefox does not support either.
@@ -136,7 +136,7 @@ export const getNumericDateTimeString = ( timestamp: number, locale = 'en' ) => 
  * https://github.com/bart-krakowski/get-week-info-polyfill
  * @param {string} locale Locale slug
  * @param {number} defaultFirstDayOfWeek Default first day of week if browser API is not available or locale is incorrect.
- * @returns {number} First day of week 1–7, 1 being Monday and 7 being Sunday.
+ * @returns {number} First day of week 1–7, 1 being Monday, 6 being Saturday, and 7 being Sunday.
  */
 export const getNumericFirstDayOfWeek = ( locale: string, defaultFirstDayOfWeek: number = 1 ) => {
 	try {

--- a/packages/i18n-utils/src/date-utils.ts
+++ b/packages/i18n-utils/src/date-utils.ts
@@ -132,13 +132,14 @@ export const getNumericDateTimeString = ( timestamp: number, locale = 'en' ) => 
  * or the currently more supported `Locale.prototype.weekInfo`.
  * As of 05/2025, Firefox does not support either.
  *
+ * Defaults to Monday (1) when API is not available.
+ *
  * If you need full support across browsers, you could load a polyfill first:
  * https://github.com/bart-krakowski/get-week-info-polyfill
  * @param {string} locale Locale slug
- * @param {number} defaultFirstDayOfWeek Default first day of week if browser API is not available or locale is incorrect.
  * @returns {number} First day of week 1–7, 1 being Monday, 6 being Saturday, and 7 being Sunday.
  */
-export const getNumericFirstDayOfWeek = ( locale: string, defaultFirstDayOfWeek: number = 1 ) => {
+export const getNumericFirstDayOfWeek = ( locale: string ) => {
 	try {
 		let weekInfo;
 		// New API
@@ -151,11 +152,11 @@ export const getNumericFirstDayOfWeek = ( locale: string, defaultFirstDayOfWeek:
 			// @ts-ignore Native browser API not available in all browsers
 			weekInfo = new Intl.Locale( locale ).weekInfo;
 		} else {
-			return defaultFirstDayOfWeek;
+			return 1;
 		}
 
 		return weekInfo.firstDay;
 	} catch ( error ) {
-		return defaultFirstDayOfWeek;
+		return 1;
 	}
 };

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -25,9 +25,10 @@ describe( '#getMappedLanguageSlug', () => {
 
 describe( '#getNumericFirstDayOfWeek', () => {
 	test( 'should correctly return the first day of week based on locale', () => {
-		expect( getNumericFirstDayOfWeek( 'en', 7 ) ).toBe( 7 ); // Sunday
 		expect( getNumericFirstDayOfWeek( 'de', 1 ) ).toBe( 1 ); // Monday
-		expect( getNumericFirstDayOfWeek( 'wrong', 3 ) ).toBe( 1 ); // Wrong locales cause default to be used
+		expect( getNumericFirstDayOfWeek( 'ar-dz', 6 ) ).toBe( 1 ); // Saturday
+		expect( getNumericFirstDayOfWeek( 'en', 7 ) ).toBe( 7 ); // Sunday
+		expect( getNumericFirstDayOfWeek( 'wrong', 3 ) ).toBe( 3 ); // Wrong locales cause default to be used
 	} );
 } );
 

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -26,7 +26,7 @@ describe( '#getMappedLanguageSlug', () => {
 describe( '#getNumericFirstDayOfWeek', () => {
 	test( 'should correctly return the first day of week based on locale', () => {
 		expect( getNumericFirstDayOfWeek( 'de', 1 ) ).toBe( 1 ); // Monday
-		expect( getNumericFirstDayOfWeek( 'ar-dz', 6 ) ).toBe( 1 ); // Saturday
+		expect( getNumericFirstDayOfWeek( 'ar-dz', 6 ) ).toBe( 6 ); // Saturday
 		expect( getNumericFirstDayOfWeek( 'en', 7 ) ).toBe( 7 ); // Sunday
 		expect( getNumericFirstDayOfWeek( 'wrong', 3 ) ).toBe( 3 ); // Wrong locales cause default to be used
 	} );

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -1,5 +1,6 @@
 import {
 	getMappedLanguageSlug,
+	getNumericFirstDayOfWeek,
 	removeLocaleFromPathLocaleInFront,
 	addLocaleToPathLocaleInFront,
 } from '../';
@@ -19,6 +20,14 @@ describe( '#getMappedLanguageSlug', () => {
 		expect( getMappedLanguageSlug( 'en' ) ).toBe( 'en' );
 		expect( getMappedLanguageSlug( 'de' ) ).toBe( 'de' );
 		expect( getMappedLanguageSlug( 'he' ) ).toBe( 'he' );
+	} );
+} );
+
+describe( '#getNumericFirstDayOfWeek', () => {
+	test( 'should correctly return the first day of week based on locale', () => {
+		expect( getNumericFirstDayOfWeek( 'en', 7 ) ).toBe( 7 ); // Sunday
+		expect( getNumericFirstDayOfWeek( 'de', 1 ) ).toBe( 1 ); // Monday
+		expect( getNumericFirstDayOfWeek( 'wrong', 3 ) ).toBe( 1 ); // Wrong locales cause default to be used
 	} );
 } );
 

--- a/packages/i18n-utils/src/test/utils.js
+++ b/packages/i18n-utils/src/test/utils.js
@@ -25,10 +25,10 @@ describe( '#getMappedLanguageSlug', () => {
 
 describe( '#getNumericFirstDayOfWeek', () => {
 	test( 'should correctly return the first day of week based on locale', () => {
-		expect( getNumericFirstDayOfWeek( 'de', 1 ) ).toBe( 1 ); // Monday
-		expect( getNumericFirstDayOfWeek( 'ar-dz', 6 ) ).toBe( 6 ); // Saturday
-		expect( getNumericFirstDayOfWeek( 'en', 7 ) ).toBe( 7 ); // Sunday
-		expect( getNumericFirstDayOfWeek( 'wrong', 3 ) ).toBe( 3 ); // Wrong locales cause default to be used
+		expect( getNumericFirstDayOfWeek( 'de' ) ).toBe( 1 ); // Monday
+		expect( getNumericFirstDayOfWeek( 'ar-dz' ) ).toBe( 6 ); // Saturday
+		expect( getNumericFirstDayOfWeek( 'en' ) ).toBe( 7 ); // Sunday
+		expect( getNumericFirstDayOfWeek( 'wrong' ) ).toBe( 1 ); // Wrong locales cause default to be used
 	} );
 } );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13034

## Proposed Changes

* Update "Plain Text" to "Plain text" for copy consistency across UIs (sentence casing)
<img width="238" alt="Screenshot 2025-05-13 at 12 46 22" src="https://github.com/user-attachments/assets/3c2db628-3528-4399-b0b4-667ec2bffdac" />
<img width="239" alt="Screenshot 2025-05-13 at 12 46 13" src="https://github.com/user-attachments/assets/3f407881-b0c2-447f-8b03-90fbd1dfc719" />


* Update "HTML" to "Visual (HTML)" to be clearer to those non-technical
<img width="249" alt="Screenshot 2025-05-13 at 12 45 11" src="https://github.com/user-attachments/assets/3cf800b9-dff6-4046-bd13-807c2b70ce7e" />
<img width="251" alt="Screenshot 2025-05-13 at 12 45 01" src="https://github.com/user-attachments/assets/cb6ba1f5-bc21-4f2c-9c8b-741616744750" />


* Star week by Monday, Saturday or Sunday in weekday selector based on locale.

Uses native `new Intl.Locale( locale ).getWeekInfo()` API from browsers if available via a new utility function in `@automattic/i18n-utils`. When not available (basically just Firefox), defaults to "Monday".

<img width="590" alt="Screenshot 2025-05-12 at 15 16 45" src="https://github.com/user-attachments/assets/735a6414-11aa-4839-b412-fc5141c7667a" />

**Before** (all locales, all browsers)
<img width="250" alt="Screenshot 2025-05-12 at 15 16 40" src="https://github.com/user-attachments/assets/901009ae-4d40-4f08-99b2-1242b76f8dc0" />

**After**
Spanish
<img width="374" alt="Screenshot 2025-05-13 at 11 59 55" src="https://github.com/user-attachments/assets/1564fc57-7308-4de8-8431-7bb16e0e2916" />

English
<img width="281" alt="Screenshot 2025-05-13 at 12 00 41" src="https://github.com/user-attachments/assets/20dcadab-f369-46e3-975c-6186aa94cbd1" />

Brazilian Portuguese
<img width="276" alt="Screenshot 2025-05-13 at 12 01 19" src="https://github.com/user-attachments/assets/928e35ef-9552-4499-bc3f-54ce7ab07964" />

Arabic
<img width="248" alt="Screenshot 2025-05-13 at 12 40 11" src="https://github.com/user-attachments/assets/8482481a-0080-40bf-9745-cac92285de76" />


Firefox on all locales
<img width="267" alt="Screenshot 2025-05-13 at 12 05 01" src="https://github.com/user-attachments/assets/c8c7d622-6e68-403d-a583-f66a2a1334a8" />





## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me/notifications/subscriptions`
* See "Email delivery window" dropdown in different locales, different browsers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
