### PR TITLE
Plugins: Update content spacing for plugin information.

### DIFF
--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -90,7 +90,6 @@
 	}
 }
 
-
 .plugin-sections__header > div {
 	margin-bottom: 0;
 }

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -68,13 +68,13 @@
 }
 
 /* Remove top margin for the element if we don't render the header. */
-.plugin-sections__content:not(:has(+ .plugin-sections__header)) img:first-of-type,
-.plugin-sections__content:not(:has(+ .plugin-sections__header)) h1:first-of-type,
-.plugin-sections__content:not(:has(+ .plugin-sections__header)) h2:first-of-type,
-.plugin-sections__content:not(:has(+ .plugin-sections__header)) h3:first-of-type,
-.plugin-sections__content:not(:has(+ .plugin-sections__header)) h4:first-of-type,
-.plugin-sections__content:not(:has(+ .plugin-sections__header)) h5:first-of-type,
-.plugin-sections__content:not(:has(+ .plugin-sections__header)) h6:first-of-type {
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) .plugin-sections__banner > img:first-child,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) > h1:first-child,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) > h2:first-child,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) > h3:first-child,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) > h4:first-child,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) > h5:first-child,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) > h6:first-child {
 	margin-top: 0;
 }
 

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -60,7 +60,22 @@
 	line-height: 21px;
 	word-wrap: break-word;
 	hyphens: auto;
+}
+
+.plugin-sections__header + .plugin-sections__content {
 	margin: 32px 0;
+
+}
+
+/* Remove top margin from first heading if we don't render the header. */
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) img:first-of-type,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) h1:first-of-type,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) h2:first-of-type,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) h3:first-of-type,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) h4:first-of-type,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) h5:first-of-type,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) h6:first-of-type {
+	margin-top: 0;
 }
 
 .plugin-sections__support {
@@ -75,6 +90,7 @@
 	}
 }
 
+
 .plugin-sections__header > div {
 	margin-bottom: 0;
 }
@@ -82,3 +98,4 @@
 .plugin-sections__banner {
 	margin-bottom: 0;
 }
+

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -60,14 +60,14 @@
 	line-height: 21px;
 	word-wrap: break-word;
 	hyphens: auto;
+	margin-bottom: 32px;
 }
 
 .plugin-sections__header + .plugin-sections__content {
-	margin: 32px 0;
-
+	margin-top: 32px;
 }
 
-/* Remove top margin from first heading if we don't render the header. */
+/* Remove top margin for the element if we don't render the header. */
 .plugin-sections__content:not(:has(+ .plugin-sections__header)) img:first-of-type,
 .plugin-sections__content:not(:has(+ .plugin-sections__header)) h1:first-of-type,
 .plugin-sections__content:not(:has(+ .plugin-sections__header)) h2:first-of-type,

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -97,4 +97,3 @@
 .plugin-sections__banner {
 	margin-bottom: 0;
 }
-

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -257,7 +257,7 @@ $calypso-header-height: 31px;
 
 	.plugin-details__content {
 		grid-area: content;
-		padding-top: 50px;
+		padding-top: 40px;
 	}
 
 	.plugin-details__actions {


### PR DESCRIPTION
Part of #100453

## Proposed Changes

Add styles to remove the top margin when 'plugin-sections__header` is not present.

These styles should improve things. I think ultimately, the "Description" tab shouldn't be hidden even if there is only one tab because it contextualizes the content, and some plugins like `\js-composer\`, don't provide an initial heading.

## Why are these changes being made?

Not all plugin listings have the Plugin Sections header, and we therefore get inconsistent spacing between the plugin section content and the plugin meta information above.



## Testing Instructions

View many plugins details and look for inconsistent padding below the plugin details.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
