### PR TITLE
Domains: prevent showing register now CTA for unsupported TLDs

### DIFF
--- a/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
+++ b/client/components/domains/use-my-domain/utilities/get-availability-error-message.js
@@ -24,7 +24,7 @@ export function getAvailabilityErrorMessage( {
 			);
 		}
 
-		if ( registerNowAction ) {
+		if ( registerNowAction && status !== domainAvailability.TLD_NOT_SUPPORTED ) {
 			return createInterpolateElement( __( "This domain isn't registered. <a>Register now.</a>" ), {
 				a: createElement( 'a', {
 					href: '#',


### PR DESCRIPTION
Linear https://linear.app/a8c/issue/NOMADO-163/dont-show-register-now-cta-for-unsupported-domains-in-use-a-domain-i

## Proposed Changes

* Prevent showing "Register now" call to action when the domain TLD is not supported, in "Use I domain I own" step.

| BEFORE | AFTER |
| -------- | -------- |
| ![Screenshot 2025-05-14 alle 10 40 33](https://github.com/user-attachments/assets/f70c6472-aa0e-44b2-96fb-e70e34298a24) | ![Screenshot 2025-05-14 alle 10 40 05](https://github.com/user-attachments/assets/43e5eae5-59f1-446b-a2a8-d5ca2db29cad) |

## Why are these changes being made?

Currently, when a user tries to use a domain with an unsupported TLD, they still see a "Register now" call to action, which is misleading since the TLD cannot be registered on WordPress.com. This change ensures that users only see the registration option when the TLD is actually supported, providing a more accurate user experience.

## Testing Instructions

1. Open the "Use a domain I own" step (`setup/onboarding/use-my-domain?step=domain-input`)
2. Try entering an available domain with an unsupported TLD (e.g., `unsupported-tld.pt`)
3. Verify that you see the message "This domain isn't registered. Try again." instead of the "Register now" call to action
4. Try entering an available domain with a supported TLD (e.g., .com)
5. Verify that you still see the "Register now" call to action when appropriate

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
