### PR TITLE
Add ESLint custom restricted syntax for useSelector object expressions

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -26,6 +26,15 @@ module.exports = {
 			},
 		],
 		'jest/no-mocks-import': 'off',
+		'no-restricted-syntax': [
+			'error',
+			{
+				selector:
+					'CallExpression[callee.name="useSelector"][arguments.0.body.type="ObjectExpression"]',
+				message:
+					'Object return values can cause unnecessary re-renders. Use separate useSelector calls instead.',
+			},
+		],
 	},
 	overrides: [
 		{

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -29,8 +29,10 @@ module.exports = {
 		'no-restricted-syntax': [
 			'error',
 			{
-				selector:
-					'CallExpression[callee.name="useSelector"][arguments.0.body.type="ObjectExpression"]',
+				selector: [
+					'CallExpression[callee.name="useSelector"] > ArrowFunctionExpression > :matches(ObjectExpression, ArrayExpression)',
+					'CallExpression[callee.name="useSelector"] > ArrowFunctionExpression > BlockStatement > ReturnStatement > :matches(ObjectExpression, ArrayExpression)',
+				].join(),
 				message:
 					'Object return values can cause unnecessary re-renders. Use separate useSelector calls instead.',
 			},

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -30,11 +30,11 @@ module.exports = {
 			'error',
 			{
 				selector: [
-					'CallExpression[callee.name="useSelector"] > ArrowFunctionExpression > :matches(ObjectExpression, ArrayExpression)',
-					'CallExpression[callee.name="useSelector"] > ArrowFunctionExpression > BlockStatement > ReturnStatement > :matches(ObjectExpression, ArrayExpression)',
+					'CallExpression[callee.name="useSelector"][arguments.length=1] > ArrowFunctionExpression > :matches(ObjectExpression, ArrayExpression)',
+					'CallExpression[callee.name="useSelector"][arguments.length=1] > ArrowFunctionExpression > BlockStatement > ReturnStatement > :matches(ObjectExpression, ArrayExpression)',
 				].join(),
 				message:
-					'Object return values can cause unnecessary re-renders. Use separate useSelector calls instead.',
+					'Object return values cause unnecessary re-renders. Use separate useSelector calls instead, or pass equalityFn to useSelector.',
 			},
 		],
 	},

--- a/client/blocks/reader-feed-header/follow.jsx
+++ b/client/blocks/reader-feed-header/follow.jsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, shallowEqual } from 'react-redux';
 import ReaderSiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import ReaderFollowButton from 'calypso/reader/follow-button';
@@ -48,7 +48,7 @@ export default function ReaderFeedHeaderFollow( props ) {
 				isWPForTeamsItem: isSiteWPForTeams( state, _siteId ) || isFeedWPForTeams( state, _feedId ),
 				subscriptionId: _feed?.subscription_id,
 			};
-		} );
+		}, shallowEqual );
 
 	const openSuggestedFollowsModal = ( followClicked ) => {
 		setIsSuggestedFollowsModalOpen( followClicked );

--- a/client/jetpack-cloud/sections/jetpack-social/promo.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/promo.jsx
@@ -39,12 +39,10 @@ export const Promo = ( { adminUrl, pluginInstallUrl, translate, siteId } ) => {
 		[ dispatch ]
 	);
 
-	const { hasPaidFeatures, isLoadingFeatures } = useSelector( ( state ) => {
-		return {
-			isLoadingFeatures: isRequestingSiteFeatures( state, siteId ),
-			hasPaidFeatures: siteHasFeature( state, siteId, FEATURE_SOCIAL_ENHANCED_PUBLISHING ),
-		};
-	} );
+	const isLoadingFeatures = useSelector( ( state ) => isRequestingSiteFeatures( state, siteId ) );
+	const hasPaidFeatures = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, FEATURE_SOCIAL_ENHANCED_PUBLISHING )
+	);
 
 	const product = slugToSelectorProduct( PRODUCT_JETPACK_SOCIAL_V1_YEARLY );
 

