### PR TITLE
Stats: Refactor navItems for TabPanel and mobile SectionNav dropdown

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -32,8 +32,11 @@ import {
 	requestModuleToggles,
 } from 'calypso/state/stats/module-toggles/actions';
 import { getModuleToggles } from 'calypso/state/stats/module-toggles/selectors';
-import { AVAILABLE_PAGE_MODULES, navItems, intervals as intervalConstants } from './constants';
-import Intervals from './intervals';
+import {
+	AVAILABLE_PAGE_MODULES,
+	navItems as allNavItems,
+	intervals as intervalConstants,
+} from './constants';
 import PageModuleToggler from './page-module-toggler';
 
 import './style.scss';
@@ -62,24 +65,15 @@ function withNoticeHook( HookedComponent ) {
 	};
 }
 
-const SelectNav = ( {
-	label,
-	validNavItems,
-	interval,
-	slugPath,
-	adminUrl,
-	selectedItem,
-	showLock,
-	isLegacy,
-	showIntervals,
-	pathTemplate,
-} ) => {
+const SelectNav = ( { navItems, interval, slugPath, adminUrl, selectedItem, showLock } ) => {
+	const { label } = allNavItems[ selectedItem ];
+
 	return (
 		<>
 			<SectionNav selectedText={ label }>
 				<NavTabs selectedText={ label }>
-					{ validNavItems.map( ( item ) => {
-						const navItem = navItems[ item ];
+					{ navItems.map( ( item ) => {
+						const navItem = allNavItems[ item ];
 						const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
 						const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
 						const className = 'stats-navigation__' + item;
@@ -110,22 +104,14 @@ const SelectNav = ( {
 						);
 					} ) }
 				</NavTabs>
-
-				{ isLegacy && showIntervals && (
-					<Intervals selected={ interval } pathTemplate={ pathTemplate } />
-				) }
 			</SectionNav>
-
-			{ isLegacy && showIntervals && (
-				<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
-			) }
 		</>
 	);
 };
 
-const TabNav = ( { validNavItems, interval, slugPath, adminUrl, selectedItem, showLock } ) => {
-	const tabs = validNavItems.map( ( item ) => {
-		const navItem = navItems[ item ];
+const TabNav = ( { navItems, interval, slugPath, adminUrl, selectedItem, showLock } ) => {
+	const tabs = navItems.map( ( item ) => {
+		const navItem = allNavItems[ item ];
 		const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
 		const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
 		return {
@@ -172,10 +158,9 @@ class StatsNavigation extends Component {
 		isSimple: PropTypes.bool,
 		isSiteJetpackNotAtomic: PropTypes.bool,
 		hasVideoPress: PropTypes.bool,
-		selectedItem: PropTypes.oneOf( Object.keys( navItems ) ).isRequired,
+		selectedItem: PropTypes.oneOf( Object.keys( allNavItems ) ).isRequired,
 		siteId: PropTypes.number,
 		slug: PropTypes.string,
-		isLegacy: PropTypes.bool,
 		adminUrl: PropTypes.string,
 		showLock: PropTypes.bool,
 		hideModuleSettings: PropTypes.bool,
@@ -249,7 +234,6 @@ class StatsNavigation extends Component {
 			slug,
 			selectedItem,
 			interval,
-			isLegacy,
 			showSettingsTooltip,
 			statsAdminVersion,
 			showLock,
@@ -262,12 +246,9 @@ class StatsNavigation extends Component {
 			adminUrl,
 		} = this.props;
 		const { isPageSettingsTooltipDismissed } = this.state;
-		const { label, showIntervals, path } = navItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
-		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
 
 		const wrapperClass = clsx( 'stats-navigation', {
-			'stats-navigation--modernized': ! isLegacy,
 			'stats-navigation--improved': isStatsNavigationImprovementEnabled,
 		} );
 
@@ -277,7 +258,6 @@ class StatsNavigation extends Component {
 			!! ( statsAdminVersion && version_compare( statsAdminVersion, '0.9.0-alpha', '>=' ) );
 
 		const shouldRenderModuleToggler =
-			! isLegacy &&
 			isModuleSettingsSupported &&
 			AVAILABLE_PAGE_MODULES[ this.props.selectedItem ] &&
 			! hideModuleSettings &&
@@ -285,7 +265,7 @@ class StatsNavigation extends Component {
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
-		const validNavItems = Object.keys( navItems ).filter( this.isValidItem );
+		const navItems = Object.keys( allNavItems ).filter( this.isValidItem );
 
 		return (
 			<div className={ wrapperClass }>
@@ -296,21 +276,17 @@ class StatsNavigation extends Component {
 						breakpoint="<480px"
 						breakpointActiveComponent={
 							<SelectNav
-								label={ label }
-								validNavItems={ validNavItems }
+								navItems={ navItems }
 								interval={ interval }
 								slugPath={ slugPath }
 								adminUrl={ adminUrl }
 								selectedItem={ selectedItem }
 								showLock={ showLock }
-								isLegacy={ isLegacy }
-								showIntervals={ showIntervals }
-								pathTemplate={ pathTemplate }
 							/>
 						}
 						breakpointInactiveComponent={
 							<TabNav
-								validNavItems={ validNavItems }
+								navItems={ navItems }
 								interval={ interval }
 								slugPath={ slugPath }
 								adminUrl={ adminUrl }
@@ -323,16 +299,12 @@ class StatsNavigation extends Component {
 				{ ! isStatsNavigationImprovementEnabled && (
 					// TODO: remove following SelectNav after 'stats/navigation-improvement' launch.
 					<SelectNav
-						label={ label }
-						validNavItems={ validNavItems }
+						navItems={ navItems }
 						interval={ interval }
 						slugPath={ slugPath }
 						adminUrl={ adminUrl }
 						selectedItem={ selectedItem }
 						showLock={ showLock }
-						isLegacy={ isLegacy }
-						showIntervals={ showIntervals }
-						pathTemplate={ pathTemplate }
 					/>
 				) }
 

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -49,7 +49,7 @@ import './style.scss';
  *   title: string,
  *   className: string,
  *   path: string,
- *   adminUrl: string,
+ *   storeAdminUrl: string,
  *   showIntervals: boolean,
  * }} StatsNavItem
  */
@@ -98,7 +98,7 @@ const SelectNav = ( { navItems, selectedItemName, isLegacy, interval, pathTempla
 								<NavItem
 									className={ navItem.className }
 									key={ navItem.name }
-									onClick={ () => ( window.location.href = navItem.adminUrl ) }
+									onClick={ () => ( window.location.href = navItem.storeAdminUrl ) }
 									selected={ false }
 								>
 									{ navItem.label }
@@ -131,28 +131,28 @@ const SelectNav = ( { navItems, selectedItemName, isLegacy, interval, pathTempla
 };
 
 /**
- * @param { { tabs: StatsNavItem[], selectedItemName: keyof typeof allNavItems } } props
+ * @param { { tabs: StatsNavItem[], selectedTabName: keyof typeof allNavItems } } props
  */
-const TabNav = ( { tabs, selectedItemName } ) => {
+const TabNav = ( { tabs, selectedTabName } ) => {
 	return (
 		<TabPanel
 			className="stats-navigation__tabs"
 			tabs={ tabs }
 			onSelect={ ( newSelectedTabName ) => {
 				// Skip navigation if the clicked tab is already active to avoid redundant actions.
-				if ( newSelectedTabName === selectedItemName ) {
+				if ( newSelectedTabName === selectedTabName ) {
 					return;
 				}
 
 				const selectedTab = tabs.find( ( { name } ) => name === newSelectedTabName );
 
 				if ( selectedTab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-					window.location.href = selectedTab.adminUrl;
+					window.location.href = selectedTab.storeAdminUrl;
 				} else if ( selectedTab.path ) {
 					page( selectedTab.path );
 				}
 			} }
-			initialTabName={ selectedItemName }
+			initialTabName={ selectedTabName }
 		>
 			{ () => (
 				// Placeholder div since content is rendered elsewhere
@@ -297,7 +297,7 @@ class StatsNavigation extends Component {
 			const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
 			return {
 				name: key,
-				adminUrl: `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`,
+				storeAdminUrl: `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`,
 				className: 'stats-navigation__' + key,
 				label: navItem.label,
 				path: itemPath,
@@ -323,7 +323,7 @@ class StatsNavigation extends Component {
 							/>
 						}
 						breakpointInactiveComponent={
-							<TabNav tabs={ navItems } selectedItemName={ selectedItem } />
+							<TabNav tabs={ navItems } selectedTabName={ selectedItem } />
 						}
 					/>
 				) }

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -37,6 +37,7 @@ import {
 	navItems as allNavItems,
 	intervals as intervalConstants,
 } from './constants';
+import Intervals from './intervals';
 import PageModuleToggler from './page-module-toggler';
 
 import './style.scss';
@@ -49,6 +50,7 @@ import './style.scss';
  *   className: string,
  *   path: string,
  *   adminUrl: string,
+ *   showIntervals: boolean,
  * }} StatsNavItem
  */
 
@@ -76,40 +78,55 @@ function withNoticeHook( HookedComponent ) {
 	};
 }
 /**
- * @param { { navItems: StatsNavItem[], selectedItemName: keyof typeof allNavItems } } props
+ * @param { { navItems: StatsNavItem[], selectedItemName: keyof typeof allNavItems, isLegacy: boolean, interval: string, pathTemplate: string } } props
  */
-const SelectNav = ( { navItems, selectedItemName } ) => {
-	const { label } = navItems.find( ( { name } ) => name === selectedItemName );
+const SelectNav = ( { navItems, selectedItemName, isLegacy, interval, pathTemplate } ) => {
+	const selectedNavItem = navItems.find( ( { name } ) => name === selectedItemName );
+	if ( ! selectedNavItem ) {
+		return null;
+	}
+
+	const { label, showIntervals } = selectedNavItem;
 
 	return (
-		<SectionNav selectedText={ label }>
-			<NavTabs selectedText={ label }>
-				{ navItems.map( ( navItem ) => {
-					if ( navItem.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+		<>
+			<SectionNav selectedText={ label }>
+				<NavTabs selectedText={ label }>
+					{ navItems.map( ( navItem ) => {
+						if ( navItem.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+							return (
+								<NavItem
+									className={ navItem.className }
+									key={ navItem.name }
+									onClick={ () => ( window.location.href = navItem.adminUrl ) }
+									selected={ false }
+								>
+									{ navItem.label }
+								</NavItem>
+							);
+						}
 						return (
 							<NavItem
 								className={ navItem.className }
 								key={ navItem.name }
-								onClick={ () => ( window.location.href = navItem.adminUrl ) }
-								selected={ false }
+								path={ navItem.path }
+								selected={ selectedItemName === navItem.name }
 							>
-								{ navItem.label }
+								{ navItem.title }
 							</NavItem>
 						);
-					}
-					return (
-						<NavItem
-							className={ navItem.className }
-							key={ navItem.name }
-							path={ navItem.path }
-							selected={ selectedItemName === navItem.name }
-						>
-							{ navItem.title }
-						</NavItem>
-					);
-				} ) }
-			</NavTabs>
-		</SectionNav>
+					} ) }
+				</NavTabs>
+
+				{ isLegacy && showIntervals && (
+					<Intervals selected={ interval } pathTemplate={ pathTemplate } />
+				) }
+			</SectionNav>
+
+			{ isLegacy && showIntervals && (
+				<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />
+			) }
+		</>
 	);
 };
 
@@ -158,6 +175,7 @@ class StatsNavigation extends Component {
 		selectedItem: PropTypes.oneOf( Object.keys( allNavItems ) ).isRequired,
 		siteId: PropTypes.number,
 		slug: PropTypes.string,
+		isLegacy: PropTypes.bool,
 		adminUrl: PropTypes.string,
 		showLock: PropTypes.bool,
 		hideModuleSettings: PropTypes.bool,
@@ -231,6 +249,7 @@ class StatsNavigation extends Component {
 			slug,
 			selectedItem,
 			interval,
+			isLegacy,
 			showSettingsTooltip,
 			statsAdminVersion,
 			showLock,
@@ -243,9 +262,12 @@ class StatsNavigation extends Component {
 			adminUrl,
 		} = this.props;
 		const { isPageSettingsTooltipDismissed } = this.state;
+		const { path } = allNavItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
+		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
 
 		const wrapperClass = clsx( 'stats-navigation', {
+			'stats-navigation--modernized': ! isLegacy,
 			'stats-navigation--improved': isStatsNavigationImprovementEnabled,
 		} );
 
@@ -262,21 +284,27 @@ class StatsNavigation extends Component {
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
-		const navItems = Object.keys( allNavItems )
-			.filter( this.isValidItem )
-			.map( ( key ) => {
-				const navItem = allNavItems[ key ];
-				const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
-				const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-				return {
-					name: key,
-					adminUrl: `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`,
-					className: 'stats-navigation__' + key,
-					label: navItem.label,
-					path: itemPath,
-					title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
-				};
-			} );
+		/** @type {(keyof typeof allNavItems)[]} */
+		const navKeys = Object.keys( allNavItems );
+		const navItems = navKeys.filter( this.isValidItem ).map( ( key ) => {
+			const navItem = allNavItems[ key ];
+
+			if ( ! navItem ) {
+				throw new Error( `navItem is null for key: ${ key }` );
+			}
+
+			const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
+			const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+			return {
+				name: key,
+				adminUrl: `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`,
+				className: 'stats-navigation__' + key,
+				label: navItem.label,
+				path: itemPath,
+				showIntervals: navItem.showIntervals,
+				title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
+			};
+		} );
 
 		return (
 			<div className={ wrapperClass }>
@@ -286,7 +314,13 @@ class StatsNavigation extends Component {
 						className="full-width"
 						breakpoint="<480px"
 						breakpointActiveComponent={
-							<SelectNav navItems={ navItems } selectedItemName={ selectedItem } />
+							<SelectNav
+								navItems={ navItems }
+								selectedItemName={ selectedItem }
+								isLegacy={ isLegacy }
+								interval={ interval }
+								pathTemplate={ pathTemplate }
+							/>
 						}
 						breakpointInactiveComponent={
 							<TabNav tabs={ navItems } selectedItemName={ selectedItem } />
@@ -295,7 +329,13 @@ class StatsNavigation extends Component {
 				) }
 				{ ! isStatsNavigationImprovementEnabled && (
 					// TODO: remove following SelectNav after 'stats/navigation-improvement' launch.
-					<SelectNav navItems={ navItems } selectedItemName={ selectedItem } />
+					<SelectNav
+						navItems={ navItems }
+						selectedItemName={ selectedItem }
+						isLegacy={ isLegacy }
+						interval={ interval }
+						pathTemplate={ pathTemplate }
+					/>
 				) }
 
 				{ ! isStatsNavigationImprovementEnabled && shouldRenderModuleToggler && (

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -41,6 +41,17 @@ import PageModuleToggler from './page-module-toggler';
 
 import './style.scss';
 
+/**
+ * @typedef {{
+ *   name: string,
+ *   label: string,
+ *   title: string,
+ *   className: string,
+ *   path: string,
+ *   adminUrl: string,
+ * }} StatsNavItem
+ */
+
 // Use HOC to wrap hooks of `react-query` for fetching the notice visibility state.
 function withNoticeHook( HookedComponent ) {
 	return function WrappedComponent( props ) {
@@ -64,81 +75,67 @@ function withNoticeHook( HookedComponent ) {
 		);
 	};
 }
-
-const SelectNav = ( { navItems, interval, slugPath, adminUrl, selectedItem, showLock } ) => {
-	const { label } = allNavItems[ selectedItem ];
+/**
+ * @param { { navItems: StatsNavItem[], selectedItemName: keyof typeof allNavItems } } props
+ */
+const SelectNav = ( { navItems, selectedItemName } ) => {
+	const { label } = navItems.find( ( { name } ) => name === selectedItemName );
 
 	return (
-		<>
-			<SectionNav selectedText={ label }>
-				<NavTabs selectedText={ label }>
-					{ navItems.map( ( item ) => {
-						const navItem = allNavItems[ item ];
-						const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
-						const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-						const className = 'stats-navigation__' + item;
-						if ( item === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-							return (
-								<NavItem
-									className={ className }
-									key={ item }
-									onClick={ () =>
-										( window.location.href = `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview` )
-									}
-									selected={ false }
-								>
-									{ navItem.label }
-								</NavItem>
-							);
-						}
+		<SectionNav selectedText={ label }>
+			<NavTabs selectedText={ label }>
+				{ navItems.map( ( navItem ) => {
+					if ( navItem.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
 						return (
 							<NavItem
-								className={ className }
-								key={ item }
-								path={ itemPath }
-								selected={ selectedItem === item }
+								className={ navItem.className }
+								key={ navItem.name }
+								onClick={ () => ( window.location.href = navItem.adminUrl ) }
+								selected={ false }
 							>
 								{ navItem.label }
-								{ navItem.paywall && showLock && ' 🔒' }
 							</NavItem>
 						);
-					} ) }
-				</NavTabs>
-			</SectionNav>
-		</>
+					}
+					return (
+						<NavItem
+							className={ navItem.className }
+							key={ navItem.name }
+							path={ navItem.path }
+							selected={ selectedItemName === navItem.name }
+						>
+							{ navItem.title }
+						</NavItem>
+					);
+				} ) }
+			</NavTabs>
+		</SectionNav>
 	);
 };
 
-const TabNav = ( { navItems, interval, slugPath, adminUrl, selectedItem, showLock } ) => {
-	const tabs = navItems.map( ( item ) => {
-		const navItem = allNavItems[ item ];
-		const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
-		const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
-		return {
-			name: item,
-			title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
-			className: 'stats-navigation__' + item,
-			path: itemPath,
-		};
-	} );
-
+/**
+ * @param { { tabs: StatsNavItem[], selectedItemName: keyof typeof allNavItems } } props
+ */
+const TabNav = ( { tabs, selectedItemName } ) => {
 	return (
 		<TabPanel
 			className="stats-navigation__tabs"
 			tabs={ tabs }
-			onSelect={ ( tabName ) => {
+			onSelect={ ( newSelectedTabName ) => {
 				// Skip navigation if the clicked tab is already active to avoid redundant actions.
-				if ( tabName !== selectedItem ) {
-					const tab = tabs.find( ( { name } ) => name === tabName );
+				if ( newSelectedTabName === selectedItemName ) {
+					return;
+				}
 
-					if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-						window.location.href = `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
-					} else if ( tab.path ) {
-						page( tab.path );
-					}
+				const selectedTab = tabs.find( ( { name } ) => name === newSelectedTabName );
+
+				if ( selectedTab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+					window.location.href = selectedTab.adminUrl;
+				} else if ( selectedTab.path ) {
+					page( selectedTab.path );
 				}
 			} }
-			initialTabName={ selectedItem }
+			initialTabName={ selectedItemName }
 		>
 			{ () => (
 				// Placeholder div since content is rendered elsewhere
@@ -265,7 +262,21 @@ class StatsNavigation extends Component {
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
-		const navItems = Object.keys( allNavItems ).filter( this.isValidItem );
+		const navItems = Object.keys( allNavItems )
+			.filter( this.isValidItem )
+			.map( ( key ) => {
+				const navItem = allNavItems[ key ];
+				const intervalPath = navItem.showIntervals ? `/${ interval || 'day' }` : '';
+				const itemPath = `${ navItem.path }${ intervalPath }${ slugPath }`;
+				return {
+					name: key,
+					adminUrl: `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`,
+					className: 'stats-navigation__' + key,
+					label: navItem.label,
+					path: itemPath,
+					title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
+				};
+			} );
 
 		return (
 			<div className={ wrapperClass }>
@@ -275,37 +286,16 @@ class StatsNavigation extends Component {
 						className="full-width"
 						breakpoint="<480px"
 						breakpointActiveComponent={
-							<SelectNav
-								navItems={ navItems }
-								interval={ interval }
-								slugPath={ slugPath }
-								adminUrl={ adminUrl }
-								selectedItem={ selectedItem }
-								showLock={ showLock }
-							/>
+							<SelectNav navItems={ navItems } selectedItemName={ selectedItem } />
 						}
 						breakpointInactiveComponent={
-							<TabNav
-								navItems={ navItems }
-								interval={ interval }
-								slugPath={ slugPath }
-								adminUrl={ adminUrl }
-								selectedItem={ selectedItem }
-								showLock={ showLock }
-							/>
+							<TabNav tabs={ navItems } selectedItemName={ selectedItem } />
 						}
 					/>
 				) }
 				{ ! isStatsNavigationImprovementEnabled && (
 					// TODO: remove following SelectNav after 'stats/navigation-improvement' launch.
-					<SelectNav
-						navItems={ navItems }
-						interval={ interval }
-						slugPath={ slugPath }
-						adminUrl={ adminUrl }
-						selectedItem={ selectedItem }
-						showLock={ showLock }
-					/>
+					<SelectNav navItems={ navItems } selectedItemName={ selectedItem } />
 				) }
 
 				{ ! isStatsNavigationImprovementEnabled && shouldRenderModuleToggler && (

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -284,7 +284,7 @@ class StatsNavigation extends Component {
 
 		// @TODO: Add loading status of modules settings to avoid toggling modules before they are loaded.
 
-		/** @type {(keyof typeof allNavItems)[]} */
+		/** @type {Array<keyof typeof allNavItems>} Array of valid navigation item keys */
 		const navKeys = Object.keys( allNavItems );
 		const navItems = navKeys.filter( this.isValidItem ).map( ( key ) => {
 			const navItem = allNavItems[ key ];


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #STATS-10

## Proposed Changes

* Refactor of https://github.com/Automattic/wp-calypso/pull/103325.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Simplified the original PR by moving the refactoring part to this PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No new feature / fix is added. This PR touches stat's nav section. There shouldn't be any change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
