### PR TITLE
Add new story that combines DataViews and DataForm

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -7,6 +7,7 @@
 - Pin the actions column on the table view when the width is insufficient.
 - Bring changes from @wordpress/dataviews 4.19.0 (no updates in this version).
 - Enhance filter component styles.
+- Adds new story that combines DataViews and DataForm.
 
 ## 0.1.1
 

--- a/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
@@ -98,8 +98,8 @@ export const Default = ( {
 		null;
 
 	return (
-		<HStack spacing={ 4 } alignment="stretch" style={ { height: '80vh' } }>
-			<div style={ { flex: 2, minWidth: 0 } }>
+		<HStack alignment="stretch">
+			<div style={ { flex: 2 } }>
 				<DataViews
 					getItemId={ ( item ) => item.id.toString() }
 					data={ shownData }
@@ -115,60 +115,42 @@ export const Default = ( {
 							newSelection.map( ( id ) => parseInt( id, 10 ) )
 						)
 					}
-					onClickItem={ ( item ) => {
-						alert( 'clicked: ' + item.title );
-					} }
+					onClickItem={ ( item ) => alert( 'clicked ' + item.title ) }
 				/>
 			</div>
-			<div
-				style={ {
-					flex: 1,
-					minWidth: 320,
-					maxWidth: 400,
-					background: '#fafbfc',
-					borderLeft: '1px solid #e0e0e0',
-					padding: 24,
-				} }
-			>
-				{ selectedItem ? (
-					<Card>
-						<CardHeader>
-							<strong>{ selectedItem.title }</strong>
-						</CardHeader>
-						<CardBody>
-							<DataForm< SpaceObject >
-								data={ selectedItem }
-								fields={ fields }
-								form={ form }
-								onChange={ ( updatedValues ) => {
-									const updatedItem = {
-										...selectedItem,
-										...updatedValues,
-									};
+			{ selectedItem ? (
+				<VStack alignment="top">
+					<DataForm
+						data={ selectedItem }
+						form={ form }
+						fields={ fields }
+						onChange={ ( updatedValues ) => {
+							const updatedItem = {
+								...selectedItem,
+								...updatedValues,
+							};
 
-									setModifiedData(
-										modifiedData.map( ( item ) =>
-											item.id === selectedItem.id
-												? updatedItem
-												: item
-										)
-									);
-								} }
-							/>
-						</CardBody>
-					</Card>
-				) : (
-					<VStack
-						alignment="center"
-						justify="center"
-						style={ { height: '100%' } }
+							setModifiedData(
+								modifiedData.map( ( item ) =>
+									item.id === selectedItem.id
+										? updatedItem
+										: item
+								)
+							);
+						} }
+					/>
+				</VStack>
+			) : (
+				<VStack alignment="center">
+					<span
+						style={ {
+							color: '#888',
+						} }
 					>
-						<span style={ { color: '#888' } }>
-							Select an item to view details
-						</span>
-					</VStack>
-				) }
-			</div>
+						Please, select a single item.
+					</span>
+				</VStack>
+			) }
 		</HStack>
 	);
 };

--- a/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews-dataform-story/index.story.tsx
@@ -1,0 +1,174 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo } from '@wordpress/element';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Card,
+	CardHeader,
+	CardBody,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import DataViews from '../dataviews/index';
+import DataForm from '../dataform/index';
+import {
+	actions,
+	data,
+	fields,
+	type SpaceObject,
+} from '../dataviews/stories/fixtures';
+import { filterSortAndPaginate } from '../../filter-and-sort-data-view';
+import type { View, Form } from '../../types';
+
+const meta = {
+	title: 'DataViews/DataViewsAndDataForm',
+	component: DataForm,
+	argTypes: {
+		type: {
+			control: { type: 'select' },
+			description:
+				'Chooses the default layout of each field. "regular" is the default layout.',
+			options: [ 'default', 'regular', 'panel' ],
+		},
+		labelPosition: {
+			control: { type: 'select' },
+			description: 'Chooses the label position of the layout.',
+			options: [ 'default', 'top', 'side', 'none' ],
+		},
+	},
+} as const;
+export default meta;
+
+const defaultLayouts = {
+	table: {},
+	grid: {},
+	list: {},
+};
+
+export const Default = ( {
+	type,
+	labelPosition,
+}: {
+	type: 'default' | 'regular' | 'panel';
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+} ) => {
+	const form = useMemo(
+		() => ( {
+			type,
+			labelPosition,
+			fields: [
+				'title',
+				'description',
+				'type',
+				'isPlanet',
+				'satellites',
+				'date',
+			],
+		} ),
+		[ type, labelPosition ]
+	) as Form;
+
+	const [ view, setView ] = useState< View >( {
+		type: 'table' as const,
+		search: '',
+		page: 1,
+		perPage: 10,
+		layout: {},
+		filters: [],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+		fields: [ 'type', 'isPlanet', 'satellites', 'categories', 'date' ],
+	} );
+
+	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
+	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( modifiedData, view, fields );
+	}, [ modifiedData, view ] );
+
+	let selectedItem =
+		( selectedIds.length === 1 &&
+			shownData.find( ( item ) => item.id === selectedIds[ 0 ] ) ) ||
+		null;
+
+	return (
+		<HStack spacing={ 4 } alignment="stretch" style={ { height: '80vh' } }>
+			<div style={ { flex: 2, minWidth: 0 } }>
+				<DataViews
+					getItemId={ ( item ) => item.id.toString() }
+					data={ shownData }
+					paginationInfo={ paginationInfo }
+					view={ view }
+					fields={ fields }
+					onChangeView={ setView }
+					actions={ actions }
+					defaultLayouts={ defaultLayouts }
+					selection={ selectedIds.map( ( id ) => id.toString() ) }
+					onChangeSelection={ ( newSelection ) =>
+						setSelectedIds(
+							newSelection.map( ( id ) => parseInt( id, 10 ) )
+						)
+					}
+					onClickItem={ ( item ) => {
+						alert( 'clicked: ' + item.title );
+					} }
+				/>
+			</div>
+			<div
+				style={ {
+					flex: 1,
+					minWidth: 320,
+					maxWidth: 400,
+					background: '#fafbfc',
+					borderLeft: '1px solid #e0e0e0',
+					padding: 24,
+				} }
+			>
+				{ selectedItem ? (
+					<Card>
+						<CardHeader>
+							<strong>{ selectedItem.title }</strong>
+						</CardHeader>
+						<CardBody>
+							<DataForm< SpaceObject >
+								data={ selectedItem }
+								fields={ fields }
+								form={ form }
+								onChange={ ( updatedValues ) => {
+									const updatedItem = {
+										...selectedItem,
+										...updatedValues,
+									};
+
+									setModifiedData(
+										modifiedData.map( ( item ) =>
+											item.id === selectedItem.id
+												? updatedItem
+												: item
+										)
+									);
+								} }
+							/>
+						</CardBody>
+					</Card>
+				) : (
+					<VStack
+						alignment="center"
+						justify="center"
+						style={ { height: '100%' } }
+					>
+						<span style={ { color: '#888' } }>
+							Select an item to view details
+						</span>
+					</VStack>
+				) }
+			</div>
+		</HStack>
+	);
+};

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -649,6 +649,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Title',
 		id: 'title',
+		type: 'text',
 		enableHiding: false,
 		enableGlobalSearch: true,
 	},
@@ -689,6 +690,7 @@ export const fields: Field< SpaceObject >[] = [
 	{
 		label: 'Description',
 		id: 'description',
+		type: 'text',
 		enableSorting: false,
 		enableGlobalSearch: true,
 	},


### PR DESCRIPTION
## Proposed Changes

This PR adds a new story that combines DataViews and DataForm.

https://github.com/user-attachments/assets/074bbcbf-1cc9-4738-a36f-04c91bbd54a8


## Why are these changes being made?

In several instances lately, I've found myself wanting to compare changes to both. It's also good to have an example for inspiration.

## Testing Instructions

Run the storybook and access the new story:

```sh
yarn workspace @automattic/dataviews storybook:start
```
