### PR TITLE
Notifications: use checkbox for "save to all sites"

### DIFF
--- a/client/me/notification-settings/settings-form/actions.tsx
+++ b/client/me/notification-settings/settings-form/actions.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect, useState } from 'react';
 import { useSelector } from 'calypso/state';
@@ -20,41 +20,48 @@ const NotificationSettingsFormActions = ( {
 }: NotificationSettingsFormActionsProps ) => {
 	const translate = useTranslate();
 	const isFetching = useSelector( isFetchingNotificationsSettings );
-	const [ savingTarget, setSavingTarget ] = useState< 'single' | 'all' | null >( null );
+	const [ savingTarget, setSavingTarget ] = useState< 'single' | 'all' >( 'single' );
 
 	useLayoutEffect( () => {
 		if ( ! isFetching ) {
-			setSavingTarget( null );
+			setSavingTarget( 'single' );
 		}
 	}, [ isFetching ] );
 
 	return (
-		<div css={ { display: 'flex', gap: '16px', marginLeft: '10px', marginBottom: '10px' } }>
+		<div
+			css={ {
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'start',
+				gap: '16px',
+				margin: '10px 0 16px 10px',
+			} }
+		>
+			{ props.isApplyAllVisible && (
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ savingTarget === 'all' }
+					disabled={ disabled || !! isFetching }
+					label={ translate( 'Apply these settings to all my sites' ) }
+					onChange={ ( checked ) => setSavingTarget( checked ? 'all' : 'single' ) }
+				/>
+			) }
+
 			<Button
 				variant="primary"
 				disabled={ disabled || !! isFetching }
 				isBusy={ isFetching && savingTarget === 'single' }
 				onClick={ () => {
-					setSavingTarget( 'single' );
-					onSave();
+					if ( props.isApplyAllVisible && savingTarget === 'all' ) {
+						props.onSaveToAll();
+					} else {
+						onSave();
+					}
 				} }
 			>
 				{ translate( 'Save settings' ) }
 			</Button>
-
-			{ props.isApplyAllVisible && (
-				<Button
-					variant="secondary"
-					disabled={ disabled || !! isFetching }
-					isBusy={ isFetching && savingTarget === 'all' }
-					onClick={ () => {
-						setSavingTarget( 'all' );
-						props.onSaveToAll();
-					} }
-				>
-					{ translate( 'Save to all sites' ) }
-				</Button>
-			) }
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-13028

## Proposed Changes

- Use checkbox instead of button for "save to all sites" action, so that choice between actions wouldn't feel so intimidating.

Before
<img width="803" alt="Screenshot 2025-05-14 at 12 40 59" src="https://github.com/user-attachments/assets/db034527-8fb8-478b-ac29-32b615658cf5" />
<img width="814" alt="Screenshot 2025-05-14 at 12 40 55" src="https://github.com/user-attachments/assets/ca0f773e-af9f-440b-816f-17623fa3880e" />


After

<img width="787" alt="Screenshot 2025-05-14 at 12 39 42" src="https://github.com/user-attachments/assets/f3e00384-fc1e-4652-9b12-9e1d4cae5533" />
<img width="785" alt="Screenshot 2025-05-14 at 12 39 46" src="https://github.com/user-attachments/assets/1272dceb-2edb-4529-b85e-a492410934cc" />

https://github.com/user-attachments/assets/43ad514e-54dc-4871-a4b6-b0fe81be94b0



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Have user with at least two sites
* Test Notification settings; saving to a single site or all sites both work

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
