### PR TITLE
A4A: Add feature flag to switch Signup v2 flow with email link.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
+++ b/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
@@ -78,6 +78,7 @@ export function getSignupDataFromRequestParameters(): AgencyDetailsPayload | nul
 		lastName: sanitizeString( searchParams.get( 'last_name' ) ),
 		agencyName: sanitizeString( searchParams.get( 'agency_name' ) ),
 		agencyUrl: sanitizeUrl( searchParams.get( 'agency_url' ) ),
+		agencySize: sanitizeString( searchParams.get( 'agency_size' ) ),
 		managedSites: sanitizeString( searchParams.get( 'number_sites' ) ),
 		userType: sanitizeString( searchParams.get( 'user_type' ) ),
 		servicesOffered,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -24,7 +24,7 @@ import './style.scss';
 
 type Props = {
 	withPersonalizedBlueprint?: boolean;
-	submitAsSurvey?: boolean;
+	signupWithMagicLinkFlow?: boolean;
 };
 
 type PersonalizationStepProgress = {
@@ -74,7 +74,10 @@ const getFinishSurveyProgress = ( step: number ): number => {
 	return step === 6 ? STEP_COMPLETED : STEP_NOT_STARTED;
 };
 
-const MultiStepForm = ( { withPersonalizedBlueprint = false, submitAsSurvey = false }: Props ) => {
+const MultiStepForm = ( {
+	withPersonalizedBlueprint = false,
+	signupWithMagicLinkFlow = false,
+}: Props ) => {
 	const notificationId = 'a4a-agency-signup-form';
 	const translate = useTranslate();
 	const [ currentStep, setCurrentStep ] = useState( 1 );
@@ -95,7 +98,7 @@ const MultiStepForm = ( { withPersonalizedBlueprint = false, submitAsSurvey = fa
 			isActive: currentStep > 3,
 			value: getPersonalizationProgress( currentStep, withPersonalizedBlueprint ),
 		},
-		...( submitAsSurvey
+		...( signupWithMagicLinkFlow
 			? [
 					{
 						label: translate( 'Finish survey' ),
@@ -146,7 +149,7 @@ const MultiStepForm = ( { withPersonalizedBlueprint = false, submitAsSurvey = fa
 			const newFormData = { ...formData, ...data };
 			setFormData( newFormData );
 			setCurrentStep( nextStep );
-			if ( nextStep === 6 && submitAsSurvey ) {
+			if ( nextStep === 6 && signupWithMagicLinkFlow ) {
 				const {
 					topPartneringGoal,
 					topYearlyGoal,
@@ -159,7 +162,7 @@ const MultiStepForm = ( { withPersonalizedBlueprint = false, submitAsSurvey = fa
 				submitSurvey( payload as AgencyDetailsSignupPayload );
 			}
 		},
-		[ formData, submitAsSurvey, submitSurvey ]
+		[ formData, signupWithMagicLinkFlow, submitSurvey ]
 	);
 
 	const clearDataAndRefresh = () => {
@@ -184,7 +187,7 @@ const MultiStepForm = ( { withPersonalizedBlueprint = false, submitAsSurvey = fa
 					<SignupContactForm
 						onContinue={ ( data ) => updateDataAndContinue( data, 2 ) }
 						initialFormData={ formData }
-						withEmail={ submitAsSurvey }
+						withEmail={ signupWithMagicLinkFlow }
 					/>
 				);
 			case 2:
@@ -195,7 +198,7 @@ const MultiStepForm = ( { withPersonalizedBlueprint = false, submitAsSurvey = fa
 							updateDataAndContinue( data, withPersonalizedBlueprint ? 3 : 6 )
 						}
 						onSubmit={ ( data ) => onCreateAgency( data ) }
-						isFinalStep={ ! submitAsSurvey }
+						isFinalStep={ ! signupWithMagicLinkFlow }
 						initialFormData={ formData }
 						goBack={ () => setCurrentStep( 1 ) }
 					/>
@@ -242,7 +245,7 @@ const MultiStepForm = ( { withPersonalizedBlueprint = false, submitAsSurvey = fa
 		currentStep,
 		formData,
 		onCreateAgency,
-		submitAsSurvey,
+		signupWithMagicLinkFlow,
 		trackView,
 		updateDataAndContinue,
 		withPersonalizedBlueprint,

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/index.tsx
@@ -89,7 +89,7 @@ const MultiStepForm = ( {
 
 	const steps: Step[] = [
 		{
-			label: translate( 'Sign up' ),
+			label: translate( 'Your agency details' ),
 			isActive: currentStep > 0,
 			value: getSignupProgress( currentStep ),
 		},
@@ -101,7 +101,7 @@ const MultiStepForm = ( {
 		...( signupWithMagicLinkFlow
 			? [
 					{
-						label: translate( 'Finish survey' ),
+						label: translate( 'Finish sign up' ),
 						isActive: currentStep > 5,
 						value: getFinishSurveyProgress( currentStep ),
 					},

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/personalization/index.tsx
@@ -308,7 +308,7 @@ export default function PersonalizationForm( {
 							</FormField>
 						</FormFieldset>
 
-						{ hasProductsOffered && productsToOfferOptions.length > 0 && (
+						{ hasProductsOffered && productsToOfferOptions.length > 1 && (
 							<>
 								<FormFieldset className="signup-personalization-form__checkbox is-horizontal">
 									<FormField label={ translate( 'Do you plan to offer more products?' ) }>

--- a/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
 import { useEffect } from 'react';
 import MultiStepForm from './components/multi-step-form';
@@ -11,7 +12,7 @@ const AgencySignupV2 = () => {
 
 	return (
 		<SignupWrapper>
-			<MultiStepForm />
+			<MultiStepForm submitAsSurvey={ isEnabled( 'a4a-signup-v2-via-email' ) } />
 		</SignupWrapper>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/index.tsx
@@ -12,7 +12,7 @@ const AgencySignupV2 = () => {
 
 	return (
 		<SignupWrapper>
-			<MultiStepForm submitAsSurvey={ isEnabled( 'a4a-signup-v2-via-email' ) } />
+			<MultiStepForm signupWithMagicLinkFlow={ isEnabled( 'a4a-signup-v2-via-email' ) } />
 		</SignupWrapper>
 	);
 };

--- a/client/a8c-for-agencies/sections/signup/signup-v2/wc-asia.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/wc-asia.tsx
@@ -4,7 +4,7 @@ import SignupWrapper from './components/signup-wrapper';
 const AgencySignupWCAsia = () => {
 	return (
 		<SignupWrapper>
-			<MultiStepForm submitAsSurvey withPersonalizedBlueprint />
+			<MultiStepForm signupWithMagicLinkFlow withPersonalizedBlueprint />
 		</SignupWrapper>
 	);
 };

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -44,6 +44,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": true,
+		"a4a-signup-v2-via-email": true,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -37,6 +37,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": false,
+		"a4a-signup-v2-via-email": false,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -37,7 +37,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": false,
-		"a4a-signup-v2-via-email": false,
+		"a4a-signup-v2-via-email": true,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -37,6 +37,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": false,
+		"a4a-signup-v2-via-email": false,
 		"a4a-client-checkout-v2": false,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -39,7 +39,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": false,
-		"a4a-signup-v2-via-email": false,
+		"a4a-signup-v2-via-email": true,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -39,6 +39,7 @@
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
 		"a4a-signup-v2": false,
+		"a4a-signup-v2-via-email": false,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true
 	},


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/103447
Context: p1747291663676739-slack-C047ACYM8UQ

## Proposed Changes

* Add the `a4a-signup-v2-via-email` feature flag and use it to switch survey submission on the new signup form.
* **Additional**: Change Stepper labels.
   <img width="678" alt="Screenshot 2025-05-19 at 7 46 46 PM" src="https://github.com/user-attachments/assets/89209f6b-45cf-48bc-a7cf-b973364c6b41" />
* **Addtional**: Fix minor render logic bug with 'Plan to offer' flow.


## Why are these changes being made?

This is part of the Improved A4A Onboarding project that enhances the conversion rate.

## Testing Instructions

* Use the A4A live link and navigate to `/signup?flags=a4a-signup-v2`.
* Verify the flow works.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?