### PR TITLE
Make DIFM migration cancellation context aware

### DIFF
--- a/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
+++ b/client/sites/overview/components/migration-overview/components/cancel-difm-migration/test/index.tsx
@@ -23,32 +23,77 @@ jest.mock( 'calypso/lib/wp', () => ( {
 	},
 } ) );
 
+jest.mock( 'calypso/blocks/blog-stickers/use-blog-stickers-query', () => ( {
+	useBlogStickersQuery: jest.fn(),
+} ) );
+
 describe( 'CancelDifmMigrationForm', () => {
 	const siteId = 123;
 	const isEnabled = jest.requireMock( '@automattic/calypso-config' ).isEnabled;
+	const useBlogStickersQuery = jest.requireMock(
+		'calypso/blocks/blog-stickers/use-blog-stickers-query'
+	).useBlogStickersQuery;
 
 	beforeEach( () => {
 		nock.cleanAll();
 		jest.clearAllMocks();
 		isEnabled.mockReturnValue( true );
+		useBlogStickersQuery.mockReturnValue( { data: [] } );
 	} );
 
 	it( 'renders nothing if feature flag is disabled', () => {
 		isEnabled.mockReturnValue( false );
 		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
-		expect( screen.queryByRole( 'button', { name: /request cancellation/i } ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: /cancel migration/i } ) ).toBeNull();
 	} );
 
-	it( 'opens dialog on button click', async () => {
-		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
-		await userEvent.click( screen.getByRole( 'button', { name: /request cancellation/i } ) );
-		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
-		expect( screen.getByText( /request migration cancellation/i ) ).toBeVisible();
+	describe( 'when migration is not in progress', () => {
+		beforeEach( () => {
+			useBlogStickersQuery.mockReturnValue( { data: [] } );
+		} );
+
+		it( 'shows cancel migration button', () => {
+			renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+			expect( screen.getByRole( 'button', { name: /cancel migration/i } ) ).toBeVisible();
+		} );
+
+		it( 'opens dialog with cancel migration content', async () => {
+			renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+			await userEvent.click( screen.getByRole( 'button', { name: /cancel migration/i } ) );
+			expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+			expect( screen.getByRole( 'heading', { name: /cancel migration/i } ) ).toBeVisible();
+			expect( screen.getByText( /our Happiness Engineers will be notified/i ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'when migration is in progress', () => {
+		beforeEach( () => {
+			useBlogStickersQuery.mockReturnValue( { data: [ 'migration-in-progress' ] } );
+		} );
+
+		it( 'shows request cancellation button', () => {
+			renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+			expect(
+				screen.getByRole( 'button', { name: /request migration cancellation/i } )
+			).toBeVisible();
+		} );
+
+		it( 'opens dialog with request cancellation content', async () => {
+			renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /request migration cancellation/i } )
+			);
+			expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+			expect(
+				screen.getByRole( 'heading', { name: /request migration cancellation/i } )
+			).toBeVisible();
+			expect( screen.getByText( /you'll lose all your progress/i ) ).toBeVisible();
+		} );
 	} );
 
 	it( 'closes dialog on cancel', async () => {
 		renderWithProvider( <CancelDifmMigrationForm siteId={ siteId } /> );
-		await userEvent.click( screen.getByRole( 'button', { name: /request cancellation/i } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /cancel migration/i } ) );
 		await userEvent.click( screen.getByRole( 'button', { name: /don't cancel migration/i } ) );
 		await waitFor( () => {
 			expect( screen.queryByRole( 'dialog' ) ).toBeNull();

--- a/client/sites/overview/components/style.scss
+++ b/client/sites/overview/components/style.scss
@@ -133,19 +133,25 @@ $blueberry-color: #3858e9;
 		}
 	}
 
+	&__navigation-header {
+		margin-bottom: 24px;
+	}
+
+	&__blog-stickers {
+		margin: 0 0 24px;
+		padding: 16px;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 4px;
+		font-size: 14px;
+		color: var(--color-text-subtle);
+	}
+
 }
 
 .hosting-overview__domain-to-plan-credit-notice {
 	grid-column: 1 / -1;
 	text-wrap: pretty;
-}
-
-.hosting-overview__navigation-header {
-	grid-column: 1 / -1;
-
-	&.navigation-header {
-		margin-bottom: 16px;
-	}
 }
 
 .hosting-overview__navigation-header,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-26

## Proposed Changes

We now display slightly different context depending on if the site has a migration in progress.

If the site doesn't have a migration in progress (no migration-in-progress sticker), the user is allowed to cancel outright.

Otherwise they are told they're sending a migration cancellation request.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR requires the functionality in 182742-ghe-Automattic/wpcom. If that endpoint change hasn't been merged, you'll need to apply it to your sandbox and sandbox the public-api.

You'll need to enable the `migration-flow/cancel-difm` if you're using the calypso.live url instead of running this locally. If you _are_ running this locally, you'll need to choose 'Share credentials' instead of 'Authorize application' when you reach that point of the migration flow.

### Direct Cancellation

In this case, the migration is _not_ in-progress (doesn't have the `migration-in-progress` sticker) and can be cancelled directly.

* Go to /start and continue to the Goals step.
* Select the 'import or migrate' intent.
* Continue with the migration flow and select a DIFM migration.
* When you reach the site overview, there should be a new 'Cancel migration' button.
![image](https://github.com/user-attachments/assets/8f0d3a62-6534-4e5a-8b22-590df88cb851)
* Clicking the button should show the following dialog.
![image](https://github.com/user-attachments/assets/25c88f80-a58c-44d5-b9aa-3de66b6b97fc)
* Clicking 'Cancel migration' in the dialog should show the following success message.
![image](https://github.com/user-attachments/assets/69193738-cbe5-4e62-aade-a0233548e877)
* Verify that the Zendesk ticket for the migration has an internal message reading 'The user has cancelled the migration'.
* The site should also have the `migration-cancelled-difm` sticker.

### Cancellation request

In this case, the migration _is_ = in-progress (has the `migration-in-progress` sticker) so a cancellation request is sent instead.

* Go to /start and continue to the Goals step.
* Select the 'import or migrate' intent.
* Continue with the migration flow and select a DIFM migration.
* When you reach the site overview, there should be a new 'Request migration cancellation' button.
![image](https://github.com/user-attachments/assets/438f2175-b327-4069-a298-d05c2046f21e)

* Clicking the button should show the following dialog.
![image](https://github.com/user-attachments/assets/78f6ef35-79d7-4125-94c0-edf47120e9ba)

* Clicking 'Send request' in the dialog should show the following success message.
![image](https://github.com/user-attachments/assets/042fb04c-788f-4ac2-b287-8cb07d11e75c)

* Verify that the Zendesk ticket for the migration has an internal message reading 'The user has requested to cancel the migration'.
* The site should _not_ have the `migration-cancellation-difm` sticker added.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?