### PR TITLE
Help Center: Add scope to CSS

### DIFF
--- a/apps/help-center/help-center.scss
+++ b/apps/help-center/help-center.scss
@@ -1,21 +1,6 @@
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/calypso-color-schemes";
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-caption,
-figcaption,
-p,
-ul,
-ol,
-blockquote {
-	text-wrap: pretty;
-}
-
 .help-center.entry-point-button {
 	&.is-active {
 		background: #1e1e1e;
@@ -49,6 +34,21 @@ blockquote {
 }
 
 .help-center__container {
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	caption,
+	figcaption,
+	p,
+	ul,
+	ol,
+	blockquote {
+		text-wrap: pretty;
+	}
+
 	&.is-mobile {
 		&.is-minimized {
 			margin-top: 0;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTUSER-3/improper-css-scoping-for-help-center-css-file

## Proposed Changes

- Add a scope to the CSS added by the Help Center (introduced recently [here](https://github.com/Automattic/wp-calypso/pull/102646))

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The CSS was modifying the websites pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox widgets
* `yarn dev --sync` from `apps/help-center`
* Visit a page in wp-admin and the CSS shouldn't be in the page, but only inside the Help Center.


