### PR TITLE
2FA: Backup codes section use standard Banner component

### DIFF
--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -2,7 +2,7 @@ import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import Notice from 'calypso/components/notice';
+import { Banner } from 'calypso/components/banner';
 import SectionHeader from 'calypso/components/section-header';
 import { bumpTwoStepAuthMCStat } from 'calypso/lib/two-step-authorization';
 import wp from 'calypso/lib/wp';
@@ -65,32 +65,33 @@ class Security2faBackupCodes extends Component {
 	};
 
 	renderStatus() {
+		const { translate } = this.props;
 		if ( ! this.state.printed ) {
 			return (
-				<Notice
-					isCompact
-					status="is-error"
-					text={ this.props.translate( 'Backup codes have not been verified.' ) }
+				<Banner
+					className="warning"
+					title={ translate( 'Backup codes have not been verified.' ) }
+					icon="info-outline"
 				/>
 			);
 		}
 
 		if ( ! this.state.verified ) {
 			return (
-				<Notice
-					isCompact
-					text={ this.props.translate(
+				<Banner
+					title={ translate(
 						'New backup codes have just been generated, but need to be verified.'
 					) }
+					icon="info-outline"
 				/>
 			);
 		}
 
 		return (
-			<Notice
-				isCompact
-				status="is-success"
-				text={ this.props.translate( 'Backup codes have been verified' ) }
+			<Banner
+				className="success"
+				title={ translate( 'Backup codes have been verified.' ) }
+				icon="checkmark"
 			/>
 		);
 	}

--- a/client/me/security-2fa-backup-codes/style.scss
+++ b/client/me/security-2fa-backup-codes/style.scss
@@ -1,3 +1,24 @@
 .security-2fa-backup-codes .security-2fa-backup-codes-prompt {
 	margin-top: 16px;
 }
+
+.banner.card{
+	&.warning {
+		border-left-color: var(--studio-red);
+
+		.banner__icons {
+			.banner__icon-circle {
+				background-color: var(--studio-red);
+			}
+		}
+	}
+	&.success {
+		border-left-color: var(--studio-green);
+
+		.banner__icons {
+			.banner__icon-circle {
+				background-color: var(--studio-green);
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of:
- DOTCOM-13096

## Proposed Changes

* Changed from Notice to Banner components for a more standard look and feel.

| Before | After |
|--------|--------|
|![Screenshot 2025-05-13 at 16 17 32](https://github.com/user-attachments/assets/9b62dc5d-85d0-45fd-b3dc-2ccb2bc86d58) |![Screenshot 2025-05-13 at 16 21 40](https://github.com/user-attachments/assets/a7feb15a-e564-459a-9b42-b8fb044e4586) |
| ![Screenshot 2025-05-13 at 16 17 54](https://github.com/user-attachments/assets/05c5ec87-b0ab-4466-a579-1dc4b1ee45ad)| ![Screenshot 2025-05-13 at 15 23 38](https://github.com/user-attachments/assets/5c334d2c-fe88-4e76-ac4e-0c83f93a4369)|
| ![Screenshot 2025-05-13 at 16 18 22](https://github.com/user-attachments/assets/6e2dbaae-b3ee-4dc3-9f9f-4d06358a7ca6) | ![Screenshot 2025-05-13 at 15 23 09](https://github.com/user-attachments/assets/712dc0d1-6842-4430-b076-c3939df65580) | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes are part of the Code Blue effort to improve our flows and UX.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/security/two-step
* Make sure you have 2FA configured
* In the Backup codes section, you should see the new banner.
* Verify your code, and you should see the other variation.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
