### PR TITLE
Reader: Remove unexpected scrollbar

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -51,18 +51,6 @@
 	}
 }
 
-html {
-	overflow-y: auto;
-}
-
-body.is-reader-page,
-.is-reader-page .layout,
-.layout.is-section-reader,
-.layout.is-section-reader .layout__content,
-.is-section-reader {
-	background: initial;
-}
-
 body.is-section-reader {
 	&.rtl .layout__content {
 		padding: calc(var(--masterbar-height) + var(--content-padding-top)) calc(var(--sidebar-width-max)) var(--content-padding-bottom) 16px;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -2,6 +2,16 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
+
+body.is-reader-page,
+.is-reader-page .layout,
+.layout.is-section-reader,
+.layout.is-section-reader .layout__content,
+.is-section-reader {
+	background: initial;
+	overflow-y: hidden;
+}
+
 body.is-section-reader {
 	div.layout.is-global-sidebar-visible {
 		.main {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-48

## Proposed Changes

* Remove unexpected scrollbar from all reader pages

## Why are these changes being made?
* UX consistency

Before
![CleanShot 2025-05-14 at 12 04 57@2x](https://github.com/user-attachments/assets/37018d09-72c0-4d77-b4bf-e5c210504c77)

After
![CleanShot 2025-05-14 at 12 06 15@2x](https://github.com/user-attachments/assets/9e829fa2-a207-49ed-8174-1108cbe8e35e)


## Testing Instructions

* Go to /reader
* Navigate by any lateral menu item
* Check that there is no scrollbar outside the content box. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
