### PR TITLE
Hosting Dashboard v2: try mshots again

### DIFF
--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -26,4 +26,4 @@ export const SITE_FIELDS = [
 	'jetpack_modules',
 ];
 
-export const SITE_OPTIONS = [ 'admin_url', 'software_version', 'is_redirect' ];
+export const SITE_OPTIONS = [ 'admin_url', 'software_version', 'is_redirect', 'updated_at' ];

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -69,6 +69,7 @@ export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
 	is_redirect?: boolean;
+	updated_at: string;
 }
 
 export interface Site {

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -101,28 +101,12 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Preview' ),
 		render: function PreviewRender( { item }: { item: Site } ) {
 			const [ resizeListener, { width } ] = useResizeObserver();
-			const { is_deleted, is_private, URL: url } = item;
-			// If the site is a private A8C site, X-Frame-Options is set to same
-			// origin.
-			const iframeDisabled = is_deleted || ( item.is_a8c && is_private );
+			const { URL: url } = item;
 			return (
 				<>
 					{ resizeListener }
-					{ iframeDisabled && (
-						<div
-							style={ {
-								fontSize: '24px',
-								display: 'flex',
-								alignItems: 'center',
-								justifyContent: 'center',
-								height: '100%',
-							} }
-						>
-							<SiteIcon site={ item } />
-						</div>
-					) }
-					{ width && ! iframeDisabled && (
-						<SitePreview url={ url } scale={ width / 1200 } height={ 1200 } />
+					{ width && (
+						<SitePreview url={ url } width={ width } style={ { objectFit: 'contain' } } />
 					) }
 				</>
 			);

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -101,12 +101,11 @@ const DEFAULT_FIELDS: Field< Site >[] = [
 		label: __( 'Preview' ),
 		render: function PreviewRender( { item }: { item: Site } ) {
 			const [ resizeListener, { width } ] = useResizeObserver();
-			const { URL: url } = item;
 			return (
 				<>
 					{ resizeListener }
 					{ width && (
-						<SitePreview url={ url } width={ width } style={ { objectFit: 'contain' } } />
+						<SitePreview site={ item } width={ width } style={ { objectFit: 'contain' } } />
 					) }
 				</>
 			);

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -24,39 +24,14 @@ function PHPVersion( { siteSlug }: { siteSlug: string } ) {
  * SiteCard component to display site information in a card format
  */
 export default function SiteCard( { site, currentPlan }: { site: Site; currentPlan: Plan } ) {
-	const { URL: url, is_private, is_wpcom_atomic } = site;
+	const { URL: url, is_wpcom_atomic } = site;
 	const wpVersion = getFormattedWordPressVersion( site );
 
-	// If the site is a private A8C site, X-Frame-Options is set to same
-	// origin.
-	const iframeDisabled = site.is_a8c && is_private;
 	return (
 		<Card>
 			<VStack spacing={ 6 }>
 				<div className="dashboard-site-overview__preview-image">
-					{ iframeDisabled && (
-						<div
-							style={ {
-								width: '300px',
-								height: '200px',
-								fontSize: '24px',
-								background: 'var(--dashboard__background-color)',
-								display: 'flex',
-								alignItems: 'center',
-								justifyContent: 'center',
-							} }
-						>
-							{ __( 'A8C Private Site' ) }
-						</div>
-					) }
-					{ ! iframeDisabled && (
-						<div
-							className="dashboard-site-overview__preview-iframe"
-							style={ { width: '300px', height: '200px' } }
-						>
-							<SitePreview url={ url } scale={ 0.25 } />
-						</div>
-					) }
+					<SitePreview width={ 300 } url={ url } />
 				</div>
 				<VStack spacing={ 6 } className="site-card-contents">
 					<Field title={ __( 'Domain' ) }>

--- a/client/dashboard/sites/overview/site-card.tsx
+++ b/client/dashboard/sites/overview/site-card.tsx
@@ -31,7 +31,7 @@ export default function SiteCard( { site, currentPlan }: { site: Site; currentPl
 		<Card>
 			<VStack spacing={ 6 }>
 				<div className="dashboard-site-overview__preview-image">
-					<SitePreview width={ 300 } url={ url } />
+					<SitePreview width={ 300 } site={ site } />
 				</div>
 				<VStack spacing={ 6 } className="site-card-contents">
 					<Field title={ __( 'Domain' ) }>

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -1,13 +1,24 @@
+import { useEffect, useState } from 'react';
+
+async function waitForMshot( url: string, retryDelay = 1000, maxRetries = 20 ) {
+	for ( let i = maxRetries; i--;  ) {
+		const response = await fetch( url, { method: 'HEAD' } );
+		if ( response.status === 200 && ! response.redirected ) {
+			return true;
+		}
+		await new Promise( ( resolve ) => setTimeout( resolve, retryDelay ) );
+	}
+	return false;
+}
+
 export default function SitePreview( {
 	url,
-	scale = 1,
-	width = 1200,
-	height = 800,
+	width,
+	style,
 }: {
 	url: string;
-	scale?: number;
-	width?: number;
-	height?: number;
+	width: number;
+	style?: React.CSSProperties;
 } ) {
 	// The /sites endpoint may return non-secure URLs. Often these _can_ be
 	// loaded securely, so it's worth trying to load over https. If it fails,
@@ -16,23 +27,31 @@ export default function SitePreview( {
 	// To do: check why the endpoint returns non-secure URLs when it will
 	// redirect to a secure URL.
 	const secureUrl = url.replace( /^http:\/\//, 'https://' );
+	const baseUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent( secureUrl ) }`;
+	const aspectRatio = 1280 / 900;
+	const [ isLoaded, setIsLoaded ] = useState( false );
+	useEffect( () => {
+		// mshot caches a 1280x960 image and then crops that, so we only need to
+		// check the default size. If the width changes, we also don't need to
+		// recheck.
+		waitForMshot( baseUrl ).then( setIsLoaded );
+	}, [ baseUrl ] );
+	if ( ! isLoaded ) {
+		return <div style={ { width, height: width / aspectRatio } } />;
+	}
+	// For every width, add a 2x and 3x width.
+	const multiples = [ 1, 2, 3 ];
 	return (
-		<iframe
+		<img
 			loading="lazy"
-			// @ts-expect-error For some reason there's no inert type.
-			inert="true"
-			title="Site Preview"
-			// Hide banners + `preview` hides cookie banners + `iframe` hides
-			// admin bar for atomic sites.
-			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }
-			style={ {
-				display: 'block',
-				border: 'none',
-				transform: `scale(${ scale })`,
-				transformOrigin: 'top left',
-			} }
+			alt="Site Preview"
+			src={ `${ baseUrl }?w=${ width }` }
+			srcSet={ multiples
+				.map( ( multiple ) => `${ baseUrl }?w=${ width * multiple } ${ multiple }x` )
+				.join( ', ' ) }
+			style={ style }
 			width={ width }
-			height={ height }
+			height={ width / aspectRatio }
 		/>
 	);
 }

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -74,6 +74,8 @@ export default function SitePreview( {
 						// generated. Otherwise we will briefly load an iframe
 						// and trigger needless requests.
 						<iframe
+							sandbox="allow-scripts"
+							scrolling="no"
 							loading="lazy"
 							// @ts-expect-error For some reason there's no inert type.
 							inert="true"

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -1,15 +1,17 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
+import type { Site } from '../../data/types';
 
 export default function SitePreview( {
-	url,
+	site,
 	width,
 	style,
 }: {
-	url: string;
+	site: Site;
 	width: number;
 	style?: React.CSSProperties;
 } ) {
+	const { URL: url } = site;
 	// The /sites endpoint may return non-secure URLs. Often these _can_ be
 	// loaded securely, so it's worth trying to load over https. If it fails,
 	// there would have been an error either way because the dasboard is loaded
@@ -17,7 +19,15 @@ export default function SitePreview( {
 	// To do: check why the endpoint returns non-secure URLs when it will
 	// redirect to a secure URL.
 	const secureUrl = url.replace( /^http:\/\//, 'https://' );
-	const baseUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent( secureUrl ) }`;
+	let updatedAtUrl = secureUrl;
+	// See https://github.com/Automattic/wp-calypso/pull/66534.
+	if ( site.options?.updated_at ) {
+		const updatedAt = new Date( site.options.updated_at );
+		updatedAt.setMinutes( 0 );
+		updatedAt.setSeconds( 0 );
+		updatedAtUrl = `${ secureUrl }?v=${ updatedAt.getTime() / 1000 }`;
+	}
+	const baseUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent( updatedAtUrl ) }`;
 	const mshotWidth = 1280;
 	const mshotHeight = 900;
 	const aspectRatio = mshotWidth / mshotHeight;
@@ -46,6 +56,8 @@ export default function SitePreview( {
 
 	if ( ! isLoaded ) {
 		const scale = width / mshotWidth;
+		const xFrameOptionsSameOrigin = site.is_a8c && site.is_private;
+		const loadIframe = isLoaded === false && ! xFrameOptionsSameOrigin;
 		return (
 			<div
 				style={ {
@@ -55,7 +67,7 @@ export default function SitePreview( {
 				} }
 			>
 				<div style={ { width, height: width / aspectRatio } }>
-					{ isLoaded === false && (
+					{ loadIframe && (
 						// Do not load the iframe if isLoaded is null. We want
 						// to wait until we know that an mshot is being
 						// generated. Otherwise we will briefly load an iframe

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -1,15 +1,5 @@
+import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
-
-async function waitForMshot( url: string, retryDelay = 1000, maxRetries = 20 ) {
-	for ( let i = maxRetries; i--;  ) {
-		const response = await fetch( url, { method: 'HEAD' } );
-		if ( response.status === 200 && ! response.redirected ) {
-			return true;
-		}
-		await new Promise( ( resolve ) => setTimeout( resolve, retryDelay ) );
-	}
-	return false;
-}
 
 export default function SitePreview( {
 	url,
@@ -28,23 +18,76 @@ export default function SitePreview( {
 	// redirect to a secure URL.
 	const secureUrl = url.replace( /^http:\/\//, 'https://' );
 	const baseUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent( secureUrl ) }`;
-	const aspectRatio = 1280 / 900;
-	const [ isLoaded, setIsLoaded ] = useState( false );
+	const mshotWidth = 1280;
+	const mshotHeight = 900;
+	const aspectRatio = mshotWidth / mshotHeight;
+	const [ isLoaded, setIsLoaded ] = useState< boolean | null >( null );
 	useEffect( () => {
-		// mshot caches a 1280x960 image and then crops that, so we only need to
-		// check the default size. If the width changes, we also don't need to
-		// recheck.
-		waitForMshot( baseUrl ).then( setIsLoaded );
+		( async () => {
+			const maxRetries = 20;
+			const retryDelay = 1000;
+			for ( let i = maxRetries; i--;  ) {
+				// mshot caches a 1280x960 image and then crops that, so we only
+				// need to check the default size. If the width changes, we also
+				// don't need to recheck.
+				const response = await fetch( baseUrl, { method: 'HEAD' } );
+				const isLoaded = response.status === 200 && ! response.redirected;
+				setIsLoaded( isLoaded );
+				if ( isLoaded ) {
+					break;
+				} else {
+					await new Promise( ( resolve ) => setTimeout( resolve, retryDelay ) );
+				}
+			}
+		} )();
 	}, [ baseUrl ] );
+
+	const title = __( 'Site Preview' );
+
 	if ( ! isLoaded ) {
-		return <div style={ { width, height: width / aspectRatio } } />;
+		const scale = width / mshotWidth;
+		return (
+			<div
+				style={ {
+					display: 'flex',
+					alignItems: 'center',
+					height: '100%',
+				} }
+			>
+				<div style={ { width, height: width / aspectRatio } }>
+					{ isLoaded === false && (
+						// Do not load the iframe if isLoaded is null. We want
+						// to wait until we know that an mshot is being
+						// generated. Otherwise we will briefly load an iframe
+						// and trigger needless requests.
+						<iframe
+							loading="lazy"
+							// @ts-expect-error For some reason there's no inert type.
+							inert="true"
+							title={ title }
+							// Hide banners + `preview` hides cookie banners + `iframe` hides
+							// admin bar for atomic sites.
+							src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }
+							style={ {
+								display: 'block',
+								border: 'none',
+								transform: `scale(${ scale })`,
+								transformOrigin: 'top left',
+							} }
+							width={ mshotWidth }
+							height={ mshotHeight }
+						/>
+					) }
+				</div>
+			</div>
+		);
 	}
 	// For every width, add a 2x and 3x width.
 	const multiples = [ 1, 2, 3 ];
 	return (
 		<img
 			loading="lazy"
-			alt="Site Preview"
+			alt={ title }
 			src={ `${ baseUrl }?w=${ width }` }
 			srcSet={ multiples
 				.map( ( multiple ) => `${ baseUrl }?w=${ width * multiple } ${ multiple }x` )

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -66,13 +66,7 @@ export default function SitePreview( {
 		const scale = width / mshotWidth;
 		const loadIframe = isLoaded === false && ! site.is_private;
 		return (
-			<div
-				style={ {
-					display: 'flex',
-					alignItems: 'center',
-					height: '100%',
-				} }
-			>
+			<div style={ { display: 'flex', alignItems: 'center', height: '100%' } }>
 				<div style={ { width, height: width / aspectRatio, overflow: 'hidden' } }>
 					{ loadIframe && (
 						// Do not load the iframe if isLoaded is null. We want
@@ -107,7 +101,7 @@ export default function SitePreview( {
 			loading="lazy"
 			alt={ title }
 			src={ imageUrl }
-			style={ style }
+			style={ { display: 'block', ...style } }
 			width={ width }
 			height={ width / aspectRatio }
 		/>

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import type { Site } from '../../data/types';
 
 export default function SitePreview( {
@@ -19,19 +19,22 @@ export default function SitePreview( {
 	// To do: check why the endpoint returns non-secure URLs when it will
 	// redirect to a secure URL.
 	const secureUrl = url.replace( /^http:\/\//, 'https://' );
-	let updatedAtUrl = secureUrl;
-	// See https://github.com/Automattic/wp-calypso/pull/66534.
-	if ( site.options?.updated_at ) {
-		const updatedAt = new Date( site.options.updated_at );
-		updatedAt.setMinutes( 0 );
-		updatedAt.setSeconds( 0 );
-		updatedAtUrl = `${ secureUrl }?v=${ updatedAt.getTime() / 1000 }`;
-	}
+	const updatedAtUrl = useMemo( () => {
+		// See https://github.com/Automattic/wp-calypso/pull/66534.
+		if ( site.options?.updated_at ) {
+			const updatedAt = new Date( site.options.updated_at );
+			updatedAt.setMinutes( 0 );
+			updatedAt.setSeconds( 0 );
+			return `${ secureUrl }?v=${ updatedAt.getTime() / 1000 }`;
+		}
+		return secureUrl;
+	}, [ site.options?.updated_at, secureUrl ] );
 	const baseUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent( updatedAtUrl ) }`;
 	const mshotWidth = 1280;
-	const mshotHeight = 900;
+	const mshotHeight = 960;
 	const aspectRatio = mshotWidth / mshotHeight;
 	const [ isLoaded, setIsLoaded ] = useState< boolean | null >( null );
+	const [ imageUrl, setImageUrl ] = useState< string >();
 	useEffect( () => {
 		( async () => {
 			const maxRetries = 20;
@@ -41,11 +44,16 @@ export default function SitePreview( {
 				// need to check the default size. If the width changes, we also
 				// don't need to recheck.
 				const response = await fetch( baseUrl, { method: 'HEAD' } );
-				const isLoaded = response.status === 200 && ! response.redirected;
-				setIsLoaded( isLoaded );
-				if ( isLoaded ) {
+				if ( response.status === 200 && ! response.redirected ) {
+					// Prefetch the image and use a local blob URL to prevent a
+					// flash when swapping out the iframe from the mshot.
+					const imageResponse = await fetch( baseUrl );
+					const imageBlob = await imageResponse.blob();
+					setIsLoaded( true );
+					setImageUrl( URL.createObjectURL( imageBlob ) );
 					break;
 				} else {
+					setIsLoaded( false );
 					await new Promise( ( resolve ) => setTimeout( resolve, retryDelay ) );
 				}
 			}
@@ -56,8 +64,7 @@ export default function SitePreview( {
 
 	if ( ! isLoaded ) {
 		const scale = width / mshotWidth;
-		const xFrameOptionsSameOrigin = site.is_a8c && site.is_private;
-		const loadIframe = isLoaded === false && ! xFrameOptionsSameOrigin;
+		const loadIframe = isLoaded === false && ! site.is_private;
 		return (
 			<div
 				style={ {
@@ -66,7 +73,7 @@ export default function SitePreview( {
 					height: '100%',
 				} }
 			>
-				<div style={ { width, height: width / aspectRatio } }>
+				<div style={ { width, height: width / aspectRatio, overflow: 'hidden' } }>
 					{ loadIframe && (
 						// Do not load the iframe if isLoaded is null. We want
 						// to wait until we know that an mshot is being
@@ -85,6 +92,7 @@ export default function SitePreview( {
 								border: 'none',
 								transform: `scale(${ scale })`,
 								transformOrigin: 'top left',
+								// filter: 'blur(10px)',
 							} }
 							width={ mshotWidth }
 							height={ mshotHeight }
@@ -94,16 +102,11 @@ export default function SitePreview( {
 			</div>
 		);
 	}
-	// For every width, add a 2x and 3x width.
-	const multiples = [ 1, 2, 3 ];
 	return (
 		<img
 			loading="lazy"
 			alt={ title }
-			src={ `${ baseUrl }?w=${ width }` }
-			srcSet={ multiples
-				.map( ( multiple ) => `${ baseUrl }?w=${ width * multiple } ${ multiple }x` )
-				.join( ', ' ) }
+			src={ imageUrl }
 			style={ style }
 			width={ width }
 			height={ width / aspectRatio }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

To compare with iframes and give it a decent chance.

Downsides of mshots:

* Takes quite long on the first load when mshot doesn't have a cached image.
* No preview for "coming soon" and private sites.
* After a site changes styles or themes, the image will not changes because it's cached.

Fixes DOTCOM-13232.

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
