### PR TITLE
My Home: Show notification when the user purchases the plan from the onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -24,6 +24,7 @@ import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { recordStepNavigation } from '../../internals/analytics/record-step-navigation';
+import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import type { FlowV2, ProvidedDependencies, SubmitHandler } from '../../internals/types';
@@ -86,6 +87,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		const coupon = useQuery().get( 'coupon' );
 
 		const [ useMyDomainTracksEventProps, setUseMyDomainTracksEventProps ] = useState( {} );
+		const { setShouldShowNotification } = usePurchasePlanNotification();
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -229,6 +231,7 @@ const onboarding: FlowV2< typeof initialize > = {
 				case 'create-site':
 					return navigate( 'processing', undefined, true );
 				case 'post-checkout-onboarding':
+					setShouldShowNotification( providedDependencies?.siteId as number );
 					return navigate( 'processing' );
 				case 'processing': {
 					const [ destination, backDestination ] =

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
@@ -40,7 +40,7 @@ export const usePurchasePlanNotification = (
 			successNotice(
 				sprintf(
 					/* translators: %(planName)s is the name of the plan, e.g. "Business Plan" */
-					__( "You're in! The %(planName)s plan is now active." ),
+					__( "You're in! The %(planName)s Plan is now active." ),
 					{ planName: plan?.getTitle() || '' }
 				)
 			)

--- a/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
@@ -1,0 +1,58 @@
+import { PLAN_FREE, getPlan } from '@automattic/calypso-products';
+import { useEffect } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
+
+const getStorageKey = ( siteId: number ): string => `show-purchase-plan-notification-${ siteId }`;
+
+type UsePurchasePlanNotificationReturn = {
+	setShouldShowNotification: ( siteId: number ) => void;
+};
+
+/**
+ * This hook is used to show a notification when a site is created with the purchase plan
+ * The notification is shown only once and is stored in the localStorage
+ */
+export const usePurchasePlanNotification = (
+	siteId?: number,
+	sitePlanSlug?: string
+): UsePurchasePlanNotificationReturn => {
+	const dispatch = useDispatch();
+	const { __ } = useI18n();
+
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		const storageKey = getStorageKey( siteId );
+		const shouldShowNotification = localStorage.getItem( storageKey ) === 'true';
+
+		if ( ! sitePlanSlug || sitePlanSlug === PLAN_FREE || ! shouldShowNotification ) {
+			return;
+		}
+
+		const plan = getPlan( sitePlanSlug );
+
+		dispatch(
+			successNotice(
+				sprintf(
+					/* translators: %(planName)s is the name of the plan, e.g. "Business Plan" */
+					__( "You're in! The %(planName)s plan is now active." ),
+					{ planName: plan?.getTitle() || '' }
+				)
+			)
+		);
+
+		// Reset the flag after showing the notification
+		localStorage.removeItem( storageKey );
+	}, [ dispatch, __, siteId, sitePlanSlug ] );
+
+	const setShouldShowNotification = ( siteId: number ) => {
+		localStorage.setItem( getStorageKey( siteId ), 'true' );
+	};
+
+	return { setShouldShowNotification };
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -130,7 +130,10 @@ const PostCheckoutOnboarding: StepType = ( { flow, navigation } ) => {
 			return providedDependencies;
 		} );
 
-		submit?.();
+		submit?.( {
+			siteId: site.ID,
+			siteSlug,
+		} );
 	}, [
 		site,
 		siteSlug,

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -1,10 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { PLAN_BUSINESS } from '@automattic/calypso-products';
 import { CircularProgressBar } from '@automattic/components';
 import {
 	updateLaunchpadSettings,
 	useSortedLaunchpadTasks,
-	useLaunchpad,
 	type OnboardSelect,
 } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
@@ -12,18 +10,20 @@ import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
+import { usePurchasePlanNotification } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { launchSiteApi } from 'calypso/lib/signup/step-actions';
 import { useDispatch } from 'calypso/state';
-import { successNotice } from 'calypso/state/notices/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import { useMyHomeCardLaunchpad } from '../cards/launchpad/use-my-home-card-launchpad';
+// import { usePurchasePlanNotification } from '../hooks/use-purchase-plan-notification';
 import './full-screen-launchpad.scss';
 
 export const FullScreenLaunchpad = ( {
@@ -39,30 +39,14 @@ export const FullScreenLaunchpad = ( {
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
 	const checklistSlug = site?.options?.site_intent ?? '';
-	const { data: launchpadData } = useLaunchpad( site?.slug || '' );
 	const layout = useHomeLayoutQuery( siteId || null );
 	const goals = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
 		[]
 	);
+	usePurchasePlanNotification( siteId, site?.plan?.product_slug );
 
 	const launchpadContext = 'focused-customer-home';
-
-	// Show success notice only once when the component first mounts
-	useEffect( () => {
-		if (
-			site &&
-			launchpadData &&
-			site?.plan?.product_slug === PLAN_BUSINESS &&
-			! launchpadData?.purchase_notification_shown
-		) {
-			dispatch( successNotice( __( "You're in! The Business Plan is now active." ) ) );
-			// Mark notification as shown
-			updateLaunchpadSettings( siteId, {
-				purchase_notification_shown: true,
-			} );
-		}
-	}, [ site, launchpadData ] );
 
 	const {
 		siteSlug,

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -23,7 +23,6 @@ import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import { useMyHomeCardLaunchpad } from '../cards/launchpad/use-my-home-card-launchpad';
-// import { usePurchasePlanNotification } from '../hooks/use-purchase-plan-notification';
 import './full-screen-launchpad.scss';
 
 export const FullScreenLaunchpad = ( {

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -1,22 +1,24 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
 import { CircularProgressBar } from '@automattic/components';
 import {
 	updateLaunchpadSettings,
 	useSortedLaunchpadTasks,
-	OnboardSelect,
+	useLaunchpad,
+	type OnboardSelect,
 } from '@automattic/data-stores';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { launchSiteApi } from 'calypso/lib/signup/step-actions';
 import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -37,6 +39,7 @@ export const FullScreenLaunchpad = ( {
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const site = useSelector( ( state: AppState ) => getSite( state, siteId ) );
 	const checklistSlug = site?.options?.site_intent ?? '';
+	const { data: launchpadData } = useLaunchpad( site?.slug || '' );
 	const layout = useHomeLayoutQuery( siteId || null );
 	const goals = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
@@ -44,6 +47,22 @@ export const FullScreenLaunchpad = ( {
 	);
 
 	const launchpadContext = 'focused-customer-home';
+
+	// Show success notice only once when the component first mounts
+	useEffect( () => {
+		if (
+			site &&
+			launchpadData &&
+			site?.plan?.product_slug === PLAN_BUSINESS &&
+			! launchpadData?.purchase_notification_shown
+		) {
+			dispatch( successNotice( __( "You're in! The Business Plan is now active." ) ) );
+			// Mark notification as shown
+			updateLaunchpadSettings( siteId, {
+				purchase_notification_shown: true,
+			} );
+		}
+	}, [ site, launchpadData ] );
 
 	const {
 		siteSlug,

--- a/client/my-sites/customer-home/components/full-screen-launchpad.tsx
+++ b/client/my-sites/customer-home/components/full-screen-launchpad.tsx
@@ -13,7 +13,6 @@ import clsx from 'clsx';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
-import { usePurchasePlanNotification } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { launchSiteApi } from 'calypso/lib/signup/step-actions';
@@ -43,7 +42,6 @@ export const FullScreenLaunchpad = ( {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals(),
 		[]
 	);
-	usePurchasePlanNotification( siteId, site?.plan?.product_slug );
 
 	const launchpadContext = 'focused-customer-home';
 

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -17,6 +17,7 @@ import useDomainDiagnosticsQuery from 'calypso/data/domains/diagnostics/use-doma
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layout-query';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
+import { usePurchasePlanNotification } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -101,6 +102,8 @@ const HomeContent = ( {
 	} );
 	const emailDnsDiagnostics = domainDiagnosticData?.email_dns_records;
 	const [ dismissedEmailDnsDiagnostics, setDismissedEmailDnsDiagnostics ] = useState( false );
+
+	usePurchasePlanNotification( siteId, site?.plan?.product_slug );
 
 	useEffect( () => {
 		if ( getQueryArgs().celebrateLaunch === 'true' && isSuccess ) {

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -46,7 +46,6 @@ export interface LaunchpadResponse {
 	is_dismissed: boolean;
 	is_dismissible: boolean;
 	title?: string | null;
-	purchase_notification_shown?: boolean;
 }
 
 type LaunchpadUpdateSettings = {
@@ -57,7 +56,6 @@ type LaunchpadUpdateSettings = {
 		dismissed_until?: number | null;
 	};
 	launchpad_screen?: 'off' | 'minimized' | 'full' | 'skipped';
-	purchase_notification_shown?: boolean;
 };
 
 export type UseLaunchpadOptions = {

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -46,6 +46,7 @@ export interface LaunchpadResponse {
 	is_dismissed: boolean;
 	is_dismissible: boolean;
 	title?: string | null;
+	purchase_notification_shown?: boolean;
 }
 
 type LaunchpadUpdateSettings = {
@@ -56,6 +57,7 @@ type LaunchpadUpdateSettings = {
 		dismissed_until?: number | null;
 	};
 	launchpad_screen?: 'off' | 'minimized' | 'full' | 'skipped';
+	purchase_notification_shown?: boolean;
 };
 
 export type UseLaunchpadOptions = {


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/98165

## Proposed Changes

* Created `usePurchasePlanNotification` hook for handling notification plan purchase
* Updated launchpad component to display a notice when the user purchases the Business plan.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* https://github.com/Automattic/wp-calypso/issues/98165

## Testing Instructions

* Go to `/setup/onboarding`
* Pass though the flow
* Once you ended up on the focus launchpad
* Check if there is a notification in the top-right corner

<img width="1340" alt="Screenshot 2025-05-14 at 15 09 17" src="https://github.com/user-attachments/assets/0b70e1d9-55f7-4a66-b24c-13ad27e2a8bd" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
