### PR TITLE
A4A: Filter out dev sites and known staging domains from migration tagging

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
@@ -43,11 +43,14 @@ export default function MigrationsAddSitesTable( {
 		return items
 			.filter( ( item ) => ! taggedSitesIds.includes( item.id ) )
 			.filter( ( item ) => item.rawSite.a4a_is_dev_site === true )
-			.filter(
-				( item ) =>
-					! item.site.includes( 'mystagingwebsite.com' ) &&
-					! item.site.includes( 'wpcomstaging.com' )
-			);
+			.filter( ( item ) => {
+				try {
+					const url = new URL( item.site );
+					return ! [ 'mystagingwebsite.com', 'wpcomstaging.com' ].includes( url.host );
+				} catch {
+					return false;
+				}
+			} );
 	}, [ items, taggedSitesIds ] );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {

--- a/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
+++ b/client/a8c-for-agencies/sections/migrations/tag-sites-modal/add-sites-table.tsx
@@ -38,9 +38,16 @@ export default function MigrationsAddSitesTable( {
 		[ taggedSites ]
 	);
 
-	// Filter out sites that are already tagged
+	// Filter out sites that are already tagged or are dev / staging sites.
 	const availableSites = useMemo( () => {
-		return items.filter( ( item ) => ! taggedSitesIds.includes( item.id ) );
+		return items
+			.filter( ( item ) => ! taggedSitesIds.includes( item.id ) )
+			.filter( ( item ) => item.rawSite.a4a_is_dev_site === true )
+			.filter(
+				( item ) =>
+					! item.site.includes( 'mystagingwebsite.com' ) &&
+					! item.site.includes( 'wpcomstaging.com' )
+			);
 	}, [ items, taggedSitesIds ] );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {


### PR DESCRIPTION


<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/2169

## Proposed Changes

* Filter out dev sites and known staging domains from showing on the list of sites able to be tagged for migration incentives.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Staging / dev sites are not eligible for migration incentives.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the live link
* Log in as `a4ademo`
* Navigate to Migrations > Commissions
* Click "Tag sites for commission" in the top-right corner
* Before this PR: staging sites are selectable
* After this PR: the list excludes staging sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
