### PR TITLE
Dashboard v2: Implement site visibility settings (basic cases)

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -116,11 +116,12 @@ export function siteSettingsQuery( siteId: string ) {
 export function siteSettingsMutation( siteId: string ) {
 	return {
 		mutationFn: ( newData: Partial< SiteSettings > ) => updateSiteSettings( siteId, newData ),
-		onSuccess: ( { updated }: { updated: Partial< SiteSettings > } ) => {
+		onSuccess: ( newData: Partial< SiteSettings > ) => {
 			queryClient.setQueryData( [ 'site-settings', siteId ], ( oldData: SiteSettings ) => ( {
 				...oldData,
-				...updated,
+				...newData,
 			} ) );
+			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 		},
 	};
 }

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -117,6 +117,19 @@ const siteSettingsRoute = createRoute( {
 	)
 );
 
+const siteSettingsSiteVisibilityRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/site-visibility',
+	loader: ( { params: { siteSlug } } ) =>
+		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+} ).lazy( () =>
+	import( '../sites/settings-site-visibility' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-site-visibility' )( {
+			component: d.default,
+		} )
+	)
+);
+
 const siteSettingsSubscriptionGiftingRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings/subscription-gifting',
@@ -293,6 +306,7 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteDeploymentsRoute,
 				sitePerformanceRoute,
 				siteSettingsRoute,
+				siteSettingsSiteVisibilityRoute,
 				siteSettingsSubscriptionGiftingRoute,
 			] )
 		);
@@ -347,6 +361,7 @@ export {
 	siteDeploymentsRoute,
 	sitePerformanceRoute,
 	siteSettingsRoute,
+	siteSettingsSiteVisibilityRoute,
 	siteSettingsSubscriptionGiftingRoute,
 	domainsRoute,
 	emailsRoute,

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -300,7 +300,7 @@ export const fetchSiteSettings = async ( siteIdOrSlug: string ): Promise< SiteSe
 		path: `/sites/${ siteIdOrSlug }/settings`,
 		apiVersion: '1.4',
 	} );
-	return settings;
+	return fromRawSiteSettings( settings );
 };
 
 export const updateSiteSettings = async ( siteIdOrSlug: string, data: Partial< SiteSettings > ) => {
@@ -309,10 +309,47 @@ export const updateSiteSettings = async ( siteIdOrSlug: string, data: Partial< S
 			path: `/sites/${ siteIdOrSlug }/settings`,
 			apiVersion: '1.4',
 		},
-		data
+		toRawSiteSettings( data )
 	);
