### PR TITLE
Notifications: change Email subscriptions tab and section title

### DIFF
--- a/client/me/notification-settings/navigation.jsx
+++ b/client/me/notification-settings/navigation.jsx
@@ -30,7 +30,7 @@ class NotificationSettingsNavigation extends Component {
 			'/me/notifications': this.props.translate( 'Notifications' ),
 			'/me/notifications/comments': this.props.translate( 'Comments' ),
 			'/me/notifications/updates': this.props.translate( 'Updates' ),
-			'/me/notifications/subscriptions': this.props.translate( 'Email Subscriptions' ),
+			'/me/notifications/subscriptions': this.props.translate( 'Subscription settings' ),
 		};
 	};
 

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -186,7 +186,7 @@ class NotificationSubscriptions extends Component {
 						onSubmit={ this.handleSubmit }
 					>
 						<FormSectionHeading>
-							{ this.props.translate( 'Email subscriptions' ) }
+							{ this.props.translate( 'Subscription settings' ) }
 						</FormSectionHeading>
 						<p>
 							{ this.props.translate(


### PR DESCRIPTION
Part of DOTCOM-13033

## Proposed Changes
This PR is a copy change on the "Email subscriptions" -> "Subscription settings" tab and its content title.

## Why are these changes being made?
Design review DOTCOM-12890

## Testing Instructions

Navigate to `/me` and into "Notification Settings". See the last tab is now called "Subscription settings". Click on it, see the section title matches "Subscription settings".

**Before:**
<img width="562" alt="image" src="https://github.com/user-attachments/assets/958683c4-6456-4c82-a2cb-9cb9a5729c42" />


**After:**
<img width="659" alt="image" src="https://github.com/user-attachments/assets/1986da27-aace-49f1-b806-83bc1e07d66c" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
