### PR TITLE
Dashboard v2: Explore routes label

### DIFF
--- a/client/dashboard/app/primary-menu-mobile/index.tsx
+++ b/client/dashboard/app/primary-menu-mobile/index.tsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
 import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAppContext } from '../context';
+import { sitesRoute, domainsRoute, emailsRoute, siteOverviewRoute } from '../router';
 
 function PrimaryMenuMobile() {
 	const { supports } = useAppContext();
@@ -18,23 +19,23 @@ function PrimaryMenuMobile() {
 			{ ( { onClose } ) => (
 				<>
 					{ supports.overview && (
-						<RouterLinkMenuItem to="/overview" onClick={ onClose }>
-							{ __( 'Overview' ) }
+						<RouterLinkMenuItem to={ siteOverviewRoute.to } onClick={ onClose }>
+							{ siteOverviewRoute.options.staticData.label() }
 						</RouterLinkMenuItem>
 					) }
 					{ supports.sites && (
-						<RouterLinkMenuItem to="/sites" onClick={ onClose }>
-							{ __( 'Sites' ) }
+						<RouterLinkMenuItem to={ sitesRoute.to }>
+							{ sitesRoute.options.staticData.label() }
 						</RouterLinkMenuItem>
 					) }
 					{ supports.domains && (
-						<RouterLinkMenuItem to="/domains" onClick={ onClose }>
-							{ __( 'Domains' ) }
+						<RouterLinkMenuItem to={ domainsRoute.to }>
+							{ domainsRoute.options.staticData.label() }
 						</RouterLinkMenuItem>
 					) }
 					{ supports.emails && (
-						<RouterLinkMenuItem to="/emails" onClick={ onClose }>
-							{ __( 'Emails' ) }
+						<RouterLinkMenuItem to={ emailsRoute.to }>
+							{ emailsRoute.options.staticData.label() }
 						</RouterLinkMenuItem>
 					) }
 				</>

--- a/client/dashboard/app/primary-menu/index.tsx
+++ b/client/dashboard/app/primary-menu/index.tsx
@@ -1,16 +1,26 @@
-import { __ } from '@wordpress/i18n';
 import Menu from '../../components/menu';
 import { useAppContext } from '../context';
+import { sitesRoute, domainsRoute, emailsRoute, siteOverviewRoute } from '../router';
 
 function PrimaryMenu() {
 	const { supports } = useAppContext();
 
 	return (
 		<Menu>
-			{ supports.overview && <Menu.Item to="/overview">{ __( 'Overview' ) }</Menu.Item> }
-			{ supports.sites && <Menu.Item to="/sites">{ __( 'Sites' ) }</Menu.Item> }
-			{ supports.domains && <Menu.Item to="/domains">{ __( 'Domains' ) }</Menu.Item> }
-			{ supports.emails && <Menu.Item to="/emails">{ __( 'Emails' ) }</Menu.Item> }
+			{ supports.overview && (
+				<Menu.Item to={ siteOverviewRoute.to }>
+					{ siteOverviewRoute.options.staticData.label() }
+				</Menu.Item>
+			) }
+			{ supports.sites && (
+				<Menu.Item to={ sitesRoute.to }>{ sitesRoute.options.staticData.label() }</Menu.Item>
+			) }
+			{ supports.domains && (
+				<Menu.Item to={ domainsRoute.to }>{ domainsRoute.options.staticData.label() }</Menu.Item>
+			) }
+			{ supports.emails && (
+				<Menu.Item to={ emailsRoute.to }>{ emailsRoute.options.staticData.label() }</Menu.Item>
+			) }
 		</Menu>
 	);
 }

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -5,6 +5,7 @@ import {
 	redirect,
 	createLazyRoute,
 } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
 import { fetchTwoStep } from '../data';
 import NotFound from './404';
 import UnknownError from './500';
@@ -24,11 +25,19 @@ interface RouteContext {
 	config?: AppConfig;
 }
 
-const rootRoute = createRootRoute( { component: Root } );
+const rootRoute = createRootRoute( {
+	component: Root,
+	staticData: {
+		label: () => __( 'Root' ),
+	},
+} );
 
 const indexRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: '/',
+	staticData: {
+		label: () => __( 'Home' ),
+	},
 	beforeLoad: ( { context }: { context: RouteContext } ) => {
 		if ( context.config ) {
 			throw redirect( { to: context.config.mainRoute } );
@@ -39,6 +48,9 @@ const indexRoute = createRoute( {
 const overviewRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'overview',
+	staticData: {
+		label: () => __( 'Overview' ),
+	},
 } ).lazy( () =>
 	import( '../agency-overview' ).then( ( d ) =>
 		createLazyRoute( 'agency-overview' )( {
@@ -51,6 +63,9 @@ const sitesRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites',
 	loader: () => queryClient.ensureQueryData( sitesQuery() ),
+	staticData: {
+		label: () => __( 'Sites' ),
+	},
 } ).lazy( () =>
 	import( '../sites' ).then( ( d ) =>
 		createLazyRoute( 'sites' )( {
@@ -63,6 +78,9 @@ const siteRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteSlug',
 	loader: ( { params: { siteSlug } } ) => queryClient.ensureQueryData( siteQuery( siteSlug ) ),
+	staticData: {
+		label: () => __( 'Site' ),
+	},
 } ).lazy( () =>
 	import( '../sites/site' ).then( ( d ) =>
 		createLazyRoute( 'site' )( {
@@ -74,6 +92,9 @@ const siteRoute = createRoute( {
 const siteOverviewRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: '/',
+	staticData: {
+		label: () => __( 'Overview' ),
+	},
 } ).lazy( () =>
 	import( '../sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'site-overview' )( {
@@ -85,6 +106,9 @@ const siteOverviewRoute = createRoute( {
 const siteDeploymentsRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'deployments',
+	staticData: {
+		label: () => __( 'Deployments' ),
+	},
 } ).lazy( () =>
 	import( '../sites/deployments' ).then( ( d ) =>
 		createLazyRoute( 'site-deployments' )( {
@@ -96,6 +120,9 @@ const siteDeploymentsRoute = createRoute( {
 const sitePerformanceRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'performance',
+	staticData: {
+		label: () => __( 'Performance' ),
+	},
 } ).lazy( () =>
 	import( '../sites/performance' ).then( ( d ) =>
 		createLazyRoute( 'site-performance' )( {
@@ -109,6 +136,9 @@ const siteSettingsRoute = createRoute( {
 	path: 'settings',
 	loader: ( { params: { siteSlug } } ) =>
 		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+	staticData: {
+		label: () => __( 'Settings' ),
+	},
 } ).lazy( () =>
 	import( '../sites/settings' ).then( ( d ) =>
 		createLazyRoute( 'site-settings' )( {
@@ -122,6 +152,9 @@ const siteSettingsSubscriptionGiftingRoute = createRoute( {
 	path: 'settings/subscription-gifting',
 	loader: ( { params: { siteSlug } } ) =>
 		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+	staticData: {
+		label: () => __( 'Subscription gifting' ),
+	},
 } ).lazy( () =>
 	import( '../sites/settings-subscription-gifting' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-subscription-gifting' )( {
@@ -134,6 +167,9 @@ const domainsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains',
 	loader: () => queryClient.ensureQueryData( domainsQuery() ),
+	staticData: {
+		label: () => __( 'Domains' ),
+	},
 } ).lazy( () =>
 	import( '../domains' ).then( ( d ) =>
 		createLazyRoute( 'domains' )( {
@@ -146,6 +182,9 @@ const emailsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'emails',
 	loader: () => queryClient.ensureQueryData( emailsQuery() ),
+	staticData: {
+		label: () => __( 'Emails' ),
+	},
 } ).lazy( () =>
 	import( '../emails' ).then( ( d ) =>
 		createLazyRoute( 'emails' )( {
@@ -157,6 +196,9 @@ const emailsRoute = createRoute( {
 const meRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'me',
+	staticData: {
+		label: () => __( 'Account' ),
+	},
 	loader: () => queryClient.ensureQueryData( profileQuery() ),
 	beforeLoad: async ( { cause } ) => {
 		if ( cause !== 'enter' ) {
@@ -180,6 +222,9 @@ const meRoute = createRoute( {
 const profileRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'profile',
+	staticData: {
+		label: () => __( 'Profile' ),
+	},
 } ).lazy( () =>
 	import( '../me/profile' ).then( ( d ) =>
 		createLazyRoute( 'profile' )( {
@@ -191,6 +236,9 @@ const profileRoute = createRoute( {
 const billingRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'billing',
+	staticData: {
+		label: () => __( 'Billing' ),
+	},
 } ).lazy( () =>
 	import( '../me/billing' ).then( ( d ) =>
 		createLazyRoute( 'billing' )( {
@@ -202,6 +250,9 @@ const billingRoute = createRoute( {
 const billingHistoryRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'billing/billing-history',
+	staticData: {
+		label: () => __( 'Billing history' ),
+	},
 } ).lazy( () =>
 	import( '../me/billing-history' ).then( ( d ) =>
 		createLazyRoute( 'billing-history' )( {
@@ -213,6 +264,9 @@ const billingHistoryRoute = createRoute( {
 const activeSubscriptionsRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'billing/active-subscriptions',
+	staticData: {
+		label: () => __( 'Active subscriptions' ),
+	},
 } ).lazy( () =>
 	import( '../me/active-subscriptions' ).then( ( d ) =>
 		createLazyRoute( 'active-subscriptions' )( {
@@ -224,6 +278,9 @@ const activeSubscriptionsRoute = createRoute( {
 const paymentMethodsRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'billing/payment-methods',
+	staticData: {
+		label: () => __( 'Payment methods' ),
+	},
 } ).lazy( () =>
 	import( '../me/payment-methods' ).then( ( d ) =>
 		createLazyRoute( 'payment-methods' )( {
@@ -235,6 +292,9 @@ const paymentMethodsRoute = createRoute( {
 const taxDetailsRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'billing/tax-details',
+	staticData: {
+		label: () => __( 'Tax details' ),
+	},
 } ).lazy( () =>
 	import( '../me/tax-details' ).then( ( d ) =>
 		createLazyRoute( 'tax-details' )( {
@@ -246,6 +306,9 @@ const taxDetailsRoute = createRoute( {
 const securityRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'security',
+	staticData: {
+		label: () => __( 'Security' ),
+	},
 } ).lazy( () =>
 	import( '../me/security' ).then( ( d ) =>
 		createLazyRoute( 'security' )( {
@@ -257,6 +320,9 @@ const securityRoute = createRoute( {
 const privacyRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'privacy',
+	staticData: {
+		label: () => __( 'Privacy' ),
+	},
 } ).lazy( () =>
 	import( '../me/privacy' ).then( ( d ) =>
 		createLazyRoute( 'privacy' )( {
@@ -268,6 +334,9 @@ const privacyRoute = createRoute( {
 const notificationsRoute = createRoute( {
 	getParentRoute: () => meRoute,
 	path: 'notifications',
+	staticData: {
+		label: () => __( 'Notifications' ),
+	},
 } ).lazy( () =>
 	import( '../me/notifications' ).then( ( d ) =>
 		createLazyRoute( 'notifications' )( {

--- a/client/dashboard/app/secondary-menu/index.tsx
+++ b/client/dashboard/app/secondary-menu/index.tsx
@@ -16,6 +16,7 @@ import RouterLinkMenuItem from '../../components/router-link-menu-item';
 import { useAuth } from '../auth';
 import { useOpenCommandPalette } from '../command-palette/utils';
 import { useAppContext } from '../context';
+import { profileRoute } from '../router';
 
 import './style.scss';
 
@@ -57,7 +58,7 @@ function UserProfile() {
 						<Text variant="muted">@{ user.username }</Text>
 					</VStack>
 					<MenuGroup>
-						<RouterLinkMenuItem to="/me/profile">{ __( 'Account' ) }</RouterLinkMenuItem>
+						<RouterLinkMenuItem to={ profileRoute.to }>{ __( 'Account' ) }</RouterLinkMenuItem>
 					</MenuGroup>
 					<MenuGroup>
 						<MenuItem

--- a/client/dashboard/app/types.d.ts
+++ b/client/dashboard/app/types.d.ts
@@ -1,0 +1,7 @@
+import '@tanstack/react-router';
+
+declare module '@tanstack/react-router' {
+	interface StaticDataRouteOption {
+		label: () => string;
+	}
+}

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -5,6 +5,7 @@ import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { domainsQuery } from '../app/queries';
+import { domainsRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -102,7 +103,7 @@ function Domains() {
 	return (
 		<PageLayout>
 			<PageHeader
-				title={ __( 'Domains' ) }
+				title={ domainsRoute.options.staticData.label() }
 				actions={
 					<Button variant="primary" __next40pxDefaultSize>
 						{ __( 'Add New Domain' ) }

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -5,6 +5,7 @@ import { Button, ExternalLink, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from 'react';
 import { emailsQuery } from '../app/queries';
+import { emailsRoute } from '../app/router';
 import DataViewsCard from '../components/dataviews-card';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -120,7 +121,7 @@ function Emails() {
 	return (
 		<PageLayout>
 			<PageHeader
-				title={ __( 'Emails' ) }
+				title={ emailsRoute.options.staticData.label() }
 				actions={
 					<>
 						<Button variant="secondary" __next40pxDefaultSize>

--- a/client/dashboard/me/active-subscriptions/index.tsx
+++ b/client/dashboard/me/active-subscriptions/index.tsx
@@ -1,11 +1,11 @@
-import { __ } from '@wordpress/i18n';
+import { activeSubscriptionsRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 export default function ActiveSubscriptions() {
 	return (
 		<PageLayout size="small">
-			<PageHeader title={ __( 'Active Subscriptions' ) } />
+			<PageHeader title={ activeSubscriptionsRoute.options.staticData.label() } />
 			<div>Active subscriptions content will go here</div>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -1,11 +1,11 @@
-import { __ } from '@wordpress/i18n';
+import { billingHistoryRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 function BillingHistory() {
 	return (
 		<PageLayout size="small">
-			<PageHeader title={ __( 'Billing History' ) } />
+			<PageHeader title={ billingHistoryRoute.options.staticData.label() } />
 			<div>Billing history content will go here</div>
 		</PageLayout>
 	);

--- a/client/dashboard/me/billing/index.tsx
+++ b/client/dashboard/me/billing/index.tsx
@@ -2,6 +2,7 @@ import { __experimentalVStack as VStack, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { backup, payment, receipt, institution } from '@wordpress/icons';
 import {
+	billingRoute,
 	activeSubscriptionsRoute,
 	billingHistoryRoute,
 	paymentMethodsRoute,
@@ -14,28 +15,28 @@ import RouterLinkSummaryButton from '../../components/router-link-summary-button
 function Billing() {
 	return (
 		<PageLayout size="small">
-			<PageHeader title={ __( 'Billing' ) } />
+			<PageHeader title={ billingRoute.options.staticData.label() } />
 			<VStack spacing={ 4 }>
 				<RouterLinkSummaryButton
-					title={ __( 'Active subscriptions' ) }
+					title={ activeSubscriptionsRoute.options.staticData.label() }
 					description={ __( 'View your current plan and usage.' ) }
 					decoration={ <Icon icon={ receipt } /> }
 					to={ activeSubscriptionsRoute.to }
 				/>
 				<RouterLinkSummaryButton
-					title={ __( 'Billing history' ) }
+					title={ billingHistoryRoute.options.staticData.label() }
 					description={ __( 'View email receipts for past purchases.' ) }
 					decoration={ <Icon icon={ backup } /> }
 					to={ billingHistoryRoute.to }
 				/>
 				<RouterLinkSummaryButton
-					title={ __( 'Payment methods' ) }
+					title={ paymentMethodsRoute.options.staticData.label() }
 					description={ __( 'Manage credit cards saved to your account.' ) }
 					decoration={ <Icon icon={ payment } /> }
 					to={ paymentMethodsRoute.to }
 				/>
 				<RouterLinkSummaryButton
-					title={ __( 'Tax details' ) }
+					title={ taxDetailsRoute.options.staticData.label() }
 					description={ __( 'Configure tax details (VAT/GST/CT) to be included on all receipts.' ) }
 					decoration={ <Icon icon={ institution } /> }
 					to={ taxDetailsRoute.to }

--- a/client/dashboard/me/notifications/index.tsx
+++ b/client/dashboard/me/notifications/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { notificationsRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
@@ -6,7 +7,7 @@ function Notifications() {
 	return (
 		<PageLayout size="small">
 			<PageHeader
-				title={ __( 'Notifications' ) }
+				title={ notificationsRoute.options.staticData.label() }
 				description={ __( 'Manage your notification settings.' ) }
 			/>
 		</PageLayout>

--- a/client/dashboard/me/payment-methods/index.tsx
+++ b/client/dashboard/me/payment-methods/index.tsx
@@ -1,11 +1,11 @@
-import { __ } from '@wordpress/i18n';
+import { paymentMethodsRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 export default function PaymentMethods() {
 	return (
 		<PageLayout size="small">
-			<PageHeader title={ __( 'Payment Methods' ) } />
+			<PageHeader title={ paymentMethodsRoute.options.staticData.label() } />
 			<div>Payment methods content will go here</div>
 		</PageLayout>
 	);

--- a/client/dashboard/me/privacy/index.tsx
+++ b/client/dashboard/me/privacy/index.tsx
@@ -1,11 +1,15 @@
 import { __ } from '@wordpress/i18n';
+import { privacyRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 function Privacy() {
 	return (
 		<PageLayout size="small">
-			<PageHeader title={ __( 'Privacy' ) } description={ __( 'Manage your privacy settings.' ) } />
+			<PageHeader
+				title={ privacyRoute.options.staticData?.label() }
+				description={ __( 'Manage your privacy settings.' ) }
+			/>
 		</PageLayout>
 	);
 }

--- a/client/dashboard/me/security/index.tsx
+++ b/client/dashboard/me/security/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { securityRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
@@ -6,7 +7,7 @@ function Security() {
 	return (
 		<PageLayout size="small">
 			<PageHeader
-				title={ __( 'Security' ) }
+				title={ securityRoute.options.staticData.label() }
 				description={ __( 'Manage your security settings.' ) }
 			/>
 		</PageLayout>

--- a/client/dashboard/me/tax-details/index.tsx
+++ b/client/dashboard/me/tax-details/index.tsx
@@ -1,11 +1,11 @@
-import { __ } from '@wordpress/i18n';
+import { taxDetailsRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 export default function TaxDetails() {
 	return (
 		<PageLayout size="small">
-			<PageHeader title={ __( 'Tax Details' ) } />
+			<PageHeader title={ taxDetailsRoute.options.staticData.label() } />
 			<div>Tax details content will go here</div>
 		</PageLayout>
 	);

--- a/client/dashboard/sites/deployments/index.tsx
+++ b/client/dashboard/sites/deployments/index.tsx
@@ -1,11 +1,11 @@
-import { __ } from '@wordpress/i18n';
+import { siteDeploymentsRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 function SiteDeployments() {
 	return (
 		<PageLayout>
-			<PageHeader title={ __( 'Deployments' ) } />
+			<PageHeader title={ siteDeploymentsRoute.options.staticData.label() } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -222,7 +222,7 @@ export default function Sites() {
 		<>
 			<PageLayout>
 				<PageHeader
-					title={ __( 'Sites' ) }
+					title={ sitesRoute.options.staticData.label() }
 					actions={
 						<Button variant="primary" __next40pxDefaultSize>
 							{ __( 'Add New Site' ) }

--- a/client/dashboard/sites/performance/index.tsx
+++ b/client/dashboard/sites/performance/index.tsx
@@ -1,11 +1,11 @@
-import { __ } from '@wordpress/i18n';
+import { sitePerformanceRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 function SitePerformance() {
 	return (
 		<PageLayout>
-			<PageHeader title={ __( 'Performance' ) } />
+			<PageHeader title={ sitePerformanceRoute.options.staticData.label() } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -57,7 +57,7 @@ export default function SubscriptionGiftingSettings() {
 	return (
 		<PageLayout size="small">
 			<SettingsPageHeader
-				title={ __( 'Accept a gift subscription' ) }
+				title={ siteSettingsSubscriptionGiftingRoute.options.staticData.label() }
 				description={ __(
 					'Allow a site visitor to cover the full cost of your site’s WordPress.com plan.'
 				) }

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -1,14 +1,13 @@
 import { __ } from '@wordpress/i18n';
+import { siteSettingsSubscriptionGiftingRoute } from '../../app/router';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
 import { hasSubscriptionGiftingFeature } from './utils';
 import type { Site, SiteSettings } from '../../data/types';
 
 export default function SubscriptionGiftingSettingsSummary( {
-	siteSlug,
 	site,
 	settings,
 }: {
-	siteSlug: string;
 	site: Site;
 	settings: SiteSettings;
 } ) {
@@ -17,8 +16,8 @@ export default function SubscriptionGiftingSettingsSummary( {
 	}
 	return (
 		<RouterLinkSummaryButton
-			to={ `/sites/${ siteSlug }/settings/subscription-gifting` }
-			title={ __( 'Accept a gift subscription' ) }
+			to={ siteSettingsSubscriptionGiftingRoute.to }
+			title={ siteSettingsSubscriptionGiftingRoute.options.staticData.label() }
 			density="medium"
 			badges={
 				settings.wpcom_gifting_subscription

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { siteQuery, siteSettingsQuery } from '../../app/queries';
-import { siteRoute } from '../../app/router';
+import { siteRoute, siteSettingsRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
@@ -22,15 +22,11 @@ export default function SiteSettings() {
 
 	return (
 		<PageLayout size="small">
-			<PageHeader title={ __( 'Settings' ) } />
+			<PageHeader title={ siteSettingsRoute.options.staticData.label() } />
 			<Heading>{ __( 'General' ) }</Heading>
 			<Card>
 				<VStack>
-					<SubscriptionGiftingSettingsSummary
-						siteSlug={ siteSlug }
-						site={ siteData.site }
-						settings={ settings }
-					/>
+					<SubscriptionGiftingSettingsSummary site={ siteData.site } settings={ settings } />
 				</VStack>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/sites/site-menu/index.tsx
+++ b/client/dashboard/sites/site-menu/index.tsx
@@ -1,20 +1,26 @@
 import { __ } from '@wordpress/i18n';
+import {
+	siteDeploymentsRoute,
+	siteSettingsRoute,
+	sitePerformanceRoute,
+	siteOverviewRoute,
+} from '../../app/router';
 import ResponsiveMenu from '../../components/responsive-menu';
 
-const SiteMenu = ( { siteSlug }: { siteSlug: string } ) => {
+const SiteMenu = () => {
 	return (
 		<ResponsiveMenu label={ __( 'Site Menu' ) }>
-			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }` } activeOptions={ { exact: true } }>
-				{ __( 'Overview' ) }
+			<ResponsiveMenu.Item to={ siteOverviewRoute.to } activeOptions={ { exact: true } }>
+				{ siteOverviewRoute.options.staticData.label() }
 			</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/deployments` }>
-				{ __( 'Deployments' ) }
+			<ResponsiveMenu.Item to={ siteDeploymentsRoute.to }>
+				{ siteDeploymentsRoute.options.staticData.label() }
 			</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/performance` }>
-				{ __( 'Performance' ) }
+			<ResponsiveMenu.Item to={ sitePerformanceRoute.to }>
+				{ sitePerformanceRoute.options.staticData.label() }
 			</ResponsiveMenu.Item>
-			<ResponsiveMenu.Item to={ `/sites/${ siteSlug }/settings` }>
-				{ __( 'Settings' ) }
+			<ResponsiveMenu.Item to={ siteSettingsRoute.to }>
+				{ siteSettingsRoute.options.staticData.label() }
 			</ResponsiveMenu.Item>
 		</ResponsiveMenu>
 	);

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -38,7 +38,7 @@ function Site() {
 						/>
 					</HeaderBar.Title>
 					{ isDesktop && <MenuDivider /> }
-					<SiteMenu siteSlug={ siteSlug } />
+					<SiteMenu />
 				</HStack>
 			</HeaderBar>
 			<Outlet />


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

This PR explores adding a `label` in every route in Dashboard v2. Additionally I've update the hardcoded strings of links `to` and get them from the route.

Pros:
1. Keep in sync menus, page titles, and breadcrumb items

Cons:
1. Almost every route needs a label but there are a couple of exceptions like `rootRoute and siteRoute`.  If we make `StaticDataRouteOption` `label` prop optional for those, we would need to make TS happy for every usage. Is it worth it? Is it a code smell if we keep it required? Personally don't think there will be many similars routes..
2. anything else? 🤔 

## Testing Instructions
1. Everything should work as before.
3. You could change one route label and observe that menus, titles, etc.. are kept in sync.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
