### PR TITLE
[Odie] Fix button styling, enable it when we have conversations and fix the new chat button

### DIFF
--- a/packages/help-center/src/components/help-center-header.scss
+++ b/packages/help-center/src/components/help-center-header.scss
@@ -107,6 +107,7 @@
 		svg {
 			fill: var(--wp-components-color-gray-600, #949494);
 		}
+		color: var(--wp-components-color-gray-600, #949494);
 	}
 
 	button {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -118,7 +118,7 @@ const ChatEllipsisMenu = () => {
 					<Icon icon={ comment } />
 					<div>{ __( 'New chat', __i18n_text_domain__ ) }</div>
 				</button>
-				<button onClick={ handleViewChats } disabled={ recentConversations.length === 0 }>
+				<button onClick={ handleViewChats } disabled={ recentConversations.length < 2 }>
 					<Icon icon={ scheduled } />
 					<div>
 						{ _n(

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useGetHistoryChats } from '@automattic/help-center/src/hooks/use-get-history-chats';
 import { EllipsisMenu } from '@automattic/odie-client';
-import { useGetMostRecentOpenConversation } from '@automattic/odie-client/src/hooks/use-get-most-recent-open-conversation';
 import { clearHelpCenterZendeskConversationStarted } from '@automattic/odie-client/src/utils/storage-utils';
 import { CardHeader, Button, Flex, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -78,16 +78,17 @@ const ChatEllipsisMenu = () => {
 	const { __ } = useI18n();
 	const resetSupportInteraction = useResetSupportInteraction();
 	const navigate = useNavigate();
-	const { totalNumberOfConversations } = useGetMostRecentOpenConversation();
+	const { recentConversations } = useGetHistoryChats();
 	const { areSoundNotificationsEnabled } = useSelect( ( select ) => {
 		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
 		return {
 			areSoundNotificationsEnabled: helpCenterSelect.getAreSoundNotificationsEnabled(),
 		};
 	}, [] );
-	const { setAreSoundNotificationsEnabled } = useDispatch( HELP_CENTER_STORE );
+	const { setAreSoundNotificationsEnabled, setOdieChatId } = useDispatch( HELP_CENTER_STORE );
 
 	const clearChat = async () => {
+		setOdieChatId( undefined );
 		await resetSupportInteraction();
 		clearHelpCenterZendeskConversationStarted();
 		recordTracksEvent( 'calypso_inlinehelp_clear_conversation' );
@@ -95,7 +96,7 @@ const ChatEllipsisMenu = () => {
 
 	const handleViewChats = () => {
 		recordTracksEvent( 'calypso_inlinehelp_view_open_chats_menu', {
-			total_number_of_conversations: totalNumberOfConversations,
+			total_number_of_conversations: recentConversations.length,
 		} );
 
 		navigate( '/chat-history' );
@@ -117,17 +118,17 @@ const ChatEllipsisMenu = () => {
 					<Icon icon={ comment } />
 					<div>{ __( 'New chat', __i18n_text_domain__ ) }</div>
 				</button>
-				<Button onClick={ handleViewChats } disabled={ totalNumberOfConversations === 0 }>
+				<button onClick={ handleViewChats } disabled={ recentConversations.length === 0 }>
 					<Icon icon={ scheduled } />
 					<div>
 						{ _n(
 							'View recent chat',
 							'View recent chats',
-							totalNumberOfConversations,
+							recentConversations.length,
 							__i18n_text_domain__
 						) }
 					</div>
-				</Button>
+				</button>
 				<button onClick={ toggleSoundNotifications }>
 					<ToggleControl
 						className="conversation-menu__notification-toggle"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/102667

## Proposed Changes

The button styling for recent conversations is not the same as the surrounding ones, actually the surrounding ones are html buttons while the wrong one is a Button component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The menu item on the top right side of the help center, when speaking with either AI Assistant or HE, its showing wrong styling for the recent conversations button, in addition of the button "new chat" is not working.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the Calypso Live link
2. Create a new test account (free account) in WordPress.com
3. Open the Help Center icon (top right side '?' icon)
4. Start a new conversation (Click on "Still need help")
5. Assert that the button for recent chats is greyed out and compare it with the provided table below (located inside the ellipsis menu in the top right side of the widget)
6. Start a new conversation with the "New chat" button in the widget's ellipsis menu on the top right side.

|FIX|BUG|
|---|---|
|![image](https://github.com/user-attachments/assets/c07756e7-7540-40ef-afc8-8e691cdfd06e)|![image](https://github.com/user-attachments/assets/87ab6687-6c5e-47a9-be6d-7ae299867f16)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