--- a/client/me/account/hooks/use-get-default-interface.ts
+++ b/client/me/account/hooks/use-get-default-interface.ts
@@ -11,10 +11,12 @@ export default function useGetDefaultInterface() {
 		( state ) => ! isSavingPreference( state ) && ! isFetchingPreferences( state )
 	);
 
-	const { sitesAsLandingPage, readerAsLandingPage } = useSelector( ( state ) => ( {
-		sitesAsLandingPage: getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage,
-		readerAsLandingPage: getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage,
-	} ) );
+	const sitesAsLandingPage = useSelector(
+		( state ) => getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage
+	);
+	const readerAsLandingPage = useSelector(
+		( state ) => getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage
+	);
 
 	if ( ! isReady ) {
 		return null;

--- a/client/me/account/toggle-landing-page.tsx
+++ b/client/me/account/toggle-landing-page.tsx
@@ -11,10 +11,12 @@ import { SITES_AS_LANDING_PAGE_PREFERENCE } from 'calypso/state/sites/selectors/
 function ToggleLandingPageSettings() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const { sitesAsLandingPage, readerAsLandingPage } = useSelector( ( state ) => ( {
-		sitesAsLandingPage: getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage,
-		readerAsLandingPage: getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage,
-	} ) );
+	const sitesAsLandingPage = useSelector(
+		( state ) => getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage
+	);
+	const readerAsLandingPage = useSelector(
+		( state ) => getPreference( state, 'reader-landing-page' )?.useReaderAsLandingPage
+	);
 
 	let selectedOption = 'default';
 	if ( sitesAsLandingPage ) {

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -111,11 +111,10 @@ const SubscriberDataViews = ( {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ filters, setFilters ] = useState< SubscribersFilterBy[] >( [ SubscribersFilterBy.All ] );
 	const [ selectedSubscriber, setSelectedSubscriber ] = useState< Subscriber | null >( null );
-	const { isSimple, isAtomic, isStaging } = useSelector( ( state ) => ( {
-		isSimple: isSimpleSite( state ),
-		isAtomic: isAtomicSite( state, siteId ),
-		isStaging: isSiteWpcomStaging( state, siteId ),
-	} ) );
+	const isSimple = useSelector( isSimpleSite );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isStaging = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
+
 	const couponsAndGiftsEnabled = useSelector( ( state ) =>
 		getCouponsAndGiftsEnabledForSiteId( state, siteId )
 	);

--- a/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
+++ b/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
@@ -15,12 +15,11 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 export const useAddSubscribersCallback = ( siteId: number | null ) => {
 	const { completedJob } = useActiveJobRecognition( siteId ?? 0 );
 	const importError = useImportError();
-	const { isJetpackNonAtomic, selectedSiteSlug } = useSelector( ( state ) => {
-		return {
-			isJetpackNonAtomic: isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ),
-			selectedSiteSlug: getSelectedSiteSlug( state ),
-		};
-	} );
+	const isJetpackNonAtomic = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const queryClient = useQueryClient();


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related: https://github.com/Automattic/wp-calypso/pull/103251#issuecomment-2880510379

## Proposed Changes

* Adds ESLint `no-restricted-syntax` rule to match and forbid use of `useSelector` with object expression return values

(see [AST Explorer playground](https://astexplorer.net/#/gist/743227b4a2220ab4563bcfed49389cba/787f1832969e7f225c0041cad0a1c7abf1063b33), [selector reference](https://eslint.org/docs/latest/extend/selectors))

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As noted in #103251, this pattern can cause unnecessary re-renders and log warnings in the browser, since object return values will always be strictly unequal to each other (`{} !== {}`)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify no regressions:

* Repeat Testing Instructions from #103135

Verify effective ESLint rule:

1. Revert changes to file: `git checkout trunk -- client/me/account/toggle-landing-page.tsx`
2. Run ESLint: `yarn eslint client/me/account/toggle-landing-page.tsx`
3. Observe error

```
/Code/wp-calypso/client/me/account/toggle-landing-page.tsx
  14:54  error  Object return values can cause unnecessary re-renders. Use separate useSelector calls instead  no-restricted-syntax
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
