### PR TITLE
Reader: Remove duplicated style importing

### DIFF
--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -8,11 +8,6 @@ import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import ReaderSidebarHelper from '../helper';
 
-/**
- * Styles
- */
-import '../style.scss';
-
 export class ReaderSidebarOrganizationsListItem extends Component {
 	static propTypes = {
 		site: PropTypes.object,

--- a/client/reader/sidebar/reader-sidebar-organizations/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list.jsx
@@ -15,7 +15,6 @@ import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants'
 import { toggleReaderSidebarOrganization } from 'calypso/state/reader-ui/sidebar/actions';
 import { isOrganizationOpen } from 'calypso/state/reader-ui/sidebar/selectors';
 import ReaderSidebarOrganizationsListItem from './list-item';
-import '../style.scss';
 
 export class ReaderSidebarOrganizationsList extends Component {
 	static propTypes = {

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import ReaderSidebarHelper from '../helper';
-import '../style.scss';
 
 export class ReaderSidebarTagsListItem extends Component {
 	static propTypes = {


### PR DESCRIPTION
## Proposed Changes
* Remove duplicated `style.scss` importing

## Why are these changes being made?
* The reader>sidebar is a composition of multiple internal components, and some of them were loading the same style file that the root component is loading, as you can see [here](https://github.com/Automattic/wp-calypso/blob/c67b7aaee954f4421f5ee07b8570e3911c7a404f/client/reader/sidebar/index.jsx#L53). It is unnecessary and is causing random issues with the hot reload feature.


## Testing Instructions
* Go to /reader
* Check if the sidebar is equal to the production version
* No visual change is expected


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
