### PR TITLE
Support import state

### DIFF
--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -7,10 +7,11 @@ import type { ImportJob } from '../../types';
 
 interface Props {
 	job?: ImportJob;
+	showHeading?: boolean;
 }
 const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { job } = props;
+	const { job, showHeading } = props;
 	const { customData } = job || {};
 	const progressValue = useProgressValue( job?.progress );
 
@@ -39,6 +40,24 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 	const title =
 		job?.importerFileType !== 'playground' ? __( 'Importing' ) : getPlaygroundImportTitle();
 
+	if ( showHeading ) {
+		return (
+			<div className="import-layout__center">
+				<Progress>
+					<div className="import__heading import__heading-center">
+						<Title>{ title }...</Title>
+						<ProgressBar compact value={ progressValue } />
+						<SubTitle>
+							{ __(
+								'Feel free to close this window. We’ll email you when your new site is ready.'
+							) }
+						</SubTitle>
+					</div>
+				</Progress>
+			</div>
+		);
+	}
+
 	return (
 		<Progress>
 			<div className="import__heading import__heading-center">
@@ -48,19 +67,6 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 				</SubTitle>
 			</div>
 		</Progress>
-	);
-	return (
-		<div className="import-layout__center">
-			<Progress>
-				<div className="import__heading import__heading-center">
-					<Title>{ title }...</Title>
-					<ProgressBar compact value={ progressValue } />
-					<SubTitle>
-						{ __( 'Feel free to close this window. We’ll email you when your new site is ready.' ) }
-					</SubTitle>
-				</div>
-			</Progress>
-		</div>
 	);
 };
 

--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -40,6 +40,16 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 		job?.importerFileType !== 'playground' ? __( 'Importing' ) : getPlaygroundImportTitle();
 
 	return (
+		<Progress>
+			<div className="import__heading import__heading-center">
+				<ProgressBar compact value={ progressValue } />
+				<SubTitle>
+					{ __( 'Feel free to close this window. We’ll email you when your new site is ready.' ) }
+				</SubTitle>
+			</div>
+		</Progress>
+	);
+	return (
 		<div className="import-layout__center">
 			<Progress>
 				<div className="import__heading import__heading-center">

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -107,7 +107,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 					} else if ( checkIsFailed() ) {
 						return <ErrorMessage onPrimaryBtnClick={ onTryAgainClick } />;
 					} else if ( checkProgress() ) {
-						return <ProgressScreen job={ job } />;
+						return <ProgressScreen job={ job } showHeading={ renderHeading } />;
 					}
 
 					/**

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -107,7 +107,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 					} else if ( checkIsFailed() ) {
 						return <ErrorMessage onPrimaryBtnClick={ onTryAgainClick } />;
 					} else if ( checkProgress() ) {
-						return <ProgressScreen job={ job } />;
+						return <ProgressScreen job={ job } showHeading={ renderHeading } />;
 					}
 
 					/**

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -146,7 +146,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 				'import__error-message': renderState === 'error',
 			} ) }
 		>
-			{ renderState === 'progress' && <ProgressScreen job={ job } /> }
+			{ renderState === 'progress' && <ProgressScreen job={ job } showHeading={ renderHeading } /> }
 
 			{ renderState === 'error' && (
 				<ErrorMessage

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -245,11 +245,15 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 				appStates.MAP_AUTHORS,
 				appStates.READY_FOR_UPLOAD,
 				appStates.UPLOAD_PROCESSING,
+				appStates.UPLOAD_SUCCESS,
 				appStates.UPLOADING,
+				appStates.IMPORTING,
 			];
 			const showHeading = statesToShowHeading.includes( importJob?.importerState ?? '' );
 			const showBackButton = importJob?.importerState !== appStates.IMPORT_SUCCESS;
 			const showSkipButton = importJob?.importerState === appStates.IMPORT_SUCCESS;
+			const title =
+				importJob?.importerState === appStates.IMPORTING ? __( 'Importing' ) : importerData.title;
 			return (
 				<>
 					<QuerySites siteId={ siteId } />
@@ -278,9 +282,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 							/>
 						}
 						heading={
-							showHeading && (
-								<Step.Heading text={ importerData.title } subText={ importerData.description } />
-							)
+							showHeading && <Step.Heading text={ title } subText={ importerData.description } />
 						}
 					>
 						{ renderStepContent() }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,7 +110,7 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-import-flow": false,
+		"onboarding/step-container-v2-import-flow": true,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,7 +110,7 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/step-container-v2-import-flow": true,
+		"onboarding/step-container-v2-import-flow": false,
 		"onboarding/step-container-v2-migration-flow": true,
 		"onboarding/trail-map-feature-grid-copy": false,
 		"onboarding/trail-map-feature-grid-structure": false,

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -4,7 +4,7 @@ import { DataHelper } from '../..';
 const selectors = {
 	// Generic
 	button: ( text: string ) => `button:text("${ text }")`,
-	backLink: '.navigation-link:text("Back")',
+	backLink: '.navigation-link:text("Back"), .step-container-v2__back-button:text("Back")',
 	dontHaveASiteButton: 'button:text-matches("choose a content platform", "i")',
 	migrationModalCancel: 'button.action-buttons__cancel',
 	// Inputs

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -19,7 +19,8 @@ const selectors = {
 
 	// Headers
 	setupHeader: 'h1:text("Themes")',
-	startBuildingHeader: ( text: string ) => `h1.onboarding-title:text("${ text }")`,
+	startBuildingHeader: ( text: string ) =>
+		`step-container-v2__heading h1:text("${ text }"), h1.onboarding-title:text("${ text }")`,
 
 	importModal: 'div.import__confirm-modal',
 

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -20,7 +20,7 @@ const selectors = {
 	// Headers
 	setupHeader: 'h1:text("Themes")',
 	startBuildingHeader: ( text: string ) =>
-		`step-container-v2__heading h1:text("${ text }"), h1.onboarding-title:text("${ text }")`,
+		`.step-container-v2__heading h1:text("${ text }"), h1.onboarding-title:text("${ text }")`,
 
 	importModal: 'div.import__confirm-modal',
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTOBRD-129

## Proposed Changes

Implement the IMPORTING state to use the container v2 heading. 

Also fixed some e2e tests. For the time being, verifying that CI passes is enough, since the changes are still behind a feature flag.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
These are before/after screenshots for Squarespace, but they should look similar for all other importers

|before|after|
|-|-|
|<img width="1474" alt="image" src="https://github.com/user-attachments/assets/d42455d2-0858-442d-917b-5d005f317be7" />|<img width="1357" alt="image" src="https://github.com/user-attachments/assets/bc09d0f2-1bb4-4f2f-85b6-213e9f796e1a" />|


* Use the calypso.live link below
* Go to /sites
* Click on `Import` in the `Add new site` CTA <img width="918" alt="image" src="https://github.com/user-attachments/assets/bbf80f7c-6040-4767-bacc-577b0cddfa95" />
* For each of the modified options (WordPress, Blogger, Medium, Squarespace)
  * You might need to enable the feature flag. You can do that by adding the `flags=onboarding%2Fstep-container-v2-import-flow` query arg to the URL and reload
  * Go through the import flow, upload a file and verify everything looks and works as expected on Container v2, especially, the progress step, after starting the import.
 
You can find demo exports files in this comment: p1747238407341339-slack-C02G2HLNB1R

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?