### PR TITLE
Stats: Fix Locations summary page title and label layout

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -56,6 +56,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	query,
 	summaryUrl,
 	summary = false,
+	listItemClassName,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -429,6 +430,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 						}
 						onShowMoreClick={ onShowMoreClick }
 						overlay={ moduleOverlay }
+						listItemClassName={ listItemClassName }
 					/>
 				</>
 			) }

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -90,7 +90,9 @@ $locations-horizontal-bar-width: 380px;
 	.stats-card.list-locations,
 	.stats-card-skeleton.locations-skeleton {
 		.stats-card--hero .stats-card-header {
-			padding: 0 24px 12px 0;
+			&:not(.stats__summary--narrow-mobile) {
+				padding: 0 24px 12px 0;
+			}
 		}
 
 		.stats-card-header.stats-card-header--split .stats-card-header--main__left {
@@ -107,6 +109,12 @@ $locations-horizontal-bar-width: 380px;
 	.stats-card-skeleton.locations-skeleton {
 		&.stats-card-skeleton--with-hero .stats-card__content {
 			flex-direction: column;
+		}
+	}
+
+	.stats__summary--narrow-mobile {
+		.stats-card--column-header {
+			padding: 0;
 		}
 	}
 }
@@ -210,6 +218,11 @@ $locations-horizontal-bar-width: 380px;
 		.stats-card__content .stats-card--hero {
 			flex: 2;
 			margin: 0 24px;
+
+			// Corresponding to .stats-card--hero above.
+			.stats-card-header {
+				padding: 0 0 12px;
+			}
 
 			.stats-geochart {
 				margin: 0 auto;

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -134,7 +134,11 @@ const StatsCard = ( props: StatsCardProps ) => {
 			>
 				{ !! heroElement && (
 					<div className={ `${ BASE_CLASS_NAME }--hero` }>
-						{ splitHeader && <div className={ `${ BASE_CLASS_NAME }-header` }>{ titleNode }</div> }
+						{ splitHeader && (
+							<div className={ clsx( `${ BASE_CLASS_NAME }-header`, headerClassName ) }>
+								{ titleNode }
+							</div>
+						) }
 						{ heroElement }
 					</div>
 				) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Fix the Locations summary page layout.

#### Top countries - Desktop
|Before|After|
|-|-|
|<img width="981" alt="截圖 2025-05-12 晚上9 15 44" src="https://github.com/user-attachments/assets/d38e73e4-e089-4f68-a516-c0cb9be95fd9" />|<img width="977" alt="截圖 2025-05-12 晚上9 15 50" src="https://github.com/user-attachments/assets/ace4e178-5595-42fb-b4a5-1bbb5f53a6b9" />|

#### Locations - Mobile
|Before|After|
|-|-|
|<img width="520" alt="截圖 2025-05-12 晚上9 16 13" src="https://github.com/user-attachments/assets/cd1ff8a1-4920-4f8c-9eb9-f41d4fe34568" />|<img width="537" alt="截圖 2025-05-12 晚上9 16 16" src="https://github.com/user-attachments/assets/5611ecc8-3740-4cd9-9212-23721ae2e7eb" />|

#### Top countries - Mobile
|Before|After|
|-|-|
|<img width="512" alt="截圖 2025-05-12 晚上9 33 36" src="https://github.com/user-attachments/assets/464e7a55-c1ac-498b-9b69-feec80ea074d" />|<img width="491" alt="截圖 2025-05-12 晚上9 33 28" src="https://github.com/user-attachments/assets/bbe3a188-f954-47fe-a8fd-2f066f63bc30" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix the layout of the Locations summary page under the navigation improvement feature flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page with the feature flag: `stats/navigation-improvement`.
* Ensure the Traffic page Locations module works as previously.
* Click on the `View all` button of the Locations module.
* Ensure the Locations module title and `Top countries` label styling work reasonably.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