-	return updated;
+	return fromRawSiteSettings( updated );
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function fromRawSiteSettings( settings: any ): SiteSettings {
+	const blog_public = Number( settings.blog_public );
+	const wpcom_coming_soon = Number( settings.wpcom_public_coming_soon );
+	const wpcom_public_coming_soon = Number( settings.wpcom_public_coming_soon );
+
+	if ( wpcom_coming_soon === 1 || wpcom_public_coming_soon === 1 ) {
+		settings.wpcom_site_visibility = 'coming-soon';
+	} else if ( blog_public === -1 ) {
+		settings.wpcom_site_visibility = 'private';
+	} else {
+		settings.wpcom_site_visibility = 'public';
+	}
+	return settings;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
+	const rawSettings = settings as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+	const { wpcom_site_visibility } = settings;
+
+	if ( wpcom_site_visibility !== undefined ) {
+		if ( wpcom_site_visibility === 'coming-soon' ) {
+			rawSettings.blog_public = 0;
+			rawSettings.wpcom_public_coming_soon = 1;
+		} else if ( wpcom_site_visibility === 'private' ) {
+			rawSettings.blog_public = -1;
+			rawSettings.wpcom_public_coming_soon = 0;
+		} else {
+			rawSettings.blog_public = 1;
+			rawSettings.wpcom_public_coming_soon = 0;
+		}
+	}
+	return rawSettings;
+}
 
 export const fetchBasicMetrics = async ( url: string ): Promise< BasicMetricsData > => {
 	return wpcom.req.get(

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -304,13 +304,14 @@ export const fetchSiteSettings = async ( siteIdOrSlug: string ): Promise< SiteSe
 };
 
 export const updateSiteSettings = async ( siteIdOrSlug: string, data: Partial< SiteSettings > ) => {
-	return await wpcom.req.post(
+	const { updated } = await wpcom.req.post(
 		{
 			path: `/sites/${ siteIdOrSlug }/settings`,
 			apiVersion: '1.4',
 		},
 		data
 	);
+	return updated;
 };
 
 export const fetchBasicMetrics = async ( url: string ): Promise< BasicMetricsData > => {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -140,10 +140,9 @@ export interface EngagementStats {
 }
 
 export interface SiteSettings {
-	blog_public?: number;
+	wpcom_site_visibility?: 'coming-soon' | 'public' | 'private';
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;
-	wpcom_public_coming_soon?: number;
 }
 
 export interface BasicMetricsData {

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -140,8 +140,10 @@ export interface EngagementStats {
 }
 
 export interface SiteSettings {
+	blog_public?: number;
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;
+	wpcom_public_coming_soon?: number;
 }
 
 export interface BasicMetricsData {

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -1,0 +1,40 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { Card, CardBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { siteQuery, siteSettingsMutation, siteSettingsQuery } from '../../app/queries';
+import { siteSettingsSiteVisibilityRoute } from '../../app/router';
+import PageLayout from '../../components/page-layout';
+import SettingsPageHeader from '../settings-page-header';
+import { LaunchForm } from './launch-form';
+import { PrivacyForm } from './privacy-form';
+
+export default function SiteVisibilitySettings() {
+	const { siteSlug } = siteSettingsSiteVisibilityRoute.useParams();
+	const { data: siteData } = useQuery( siteQuery( siteSlug ) );
+	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
+	const mutation = useMutation( siteSettingsMutation( siteSlug ) );
+
+	if ( ! settings || ! siteData ) {
+		return null;
+	}
+
+	const { site } = siteData;
+
+	return (
+		<PageLayout size="small">
+			<SettingsPageHeader
+				title={ __( 'Site visibility' ) }
+				description={ __( 'Control who can view your site.' ) }
+			/>
+			<Card>
+				<CardBody>
+					{ site.launch_status === 'unlaunched' ? (
+						<LaunchForm site={ site } />
+					) : (
+						<PrivacyForm settings={ settings } mutation={ mutation } />
+					) }
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -8,14 +8,6 @@ import { addQueryArgs } from '@wordpress/url';
 import type { Site } from '../../data/types';
 
 export function LaunchForm( { site }: { site: Site } ) {
-	const handleLaunch = () => {
-		window.location.href = addQueryArgs( '/start/launch-site', {
-			siteSlug: site.slug,
-			new: site.name,
-			hide_initial_query: 'yes',
-		} );
-	};
-
 	return (
 		<VStack spacing={ 4 } alignment="left">
 			<Text>
@@ -23,7 +15,15 @@ export function LaunchForm( { site }: { site: Site } ) {
 					'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
 				) }
 			</Text>
-			<Button __next40pxDefaultSize variant="primary" onClick={ handleLaunch }>
+			<Button
+				__next40pxDefaultSize
+				variant="primary"
+				href={ addQueryArgs( '/start/launch-site', {
+					siteSlug: site.slug,
+					new: site.name,
+					hide_initial_query: 'yes',
+				} ) }
+			>
 				{ __( 'Launch site' ) }
 			</Button>
 		</VStack>

--- a/client/dashboard/sites/settings-site-visibility/launch-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/launch-form.tsx
@@ -1,0 +1,31 @@
+import {
+	__experimentalText as Text,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import type { Site } from '../../data/types';
+
+export function LaunchForm( { site }: { site: Site } ) {
+	const handleLaunch = () => {
+		window.location.href = addQueryArgs( '/start/launch-site', {
+			siteSlug: site.slug,
+			new: site.name,
+			hide_initial_query: 'yes',
+		} );
+	};
+
+	return (
+		<VStack spacing={ 4 } alignment="left">
+			<Text>
+				{ __(
+					'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
+				) }
+			</Text>
+			<Button __next40pxDefaultSize variant="primary" onClick={ handleLaunch }>
+				{ __( 'Launch site' ) }
+			</Button>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -10,6 +10,39 @@ import type { SiteSettings } from '../../data/types';
 import type { Field, SimpleFormField } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
+const fields: Field< SiteSettings >[] = [
+	{
+		id: 'wpcom_site_visibility',
+		Edit: 'toggleGroup',
+		elements: [
+			{
+				label: __( 'Coming soon' ),
+				value: 'coming-soon',
+				description: __(
+					'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+				),
+			},
+			{
+				label: __( 'Public' ),
+				value: 'public',
+				description: __( 'Your site is visible to everyone.' ),
+			},
+			{
+				label: __( 'Private' ),
+				value: 'private',
+				description: __(
+					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+				),
+			},
+		],
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } as SimpleFormField ],
+};
+
 export function PrivacyForm( {
 	settings,
 	mutation,
@@ -28,37 +61,6 @@ export function PrivacyForm( {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-	};
-
-	let description;
-	if ( formData.wpcom_site_visibility === 'coming-soon' ) {
-		description = __(
-			'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-		);
-	} else if ( formData.wpcom_site_visibility === 'public' ) {
-		description = __( 'Your site is visible to everyone.' );
-	} else {
-		description = __(
-			'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-		);
-	}
-
-	const fields: Field< SiteSettings >[] = [
-		{
-			id: 'wpcom_site_visibility',
-			description,
-			Edit: 'toggleGroup',
-			elements: [
-				{ label: __( 'Coming soon' ), value: 'coming-soon' },
-				{ label: __( 'Public' ), value: 'public' },
-				{ label: __( 'Private' ), value: 'private' },
-			],
-		},
-	];
-
-	const form = {
-		type: 'regular' as const,
-		fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } as SimpleFormField ],
 		mutation.mutate( { ...formData } );
 	};
 

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -48,9 +48,9 @@ const fields: Field< SitePrivacy >[] = [
 						onChange( { [ id ]: newValue } );
 					} }
 				>
-					<ToggleGroupControlOption label="Coming soon" value="coming-soon" />
-					<ToggleGroupControlOption label="Public" value="public" />
-					<ToggleGroupControlOption label="Private" value="private" />
+					<ToggleGroupControlOption label={ __( 'Coming soon' ) } value="coming-soon" />
+					<ToggleGroupControlOption label={ __( 'Public' ) } value="public" />
+					<ToggleGroupControlOption label={ __( 'Private' ) } value="private" />
 				</ToggleGroupControl>
 			);
 		},

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -10,45 +10,6 @@ import type { SiteSettings } from '../../data/types';
 import type { Field, SimpleFormField } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
-interface SitePrivacy {
-	visibility: string;
-}
-
-function privacyToSettings( { visibility }: SitePrivacy ): Partial< SiteSettings > {
-	let blog_public;
-	let wpcom_public_coming_soon;
-
-	if ( visibility === 'public' ) {
-		blog_public = 1;
-		wpcom_public_coming_soon = 0;
-	} else if ( visibility === 'coming-soon' ) {
-		blog_public = 0;
-		wpcom_public_coming_soon = 1;
-	} else {
-		blog_public = -1;
-		wpcom_public_coming_soon = 0;
-	}
-
-	return { blog_public, wpcom_public_coming_soon };
-}
-
-function settingsToPrivacy( settings: Partial< SiteSettings > ): SitePrivacy {
-	const blog_public = Number( settings.blog_public );
-	const wpcom_public_coming_soon = Number( settings.wpcom_public_coming_soon );
-
-	let visibility;
-
-	if ( blog_public === 1 || ( blog_public === 0 && ! wpcom_public_coming_soon ) ) {
-		visibility = 'public';
-	} else if ( wpcom_public_coming_soon ) {
-		visibility = 'coming-soon';
-	} else {
-		visibility = 'private';
-	}
-
-	return { visibility };
-}
-
 export function PrivacyForm( {
 	settings,
 	mutation,
@@ -56,25 +17,24 @@ export function PrivacyForm( {
 	settings: SiteSettings;
 	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
 } ) {
-	const initialData = settingsToPrivacy( settings );
-	const [ formData, setFormData ] = useState< SitePrivacy >( initialData );
+	const [ formData, setFormData ] = useState( settings );
 
-	const isDirty = Object.entries( initialData ).some(
-		( [ key, value ] ) => formData[ key as keyof SitePrivacy ] !== value
+	const isDirty = Object.entries( settings ).some(
+		( [ key, value ] ) => formData[ key as keyof SiteSettings ] !== value
 	);
 	const { isPending } = mutation;
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( privacyToSettings( formData ) );
+		mutation.mutate( formData );
 	};
 
 	let description;
-	if ( formData.visibility === 'coming-soon' ) {
+	if ( formData.wpcom_site_visibility === 'coming-soon' ) {
 		description = __(
 			'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
 		);
-	} else if ( formData.visibility === 'public' ) {
+	} else if ( formData.wpcom_site_visibility === 'public' ) {
 		description = __( 'Your site is visible to everyone.' );
 	} else {
 		description = __(
@@ -82,9 +42,9 @@ export function PrivacyForm( {
 		);
 	}
 
-	const fields: Field< SitePrivacy >[] = [
+	const fields: Field< SiteSettings >[] = [
 		{
-			id: 'visibility',
+			id: 'wpcom_site_visibility',
 			description,
 			Edit: 'toggleGroup',
 			elements: [
@@ -97,17 +57,17 @@ export function PrivacyForm( {
 
 	const form = {
 		type: 'regular' as const,
-		fields: [ { id: 'visibility', labelPosition: 'none' } as SimpleFormField ],
+		fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } as SimpleFormField ],
 	};
 
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
-				<DataForm< SitePrivacy >
+				<DataForm< SiteSettings >
 					data={ formData }
 					fields={ fields }
 					form={ form }
-					onChange={ ( edits: Partial< SitePrivacy > ) => {
+					onChange={ ( edits: Partial< SiteSettings > ) => {
 						setFormData( ( data ) => ( { ...data, ...edits } ) );
 					} }
 				/>

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -17,16 +17,17 @@ export function PrivacyForm( {
 	settings: SiteSettings;
 	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
 } ) {
-	const [ formData, setFormData ] = useState( settings );
+	const [ formData, setFormData ] = useState( {
+		wpcom_site_visibility: settings.wpcom_site_visibility,
+	} );
 
-	const isDirty = Object.entries( settings ).some(
-		( [ key, value ] ) => formData[ key as keyof SiteSettings ] !== value
+	const isDirty = Object.entries( formData ).some(
+		( [ key, value ] ) => settings[ key as keyof SiteSettings ] !== value
 	);
 	const { isPending } = mutation;
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		mutation.mutate( formData );
 	};
 
 	let description;
@@ -58,6 +59,7 @@ export function PrivacyForm( {
 	const form = {
 		type: 'regular' as const,
 		fields: [ { id: 'wpcom_site_visibility', labelPosition: 'none' } as SimpleFormField ],
+		mutation.mutate( { ...formData } );
 	};
 
 	return (

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -1,0 +1,144 @@
+import { DataForm } from '@automattic/dataviews';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	Button,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import type { SiteSettings } from '../../data/types';
+import type { Field } from '@automattic/dataviews';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+interface SitePrivacy {
+	visibility: string;
+}
+
+const fields: Field< SitePrivacy >[] = [
+	{
+		id: 'visibility',
+		Edit: ( { field, onChange, data } ) => {
+			const { id, getValue } = field;
+			const value = getValue( { item: data } );
+
+			let help;
+			if ( value === 'coming-soon' ) {
+				help = __(
+					'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+				);
+			} else if ( value === 'public' ) {
+				help = __( 'Your site is visible to everyone.' );
+			} else {
+				help = __(
+					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+				);
+			}
+
+			return (
+				<ToggleGroupControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					isBlock
+					label=""
+					help={ help }
+					value={ value }
+					onChange={ ( newValue ) => {
+						onChange( { [ id ]: newValue } );
+					} }
+				>
+					<ToggleGroupControlOption label="Coming soon" value="coming-soon" />
+					<ToggleGroupControlOption label="Public" value="public" />
+					<ToggleGroupControlOption label="Private" value="private" />
+				</ToggleGroupControl>
+			);
+		},
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields,
+};
+
+function privacyToSettings( { visibility }: SitePrivacy ): Partial< SiteSettings > {
+	let blog_public;
+	let wpcom_public_coming_soon;
+
+	if ( visibility === 'public' ) {
+		blog_public = 1;
+		wpcom_public_coming_soon = 0;
+	} else if ( visibility === 'coming-soon' ) {
+		blog_public = 0;
+		wpcom_public_coming_soon = 1;
+	} else {
+		blog_public = -1;
+		wpcom_public_coming_soon = 0;
+	}
+
+	return { blog_public, wpcom_public_coming_soon };
+}
+
+function settingsToPrivacy( settings: Partial< SiteSettings > ): SitePrivacy {
+	const blog_public = Number( settings.blog_public );
+	const wpcom_public_coming_soon = Number( settings.wpcom_public_coming_soon );
+
+	let visibility;
+
+	if ( blog_public === 1 || ( blog_public === 0 && ! wpcom_public_coming_soon ) ) {
+		visibility = 'public';
+	} else if ( wpcom_public_coming_soon ) {
+		visibility = 'coming-soon';
+	} else {
+		visibility = 'private';
+	}
+
+	return { visibility };
+}
+
+export function PrivacyForm( {
+	settings,
+	mutation,
+}: {
+	settings: SiteSettings;
+	mutation: UseMutationResult< Partial< SiteSettings >, Error, Partial< SiteSettings >, unknown >;
+} ) {
+	const initialData = settingsToPrivacy( settings );
+	const [ formData, setFormData ] = useState< SitePrivacy >( initialData );
+
+	const isDirty = Object.entries( initialData ).some(
+		( [ key, value ] ) => formData[ key as keyof SitePrivacy ] !== value
+	);
+	const { isPending } = mutation;
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		mutation.mutate( privacyToSettings( formData ) );
+	};
+
+	return (
+		<form onSubmit={ handleSubmit }>
+			<VStack spacing={ 4 }>
+				<DataForm< SitePrivacy >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ ( edits: Partial< SitePrivacy > ) => {
+						setFormData( ( data ) => ( { ...data, ...edits } ) );
+					} }
+				/>
+				<HStack justify="flex-start">
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={ isPending }
+						disabled={ isPending || ! isDirty }
+					>
+						{ __( 'Save' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</form>
+	);
+}

--- a/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
+++ b/client/dashboard/sites/settings-site-visibility/privacy-form.tsx
@@ -2,65 +2,17 @@ import { DataForm } from '@automattic/dataviews';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import type { SiteSettings } from '../../data/types';
-import type { Field } from '@automattic/dataviews';
+import type { Field, SimpleFormField } from '@automattic/dataviews';
 import type { UseMutationResult } from '@tanstack/react-query';
 
 interface SitePrivacy {
 	visibility: string;
 }
-
-const fields: Field< SitePrivacy >[] = [
-	{
-		id: 'visibility',
-		Edit: ( { field, onChange, data } ) => {
-			const { id, getValue } = field;
-			const value = getValue( { item: data } );
-
-			let help;
-			if ( value === 'coming-soon' ) {
-				help = __(
-					'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
-				);
-			} else if ( value === 'public' ) {
-				help = __( 'Your site is visible to everyone.' );
-			} else {
-				help = __(
-					'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
-				);
-			}
-
-			return (
-				<ToggleGroupControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					isBlock
-					label=""
-					help={ help }
-					value={ value }
-					onChange={ ( newValue ) => {
-						onChange( { [ id ]: newValue } );
-					} }
-				>
-					<ToggleGroupControlOption label={ __( 'Coming soon' ) } value="coming-soon" />
-					<ToggleGroupControlOption label={ __( 'Public' ) } value="public" />
-					<ToggleGroupControlOption label={ __( 'Private' ) } value="private" />
-				</ToggleGroupControl>
-			);
-		},
-	},
-];
-
-const form = {
-	type: 'regular' as const,
-	fields,
-};
 
 function privacyToSettings( { visibility }: SitePrivacy ): Partial< SiteSettings > {
 	let blog_public;
@@ -115,6 +67,37 @@ export function PrivacyForm( {
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
 		mutation.mutate( privacyToSettings( formData ) );
+	};
+
+	let description;
+	if ( formData.visibility === 'coming-soon' ) {
+		description = __(
+			'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+		);
+	} else if ( formData.visibility === 'public' ) {
+		description = __( 'Your site is visible to everyone.' );
+	} else {
+		description = __(
+			'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+		);
+	}
+
+	const fields: Field< SitePrivacy >[] = [
+		{
+			id: 'visibility',
+			description,
+			Edit: 'toggleGroup',
+			elements: [
+				{ label: __( 'Coming soon' ), value: 'coming-soon' },
+				{ label: __( 'Public' ), value: 'public' },
+				{ label: __( 'Private' ), value: 'private' },
+			],
+		},
+	];
+
+	const form = {
+		type: 'regular' as const,
+		fields: [ { id: 'visibility', labelPosition: 'none' } as SimpleFormField ],
 	};
 
 	return (

--- a/client/dashboard/sites/settings-site-visibility/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/summary.tsx
@@ -9,7 +9,7 @@ export default function SiteVisibilitySettingsSummary( { site }: { site: Site } 
 	if ( site.launch_status === 'unlaunched' || site.is_coming_soon ) {
 		badges = [ { text: __( 'Coming soon' ), intent: 'warning' as const } ];
 	} else if ( site.is_private ) {
-		badges = [ { text: __( 'Private' ), intent: 'error' as const } ];
+		badges = [ { text: __( 'Private' ) } ];
 	} else {
 		badges = [ { text: __( 'Public' ), intent: 'success' as const } ];
 	}

--- a/client/dashboard/sites/settings-site-visibility/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/summary.tsx
@@ -1,0 +1,26 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { seen } from '@wordpress/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Site } from '../../data/types';
+
+export default function SiteVisibilitySettingsSummary( { site }: { site: Site } ) {
+	let badges = [];
+	if ( site.launch_status === 'unlaunched' || site.is_coming_soon ) {
+		badges = [ { text: __( 'Coming soon' ), intent: 'warning' as const } ];
+	} else if ( site.is_private ) {
+		badges = [ { text: __( 'Private' ), intent: 'error' as const } ];
+	} else {
+		badges = [ { text: __( 'Public' ), intent: 'success' as const } ];
+	}
+
+	return (
+		<RouterLinkSummaryButton
+			to={ `/sites/${ site.slug }/settings/site-visibility` }
+			title={ __( 'Site visibility' ) }
+			density="medium"
+			decoration={ <Icon icon={ seen } /> }
+			badges={ badges }
+		/>
+	);
+}

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -1,4 +1,6 @@
+import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { heading } from '@wordpress/icons';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { hasSubscriptionGiftingFeature } from './utils';
 import type { Site, SiteSettings } from '../../data/types';
@@ -20,6 +22,7 @@ export default function SubscriptionGiftingSettingsSummary( {
 			to={ `/sites/${ siteSlug }/settings/subscription-gifting` }
 			title={ __( 'Accept a gift subscription' ) }
 			density="medium"
+			decoration={ <Icon icon={ heading } /> }
 			badges={
 				settings.wpcom_gifting_subscription
 					? [ { text: __( 'Enabled' ), intent: 'success' as const } ]

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -9,6 +9,7 @@ import { siteQuery, siteSettingsQuery } from '../../app/queries';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
+import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
 
 export default function SiteSettings() {
@@ -20,15 +21,18 @@ export default function SiteSettings() {
 		return null;
 	}
 
+	const { site } = siteData;
+
 	return (
 		<PageLayout size="small">
 			<PageHeader title={ __( 'Settings' ) } />
-			<Heading>{ __( 'General' ) }</Heading>
+			<Heading level={ 2 }>{ __( 'General' ) }</Heading>
 			<Card>
 				<VStack>
+					<SiteVisibilitySettingsSummary site={ site } />
 					<SubscriptionGiftingSettingsSummary
 						siteSlug={ siteSlug }
-						site={ siteData.site }
+						site={ site }
 						settings={ settings }
 					/>
 				</VStack>

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -26,7 +26,7 @@ export default function SiteSettings() {
 	return (
 		<PageLayout size="small">
 			<PageHeader title={ __( 'Settings' ) } />
-			<Heading level={ 2 }>{ __( 'General' ) }</Heading>
+			<Heading>{ __( 'General' ) }</Heading>
 			<Card>
 				<VStack>
 					<SiteVisibilitySettingsSummary site={ site } />

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Add a new DataForm Edit control: `toggleGroup`, which renders a `<ToggleGroupControl />`.
+- Add a new DataForm Edit control: `toggleGroup`, which renders a `<ToggleGroupControl />`. If the field elements (options) have a `description`, then the selected option's description will be also rendered.
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 - Pin the actions column on the table view when the width is insufficient.

--- a/packages/dataviews/src/dataform-controls/toggle-group.tsx
+++ b/packages/dataviews/src/dataform-controls/toggle-group.tsx
@@ -30,13 +30,16 @@ export default function ToggleGroup< Item >( {
 	);
 
 	if ( field.elements ) {
+		const selectedOption = field.elements.find(
+			( el ) => el.value === value
+		);
 		return (
 			<ToggleGroupControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				isBlock
 				label={ field.label }
-				help={ field.description }
+				help={ selectedOption?.description || field.description }
 				onChange={ onChangeControl }
 				value={ value }
 				hideLabelFromVision={ hideLabelFromVision }


### PR DESCRIPTION
Part of DOTCOM-13099

## Proposed Changes

This PR implements the very basic cases of Settings -> Site visibility.

The form controls (`ToggleGroupControl`s) are chosen to support conditional fields later. See this Slack discussion for more context: p1747231629871859-slack-C08JZTRS6NA

|<img width="654" alt="image" src="https://github.com/user-attachments/assets/3bdae12d-29f5-4053-ba33-4c9edec43cb8" />|<img width="645" alt="image" src="https://github.com/user-attachments/assets/e53a963f-77b2-4eb8-b960-5b3d38d7454d" />|
|-|-|

### `SummaryButton` states

|Case|Screenshot|
|-|-|
|Unlaunched/coming soon|<img width="500" src="https://github.com/user-attachments/assets/10063abc-b629-444d-9711-80c8da57073c">|
|Public|<img width="500" src="https://github.com/user-attachments/assets/60a3d0dc-609d-4356-85cc-204806480ac8">|
|Private|<img width="500" src="https://github.com/user-attachments/assets/084cba15-fdf1-4f0c-b093-bf31f5541e37">

### Form states

|Case|Screenshot|
|-|-|
|Unlaunched|<img width="500" src="https://github.com/user-attachments/assets/80f0bf31-85a0-4330-bde8-562350b708f0">|
|Coming soon|<img width="500" src="https://github.com/user-attachments/assets/c1944a29-f210-4fd0-a2b4-db6f09540d4c">|
|Public|<img width="500" src="https://github.com/user-attachments/assets/90ea52d5-c5ac-4629-804a-ffd053407207">|
|Private|<img width="500" src="https://github.com/user-attachments/assets/cd4b73dc-642e-44dc-b186-3f721b22bd33">|

### Out of Scope

The following are intentionally not implemented yet in this PR:

- Showing the conditional fields (e.g. "Discourage search engine")
- Showing notices after the form is successfully submitted
- Support for more complex site types (staging sites, A4A sites, ...)

## Testing Instructions

1. It's best to test with a brand new site
2. Go to `/v2/sites`
3. Click that site
4. Go to Settings -> Site visibility
5. Launch the site
6. Finish the flow and go back to the form
7. Try updating the site visibility; verify no bug.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?