### PR TITLE
Notifications: change Publicized copy

### DIFF
--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -14,7 +14,10 @@ export const settingLabels = {
 	follow: () => i18n.translate( 'Subscriptions' ),
 	achievement: () => i18n.translate( 'Site achievements' ),
 	mentions: () => i18n.translate( 'Username mentions' ),
-	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),
+	scheduled_publicize: () =>
+		i18n.translate( 'Jetpack Social', {
+			comment: 'brand Jetpack Social does not need translation',
+		} ),
 	blogging_prompt: () => i18n.translate( 'Daily writing prompts' ),
 	draft_post_prompt: () => i18n.translate( 'Draft post reminders' ),
 	store_order: () => i18n.translate( 'New order' ),


### PR DESCRIPTION
This PR is a reinstatement after a revert.

Original PR #103265
Revert PR #103392

Part of DOTCOM-13027

## Proposed Changes
This PR changes string "Post Publicized" to "Jetpack Social" brand.

## Why are these changes being made?
Design review DOTCOM-12890

## Testing Instructions
Visit /me and go to Notifications Settings, uncollapse a site and look for Jetpack Social row.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
