### PR TITLE
Plugins: Update plugins page upgrade upsell to disable one click checkout

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -127,6 +127,7 @@ const UpgradeNudge = ( {
 				feature={ FEATURE_INSTALL_PLUGINS }
 				plan={ PLAN_ECOMMERCE_MONTHLY }
 				title={ translate( 'To install additional plugins, please upgrade to a paid plan.' ) }
+				isOneClickCheckoutEnabled={ false }
 			/>
 		);
 	}
@@ -153,7 +154,7 @@ const UpgradeNudge = ( {
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }
-			isOneClickCheckoutEnabled
+			isOneClickCheckoutEnabled={ false }
 		/>
 	);
 };


### PR DESCRIPTION
In #85633, the Upsell nudge was changed to use the one-click checkout and use a modal, but it seems like we don't like that for the upgrade nudge on the plugins page for Simple sites with a free plan.

Fixes MYJP-122

## Proposed Changes

* Disable one-click modal checkout for plugins page upgrade upsell for Plugins page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you have a Simple site with a free plan
* Ensure that the site has a valid payment method added at `https://wordpress.com/purchases/payment-methods/:site`
* Open the Calypso live link below
* Goto `/plugins/:site` for the above Simple site
* Click on "Upgrade" in the upsell
* Confirm that it does not open the checkout modal
* Confirm that goes to the upgrade page instead

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/7fcb8eb1-a34d-40e7-86f3-07eedb0d57a4

</td>
            <td>

https://github.com/user-attachments/assets/2a7c4d76-6668-43c4-9eff-b6ed6928df68

</td>
        </tr>
    </tbody>
</table>