### PR TITLE
Notifications: use toggles for updates section

### DIFF
--- a/client/me/notification-settings/wpcom-settings/email-category.jsx
+++ b/client/me/notification-settings/wpcom-settings/email-category.jsx
@@ -1,11 +1,12 @@
-import { FormLabel } from '@automattic/components';
-import { CheckboxControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormLegend from 'calypso/components/forms/form-legend';
-import { toggleWPcomEmailSetting } from 'calypso/state/notification-settings/actions';
+import { toggleWPcomEmailSetting, saveSettings } from 'calypso/state/notification-settings/actions';
+import {
+	getNotificationSettings,
+	isFetchingNotificationsSettings,
+} from 'calypso/state/notification-settings/selectors';
 
 class EmailCategory extends Component {
 	static propTypes = {
@@ -15,24 +16,35 @@ class EmailCategory extends Component {
 		description: PropTypes.string,
 	};
 
-	toggleSetting = () => {
+	toggleSetting = ( toggleValue ) => {
 		this.props.toggleWPcomEmailSetting( this.props.name );
+		// settings is not updated immediately, so we need to save the settings manually
+		this.props.saveSettings( 'wpcom', {
+			...this.props.settings,
+			[ this.props.name ]: toggleValue,
+		} );
 	};
 
 	render() {
+		const { isEnabled, description, title } = this.props;
 		return (
-			<FormFieldset>
-				<FormLegend>{ this.props.title }</FormLegend>
-				<FormLabel>
-					<CheckboxControl
-						checked={ this.props.isEnabled }
-						onChange={ this.toggleSetting }
-						label={ this.props.description }
-					/>
-				</FormLabel>
-			</FormFieldset>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				checked={ isEnabled }
+				className="wpcom-settings__notification-settings-emailcategory"
+				help={ description }
+				label={ title }
+				onChange={ this.toggleSetting }
+				disabled={ this.props.isFetching }
+			/>
 		);
 	}
 }
 
-export default connect( null, { toggleWPcomEmailSetting } )( EmailCategory );
+export default connect(
+	( state ) => ( {
+		settings: getNotificationSettings( state, 'wpcom' ),
+		isFetching: isFetchingNotificationsSettings( state ),
+	} ),
+	{ toggleWPcomEmailSetting, saveSettings }
+)( EmailCategory );

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -144,18 +144,7 @@ class WPCOMNotifications extends Component {
 
 						<p>
 							{ this.props.translate(
-								'{{link}}Jetpack{{/link}} is a suite of tools connected to your WordPress site, like backups, security, and performance reports.',
-								{
-									components: {
-										link: (
-											<a
-												target="_blank"
-												rel="external noopener noreferrer"
-												href="https://jetpack.com/"
-											/>
-										),
-									},
-								}
+								'Jetpack is a suite of tools connected to your WordPress site, like backups, security, and performance reports.'
 							) }
 						</p>
 

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Card, LoadingPlaceholder } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { Component } from 'react';
@@ -9,18 +9,10 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
-import {
-	fetchSettings,
-	toggleWPcomEmailSetting,
-	saveSettings,
-} from 'calypso/state/notification-settings/actions';
-import {
-	getNotificationSettings,
-	hasUnsavedNotificationSettingsChanges,
-} from 'calypso/state/notification-settings/selectors';
+import { fetchSettings } from 'calypso/state/notification-settings/actions';
+import { getNotificationSettings } from 'calypso/state/notification-settings/selectors';
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 import Navigation from '../navigation';
-import ActionButtons from '../settings-form/actions';
 import SubscriptionManagementBackButton from '../subscription-management-back-button';
 import EmailCategory from './email-category';
 
@@ -54,14 +46,6 @@ class WPCOMNotifications extends Component {
 	componentDidMount() {
 		this.props.fetchSettings();
 	}
-
-	toggleSetting = ( setting ) => {
-		this.props.toggleWPcomEmailSetting( setting );
-	};
-
-	saveSettings = () => {
-		this.props.saveSettings( 'wpcom', this.props.settings );
-	};
 
 	renderWpcomPreferences = () => {
 		const { settings, translate } = this.props;
@@ -152,11 +136,28 @@ class WPCOMNotifications extends Component {
 					description={ translate( 'Complimentary reports regarding scheduled plugin updates.' ) }
 				/>
 
-				{ this.props.hasJetpackSites ? (
+				{ this.props.hasJetpackSites && (
 					<>
 						<FormSectionHeading>
 							{ this.props.translate( 'Email from Jetpack' ) }
 						</FormSectionHeading>
+
+						<p>
+							{ this.props.translate(
+								'{{link}}Jetpack{{/link}} is a suite of tools connected to your WordPress site, like backups, security, and performance reports.',
+								{
+									components: {
+										link: (
+											<a
+												target="_blank"
+												rel="external noopener noreferrer"
+												href="https://jetpack.com/"
+											/>
+										),
+									},
+								}
+							) }
+						</p>
 
 						<EmailCategory
 							name={ options.jetpack_marketing }
@@ -195,17 +196,13 @@ class WPCOMNotifications extends Component {
 							description={ translate( 'Jetpack security and performance reports.' ) }
 						/>
 					</>
-				) : (
-					''
 				) }
-
-				<ActionButtons onSave={ this.saveSettings } disabled={ ! this.props.hasUnsavedChanges } />
 			</div>
 		);
 	};
 
 	renderPlaceholder = () => {
-		return <p className="wpcom-settings__notification-settings-placeholder">&nbsp;</p>;
+		return <LoadingPlaceholder />;
 	};
 
 	render() {
@@ -221,7 +218,7 @@ class WPCOMNotifications extends Component {
 
 				<NavigationHeader
 					navigationItems={ [] }
-					title={ this.props.translate( 'Notification Settings' ) }
+					label={ this.props.translate( 'Notification Settings' ) }
 				/>
 
 				<Navigation path={ this.props.path } />
@@ -237,8 +234,7 @@ class WPCOMNotifications extends Component {
 export default connect(
 	( state ) => ( {
 		settings: getNotificationSettings( state, 'wpcom' ),
-		hasUnsavedChanges: hasUnsavedNotificationSettingsChanges( state, 'wpcom' ),
 		hasJetpackSites: hasJetpackSites( state ),
 	} ),
-	{ fetchSettings, toggleWPcomEmailSetting, saveSettings }
+	{ fetchSettings }
 )( localize( WPCOMNotifications ) );

--- a/client/me/notification-settings/wpcom-settings/style.scss
+++ b/client/me/notification-settings/wpcom-settings/style.scss
@@ -1,6 +1,3 @@
-.wpcom-settings__notification-settings-placeholder {
-	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: var(--color-neutral-0);
-	line-height: 1;
-	margin-bottom: 0.5em;
+.wpcom-settings__notification-settings-emailcategory {
+	margin-bottom: 20px;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13031

~TODO: saving doesn't work~

Each toggle saves the setting immediately. Disabled state while saving for sanity.

## Proposed Changes

* Uses toggles instead of checkboxes
* Updates loading placeholder to use component

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

**Before**
<img width="678" alt="image" src="https://github.com/user-attachments/assets/2c022e15-17fd-472e-ac04-09a2eaf654cd" />


**After**

<img width="640" alt="Screenshot 2025-05-14 at 13 29 35" src="https://github.com/user-attachments/assets/e1d40e6f-f87d-4033-b0cc-8dd9a6e8b1ea" />
<img width="806" alt="Screenshot 2025-05-14 at 13 51 56" src="https://github.com/user-attachments/assets/f73b9791-2b55-4962-a722-d79c97bfe210" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
