### PR TITLE
Follow up of #103321

### DIFF
--- a/packages/components/src/breadcrumbs/test/index.tsx
+++ b/packages/components/src/breadcrumbs/test/index.tsx
@@ -138,9 +138,14 @@ describe( 'Breadcrumbs', () => {
 		expect( consoleLog ).toHaveBeenCalledWith( `clicked ${ firstItemLabel }` );
 
 		// The renderProp should not be applied to the current item.
-		// We have two items with the same label due to the internal implementation
-		// for calculating when to render as 'compact'.
-		await user.click( screen.getAllByText( FIVE_ITEMS[ FIVE_ITEMS.length - 1 ].label )[ 1 ] );
+		// Since getByText would also match the offscreen copy, we are first
+		// finding the nav container via getByRole, which instead ignores the
+		// offscreen copy.
+		await user.click(
+			within( screen.getByRole( 'navigation', { name: 'Breadcrumbs' } ) ).getByText(
+				FIVE_ITEMS[ FIVE_ITEMS.length - 1 ].label
+			)
+		);
 		expect( consoleLog ).toHaveBeenCalledTimes( 1 );
 
 		// Also test the dropdown menu items.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Quick follow up of https://github.com/Automattic/wp-calypso/pull/103321 to enhance the test selector.

See: https://github.com/Automattic/wp-calypso/pull/103321#discussion_r2086677336


## Testing Instructions
- tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
