### PR TITLE
Move plugin tags under description.

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -79,14 +79,13 @@ const PluginDetailsHeader = ( {
 						</span>
 
 						<span className="plugin-details-header__subtitle-separator">·</span>
-
-						{ ! isJetpackCloud && <Tags plugin={ plugin } /> }
 					</div>
 				</div>
 			</div>
 			<div className="plugin-details-header__description">
 				{ preventWidows( plugin.short_description || plugin.description ) }
 			</div>
+			{ ! isJetpackCloud && <Tags plugin={ plugin } /> }
 			<div className="plugin-details-header__additional-info">
 				{ /* We want to accept rating 0, which means no rating for Marketplace products */ }
 				{ rating !== null && (
@@ -154,7 +153,7 @@ function Tags( { plugin } ) {
 	const tagKeys = Object.keys( plugin.tags || {} ).slice( 0, LIMIT_OF_TAGS );
 
 	return (
-		<span className="plugin-details-header__tag-badge-container">
+		<div className="plugin-details-header__tag-badge-container">
 			{ tagKeys.map( ( tagKey ) => (
 				<a
 					key={ `badge-${ tagKey.replace( ' ', '' ) }` }
@@ -164,7 +163,7 @@ function Tags( { plugin } ) {
 					<Badge type="info">{ plugin.tags[ tagKey ] }</Badge>
 				</a>
 			) ) }
-		</span>
+		</div>
 	);
 }
 

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -4,6 +4,7 @@
 
 $plugin-details-header-padding: 100px;
 $mobile-icon-height: 175px;
+$block-spacing: 24px;
 
 .plugin-details-header__container {
 	display: block;
@@ -111,12 +112,7 @@ $mobile-icon-height: 175px;
 }
 
 .plugin-details-header__tag-badge-container {
-	display: inline-block;
-
-	@include breakpoint-deprecated( "<960px" ) {
-		margin-top: 12px;
-		display: block;
-	}
+	margin-bottom: $block-spacing;
 }
 
 .plugin-details-header__tag-badge {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -341,7 +341,7 @@ $calypso-header-height: 31px;
 	}
 
 	.section-nav-tabs__list {
-		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);
+		box-shadow: inset 0 -1px 0 var(--studio-gray-5);
 	}
 
 	.section-nav-tab {


### PR DESCRIPTION
Part of #100453

## Proposed Changes

Moves plugin tags under the description and updates spacing.

Note: This includes one small incidental change to the underline color for the tabs. It's very minor, and decided to add it to this PR.

### Screenshots
| Before | After |
|--------|--------|
|<img width="570" alt="Screenshot 2025-05-13 at 9 45 11 AM" src="https://github.com/user-attachments/assets/376e2dd1-c81c-4bbd-a5c8-d342c2058fd1" /> | <img width="531" alt="Screenshot 2025-05-13 at 9 44 19 AM" src="https://github.com/user-attachments/assets/f68510b5-d513-4723-b45e-1bfbf9a2974b" /> |
| <img width="471" alt="Screenshot 2025-05-13 at 9 45 20 AM" src="https://github.com/user-attachments/assets/17444ed0-e3d6-4393-bef7-3a3006153f74" /> | <img width="506" alt="Screenshot 2025-05-13 at 9 44 12 AM" src="https://github.com/user-attachments/assets/fc8cbe76-a9de-48f7-9443-06a10d9c1b1e" /> | 




## Testing Instructions

* View any plugin, expect the tags to be below the description and appropriately spaced. Check mobile as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
