### PR TITLE
Stats: Adjust summary navigation styles on mobile

### DIFF
--- a/client/blocks/stats-navigation/page-module-toggler.scss
+++ b/client/blocks/stats-navigation/page-module-toggler.scss
@@ -6,7 +6,7 @@
 
 	// Add gap for not open .section-nav on tablet and mobile.
 	@media (max-width: $break-small) {
-		padding-right: 16px;
+		padding-right: 4px;
 	}
 
 	button {

--- a/client/components/navigation-header/navigation-header.scss
+++ b/client/components/navigation-header/navigation-header.scss
@@ -34,7 +34,7 @@
 
 		.components-button {
 			height: 32px;
-			padding: 4px 8px;
+			padding: 4px;
 		}
 	}
 

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -44,6 +44,18 @@
 		}
 	}
 
+	@media (max-width: $break-small) {
+		.stats-summary-nav__select {
+			background-color: var(--studio-white);
+			border-top: 0;
+
+			svg {
+				position: absolute;
+				right: 16px;
+			}
+		}
+	}
+
 	.stats__summary--narrow-mobile {
 		@media (max-width: $break-medium) {
 			padding-inline: 0;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-58

## Proposed Changes

* Adjust the styles of summary navigation on mobile.

### Traffic page
|Before|After|
|-|-|
|<img width="504" alt="截圖 2025-05-13 上午8 20 50" src="https://github.com/user-attachments/assets/0049106e-1f2a-412f-b2bd-bab11a7e8dbd" />|<img width="499" alt="截圖 2025-05-13 上午8 19 51" src="https://github.com/user-attachments/assets/72559286-eb70-4586-8a3a-ef7c28370fad" />|

### Locations module
|Before|After|
|-|-|
|<img width="524" alt="截圖 2025-05-13 上午8 06 56" src="https://github.com/user-attachments/assets/41a52563-1548-4525-8292-080f1d98994d" />|<img width="527" alt="截圖 2025-05-13 上午8 07 06" src="https://github.com/user-attachments/assets/0431d3b3-0b08-4418-9d8d-165321bb80de" />|

### Posts & pages module
|Before|After|
|-|-|
|<img width="511" alt="截圖 2025-05-13 上午8 07 59" src="https://github.com/user-attachments/assets/ec88008e-efff-4ffa-87f2-81a61375dfd2" />|<img width="538" alt="截圖 2025-05-13 上午8 07 13" src="https://github.com/user-attachments/assets/aa656afd-404c-4a0b-ae59-a4a71754ece1" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic with the feature flag: `stats/navigation-improvement`.
* Inspect the page on mobile viewport.
* Ensure the module settings icon is aligned better with the dropdown arrow.
* Navigate to the respective module summary page.
* Ensure the summary nav styling looks better, and the period dropdown arrow is aligned to the right.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
