### PR TITLE
Fix/stop import redirect after failed wix

### DIFF
--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -107,7 +107,6 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function checkIsFailed() {
-		return true;
 		return (
 			( job && job.importerState === appStates.IMPORT_FAILURE ) ||
 			( error?.error && error?.errorType === 'importError' )

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -107,6 +107,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function checkIsFailed() {
+		return true;
 		return (
 			( job && job.importerState === appStates.IMPORT_FAILURE ) ||
 			( error?.error && error?.errorType === 'importError' )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -39,7 +39,13 @@ export function useStepNavigator(
 	}
 
 	function goToImportCapturePage() {
-		navigation.goToStep?.( 'import' );
+		const migrationUrl = `/setup/site-migration?siteSlug=${ siteSlug }&ref=importer`;
+		const urlWithFromParam = fromSite ? `${ migrationUrl }&from=${ fromSite }` : migrationUrl;
+
+		navigation.submit?.( {
+			type: 'redirect',
+			url: urlWithFromParam,
+		} );
 	}
 
 	function goToImportContentOnlyPage() {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-34

## Proposed Changes

Continuing with the wack-a-mole game to stop navigation to the old capture flow, this time we are stopping navigation to it after a failed wix import.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To mitigate navigation to the old capture step

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR on your local env
* Modify [this function](https://github.com/Automattic/wp-calypso/blob/329877ea2809a19aa0eae91b781eb7bd1adadefb/client/blocks/importer/wix/index.tsx#L109) so it always returns `true`
* Go to `/setup/site-migration`
* Enter a wix site
* When you see the Error click the try again CTA <img width="640" alt="image" src="https://github.com/user-attachments/assets/7eb54934-ae25-4476-83df-0b3a4fec489c" />
* Verify you get redirected back to `/setup/site-migration/site-migration-identify` step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
