### PR TITLE
Notifications: limit confirm modal width and use core component

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,6 +1,10 @@
-import { Card, FormLabel, Dialog } from '@automattic/components';
+import { Card, FormLabel } from '@automattic/components';
 import { getNumericFirstDayOfWeek, withLocale } from '@automattic/i18n-utils';
-import { Button, CheckboxControl } from '@wordpress/components';
+import {
+	Button,
+	CheckboxControl,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
@@ -95,6 +99,15 @@ class NotificationSubscriptions extends Component {
 		};
 
 		this.props.updateSetting( syntheticEvent );
+		this.setState( { showConfirmModal: false } );
+	};
+
+	handleModalConfirm = () => {
+		// Create a synthetic event object that matches what updateSetting expects
+		const syntheticEvent = {
+			preventDefault: () => {},
+		};
+		this.props.submitForm( syntheticEvent );
 		this.setState( { showConfirmModal: false } );
 	};
 
@@ -340,36 +353,17 @@ class NotificationSubscriptions extends Component {
 					</form>
 				</Card>
 
-				<Dialog
-					isVisible={ this.state.showConfirmModal }
-					onClose={ () => this.setState( { showConfirmModal: false } ) }
-					buttons={ [
-						{
-							action: 'cancel',
-							label: this.props.translate( 'Cancel' ),
-							onClick: () => this.handleModalCancel(),
-						},
-						{
-							action: 'confirm',
-							label: this.props.translate( 'Confirm' ),
-							onClick: () => {
-								this.setState( { showConfirmModal: false } );
-								// Create a synthetic event object
-								const syntheticEvent = {
-									preventDefault: () => {},
-								};
-								this.props.submitForm( syntheticEvent );
-							},
-							isPrimary: true,
-						},
-					] }
+				<ConfirmDialog
+					isOpen={ this.state.showConfirmModal }
+					onConfirm={ () => this.handleModalConfirm() }
+					onCancel={ () => this.handleModalCancel() }
+					confirmButtonText={ this.props.translate( 'Confirm' ) }
+					style={ { maxWidth: '480px' } }
 				>
-					<p>
-						{ this.props.translate(
-							"You have active newsletter subscriptions. Pausing emails means you won't receive any newsletter updates. Are you sure you want to continue?"
-						) }
-					</p>
-				</Dialog>
+					{ this.props.translate(
+						"You have active newsletter subscriptions. Pausing emails means you won't receive any newsletter updates. Are you sure you want to continue?"
+					) }
+				</ConfirmDialog>
 			</Main>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13034

## Proposed Changes

* Swap to use new core confirm component
* Limit confirm modal width to 480px

Before

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/0ac6dcd2-c181-4c27-bf02-0d2bdba227d4" />

After

<img width="637" alt="image" src="https://github.com/user-attachments/assets/54925c55-bb3d-4256-9342-7b05a1deeec3" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Try check the box and save; cancelling and confirming still work

<img width="810" alt="Screenshot 2025-05-14 at 12 01 24" src="https://github.com/user-attachments/assets/b233358f-204b-4399-94f8-7f1d25e05730" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
