### PR TITLE
Stats: Fix styling on Odyssey Stats for Navigation Improvement

### DIFF
--- a/apps/odyssey-stats/src/app.scss
+++ b/apps/odyssey-stats/src/app.scss
@@ -2,6 +2,7 @@
 @import "./styles/layout";
 @import "./styles/wp-admin";
 @import "./styles/typography";
+@import "@wordpress/base-styles/breakpoints";
 
 .wp-admin {
 	.card {
@@ -50,8 +51,10 @@
 	}
 
 	.stats-navigation.stats-navigation--modernized .section-nav-tab .section-nav-tab__link {
-		padding-left: 0;
-		padding-right: 0;
+		@media (min-width: $break-mobile) {
+			padding-left: 0;
+			padding-right: 0;
+		}
 
 		&:focus {
 			box-shadow: none;

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -1,5 +1,6 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .section-nav {
 	position: relative;
@@ -236,6 +237,11 @@
 	.select-dropdown__container {
 		max-width: 200px;
 		position: static;
+
+		@media (max-width: $break-small) {
+			max-width: unset;
+			width: 100%;
+		}
 	}
 }
 

--- a/client/my-sites/stats/features/modules/stats-locations/style.scss
+++ b/client/my-sites/stats/features/modules/stats-locations/style.scss
@@ -64,6 +64,10 @@ $locations-horizontal-bar-width: 380px;
 		display: flex;
 		justify-content: space-between;
 		padding: 12px 24px;
+
+		@media (max-width: $break-small) {
+			padding: 12px 16px;
+		}
 	}
 
 	.stats-card--column-header__left {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-65

## Proposed Changes

* Fix mobile styling issue on Odyssey Stats.

### Stats navigation tabs - mobile
|Before|After|
|-|-|
|<img width="484" alt="截圖 2025-05-13 下午2 11 47" src="https://github.com/user-attachments/assets/9a9e2e3b-5da1-4671-868c-234f0dc95a0a" />|<img width="479" alt="截圖 2025-05-13 下午2 11 20" src="https://github.com/user-attachments/assets/6b0c0018-1758-4785-adec-76fb8ff66c3e" />|

### Summary page nav - mobile
|Before|After|
|-|-|
|<img width="425" alt="截圖 2025-05-13 下午2 36 01" src="https://github.com/user-attachments/assets/9b2863a5-61e5-4bdd-a886-2d49f1d3a623" />|<img width="433" alt="截圖 2025-05-13 下午2 35 46" src="https://github.com/user-attachments/assets/4b8a406e-8223-430b-911d-d292f4fb1fb9" />|

### Locations summary page - mobile
|Before|After|
|-|-|
|<img width="544" alt="截圖 2025-05-13 下午2 59 45" src="https://github.com/user-attachments/assets/745c2541-070e-4fb5-adb1-4d654e009148" />|<img width="531" alt="截圖 2025-05-13 下午3 00 42" src="https://github.com/user-attachments/assets/25ae0ff2-b13a-4ab0-b0ae-2e961b723288" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the local self-hosted site: `cd /some-path-to/wp-calypso/apps/odyssey-stats && STATS_PACKAGE_PATH=/some-path-to/jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to Stats > Traffic page.
* Inspect the page on the mobile viewport.
* Ensure the navigation tabs dropdown item works with padding.
* Navigate to the Locations summary page.
* Ensure the summary nav dropdown and item list label work reasonably.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
