### PR TITLE
Stats: Fix stats tabs click E2E

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -1,16 +1,20 @@
 import { Locator, Page, Frame } from 'playwright';
 import envVariables from './env-variables';
 
-const navTabParent = 'div.stats-navigation__tabs';
-const legacyNavTabParent = 'div.section-nav';
+const coreNavTabParent = 'div.stats-navigation__tabs';
+const calypsoNavTabParent = 'div.section-nav';
 
 const selectors = {
 	// clickNavTab
-	navTabItem: ( { name = '', selected = false }: { name?: string; selected?: boolean } = {} ) =>
-		envVariables.VIEWPORT_NAME === 'mobile'
-			? `${ legacyNavTabParent } a[aria-current="${ selected }"]:has(span:has-text("${ name }"))`
-			: `${ navTabParent } button[aria-selected="${ selected }"]:has-text("${ name }")`,
-	navTabMobileToggleButton: `${ legacyNavTabParent } button.section-nav__mobile-header`,
+	navTabItem: ( {
+		name = '',
+		selected = false,
+		isCoreTabs = false,
+	}: { name?: string; selected?: boolean; isCoreTabs?: boolean } = {} ) =>
+		! isCoreTabs
+			? `${ calypsoNavTabParent } a[aria-current="${ selected }"]:has(span:has-text("${ name }"))`
+			: `${ coreNavTabParent } button[aria-selected="${ selected }"]:has-text("${ name }")`,
+	navTabMobileToggleButton: `${ calypsoNavTabParent } button.section-nav__mobile-header`,
 };
 
 /**
@@ -61,7 +65,7 @@ export async function waitForElementEnabled(
 export async function clickNavTab(
 	page: Page,
 	name: string,
-	{ force }: { force?: boolean } = {}
+	{ force, isCoreTabs = false }: { force?: boolean; isCoreTabs?: boolean } = {}
 ): Promise< void > {
 	// Short circuit operation if the active tab and target tabs are the same.
 	// Strip numerals from the extracted tab name to account for the slightly
@@ -74,7 +78,7 @@ export async function clickNavTab(
 
 	// If force option is specified, force click using a `dispatchEvent`.
 	if ( force ) {
-		return await page.dispatchEvent( selectors.navTabItem( { name: name } ), 'click' );
+		return await page.dispatchEvent( selectors.navTabItem( { name: name, isCoreTabs } ), 'click' );
 	}
 
 	// Mobile view - navtabs become a dropdown and thus it must be opened first.
@@ -83,19 +87,21 @@ export async function clickNavTab(
 		const navTabsButtonLocator = page.locator( selectors.navTabMobileToggleButton );
 		await navTabsButtonLocator.click( { noWaitAfter: true } );
 
-		const navTabIsOpenLocator = page.locator( `${ legacyNavTabParent }.is-open` );
+		const navTabIsOpenLocator = page.locator( `${ calypsoNavTabParent }.is-open` );
 		await navTabIsOpenLocator.waitFor();
 	}
 
 	// Click on the intended item and wait for navigation to finish.
-	const navTabItem = page.locator( selectors.navTabItem( { name: name, selected: false } ) );
+	const navTabItem = page.locator(
+		selectors.navTabItem( { name: name, selected: false, isCoreTabs } )
+	);
 
 	const regex = new RegExp( `.*/${ name.toLowerCase() }/.*` );
 	await Promise.all( [ page.waitForURL( regex ), navTabItem.click() ] );
 
 	// Final verification, check that we are now on the expected navtab.
 	const newSelectedTabLocator = page.locator(
-		selectors.navTabItem( { name: name, selected: true } )
+		selectors.navTabItem( { name: name, selected: true, isCoreTabs } )
 	);
 	const newSelectedTabName = await newSelectedTabLocator.innerText();
 

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -1,7 +1,7 @@
 import { Locator, Page, Frame } from 'playwright';
 import envVariables from './env-variables';
 
-const coreNavTabParent = 'div.stats-navigation__tabs';
+const coreNavTabParent = 'div.components-tab-panel__tabs';
 const calypsoNavTabParent = 'div.section-nav';
 
 const selectors = {

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -70,7 +70,7 @@ export async function clickNavTab(
 	// Short circuit operation if the active tab and target tabs are the same.
 	// Strip numerals from the extracted tab name to account for the slightly
 	// different implementation in PostsPage.
-	const selectedTabLocator = page.locator( selectors.navTabItem( { selected: true } ) );
+	const selectedTabLocator = page.locator( selectors.navTabItem( { selected: true, isCoreTabs } ) );
 	const selectedTabName = await selectedTabLocator.innerText();
 	if ( selectedTabName.replace( /[0-9]|,/g, '' ) === name ) {
 		return;

--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -11,7 +11,7 @@ const selectors = {
 		selected = false,
 		isCoreTabs = false,
 	}: { name?: string; selected?: boolean; isCoreTabs?: boolean } = {} ) =>
-		! isCoreTabs
+		! isCoreTabs || envVariables.VIEWPORT_NAME === 'mobile'
 			? `${ calypsoNavTabParent } a[aria-current="${ selected }"]:has(span:has-text("${ name }"))`
 			: `${ coreNavTabParent } button[aria-selected="${ selected }"]:has-text("${ name }")`,
 	navTabMobileToggleButton: `${ calypsoNavTabParent } button.section-nav__mobile-header`,

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -70,7 +70,7 @@ export class StatsPage {
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
 		await this.dismissTooltip();
-		await clickNavTab( this.page, name );
+		await clickNavTab( this.page, name, true );
 
 		// Wait for the expected URL scheme to load.
 		// Note, the Store tab is only available for Business and above plans.

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -70,7 +70,7 @@ export class StatsPage {
 	 */
 	async clickTab( name: StatsTabs ): Promise< void > {
 		await this.dismissTooltip();
-		await clickNavTab( this.page, name, true );
+		await clickNavTab( this.page, name, { isCoreTabs: true } );
 
 		// Wait for the expected URL scheme to load.
 		// Note, the Store tab is only available for Business and above plans.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of STATS-65

## Proposed Changes

* Add the right parent for Core tabs

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* E2E fix after https://github.com/Automattic/wp-calypso/pull/103032 for Stats only

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure all E2E tests pass
* Particularly no error like the following

![image](https://github.com/user-attachments/assets/91e8d006-4729-4450-bb5e-4597102b8cd4)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
