### PR TITLE
Remove extra help link from the importer error notice

### DIFF
--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -73,7 +73,7 @@ class ImporterError extends PureComponent {
 		);
 
 		const generalMessage = this.props.translate(
-			'%(errorDescription)s{{br/}}Make sure you are using a valid export file in XML or ZIP format. {{cs}}Still need help{{/cs}}?',
+			'%(errorDescription)s{{br/}}Make sure you are using a valid export file in XML or ZIP format.',
 			{
 				args: {
 					errorDescription: description.length ? description : defaultError,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCON-36

## Proposed Changes

This removes the 'Still need help' link from the importer error notice in stepper.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The 'Still need help' link takes the user out of the flow. There's already a 'Need help exporting' link below that keeps the user in stepper.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this locally or use the calypso.live url.
* Go to `/start` and pick the 'Import or migrate' intent on the Goals step.
* On the site identification step, click 'pick your current platform from a list'
![CleanShot 2025-05-14 at 13 28 39@2x](https://github.com/user-attachments/assets/8e37cd54-8e79-4a94-b831-1b20029310cf)
* Pick Squarespace.
* Upload any file that _isn't_ a valid Squarespace export file. Blogger export files are a good choice (like this one p1747238407341339-slack-C02G2HLNB1R)
* Verify that the error notice does _not_ have a 'Still need help link'
![image](https://github.com/user-attachments/assets/7cd63d80-5bb9-434f-a6b3-a6a62e435a3b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?