### PR TITLE
STATS-64: Don't dispatch legacy country data

### DIFF
--- a/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
+++ b/client/my-sites/stats/features/modules/stats-locations/stats-locations.tsx
@@ -170,9 +170,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 		}
 
 		let dataToDispatch;
-		if ( ! supportsLocationsStatsFeature ) {
-			dataToDispatch = legacyCountriesViewsData;
-		} else if ( geoMode === 'country' ) {
+		if ( geoMode === 'country' ) {
 			dataToDispatch = countriesList;
 		} else {
 			dataToDispatch = locationsViewsData;
@@ -186,9 +184,7 @@ const StatsLocations: React.FC< StatsModuleLocationsProps > = ( {
 	}, [
 		countriesList,
 		geoMode,
-		supportsLocationsStatsFeature,
 		locationsViewsData,
-		legacyCountriesViewsData,
 		isRequestingCountriesList,
 		isRequestingData,
 		dispatch,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-64

## Proposed Changes

* Don't dispatch legacyCountryViewsData, the data fetch from the legacy selector
* We are dispatching the data for the same selector `getSiteStatsNormalizedData()` - which causes the loop 
* Since the data is already fetched from the same selector which, don't need to dispatch the data in this case

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix the loop errors in location stats when the `supportsLocationsStats` option is false.

<img width="613" alt="image" src="https://github.com/user-attachments/assets/7716371b-aa52-43a3-a6ea-2f96e6565d79" />

<img width="615" alt="image" src="https://github.com/user-attachments/assets/c15049b8-49a8-42cb-b800-4e05777a3239" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Override the support test to false here for easier reproduce of the issue: https://github.com/Automattic/wp-calypso/blob/572f27fd3c6f3b8c29e546b80b2115303734376f/client/state/sites/selectors/get-env-stats-feature-supports.ts#L61
* The errors should not be reported in the stats home page and location stats
* The CSV download should match for the data on the screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
