### PR TITLE
Plugins: Update layout and remove components in plugin sidebar.

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -365,12 +365,8 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						) }
 					</div>
 				) }
-				{ ! plugin.isSaasProduct && shouldUpgrade && isLoggedIn && selectedSite && (
-					<UpgradeRequiredContent translate={ translate } />
-				) }
 				{ plugin.isSaasProduct && shouldUpgrade && isLoggedIn && selectedSite && (
 					<div className="plugin-details-cta__upgrade-required-card">
-						<UpgradeRequiredContent translate={ translate } />
 						<Button
 							href={ upgradeToBusinessHref }
 							className="plugin-details-cta__install-button"
@@ -556,21 +552,6 @@ function FreePrice( { shouldUpgrade } ) {
 				</span>
 			) }
 		</>
-	);
-}
-
-function UpgradeRequiredContent( { translate } ) {
-	return (
-		<div className="plugin-details-cta__upgrade-required">
-			<span className="plugin-details-cta__upgrade-required-icon">
-				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
-				<Gridicon icon="notice-outline" size={ 20 } />
-				{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-			</span>
-			<span className="plugin-details-cta__upgrade-required-text">
-				{ translate( 'You need to upgrade your plan to install plugins.' ) }
-			</span>
-		</div>
 	);
 }
 

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon, Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { Fragment, useState, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
@@ -167,6 +167,39 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 			span: <span className="plugin-details-cta__installed-text-inactive"></span>,
 		},
 	} );
