### PR TITLE
Call the useStore hook to get the entire Redux state

### DIFF
--- a/client/blocks/plugins-scheduled-updates/hooks/use-create-monitor.tsx
+++ b/client/blocks/plugins-scheduled-updates/hooks/use-create-monitor.tsx
@@ -3,7 +3,7 @@ import {
 	useBatchCreateMonitorSettingsMutation,
 	useCreateMonitorSettingsMutation,
 } from 'calypso/data/plugins/use-monitor-settings-mutation';
-import { useSelector } from 'calypso/state';
+import { useSelector, useStore } from 'calypso/state';
 import { JETPACK_MODULE_ACTIVATE_SUCCESS } from 'calypso/state/action-types';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
@@ -61,11 +61,12 @@ export function useCreateMonitor( siteSlug: SiteSlug ) {
 }
 
 export function useCreateMonitors() {
+	const store = useStore();
 	const { createMonitorSettings } = useBatchCreateMonitorSettingsMutation();
-	const state = useSelector( ( state ) => state );
 
 	const createMonitors = useCallback(
 		( siteSlugs: SiteSlug[] ) => {
+			const state = store.getState();
 			const siteIds = siteSlugs.map( ( slug ) => getSiteId( state, slug ) );
 			const siteUrls = siteIds.map( ( siteId ) => getSiteUrl( state, siteId as number ) );
 
@@ -80,7 +81,7 @@ export function useCreateMonitors() {
 				} );
 			} );
 		},
