### PR TITLE
STATS-67 - Don't navigate to the current tab if we are already on the current tab

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -141,12 +141,14 @@ const TabNav = ( { validNavItems, interval, slugPath, adminUrl, selectedItem, sh
 			className="stats-navigation__tabs"
 			tabs={ tabs }
 			onSelect={ ( tabName ) => {
-				const tab = tabs.find( ( { name } ) => name === tabName );
+				if ( tabName !== selectedItem ) {
+					const tab = tabs.find( ( { name } ) => name === tabName );
 
-				if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
-					window.location.href = `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
-				} else if ( tab.path ) {
-					page( tab.path );
+					if ( tab.name === 'store' && config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+						window.location.href = `${ adminUrl }admin.php?page=wc-admin&path=%2Fanalytics%2Foverview`;
+					} else if ( tab.path ) {
+						page( tab.path );
+					}
 				}
 			} }
 			initialTabName={ selectedItem }

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -141,6 +141,7 @@ const TabNav = ( { validNavItems, interval, slugPath, adminUrl, selectedItem, sh
 			className="stats-navigation__tabs"
 			tabs={ tabs }
 			onSelect={ ( tabName ) => {
+				// Skip navigation if the clicked tab is already active to avoid redundant actions.
 				if ( tabName !== selectedItem ) {
 					const tab = tabs.find( ( { name } ) => name === tabName );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-67

## Proposed Changes

* For the currentTab of the new tab navigation, don't navigate the page if the selectedtab is already the current tab

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This fixes an issue If there are any query parameters on the stats traffic page and if you reload the page, the query parameters are gone and the page reloads to the stats default selection of duration

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * Go to Stats -> Insights
 * Scroll to "All time stats" and click on any month
 * The correct selected month should be displayed

Example
- This example link `* https://wordpress.com/stats/day/<site>?chartStart=2011-02-01&chartEnd=2011-02-28` should load correct duration selection and the page should not reload to the default selection of the tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
