### PR TITLE
Notifications: Browser notifications banner updates

### DIFF
--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -605,12 +605,10 @@ class PushNotificationSettings extends Component {
 			<Modal
 				className="notification-settings-push-notification-settings__instruction-dialog"
 				onRequestClose={ this.props.toggleUnblockInstructions }
+				title={ this.props.translate( 'Enable browser notifications' ) }
 			>
 				<div className="notification-settings-push-notification-settings__instruction-content">
 					<div>
-						<div className="notification-settings-push-notification-settings__instruction-title">
-							{ this.props.translate( 'Enable browser notifications' ) }
-						</div>
 						<div className="notification-settings-push-notification-settings__instruction-step">
 							<div className="notification-settings-push-notification-settings__instruction-image">
 								<SvgAddressBar />

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -1,6 +1,6 @@
 import { Card, Button } from '@automattic/components';
-import { Icon, bell } from '@automattic/icons';
 import { Modal } from '@wordpress/components';
+import { Icon, bell } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -762,9 +762,13 @@ class PushNotificationSettings extends Component {
 					</small>
 				</h2>
 				<p className="notification-settings-push-notification-settings__settings-description">
-					{ this.props.translate(
-						"Get notified instantly about new comments and likes — even when you're not on WordPress.com"
-					) }
+					{ this.props.status === 'subscribed'
+						? this.props.translate(
+								"You're all set to get real-time alerts for new comments and likes."
+						  )
+						: this.props.translate(
+								"Get notified instantly about new comments and likes — even when you're not on WordPress.com"
+						  ) }
 				</p>
 				<Button
 					className={ clsx(

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -768,17 +768,19 @@ class PushNotificationSettings extends Component {
 								"Get notified instantly about new comments and likes — even when you're not on WordPress.com"
 						  ) }
 				</p>
-				<Button
-					className={ clsx(
-						'notification-settings-push-notification-settings__settings-button',
-						buttonClass
-					) }
-					disabled={ buttonDisabled }
-					primary={ buttonPrimary }
-					onClick={ this.clickHandler }
-				>
-					{ buttonText }
-				</Button>
+				{ this.props.status !== 'denied' && (
+					<Button
+						className={ clsx(
+							'notification-settings-push-notification-settings__settings-button',
+							buttonClass
+						) }
+						disabled={ buttonDisabled }
+						primary={ buttonPrimary }
+						onClick={ this.clickHandler }
+					>
+						{ buttonText }
+					</Button>
+				) }
 				{ deniedText }
 			</Card>
 			/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -1,4 +1,6 @@
-import { Card, Button, Dialog, ScreenReaderText, Gridicon } from '@automattic/components';
+import { Card, Button } from '@automattic/components';
+import { Icon, bell } from '@automattic/icons';
+import { Modal } from '@wordpress/components';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -598,12 +600,11 @@ class PushNotificationSettings extends Component {
 			</svg>
 		);
 
-		return (
+		return this.props.showDialog ? (
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
-			<Dialog
-				isVisible={ this.props.showDialog }
+			<Modal
 				className="notification-settings-push-notification-settings__instruction-dialog"
-				onClose={ this.props.toggleUnblockInstructions }
+				onRequestClose={ this.props.toggleUnblockInstructions }
 			>
 				<div className="notification-settings-push-notification-settings__instruction-content">
 					<div>
@@ -641,16 +642,9 @@ class PushNotificationSettings extends Component {
 						) }
 					/>
 				</div>
-				<button
-					className="notification-settings-push-notification-settings__instruction-dismiss"
-					onClick={ this.props.toggleUnblockInstructions }
-				>
-					<Gridicon icon="cross" size={ 24 } />
-					<ScreenReaderText>{ this.props.translate( 'Dismiss' ) }</ScreenReaderText>
-				</button>
-			</Dialog>
-			/* eslint-enable wpcalypso/jsx-classname-namespace */
-		);
+			</Modal>
+		) : /* eslint-enable wpcalypso/jsx-classname-namespace */
+		null;
 	};
 
 	render() {
@@ -752,10 +746,10 @@ class PushNotificationSettings extends Component {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<Card className="notification-settings-push-notification-settings__settings">
 				<h2 className="notification-settings-push-notification-settings__settings-heading">
-					<Gridicon
+					<Icon
 						size={ 24 }
 						className="notification-settings-push-notification-settings__settings-icon"
-						icon="bell"
+						icon={ bell }
 					/>
 					{ this.props.translate( 'Browser notifications' ) }
 					<small
@@ -769,7 +763,7 @@ class PushNotificationSettings extends Component {
 				</h2>
 				<p className="notification-settings-push-notification-settings__settings-description">
 					{ this.props.translate(
-						'Get instant notifications for new comments and likes, even when you are not actively using WordPress.com.'
+						"Get notified instantly about new comments and likes — even when you're not on WordPress.com"
 					) }
 				</p>
 				<Button

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -29,12 +29,6 @@
 	}
 }
 
-.notification-settings-push-notification-settings__instruction-title {
-	font-weight: 600;
-	display: block;
-	margin-bottom: 24px;
-}
-
 .notification-settings-push-notification-settings__instruction-step {
 	width: 50%;
 	box-sizing: border-box;

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -20,24 +20,6 @@
 	}
 }
 
-.notification-settings-push-notification-settings__instruction-dismiss {
-	position: absolute;
-	top: 8px;
-	right: 8px;
-	padding: 0;
-	cursor: pointer;
-	color: var(--color-neutral-light);
-
-	&:hover,
-	&:focus {
-		color: var(--color-neutral-70);
-	}
-
-	.gridicon {
-		display: block;
-	}
-}
-
 .notification-settings-push-notification-settings__instruction-content {
 	max-width: 500px;
 	text-align: center;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-13025

Updates to Browsre notifications banner:
- Icon
- Copy; copy is now conditional depending if notifications are enabled
- Use core modal component for modal


I'm discussing more changes in the issue but these are ready to go already once translations are done.

## Proposed Changes

**Before**

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/a1c61eb6-c85c-4bcb-8b0e-42194f00dd5b" />

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/619ed0b3-9058-4420-9666-d867afe86968" />

<img width="1056" alt="Screenshot 2025-05-12 at 16 01 17" src="https://github.com/user-attachments/assets/f762df45-b567-4537-b046-5ef845676c33" />


**After**

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/f1a7d590-b7a9-44f3-86f0-0506096d9b1f" />

<img width="1090" alt="image" src="https://github.com/user-attachments/assets/4e82646f-6539-40a7-8747-6779a2210cca" />
<img width="1066" alt="Screenshot 2025-05-12 at 16 03 19" src="https://github.com/user-attachments/assets/7a604f98-f66a-43ff-aa7d-71f8f92890b7" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go /me/notifications
* Enable/disable notifications
* Try disabling notifications for banner, and see the modal for instructions
    <img width="334" alt="Screenshot 2025-05-12 at 15 54 26" src="https://github.com/user-attachments/assets/cf5aedd8-4bc7-4bf8-82cb-0bc113a8fc25" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
