### PR TITLE
WooCoreProfilerMasterbar: fix useSelector and useTranslate usages

### DIFF
--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -1,7 +1,7 @@
 import { ProgressBar } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import { isWebUri } from 'valid-url';
 import WooLogo from 'calypso/assets/images/icons/Woo_logo_color.svg';
@@ -16,10 +16,12 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { isWooCommercePaymentsOnboardingFlow } from 'calypso/state/selectors/is-woo-jpc-flow';
 
 // Masterbar for WooCommerce Core Profiler Jetpack step
-const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) => string } ) => {
+export default function WooCoreProfilerMasterbar() {
+	const translate = useTranslate();
 	const currentQueryArguments = useSelector( getCurrentQueryArguments );
 	const currentRoute = useSelector( getCurrentRoute );
 	const redirectToOriginal = useSelector( getRedirectToOriginal );
+	const isWooPaymentsFlow = useSelector( isWooCommercePaymentsOnboardingFlow );
 
 	let redirectTo = null;
 	let shouldShowProgressBar = true;
@@ -41,9 +43,6 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 		shouldShowProgressBar = false;
 		shouldShowNoThanks = false;
 	}
-
-	const state = useSelector( ( state ) => state );
-	const isWooPaymentsFlow = isWooCommercePaymentsOnboardingFlow( state );
 
 	if ( isWooPaymentsFlow ) {
 		shouldShowProgressBar = false;
@@ -87,6 +86,4 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 			</header>
 		</Fragment>
 	);
-};
-
-export default localize( WooCoreProfilerMasterbar );
+}


### PR DESCRIPTION
While testing login and its various variations, I noticed an opportunity to improve the `WooCoreProfilerMasterbar` component. It can use the `useTranslate` hook, and also the usage of the `isWooCommercePaymentsOnboardingFlow` is very strange -- probably AI generated.

## Testing instructions
Go to a page that uses the `WooCoreProfilerMasterbar`, for example:
```
http://calypso.localhost:3000/log-in?from=woocommerce-onboarding&lostpassword_flow=true
```
and verify that the Woo masterbar is displayed correctly.