### PR TITLE
Add scape char to percentage symbol

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-how-to-migrate/index.tsx
@@ -100,8 +100,9 @@ const SiteMigrationHowToMigrate: StepType< {
 						},
 					}
 			  )
-			: translate(
-					'Skip the migration hassle. Our team handles everything without disrupting your current site, plus you get 50% off our annual %(planName)s plan.',
+			: // translators: %% is the percentage symbol, please leave it as is. %(planName)s is the name of the Business plan.
+			  translate(
+					'Skip the migration hassle. Our team handles everything without disrupting your current site, plus you get 50%% off our annual %(planName)s plan.',
 					{
 						args: {
 							planName,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTCON-45

## Proposed Changes

Scape the percentage symbol so it's correctly ignored when interpolating. This should be merged once all the translations are ready and the string displays correctly in all languages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

On languages different than English this string is producing an unexpected translation.

Current translation looks like:
<img alt="image" src="https://github.com/user-attachments/assets/54526666-0227-46b8-9488-09e1d20252d5" />


Since the `%` is a reserved character for interpolation, we need to scape it so it's dealt with correctly when translating.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**NOTE: this will only work when the translation for the new string with the scaped % exists**

* Change [your account](https://wordpress.com/me/account) to a language different that English
* Open the calypso.live link below and navigate to `/setup/site-migration/site-migration-how-to-migrate`
* Verify the percentage symbol is displayed correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
