### PR TITLE
Notifications: browser notif banner — use "external link" and clean out un-used CSS

### DIFF
--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -1,5 +1,5 @@
-import { Card, Button } from '@automattic/components';
-import { ToggleControl } from '@wordpress/components';
+import { Card } from '@automattic/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -113,16 +113,11 @@ class PushNotificationSettings extends Component {
 								<div>
 									{ blockedInstructionUrl &&
 										this.props.translate(
-											'{{instructionsButton}}View Instructions to Enable{{/instructionsButton}}',
+											'{{instructionsButton}}View instructions to enable{{/instructionsButton}}',
 											{
 												components: {
 													instructionsButton: (
-														<Button
-															className="is-link"
-															href={ blockedInstructionUrl }
-															target="_blank"
-															rel="noopener noreferrer"
-														/>
+														<ExternalLink href={ blockedInstructionUrl } target="_blank" />
 													),
 												},
 											}

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -11,81 +11,15 @@
 		}
 	}
 
-	.is-link {
-
-		&:focus,
-		&:active {
-			color: var(--color-neutral-20);
+	// Removes underline from the ↗ icon
+	a.components-external-link.components-external-link {
+		text-decoration: none;
+		.components-external-link__contents {
+			text-decoration: underline;
 		}
-	}
-}
-
-.notification-settings-push-notification-settings__instruction-dialog {
-	position: relative;
-}
-
-.notification-settings-push-notification-settings__instruction-image {
-	svg {
-		width: 180px;
-		height: 180px;
-	}
-}
-
-.notification-settings-push-notification-settings__instruction-dismiss {
-	position: absolute;
-	top: 8px;
-	right: 8px;
-	padding: 0;
-	cursor: pointer;
-	color: var(--color-neutral-light);
-
-	&:hover,
-	&:focus {
-		color: var(--color-neutral-70);
-	}
-
-	.gridicon {
-		display: block;
-	}
-}
-
-.notification-settings-push-notification-settings__instruction-content {
-	max-width: 500px;
-	text-align: center;
-
-	@include breakpoint-deprecated("<660px") {
-		text-align: left;
-	}
-}
-
-.notification-settings-push-notification-settings__instruction-title {
-	font-weight: 600;
-	display: block;
-	margin-bottom: 24px;
-}
-
-.notification-settings-push-notification-settings__instruction-step {
-	width: 50%;
-	box-sizing: border-box;
-	display: inline-block;
-	padding: 0 24px;
-
-	p {
-		margin: 16px 0 0;
-	}
-
-	@include breakpoint-deprecated("<660px") {
-		width: 100%;
-		min-height: 80px;
-		position: relative;
-		text-align: left;
-		padding: 11px 16px 0 82px;
-
-		img {
-			position: absolute;
-			top: 8px;
-			left: 8px;
-			max-width: 60px;
+		&:hover .components-external-link__contents,
+		&:active .components-external-link__contents {
+			text-decoration: none;
 		}
 	}
 }
@@ -93,53 +27,4 @@
 .card.notification-settings-push-notification-settings__settings {
 	position: relative;
 	margin-top: 1em;
-}
-
-.notification-settings-push-notification-settings__settings-heading {
-	font-weight: 600;
-	position: relative;
-	margin-bottom: 8px;
-}
-
-.notification-settings-push-notification-settings__settings-icon {
-	position: absolute;
-	top: 0;
-	left: -32px;
-}
-
-.push-notification-settings__instruction-refresh-notice {
-	text-align: left;
-	margin-top: 32px;
-	margin-bottom: 0;
-}
-
-.notification-settings-push-notification-settings__settings-state {
-	font-size: $font-body-small;
-	font-weight: 600;
-	margin-left: 8px;
-	text-transform: uppercase;
-	color: var(--color-text-subtle);
-
-	&.is-enabled {
-		color: var(--color-success);
-	}
-}
-
-.notification-settings-push-notification-settings__settings-description {
-	margin-bottom: 0;
-
-	@include breakpoint-deprecated(">660px") {
-		margin-right: 130px;
-	}
-}
-
-.notification-settings-push-notification-settings__settings-button {
-	margin-top: 8px;
-
-	@include breakpoint-deprecated(">660px") {
-		margin-top: 0;
-		position: absolute;
-		bottom: 24px;
-		right: 24px;
-	}
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/103258

## Proposed Changes

* Use sentence case instead of title case in the link, as is our writing style now (pgijrj-42-p2)
* Use `ExternalLink` instead of button, mostly to get `↗` symbol visible as is style for external links
    * Adds CSS to remove underline style from arrow in the link; not ideal, and I could move this to `Notice` component itself to solve everywhere. Without the fix (inactive + hover):

        <img width="243" alt="Screenshot 2025-05-15 at 11 19 58" src="https://github.com/user-attachments/assets/182b74c0-28e3-42a0-833f-3892edcbc844" />
        <img width="235" alt="Screenshot 2025-05-15 at 11 20 05" src="https://github.com/user-attachments/assets/8cb2be88-4b45-4661-a057-d7a4426c916d" />

     
* Remove now unused CSS that was left over from the modal removal done at https://github.com/Automattic/wp-calypso/pull/103258

**Before**

<img width="1081" alt="Screenshot 2025-05-15 at 11 13 19" src="https://github.com/user-attachments/assets/2fbf02f2-3df9-4db1-ad6a-ec0d4e7d044f" />


**After**

<img width="1062" alt="Screenshot 2025-05-15 at 11 15 11" src="https://github.com/user-attachments/assets/b2ca82af-5442-4925-9885-af20657864d2" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* At `/me/notifications`
* Block notifications in browser
    <img width="342" alt="Screenshot 2025-05-15 at 10 58 36" src="https://github.com/user-attachments/assets/68d0ea19-ef83-4c8a-b9cb-75862381d660" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
