### PR TITLE
Fix Storybook compilation in components package

### DIFF
--- a/packages/calypso-storybook/src/index.js
+++ b/packages/calypso-storybook/src/index.js
@@ -86,6 +86,7 @@ module.exports = function storybookDefaultConfig( {
 				},
 			];
 			config.resolve.mainFields = [ 'browser', 'calypso:src', 'module', 'main' ];
+			config.resolve.conditionNames = [ 'calypso:src', 'import', 'module', 'require' ];
 			config.plugins.push( ...plugins );
 			return config;
 		},

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,9 +18,7 @@
 		"./src/*": {
 			"calypso:src": "./src/*"
 		},
-		"./styles/*": {
-			"calypso:src": "./styles/*"
-		}
+		"./styles/*": "./styles/*"
 	},
 	"sideEffects": [
 		"*.css",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,7 +18,9 @@
 		"./src/*": {
 			"calypso:src": "./src/*"
 		},
-		"./styles/*": "./styles/*"
+		"./styles/*": {
+			"calypso:src": "./styles/*"
+		}
 	},
 	"sideEffects": [
 		"*.css",


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to #103103

## Proposed Changes

* Fixes Storybook compilation in `@automattic/components` package by ensuring that Calypso's Webpack-based Storybook compilation is able to match the `calypso:src` exports, using [`conditionNames`](https://webpack.js.org/configuration/resolve/#resolveconditionnames) (similar to [what we do in the main client compilation](https://github.com/Automattic/wp-calypso/blob/532540b56ddf560af4f18845b98b4fcc186e7e75/client/webpack.config.js#L280-L282)).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So that Storybook previews can compile successfully

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify both Storybook build produces no errors:

```
yarn workspace @automattic/components run storybook:build
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
