### PR TITLE
Notifications: update header bell

### DIFF
--- a/client/me/notification-settings/settings-form/stream-header.jsx
+++ b/client/me/notification-settings/settings-form/stream-header.jsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Icon, bell } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { getLabelForStream } from './locales';
@@ -19,7 +19,7 @@ export default class extends PureComponent {
 		return (
 			<div className="notification-settings-form-header">
 				<div className="notification-settings-form-header__title">
-					{ this.props.stream === 'timeline' ? <Gridicon icon="bell" /> : this.renderTitle() }
+					{ this.props.stream === 'timeline' ? <Icon icon={ bell } /> : this.renderTitle() }
 				</div>
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13029



## Proposed Changes

* Updates Gridicon bell to WP Icons bell

Before

<img width="1085" alt="Screenshot 2025-05-12 at 17 27 47" src="https://github.com/user-attachments/assets/5d3ece23-8002-45c6-99aa-e4dd54cdf355" />
<img width="1084" alt="Screenshot 2025-05-12 at 17 27 52" src="https://github.com/user-attachments/assets/dc7be837-8294-4d06-baa9-0d8e5932263f" />


After
<img width="1083" alt="Screenshot 2025-05-12 at 17 21 03" src="https://github.com/user-attachments/assets/b5b804f9-d3fa-44d3-accc-e6c8319fe171" />
<img width="1096" alt="Screenshot 2025-05-12 at 17 18 38" src="https://github.com/user-attachments/assets/de55a771-d360-4f3c-bc07-a8227ddab1ab" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
