### PR TITLE
Fix broken domain connect cta in the onboarding flow

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -264,7 +264,7 @@ class DomainSearchResults extends Component {
 	handleAddMapping = ( event ) => {
 		event.preventDefault();
 		if ( this.props.isSignupStep ) {
-			this.props.onClickMapping( event );
+			this.props.onClickUseYourDomain( event );
 		} else {
 			this.props.onAddMapping( this.props.lastDomainSearched );
 		}

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -61,7 +61,7 @@ body.is-section-signup {
 }
 
 .domain-search-results__domain-available-notice {
-	display: flex;
+	display: flex !important;
 	.domain-search-results__domain-available-notice-icon {
 		margin-right: 8px;
 		svg {


### PR DESCRIPTION
Linear https://linear.app/a8c/issue/NOMADO-160/connect-it-cta-for-unsopported-tlds-in-domain-search-is-not-working

## Proposed Changes
This PR fixes two issues in the domain onboarding flow when users search for unsupported TLDs:

The `connect it` call-to-action in the availability message was broken and did not trigger any action. This has been fixed to correctly open the `Use a domain I own` step.

The info icon was misaligned and not displayed on the same line as the message. The layout has been adjusted for proper alignment.

![Screenshot 2025-05-13 alle 17 19 48](https://github.com/user-attachments/assets/c2c99a5b-eb29-4367-8c25-1a32a67637cb)

## Why are these changes being made?
The “Connect it” link is intended to help users proceed with domains not available for direct registration, by opening the “Use a domain I own” flow. This interaction was broken, potentially blocking users from completing onboarding.

## Testing Instructions
Apply this PR locally or use the Calypso live build link.

1. Navigate to `/start/domains`.

2. Search for an unsupported TLD (e.g., .pt or .it).

3. Confirm that:

- The availability message displays correctly with the info icon aligned next to the text.

- Clicking “Connect it” opens the “Use a domain I own” step as expected.

> [!IMPORTANT]  
> If you enter an available not supported domain in the `Use I domain I own step`, a `Register now` call to action appears. I created [a task to fix this issue](https://linear.app/a8c/issue/NOMADO-163/dont-show-register-now-cta-for-unsupported-domains-in-use-a-domain-i).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
