### PR TITLE
Stats: Avoid changing the current URL based on tab if current tab is already set

### DIFF
--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -55,9 +55,11 @@ function StatsDetailsNavigationImproved( {
 			tabs={ tabPanelTabs }
 			initialTabName={ selectedTab }
 			onSelect={ ( tabName ) => {
-				const tab = tabPanelTabs.find( ( tab ) => tab.name === tabName );
-				if ( tab?.path ) {
-					page( tab.path );
+				if ( tabName !== selectedTab ) {
+					const tab = tabPanelTabs.find( ( tab ) => tab.name === tabName );
+					if ( tab?.path ) {
+						page( tab.path );
+					}
 				}
 			} }
 		>

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -55,6 +55,7 @@ function StatsDetailsNavigationImproved( {
 			tabs={ tabPanelTabs }
 			initialTabName={ selectedTab }
 			onSelect={ ( tabName ) => {
+				// Skip navigation if the clicked tab is already active to avoid redundant actions.
 				if ( tabName !== selectedTab ) {
 					const tab = tabPanelTabs.find( ( tab ) => tab.name === tabName );
 					if ( tab?.path ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Similar to a previous PR - https://github.com/Automattic/wp-calypso/pull/103379
* When tabs are rendered on, the current tab URL is set even if you are already on the same page

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To avoid un-necessary URL change when tabs are present on a page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce, open this URL - https://wordpress.com/stats/email/opens/day/219178/jetpack.com?foo=bar
* This will redirect to remove the extra `foo=bar` query parameter as the URL for the tab is set when the component renders
* When testing this PR the URL http://calypso.localhost:3000/stats/email/opens/day/219178/jetpack.com?foo=bar should not redirect to remove the extra query parameters

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
