### PR TITLE
Stats: Fix tabs margin on mobile and a couple other small styling fixes

### DIFF
--- a/client/blocks/stats-navigation/page-module-toggler.scss
+++ b/client/blocks/stats-navigation/page-module-toggler.scss
@@ -6,7 +6,7 @@
 
 	// Add gap for not open .section-nav on tablet and mobile.
 	@media (max-width: $break-small) {
-		padding-right: 4px;
+		padding-right: 0;
 	}
 
 	button {

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -6,7 +6,7 @@
 	// When the feature flag is enabled, adjust TabPanel padding
 	.stats-navigation__tabs {
 		margin: 0 -16px;  // This creates a negative margin to counteract the parent's padding
-		
+
 		.components-tab-panel__tabs {
 			padding: 0 16px;  // This sets the actual padding to 16px
 		}
@@ -61,8 +61,6 @@
 			}
 
 			@media (max-width: $break-small) {
-				margin-left: 0;
-				
 				.components-tab-panel__tabs {
 					padding-left: 16px;
 					padding-right: 16px;

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -66,6 +66,9 @@ $sidebar-appearance-break-point: $break-medium;
 		@media (max-width: $break-small) {
 			padding-top: 16px;
 			padding-inline: 16px;
+			.stats-download-csv {
+				padding-right: 0;
+			}
 		}
 
 		@media (max-width: $break-mobile) {

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -272,7 +272,7 @@ ul.module-tabs {
 		}
 
 		.stats-interval-dropdown, .stats-interval-display {
-			margin-left: 48px;
+			margin-left: auto;
 
 			& > .components-button {
 				width: auto;

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -77,8 +77,6 @@
 		}
 
 		@media (max-width: $break-small) {
-			margin-left: 0;
-
 			.components-tab-panel__tabs {
 				padding-left: 16px;
 				padding-right: 16px;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Minor styling tweaks after talking with @ederrengifo 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Polishing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:

https://github.com/user-attachments/assets/36e04705-4e1e-442c-89fb-076c511929f9

After:

https://github.com/user-attachments/assets/07e8e840-13b3-4985-95d1-38ed588244df

| Before | After |
|-------|-------|
| <img width="491" alt="image" src="https://github.com/user-attachments/assets/6af9d956-0278-47d0-bd03-9d774c525020" />| <img width="489" alt="image" src="https://github.com/user-attachments/assets/d5488719-182d-4151-befb-37929728e209" />|

| Before | After |
|-------|-------|
| <img width="431" alt="image" src="https://github.com/user-attachments/assets/3ba07969-88f3-4aef-bc96-389803c0230f" /> | ![image](https://github.com/user-attachments/assets/27ee1dac-80a3-4b9a-8d52-12b3799e22a1) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