-		[ createMonitorSettings, state ]
+		[ createMonitorSettings, store ]
 	);
 
 	return {

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-get-original-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-get-original-price.tsx
@@ -1,6 +1,6 @@
 import { TERM_MONTHLY, JETPACK_CRM_PRODUCTS } from '@automattic/calypso-products';
 import { useCallback } from 'react';
-import { useSelector } from 'calypso/state';
+import { useStore } from 'calypso/state';
 import { getProductCost } from 'calypso/state/products-list/selectors';
 import { getSiteAvailableProductCost } from 'calypso/state/sites/products/selectors';
 import { SelectorProduct } from '../../types';
@@ -8,7 +8,7 @@ import { SelectorProduct } from '../../types';
 const getMonthlyPrice = ( yearlyPrice: number ): number => ( yearlyPrice * 100 ) / 12 / 100;
 
 export const useGetOriginalPrice = ( siteId: number | null ) => {
-	const state = useSelector( ( state ) => state );
+	const store = useStore();
 
 	return useCallback(
 		( product: SelectorProduct ) => {
@@ -21,8 +21,9 @@ export const useGetOriginalPrice = ( siteId: number | null ) => {
 				return product.displayPrice || -1;
 			}
 
-			const productSlug = product?.costProductSlug || product?.productSlug;
+			const productSlug = product.costProductSlug || product.productSlug;
 
+			const state = store.getState();
 			const sitePricesItemCost =
 				siteId && productSlug && getSiteAvailableProductCost( state, siteId, productSlug );
 			const listPricesItemCost = productSlug && getProductCost( state, productSlug );
@@ -36,6 +37,6 @@ export const useGetOriginalPrice = ( siteId: number | null ) => {
 
 			return originalPrice;
 		},
-		[ siteId, state ]
+		[ siteId, store ]
 	);
 };

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -92,7 +92,7 @@ export default function PluginRowFormatter( {
 	);
 
 	const { activation, autoupdate } = useSelector( ( state ) =>
-		getAllowedPluginActions( item, state, selectedSite )
+		getAllowedPluginActions( state, item, selectedSite )
 	);
 
 	if ( selectedSite ) {

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -26,7 +26,6 @@ interface Props {
 
 export default function UpdatePlugin( { plugin, selectedSite, className, updatePlugin }: Props ) {
 	const translate = useTranslate();
-	const state = useSelector( ( state ) => state );
 	const showPluginActionDialog = useShowPluginActionDialog();
 
 	const onShowUpdateConfirmationModal = useCallback( () => {
@@ -44,11 +43,11 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 		selectedSite?.ID
 	);
 
-	const allowedActions = getAllowedPluginActions( plugin, state, selectedSite );
+	const allowedActions = useSelector( ( state ) =>
+		getAllowedPluginActions( state, plugin, selectedSite )
+	);
 
-	let content;
-
-	const allStatuses = getPluginActionStatuses( state );
+	const allStatuses = useSelector( getPluginActionStatuses );
 
 	const updateStatuses = allStatuses.filter(
 		( status ) =>
@@ -59,8 +58,10 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 	);
 
 	const onUpdatePlugin = useCallback( () => {
-		updatePlugin && updatePlugin( plugin );
+		updatePlugin?.( plugin );
 	}, [ plugin, updatePlugin ] );
+
+	let content;
 
 	if ( ! allowedActions?.autoupdate ) {
 		content = <div>{ translate( 'Auto-managed on this site' ) }</div>;

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
@@ -8,7 +8,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 import type { AppState } from 'calypso/types';
 
 export const getAllowedPluginActions = createSelector(
-	( plugin: PluginComponentProps, state: AppState, selectedSite?: SiteDetails ) => {
+	( state: AppState, plugin: PluginComponentProps, selectedSite?: SiteDetails ) => {
 		const autoManagedPlugins = [ 'jetpack', 'vaultpress', 'akismet' ];
 		const siteIsAtomic = selectedSite && isSiteAutomatedTransfer( state, selectedSite?.ID );
 		const siteIsJetpack = selectedSite && isJetpackSite( state, selectedSite?.ID );

--- a/client/my-sites/plugins/plugin-management-v2/utils/test/get-allowed-plugin-actions.js
+++ b/client/my-sites/plugins/plugin-management-v2/utils/test/get-allowed-plugin-actions.js
@@ -17,7 +17,7 @@ describe( 'getAllowedPluginActions', () => {
 	it.each( [ [ 'randomstring' ], [ 'jetpack' ] ] )(
 		'returns true for activation and auto-updates if no site is selected',
 		( slug ) => {
-			const result = getAllowedPluginActions( { slug }, {} );
+			const result = getAllowedPluginActions( {}, { slug } );
 			expect( result.activation ).toBe( true );
 			expect( result.autoupdate ).toBe( true );
 		}
@@ -34,7 +34,7 @@ describe( 'getAllowedPluginActions', () => {
 				isJetpackSite.mockReturnValue( false );
 				isSiteAutomatedTransfer.mockReturnValue( false );
 
-				const result = getAllowedPluginActions( { slug }, {}, {} );
+				const result = getAllowedPluginActions( {}, { slug }, {} );
 				expect( result.activation ).toBe( false );
 				expect( result.autoupdate ).toBe( false );
 			}
@@ -46,7 +46,7 @@ describe( 'getAllowedPluginActions', () => {
 				isJetpackSite.mockReturnValue( true );
 				isSiteAutomatedTransfer.mockReturnValue( false );
 
-				const result = getAllowedPluginActions( { slug }, {}, {} );
+				const result = getAllowedPluginActions( {}, { slug }, {} );
 				expect( result.activation ).toBe( true );
 				expect( result.autoupdate ).toBe( true );
 			}
@@ -65,7 +65,7 @@ describe( 'getAllowedPluginActions', () => {
 				( slug ) => {
 					siteHasFeature.mockReturnValue( true );
 
-					const result = getAllowedPluginActions( { slug }, {}, {} );
+					const result = getAllowedPluginActions( {}, { slug }, {} );
 					expect( result.activation ).toBe( true );
 					expect( result.autoupdate ).toBe( true );
 				}
@@ -76,7 +76,7 @@ describe( 'getAllowedPluginActions', () => {
 				( slug ) => {
 					siteHasFeature.mockReturnValue( false );
 
-					const result = getAllowedPluginActions( { slug }, {}, {} );
+					const result = getAllowedPluginActions( {}, { slug }, {} );
 					expect( result.activation ).toBe( false );
 					expect( result.autoupdate ).toBe( false );
 				}
@@ -95,7 +95,7 @@ describe( 'getAllowedPluginActions', () => {
 				isJetpackSite.mockReturnValue( false );
 				isSiteAutomatedTransfer.mockReturnValue( false );
 
-				const result = getAllowedPluginActions( { slug }, {}, {} );
+				const result = getAllowedPluginActions( {}, { slug }, {} );
 				expect( result.activation ).toBe( false );
 				expect( result.autoupdate ).toBe( false );
 			}
@@ -107,7 +107,7 @@ describe( 'getAllowedPluginActions', () => {
 				isJetpackSite.mockReturnValue( true );
 				isSiteAutomatedTransfer.mockReturnValue( false );
 
-				const result = getAllowedPluginActions( { slug }, {}, {} );
+				const result = getAllowedPluginActions( {}, { slug }, {} );
 				expect( result.activation ).toBe( true );
 				expect( result.autoupdate ).toBe( true );
 			}
@@ -119,7 +119,7 @@ describe( 'getAllowedPluginActions', () => {
 				isJetpackSite.mockReturnValue( true );
 				isSiteAutomatedTransfer.mockReturnValue( false );
 
-				const result = getAllowedPluginActions( { slug }, {}, {} );
+				const result = getAllowedPluginActions( {}, { slug }, {} );
 				expect( result.activation ).toBe( true );
 				expect( result.autoupdate ).toBe( true );
 			}
@@ -137,7 +137,7 @@ describe( 'getAllowedPluginActions', () => {
 				( slug ) => {
 					siteHasFeature.mockReturnValue( true );
 
-					const result = getAllowedPluginActions( { slug }, {}, {} );
+					const result = getAllowedPluginActions( {}, { slug }, {} );
 					expect( result.activation ).toBe( false );
 					expect( result.autoupdate ).toBe( false );
 				}
@@ -148,7 +148,7 @@ describe( 'getAllowedPluginActions', () => {
 				( slug ) => {
 					siteHasFeature.mockReturnValue( false );
 
-					const result = getAllowedPluginActions( { slug }, {}, {} );
+					const result = getAllowedPluginActions( {}, { slug }, {} );
 					expect( result.activation ).toBe( false );
 					expect( result.autoupdate ).toBe( false );
 				}

--- a/client/sites/components/sites-dataviews/actions.tsx
+++ b/client/sites/components/sites-dataviews/actions.tsx
@@ -27,7 +27,7 @@ import {
 	isStagingSite,
 	isSitePreviewPaneEligible,
 } from 'calypso/sites-dashboard/utils';
-import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, infoNotice, successNotice } from 'calypso/state/notices/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
@@ -267,13 +267,10 @@ export function useActions( {
 	viewType: 'list' | 'table' | 'grid';
 } ): Action< SiteExcerptData >[] {
 	const { __ } = useI18n();
-
 	const localizeUrl = useLocalizeUrl();
-
-	const dispatch = useReduxDispatch();
-
+	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
-	const reduxDispatch = useReduxDispatch();
+
 	const { mutate: restoreSite } = useRestoreSiteMutation( {
 		onSuccess() {
 			queryClient.invalidateQueries( {
@@ -294,23 +291,17 @@ export function useActions( {
 					'deleted',
 				],
 			} );
-			reduxDispatch(
-				successNotice( __( 'The site has been restored.' ), {
-					duration: 3000,
-				} )
-			);
+			dispatch( successNotice( __( 'The site has been restored.' ), { duration: 3000 } ) );
 		},
 		onError: ( error ) => {
 			if ( error.status === 403 ) {
-				reduxDispatch(
+				dispatch(
 					errorNotice( __( 'Only an administrator can restore a deleted site.' ), {
 						duration: 5000,
 					} )
 				);
 			} else {
-				reduxDispatch(
-					errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } )
-				);
+				dispatch( errorNotice( __( 'We were unable to restore the site.' ), { duration: 5000 } ) );
 			}
 		},
 	} );

--- a/client/sites/components/sites-dataviews/index.tsx
+++ b/client/sites/components/sites-dataviews/index.tsx
@@ -8,7 +8,7 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import { navigate } from 'calypso/lib/navigate';
 import { SitePlan } from 'calypso/sites-dashboard/components/sites-site-plan';
 import { isSitePreviewPaneEligible } from 'calypso/sites-dashboard/utils';
-import { useSelector } from 'calypso/state';
+import { useSelector, useStore } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isA8cTeamMember } from 'calypso/state/teams/selectors';
@@ -58,7 +58,7 @@ const DotcomSitesDataViews = ( {
 	sitePreviewPane,
 }: Props ) => {
 	const { __ } = useI18n();
-	const state = useSelector( ( state ) => state );
+	const store = useStore();
 	const userId = useSelector( getCurrentUserId );
 
 	// By default, DataViews is in an "uncontrolled" mode, meaning the current selection is handled internally.
@@ -66,7 +66,7 @@ const DotcomSitesDataViews = ( {
 	// To prevent that, we want to use DataViews in "controlled" mode, so that we can pass an initial selection during initial mount.
 	//
 	// To do that, we need to pass a required `onSelectionChange` callback to signal that it is being used in controlled mode.
-	// The current selection is a derived value which is [selectedItem.ID] (see getSelection()).
+	// The current selection is a derived value which is [selectedItem.ID] (see `selection`).
 	const onSelectionChange = useCallback(
 		( selectedSiteIds: string[] ) => {
 			// In table view, when a row is clicked, the item is selected for a bulk action, so the panel should not open.
@@ -79,7 +79,7 @@ const DotcomSitesDataViews = ( {
 
 			const site = sites.find( ( s ) => s.ID === Number( selectedSiteIds[ 0 ] ) );
 			if ( site && ! site.is_deleted ) {
-				const canManageOptions = canCurrentUser( state, site.ID, 'manage_options' );
+				const canManageOptions = canCurrentUser( store.getState(), site.ID, 'manage_options' );
 				if ( isSitePreviewPaneEligible( site, canManageOptions ) ) {
 					sitePreviewPane.open( site, 'list_row_click' );
 					return;
@@ -88,13 +88,10 @@ const DotcomSitesDataViews = ( {
 				navigate( site.options?.admin_url || '' );
 			}
 		},
-		[ dataViewsState.type, sitePreviewPane, sites, state ]
+		[ dataViewsState.type, sitePreviewPane, sites, store ]
 	);
 
-	const getSelection = useCallback(
-		() => ( selectedItem ? [ selectedItem.ID.toString() ] : undefined ),
-		[ selectedItem ]
-	);
+	const selection = selectedItem ? [ selectedItem.ID.toString() ] : undefined;
 
 	const siteStatusGroups = useSiteStatusGroups();
 
@@ -228,7 +225,7 @@ const DotcomSitesDataViews = ( {
 				actions={ actions }
 				search
 				searchLabel={ __( 'Search sites…' ) }
-				selection={ getSelection() }
+				selection={ selection }
 				paginationInfo={ paginationInfo }
 				getItemId={ ( item ) => {
 					return item.ID.toString();


### PR DESCRIPTION
Follow-up to #103373 where I fix a few more usages of `useSelector` returning the entire Redux state:
```js
const state = useSelector( ( state ) => state );
```
This is replaced with two kinds of replacement:
- if the `state` was used to call a selector, just call that selector inside `useSelector`.
- if the `state` was used inside a callback (event handler) to read something from Redux when the handler is called, use the `useStore().getState()` return value. That's the right way to do it, and it prevents rerender of a component on every Redux state change.

## Testing instructions:
Mostly verify that unit tests and e2e tests pass and that the changes look safe.