### PR TITLE
A4A > Add sites: Fix the Pressable & WordPress.com sub-heading language

### DIFF
--- a/client/components/add-new-site/menu-items/a4a.tsx
+++ b/client/components/add-new-site/menu-items/a4a.tsx
@@ -95,7 +95,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 				<AddNewSiteMenuItem
 					icon={ <img src={ pressableIcon } alt="Pressable" /> }
 					heading="Pressable"
-					description={ translate( 'Bring your theme, plugins, and content to WordPress.com.' ) }
+					description={ translate( 'Optimized and hassle-free hosting for business websites.' ) }
 					buttonProps={ {
 						href:
 							pressableOwnership === 'regular'
@@ -107,7 +107,7 @@ const AddNewSiteA4AMenuItems = ( { setMenuVisible }: AddNewSiteMenuItemsProps ) 
 				<AddNewSiteMenuItem
 					icon={ <WordPressLogo /> }
 					heading="WordPress.com"
-					description={ translate( 'Use a backup file to import your content into a new site.' ) }
+					description={ translate( 'Best for large-scale businesses and major eCommerce sites.' ) }
 					buttonProps={ {
 						href: hasPendingWPCOMSites
 							? A4A_SITES_LINK_NEEDS_SETUP


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-711/add-sites-add-a-new-production-site-wordpresscom-and-pressable

## Proposed Changes

This PR fixes the Pressable & WordPress.com sub-heading language

## Why are these changes being made?

* To fix the Pressable & WordPress.com sub-heading language

## Testing Instructions

* Open the A4A live link
* Click the `Add sites` button > Verify the text is updated for:

Pressable: Optimized and hassle-free hosting for business websites.
WordPress.com: Best for large-scale businesses and major eCommerce sites.

<img width="916" alt="Screenshot 2025-05-15 at 12 10 16 PM" src="https://github.com/user-attachments/assets/40b52fda-ba5b-4d05-bdd8-d3abe9eddcfb" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
