### PR TITLE
Subscriptions management - add unsusbscribe cell

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscriptions-list.tsx
@@ -85,6 +85,9 @@ const SiteSubscriptionsList: React.FC< SiteSubscriptionsListProps > = ( {
 				<span className="email-frequency-cell" role="columnheader">
 					{ translate( 'Email frequency' ) }
 				</span>
+				<span className="unsubscribe-action-cell" role="columnheader">
+					{ translate( 'Action' ) }
+				</span>
 				<span className="actions-cell" role="columnheader" />
 			</HStack>
 			{ subscriptions.map( ( siteSubscription ) => (

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -79,9 +79,11 @@
 		.email-frequency-cell,
 		.date-cell,
 		.new-posts-cell,
-		.new-comments-cell {
+		.new-comments-cell,
+		.unsubscribe-action-cell {
 			@extend %site-subscriptions-list-default-text;
 		}
+
 
 		.new-posts-cell,
 		.new-comments-cell {
@@ -103,6 +105,7 @@
 		.actions-cell {
 			flex-basis: 36px;
 			flex-grow: initial;
+			margin: 0 5px;
 
 			.gridicon {
 				fill: $studio-gray-50;
@@ -117,12 +120,7 @@
 	}
 
 	@media (max-width: $break-large) {
-		.new-posts-cell {
-			display: none;
-		}
-	}
-
-	@media (max-width: $break-medium) {
+		.new-posts-cell,
 		.email-frequency-cell {
 			display: none;
 		}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # p1747117057126739/1747074984.370769-slack-C03NLNTPZ2T / https://linear.app/a8c/issue/CML-380/one-click-unsubscribe 

## Proposed Changes

Add an unsubscribe cell to subscriptions management. The unsubscribe action needs to be more prominent for people who click newsletter emails to manage/unsubscribe both logged in and logged out.

AFTER
<img width="1034" alt="Screenshot 2025-05-13 at 11 33 01 AM" src="https://github.com/user-attachments/assets/58c33b76-9b91-414c-a2e0-a1d63be3531b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The unsubscribe action needs to be more prominent for people who click newsletter emails to manage/unsubscribe both logged in and logged out. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to subscribers management 
* Verify there is an "unsubscribe" button in the row.
* Verify it works to unsubscribe.
* Verify it fits well at various viewport widths.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?