### PR TITLE
Performance Profiler: Gaps between performance profiler elements should be transparent

### DIFF
--- a/client/performance-profiler/components/core-web-vitals-display/style.scss
+++ b/client/performance-profiler/components/core-web-vitals-display/style.scss
@@ -94,6 +94,7 @@ $blueberry-color: #3858e9;
 
 .core-web-vitals-display__details {
 	border: 1px solid var(--studio-gray-5);
+	background: var(--studio-white);
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;
 	padding: 24px;

--- a/client/performance-profiler/components/dashboard-content/style.scss
+++ b/client/performance-profiler/components/dashboard-content/style.scss
@@ -1,5 +1,4 @@
 .performance-profiler-content {
-	background: #fff;
 	min-height: 600px;
 
 	.container {

--- a/client/performance-profiler/components/insights-section/style.scss
+++ b/client/performance-profiler/components/insights-section/style.scss
@@ -8,6 +8,7 @@
 	border: 1px solid var(--studio-gray-5);
 	padding: 24px;
 	border-radius: 4px;
+	background: var(--studio-white);
 
 	.header {
 		display: flex;

--- a/client/performance-profiler/components/metric-tab-bar/style.scss
+++ b/client/performance-profiler/components/metric-tab-bar/style.scss
@@ -40,9 +40,9 @@ $blueberry-color: #3858e9;
 		outline: 3px solid transparent;
 
 		&.metric-tab-bar__performance {
-			border-inline-width: 0;
+			border-width: 0;
 			margin-inline: -1px;
-			padding-inline: 24px;
+			padding: 17px 24px;
 			width: calc(100% + 2px);
 			box-shadow: $metric-tab-shadow inset;
 		}
@@ -97,4 +97,5 @@ $blueberry-color: #3858e9;
 	border: 1px solid var(--studio-gray-5);
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;
+	background: var(--studio-white);
 }

--- a/client/performance-profiler/components/screenshot-timeline.tsx
+++ b/client/performance-profiler/components/screenshot-timeline.tsx
@@ -12,6 +12,7 @@ const Container = styled.div`
 	padding: 24px;
 	border-radius: 4px;
 	overflow: hidden;
+	background: var( --studio-white );
 `;
 
 const Timeline = styled.div`


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to #102995
Part of DOTCOM-10673

## Proposed Changes

Ensures the gaps between the various elements of the performance profiler are transparent.

Using a magenta background to make it more obvious.

![CleanShot 2025-05-13 at 19 24 33@2x](https://github.com/user-attachments/assets/df5adace-80e1-473f-b477-352c50dfc952)

![CleanShot 2025-05-13 at 19 27 41@2x](https://github.com/user-attachments/assets/ecf15cea-d28a-4336-87e8-f573e69372a2)

For reference, it used to be like this:

![CleanShot 2025-05-13 at 19 36 41@2x](https://github.com/user-attachments/assets/4b57daa1-12d7-474a-8954-56bde3650e72)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The performance profiler component has always been somewhere that had a white background, so the component has gotten away with the gaps between its elements not being transparent.

Now we want to embed it on the hosting dashboard which has an off-white background.

Cleaning up the component colours here means we won't need to use CSS overrides in the hosting dashboard environment (once these changes are rebased into #102995 we can remove the colour overrides)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test in `/sites`**

You can change this line to `magenta` if you want to test like the screenshots above: https://github.com/Automattic/wp-calypso/blob/bb96c361ae5b1c4418b02ef5630b9c135a5234ef/client/sites/components/style.scss#L5

Got to `/sites/performace/{{ site slug }}` with a launched atomic site

Confirm the negative space between elements is transparent

**Test in LOHP profiler**

In an incognito window go to `wordpress.com/speed-test`

Choose a page to test

Once the results are loaded, switch the base of the URL from `wordpress.com` to `calypso.localhost:3000`

Confirm the negative space between elements is transparent

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
