### PR TITLE
Account: Clean-up profile settings

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import EditGravatar from 'calypso/blocks/edit-gravatar';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -116,9 +115,6 @@ class Profile extends Component {
 								onFocus={ this.getFocusHandler( 'Display Name Field' ) }
 								value={ this.props.getSetting( 'display_name' ) }
 							/>
-							<FormSettingExplanation>
-								{ this.props.translate( 'Shown publicly when you comment on blogs.' ) }
-							</FormSettingExplanation>
 						</FormFieldset>
 
 						<FormFieldset>
@@ -135,26 +131,6 @@ class Profile extends Component {
 								placeholder="https://example.com"
 								value={ this.props.getSetting( 'user_URL' ) }
 							/>
-							<FormSettingExplanation>
-								{ this.props.translate( 'Shown publicly when you comment on blogs.' ) }
-							</FormSettingExplanation>
-						</FormFieldset>
-
-						<FormFieldset>
-							<div className="form-label">{ this.props.translate( 'Public profile' ) }</div>
-							<FormSettingExplanation>
-								<span>
-									{ this.props.translate(
-										'You can find your public profile at {{a}}{{url/}}{{/a}}',
-										{
-											components: {
-												a: <a href={ relativeProfileUrl }></a>,
-												url: <>{ absoluteProfileUrl }</>,
-											},
-										}
-									) }
-								</span>
-							</FormSettingExplanation>
 						</FormFieldset>
 
 						<FormFieldset>
@@ -169,11 +145,20 @@ class Profile extends Component {
 							/>
 						</FormFieldset>
 
+						<p className="profile__public-url">
+							{ this.props.translate( 'View your public profile at {{a}}{{url/}}{{/a}}.', {
+								components: {
+									a: <ExternalLink href={ relativeProfileUrl } />,
+									url: <>{ absoluteProfileUrl }</>,
+								},
+							} ) }
+						</p>
+
 						<p className="profile__gravatar-profile-description">
 							<span>
 								{ this.props.translate(
-									'Your WordPress.com profile is connected to Gravatar. Your Gravatar is public by default and may appear on any site using Gravatar when you’re logged in with {{strong}}%(email)s{{/strong}}.' +
-										' To manage your Gravatar profile, profile links, and visibility settings, {{a}}visit your Gravatar profile{{/a}}.',
+									'Your WordPress.com profile is linked to Gravatar, making your Gravatar public by default. It may appear on sites using Gravatar when logged in with {{strong}}%(email)s{{/strong}}.' +
+										' Any changes you make here will be synced to your {{a}}Gravatar profile{{/a}}.',
 									{
 										components: {
 											strong: <strong />,

--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -24,6 +24,10 @@
 	}
 }
 
+.profile__settings .profile__public-url {
+	font-size: $font-body-small;
+}
+
 .profile__is_dev_account-fieldset-is-loading {
 	.components-form-toggle {
 		> * {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCOM-12845

## Proposed Changes

* Removed unnecessary field notes on display name and web address. The field labels and page description already make it clear that this information will be public.
* Moved public profile URL to the bottom of the page, switched to an ExternalLink, and dropped the unnecessary label. (This is not a form field that's editable.)
* Improved copy for Gravatar explanation, eliminating the widowed link in the current implementation.

We have some additional ideas for improving the overall layout of this page, but those will be tackled as part of the hosting dashboard redesign.

I also fixed some translation issues for English (UK) where we have inconsistent capitalization. These are not included as part of this PR.

| Before | After |
|--------|--------|
| <img width="1872" alt="Screenshot 2025-05-15 at 14 13 58" src="https://github.com/user-attachments/assets/c100b6de-b125-4257-86fc-0b14c91b706d" /> | <img width="1872" alt="Screenshot 2025-05-15 at 14 13 56" src="https://github.com/user-attachments/assets/88b37ccc-7fdd-49b9-aa68-15caa601956d" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Related to Code Blue reports in [DOTCOM-12845](https://linear.app/a8c/issue/DOTCOM-12845/improve-copy-on-profile-page).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Run the app using `yarn start`
* Visit `/me` and verify that all the changes are visible.
