### PR TITLE
Experiment streamlining the plans grid + checkout: Restrict assignment to the onboarding flow

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -1,10 +1,20 @@
+import { getFlowFromURL } from 'calypso/landing/stepper/utils/get-flow-from-url';
 import { useExperiment, loadExperimentAssignment } from 'calypso/lib/explat';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 
 const STREAMLINED_PRICE_EXPERIMENT_NAME = 'calypso_streamlined_plans_checkout';
 
 export function useStreamlinedPriceExperiment(): [ boolean, string | null ] {
-	const [ isLoading, assignment ] = useExperiment( STREAMLINED_PRICE_EXPERIMENT_NAME );
-	return [ isLoading, assignment?.variationName ?? null ];
+	const flowFromStorage = getSignupCompleteFlowName(); // The flow for the Checkout page
+	const flowFromURL = getFlowFromURL(); // The flow for the Plans step
+	const flow = flowFromStorage || flowFromURL;
+
+	const [ isLoadingExperiment, assignment ] = useExperiment(
+		STREAMLINED_PRICE_EXPERIMENT_NAME,
+		{ isEligible: flow === 'onboarding' } // Only onboarding flow is eligible for streamlined pricing
+	);
+
+	return [ isLoadingExperiment, assignment?.variationName ?? null ];
 }
 
 export async function isStreamlinedPriceExperiment() {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p58i-kUT-p2#comment-68375

## Proposed Changes

* skips experiment assignment if the user is not on the `onboarding` flow

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want to limit the streamlining the plans + checkout experiment to the `onboarding` flow to avoid noise.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You'll need to be assigned to on of the plans and checkout treatment variations of `calypso_streamlined_plans_checkout`

* Access the checkout page directly
* You should not assigned any variations and see the control checkout
<img width="480" alt="Screenshot 2025-05-13 at 14 27 38" src="https://github.com/user-attachments/assets/a130f644-44c7-4f40-b45a-f2f3d080593b" />

* Create a new site through the `onboarding` flow
* You should be assigned the experiment variation and see the treatment plans and checkout
<img width="480" alt="Screenshot 2025-05-13 at 14 35 14" src="https://github.com/user-attachments/assets/7e26b209-3e2e-4f5e-beed-4fea22fdaa64" />
<img width="480" alt="Screenshot 2025-05-13 at 14 35 38" src="https://github.com/user-attachments/assets/c23b571f-1173-4e4d-9add-4eb8ddcb1be5" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?