### PR TITLE
Hosting Dashboard V2: Add new site dropdown

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -11,12 +11,16 @@ module.exports = {
 							'!calypso/lib',
 							'calypso/lib/*',
 							'!calypso/lib/wp',
-							'!calypso/components',
-							'calypso/components/*',
+							// Allowed: calypso/lib/formatting/prevent-widows
+							'!calypso/lib/formatting',
+							'calypso/lib/formatting/*',
+							'!calypso/lib/formatting/prevent-widows',
 							// Allowed: calypso/assets/icons
+							// Allowed: calypso/assets/images
 							'!calypso/assets',
 							'calypso/assets/*',
 							'!calypso/assets/icons',
+							'!calypso/assets/images',
 							// Please do not add exceptions unless agreed on
 							// with the #architecture group.
 						],
@@ -34,7 +38,9 @@ module.exports = {
 							'!@automattic/components/src/core-badge',
 							'!@automattic/components/src/breadcrumbs',
 							'!@automattic/components/src/breadcrumbs/types',
+							'!@automattic/calypso-analytics',
 							'!@automattic/dataviews',
+							'!@automattic/number-formatters',
 							// Please do not add exceptions unless agreed on
 							// with the #architecture group.
 						],

--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -11,10 +11,6 @@ module.exports = {
 							'!calypso/lib',
 							'calypso/lib/*',
 							'!calypso/lib/wp',
-							// Allowed: calypso/lib/formatting/prevent-widows
-							'!calypso/lib/formatting',
-							'calypso/lib/formatting/*',
-							'!calypso/lib/formatting/prevent-widows',
 							// Allowed: calypso/assets/icons
 							// Allowed: calypso/assets/images
 							'!calypso/assets',

--- a/client/dashboard/sites/add-new-site/column.tsx
+++ b/client/dashboard/sites/add-new-site/column.tsx
@@ -4,7 +4,7 @@ function Column( { title, children }: { title?: string; children: React.ReactNod
 	return (
 		<VStack spacing={ 4 } style={ { width: '260px' } }>
 			{ title && (
-				<Text variant="muted" size="title">
+				<Text variant="muted" size="subheadline" upperCase weight={ 500 }>
 					{ title }
 				</Text>
 			) }

--- a/client/dashboard/sites/add-new-site/column.tsx
+++ b/client/dashboard/sites/add-new-site/column.tsx
@@ -1,0 +1,16 @@
+import { __experimentalVStack as VStack, __experimentalText as Text } from '@wordpress/components';
+
+function Column( { title, children }: { title?: string; children: React.ReactNode } ) {
+	return (
+		<VStack spacing={ 4 } style={ { width: '260px' } }>
+			{ title && (
+				<Text variant="muted" size="title">
+					{ title }
+				</Text>
+			) }
+			{ children }
+		</VStack>
+	);
+}
+
+export default Column;

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -10,7 +10,6 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
-import { preventWidows } from 'calypso/lib/formatting';
 import Column from './column';
 import MenuItem from './menu-item';
 import './style.scss';
@@ -53,16 +52,14 @@ function AddNewSite() {
 				<MenuItem
 					icon={ <WordPressLogo /> }
 					title={ __( 'WordPress.com' ) }
-					description={ preventWidows(
-						__( 'Build and grow your site, all in one powerful platform.' )
-					) }
+					description={ __( 'Build and grow your site, all in one powerful platform.' ) }
 					onClick={ wordpressClick }
 					href="/start?source=sites-dashboard&ref=new-site-popover"
 				/>
 				<MenuItem
 					icon={ <JetpackLogo /> }
 					title={ __( 'Via the Jetpack plugin' ) }
-					description={ preventWidows( __( 'Install the Jetpack plugin on an existing site.' ) ) }
+					description={ __( 'Install the Jetpack plugin on an existing site.' ) }
 					onClick={ jetpackClick }
 					href={ `/jetpack/connect?cta_from=${ TRACK_SOURCE_NAME }&cta_id=add-site` }
 				/>
@@ -71,18 +68,14 @@ function AddNewSite() {
 				<MenuItem
 					icon={ reusableBlock }
 					title={ __( 'Migrate' ) }
-					description={ preventWidows(
-						__( 'Bring your entire WordPress site to WordPress.com.' )
-					) }
+					description={ __( 'Bring your entire WordPress site to WordPress.com.' ) }
 					onClick={ migrateClick }
 					href="/setup/site-migration?source=sites-dashboard&ref=new-site-popover&action=migrate"
 				/>
 				<MenuItem
 					icon={ <Icon icon={ download } size={ 18 } /> }
 					title={ __( 'Import' ) }
-					description={ preventWidows(
-						__( 'Use a backup to only import content from other platforms.' )
-					) }
+					description={ __( 'Use a backup to only import content from other platforms.' ) }
 					onClick={ importClick }
 					href="/setup/site-migration/create-site?source=sites-dashboard&ref=new-site-popover&action=import"
 				/>
@@ -111,17 +104,15 @@ function AddNewSite() {
 							} )
 						) }
 					</Text>
-					<Text variant="muted">
-						{ preventWidows(
-							sprintf(
-								// translators: %s is a percentage like 55% off
-								__(
-									'Save up to %s on annual plans and get a free custom domain for a year. Your next site is just a step away.'
-								),
-								formatNumber( 0.55, {
-									numberFormatOptions: { style: 'percent' },
-								} )
-							)
+					<Text variant="muted" as="p">
+						{ sprintf(
+							// translators: %s is a percentage like 55% off
+							__(
+								'Save up to %s on annual plans and get a free custom domain for a year. Your next site is just a step away.'
+							),
+							formatNumber( 0.55, {
+								numberFormatOptions: { style: 'percent' },
+							} )
 						) }
 					</Text>
 					<div>{ __( 'Unlock offer' ) }</div>

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -1,0 +1,139 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { WordPressLogo, JetpackLogo } from '@automattic/components';
+import { formatNumber } from '@automattic/number-formatters';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { download, reusableBlock, Icon } from '@wordpress/icons';
+import clsx from 'clsx';
+import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
+import { preventWidows } from 'calypso/lib/formatting';
+import Column from './column';
+import MenuItem from './menu-item';
+import './style.scss';
+
+const TRACK_SOURCE_NAME = 'sites-dashboard';
+
+const wordpressClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_add' );
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'wordpress',
+	} );
+};
+const jetpackClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_jetpack' );
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'jetpack',
+	} );
+};
+const migrateClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'migrate',
+	} );
+};
+const importClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_import' );
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'import',
+	} );
+};
+const offerClick = () => {
+	recordTracksEvent( 'calypso_sites_dashboard_new_site_action_click_item', {
+		action: 'offer',
+	} );
+};
+
+function AddNewSite() {
+	return (
+		<HStack alignment="flex-start" style={ { padding: '16px' } } spacing={ 4 }>
+			<Column title={ __( 'Add new site' ) }>
+				<MenuItem
+					icon={ <WordPressLogo /> }
+					title={ __( 'WordPress.com' ) }
+					description={ preventWidows(
+						__( 'Build and grow your site, all in one powerful platform.' )
+					) }
+					onClick={ wordpressClick }
+					href="/start?source=sites-dashboard&ref=new-site-popover"
+				/>
+				<MenuItem
+					icon={ <JetpackLogo /> }
+					title={ __( 'Via the Jetpack plugin' ) }
+					description={ preventWidows( __( 'Install the Jetpack plugin on an existing site.' ) ) }
+					onClick={ jetpackClick }
+					href={ `/jetpack/connect?cta_from=${ TRACK_SOURCE_NAME }&cta_id=add-site` }
+				/>
+			</Column>
+			<Column title={ __( 'Migrate and import' ) }>
+				<MenuItem
+					icon={ reusableBlock }
+					title={ __( 'Migrate' ) }
+					description={ preventWidows(
+						__( 'Bring your entire WordPress site to WordPress.com.' )
+					) }
+					onClick={ migrateClick }
+					href="/setup/site-migration?source=sites-dashboard&ref=new-site-popover&action=migrate"
+				/>
+				<MenuItem
+					icon={ <Icon icon={ download } size={ 18 } /> }
+					title={ __( 'Import' ) }
+					description={ preventWidows(
+						__( 'Use a backup to only import content from other platforms.' )
+					) }
+					onClick={ importClick }
+					href="/setup/site-migration/create-site?source=sites-dashboard&ref=new-site-popover&action=import"
+				/>
+			</Column>
+
+			<Button
+				// Figure out localizeUrl
+				href="https://wordpress.com/setup/onboarding"
+				onClick={ offerClick }
+				style={ {
+					display: 'block',
+					height: 'auto',
+					textAlign: 'left',
+					width: '260px',
+					padding: 0,
+				} }
+			>
+				<VStack className="dashboard-add-new-site__banner">
+					<img src={ devSiteBanner } alt="Get a free domain and up to 55% off" />
+					<Text size="title">
+						{ sprintf(
+							// translators: %s is a percentage like 55% off
+							__( 'Get a free domain and up to %s off' ),
+							formatNumber( 0.55, {
+								numberFormatOptions: { style: 'percent' },
+							} )
+						) }
+					</Text>
+					<Text variant="muted">
+						{ preventWidows(
+							sprintf(
+								// translators: %s is a percentage like 55% off
+								__(
+									'Save up to %s on annual plans and get a free custom domain for a year. Your next site is just a step away.'
+								),
+								formatNumber( 0.55, {
+									numberFormatOptions: { style: 'percent' },
+								} )
+							)
+						) }
+					</Text>
+					<div>
+						<div className={ clsx( 'sites-add-new-site-popover__cta' ) }>
+							{ __( 'Unlock offer' ) }
+						</div>
+					</div>
+				</VStack>
+			</Button>
+		</HStack>
+	);
+}
+
+export default AddNewSite;

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -49,13 +49,20 @@ const offerClick = () => {
 function AddNewSite() {
 	const isDesktop = useViewportMatch( 'medium' );
 	const Wrapper = isDesktop ? HStack : VStack;
+	const offer = sprintf(
+		// translators: %s is a percentage like 55% off
+		__( 'Get a free domain and up to %s off' ),
+		formatNumber( 0.55, {
+			numberFormatOptions: { style: 'percent' },
+		} )
+	);
 
 	return (
 		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 4 }>
 			<Column title={ __( 'Add new site' ) }>
 				<MenuItem
 					icon={ <WordPressLogo /> }
-					title={ __( 'WordPress.com' ) }
+					title="WordPress.com"
 					description={ __( 'Build and grow your site, all in one powerful platform.' ) }
 					onClick={ wordpressClick }
 					href="/start?source=sites-dashboard&ref=new-site-popover"
@@ -98,16 +105,8 @@ function AddNewSite() {
 				} }
 			>
 				<VStack className="dashboard-add-new-site__banner">
-					<img src={ devSiteBanner } alt="Get a free domain and up to 55% off" />
-					<Text size="title">
-						{ sprintf(
-							// translators: %s is a percentage like 55% off
-							__( 'Get a free domain and up to %s off' ),
-							formatNumber( 0.55, {
-								numberFormatOptions: { style: 'percent' },
-							} )
-						) }
-					</Text>
+					<img src={ devSiteBanner } alt={ offer } />
+					<Text size="title">{ offer }</Text>
 					<Text variant="muted" as="p">
 						{ sprintf(
 							// translators: %s is a percentage like 55% off

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -58,7 +58,7 @@ function AddNewSite() {
 	);
 
 	return (
-		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 4 }>
+		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 6 }>
 			<Column title={ __( 'Add new site' ) }>
 				<MenuItem
 					icon={ <WordPressLogo /> }

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -93,7 +93,6 @@ function AddNewSite() {
 			</Column>
 
 			<Button
-				// Figure out localizeUrl
 				href="https://wordpress.com/setup/onboarding"
 				onClick={ offerClick }
 				style={ {

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -7,6 +7,7 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
@@ -46,8 +47,11 @@ const offerClick = () => {
 };
 
 function AddNewSite() {
+	const isDesktop = useViewportMatch( 'medium' );
+	const Wrapper = isDesktop ? HStack : VStack;
+
 	return (
-		<HStack alignment="flex-start" style={ { padding: '16px' } } spacing={ 4 }>
+		<Wrapper alignment="flex-start" style={ { padding: '16px' } } spacing={ 4 }>
 			<Column title={ __( 'Add new site' ) }>
 				<MenuItem
 					icon={ <WordPressLogo /> }
@@ -118,7 +122,7 @@ function AddNewSite() {
 					<div>{ __( 'Unlock offer' ) }</div>
 				</VStack>
 			</Button>
-		</HStack>
+		</Wrapper>
 	);
 }
 

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { download, reusableBlock, Icon } from '@wordpress/icons';
-import clsx from 'clsx';
 import devSiteBanner from 'calypso/assets/images/a8c-for-agencies/dev-site-banner.svg';
 import { preventWidows } from 'calypso/lib/formatting';
 import Column from './column';
@@ -125,11 +124,7 @@ function AddNewSite() {
 							)
 						) }
 					</Text>
-					<div>
-						<div className={ clsx( 'sites-add-new-site-popover__cta' ) }>
-							{ __( 'Unlock offer' ) }
-						</div>
-					</div>
+					<div>{ __( 'Unlock offer' ) }</div>
 				</VStack>
 			</Button>
 		</HStack>

--- a/client/dashboard/sites/add-new-site/menu-item.tsx
+++ b/client/dashboard/sites/add-new-site/menu-item.tsx
@@ -29,7 +29,9 @@ function MenuItem( {
 				</div>
 				<VStack>
 					<Text>{ title }</Text>
-					<Text variant="muted">{ description }</Text>
+					<Text variant="muted" as="p">
+						{ description }
+					</Text>
 					{ children }
 				</VStack>
 			</HStack>

--- a/client/dashboard/sites/add-new-site/menu-item.tsx
+++ b/client/dashboard/sites/add-new-site/menu-item.tsx
@@ -22,8 +22,13 @@ function MenuItem( {
 	...buttonProps
 }: Props & React.ComponentProps< typeof Button > ) {
 	return (
-		<Button { ...buttonProps } label={ title } style={ { height: 'auto', textAlign: 'left' } }>
-			<HStack alignment="start">
+		<Button
+			className="dashboard-add-new-site__menu-item"
+			{ ...buttonProps }
+			label={ title }
+			showTooltip={ false }
+		>
+			<HStack alignment="start" spacing={ 2 }>
 				<div style={ { flexShrink: 0 } }>
 					<Icon className="dashboard-add-new-site__menu-item-icon" icon={ icon } />
 				</div>

--- a/client/dashboard/sites/add-new-site/menu-item.tsx
+++ b/client/dashboard/sites/add-new-site/menu-item.tsx
@@ -1,0 +1,40 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
+import { Icon } from '@wordpress/icons';
+import React from 'react';
+
+type Props = {
+	children?: JSX.Element;
+	description: string;
+	title: string;
+	icon: JSX.Element;
+};
+
+function MenuItem( {
+	children,
+	description,
+	title,
+	icon,
+	...buttonProps
+}: Props & React.ComponentProps< typeof Button > ) {
+	return (
+		<Button { ...buttonProps } label={ title } style={ { height: 'auto', textAlign: 'left' } }>
+			<HStack alignment="start">
+				<div style={ { flexShrink: 0 } }>
+					<Icon className="dashboard-add-new-site__menu-item-icon" icon={ icon } />
+				</div>
+				<VStack>
+					<Text>{ title }</Text>
+					<Text variant="muted">{ description }</Text>
+					{ children }
+				</VStack>
+			</HStack>
+		</Button>
+	);
+}
+
+export default MenuItem;

--- a/client/dashboard/sites/add-new-site/style.scss
+++ b/client/dashboard/sites/add-new-site/style.scss
@@ -1,0 +1,13 @@
+@import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/colors';
+
+.dashboard-add-new-site__menu-item-icon {
+	width: 24px;
+	height: auto;
+}
+
+.dashboard-add-new-site__banner {
+	background: $gray-100;
+	border-radius: $radius-medium;
+	padding: $grid-unit-20;
+}

--- a/client/dashboard/sites/add-new-site/style.scss
+++ b/client/dashboard/sites/add-new-site/style.scss
@@ -1,9 +1,28 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/colors';
+
+.dashboard-add-new-site__menu-item {
+	height: auto;
+	text-align: left;;
+	padding: 8px;
+
+	&:hover {
+		color: inherit !important; // avoid changing the color on hover
+		background: $gray-100;
+		border-radius: $radius-medium;
+	}
+}
 
 .dashboard-add-new-site__menu-item-icon {
 	width: 24px;
 	height: auto;
+	display: none;
+
+	@include break-medium {
+		display: block;
+	}
 }
 
 .dashboard-add-new-site__banner {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,7 +1,7 @@
 import { DataViews, filterSortAndPaginate } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, Dropdown } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
@@ -12,6 +12,7 @@ import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { STATUS_LABELS, getSiteStatus, getSiteStatusLabel } from '../utils/site-status';
+import AddNewSite from './add-new-site';
 import SiteIcon from './site-icon';
 import SitePreview from './site-preview';
 import type { Site } from '../data/types';
@@ -224,9 +225,21 @@ export default function Sites() {
 				<PageHeader
 					title={ __( 'Sites' ) }
 					actions={
-						<Button variant="primary" __next40pxDefaultSize>
-							{ __( 'Add New Site' ) }
-						</Button>
+						<Dropdown
+							popoverProps={ { placement: 'bottom-end', offset: 10, noArrow: false } }
+							focusOnMount
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<Button
+									variant="primary"
+									onClick={ onToggle }
+									__next40pxDefaultSize
+									aria-expanded={ isOpen }
+								>
+									{ __( 'Add New Site' ) }
+								</Button>
+							) }
+							renderContent={ () => <AddNewSite /> }
+						/>
 					}
 				/>
 				<DataViewsCard>


### PR DESCRIPTION
DOTCOM-12982

## Proposed Changes

This PR makes the "Add new site" button work in the hosting dashboard v2. While right now it duplicates the code base of the existing component and adapts it to the guidelines of the v2 dashboard, the ultimate goal (either in this PR or a follow-up is to reuse this new rewritten component in the v1 dashboard too, that way we evolve it in a unique place).

We need to address a few questions before able to merge this, check inline comments.

## Testing Instructions

 - Open the v2 dashboard /v2
 - Click "Add new site"
 - Ensure the different options work as intended