### PR TITLE
E2E Auth: Fix magic link auth test

### DIFF
--- a/packages/calypso-e2e/src/email-client.ts
+++ b/packages/calypso-e2e/src/email-client.ts
@@ -136,7 +136,7 @@ export class EmailClient {
 	 * @throws {Error} IF the message did not have any links.
 	 */
 	getMagicLink( message: Message ): URL {
-		const link = message.text?.links?.pop();
+		const link = message.text?.links?.shift();
 
 		if ( ! link ) {
 			throw new Error( 'Message did not contain text links. ' );


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTCOM-10590/fix-authentication-tests-and-ensure-a-failure-will-trigger-a-slack

## Proposed Changes

* Fix getting magic link logic

## Why are these changes being made?

* https://linear.app/a8c/issue/DOTCOM-10590/fix-authentication-tests-and-ensure-a-failure-will-trigger-a-slack

## Testing Instructions

* check the Team City test status, should be green: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/14886302?buildTab=tests&name=magic&expandedTest=build%3A%28id%3A14886302%29%2Cid%3A2000000005

--

* run `yarn workspace @automattic/calypso-e2e build`
* run `yarn workspace wp-e2e-tests test -- specs/authentication/authentication__magic-link.ts`
* check if e2e test pass

Currently, this test is muted in Team City; after merging, it will be automatically unmuted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
