### PR TITLE
STATS-51: Make post likes same height as post details.

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -105,7 +105,8 @@
 	}
 
 	.card.stats-post-likes {
-		padding: 0;
+		position: absolute;
+		padding: 0 24px 16px 0;
 		margin: 0 0 -7px 0;
 		box-shadow: none;
 		overflow: hidden;

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -77,7 +77,6 @@
 
 	.highlight-card {
 		width: 100%;
-		max-height: 300px;
 		padding: 24px;
 		overflow-y: auto;
 	}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #STATS-51

## Proposed Changes

* Make post likes same height as post details.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->
* The post like card was having smaller height than post details card, if there's a post cover / featured image.

![Before](https://github.com/user-attachments/assets/146f1f1f-df2e-4dc0-ae0b-64810ba2d983)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live branch.
* Navigate to Stats > Traffic page.
* Click a post from the `Posts & pages` module, **that has a feature/cover image**.
* Ensure when the cards are side-by-side, they have same height in all aspect ratio,

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
