### PR TITLE
Experiment streamlining the plans grid + checkout: Implement the checkout layout changes

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -661,7 +661,12 @@ export default function CheckoutMainContent( {
 	);
 
 	const checkoutMainContent = (
-		<WPCheckoutMainContent className="checkout-main-content">
+		<WPCheckoutMainContent
+			className="checkout-main-content"
+			isStreamlinedPrice={ isStreamlinedPriceCheckoutTreatment(
+				streamlinedPriceExperimentAssignment
+			) }
+		>
 			<CheckoutOrderBanner />
 			{ isStepContainerV2 ? (
 				<Step.Heading
@@ -974,31 +979,6 @@ const StepContainerV2CheckoutFixer = styled.div< {
 		margin-inline: 0;
 		max-width: 100%;
 	}
-
-	${ ( props ) =>
-		props.isStreamlinedPrice &&
-		css`
-			.order-review-line-items .checkout-line-item__remove-product {
-				font-size: 14px;
-			}
-			.form-fieldset.contact-details-form-fields .form__hidden-input a,
-			.checkout__content .wp-checkout-order-review__show-coupon-field-button {
-				font-weight: 500;
-				text-decoration: none;
-				color: ${ props.theme.colors.textColorDark };
-				font-size: 14px;
-			}
-			.form-fieldset.contact-details-form-fields .contact-details-form-fields__row,
-			.form-fieldset.contact-details-form-fields .custom-form-fieldsets__address-fields {
-				gap: 10px;
-			}
-			.form-fieldset.contact-details-form-fields .contact-details-form-fields__field {
-				margin-bottom: 10px;
-			}
-			.checkout-terms-and-checkboxes a {
-				color: ${ props.theme.colors.textColorDark };
-			}
-		` }
 
 	${ ( props ) =>
 		! props.isLargeViewport &&
@@ -1566,7 +1546,9 @@ const WPCheckoutCompletedWrapper = styled.div`
 	}
 `;
 
-const WPCheckoutMainContent = styled.div`
+const WPCheckoutMainContent = styled.div< {
+	isStreamlinedPrice?: boolean;
+} >`
 	grid-area: main-content;
 	margin-top: 50px;
 	min-height: 100vh;
@@ -1585,6 +1567,30 @@ const WPCheckoutMainContent = styled.div`
 			padding: 0 24px 0 64px;
 		}
 	}
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			.checkout-line-item .checkout-line-item__remove-product {
+				font-size: 14px;
+			}
+			.form-fieldset.contact-details-form-fields .form__hidden-input a,
+			.checkout__content .wp-checkout-order-review__show-coupon-field-button {
+				font-weight: 500;
+				text-decoration: none;
+				color: ${ props.theme.colors.textColorDark };
+				font-size: 14px;
+			}
+			.form-fieldset.contact-details-form-fields .contact-details-form-fields__row,
+			.form-fieldset.contact-details-form-fields .custom-form-fieldsets__address-fields {
+				gap: 10px;
+			}
+			.form-fieldset.contact-details-form-fields .contact-details-form-fields__field {
+				margin-bottom: 10px;
+			}
+			.checkout-terms-and-checkboxes a {
+				color: ${ props.theme.colors.textColorDark };
+			}
+		` }
 `;
 
 const WPCheckoutCompletedMainContent = styled.div`

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -405,6 +405,9 @@ export default function CheckoutMainContent( {
 
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
 		useStreamlinedPriceExperiment();
+	const isStreamlinedPrice =
+		! isStreamlinedPriceExperimentLoading &&
+		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment );
 
 	const searchParams = new URLSearchParams( window.location.search );
 	const isDIFMInCart = hasDIFMProduct( responseCart );
@@ -673,24 +676,146 @@ export default function CheckoutMainContent( {
 				<PerformanceTrackerStop />
 				{ infoMessage }
 
-				<CheckoutStepBody
-					onError={ onReviewError }
-					className="wp-checkout__review-order-step"
-					stepId="review-order-step"
-					isStepActive={ false }
-					isStepComplete
-					titleContent={ <OrderReviewTitle /> }
-					completeStepContent={
-						<WPCheckoutOrderReview
-							removeProductFromCart={ removeProductFromCart }
-							replaceProductInCart={ replaceProductInCart }
-							couponFieldStateProps={ couponFieldStateProps }
-							removeCouponAndClearField={ removeCouponAndClearField }
+					<CheckoutStepBody
+						onError={ onReviewError }
+						className="wp-checkout__review-order-step"
+						stepId="review-order-step"
+						isStepActive={ false }
+						isStepComplete
+						titleContent={ <OrderReviewTitle /> }
+						completeStepContent={
+							<WPCheckoutOrderReview
+								removeProductFromCart={ removeProductFromCart }
+								replaceProductInCart={ replaceProductInCart }
+								couponFieldStateProps={ couponFieldStateProps }
+								removeCouponAndClearField={ removeCouponAndClearField }
+								isCouponFieldVisible={ isCouponFieldVisible }
+								setCouponFieldVisible={ setCouponFieldVisible }
+								onChangeSelection={ changeSelection }
+								siteUrl={ siteUrl }
+								createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+							/>
+						}
+						formStatus={ formStatus }
+					/>
+
+					{ isStreamlinedPrice && (
+						<CouponFieldArea
 							isCouponFieldVisible={ isCouponFieldVisible }
 							setCouponFieldVisible={ setCouponFieldVisible }
-							onChangeSelection={ changeSelection }
-							siteUrl={ siteUrl }
-							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+							isPurchaseFree={ isPurchaseFree }
+							couponStatus={ couponStatus }
+							couponFieldStateProps={ couponFieldStateProps }
+						/>
+					) }
+
+					{ contactDetailsType !== 'none' && (
+						<CheckoutStep
+							className="checkout-contact-form-step"
+							stepId="contact-form"
+							isCompleteCallback={ async () => {
+								// Touch the fields so they display validation errors
+								shouldShowContactDetailsValidationErrors && touchContactFields();
+								const validationResponse = await validateContactDetails(
+									contactInfo,
+									isLoggedOutCart,
+									responseCart,
+									showErrorMessageBriefly,
+									applyDomainContactValidationResults,
+									clearDomainContactErrorMessages,
+									reduxDispatch,
+									translate,
+									shouldShowContactDetailsValidationErrors
+								);
+								if ( validationResponse ) {
+									// When the contact details change, update the VAT details on the server.
+									try {
+										if (
+											! isLoggedOutCart &&
+											vatDetailsInForm.id &&
+											! areVatDetailsSame( vatDetailsInForm, vatDetailsFromServer )
+										) {
+											await setVatDetails( vatDetailsInForm );
+										}
+									} catch ( error ) {
+										reduxDispatch( removeNotice( 'vat_info_notice' ) );
+										if ( shouldShowContactDetailsValidationErrors ) {
+											reduxDispatch(
+												errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
+											);
+										}
+										return false;
+									}
+									reduxDispatch( removeNotice( 'vat_info_notice' ) );
+
+									// When the contact details change, update the cart's tax location to match.
+									try {
+										await updateCartContactDetailsForCheckout(
+											countriesList,
+											responseCart,
+											updateLocation,
+											contactInfo,
+											vatDetailsInForm
+										);
+									} catch {
+										// If updating the cart fails, we should not continue. No need
+										// to do anything else, though, because CartMessages will
+										// display the error.
+										return false;
+									}
+
+									// When the contact details change, update the cached contact details on
+									// the server. This can fail if validation fails but we will silently
+									// ignore failures here because the validation call will handle them better
+									// than this will.
+									updateCachedContactDetails(
+										prepareDomainContactValidationRequest( contactInfo )
+									);
+
+									reduxDispatch(
+										recordTracksEvent( 'calypso_checkout_composite_step_complete', {
+											step: 1,
+											step_name: 'contact-form',
+										} )
+									);
+								}
+								return validationResponse;
+							} }
+							activeStepContent={
+								<>
+									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
+									<WPContactForm
+										countriesList={ countriesList }
+										shouldShowContactDetailsValidationErrors={
+											shouldShowContactDetailsValidationErrors
+										}
+										contactDetailsType={ contactDetailsType }
+										isLoggedOutCart={ isLoggedOutCart }
+										setShouldShowContactDetailsValidationErrors={
+											setShouldShowContactDetailsValidationErrors
+										}
+									/>
+								</>
+							}
+							completeStepContent={
+								<>
+									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
+									<WPContactFormSummary
+										areThereDomainProductsInCart={ areThereDomainProductsInCart }
+										isGSuiteInCart={ isGSuiteInCart }
+										isLoggedOutCart={ isLoggedOutCart }
+									/>
+								</>
+							}
+							titleContent={ <ContactFormTitle /> }
+							editButtonText={ String( translate( 'Edit' ) ) }
+							editButtonAriaLabel={ String( translate( 'Edit the contact details' ) ) }
+							nextStepButtonText={ nextStepButtonText }
+							nextStepButtonAriaLabel={ String(
+								translate( 'Continue with the entered contact details' )
+							) }
+							validatingButtonText={ validatingButtonText }
+							validatingButtonAriaLabel={ validatingButtonText }
 						/>
 					}
 					formStatus={ formStatus }
@@ -833,13 +958,15 @@ export default function CheckoutMainContent( {
 					} }
 				/>
 
-				<CouponFieldArea
-					isCouponFieldVisible={ isCouponFieldVisible }
-					setCouponFieldVisible={ setCouponFieldVisible }
-					isPurchaseFree={ isPurchaseFree }
-					couponStatus={ couponStatus }
-					couponFieldStateProps={ couponFieldStateProps }
-				/>
+					{ ! isStreamlinedPrice && (
+						<CouponFieldArea
+							isCouponFieldVisible={ isCouponFieldVisible }
+							setCouponFieldVisible={ setCouponFieldVisible }
+							isPurchaseFree={ isPurchaseFree }
+							couponStatus={ couponStatus }
+							couponFieldStateProps={ couponFieldStateProps }
+						/>
+					) }
 
 				<CheckoutTermsAndCheckboxes
 					is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
@@ -966,6 +1093,30 @@ const StepContainerV2CheckoutFixer = styled.div< {
 			div:has( .checkout-sidebar-content ) {
 				position: sticky;
 				top: 32px;
+			}
+
+			.order-review-line-items .checkout-line-item {
+				font-size: 20px;
+			}
+			.order-review-line-items .checkout-line-item__remove-product {
+				font-size: 14px;
+			}
+			.form-fieldset.contact-details-form-fields .form__hidden-input a,
+			.checkout__content .wp-checkout-order-review__show-coupon-field-button {
+				font-weight: 500;
+				text-decoration: none;
+				color: ${ props.theme.colors.textColorDark };
+				font-size: 14px;
+			}
+			.form-fieldset.contact-details-form-fields .contact-details-form-fields__row,
+			.form-fieldset.contact-details-form-fields .custom-form-fieldsets__address-fields {
+				gap: 10px;
+			}
+			.form-fieldset.contact-details-form-fields .contact-details-form-fields__field {
+				margin-bottom: 10px;
+			}
+			.checkout-terms-and-checkboxes a {
+				color: ${ props.theme.colors.textColorDark };
 			}
 		` }
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -676,150 +676,38 @@ export default function CheckoutMainContent( {
 				<PerformanceTrackerStop />
 				{ infoMessage }
 
-					<CheckoutStepBody
-						onError={ onReviewError }
-						className="wp-checkout__review-order-step"
-						stepId="review-order-step"
-						isStepActive={ false }
-						isStepComplete
-						titleContent={ <OrderReviewTitle /> }
-						completeStepContent={
-							<WPCheckoutOrderReview
-								removeProductFromCart={ removeProductFromCart }
-								replaceProductInCart={ replaceProductInCart }
-								couponFieldStateProps={ couponFieldStateProps }
-								removeCouponAndClearField={ removeCouponAndClearField }
-								isCouponFieldVisible={ isCouponFieldVisible }
-								setCouponFieldVisible={ setCouponFieldVisible }
-								onChangeSelection={ changeSelection }
-								siteUrl={ siteUrl }
-								createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-							/>
-						}
-						formStatus={ formStatus }
-					/>
-
-					{ isStreamlinedPrice && (
-						<CouponFieldArea
+				<CheckoutStepBody
+					onError={ onReviewError }
+					className="wp-checkout__review-order-step"
+					stepId="review-order-step"
+					isStepActive={ false }
+					isStepComplete
+					titleContent={ <OrderReviewTitle /> }
+					completeStepContent={
+						<WPCheckoutOrderReview
+							removeProductFromCart={ removeProductFromCart }
+							replaceProductInCart={ replaceProductInCart }
+							couponFieldStateProps={ couponFieldStateProps }
+							removeCouponAndClearField={ removeCouponAndClearField }
 							isCouponFieldVisible={ isCouponFieldVisible }
 							setCouponFieldVisible={ setCouponFieldVisible }
-							isPurchaseFree={ isPurchaseFree }
-							couponStatus={ couponStatus }
-							couponFieldStateProps={ couponFieldStateProps }
-						/>
-					) }
-
-					{ contactDetailsType !== 'none' && (
-						<CheckoutStep
-							className="checkout-contact-form-step"
-							stepId="contact-form"
-							isCompleteCallback={ async () => {
-								// Touch the fields so they display validation errors
-								shouldShowContactDetailsValidationErrors && touchContactFields();
-								const validationResponse = await validateContactDetails(
-									contactInfo,
-									isLoggedOutCart,
-									responseCart,
-									showErrorMessageBriefly,
-									applyDomainContactValidationResults,
-									clearDomainContactErrorMessages,
-									reduxDispatch,
-									translate,
-									shouldShowContactDetailsValidationErrors
-								);
-								if ( validationResponse ) {
-									// When the contact details change, update the VAT details on the server.
-									try {
-										if (
-											! isLoggedOutCart &&
-											vatDetailsInForm.id &&
-											! areVatDetailsSame( vatDetailsInForm, vatDetailsFromServer )
-										) {
-											await setVatDetails( vatDetailsInForm );
-										}
-									} catch ( error ) {
-										reduxDispatch( removeNotice( 'vat_info_notice' ) );
-										if ( shouldShowContactDetailsValidationErrors ) {
-											reduxDispatch(
-												errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
-											);
-										}
-										return false;
-									}
-									reduxDispatch( removeNotice( 'vat_info_notice' ) );
-
-									// When the contact details change, update the cart's tax location to match.
-									try {
-										await updateCartContactDetailsForCheckout(
-											countriesList,
-											responseCart,
-											updateLocation,
-											contactInfo,
-											vatDetailsInForm
-										);
-									} catch {
-										// If updating the cart fails, we should not continue. No need
-										// to do anything else, though, because CartMessages will
-										// display the error.
-										return false;
-									}
-
-									// When the contact details change, update the cached contact details on
-									// the server. This can fail if validation fails but we will silently
-									// ignore failures here because the validation call will handle them better
-									// than this will.
-									updateCachedContactDetails(
-										prepareDomainContactValidationRequest( contactInfo )
-									);
-
-									reduxDispatch(
-										recordTracksEvent( 'calypso_checkout_composite_step_complete', {
-											step: 1,
-											step_name: 'contact-form',
-										} )
-									);
-								}
-								return validationResponse;
-							} }
-							activeStepContent={
-								<>
-									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
-									<WPContactForm
-										countriesList={ countriesList }
-										shouldShowContactDetailsValidationErrors={
-											shouldShowContactDetailsValidationErrors
-										}
-										contactDetailsType={ contactDetailsType }
-										isLoggedOutCart={ isLoggedOutCart }
-										setShouldShowContactDetailsValidationErrors={
-											setShouldShowContactDetailsValidationErrors
-										}
-									/>
-								</>
-							}
-							completeStepContent={
-								<>
-									<ConditionalContactDetailsMessage contactDetailsType={ contactDetailsType } />
-									<WPContactFormSummary
-										areThereDomainProductsInCart={ areThereDomainProductsInCart }
-										isGSuiteInCart={ isGSuiteInCart }
-										isLoggedOutCart={ isLoggedOutCart }
-									/>
-								</>
-							}
-							titleContent={ <ContactFormTitle /> }
-							editButtonText={ String( translate( 'Edit' ) ) }
-							editButtonAriaLabel={ String( translate( 'Edit the contact details' ) ) }
-							nextStepButtonText={ nextStepButtonText }
-							nextStepButtonAriaLabel={ String(
-								translate( 'Continue with the entered contact details' )
-							) }
-							validatingButtonText={ validatingButtonText }
-							validatingButtonAriaLabel={ validatingButtonText }
+							onChangeSelection={ changeSelection }
+							siteUrl={ siteUrl }
+							createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						/>
 					}
 					formStatus={ formStatus }
 				/>
+
+				{ isStreamlinedPrice && (
+					<CouponFieldArea
+						isCouponFieldVisible={ isCouponFieldVisible }
+						setCouponFieldVisible={ setCouponFieldVisible }
+						isPurchaseFree={ isPurchaseFree }
+						couponStatus={ couponStatus }
+						couponFieldStateProps={ couponFieldStateProps }
+					/>
+				) }
 
 				{ contactDetailsType !== 'none' && (
 					<CheckoutStep
@@ -958,15 +846,15 @@ export default function CheckoutMainContent( {
 					} }
 				/>
 
-					{ ! isStreamlinedPrice && (
-						<CouponFieldArea
-							isCouponFieldVisible={ isCouponFieldVisible }
-							setCouponFieldVisible={ setCouponFieldVisible }
-							isPurchaseFree={ isPurchaseFree }
-							couponStatus={ couponStatus }
-							couponFieldStateProps={ couponFieldStateProps }
-						/>
-					) }
+				{ ! isStreamlinedPrice && (
+					<CouponFieldArea
+						isCouponFieldVisible={ isCouponFieldVisible }
+						setCouponFieldVisible={ setCouponFieldVisible }
+						isPurchaseFree={ isPurchaseFree }
+						couponStatus={ couponStatus }
+						couponFieldStateProps={ couponFieldStateProps }
+					/>
+				) }
 
 				<CheckoutTermsAndCheckboxes
 					is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1090,14 +1090,6 @@ const StepContainerV2CheckoutFixer = styled.div< {
 	${ ( props ) =>
 		props.isStreamlinedPrice &&
 		css`
-			div:has( .checkout-sidebar-content ) {
-				position: sticky;
-				top: 32px;
-			}
-
-			.order-review-line-items .checkout-line-item {
-				font-size: 20px;
-			}
 			.order-review-line-items .checkout-line-item__remove-product {
 				font-size: 14px;
 			}
@@ -1237,6 +1229,10 @@ const StepContainerV2CheckoutFixer = styled.div< {
 		props.isLargeViewport &&
 		props.isStreamlinedPrice &&
 		css`
+			div:has( .checkout-sidebar-content ) {
+				position: sticky;
+				top: 32px;
+			}
 			.checkout__summary-area,
 			.checkout-loading-sidebar {
 				min-width: 384px;

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -148,7 +148,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 
 	let compareTo = undefined;
 	if ( isStreamlinedPrice ) {
-		compareTo = variants.find( ( variant ) => variant.termIntervalInMonths === 1 );
+		compareTo = variants[ 0 ];
 	}
 	const ItemVariantDropDownPriceWrapper: FunctionComponent< { variant: WPCOMProductVariant } > = (
 		props
@@ -213,7 +213,7 @@ function ItemVariantOptionList( {
 	isStreamlinedPrice: boolean;
 } ) {
 	const compareTo = isStreamlinedPrice
-		? variants.find( ( variant ) => variant.termIntervalInMonths === 1 )
+		? variants[ 0 ]
 		: variants.find( ( variant ) => variant.productId === selectedItem.product_id );
 	return (
 		<OptionList role="listbox" tabIndex={ -1 } detached={ isStreamlinedPrice }>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -300,6 +300,13 @@ function LineItemWrapper( {
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 	const has100YearPlanProduct = has100YearPlan( responseCart );
 	const signupFlowName = getSignupCompleteFlowName();
+	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
+		useStreamlinedPriceExperiment();
+	const isStreamlinedPrice =
+		! isStreamlinedPriceExperimentLoading &&
+		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
+		isWpComPlan( product.product_slug );
+
 	if ( isCopySiteFlow( signupFlowName ) && ! product.is_domain_registration ) {
 		isDeletable = false;
 	}
@@ -381,14 +388,6 @@ function LineItemWrapper( {
 		isJetpackPurchasableItem( product.product_slug )
 	);
 
-	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
-		useStreamlinedPriceExperiment();
-
-	const isStreamlinedPrice =
-		! isStreamlinedPriceExperimentLoading &&
-		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
-		isWpComPlan( product.product_slug );
-
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
@@ -431,6 +430,8 @@ function LineItemWrapper( {
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
+				isStreamlinedPrice={ isStreamlinedPrice }
+				variants={ variants }
 			>
 				<DropdownWrapper>
 					{ finalShouldShowVariantSelector && (

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -415,8 +415,9 @@ function LineItemWrapper( {
 	const finalShouldShowVariantSelector =
 		areThereVariants && shouldShowVariantSelector && onChangeSelection;
 
-	const monthlyProductPrice = variants.find( ( variant ) => variant.termIntervalInMonths === 1 )
-		?.priceBeforeDiscounts;
+	const firstVariant = variants[ 0 ];
+	const compareToPrice = firstVariant?.priceBeforeDiscounts / firstVariant?.termIntervalInMonths;
+
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
 			<LineItem
@@ -432,8 +433,8 @@ function LineItemWrapper( {
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
-				shouldShowMonthlyComparison={ isStreamlinedPrice }
-				monthlyProductPrice={ monthlyProductPrice }
+				shouldShowComparison={ isStreamlinedPrice }
+				compareToPrice={ compareToPrice }
 			>
 				<DropdownWrapper>
 					{ finalShouldShowVariantSelector && (

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -415,6 +415,8 @@ function LineItemWrapper( {
 	const finalShouldShowVariantSelector =
 		areThereVariants && shouldShowVariantSelector && onChangeSelection;
 
+	const monthlyProductPrice = variants.find( ( variant ) => variant.termIntervalInMonths === 1 )
+		?.priceBeforeDiscounts;
 	return (
 		<WPOrderReviewListItem key={ product.uuid }>
 			<LineItem
@@ -430,8 +432,8 @@ function LineItemWrapper( {
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
-				isStreamlinedPrice={ isStreamlinedPrice }
-				variants={ variants }
+				shouldShowMonthlyComparison={ isStreamlinedPrice }
+				monthlyProductPrice={ monthlyProductPrice }
 			>
 				<DropdownWrapper>
 					{ finalShouldShowVariantSelector && (

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -54,10 +54,3 @@ export function isStreamlinedPriceDropdownTreatment( variationName?: string | nu
 	}
 	return variationName.includes( 'checkout_dropdown' );
 }
-
-export function isStreamlinedPriceCheckoutTreatment( variationName?: string | null ) {
-	if ( ! variationName ) {
-		return false;
-	}
-	return ! variationName.includes( 'checkout_control' );
-}

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -34,6 +34,13 @@ export function isStreamlinedPricePlansTreatment( variationName?: string | null 
 	return ! variationName.includes( 'plans_control' );
 }
 
+export function isStreamlinedPriceCheckoutTreatment( variationName?: string | null ) {
+	if ( ! variationName ) {
+		return false;
+	}
+	return ! variationName.includes( 'checkout_control' );
+}
+
 export function isStreamlinedPriceRadioTreatment( variationName?: string | null ) {
 	if ( ! variationName ) {
 		return false;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -87,7 +87,9 @@ export const LineItem = styled( CheckoutLineItem )< {
 
 	font-weight: ${ ( { theme } ) => theme.weights.normal };
 	color: ${ ( { theme } ) => theme.colors.textColorDark };
-	font-size: 1.1em;
+	font-size: ${ ( { shouldShowMonthlyComparison } ) =>
+		shouldShowMonthlyComparison ? '20px' : '1.1em' };
+
 	position: relative;
 
 	.checkout-line-item__price {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -172,6 +172,9 @@ const LineItemTitle = styled.div< {
 	gap: 0.5em;
 	font-size: inherit;
 `;
+const LineItemSublabelTitle = styled.div`
+	flex: 1;
+`;
 
 const LineItemPriceWrapper = styled.span`
 	display: flex;
@@ -799,14 +802,10 @@ export function LineItemSublabelAndPrice( {
 	}
 
 	if ( shouldShowMonthlyComparison && monthlyProductPrice ) {
-		const monthlyPrice = formatCurrency(
-			monthlyProductPrice || product.item_original_monthly_cost_integer,
-			product.currency,
-			{
-				isSmallestUnit: true,
-				stripZeros: true,
-			}
-		);
+		const monthlyPrice = formatCurrency( monthlyProductPrice, product.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
 		if ( isMonthlyProduct( product ) ) {
 			return <>{ translate( 'Billed every month' ) } </>;
 		}
@@ -814,7 +813,7 @@ export function LineItemSublabelAndPrice( {
 		if ( isYearly( product ) ) {
 			return (
 				<>
-					{ translate( 'Billed every year' ) }
+					<LineItemSublabelTitle>{ translate( 'Billed every year' ) }</LineItemSublabelTitle>
 					<s>
 						{ monthlyPrice } { translate( '/month' ) }
 					</s>
@@ -825,7 +824,7 @@ export function LineItemSublabelAndPrice( {
 		if ( isBiennially( product ) ) {
 			return (
 				<>
-					{ translate( 'Billed every 2 years' ) }
+					<LineItemSublabelTitle>{ translate( 'Billed every 2 years' ) }</LineItemSublabelTitle>
 					<s>
 						{ monthlyPrice } { translate( '/month' ) }
 					</s>
@@ -836,7 +835,7 @@ export function LineItemSublabelAndPrice( {
 		if ( isTriennially( product ) ) {
 			return (
 				<>
-					{ translate( 'Billed every 3 years' ) }
+					<LineItemSublabelTitle>{ translate( 'Billed every 3 years' ) }</LineItemSublabelTitle>
 					<s>
 						{ monthlyPrice } { translate( '/month' ) }
 					</s>
@@ -1317,14 +1316,22 @@ function CheckoutLineItem( {
 		stripZeros: true,
 	} );
 
-	const monthlyAmountDisplay = formatCurrency(
-		product.item_original_monthly_cost_integer,
-		product.currency,
-		{
-			isSmallestUnit: true,
-			stripZeros: true,
+	let pricePerMonth = 0;
+	if ( shouldShowMonthlyComparison ) {
+		const productVariant = product.product_variants.find(
+			( variant ) => variant.product_id === product.product_id
+		);
+		if ( productVariant ) {
+			pricePerMonth = Math.round(
+				productVariant.price_integer / productVariant.bill_period_in_months
+			);
 		}
-	);
+	}
+
+	const monthlyAmountDisplay = formatCurrency( pricePerMonth, product.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
 
 	const isDiscounted = Boolean(
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -634,12 +634,12 @@ function ProductTier( { product }: { product: ResponseCartProduct } ) {
 
 export function LineItemSublabelAndPrice( {
 	product,
-	isStreamlinedPrice,
-	variants,
+	shouldShowMonthlyComparison,
+	monthlyProductPrice,
 }: {
 	product: ResponseCartProduct;
-	isStreamlinedPrice?: boolean;
-	variants?: any[];
+	shouldShowMonthlyComparison?: boolean;
+	monthlyProductPrice?: number;
 } ) {
 	const translate = useTranslate();
 	const productSlug = product.product_slug;
@@ -796,51 +796,51 @@ export function LineItemSublabelAndPrice( {
 		);
 	}
 
-	const monthlyProduct = variants?.find( ( variant ) => variant.termIntervalInMonths === 1 );
-	const monthlyPrice = formatCurrency(
-		monthlyProduct?.priceBeforeDiscounts || product.item_original_monthly_cost_integer,
-		product.currency,
-		{
-			isSmallestUnit: true,
-			stripZeros: true,
+	if ( shouldShowMonthlyComparison && monthlyProductPrice ) {
+		const monthlyPrice = formatCurrency(
+			monthlyProductPrice || product.item_original_monthly_cost_integer,
+			product.currency,
+			{
+				isSmallestUnit: true,
+				stripZeros: true,
+			}
+		);
+		if ( isMonthlyProduct( product ) ) {
+			return <>{ translate( 'Billed every month' ) } </>;
 		}
-	);
 
-	if ( isStreamlinedPrice && isMonthlyProduct( product ) ) {
-		return <>{ translate( 'Billed every month' ) } </>;
-	}
+		if ( isYearly( product ) ) {
+			return (
+				<>
+					{ translate( 'Billed every year' ) }
+					<s>
+						{ monthlyPrice } { translate( '/month' ) }
+					</s>
+				</>
+			);
+		}
 
-	if ( isStreamlinedPrice && isYearly( product ) ) {
-		return (
-			<>
-				{ translate( 'Billed every year' ) }
-				<s>
-					{ monthlyPrice } { translate( '/month' ) }
-				</s>
-			</>
-		);
-	}
+		if ( isBiennially( product ) ) {
+			return (
+				<>
+					{ translate( 'Billed every 2 years' ) }
+					<s>
+						{ monthlyPrice } { translate( '/month' ) }
+					</s>
+				</>
+			);
+		}
 
-	if ( isStreamlinedPrice && isBiennially( product ) ) {
-		return (
-			<>
-				{ translate( 'Billed every 2 years' ) }
-				<s>
-					{ monthlyPrice } { translate( '/month' ) }
-				</s>
-			</>
-		);
-	}
-
-	if ( isStreamlinedPrice && isTriennially( product ) ) {
-		return (
-			<>
-				{ translate( 'Billed every 3 years' ) }
-				<s>
-					{ monthlyPrice } { translate( '/month' ) }
-				</s>
-			</>
-		);
+		if ( isTriennially( product ) ) {
+			return (
+				<>
+					{ translate( 'Billed every 3 years' ) }
+					<s>
+						{ monthlyPrice } { translate( '/month' ) }
+					</s>
+				</>
+			);
+		}
 	}
 
 	const shouldRenderBasicTermSublabel =
@@ -1248,8 +1248,8 @@ function CheckoutLineItem( {
 	onRemoveProductClick,
 	onRemoveProductCancel,
 	isAkPro500Cart,
-	isStreamlinedPrice,
-	variants,
+	shouldShowMonthlyComparison,
+	monthlyProductPrice,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1264,8 +1264,8 @@ function CheckoutLineItem( {
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
 	shouldShowBillingInterval?: boolean;
-	isStreamlinedPrice?: boolean;
-	variants?: any[];
+	shouldShowMonthlyComparison?: boolean;
+	monthlyProductPrice?: number;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -1358,7 +1358,7 @@ function CheckoutLineItem( {
 			</LineItemTitle>
 
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-				{ isStreamlinedPrice ? (
+				{ shouldShowMonthlyComparison ? (
 					<>
 						{ monthlyAmountDisplay } { translate( '/month' ) }
 					</>
@@ -1381,8 +1381,8 @@ function CheckoutLineItem( {
 						<LineItemMeta>
 							<LineItemSublabelAndPrice
 								product={ product }
-								isStreamlinedPrice={ isStreamlinedPrice }
-								variants={ variants }
+								shouldShowMonthlyComparison={ shouldShowMonthlyComparison }
+								monthlyProductPrice={ monthlyProductPrice }
 							/>
 							<DomainDiscountCallout product={ product } />
 							<IntroductoryOfferCallout product={ product } />

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -87,8 +87,7 @@ export const LineItem = styled( CheckoutLineItem )< {
 
 	font-weight: ${ ( { theme } ) => theme.weights.normal };
 	color: ${ ( { theme } ) => theme.colors.textColorDark };
-	font-size: ${ ( { shouldShowMonthlyComparison } ) =>
-		shouldShowMonthlyComparison ? '20px' : '1.1em' };
+	font-size: ${ ( { shouldShowComparison } ) => ( shouldShowComparison ? '20px' : '1.1em' ) };
 
 	position: relative;
 
@@ -639,12 +638,12 @@ function ProductTier( { product }: { product: ResponseCartProduct } ) {
 
 export function LineItemSublabelAndPrice( {
 	product,
-	shouldShowMonthlyComparison,
-	monthlyProductPrice,
+	shouldShowComparison,
+	compareToPrice,
 }: {
 	product: ResponseCartProduct;
-	shouldShowMonthlyComparison?: boolean;
-	monthlyProductPrice?: number;
+	shouldShowComparison?: boolean;
+	compareToPrice?: number;
 } ) {
 	const translate = useTranslate();
 	const productSlug = product.product_slug;
@@ -801,22 +800,36 @@ export function LineItemSublabelAndPrice( {
 		);
 	}
 
-	if ( shouldShowMonthlyComparison && monthlyProductPrice ) {
-		const monthlyPrice = formatCurrency( monthlyProductPrice, product.currency, {
+	if ( shouldShowComparison && compareToPrice ) {
+		const monthlyPrice = formatCurrency( compareToPrice, product.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
 		} );
+		const showCrossedOutPrice =
+			product.item_original_subtotal_integer / ( product.months_per_bill_period ?? 1 ) !==
+			compareToPrice;
 		if ( isMonthlyProduct( product ) ) {
-			return <>{ translate( 'Billed every month' ) } </>;
+			return (
+				<>
+					<LineItemSublabelTitle>{ translate( 'Billed every month' ) }</LineItemSublabelTitle>
+					{ showCrossedOutPrice && (
+						<s>
+							{ monthlyPrice } { translate( '/month' ) }
+						</s>
+					) }
+				</>
+			);
 		}
 
 		if ( isYearly( product ) ) {
 			return (
 				<>
 					<LineItemSublabelTitle>{ translate( 'Billed every year' ) }</LineItemSublabelTitle>
-					<s>
-						{ monthlyPrice } { translate( '/month' ) }
-					</s>
+					{ showCrossedOutPrice && (
+						<s>
+							{ monthlyPrice } { translate( '/month' ) }
+						</s>
+					) }
 				</>
 			);
 		}
@@ -825,9 +838,11 @@ export function LineItemSublabelAndPrice( {
 			return (
 				<>
 					<LineItemSublabelTitle>{ translate( 'Billed every 2 years' ) }</LineItemSublabelTitle>
-					<s>
-						{ monthlyPrice } { translate( '/month' ) }
-					</s>
+					{ showCrossedOutPrice && (
+						<s>
+							{ monthlyPrice } { translate( '/month' ) }
+						</s>
+					) }
 				</>
 			);
 		}
@@ -836,9 +851,11 @@ export function LineItemSublabelAndPrice( {
 			return (
 				<>
 					<LineItemSublabelTitle>{ translate( 'Billed every 3 years' ) }</LineItemSublabelTitle>
-					<s>
-						{ monthlyPrice } { translate( '/month' ) }
-					</s>
+					{ showCrossedOutPrice && (
+						<s>
+							{ monthlyPrice } { translate( '/month' ) }
+						</s>
+					) }
 				</>
 			);
 		}
@@ -1249,8 +1266,8 @@ function CheckoutLineItem( {
 	onRemoveProductClick,
 	onRemoveProductCancel,
 	isAkPro500Cart,
-	shouldShowMonthlyComparison,
-	monthlyProductPrice,
+	shouldShowComparison,
+	compareToPrice,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1265,8 +1282,8 @@ function CheckoutLineItem( {
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
 	shouldShowBillingInterval?: boolean;
-	shouldShowMonthlyComparison?: boolean;
-	monthlyProductPrice?: number;
+	shouldShowComparison?: boolean;
+	compareToPrice?: number;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -1317,7 +1334,7 @@ function CheckoutLineItem( {
 	} );
 
 	let pricePerMonth = 0;
-	if ( shouldShowMonthlyComparison ) {
+	if ( shouldShowComparison ) {
 		const productVariant = product.product_variants.find(
 			( variant ) => variant.product_id === product.product_id
 		);
@@ -1369,7 +1386,7 @@ function CheckoutLineItem( {
 			</LineItemTitle>
 
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-				{ shouldShowMonthlyComparison ? (
+				{ shouldShowComparison ? (
 					<>
 						{ monthlyAmountDisplay } { translate( '/month' ) }
 					</>
@@ -1392,8 +1409,8 @@ function CheckoutLineItem( {
 						<LineItemMeta>
 							<LineItemSublabelAndPrice
 								product={ product }
-								shouldShowMonthlyComparison={ shouldShowMonthlyComparison }
-								monthlyProductPrice={ monthlyProductPrice }
+								shouldShowComparison={ shouldShowComparison }
+								compareToPrice={ compareToPrice }
 							/>
 							<DomainDiscountCallout product={ product } />
 							<IntroductoryOfferCallout product={ product } />

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -806,8 +806,7 @@ export function LineItemSublabelAndPrice( {
 			stripZeros: true,
 		} );
 		const showCrossedOutPrice =
-			product.item_original_subtotal_integer / ( product.months_per_bill_period ?? 1 ) !==
-			compareToPrice;
+			product.item_subtotal_integer / ( product.months_per_bill_period ?? 1 ) !== compareToPrice;
 		if ( isMonthlyProduct( product ) ) {
 			return (
 				<>
@@ -1335,16 +1334,9 @@ function CheckoutLineItem( {
 
 	let pricePerMonth = 0;
 	if ( shouldShowComparison ) {
-		const productVariant = product.product_variants.find(
-			( variant ) => variant.product_id === product.product_id
+		pricePerMonth = Math.round(
+			product.item_subtotal_integer / ( product.months_per_bill_period ?? 1 )
 		);
-		if ( productVariant ) {
-			pricePerMonth = Math.round(
-				productVariant.price_integer / productVariant.bill_period_in_months
-			);
-		} else {
-			pricePerMonth = product.item_original_monthly_cost_integer;
-		}
 	}
 
 	const monthlyAmountDisplay = formatCurrency( pricePerMonth, product.currency, {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -632,7 +632,15 @@ function ProductTier( { product }: { product: ResponseCartProduct } ) {
 	return null;
 }
 
-export function LineItemSublabelAndPrice( { product }: { product: ResponseCartProduct } ) {
+export function LineItemSublabelAndPrice( {
+	product,
+	isStreamlinedPrice,
+	variants,
+}: {
+	product: ResponseCartProduct;
+	isStreamlinedPrice?: boolean;
+	variants?: any[];
+} ) {
 	const translate = useTranslate();
 	const productSlug = product.product_slug;
 	const price = formatCurrency( product.item_original_subtotal_integer, product.currency, {
@@ -784,6 +792,53 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />:{ ' ' }
 				{ translate( 'billed annually' ) } { price }
+			</>
+		);
+	}
+
+	const monthlyProduct = variants?.find( ( variant ) => variant.termIntervalInMonths === 1 );
+	const monthlyPrice = formatCurrency(
+		monthlyProduct?.priceBeforeDiscounts || product.item_original_monthly_cost_integer,
+		product.currency,
+		{
+			isSmallestUnit: true,
+			stripZeros: true,
+		}
+	);
+
+	if ( isStreamlinedPrice && isMonthlyProduct( product ) ) {
+		return <>{ translate( 'Billed every month' ) } </>;
+	}
+
+	if ( isStreamlinedPrice && isYearly( product ) ) {
+		return (
+			<>
+				{ translate( 'Billed every year' ) }
+				<s>
+					{ monthlyPrice } { translate( '/month' ) }
+				</s>
+			</>
+		);
+	}
+
+	if ( isStreamlinedPrice && isBiennially( product ) ) {
+		return (
+			<>
+				{ translate( 'Billed every 2 years' ) }
+				<s>
+					{ monthlyPrice } { translate( '/month' ) }
+				</s>
+			</>
+		);
+	}
+
+	if ( isStreamlinedPrice && isTriennially( product ) ) {
+		return (
+			<>
+				{ translate( 'Billed every 3 years' ) }
+				<s>
+					{ monthlyPrice } { translate( '/month' ) }
+				</s>
 			</>
 		);
 	}
@@ -1193,6 +1248,8 @@ function CheckoutLineItem( {
 	onRemoveProductClick,
 	onRemoveProductCancel,
 	isAkPro500Cart,
+	isStreamlinedPrice,
+	variants,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1207,6 +1264,8 @@ function CheckoutLineItem( {
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
 	shouldShowBillingInterval?: boolean;
+	isStreamlinedPrice?: boolean;
+	variants?: any[];
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -1255,6 +1314,16 @@ function CheckoutLineItem( {
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
+
+	const monthlyAmountDisplay = formatCurrency(
+		product.item_original_monthly_cost_integer,
+		product.currency,
+		{
+			isSmallestUnit: true,
+			stripZeros: true,
+		}
+	);
+
 	const isDiscounted = Boolean(
 		itemSubtotalInteger < originalAmountInteger && originalAmountDisplay
 	);
@@ -1289,10 +1358,18 @@ function CheckoutLineItem( {
 			</LineItemTitle>
 
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-				<LineItemPrice
-					actualAmount={ actualAmountDisplay }
-					crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
-				/>
+				{ isStreamlinedPrice ? (
+					<>
+						{ monthlyAmountDisplay } { translate( '/month' ) }
+					</>
+				) : (
+					<>
+						<LineItemPrice
+							actualAmount={ actualAmountDisplay }
+							crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
+						/>
+					</>
+				) }
 			</span>
 
 			{ ! containsPartnerCoupon && (
@@ -1302,7 +1379,11 @@ function CheckoutLineItem( {
 							<UpgradeCreditInformation product={ product } />
 						</UpgradeCreditInformationLineItem>
 						<LineItemMeta>
-							<LineItemSublabelAndPrice product={ product } />
+							<LineItemSublabelAndPrice
+								product={ product }
+								isStreamlinedPrice={ isStreamlinedPrice }
+								variants={ variants }
+							/>
 							<DomainDiscountCallout product={ product } />
 							<IntroductoryOfferCallout product={ product } />
 							<JetpackAkismetSaleCouponCallout product={ product } />

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1325,6 +1325,8 @@ function CheckoutLineItem( {
 			pricePerMonth = Math.round(
 				productVariant.price_integer / productVariant.bill_period_in_months
 			);
+		} else {
+			pricePerMonth = product.item_original_monthly_cost_integer;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p58i-kUT-p2
## Proposed Changes

The changes bring the checkout closer to the proposed experiment design:
* shows monthly prices for the plan cart items
* increases font size for the plan name, the remove item links and hidden form field links
* moves the `Have a coupon?` section after the cart list
* changes link colors to black

<img width="480px" src="https://github.com/user-attachments/assets/c0994b2b-e589-413f-9651-2773e35c11f2" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're experimenting with streamlining the plans and checkout user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this feature, you'll need to be assigned to any checkout treatment variation of the `calypso_streamlined_plans_checkout` experiment 
* Go through the `onboarding` flow to get assigned
* In the checkout screen:
   * the plan should show monthly plan prices
   * the text below the plan name should indicate the payment intervals + the crossed out price for monthly
  * `Remove from cart` button is slightly increased
  * `Have a coupon?` is moved below cart items
  * more spacing in the contact info form 
  * `+Add ` links in the contact info from are bigger
  * links are black
* Jetpack/Akismet checkouts should be unaffected

|Before|After|
|------|-----|
|![screencapture-calypso-localhost-3000-checkout-evaluate19-wordpress-com-2025-05-15-16_21_36](https://github.com/user-attachments/assets/d5dc7ba1-abaa-47b3-9ad9-6426f5104e35)|![screencapture-calypso-localhost-3000-checkout-evaluate19-wordpress-com-2025-05-15-16_21_33](https://github.com/user-attachments/assets/ec3da932-1dd6-4efb-8284-d96d740f2b29)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
