### PR TITLE
Fix Woo login layout issues

### DIFF
--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -106,9 +106,7 @@ export function getHeaderText(
 
 	if ( action === 'lostpassword' ) {
 		headerText = translate( 'Forgot your password?' );
-	}
-
-	if ( oauth2Client ) {
+	} else if ( oauth2Client ) {
 		if ( isWCCOM ) {
 			if ( wccomFrom === 'cart' ) {
 				headerText = translate( 'Log in with a WordPress.com account' );
@@ -173,9 +171,7 @@ export function getHeaderText(
 		if ( isBlazeProOAuth2Client( oauth2Client ) ) {
 			headerText = translate( 'Log in to your Blaze Pro account' );
 		}
-	}
-
-	if ( isWooJPC ) {
+	} else if ( isWooJPC ) {
 		const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';
 		if ( isLostPasswordFlow ) {
 			headerText = translate( "You've got mail" );
@@ -184,13 +180,9 @@ export function getHeaderText(
 		} else {
 			headerText = translate( 'Log in to your account' );
 		}
-	}
-
-	if ( isFromMigrationPlugin ) {
+	} else if ( isFromMigrationPlugin ) {
 		headerText = translate( 'Log in to your account' );
-	}
-
-	if ( isJetpack && ! isFromAutomatticForAgenciesPlugin ) {
+	} else if ( isJetpack && ! isFromAutomatticForAgenciesPlugin ) {
 		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
 		headerText = isJetpackMagicLinkSignUpFlow
 			? translate(

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -177,13 +177,12 @@ export function getHeaderText(
 
 	if ( isWooJPC ) {
 		const isLostPasswordFlow = currentQuery.lostpassword_flow === 'true';
-		switch ( true ) {
-			case isLostPasswordFlow:
-				headerText = translate( "You've got mail" );
-			case twoFactorEnabled:
-				headerText = translate( 'Authenticate your login' );
-			default:
-				headerText = translate( 'Log in to your account' );
+		if ( isLostPasswordFlow ) {
+			headerText = translate( "You've got mail" );
+		} else if ( twoFactorEnabled ) {
+			headerText = translate( 'Authenticate your login' );
+		} else {
+			headerText = translate( 'Log in to your account' );
 		}
 	}
 
@@ -443,36 +442,32 @@ export function LoginHeader( {
 		);
 		let subtitle = null;
 
-		switch ( true ) {
-			case isLostPasswordFlow:
-				header = <h3>{ headerText }</h3>;
-
-				subtitle = translate(
-					"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
-				);
-				break;
-			case isTwoFactorAuthFlow:
-				header = <h3>{ headerText }</h3>;
-				break;
-			default:
-				header = <h3>{ headerText }</h3>;
-				subtitle = translate(
-					'To access all of the features and functionality %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
-					{
-						components: {
-							signupLink,
-							br: <br />,
-							doc: (
-								<a
-									href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-						},
-						args: { pluginName },
-					}
-				);
+		if ( isLostPasswordFlow ) {
+			header = <h3>{ headerText }</h3>;
+			subtitle = translate(
+				"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
+			);
+		} else if ( isTwoFactorAuthFlow ) {
+			header = <h3>{ headerText }</h3>;
+		} else {
+			header = <h3>{ headerText }</h3>;
+			subtitle = translate(
+				'To access all of the features and functionality %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
+				{
+					components: {
+						signupLink,
+						br: <br />,
+						doc: (
+							<a
+								href="https://woocommerce.com/document/connect-your-store-to-a-wordpress-com-account/"
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+					args: { pluginName },
+				}
+			);
 		}
 		preHeader = null;
 		postHeader = <p className="login__header-subtitle">{ subtitle }</p>;

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -432,16 +432,14 @@ export function LoginHeader( {
 			new URLSearchParams( initialQuery?.redirect_to ).get( 'plugin_name' ),
 			translate
 		);
+		header = <h3>{ headerText }</h3>;
 		let subtitle = null;
 
 		if ( isLostPasswordFlow ) {
-			header = <h3>{ headerText }</h3>;
 			subtitle = translate(
 				"Your password reset confirmation is on its way to your email address – please check your junk folder if it's not in your inbox! Once you've reset your password, head back to this page to log in to your account."
 			);
-		} else if ( isTwoFactorAuthFlow ) {
-			header = <h3>{ headerText }</h3>;
-		} else {
+		} else if ( ! isTwoFactorAuthFlow ) {
 			header = <h3>{ headerText }</h3>;
 			subtitle = translate(
 				'To access all of the features and functionality %(pluginName)s, you’ll first need to connect your store to a WordPress.com account. Log in now, or {{signupLink}}create a new account{{/signupLink}}. For more information, please {{doc}}review our documentation{{/doc}}.',
@@ -461,7 +459,6 @@ export function LoginHeader( {
 				}
 			);
 		}
-		preHeader = null;
 		postHeader = <p className="login__header-subtitle">{ subtitle }</p>;
 	} else if ( isJetpack && ! isFromAutomatticForAgenciesPlugin ) {
 		preHeader = <p className="login__jetpack-pre-header">{ translate( 'Log in or sign up' ) }</p>;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -332,12 +332,16 @@ export default withCurrentRoute(
 			const isWPJobManager = isWPJobManagerOAuth2Client( oauth2Client );
 			const isBlazePro = getIsBlazePro( state );
 			const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
-			const isWPComLogin =
-				currentRoute.startsWith( '/log-in' ) &&
-				! isJetpackLogin &&
-				Boolean( currentQuery?.client_id ) === false;
 			const isPartnerPortal = isPartnerPortalOAuth2Client( oauth2Client );
-			const isWhiteLogin = isWPComLogin || isPartnerPortal;
+			const isWooJPC = isWooJPCFlow( state );
+
+			const isWhiteLogin =
+				( ! isJetpackLogin &&
+					Boolean( currentQuery?.client_id ) === false &&
+					Boolean( currentQuery?.oauth2_client_id ) === false &&
+					! isWooJPC ) ||
+				isPartnerPortal;
+
 			const noMasterbarForRoute =
 				isJetpackLogin ||
 				( isWhiteLogin && ! isBlazePro ) ||
@@ -348,7 +352,6 @@ export default withCurrentRoute(
 				! isWooOAuth2Client( oauth2Client ) &&
 				! isBlazeProOAuth2Client( oauth2Client ) &&
 				[ 'signup', 'jetpack-connect' ].includes( sectionName );
-			const isWooJPC = isWooJPCFlow( state );
 			const wccomFrom = getWccomFrom( state );
 			const masterbarIsHidden =
 				! ( currentSection || currentRoute ) ||

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -62,9 +62,13 @@ const enhanceContextWithLogin = ( context ) => {
 		getOAuth2Client( context.store.getState(), Number( clientId || oauth2ClientId ) ) || {};
 	const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
 	const isPartnerPortalClient = isPartnerPortalOAuth2Client( oauth2Client );
+	const isWooJPC = isWooJPCFlow( context.store.getState() );
 
 	const isWhiteLogin =
-		( ! isJetpackLogin && Boolean( clientId ) === false && Boolean( oauth2ClientId ) === false ) ||
+		( ! isJetpackLogin &&
+			Boolean( clientId ) === false &&
+			Boolean( oauth2ClientId ) === false &&
+			! isWooJPC ) ||
 		isPartnerPortalClient;
 
 	context.primary = (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up from #102811 and #102353.

As per @jsnajdr's [comment](https://github.com/Automattic/wp-calypso/pull/102811#issuecomment-2879009245), a few of the Woo login screens look a bit broken after my recent changes. 

This PR fixes those issues by making sure WooJPC screens don't  accidentally get treated as `isWhiteLogin`. It also fixes the faulty switch statement that was causing some incorrect headings.

The screens in question can be directly reached with the following URLs:

http://calypso.localhost:3000/log-in?from=woocommerce-onboarding&lostpassword_flow=true

http://calypso.localhost:3000/log-in?from=woocommerce-core-profiler

Because I don't know how a regular user would reach these URLs (they're different from both login and get started > wordpress.com flows available from https://woocommerce.com/), I'm not sure if they would ever display exactly in that shape. Given one of the conditions for `isWhiteLogin` to be true is the query not containing a `client_id`, if the path to those screens were to inject that query parameter they would display differently.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the above linked screens display with only one header and that their headings make sense:

<img width="1043" alt="Screenshot 2025-05-15 at 12 49 34 pm" src="https://github.com/user-attachments/assets/35e73c0f-d904-4289-9bd7-114561033cfc" />

<img width="1050" alt="Screenshot 2025-05-15 at 12 53 37 pm" src="https://github.com/user-attachments/assets/6de8129d-6f18-44f0-a8da-48101a492c43" />

(The weird blue line at the top of the second one is a `masterbar__progress-bar` and I'm not sure why it displays there but it seems unrelated to my PRs)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
