### PR TITLE
Stats: Fix e2e tests by handling new selectors for the new nav header

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -99,7 +99,9 @@ const SelectNav = ( {
 						}
 						return (
 							<NavItem
-								className={ className }
+								className={ clsx( className, {
+									'is-active': selectedItem === item,
+								} ) }
 								key={ item }
 								path={ itemPath }
 								selected={ selectedItem === item }
@@ -131,7 +133,7 @@ const TabNav = ( { validNavItems, interval, slugPath, adminUrl, selectedItem, sh
 		return {
 			name: item,
 			title: navItem.label + ( navItem.paywall && showLock ? ' 🔒' : '' ),
-			className: 'stats-navigation__' + item,
+			className: clsx( 'stats-navigation__' + item, 'navigation-tab' ),
 			path: itemPath,
 		};
 	} );

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -56,7 +56,11 @@ class NavItem extends PureComponent {
 				<a
 					href={ this.props.path }
 					target={ target }
-					className={ 'section-nav-' + itemClassPrefix + '__link' }
+					className={ clsx(
+						'section-nav-' + itemClassPrefix + '__link',
+						this.props.className,
+						'navigation-tab'
+					) }
 					onClick={ onClick }
 					onMouseEnter={ this.preload }
 					tabIndex={ this.props.tabIndex || 0 }

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -60,10 +60,33 @@ export async function clickNavTab(
 	name: string,
 	{ force }: { force?: boolean } = {}
 ): Promise< void > {
+	await clickNavTabBase( page, name, selectors.navTabItem, selectors.navTabMobileToggleButton, {
+		force,
+	} );
+}
+
+/**
+ * Locates and clicks on a specified tab on the NavTab.
+ *
+ * NavTabs are used throughout calypso to contain sub-pages within the parent page.
+ * For instance, on the Media gallery page a NavTab is used to filter the gallery to
+ * show a specific category of gallery items.
+ *
+ * @param {Page} page Underlying page on which interactions take place.
+ * @param {string} name Name of the tab to be clicked.
+ * @throws {Error} If the tab name is not the active tab.
+ */
+export async function clickNavTabBase(
+	page: Page,
+	name: string,
+	tabSelector: ( params: { name?: string; selected?: boolean } ) => string,
+	tabSelectorMobile: string,
+	{ force }: { force?: boolean } = {}
+): Promise< void > {
 	// Short circuit operation if the active tab and target tabs are the same.
 	// Strip numerals from the extracted tab name to account for the slightly
 	// different implementation in PostsPage.
-	const selectedTabLocator = page.locator( selectors.navTabItem( { selected: true } ) );
+	const selectedTabLocator = page.locator( tabSelector( { selected: true } ) );
 	const selectedTabName = await selectedTabLocator.innerText();
 	if ( selectedTabName.replace( /[0-9]|,/g, '' ) === name ) {
 		return;
@@ -71,13 +94,13 @@ export async function clickNavTab(
 
 	// If force option is specified, force click using a `dispatchEvent`.
 	if ( force ) {
-		return await page.dispatchEvent( selectors.navTabItem( { name: name } ), 'click' );
+		return await page.dispatchEvent( tabSelector( { name: name } ), 'click' );
 	}
 
 	// Mobile view - navtabs become a dropdown and thus it must be opened first.
 	if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
 		// Open the Navtabs which now act as a pseudo-dropdown menu.
-		const navTabsButtonLocator = page.locator( selectors.navTabMobileToggleButton );
+		const navTabsButtonLocator = page.locator( tabSelectorMobile );
 		await navTabsButtonLocator.click( { noWaitAfter: true } );
 
 		const navTabIsOpenLocator = page.locator( `${ navTabParent }.is-open` );
@@ -85,15 +108,13 @@ export async function clickNavTab(
 	}
 
 	// Click on the intended item and wait for navigation to finish.
-	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
+	const navTabItem = page.locator( tabSelector( { name: name, selected: false } ) );
 
 	const regex = new RegExp( `.*/${ name.toLowerCase() }/.*` );
 	await Promise.all( [ page.waitForURL( regex ), navTabItem.click() ] );
 
 	// Final verification, check that we are now on the expected navtab.
-	const newSelectedTabLocator = page.locator(
-		selectors.navTabItem( { name: name, selected: true } )
-	);
+	const newSelectedTabLocator = page.locator( tabSelector( { name: name, selected: true } ) );
 	const newSelectedTabName = await newSelectedTabLocator.innerText();
 
 	if ( newSelectedTabName.replace( /[0-9]|,/g, '' ) !== name ) {

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -6,7 +6,9 @@ const navTabParent = 'div.section-nav';
 const selectors = {
 	// clickNavTab
 	navTabItem: ( { name = '', selected = false }: { name?: string; selected?: boolean } = {} ) =>
-		`${ navTabParent } a[aria-current="${ selected }"]:has(span:has-text("${ name }"))`,
+		`${ navTabParent } .navigation-tab${
+			selected ? '.is-active' : ''
+		} a:has(span:has-text("${ name }"))`,
 	navTabMobileToggleButton: `${ navTabParent } button.section-nav__mobile-header`,
 };
 

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -6,9 +6,7 @@ const navTabParent = 'div.section-nav';
 const selectors = {
 	// clickNavTab
 	navTabItem: ( { name = '', selected = false }: { name?: string; selected?: boolean } = {} ) =>
-		`${ navTabParent } .navigation-tab${
-			selected ? '.is-active' : ''
-		} a:has(span:has-text("${ name }"))`,
+		`${ navTabParent } a[aria-current="${ selected }"]:has(span:has-text("${ name }"))`,
 	navTabMobileToggleButton: `${ navTabParent } button.section-nav__mobile-header`,
 };
 

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page } from 'playwright';
 import { envVariables } from '../..';
 import { getCalypsoURL } from '../../data-helper';
-import { clickNavTab } from '../../element-helper';
+import { clickNavTab } from '../utils';
 
 export type StatsTabs = 'Traffic' | 'Insights' | 'Subscribers' | 'Store';
 type TrafficActivityType = 'Views' | 'Visitors' | 'Likes' | 'Comments';

--- a/packages/calypso-e2e/src/lib/utils/click-nav-tab.ts
+++ b/packages/calypso-e2e/src/lib/utils/click-nav-tab.ts
@@ -1,0 +1,40 @@
+import { Page } from 'playwright';
+import { clickNavTabBase } from '../../element-helper';
+
+const navTabParent = '.stats-navigation';
+
+const selectors = {
+	navTabItem: ( { name = '', selected = false }: { name?: string; selected?: boolean } = {} ) => {
+		let selector = `${ navTabParent } button[aria-selected="${ selected ? 'true' : 'false' }"]`;
+
+		if ( name ) {
+			selector += `:has-text("${ name }")`;
+		}
+
+		return selector;
+	},
+	navTabMobileToggleButton: `${ navTabParent } button.section-nav__mobile-header`,
+};
+
+/**
+ * Locates and clicks on a specified tab on the NavTab.
+ *
+ * NavTabs are used throughout calypso to contain sub-pages within the parent page.
+ * For instance, on the Media gallery page a NavTab is used to filter the gallery to
+ * show a specific category of gallery items.
+ *
+ * @param {Page} page Underlying page on which interactions take place.
+ * @param {string} name Name of the tab to be clicked.
+ * @throws {Error} If the tab name is not the active tab.
+ */
+async function clickNavTab(
+	page: Page,
+	name: string,
+	{ force }: { force?: boolean } = {}
+): Promise< void > {
+	await clickNavTabBase( page, name, selectors.navTabItem, selectors.navTabMobileToggleButton, {
+		force,
+	} );
+}
+
+export { clickNavTab };

--- a/packages/calypso-e2e/src/lib/utils/click-nav-tab.ts
+++ b/packages/calypso-e2e/src/lib/utils/click-nav-tab.ts
@@ -4,15 +4,8 @@ import { clickNavTabBase } from '../../element-helper';
 const navTabParent = '.stats-navigation';
 
 const selectors = {
-	navTabItem: ( { name = '', selected = false }: { name?: string; selected?: boolean } = {} ) => {
-		let selector = `${ navTabParent } button[aria-selected="${ selected ? 'true' : 'false' }"]`;
-
-		if ( name ) {
-			selector += `:has-text("${ name }")`;
-		}
-
-		return selector;
-	},
+	navTabItem: ( { name = '', selected = false }: { name?: string; selected?: boolean } = {} ) =>
+		`${ navTabParent } .navigation-tab${ selected ? '.is-active' : '' }:has-text("${ name }")`,
 	navTabMobileToggleButton: `${ navTabParent } button.section-nav__mobile-header`,
 };
 

--- a/packages/calypso-e2e/src/lib/utils/index.ts
+++ b/packages/calypso-e2e/src/lib/utils/index.ts
@@ -3,6 +3,7 @@ export * from './validate-translations';
 export * from './get-test-account-by-feature';
 export * from './translate';
 export * from './social-connections-manager';
+export * from './click-nav-tab';
 
 // Other items are exported for unit testing, we only care about the manager class.
 export { EditorTracksEventManager } from './editor-tracks-event-manager';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Introduce a custom clickNavTab utility function for Stats navigation e2e tests
* Add the same class names in the new navigation header and old navigation header to be able to target the selectors

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Fix failing e2e tests after new navigation header and nav tabs for stats

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* e2e tests should pass in CI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
