### PR TITLE
Add conversation id check

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -55,9 +55,9 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const { startNewInteraction } = useManageSupportInteraction();
 	const { data } = useSupportStatus();
 	const { data: openSupportInteractions, isLoading: isLoadingOpenSupportInteractions } =
-		useGetSupportInteractions( 'help-center', 1, 'open' );
+		useGetSupportInteractions( null, 1, 'open' );
 	const { data: resolvedSupportInteractions, isLoading: isLoadingResolvedSupportInteractions } =
-		useGetSupportInteractions( 'help-center', 1, 'resolved' );
+		useGetSupportInteractions( null, 1, 'resolved' );
 
 	const { currentSupportInteraction, navigateToRoute, isMinimized, allowPremiumSupport } =
 		useSelect( ( select ) => {

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -58,7 +58,8 @@ export const UserMessage = ( {
 	const showExtraContactOptions =
 		( hasFeedback && ! isPositiveFeedback ) || isRequestingHumanSupport;
 
-	const showDirectEscalationLink = userProvidedEnoughInformation( chat?.messages );
+	const showDirectEscalationLink =
+		! chat.conversationId && userProvidedEnoughInformation( chat?.messages );
 
 	const forwardMessage = isUserEligibleForPaidSupport
 		? ODIE_FORWARD_TO_ZENDESK_MESSAGE

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -41,6 +41,7 @@ export const useSendOdieMessage = () => {
 		odieBroadcastClientId,
 		setChatStatus,
 		setExperimentVariationName,
+		chat,
 		isUserEligibleForPaidSupport,
 		canConnectToZendesk,
 	} = useOdieAssistantContext();
@@ -48,7 +49,12 @@ export const useSendOdieMessage = () => {
 	const addMessage = ( message: Message | Message[], props?: Partial< Chat > ) => {
 		if ( ! Array.isArray( message ) ) {
 			const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support ?? false;
-			if ( isRequestingHumanSupport && canConnectToZendesk && isUserEligibleForPaidSupport ) {
+			if (
+				! chat.conversationId &&
+				isRequestingHumanSupport &&
+				canConnectToZendesk &&
+				isUserEligibleForPaidSupport
+			) {
 				newConversation( { createdFrom: 'automatic_escalation' } );
 				return;
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

This PR improves the help center checks.

In Help center content we were getting the open and resolved interactions by source: `help-center`.
However if we have interactions that created direct chats with support that source won't be present and it could lead to those getting ignored.

Also this PR adds checks for conversation id in the current chat before allowing direct escalation and automatic escalation which potentially can lead to interactions with multiple zendesk conversations. 


## Proposed Changes

* Add checks before direct and automatic escalation
* Avoid filtering by source for the last open and resolved interactions

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
