### PR TITLE
Stats: fix the "View Posts" button on email stats

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -20,6 +20,7 @@ import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import EmptyContent from 'calypso/components/empty-content';
 import NavigationHeader from 'calypso/components/navigation-header';
+import WebPreview from 'calypso/components/web-preview';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import memoizeLast from 'calypso/lib/memoize-last';
 import PageHeader from 'calypso/my-sites/stats/components/headers/page-header';
@@ -27,7 +28,7 @@ import Main from 'calypso/my-sites/stats/components/stats-main';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import StatsEmailModule from 'calypso/my-sites/stats/stats-email-module';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
-import { getSitePost } from 'calypso/state/posts/selectors';
+import { getSitePost, getPostPreviewUrl } from 'calypso/state/posts/selectors';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
 import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { PERIOD_ALL_TIME } from 'calypso/state/stats/emails/constants';
@@ -162,6 +163,18 @@ class StatsEmailDetail extends Component {
 		return null;
 	};
 
+	openPreview = () => {
+		this.setState( {
+			showPreview: true,
+		} );
+	};
+
+	closePreview = () => {
+		this.setState( {
+			showPreview: false,
+		} );
+	};
+
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
 
 	onChangeMaxBars = ( maxBars ) => this.setState( { maxBars } );
@@ -193,6 +206,8 @@ class StatsEmailDetail extends Component {
 			hasValidDate,
 			showNoDataInfo,
 			showViewLink,
+			previewUrl,
+			siteSlug,
 		} = this.props;
 		const { maxBars } = this.state;
 
@@ -397,6 +412,18 @@ class StatsEmailDetail extends Component {
 									) }
 								</div>
 							</div>
+
+							<WebPreview
+								showPreview={ this.state.showPreview }
+								defaultViewportDevice="tablet"
+								previewUrl={ `${ previewUrl }?demo=true&iframe=true&theme_preview=true` }
+								externalUrl={ previewUrl }
+								onClose={ this.closePreview }
+							>
+								<CoreButton href={ `/post/${ siteSlug }/${ postId }` }>
+									{ translate( 'Edit' ) }
+								</CoreButton>
+							</WebPreview>
 						</>
 					) : (
 						<Spinner baseClassName="calypso-spinner" />
@@ -452,6 +479,7 @@ const connectComponent = connect(
 			hasValidDate,
 			showNoDataInfo,
 			showViewLink: ! isJetpack && isPreviewable,
+			previewUrl: getPostPreviewUrl( state, siteId, postId ),
 		};
 	},
 	{ recordGoogleEvent }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Handle the onclick action for the "View Post" button on email stats for a post

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The "View post" button should work on "email open" and "email click" stats for a post, example links -
  * http://calypso.localhost:3000/stats/email/opens/day/218915/jetpack.com
  * http://calypso.localhost:3000/stats/email/clicks/day/218915/jetpack.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
