### PR TITLE
Showing Continue button after having a domain in the cart when coming from /new-hosted-site flow

### DIFF
--- a/client/signup/steps/domains/utils.js
+++ b/client/signup/steps/domains/utils.js
@@ -1,4 +1,4 @@
-import { EXAMPLE_FLOW } from '@automattic/onboarding';
+import { EXAMPLE_FLOW, NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import validUrl from 'valid-url';
 
 // Only override the back button from an external URL source on the below step(s) which is typically where we'd send them to as the 'entry'.
@@ -34,7 +34,7 @@ export function getExternalBackUrl( source, sectionName = null ) {
  * Check if we should use multiple domains in domain flows.
  */
 export function shouldUseMultipleDomainsInCart( flowName ) {
-	const enabledFlows = [ 'domain', 'onboarding', EXAMPLE_FLOW ];
+	const enabledFlows = [ 'domain', 'onboarding', EXAMPLE_FLOW, NEW_HOSTED_SITE_FLOW ];
 
 	return enabledFlows.includes( flowName );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://linear.app/a8c/issue/DOTCOM-13094/showing-continue-button-at-the-domains-page-for-new-hosted-site-flow

## Proposed Changes

* Showing the mini cart for users coming from the /new-hosted-site flow so they can see the Continue button there

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reported here (p1746552097987089-slack-C029GN3KD), we want to have a good usability while we're revamping the domain page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a new site using [the hosting flow](http://calypso.localhost:3000/setup/new-hosted-site/domains?showDomainStep)
* Select a domain and a plan
* Once you arrive at the cart, open [the domain page again](http://calypso.localhost:3000/setup/new-hosted-site/domains?showDomainStep=) and make sure you can see the `Continue` button:

![image](https://github.com/user-attachments/assets/ac9a03a1-2976-443e-91fb-fedfc9c77a52)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?