### PR TITLE
Apps: Fix Odyssey translation extraction.

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -161,6 +161,7 @@ module.exports = {
 		! isDevelopment &&
 			new GenerateChunksMapPlugin( {
 				output: path.resolve( outBasePath, 'dist/chunks-map.json' ),
+				base_dir: '../../',
 			} ),
 		/*
 		 * ExPlat: Don't import the server logger when we are in the browser

--- a/build-tools/webpack/generate-chunks-map-plugin.js
+++ b/build-tools/webpack/generate-chunks-map-plugin.js
@@ -8,8 +8,9 @@ const path = require( 'path' );
 const PLUGIN_NAME = 'GenerateChunksMap';
 
 class GenerateChunksMapPlugin {
-	constructor( { output = path.resolve( '.', 'map.json' ) } = {} ) {
+	constructor( { output = path.resolve( '.', 'map.json' ), base_dir = '.' } = {} ) {
 		this.output = output;
+		this.base_dir = base_dir;
 	}
 
 	apply( compiler ) {
@@ -25,10 +26,9 @@ class GenerateChunksMapPlugin {
 				if ( ! name ) {
 					continue;
 				}
-
 				const modules = [ ...compilation.chunkGraph.getChunkModulesIterable( chunk ) ]
 					.reduce( ( acc, item ) => acc.concat( item.modules || item ), [] )
-					.map( ( { userRequest } ) => userRequest && path.relative( '.', userRequest ) )
+					.map( ( { userRequest } ) => userRequest && path.relative( this.base_dir, userRequest ) )
 					.filter( ( module ) => !! module );
 
 				chunksMap[ name ] = modules;


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
such as requiring a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-12980

## Proposed Changes

This PR updates `GenerateChunksMapPlugin` to accept a base path instead of defaulting to `.`.  

## Why are these changes being made?
<!--
It's easy to see what a PR does, but much harder to find out why it was made,
particularly when researching old historical changes. Record an explanation of
the motivation behind this change and how it will help.
-->

The following three-step process is used to translate Calypso apps:
- `wp-babel-makepot` extracts all strings from the application, starting from the root, generating `<app>-strings.pot` and adding path references to each string: 
```
#: apps/odyssey-stats/src/widget/highlights.tsx:67
msgid "%(views)s Views"
msgstr ""
```
-  `GenerateChunksMapPlugin` to generate `chunks-map.json`, containing the files used by the specific app. 
- `build-app-languages` downloads Calypso translations, merges `<app>-strings.pot` and `chunks-map.json` together based on the file path in the reference, and generates the language files.

While `wp-babel-makepot` uses the root path as the starting point for file references, GenerateChunksMapPlugin uses `.`. 

This results in `chunks-map.json` containing the wrong path for some references. 

This PR updates the plugin to accept a base path instead of defaulting to `.` This allows us to fix the references and generate the appropriate language files.

## Testing Instructions

<!--
Could you add as many details as possible to help others reproduce the issue and test the fix?
"Before / After" screenshots can also be beneficial when the change is visual.
-->

* Build the Odyssey Stats app, navigate to `dist/languages` and save the content of a specific file, e.g., `fr-v1.1.json`.
* Build the app after this PR is applied and save the contents of the same file.
* Compare the 2 files and confirm that no existing strings are removed and new strings are added.

__Note:__ The same issue might be present in the other apps, I'll review them one by one to limit the impact if anything goes wrong.
## Pre-merge Checklist

<!--
Could you complete the items on this checklist **before** merging into trunk? Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScrip,t, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words varies significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
