### PR TITLE
Purchase Management: Show second DataViews table for membership purchases

### DIFF
--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -85,7 +85,7 @@ const MembershipType = ( { subscription }: { subscription: MembershipSubscriptio
 	);
 };
 
-const Icon = ( { subscription }: { subscription: MembershipSubscription } ) => {
+export const Icon = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const [ hasError, setErrors ] = useState( false );
 	const [ site, setSite ] = useState< { icon?: { ico: string } } >();
 	const siteId = subscription.site_id;

--- a/client/me/purchases/membership-item/index.tsx
+++ b/client/me/purchases/membership-item/index.tsx
@@ -8,7 +8,7 @@ import { MembershipSubscription } from 'calypso/lib/purchases/types';
 
 import 'calypso/me/purchases/style.scss';
 
-const MembershipTerms = ( { subscription }: { subscription: MembershipSubscription } ) => {
+export const MembershipTerms = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
@@ -34,7 +34,7 @@ const MembershipTerms = ( { subscription }: { subscription: MembershipSubscripti
 	);
 };
 
-const SiteLink = ( { subscription }: { subscription: MembershipSubscription } ) => {
+export const SiteLink = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const translate = useTranslate();
 	const siteUrl = subscription.site_url.replace( /^https?:\/\//, '' );
 
@@ -59,7 +59,7 @@ const SiteLink = ( { subscription }: { subscription: MembershipSubscription } ) 
 	);
 };
 
-const MembershipType = ( { subscription }: { subscription: MembershipSubscription } ) => {
+export const MembershipType = ( { subscription }: { subscription: MembershipSubscription } ) => {
 	const translate = useTranslate();
 
 	if ( subscription.end_date === null ) {

--- a/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
+++ b/client/me/purchases/purchases-list-in-dataviews/hooks/use-field-definitions.ts
@@ -2,7 +2,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
-import { getPurchasesFieldDefinitions } from '../purchases-data-field';
+import {
+	getPurchasesFieldDefinitions,
+	getMembershipsFieldDefinitions,
+} from '../purchases-data-field';
 
 export function usePurchasesFieldDefinitions() {
 	const translate = useTranslate();
@@ -17,4 +20,15 @@ export function usePurchasesFieldDefinitions() {
 		} );
 		return fieldDefinitions;
 	}, [ translate, moment, paymentMethods ] );
+}
+
+export function useMembershipsFieldDefinitions() {
+	const translate = useTranslate();
+
+	return useMemo( () => {
+		const fieldDefinitions = getMembershipsFieldDefinitions( {
+			translate,
+		} );
+		return fieldDefinitions;
+	}, [ translate ] );
 }

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -55,6 +55,20 @@ export interface PurchasesListConnectedProps {
 	siteId: number | null;
 }
 
+function MembershipSubscriptions({
+	subscriptions,
+}:{
+	subscriptions: Array< MembershipSubscription >;
+} ) {
+	if ( ! subscriptions.length ) {
+		return null;
+	}
+
+	return getSubscriptionsBySite( subscriptions ).map( ( site ) => (
+		<SubscriptionsDataView site={ site } key={ site.id } />
+	) );
+}
+
 class PurchasesListDataView extends Component<
 	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps & LocalizeProps
 > {
@@ -77,23 +91,16 @@ class PurchasesListDataView extends Component<
 		);
 	}
 
-	renderMembershipSubscriptions() {
-		const { subscriptions } = this.props;
-
-		if ( ! subscriptions.length || this.isDataLoading() ) {
-			return null;
-		}
-
-		return getSubscriptionsBySite( subscriptions ).map( ( site ) => (
-			<MembershipSite site={ site } key={ site.id } />
-		) );
-	}
-
 	render() {
 		const { purchases, sites, translate, subscriptions } = this.props;
 		let content;
 
-		if ( this.isDataLoading() ) {
+		if (
+			isDataLoading( {
+				isFetchingUserPurchases: this.props.isFetchingUserPurchases,
+				hasLoadedUserPurchasesFromServer: this.props.hasLoadedUserPurchasesFromServer,
+			} )
+		) {
 			content = <PurchasesSite isPlaceholder />;
 		}
 
@@ -134,7 +141,7 @@ class PurchasesListDataView extends Component<
 				/>
 				<PurchasesNavigation section="activeUpgrades" />
 				{ content }
-				{ this.renderMembershipSubscriptions() }
+				<MembershipSubscriptions subscriptions={ subscriptions } />
 				<QueryConciergeInitial />
 			</Main>
 		);

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -101,7 +101,6 @@ class PurchasesListDataView extends Component<
 	render() {
 		const { purchases, sites, translate, subscriptions } = this.props;
 		const commonEventProps = { context: 'me' };
-		s;
 		let content;
 
 		if (

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -1,17 +1,21 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { CompactCard } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
-import { LocalizeProps, localize } from 'i18n-calypso';
+import { LocalizeProps, localize, useTranslate } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import noSitesIllustration from 'calypso/assets/images/illustrations/illustration-nosites.svg';
 import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getSubscriptionsBySite } from 'calypso/lib/purchases';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { MembershipSubscription, Purchase } from 'calypso/lib/purchases/types';
 import { PurchaseListConciergeBanner } from 'calypso/me/purchases/purchases-list/purchase-list-concierge-banner';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
@@ -34,9 +38,8 @@ import getConciergeUserBlocked from 'calypso/state/selectors/get-concierge-user-
 import getSites from 'calypso/state/selectors/get-sites';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { AppState } from 'calypso/types';
-import MembershipSite from '../membership-site';
 import PurchasesSite from '../purchases-site';
-import { PurchasesDataViews } from './purchases-data-view';
+import { PurchasesDataViews, MembershipsDataViews } from './purchases-data-view';
 import './style.scss';
 
 export interface PurchasesListProps {
@@ -55,18 +58,18 @@ export interface PurchasesListConnectedProps {
 	siteId: number | null;
 }
 
-function MembershipSubscriptions({
-	subscriptions,
-}:{
-	subscriptions: Array< MembershipSubscription >;
+function MembershipSubscriptions( {
+	memberships,
+}: {
+	memberships: Array< MembershipSubscription >;
 } ) {
-	if ( ! subscriptions.length ) {
+	const translate = useTranslate();
+
+	if ( ! memberships.length ) {
 		return null;
 	}
 
-	return getSubscriptionsBySite( subscriptions ).map( ( site ) => (
-		<SubscriptionsDataView site={ site } key={ site.id } />
-	) );
+	return <MembershipsDataViews memberships={ memberships } translate={ translate } />;
 }
 
 function isDataLoading( {
@@ -97,6 +100,8 @@ class PurchasesListDataView extends Component<
 
 	render() {
 		const { purchases, sites, translate, subscriptions } = this.props;
+		const commonEventProps = { context: 'me' };
+		s;
 		let content;
 
 		if (
@@ -132,7 +137,7 @@ class PurchasesListDataView extends Component<
 								eventName="calypso_no_purchases_upgrade_nudge_impression"
 								eventProperties={ commonEventProps }
 							/>
-							{ this.renderPurchasesByOtherAdminsNotice() }
+							{ /* this.renderPurchasesByOtherAdminsNotice() to-do: render this as functional component */ }
 							<EmptyContent
 								title={ translate( 'Looking to upgrade?' ) }
 								line={ translate(
@@ -172,7 +177,7 @@ class PurchasesListDataView extends Component<
 				/>
 				<PurchasesNavigation section="activeUpgrades" />
 				{ content }
-				<MembershipSubscriptions subscriptions={ subscriptions } />
+				<MembershipSubscriptions memberships={ subscriptions } />
 				<QueryConciergeInitial />
 			</Main>
 		);

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -69,17 +69,21 @@ function MembershipSubscriptions({
 	) );
 }
 
+function isDataLoading( {
+	isFetchingUserPurchases,
+	hasLoadedUserPurchasesFromServer,
+}: {
+	hasLoadedUserPurchasesFromServer: boolean;
+	isFetchingUserPurchases: boolean;
+} ) {
+	if ( isFetchingUserPurchases && ! hasLoadedUserPurchasesFromServer ) {
+		return true;
+	}
+}
+
 class PurchasesListDataView extends Component<
 	PurchasesListProps & PurchasesListConnectedProps & WithStoredPaymentMethodsProps & LocalizeProps
 > {
-	isDataLoading() {
-		if ( this.props.isFetchingUserPurchases && ! this.props.hasLoadedUserPurchasesFromServer ) {
-			return true;
-		}
-
-		return ! this.props.sites.length && ! this.props.subscriptions.length;
-	}
-
 	renderConciergeBanner() {
 		const { nextAppointment, availableSessions, isUserBlocked } = this.props;
 		return (

--- a/client/me/purchases/purchases-list-in-dataviews/index.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/index.tsx
@@ -123,6 +123,33 @@ class PurchasesListDataView extends Component<
 					</Main>
 				);
 			}
+			content = (
+				<>
+					{ this.renderConciergeBanner() }
+					<CompactCard className="purchases-list__no-content">
+						<>
+							<TrackComponentView
+								eventName="calypso_no_purchases_upgrade_nudge_impression"
+								eventProperties={ commonEventProps }
+							/>
+							{ this.renderPurchasesByOtherAdminsNotice() }
+							<EmptyContent
+								title={ translate( 'Looking to upgrade?' ) }
+								line={ translate(
+									'Our plans give your site the power to thrive. ' +
+										'Find the plan that works for you.'
+								) }
+								action={ translate( 'Upgrade now' ) }
+								actionURL="/plans"
+								illustration={ noSitesIllustration }
+								actionCallback={ () => {
+									recordTracksEvent( 'calypso_no_purchases_upgrade_nudge_click', commonEventProps );
+								} }
+							/>
+						</>
+					</CompactCard>
+				</>
+			);
 		}
 
 		return (

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -14,6 +14,8 @@ import {
 	BackupPaymentMethodNotice,
 } from '../purchase-item';
 import OwnerInfo from '../purchase-item/owner-info';
+import { MembershipSubscription } from 'calypso/lib/purchases/types';
+import { Icon, MembershipType, MembershipTerms } from '../membership-item';
 
 function PurchaseItemRowProduct( props: {
 	purchase: Purchases.Purchase;
@@ -166,6 +168,83 @@ export function getPurchasesFieldDefinitions( {
 					<div className="purchase-item__payment-method">
 						<PurchaseItemPaymentMethod purchase={ item } translate={ translate } />
 						{ isBackupMethodAvailable && isRenewing( item ) && <BackupPaymentMethodNotice /> }
+					</div>
+				);
+			},
+		},
+	];
+}
+
+export function getMembershipsFieldDefinitions( {
+	translate,
+}: {
+	translate: LocalizeProps[ 'translate' ];
+} ): Fields< MembershipSubscription > {
+	return [
+		{
+			id: 'site',
+			label: translate( 'Site' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			enableSorting: true,
+			enableHiding: false,
+			filterBy: {
+				operators: [ 'is' as Operator ],
+			},
+			// Filter by site ID
+			getValue: ( { item }: { item: MembershipSubscription } ) => {
+				return item.site_id;
+			},
+			// Render the site icon
+			render: ( { item }: { item: MembershipSubscription } ) => {
+				return (
+					<div className="membership-item__site purchases-layout__site">
+						<Icon subscription={ item } />
+					</div>
+				);
+			},
+		},
+		{
+			id: 'product',
+			label: translate( 'Product' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			enableSorting: true,
+			enableHiding: false,
+			filterBy: {
+				operators: [ 'is' as Operator ],
+			},
+			getValue: ( { item }: { item: MembershipSubscription } ) => {
+				return item.product_id;
+			},
+			render: ( { item }: { item: MembershipSubscription } ) => {
+				return (
+					<div className="membership-item__information purchase-item__information purchases-layout__information">
+						<div className="membership-item__title purchase-item__title">{ item.title }</div>
+						<div className="membership-item__purchase-type purchase-item__purchase-type">
+							<MembershipType subscription={ item } />
+						</div>
+					</div>
+				);
+			},
+		},
+		{
+			id: 'status',
+			label: translate( 'Status' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			enableSorting: true,
+			enableHiding: false,
+			filterBy: {
+				operators: [ 'is' as Operator ],
+			},
+			getValue: ( { item }: { item: MembershipSubscription } ) => {
+				return item.end_date;
+			},
+			render: ( { item }: { item: MembershipSubscription } ) => {
+				return (
+					<div className="membership-item__status purchase-item__status purchases-layout__status">
+						<MembershipTerms subscription={ item } />
 					</div>
 				);
 			},

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-field.tsx
@@ -4,8 +4,10 @@ import { LocalizeProps } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import { getDisplayName, isRenewing } from 'calypso/lib/purchases';
+import { MembershipSubscription } from 'calypso/lib/purchases/types';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
+import { Icon, MembershipType, MembershipTerms } from '../membership-item';
 import {
 	PurchaseItemSiteIcon,
 	PurchaseItemProduct,
@@ -14,8 +16,6 @@ import {
 	BackupPaymentMethodNotice,
 } from '../purchase-item';
 import OwnerInfo from '../purchase-item/owner-info';
-import { MembershipSubscription } from 'calypso/lib/purchases/types';
-import { Icon, MembershipType, MembershipTerms } from '../membership-item';
 
 function PurchaseItemRowProduct( props: {
 	purchase: Purchases.Purchase;

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -73,7 +73,7 @@ export function MembershipsDataViews( props: {
 	};
 
 	const getItemId = ( item: MembershipSubscription ) => {
-		return item.ID.toString();
+		return item.ID;
 	};
 	const membershipsDataFields = useMembershipsFieldDefinitions();
 	return (

--- a/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
+++ b/client/me/purchases/purchases-list-in-dataviews/purchases-data-view.tsx
@@ -2,7 +2,11 @@ import { Card } from '@automattic/components';
 import { Purchases } from '@automattic/data-stores';
 import { DataViews, View } from '@wordpress/dataviews';
 import { LocalizeProps } from 'i18n-calypso';
-import { usePurchasesFieldDefinitions } from './hooks/use-field-definitions';
+import { MembershipSubscription } from 'calypso/lib/purchases/types';
+import {
+	usePurchasesFieldDefinitions,
+	useMembershipsFieldDefinitions,
+} from './hooks/use-field-definitions';
 
 export const purchasesDataView = {
 	type: 'table',
@@ -36,6 +40,48 @@ export function PurchasesDataViews( props: {
 				data={ purchases }
 				fields={ purchasesDataFields }
 				view={ purchasesDataView }
+				onChangeView={ onChangeView }
+				defaultLayouts={ { table: {} } }
+				actions={ undefined }
+				getItemId={ getItemId }
+				paginationInfo={ { totalItems: 100, totalPages: 10 } }
+			/>
+		</Card>
+	);
+}
+
+export const membershipDataView = {
+	type: 'table',
+	page: 1,
+	perPage: 5,
+	titleField: 'site',
+	fields: [ 'product', 'status' ],
+	sort: {
+		field: 'site',
+		direction: 'desc',
+	},
+	layout: {},
+} as View;
+
+export function MembershipsDataViews( props: {
+	memberships: MembershipSubscription[];
+	translate: LocalizeProps[ 'translate' ];
+} ) {
+	const { memberships } = props;
+	const onChangeView = () => {
+		return;
+	};
+
+	const getItemId = ( item: MembershipSubscription ) => {
+		return item.ID.toString();
+	};
+	const membershipsDataFields = useMembershipsFieldDefinitions();
+	return (
+		<Card id="purchases-list" className="section-content" tagName="section">
+			<DataViews
+				data={ memberships }
+				fields={ membershipsDataFields }
+				view={ membershipDataView }
 				onChangeView={ onChangeView }
 				defaultLayouts={ { table: {} } }
 				actions={ undefined }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/issues/102945
Related to https://github.com/Automattic/wp-calypso/issues/86616

## Proposed Changes

* In order to render both products purchased via services owned by Automattic and products created by Automattic users (Earn/Memberships/Newsletters etc), this PR introduces a second and separate table to render the purchases for products created by Automattic users.
* Important to note, this change will remove the `Payment method` column from the memberships table. The memberships API doesn't actually include the original payment method information for display and instead was rendering only a [translated string of "Credit Card"](https://github.com/Automattic/wp-calypso/blob/d1042e76513e3b67a0280bac83d7db4a548a7150/client/me/purchases/membership-item/index.tsx#L144). This isn't particularly helpful to the user, so we are just removing it.


**Before**

<img width="1076" alt="Screenshot 2025-05-12 at 7 36 33 AM" src="https://github.com/user-attachments/assets/57d296b7-1738-457f-be67-216c112286e1" />

**After**

<img width="1100" alt="Screenshot 2025-05-12 at 7 44 40 AM" src="https://github.com/user-attachments/assets/f3c60a32-6142-487e-881d-af82253cd687" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As noted in https://github.com/Automattic/wp-calypso/issues/102945#issuecomment-2867803839, the API's for returning Automattic created products vs user created products are completely separate and return different data structures.
* This behavior was previously masked by rendering purchases of user created products in a format similar to the `PurchaseItem` component and then just tacking it on to the bottom of the purchases list:

https://github.com/Automattic/wp-calypso/blob/d1042e76513e3b67a0280bac83d7db4a548a7150/client/me/purchases/purchases-list-in-dataviews/index.tsx#L137

* To avoid delaying this project by having to change the API to fetch all products in a single flow (an improvement for a later date, maybe) we will continue to render both purchases for products created by Automattic and products created by users. We are just being more distinct about it now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To manually test this PR, you will need a product that was purchases from another Automattic user. You can set this up with two users (one to be the seller, one to be the purchaser)
* For A12s with super-admin access, you can test with the user `Receiptor`

Once you have a test user purchase:
* Apply this PR to your dev environment and start up Calypso
* Make sure to set `purchases/purchase-list-dataview` to "true" in [development.json](https://github.com/Automattic/wp-calypso/blob/d1042e76513e3b67a0280bac83d7db4a548a7150/config/development.json)
* Go to `me/purchases`
* Scroll below the initial DataViews table to see the second table for memberships

**Note** This is one piece of a larger puzzle. Here are some things not included in this PR:
- Pagination tools
- Filtering, sorting, or searching
- CSS (In progress: https://github.com/Automattic/wp-calypso/pull/102711)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
