### PR TITLE
Crowdsignal Log-in: Remove duplicate Connect paragraph

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1136,7 +1136,6 @@ export class LoginForm extends Component {
 	render() {
 		const {
 			accountType,
-			oauth2Client,
 			isJetpackWooDnaFlow,
 			currentQuery,
 			showSocialLoginFormOnly,
@@ -1201,12 +1200,6 @@ export class LoginForm extends Component {
 				onSubmit={ this.onSubmitForm }
 				method="post"
 			>
-				{ isCrowdsignalOAuth2Client( oauth2Client ) && (
-					<p className="login__form-subheader">
-						{ this.props.translate( 'Connect with your WordPress.com account:' ) }
-					</p>
-				) }
-
 				{ this.renderLoginOptions() }
 
 				{ this.showJetpackConnectSiteOnly() && (


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Found while testing: https://github.com/Automattic/wp-calypso/pull/102811 (but as mentioned [in this comment](https://github.com/Automattic/wp-calypso/pull/103449#pullrequestreview-2842279511), looks like it was introduced earlier)

## Proposed Changes

* Remove duplicate "Connect with your WordPress.com account" Crowdsignal log in text

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Looks like it was accidentally duplicated, in https://github.com/Automattic/wp-calypso/pull/102877, which moved around where the paragraph is output.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to: http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Df5da55616562ed1b1ef36c8e88328853efcc0167150831e59437c3330ec11509%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1 and double check that only one "Connect with" text displays for Crowd Signal log in.
* Double-check that this change doesn't affect any of the other log in flows (just a quick smoke test is fine)

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/66bec19a-feed-46df-b776-c2530fb2247f) | ![image](https://github.com/user-attachments/assets/5dfd1722-6576-402f-88f1-43c13a0b5993) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
