### PR TITLE
Remove "login/social-first" feature flag

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -555,12 +555,7 @@ export class Login extends Component {
 		} = this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
-		const isSocialFirst =
-			config.isEnabled( 'login/social-first' ) &&
-			isWhiteLogin &&
-			! isGravPoweredClient &&
-			! isWoo &&
-			! isBlazePro;
+		const isSocialFirst = isWhiteLogin && ! isGravPoweredClient && ! isWoo && ! isBlazePro;
 
 		const akismetLogo = (
 			<svg

--- a/config/development.json
+++ b/config/development.json
@@ -115,7 +115,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/social-first": true,
 		"logmein": true,
 		"mailchimp": true,
 		"manage/import/site-importer-endpoints": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -76,7 +76,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/social-first": true,
 		"mailchimp": false,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/production.json
+++ b/config/production.json
@@ -92,7 +92,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/social-first": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-personal-premium": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,7 +89,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/social-first": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/test.json
+++ b/config/test.json
@@ -73,7 +73,6 @@
 		"layout/support-article-dialog": true,
 		"legal-updates-banner": true,
 		"login/last-used-method": true,
-		"login/social-first": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,6 @@
 		"livechat_solution": true,
 		"login/last-used-method": true,
 		"login/magic-login": true,
-		"login/social-first": true,
 		"logmein": true,
 		"mailchimp": true,
 		"marketplace-fetch-all-dynamic-products": true,

--- a/packages/calypso-config/src/desktop.ts
+++ b/packages/calypso-config/src/desktop.ts
@@ -15,7 +15,6 @@ const config = {
 const features = {
 	desktop: true,
 	'login/last-used-method': false,
-	'login/social-first': false,
 	'sign-in-with-apple': false,
 	// Note: there is also a sign-in-with-apple/redirect flag
 	// that may/may not be relevant to override for the Desktop app.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up from #102811.

The "login/social-first" flag has been [true in production env](https://github.com/Automattic/wp-calypso/blame/trunk/config/production.json#L95) for 2 years now.

The only place it's still set to false is the [desktop config](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-config/src/desktop.ts#L18), but desktop app logins are now routed [through the browser](https://github.com/Automattic/wp-calypso/pull/98345) so the flag is no longer relevant in that context.


This PR only deals with removing the flag. There's some confusing logic around the use of the `isSocialFirst` variable which can be dealt with afterwards. That variable is also defined in [here](https://github.com/Automattic/wp-calypso/blob/remove/social-first-feature-flag/client/signup/config/steps-pure.js#L160) without reference to the feature flag, and [here](https://github.com/Automattic/wp-calypso/blob/remove/social-first-feature-flag/client/blocks/signup-form/index.jsx#L133) it's given a default value of `false`. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that /log-in/ related paths are unchanged;
* For the desktop app, follow [instructions to start it up locally](https://github.com/Automattic/wp-calypso/tree/trunk/desktop) and check that its login screen looks identical to the production version:

<img width="1191" alt="Screenshot 2025-05-14 at 5 15 24 pm" src="https://github.com/user-attachments/assets/7dbd3b39-0843-40e8-865c-076005909800" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