+
+	const getTermsAndConditions = () => {
+		const translateArgs = {
+			components: {
+				a: (
+					<a
+						target="_blank"
+						rel="noopener noreferrer"
+						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+					/>
+				),
+				thirdPartyTos: (
+					<a
+						target="_blank"
+						rel="noopener noreferrer"
+						href="https://wordpress.com/third-party-plugins-terms/"
+					/>
+				),
+			},
+		};
+
+		return fixMe( {
+			text: 'By installing, you agree to {{a}}WordPress.com Terms of Service{{/a}} and {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
+			newCopy: translate(
+				'By installing, you agree to {{a}}WordPress.com Terms of Service{{/a}} and {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
+				translateArgs
+			),
+			oldCopy: translate(
+				'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
+				translateArgs
+			),
+		} );
+	};
 
 	// If we cannot retrieve plugin status through jetpack ( ! isJetpack ) and plugin is preinstalled.
 	if ( ! isJetpack && PREINSTALLED_PLUGINS.includes( plugin.slug ) ) {
@@ -341,29 +374,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 				</div>
 				{ isDisabledForWpcomStaging && <StagingSiteNotice plugin={ plugin } /> }
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
-					<div className="plugin-details-cta__t-and-c">
-						{ translate(
-							'By installing, you agree to {{a}}WordPress.com Terms of Service{{/a}} and {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
-							{
-								components: {
-									a: (
-										<a
-											target="_blank"
-											rel="noopener noreferrer"
-											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-										/>
-									),
-									thirdPartyTos: (
-										<a
-											target="_blank"
-											rel="noopener noreferrer"
-											href="https://wordpress.com/third-party-plugins-terms/"
-										/>
-									),
-								},
-							}
-						) }
-					</div>
+					<div className="plugin-details-cta__t-and-c">{ getTermsAndConditions() }</div>
 				) }
 				{ plugin.isSaasProduct && shouldUpgrade && isLoggedIn && selectedSite && (
 					<div className="plugin-details-cta__upgrade-required-card">

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -343,7 +343,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 					<div className="plugin-details-cta__t-and-c">
 						{ translate(
-							'By installing, you agree to {{a}}WordPress.com’s Terms of Service{{/a}} and the {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
+							'By installing, you agree to {{a}}WordPress.com Terms of Service{{/a}} and {{thirdPartyTos}}Third-Party plugin Terms{{/thirdPartyTos}}.',
 							{
 								components: {
 									a: (

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -120,6 +120,10 @@
 	justify-content: space-between;
 }
 
+.plugin-details-cta__container .plugin-autoupdate-toggle {
+	margin: 24px 0;
+}
+
 .plugin-details-cta__manage-plugin-menu {
 	margin-top: -12px;
 }

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -50,7 +50,10 @@
 
 .plugin-details-cta__preinstalled {
 	width: 100%;
-	margin-bottom: 20px;
+}
+
+.plugin-details-cta__preinstalled p {
+	margin-bottom: 24px;
 }
 
 .plugin-details-cta__install .plugin-details-cta__install-button {

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -70,9 +70,9 @@
 }
 
 .plugin-details-cta__t-and-c {
+	margin: 24px 0 0;
 	font-size: $font-body-extra-small;
 	color: var(--studio-gray-50);
-	margin: 24px 0;
 }
 
 .plugin-details-cta__not-available {
@@ -121,7 +121,7 @@
 }
 
 .plugin-details-cta__container .plugin-autoupdate-toggle {
-	margin: 24px 0;
+	margin: 24px 0 0;
 }
 
 .plugin-details-cta__manage-plugin-menu {

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -65,7 +65,7 @@
 	}
 }
 
-.plugin-details-cta__install.plugin-details-cta__manage-button {
+.plugin-details-cta__install .plugin-details-cta__manage-button {
 	width: 100%;
 }
 

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -18,8 +18,8 @@
 	font-family: $brand-serif;
 	font-size: $font-title-large;
 	color: var(--studio-gray-100);
-	margin-bottom: 16px;
-	min-height: 48px;
+	margin-bottom: 24px;
+	line-height: 1;
 	display: flex;
 	align-items: baseline;
 
@@ -53,27 +53,23 @@
 	margin-bottom: 20px;
 }
 
-.plugin-details-cta__install {
-	margin-bottom: 20px;
+.plugin-details-cta__install .plugin-details-cta__install-button {
+	width: 100%;
+	padding: 12px 16px;
 
-	.plugin-details-cta__install-button {
-		width: 100%;
-		padding: 12px 16px;
-
-		.gridicon {
-			margin: 0 0 0 5px;
-		}
+	.gridicon {
+		margin: 0 0 0 5px;
 	}
+}
 
-	.plugin-details-cta__manage-button {
-		width: 100%;
-	}
+.plugin-details-cta__install.plugin-details-cta__manage-button {
+	width: 100%;
 }
 
 .plugin-details-cta__t-and-c {
 	font-size: $font-body-extra-small;
 	color: var(--studio-gray-50);
-	margin-bottom: 16px;
+	margin: 24px 0;
 }
 
 .plugin-details-cta__not-available {

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -132,7 +132,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 	const planDisplayCost = useSelector( ( state ) => {
 		return getProductDisplayCost( state, requiredPlan || '' );
 	} );
-	const monthlyLabel = translate( 'Monthly' );
+	const monthlyLabel = translate( 'month' );
 	const annualLabel = translate( 'Annually' );
 	const periodicityLabel = isAnnualPeriod ? annualLabel : monthlyLabel;
 

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -48,7 +48,7 @@ const StyledLi = styled.li`
 	}
 `;
 
-const GreenGridicon = styled( Icon )`
+const GreenIcon = styled( Icon )`
 	fill: var( --studio-green-50 );
 `;
 
@@ -105,7 +105,7 @@ export const USPS: React.FC< Props > = ( { isMarketplaceProduct, billingPeriod }
 				<StyledUl>
 					{ filteredUSPS.map( ( usp, i ) => (
 						<StyledLi key={ `usp-${ i }` }>
-							<GreenGridicon icon={ check } size={ 24 } />
+							<GreenIcon icon={ check } size={ 24 } />
 							<span>{ usp }</span>
 						</StyledLi>
 					) ) }
@@ -202,7 +202,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 				<StyledUl>
 					{ filteredUSPS.map( ( usp, i ) => (
 						<StyledLi key={ `usps__-${ i }` }>
-							<GreenGridicon icon={ check } size={ 24 } />
+							<GreenIcon icon={ check } size={ 24 } />
 							<span>{ usp }</span>
 						</StyledLi>
 					) ) }

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -134,7 +134,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 		return getProductDisplayCost( state, requiredPlan || '' );
 	} );
 	const monthlyLabel = translate( 'month' );
-	const annualLabel = translate( 'Annually' );
+	const annualLabel = translate( 'year' );
 	const periodicityLabel = isAnnualPeriod ? annualLabel : monthlyLabel;
 
 	if ( ! shouldUpgrade ) {

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -7,8 +7,8 @@ import {
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	getPlan,
 } from '@automattic/calypso-products';
-import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
+import { Icon, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
@@ -43,13 +43,12 @@ const StyledLi = styled.li`
 
 	svg {
 		min-width: 16px;
-		margin-right: 8px;
-		margin-top: 4px;
+		margin-right: 4px;
 	}
 `;
 
-const GreenGridicon = styled( Gridicon )`
-	color: var( --studio-green-50 );
+const GreenGridicon = styled( Icon )`
+	fill: var( --studio-green-50 );
 `;
 
 const useRequiredPlan = ( shouldUpgrade: boolean ) => {
@@ -105,7 +104,7 @@ export const USPS: React.FC< Props > = ( { isMarketplaceProduct, billingPeriod }
 				<StyledUl>
 					{ filteredUSPS.map( ( usp, i ) => (
 						<StyledLi key={ `usp-${ i }` }>
-							<GreenGridicon icon="checkmark" size={ 16 } />
+							<GreenGridicon icon={ check } size={ 24 } />
 							<span>{ usp }</span>
 						</StyledLi>
 					) ) }
@@ -202,7 +201,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 				<StyledUl>
 					{ filteredUSPS.map( ( usp, i ) => (
 						<StyledLi key={ `usps__-${ i }` }>
-							<GreenGridicon icon="checkmark" size={ 16 } />
+							<GreenGridicon icon={ check } size={ 24 } />
 							<span>{ usp }</span>
 						</StyledLi>
 					) ) }

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -24,6 +24,7 @@ import { PREINSTALLED_PLUGINS } from '../constants';
 
 const StyledUl = styled.ul`
 	margin-left: 0;
+	margin-bottom: 0;
 	list-style-type: none;
 `;
 

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -26,7 +26,7 @@ const Container = styled( FoldableCard )`
 	&&.is-expanded .foldable-card__content {
 		${ ( props ) => props.first && 'border-top: 0' };
 		${ ( props ) => props.showAsAccordion && 'border: 0' };
-		padding: ${ ( props ) => ( props.first ? '0 0 32px' : '32px 0' ) };
+		padding: ${ ( props ) => ( props.first ? '0 0 24px' : '24px 0' ) };
 		${ ( props ) => props.showAsAccordion && 'padding: 0' };
 	}
 
@@ -49,11 +49,10 @@ const Title = styled.div`
 	color: var( --studio-gray-100 );
 	font-size: 14px;
 	${ ( props ) => ! props.showAsAccordion && 'font-weight: 600' };
-	${ ( props ) => ! props.showAsAccordion && 'margin-bottom: 8px;' };
+	${ ( props ) => ! props.showAsAccordion && 'margin-bottom: 12px;' };
 `;
 const Description = styled.div`
 	color: var( --studio-gray-80 );
-	margin-bottom: 12px;
 	font-size: 14px;
 `;
 

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -1,5 +1,6 @@
 import { FoldableCard, ExternalLink as ExternalLinkComponent } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Fragment } from 'react';
 
@@ -56,12 +57,18 @@ const Description = styled.div`
 	font-size: 14px;
 `;
 
-const ExternalLink = styled( ExternalLinkComponent )`
+const linkStyles = css`
+	display: inline-block;
+	margin-top: 6px;
 	font-size: 14px;
 `;
 
+const ExternalLink = styled( ExternalLinkComponent )`
+	${ linkStyles }
+`;
+
 const Link = styled.a`
-	font-size: 14px;
+	${ linkStyles }
 `;
 
 const PluginDetailsSidebarUSP = ( {

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -55,6 +55,7 @@ const Title = styled.div`
 const Description = styled.div`
 	color: var( --studio-gray-80 );
 	font-size: 14px;
+	${ ( props ) => props.showAsAccordion && 'margin-bottom: 12px;' };
 `;
 
 const linkStyles = css`
@@ -103,7 +104,7 @@ const PluginDetailsSidebarUSP = ( {
 			first={ first }
 		>
 			{ ! isNarrow && <Header /> }
-			<Description>{ description }</Description>
+			<Description showAsAccordion={ isNarrow }>{ description }</Description>
 			{ links &&
 				links.map( ( link, idx ) => {
 					return (

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -61,7 +61,6 @@ const ExternalLink = styled( ExternalLinkComponent )`
 `;
 
 const Link = styled.a`
-	display: inline-block;
 	font-size: 14px;
 `;
 
@@ -102,14 +101,14 @@ const PluginDetailsSidebarUSP = ( {
 				links.map( ( link, idx ) => {
 					return (
 						<Fragment key={ idx }>
-							{ '_blank' === link.target ? (
-								<Link href={ link.href } onClick={ link.onClick }>
-									{ link.label }
-								</Link>
-							) : (
+							{ link.openInNewTab ? (
 								<ExternalLink icon href={ link.href } onClick={ link.onClick }>
 									{ link.label }
 								</ExternalLink>
+							) : (
+								<Link href={ link.href } onClick={ link.onClick }>
+									{ link.label }
+								</Link>
 							) }
 							<br />
 						</Fragment>

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -92,9 +92,8 @@ const PluginDetailsSidebar = ( {
 					links={ [
 						{
 							href: premiumVersionLink,
-							label: translate( 'Check out the premium version' ),
+							label: translate( 'Learn more' ),
 							onClick: premiumVersionLinkOnClik,
-							openInNewTab: true,
 						},
 					] }
 					first

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -4,6 +4,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { sprintf, __ } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
@@ -153,7 +154,13 @@ const PluginDetailsSidebar = ( {
 					<div className="plugin-details-sidebar__tested-text title">
 						{ translate( 'Tested up to' ) }
 					</div>
-					<div className="plugin-details-sidebar__tested-value value">{ tested }</div>
+					<div className="plugin-details-sidebar__tested-value value">
+						{ sprintf(
+							// translators: %s is the version of WordPress that the plugin has been tested with
+							__( 'WordPress %s' ),
+							tested
+						) }
+					</div>
 				</div>
 			) }
 		</div>

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -4,7 +4,6 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { formatNumberCompact } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
@@ -22,7 +21,6 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 const PluginDetailsSidebar = ( {
 	plugin: {
 		slug,
-		active_installs,
 		tested,
 		isMarketplaceProduct = false,
 		demo_url = null,
@@ -149,16 +147,6 @@ const PluginDetailsSidebar = ( {
 					links={ supportLinks }
 					first
 				/>
-			) }
-			{ Boolean( active_installs ) && (
-				<div className="plugin-details-sidebar__active-installs">
-					<div className="plugin-details-sidebar__active-installs-text title">
-						{ translate( 'Active installations' ) }
-					</div>
-					<div className="plugin-details-sidebar__active-installs-value value">
-						{ formatNumberCompact( active_installs ) }
-					</div>
-				</div>
 			) }
 			{ Boolean( tested ) && (
 				<div className="plugin-details-sidebar__tested">

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -4,7 +4,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { sprintf, __ } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
@@ -162,7 +162,7 @@ const PluginDetailsSidebar = ( {
 					<div className="plugin-details-sidebar__tested-value value">
 						{ sprintf(
 							// translators: %s is the version of WordPress that the plugin has been tested with
-							__( 'WordPress %s' ),
+							translate( 'WordPress %s' ),
 							tested
 						) }
 					</div>

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -160,11 +160,7 @@ const PluginDetailsSidebar = ( {
 						{ translate( 'Tested up to' ) }
 					</div>
 					<div className="plugin-details-sidebar__tested-value value">
-						{ sprintf(
-							// translators: %s is the version of WordPress that the plugin has been tested with
-							translate( 'WordPress %s' ),
-							tested
-						) }
+						{ sprintf( 'WordPress %s', tested ) }
 					</div>
 				</div>
 			) }

--- a/client/my-sites/plugins/plugin-details-sidebar/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar/index.jsx
@@ -55,16 +55,19 @@ const PluginDetailsSidebar = ( {
 		{
 			href: localizeUrl( 'https://wordpress.com/support/help-support-options' ),
 			label: translate( 'How to get help!' ),
+			openInNewTab: true,
 		},
 		{
 			href: localizeUrl( 'https://automattic.com/privacy/' ),
 			label: translate( 'See privacy policy' ),
+			openInNewTab: true,
 		},
 	];
 	documentation_url &&
 		supportLinks.unshift( {
 			href: documentation_url,
 			label: translate( 'View documentation' ),
+			openInNewTab: true,
 		} );
 
 	const isPremiumVersionAvailable = !! premium_slug;
@@ -91,7 +94,7 @@ const PluginDetailsSidebar = ( {
 							href: premiumVersionLink,
 							label: translate( 'Check out the premium version' ),
 							onClick: premiumVersionLinkOnClik,
-							target: '_blank',
+							openInNewTab: true,
 						},
 					] }
 					first
@@ -136,7 +139,9 @@ const PluginDetailsSidebar = ( {
 					description={ translate(
 						'Take a look at the posibilities of this plugin before your commit.'
 					) }
-					links={ [ { href: { demo_url }, label: translate( 'View live demo' ) } ] }
+					links={ [
+						{ href: { demo_url }, label: translate( 'View live demo' ), openInNewTab: true },
+					] }
 					first
 				/>
 			) }

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -12,12 +12,16 @@
 }
 
 .plugin-details-sidebar__plugin-details-content {
-	padding-top: 24px;
+	margin-top: 30px; /* Extra 6px because of line-height and border */
 	border-style: solid none;
 	border-width: 1px;
 	border-color: #eee;
 	border-bottom: none;
 	border-top: 1px solid var(--studio-gray-5);
+
+	@media (min-width: $break-small) {
+		padding-top: 24px;
+	}
 
 	.title {
 		color: var(--studio-gray-60);

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -25,7 +25,7 @@
 
 	.value {
 		color: var(--studio-gray-90);
-		font-size: $font-body-small;
+		font-size: $font-body;
 		padding-bottom: 16px;
 
 		&.plugin-details-sidebar__active-installs-value {

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .plugin-details-sidebar__plugin-details-title {
 	padding: 15px 0;
 	display: none;
@@ -39,5 +41,11 @@
 		display: flex;
 		justify-content: space-between;
 		flex-wrap: wrap; // Needed for paid plugin USPs.
+	}
+
+	@media (max-width: $break-small) {
+		.plugin-details-sidebar__tested {
+			margin-top: 12px;
+		}
 	}
 }

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -16,7 +16,7 @@
 	border-width: 1px;
 	border-color: #eee;
 	border-bottom: none;
-	border-top: 2px solid var(--studio-gray-5);
+	border-top: 1px solid var(--studio-gray-5);
 
 	.title {
 		color: var(--studio-gray-60);

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -24,7 +24,7 @@
 
 	.value {
 		color: var(--studio-gray-90);
-		font-size: $font-body;
+		font-size: $font-body-small;
 
 		&.plugin-details-sidebar__active-installs-value {
 			font-size: $font-body;

--- a/client/my-sites/plugins/plugin-details-sidebar/style.scss
+++ b/client/my-sites/plugins/plugin-details-sidebar/style.scss
@@ -10,8 +10,7 @@
 }
 
 .plugin-details-sidebar__plugin-details-content {
-	margin-top: 32px;
-	padding-top: 32px;
+	padding-top: 24px;
 	border-style: solid none;
 	border-width: 1px;
 	border-color: #eee;
@@ -26,7 +25,6 @@
 	.value {
 		color: var(--studio-gray-90);
 		font-size: $font-body;
-		padding-bottom: 16px;
 
 		&.plugin-details-sidebar__active-installs-value {
 			font-size: $font-body;

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { fixMe, useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Banner from 'calypso/components/banner';
@@ -326,29 +326,38 @@ function PluginDetails( props ) {
 		);
 	}
 
-	const downloadText = translate(
-		'This plugin is {{org_link}}available for download{{/org_link}} for your {{wpcom_vs_wporg_link}}WordPress self-hosted{{/wpcom_vs_wporg_link}} site.',
-		{
-			components: {
-				org_link: (
-					<a
-						href={ 'https://wordpress.org/plugins/' + ( fullPlugin?.slug || '' ) }
-						target="_blank"
-						rel="noreferrer noopener"
-					/>
-				),
-				wpcom_vs_wporg_link: (
-					<a
-						href={ localizeUrl(
-							'https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/'
-						) }
-						target="_blank"
-						rel="noreferrer noopener"
-					/>
-				),
-			},
-		}
-	);
+	const downloadTranslationArgs = {
+		components: {
+			org_link: (
+				<a
+					href={ 'https://wordpress.org/plugins/' + ( fullPlugin?.slug || '' ) }
+					target="_blank"
+					rel="noreferrer noopener"
+				/>
+			),
+			wpcom_vs_wporg_link: (
+				<a
+					href={ localizeUrl(
+						'https://wordpress.com/go/website-building/wordpress-com-vs-wordpress-org/'
+					) }
+					target="_blank"
+					rel="noreferrer noopener"
+				/>
+			),
+		},
+	};
+
+	const downloadText = fixMe( {
+		text: 'This plugin is {{org_link}}available for download{{/org_link}} for your {{wpcom_vs_wporg_link}}WordPress self-hosted{{/wpcom_vs_wporg_link}} site.',
+		newCopy: translate(
+			'This plugin is {{org_link}}available for download{{/org_link}} for your {{wpcom_vs_wporg_link}}WordPress self-hosted{{/wpcom_vs_wporg_link}} site.',
+			downloadTranslationArgs
+		),
+		oldCopy: translate(
+			'This plugin is {{org_link}}available for download{{/org_link}} to be used on your {{wpcom_vs_wporg_link}}WordPress self-hosted{{/wpcom_vs_wporg_link}} installation.',
+			downloadTranslationArgs
+		),
+	} );
 
 	const structuredData = JSON.stringify( {
 		'@context': 'https://schema.org',

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -327,7 +327,7 @@ function PluginDetails( props ) {
 	}
 
 	const downloadText = translate(
-		'This plugin is {{org_link}}available for download{{/org_link}} to be used on your {{wpcom_vs_wporg_link}}WordPress self-hosted{{/wpcom_vs_wporg_link}} installation.',
+		'This plugin is {{org_link}}available for download{{/org_link}} for your {{wpcom_vs_wporg_link}}WordPress self-hosted{{/wpcom_vs_wporg_link}} site.',
 		{
 			components: {
 				org_link: (

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -302,7 +302,7 @@ $calypso-header-height: 31px;
 	}
 
 	.plugin-details__plugin-download {
-		margin-top: 20px;
+		margin-top: 24px;
 		gap: 16px;
 		display: flex;
 		font-size: $font-body-extra-small;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -303,7 +303,7 @@ $calypso-header-height: 31px;
 
 	.plugin-details__plugin-download {
 		margin-top: 20px;
-		gap: 5px;
+		gap: 16px;
 		display: flex;
 		font-size: $font-body-extra-small;
 

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -30,7 +30,7 @@ const selectors = {
 	searchResultTitle: ( text: string ) => `:text('plugins for "${ text }"')`,
 
 	// Plugin view
-	installButton: 'button:text("Install and activate")',
+	installButton: '.plugin-details-cta__install-button',
 	deactivateButton: 'button:text("Deactivate")',
 	activateButton: 'button:text("Activate")',
 	openRemoveMenuButton: '.plugin-details-cta__manage-plugin-menu button[title="Toggle menu"]',
@@ -285,7 +285,7 @@ export class PluginsPage {
 	 * modal that appears prompting the user to purchase a plan upgrade.
 	 */
 	async clickInstallPlugin(): Promise< void > {
-		const button = await this.page.locator( '.plugin-details-cta__install-button' );
+		const button = await this.page.locator( selectors.installButton );
 
 		const text = await button.innerText();
 		if ( /^(Purchase|Upgrade) and activate$/.test( text ) ) {

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -285,17 +285,11 @@ export class PluginsPage {
 	 * modal that appears prompting the user to purchase a plan upgrade.
 	 */
 	async clickInstallPlugin(): Promise< void > {
-		// check the name of the button
 		const button = await this.page.locator( '.plugin-details-cta__install-button' );
 
 		const text = await button.innerText();
 		if ( /^(Purchase|Upgrade) and activate$/.test( text ) ) {
-			await Promise.all( [
-				this.page.waitForResponse( /eligibility/ ),
-				// Depending on whethe the plugin is free or requires a monthly subscription,
-				// the text shown on the install button is slightly different.
-				button.click(),
-			] );
+			await Promise.all( [ this.page.waitForResponse( /eligibility/ ), button.click() ] );
 			// Modal will appear to re-confirm to the user that an upgrade is necessary.
 			// Accept the confirmation.
 			await this.page.getByRole( 'button', { name: 'Upgrade and activate plugin' } ).click();

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -285,23 +285,22 @@ export class PluginsPage {
 	 * modal that appears prompting the user to purchase a plan upgrade.
 	 */
 	async clickInstallPlugin(): Promise< void > {
-		const needsPlanUpgrade = await this.page.locator( selectors.planUpgradeRequiredIcon ).count();
+		// check the name of the button
+		const button = await this.page.locator( '.plugin-details-cta__install-button' );
 
-		if ( needsPlanUpgrade ) {
+		const text = await button.innerText();
+		if ( /^(Purchase|Upgrade) and activate$/.test( text ) ) {
 			await Promise.all( [
 				this.page.waitForResponse( /eligibility/ ),
 				// Depending on whethe the plugin is free or requires a monthly subscription,
 				// the text shown on the install button is slightly different.
-				this.page.getByRole( 'button', { name: /(Purchase|Upgrade) and activate/ } ).click(),
+				button.click(),
 			] );
 			// Modal will appear to re-confirm to the user that an upgrade is necessary.
 			// Accept the confirmation.
 			await this.page.getByRole( 'button', { name: 'Upgrade and activate plugin' } ).click();
 		} else {
-			await Promise.all( [
-				this.page.waitForResponse( /.*install\?.*/ ),
-				this.page.getByRole( 'button', { name: 'Install and activate' } ).click(),
-			] );
+			await Promise.all( [ this.page.waitForResponse( /.*install\?.*/ ), button.click() ] );
 		}
 	}
 

--- a/test/e2e/specs/plugins/plugins__purchase.ts
+++ b/test/e2e/specs/plugins/plugins__purchase.ts
@@ -48,10 +48,6 @@ describe( 'Plugins: Add multiple to cart', function () {
 			);
 		} );
 
-		it( 'Plan upgrade CTA is shown on page', async function () {
-			await page.getByText( 'You need to upgrade your plan to install plugins' ).waitFor();
-		} );
-
 		it( 'Click on install button', async function () {
 			await pluginsPage.clickInstallPlugin();
 		} );


### PR DESCRIPTION
Extension of #103366, which was reverted in #103441, due to a failed test.


## Proposed Changes

See #103366 for more details on the initial review.

The changes specific to this PR occur in:
- packages/calypso-e2e/src/lib/pages/plugins-page.ts
- test/e2e/specs/plugins/plugins__purchase.ts

This PR extends #103366 in two ways:
- Removes the test that checks for `UpgradeRequiredContent`
  - We removed it as part of #100453
- Updates `clickInstallPlugin` to not use `UpgradeRequiredContent` to determine how to proceed with the install button click.


### Screenshot for translations
<img width="466" alt="Screenshot 2025-05-16 at 6 42 28 PM" src="https://github.com/user-attachments/assets/133b1b61-b9cd-4ce2-9eda-e152364b566b" />



## Considerations

In `clickInstallPlugin`, I've decided to use the button name (text) to determine which button exists on the page and use that to determine the next flow. Maybe that is too naive?
 
## Testing Instructions

Expect `yarn workspace wp-e2e-tests test plugins__purchase` to pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
