### PR TITLE
Apps: Fix Odyssey widget reactivity.

### DIFF
--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -1,6 +1,7 @@
 import '@automattic/calypso-polyfills';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
 import { createRoot } from 'react-dom/client';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import config from '../lib/config-api';
@@ -31,9 +32,9 @@ export function init() {
 		if ( ! statsWidgetEl ) {
 			return;
 		}
-		const root = createRoot( statsWidgetEl );
-		root.render(
-			<QueryClientProvider client={ queryClient }>
+		const App: FunctionComponent = () => {
+			const translate = useTranslate();
+			return (
 				<div id="stats-widget-content" className="stats-widget-content">
 					<MiniChart
 						siteId={ currentSiteId }
@@ -62,6 +63,12 @@ export function init() {
 						</div>
 					</div>
 				</div>
+			);
+		};
+		const root = createRoot( statsWidgetEl );
+		root.render(
+			<QueryClientProvider client={ queryClient }>
+				<App />
 			</QueryClientProvider>
 		);
 	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-12980

## Proposed Changes

* Wrap the widget in an App container to be able to load translations.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To fix translations for text outside a functional component.
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the build: `14898785:id` on your sandbox and confirm the `View all stats` link is now translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
