### PR TITLE
[WiP] Add option to undo `Remove from cart` action

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -339,6 +339,7 @@ function CheckoutSidebarNudge( {
 
 export default function CheckoutMainContent( {
 	addItemToCart,
+	addRestorableProductToCart,
 	changeSelection,
 	countriesList,
 	createUserAndSiteBeforeTransaction,
@@ -674,6 +675,7 @@ export default function CheckoutMainContent( {
 					titleContent={ <OrderReviewTitle /> }
 					completeStepContent={
 						<WPCheckoutOrderReview
+							addRestorableProductToCart={ addRestorableProductToCart }
 							removeProductFromCart={ removeProductFromCart }
 							replaceProductInCart={ replaceProductInCart }
 							couponFieldStateProps={ couponFieldStateProps }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -230,9 +230,10 @@ export default function CheckoutMain( {
 		loadingError: cartLoadingError,
 		loadingErrorType: cartLoadingErrorType,
 		addProductsToCart,
+		addRestorableProductToCart,
 		reloadFromServer,
 	} = useShoppingCart( cartKey );
-
+	// console.debug( 'CheckoutMain - responseCart', responseCart );
 	const { shouldSetMigrationSticker, isLoading: isStickerLoading } =
 		useCheckoutMigrationIntroductoryOfferSticker( siteId, reloadFromServer );
 
@@ -814,6 +815,7 @@ export default function CheckoutMain( {
 					areThereErrors={ areThereErrors }
 					isInitialCartLoading={ isInitialCartLoading }
 					addItemToCart={ addItemAndLog }
+					addRestorableProductToCart={ addRestorableProductToCart }
 					changeSelection={ changeSelection }
 					countriesList={ countriesList }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }

--- a/client/my-sites/checkout/src/components/removed-from-cart-items.tsx
+++ b/client/my-sites/checkout/src/components/removed-from-cart-items.tsx
@@ -1,0 +1,19 @@
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+export const RemovedFromCartItems = ( {
+	responseCart: { restorable_products },
+}: {
+	responseCart: ResponseCart;
+} ) => {
+	console.debug( 'restorable_products', restorable_products );
+
+	if ( ! restorable_products || restorable_products.length === 0 ) {
+		return (
+			<p>
+				<b>NO RESTORABLE PRODUCTS YET</b>
+			</p>
+		);
+	}
+
+	return <ul className="removed-from-cart-items" />;
+};

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -17,6 +17,7 @@ import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/s
 import { getIsOnboardingAffiliateFlow } from 'calypso/state/signup/flow/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import Coupon from './coupon';
+import { RemovedFromCartItems } from './removed-from-cart-items';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
@@ -78,6 +79,7 @@ const CouponEnableButton = styled.button`
 
 export default function WPCheckoutOrderReview( {
 	className,
+	addRestorableProductToCart,
 	removeProductFromCart,
 	removeCouponAndClearField,
 	replaceProductInCart,
@@ -160,8 +162,11 @@ export default function WPCheckoutOrderReview( {
 					</SiteSummary>
 				) }
 
+				<RemovedFromCartItems responseCart={ responseCart } />
+
 				<WPOrderReviewSection>
 					<WPOrderReviewLineItems
+						addRestorableProductToCart={ addRestorableProductToCart }
 						removeProductFromCart={ removeProductFromCart }
 						replaceProductInCart={ replaceProductInCart }
 						removeCoupon={ removeCouponAndClearField }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -66,6 +66,7 @@ export function WPOrderReviewSection( {
 export function WPOrderReviewLineItems( {
 	className,
 	isSummary,
+	addRestorableProductToCart,
 	removeProductFromCart,
 	replaceProductInCart,
 	removeCoupon,
@@ -193,6 +194,7 @@ export function WPOrderReviewLineItems( {
 					key={ product.uuid }
 					product={ product }
 					isSummary={ isSummary }
+					addRestorableProductToCart={ addRestorableProductToCart }
 					removeProductFromCart={ removeProductFromCart }
 					onChangeSelection={ onChangeSelection }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -251,6 +253,7 @@ const DropdownWrapper = styled.span`
 function LineItemWrapper( {
 	product,
 	isSummary,
+	addRestorableProductToCart,
 	removeProductFromCart,
 	onChangeSelection,
 	createUserAndSiteBeforeTransaction,
@@ -405,6 +408,7 @@ function LineItemWrapper( {
 			<LineItem
 				product={ product }
 				hasDeleteButton={ isDeletable }
+				addRestorableProductToCart={ addRestorableProductToCart }
 				removeProductFromCart={ removeProductFromCart }
 				isSummary={ isSummary }
 				createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -310,6 +310,16 @@ export function addItemsToResponseCart(
 	};
 }
 
+export function addRestorableItemToResponseCart(
+	responseCart: TempResponseCart,
+	product: RequestCartProduct
+): TempResponseCart {
+	return {
+		...responseCart,
+		restorable_products: [ ...responseCart.restorable_products, product ],
+	};
+}
+
 export function replaceAllItemsInResponseCart(
 	responseCart: TempResponseCart,
 	products: RequestCartProduct[]

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -6,6 +6,7 @@ export function getEmptyResponseCart(): ResponseCart {
 		cart_generated_at_timestamp: 0,
 		cart_key: 'no-site',
 		products: [],
+		restorable_products: [],
 		total_tax: '0',
 		total_tax_integer: 0,
 		total_tax_breakdown: [],

--- a/packages/shopping-cart/src/shopping-cart-actions.ts
+++ b/packages/shopping-cart/src/shopping-cart-actions.ts
@@ -11,6 +11,11 @@ export function createActions( dispatch: DispatchAndWaitForValid ): ShoppingCart
 				type: 'CART_PRODUCTS_ADD',
 				products: createRequestCartProducts( products ),
 			} ),
+		addRestorableProductToCart: ( product ) =>
+			dispatch( {
+				type: 'CART_PRODUCT_ADD_RESTORABLE',
+				product,
+			} ),
 		removeProductFromCart: ( uuidToRemove ) =>
 			dispatch( { type: 'REMOVE_CART_ITEM', uuidToRemove } ),
 		replaceProductsInCart: async ( products ) =>

--- a/packages/shopping-cart/src/shopping-cart-reducer.ts
+++ b/packages/shopping-cart/src/shopping-cart-reducer.ts
@@ -2,6 +2,7 @@ import debugFactory from 'debug';
 import {
 	removeItemFromResponseCart,
 	addItemsToResponseCart,
+	addRestorableItemToResponseCart,
 	replaceAllItemsInResponseCart,
 	replaceItemInResponseCart,
 	addCouponToResponseCart,
@@ -170,6 +171,25 @@ function shoppingCartReducer(
 				loadingError: undefined,
 				loadingErrorType: undefined,
 			};
+
+		case 'CART_PRODUCT_ADD_RESTORABLE': {
+			debug( 'adding restorable item to cart', action.product );
+
+			const cartWithoutRestorableProduct = removeItemFromResponseCart(
+				state.responseCart,
+				action.product.uuid
+			);
+
+			const cart = addRestorableItemToResponseCart( cartWithoutRestorableProduct, action.product );
+
+			return {
+				...state,
+				responseCart: cart,
+				cacheStatus: 'invalid',
+				loadingError: undefined,
+				loadingErrorType: undefined,
+			};
+		}
 
 		case 'CART_PRODUCTS_REPLACE_ALL':
 			debug( 'replacing items in cart with', action.products );

--- a/packages/shopping-cart/src/sync.ts
+++ b/packages/shopping-cart/src/sync.ts
@@ -63,7 +63,6 @@ export function createCartSyncManager(
 
 		fetchInitialCartFromServer( dispatch: Dispatch< ShoppingCartAction > ): void {
 			debug( 'fetching initial cart from server' );
-
 			getServerCart()
 				.then( ( response ) => {
 					debug( 'initialized cart is', response );

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -604,6 +604,61 @@ function returnModalCopy(
 	}
 }
 
+function getHasRemoveFromCartModal( {
+	product,
+	translate,
+	hasBundledDomainsInCart,
+	hasMarketplaceProductsInCart,
+	isPwpoUser = false,
+}: {
+	product: ResponseCartProduct;
+	translate: ReturnType< typeof useTranslate >;
+	hasBundledDomainsInCart: boolean;
+	hasMarketplaceProductsInCart: boolean;
+	isPwpoUser?: boolean;
+} ) {
+	const productType = getProductTypeForModalCopy(
+		product,
+		hasBundledDomainsInCart,
+		hasMarketplaceProductsInCart,
+		isPwpoUser
+	);
+	const isRenewal = isWpComProductRenewal( product );
+
+	switch ( productType ) {
+		case 'gift purchase':
+			return true;
+
+		case 'plan with marketplace dependencies':
+			return true;
+
+		case 'plan with domain dependencies': {
+			if ( isRenewal ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		case 'plan':
+			return false;
+
+		case 'domain':
+			return false;
+
+		case 'coupon':
+			return {
+				title: String( translate( 'You are about to remove your coupon from the cart' ) ),
+				description: String(
+					translate( 'When you press Continue, you will need to confirm your payment details.' )
+				),
+			};
+
+		default:
+			return false;
+	}
+}
+
 function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ) {
 	return <ProductTier product={ product } />;
 }
@@ -1184,6 +1239,7 @@ function CheckoutLineItem( {
 	product,
 	className,
 	hasDeleteButton,
+	addRestorableProductToCart,
 	removeProductFromCart,
 	isSummary,
 	createUserAndSiteBeforeTransaction,
@@ -1223,6 +1279,13 @@ function CheckoutLineItem( {
 	const { formStatus } = useFormStatus();
 	const itemSpanId = `checkout-line-item-${ id }`;
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const hasRemoveFromCartModal = getHasRemoveFromCartModal( {
+		product,
+		translate,
+		hasBundledDomainsInCart,
+		hasMarketplaceProductsInCart,
+		isPwpoUser,
+	} );
 	const modalCopy = returnModalCopyForProduct(
 		product,
 		translate,
@@ -1336,8 +1399,17 @@ function CheckoutLineItem( {
 							) }
 							disabled={ isDisabled }
 							onClick={ () => {
-								setIsModalVisible( true );
-								onRemoveProductClick?.( label );
+								addRestorableProductToCart( product );
+								// l'acció per reafegir seria addProductsToCart
+								if ( hasRemoveFromCartModal ) {
+									setIsModalVisible( true );
+									onRemoveProductClick?.( label ); // recordTracksEvent
+								} else {
+									// removeProductFromCart( product.uuid ).catch( () => {
+									// 	// Nothing needs to be done here. CartMessages will display the error to the user.
+									// } );
+									// onRemoveProduct?.( label );
+								}
 							} }
 						>
 							{ translate( 'Remove from cart' ) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
