### PR TITLE
Use core buttons on accept invite screen

### DIFF
--- a/client/blocks/signup-form/signup-submit-button.tsx
+++ b/client/blocks/signup-form/signup-submit-button.tsx
@@ -8,6 +8,7 @@ interface SignupSubmitButtonProps {
 	variationName?: string;
 	children: ReactNode;
 	className?: string;
+	onClick?: () => void;
 }
 
 const SignupSubmitButton = ( {
@@ -16,6 +17,7 @@ const SignupSubmitButton = ( {
 	variationName,
 	children,
 	className,
+	onClick,
 }: SignupSubmitButtonProps ) => {
 	return (
 		<Button
@@ -28,6 +30,7 @@ const SignupSubmitButton = ( {
 			) }
 			disabled={ isDisabled }
 			isBusy={ isBusy }
+			onClick={ onClick }
 			__next40pxDefaultSize
 		>
 			{ children }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1050,11 +1050,6 @@ $colophon-height: 50px;
 			color: var(--color-neutral-80);
 		}
 
-		.signup-form__submit {
-			border: 0;
-			box-shadow: none;
-		}
-
 		.jetpack-header__partner-logo-plus svg {
 			stroke: var(--color-neutral-80);
 		}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -19,7 +19,7 @@ $image-height: 47px;
 		padding-bottom: $image-height;
 		min-height: calc(100% - #{$image-height});
 	}
-	
+
 	.layout__content {
 		position: static;
 	}
@@ -315,7 +315,6 @@ $image-height: 47px;
 	}
 
 	.login .button.is-primary {
-		// Note: Matches primary button to `button.signup-form__submit`
 		background-color: var(--studio-wordpress-blue, #3858e9);
 		color: var(--color-text-inverted);
 		box-shadow: none;
@@ -363,7 +362,7 @@ $image-height: 47px;
 		// following overrides could be safely deleted.
 		input:not(.components-text-control__input),
 		button:not(.components-button) {
-			/* Note: Same as `button.signup-form__submit, .signup-form__input.form-text-input` */
+			/* Note: Same as `.signup-form__input.form-text-input` */
 			height: 40px; // Matches .components-button height __next40pxDefaultSize
 			border: 1px solid var(--studio-gray-10);
 			font-size: $font-body;

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -6,7 +6,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import store from 'store';
 import SignupForm from 'calypso/blocks/signup-form';
-import FormButton from 'calypso/components/forms/form-button';
+import SignupSubmitButton from 'calypso/blocks/signup-form/signup-submit-button';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -150,9 +150,9 @@ class InviteAcceptLoggedOut extends Component {
 				<div className="logged-out-form">
 					{ this.renderFormHeader() }
 					<Card className="logged-out-form__footer">
-						<FormButton className="signup-form__submit" onClick={ this.clickSignInLink }>
+						<SignupSubmitButton onClick={ this.clickSignInLink }>
 							{ this.props.translate( 'Sign In' ) }
-						</FormButton>
+						</SignupSubmitButton>
 					</Card>
 				</div>
 			</div>

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -64,27 +64,6 @@ body.is-section-accept-invite {
 		margin: 0 auto;
 		background: none;
 
-		button.is-primary {
-			border-radius: 2px;
-			border: 1px solid var(--studio-wordpress-blue, #3858e9);
-			background: var(--studio-wordpress-blue, #3858e9);
-			height: 48px;
-			font-weight: 500;
-			&:hover {
-				background: var(--studio-wordpress-blue-60);
-			}
-			&:focus {
-				background-color: var(--studio-wordpress-blue-60);
-				border-color: var(--studio-wordpress-blue-60);
-				color: var(--color-text-inverted);
-				box-shadow: none;
-			}
-			&:disabled {
-				background: var(--studio-gray-20);
-				border: 1px solid var(--studio-gray-20);
-				color: var(--color-surface);
-			}
-		}
 		label.form-label {
 			color: var(--studio-gray-60, #50575e);
 			font-size: 0.875rem;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -307,27 +307,6 @@ body.is-section-signup .layout:not(.dops):not(.is-wccom-oauth-flow) {
 
 	.signup__step.is-user,
 	.signup__step.is-user-social {
-		.button.signup-form__submit[disabled],
-		.button.signup-form__submit:disabled,
-		.button.signup-form__submit.disabled {
-			background-color: var(--studio-gray-20);
-			color: var(--color-surface);
-		}
-
-		.button.signup-form__submit {
-			border-radius: 4px;
-			max-width: 408px;
-			height: 44px;
-			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-			font-weight: 500;
-			letter-spacing: 0.32px;
-			line-height: 17px;
-
-			&.newsletter-signup-form {
-				background-color: var(--color-primary);
-			}
-		}
-
 		.signup-form__terms-of-service-link {
 			text-align: start;
 			font-size: 0.875rem;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes [DSGCOM-102: Update primary button on accept email link screen](https://linear.app/a8c/issue/DSGCOM-102/update-primary-button-on-accept-email-link-screen)

## Proposed Changes

* Replace the primary button on the accept invite screen with a core button
* Remove all remaining styles for the non-core `signup__submit-button` as this is the last instance to be replaced with a core button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This button has no visible focus style, and is inconsistent with the buttons on the login, magic login and signup screens, which have all been replaced.

- Focus styles are necessary for accessibility
- Consistent button styles and behaviours form a more high quality experience

## Testing

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Screenshots (showing button focused)

| Before | After |
|-|-|
| ![wordpress com_accept-invite_240365119_1ce54531d0a7a7f82a8605d3f10a768c_Gy0hDOiiGstQrwhTf2grJd01_email_verification_secret=db2762bd5a313f1dcac218a3d958acdff639db3bfeb92553dc966f249509206c(Desktop)](https://github.com/user-attachments/assets/a1993c76-cc0c-496e-a331-0b286ca2a57e) | ![calypso localhost_3000_accept-invite_240365119_1ce54531d0a7a7f82a8605d3f10a768c_Gy0hDOiiGstQrwhTf2grJd01_email_verification_secret=db2762bd5a313f1dcac218a3d958acdff639db3bfeb92553dc966f249509206c(Desktop) (1)](https://github.com/user-attachments/assets/62f83937-b7e2-4e6e-b07e-afa2d465fd66) |

### Instructions

* Log in to a WordPress.com site
* Go to the WP admin users screen
* Invite a new user by email
* Log out
* In your email client open the email invitation which was sent and click the 'Accept invitation' button
* In the screen that opens change the host to `calypso.localhost:3000`
* The primary button should be a core button matching those on login and signup, with a solid focus ring and slightly darker background on hover
* Check the button still works; you should be able to add yourself to the site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
