### PR TITLE
WIP: Social Login Experiment

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -29,7 +29,7 @@ const SocialLoginForm = ( {
 	lastUsedAuthenticationMethod,
 	resetLastUsedAuthenticationMethod,
 } ) => {
-	const [ , experimentAssignment ] = useSocialLoginExperiment();
+	const [ isLoading, experimentAssignment ] = useSocialLoginExperiment();
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const initialQuery = useSelector( getInitialQueryArguments );
 	const isSignupExistingAccount = !! (
@@ -38,7 +38,7 @@ const SocialLoginForm = ( {
 
 	// Only show buttons if we have a definitive answer from the experiment
 	// This prevents flashing by ensuring we have a valid experiment assignment
-	const isTreatment = experimentAssignment?.variationName !== 'control';
+	const isTreatment = isLoading || experimentAssignment?.variationName === 'treatment';
 	const shouldShowApple = ! isTreatment;
 	const shouldShowQrCode = ! isTreatment && ! isSignupExistingAccount;
 

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -11,13 +11,11 @@ import {
 	QrCodeLoginButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
-import { useExperiment } from 'calypso/lib/explat';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import { useSocialLoginExperiment } from './use-social-login-experiment.ts';
 
 import './social.scss';
-
-const SOCIAL_LOGIN_EXPERIMENT = 'calypso_social_login_hide_apple_jetpack';
 
 const SocialLoginForm = ( {
 	handleLogin,
@@ -31,17 +29,17 @@ const SocialLoginForm = ( {
 	lastUsedAuthenticationMethod,
 	resetLastUsedAuthenticationMethod,
 } ) => {
-	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
+	const [ isLoading, experimentAssignment ] = useSocialLoginExperiment();
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const initialQuery = useSelector( getInitialQueryArguments );
-	const isTreatment =
-		! experimentAssignment || isLoading || experimentAssignment.variationName === 'treatment';
 	const isSignupExistingAccount = !! (
 		initialQuery?.is_signup_existing_account || currentQuery?.is_signup_existing_account
 	);
 
 	// Only show buttons if we have a definitive answer from the experiment
 	// This prevents flashing by ensuring we have a valid experiment assignment
+	const isTreatment =
+		! experimentAssignment || isLoading || experimentAssignment.variationName === 'treatment';
 	const shouldShowApple = experimentAssignment && ! isTreatment;
 	const shouldShowQrCode = experimentAssignment && ! isTreatment && ! isSignupExistingAccount;
 

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -31,6 +31,7 @@ const SocialLoginForm = ( {
 	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
 	const isTreatment = experimentAssignment?.variationName === 'treatment';
 	const shouldShowApple = ! isLoading && ! isTreatment;
+	const shouldShowQrCode = ! isLoading && ! isTreatment;
 
 	const socialLoginButtons = [
 		{
@@ -76,7 +77,7 @@ const SocialLoginForm = ( {
 		},
 		{
 			service: 'qr-code',
-			button: ( isSocialFirst || isWoo ) && qrLoginLink && (
+			button: ( isSocialFirst || isWoo ) && qrLoginLink && shouldShowQrCode && (
 				<QrCodeLoginButton loginUrl={ qrLoginLink } key={ 5 } />
 			),
 		},

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -34,12 +34,16 @@ const SocialLoginForm = ( {
 	initialQuery,
 } ) => {
 	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
-	const isTreatment = experimentAssignment?.variationName === 'treatment';
-	const shouldShowApple = ! isLoading && ! isTreatment;
+	const isTreatment =
+		! experimentAssignment || isLoading || experimentAssignment.variationName === 'treatment';
 	const isSignupExistingAccount = !! (
 		initialQuery?.is_signup_existing_account || currentQuery?.is_signup_existing_account
 	);
-	const shouldShowQrCode = ! isLoading && ! isTreatment && ! isSignupExistingAccount;
+
+	// Only show buttons if we have a definitive answer from the experiment
+	// This prevents flashing by ensuring we have a valid experiment assignment
+	const shouldShowApple = experimentAssignment && ! isTreatment;
+	const shouldShowQrCode = experimentAssignment && ! isTreatment && ! isSignupExistingAccount;
 
 	const socialLoginButtons = [
 		{

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -1,7 +1,6 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import SocialToS from 'calypso/blocks/authentication/social/social-tos.jsx';
 import {
 	GoogleSocialButton,
@@ -11,33 +10,35 @@ import {
 	QrCodeLoginButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
+import { useExperiment } from 'calypso/lib/explat';
 
 import './social.scss';
 
-class SocialLoginForm extends Component {
-	static propTypes = {
-		handleLogin: PropTypes.func.isRequired,
-		trackLoginAndRememberRedirect: PropTypes.func.isRequired,
-		socialServiceResponse: PropTypes.object,
-		shouldRenderToS: PropTypes.bool,
-		magicLoginLink: PropTypes.string,
-		qrLoginLink: PropTypes.string,
-		isSocialFirst: PropTypes.bool,
-		lastUsedAuthenticationMethod: PropTypes.string,
-		resetLastUsedAuthenticationMethod: PropTypes.func,
-	};
+const SOCIAL_LOGIN_EXPERIMENT = 'calypso_social_login_hide_apple_jetpack';
 
-	static defaultProps = {
-		shouldRenderToS: false,
-	};
+const SocialLoginForm = ( {
+	handleLogin,
+	trackLoginAndRememberRedirect,
+	socialServiceResponse,
+	shouldRenderToS = false,
+	magicLoginLink,
+	qrLoginLink,
+	isSocialFirst,
+	isWoo,
+	lastUsedAuthenticationMethod,
+	resetLastUsedAuthenticationMethod,
+} ) => {
+	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
+	const isTreatment = experimentAssignment?.variationName === 'treatment';
+	const shouldShowApple = ! isLoading && ! isTreatment;
 
-	socialLoginButtons = [
+	const socialLoginButtons = [
 		{
 			service: 'google',
 			button: (
 				<GoogleSocialButton
-					responseHandler={ this.props.handleLogin }
-					onClick={ this.props.trackLoginAndRememberRedirect }
+					responseHandler={ handleLogin }
+					onClick={ trackLoginAndRememberRedirect }
 					key={ 1 }
 					isLogin
 				/>
@@ -45,11 +46,11 @@ class SocialLoginForm extends Component {
 		},
 		{
 			service: 'apple',
-			button: (
+			button: shouldShowApple && (
 				<AppleLoginButton
-					responseHandler={ this.props.handleLogin }
-					onClick={ this.props.trackLoginAndRememberRedirect }
-					socialServiceResponse={ this.props.socialServiceResponse }
+					responseHandler={ handleLogin }
+					onClick={ trackLoginAndRememberRedirect }
+					socialServiceResponse={ socialServiceResponse }
 					key={ 2 }
 					isLogin
 				/>
@@ -59,9 +60,9 @@ class SocialLoginForm extends Component {
 			service: 'github',
 			button: (
 				<GithubSocialButton
-					responseHandler={ this.props.handleLogin }
-					onClick={ this.props.trackLoginAndRememberRedirect }
-					socialServiceResponse={ this.props.socialServiceResponse }
+					responseHandler={ handleLogin }
+					onClick={ trackLoginAndRememberRedirect }
+					socialServiceResponse={ socialServiceResponse }
 					key={ 3 }
 					isLogin
 				/>
@@ -69,44 +70,53 @@ class SocialLoginForm extends Component {
 		},
 		{
 			service: 'magic-login',
-			button: ( this.props.isSocialFirst || this.props.isWoo ) && this.props.magicLoginLink && (
-				<MagicLoginButton loginUrl={ this.props.magicLoginLink } key={ 4 } />
+			button: ( isSocialFirst || isWoo ) && magicLoginLink && (
+				<MagicLoginButton loginUrl={ magicLoginLink } key={ 4 } />
 			),
 		},
 		{
 			service: 'qr-code',
-			button: ( this.props.isSocialFirst || this.props.isWoo ) && this.props.qrLoginLink && (
-				<QrCodeLoginButton loginUrl={ this.props.qrLoginLink } key={ 5 } />
+			button: ( isSocialFirst || isWoo ) && qrLoginLink && (
+				<QrCodeLoginButton loginUrl={ qrLoginLink } key={ 5 } />
 			),
 		},
 	];
 
-	render() {
-		const { shouldRenderToS, isWoo, isSocialFirst, lastUsedAuthenticationMethod } = this.props;
-
-		return (
-			<Card
-				className={ clsx( 'auth-form__social', 'is-login', { 'is-social-first': isSocialFirst } ) }
-			>
-				<div className="auth-form__social-buttons">
-					<div className="auth-form__social-buttons-container">
-						{ this.socialLoginButtons.map( ( { service, button }, index ) =>
-							isSocialFirst && service === lastUsedAuthenticationMethod ? (
-								<UsernameOrEmailButton
-									key={ index + 1 }
-									onClick={ this.props.resetLastUsedAuthenticationMethod }
-								/>
-							) : (
-								button
-							)
-						) }
-					</div>
-					{ ! isWoo && shouldRenderToS && <SocialToS /> }
+	return (
+		<Card
+			className={ clsx( 'auth-form__social', 'is-login', { 'is-social-first': isSocialFirst } ) }
+		>
+			<div className="auth-form__social-buttons">
+				<div className="auth-form__social-buttons-container">
+					{ socialLoginButtons.map( ( { service, button }, index ) =>
+						isSocialFirst && service === lastUsedAuthenticationMethod ? (
+							<UsernameOrEmailButton
+								key={ index + 1 }
+								onClick={ resetLastUsedAuthenticationMethod }
+							/>
+						) : (
+							button
+						)
+					) }
 				</div>
-				{ isWoo && shouldRenderToS && <SocialToS /> }
-			</Card>
-		);
-	}
-}
+				{ ! isWoo && shouldRenderToS && <SocialToS /> }
+			</div>
+			{ isWoo && shouldRenderToS && <SocialToS /> }
+		</Card>
+	);
+};
+
+SocialLoginForm.propTypes = {
+	handleLogin: PropTypes.func.isRequired,
+	trackLoginAndRememberRedirect: PropTypes.func.isRequired,
+	socialServiceResponse: PropTypes.object,
+	shouldRenderToS: PropTypes.bool,
+	magicLoginLink: PropTypes.string,
+	qrLoginLink: PropTypes.string,
+	isSocialFirst: PropTypes.bool,
+	isWoo: PropTypes.bool,
+	lastUsedAuthenticationMethod: PropTypes.string,
+	resetLastUsedAuthenticationMethod: PropTypes.func,
+};
 
 export default SocialLoginForm;

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -29,7 +29,7 @@ const SocialLoginForm = ( {
 	lastUsedAuthenticationMethod,
 	resetLastUsedAuthenticationMethod,
 } ) => {
-	const [ isLoading, experimentAssignment ] = useSocialLoginExperiment();
+	const [ , experimentAssignment ] = useSocialLoginExperiment();
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const initialQuery = useSelector( getInitialQueryArguments );
 	const isSignupExistingAccount = !! (
@@ -38,10 +38,9 @@ const SocialLoginForm = ( {
 
 	// Only show buttons if we have a definitive answer from the experiment
 	// This prevents flashing by ensuring we have a valid experiment assignment
-	const isTreatment =
-		! experimentAssignment || isLoading || experimentAssignment.variationName === 'treatment';
-	const shouldShowApple = experimentAssignment && ! isTreatment;
-	const shouldShowQrCode = experimentAssignment && ! isTreatment && ! isSignupExistingAccount;
+	const isTreatment = experimentAssignment?.variationName !== 'control';
+	const shouldShowApple = ! isTreatment;
+	const shouldShowQrCode = ! isTreatment && ! isSignupExistingAccount;
 
 	const socialLoginButtons = [
 		{

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import SocialToS from 'calypso/blocks/authentication/social/social-tos.jsx';
 import {
 	GoogleSocialButton,
@@ -30,10 +30,10 @@ const SocialLoginForm = ( {
 	isWoo,
 	lastUsedAuthenticationMethod,
 	resetLastUsedAuthenticationMethod,
-	currentQuery,
-	initialQuery,
 } ) => {
 	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const initialQuery = useSelector( getInitialQueryArguments );
 	const isTreatment =
 		! experimentAssignment || isLoading || experimentAssignment.variationName === 'treatment';
 	const isSignupExistingAccount = !! (
@@ -130,11 +130,6 @@ SocialLoginForm.propTypes = {
 	isWoo: PropTypes.bool,
 	lastUsedAuthenticationMethod: PropTypes.string,
 	resetLastUsedAuthenticationMethod: PropTypes.func,
-	currentQuery: PropTypes.object,
-	initialQuery: PropTypes.object,
 };
 
-export default connect( ( state ) => ( {
-	currentQuery: getCurrentQueryArguments( state ),
-	initialQuery: getInitialQueryArguments( state ),
-} ) )( SocialLoginForm );
+export default SocialLoginForm;

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import SocialToS from 'calypso/blocks/authentication/social/social-tos.jsx';
 import {
 	GoogleSocialButton,
@@ -11,6 +12,8 @@ import {
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
 import { useExperiment } from 'calypso/lib/explat';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 
 import './social.scss';
 
@@ -27,11 +30,16 @@ const SocialLoginForm = ( {
 	isWoo,
 	lastUsedAuthenticationMethod,
 	resetLastUsedAuthenticationMethod,
+	currentQuery,
+	initialQuery,
 } ) => {
 	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
 	const isTreatment = experimentAssignment?.variationName === 'treatment';
 	const shouldShowApple = ! isLoading && ! isTreatment;
-	const shouldShowQrCode = ! isLoading && ! isTreatment;
+	const isSignupExistingAccount = !! (
+		initialQuery?.is_signup_existing_account || currentQuery?.is_signup_existing_account
+	);
+	const shouldShowQrCode = ! isLoading && ! isTreatment && ! isSignupExistingAccount;
 
 	const socialLoginButtons = [
 		{
@@ -118,6 +126,11 @@ SocialLoginForm.propTypes = {
 	isWoo: PropTypes.bool,
 	lastUsedAuthenticationMethod: PropTypes.string,
 	resetLastUsedAuthenticationMethod: PropTypes.func,
+	currentQuery: PropTypes.object,
+	initialQuery: PropTypes.object,
 };
 
-export default SocialLoginForm;
+export default connect( ( state ) => ( {
+	currentQuery: getCurrentQueryArguments( state ),
+	initialQuery: getInitialQueryArguments( state ),
+} ) )( SocialLoginForm );

--- a/client/blocks/login/use-social-login-experiment.ts
+++ b/client/blocks/login/use-social-login-experiment.ts
@@ -1,4 +1,3 @@
-import { useExperiment } from 'calypso/lib/explat';
 import type { ExperimentAssignment } from '@automattic/explat-client';
 
 const SOCIAL_LOGIN_EXPERIMENT = 'calypso_social_login_hide_apple_jetpack';
@@ -11,12 +10,13 @@ const DEFAULT_EXPERIMENT_ASSIGNMENT: ExperimentAssignment = {
 	ttl: 0,
 };
 
-type UseExperimentReturn = ReturnType< typeof useExperiment >;
+type UseExperimentReturn = [ boolean, ExperimentAssignment ];
 
 // Only load the real hook on the client side
 let useSocialLoginExperiment = (): UseExperimentReturn => [ false, DEFAULT_EXPERIMENT_ASSIGNMENT ];
 
 if ( typeof window !== 'undefined' ) {
+	const { useExperiment } = require( 'calypso/lib/explat' );
 	useSocialLoginExperiment = () => useExperiment( SOCIAL_LOGIN_EXPERIMENT );
 }
 

--- a/client/blocks/login/use-social-login-experiment.ts
+++ b/client/blocks/login/use-social-login-experiment.ts
@@ -1,0 +1,23 @@
+import { useExperiment } from 'calypso/lib/explat';
+import type { ExperimentAssignment } from '@automattic/explat-client';
+
+const SOCIAL_LOGIN_EXPERIMENT = 'calypso_social_login_hide_apple_jetpack';
+
+// Default to showing all buttons during SSR
+const DEFAULT_EXPERIMENT_ASSIGNMENT: ExperimentAssignment = {
+	experimentName: SOCIAL_LOGIN_EXPERIMENT,
+	variationName: null,
+	retrievedTimestamp: 0,
+	ttl: 0,
+};
+
+type UseExperimentReturn = ReturnType< typeof useExperiment >;
+
+// Only load the real hook on the client side
+let useSocialLoginExperiment = (): UseExperimentReturn => [ false, DEFAULT_EXPERIMENT_ASSIGNMENT ];
+
+if ( typeof window !== 'undefined' ) {
+	useSocialLoginExperiment = () => useExperiment( SOCIAL_LOGIN_EXPERIMENT );
+}
+
+export { useSocialLoginExperiment, SOCIAL_LOGIN_EXPERIMENT };

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -32,8 +32,8 @@ const SocialSignupForm = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ , experimentAssignment ] = useSocialLoginExperiment();
-	const isTreatment = experimentAssignment?.variationName !== 'control';
+	const [ isLoading, experimentAssignment ] = useSocialLoginExperiment();
+	const isTreatment = isLoading || experimentAssignment?.variationName === 'treatment';
 	const shouldShowApple = ! isTreatment;
 
 	const currentQuery = useSelector( getCurrentQueryArguments );

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -5,21 +5,19 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import SocialToS from 'calypso/blocks/authentication/social/social-tos.jsx';
+import { useSocialLoginExperiment } from 'calypso/blocks/login/use-social-login-experiment';
 import {
 	GoogleSocialButton,
 	AppleLoginButton,
 	GithubSocialButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
-import { useExperiment } from 'calypso/lib/explat';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { recordTracksEvent as recordTracks } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
-
-const SOCIAL_LOGIN_EXPERIMENT = 'calypso_social_login_hide_apple_jetpack';
 
 const SocialSignupForm = ( {
 	compact = false,
@@ -34,7 +32,7 @@ const SocialSignupForm = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
+	const [ isLoading, experimentAssignment ] = useSocialLoginExperiment();
 	const isTreatment = experimentAssignment?.variationName === 'treatment';
 	const shouldShowApple = ! isLoading && ! isTreatment;
 

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,9 +1,9 @@
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import SocialToS from 'calypso/blocks/authentication/social/social-tos.jsx';
 import {
 	GoogleSocialButton,
@@ -17,7 +17,6 @@ import { recordTracksEvent as recordTracks } from 'calypso/state/analytics/actio
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
 const SOCIAL_LOGIN_EXPERIMENT = 'calypso_social_login_hide_apple_jetpack';
@@ -26,26 +25,32 @@ const SocialSignupForm = ( {
 	compact = false,
 	handleResponse,
 	setCurrentStep,
-	translate,
 	socialServiceResponse,
 	disableTosText,
 	flowName,
 	redirectToAfterLoginUrl,
 	isSocialFirst,
-	recordTracksEvent,
-	isDevAccount,
-	oauth2Client,
-	isWoo,
-	showErrorNotice,
+	isDevAccount: propIsDevAccount,
 } ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
 	const isTreatment = experimentAssignment?.variationName === 'treatment';
 	const shouldShowApple = ! isLoading && ! isTreatment;
 
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const isWoo = useSelector( getIsWoo );
+
+	const devAccountLandingPageRefs = [ 'hosting-lp', 'developer-lp' ];
+	const isDevAccount = propIsDevAccount ?? devAccountLandingPageRefs.includes( currentQuery?.ref );
+
 	const handleSignup = ( result ) => {
-		recordTracksEvent( 'calypso_signup_social_button_success', {
-			social_account_type: result.service,
-		} );
+		dispatch(
+			recordTracks( 'calypso_signup_social_button_success', {
+				social_account_type: result.service,
+			} )
+		);
 
 		window.sessionStorage?.removeItem( 'login_redirect_to' );
 
@@ -58,30 +63,34 @@ const SocialSignupForm = ( {
 	const trackSignupAndRememberRedirect = ( event ) => {
 		const service = event.currentTarget.getAttribute( 'data-social-service' );
 
-		recordTracksEvent( 'calypso_signup_social_button_click', {
-			social_account_type: service,
-			client_id: oauth2Client?.id,
-		} );
+		dispatch(
+			recordTracks( 'calypso_signup_social_button_click', {
+				social_account_type: service,
+				client_id: oauth2Client?.id,
+			} )
+		);
 
 		try {
 			if ( redirectToAfterLoginUrl && typeof window !== 'undefined' ) {
 				window.sessionStorage.setItem( 'signup_redirect_to', redirectToAfterLoginUrl );
 			}
 		} catch ( error ) {
-			showErrorNotice(
-				translate(
-					'Error accessing sessionStorage. {{a}}Please check your browser settings{{/a}}.',
-					{
-						components: {
-							a: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/support/browser-issues/' ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-						},
-					}
+			dispatch(
+				errorNotice(
+					translate(
+						'Error accessing sessionStorage. {{a}}Please check your browser settings{{/a}}.',
+						{
+							components: {
+								a: (
+									<a
+										href={ localizeUrl( 'https://wordpress.com/support/browser-issues/' ) }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+							},
+						}
+					)
 				)
 			);
 		}
@@ -131,32 +140,12 @@ SocialSignupForm.propTypes = {
 	compact: PropTypes.bool,
 	handleResponse: PropTypes.func.isRequired,
 	setCurrentStep: PropTypes.func,
-	translate: PropTypes.func.isRequired,
 	socialServiceResponse: PropTypes.object,
 	disableTosText: PropTypes.bool,
 	flowName: PropTypes.string,
 	redirectToAfterLoginUrl: PropTypes.string,
 	isSocialFirst: PropTypes.bool,
-	recordTracksEvent: PropTypes.func.isRequired,
 	isDevAccount: PropTypes.bool,
-	oauth2Client: PropTypes.object,
-	isWoo: PropTypes.bool,
-	showErrorNotice: PropTypes.func.isRequired,
 };
 
-export default connect(
-	( state ) => {
-		const query = getCurrentQueryArguments( state );
-		const devAccountLandingPageRefs = [ 'hosting-lp', 'developer-lp' ];
-		const isDevAccount = devAccountLandingPageRefs.includes( query?.ref );
-
-		return {
-			recordTracksEvent: recordTracks,
-			currentRoute: getCurrentRoute( state ),
-			oauth2Client: getCurrentOAuth2Client( state ),
-			isDevAccount: isDevAccount,
-			isWoo: getIsWoo( state ),
-		};
-	},
-	{ showErrorNotice: errorNotice }
-)( localize( SocialSignupForm ) );
+export default SocialSignupForm;

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -32,9 +32,9 @@ const SocialSignupForm = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ isLoading, experimentAssignment ] = useSocialLoginExperiment();
-	const isTreatment = experimentAssignment?.variationName === 'treatment';
-	const shouldShowApple = ! isLoading && ! isTreatment;
+	const [ , experimentAssignment ] = useSocialLoginExperiment();
+	const isTreatment = experimentAssignment?.variationName !== 'control';
+	const shouldShowApple = ! isTreatment;
 
 	const currentQuery = useSelector( getCurrentQueryArguments );
 	const oauth2Client = useSelector( getCurrentOAuth2Client );

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -3,7 +3,6 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
 import { connect } from 'react-redux';
 import SocialToS from 'calypso/blocks/authentication/social/social-tos.jsx';
 import {
@@ -12,6 +11,7 @@ import {
 	GithubSocialButton,
 	UsernameOrEmailButton,
 } from 'calypso/components/social-buttons';
+import { useExperiment } from 'calypso/lib/explat';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { recordTracksEvent as recordTracks } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -20,25 +20,29 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 
-class SocialSignupForm extends Component {
-	static propTypes = {
-		compact: PropTypes.bool,
-		handleResponse: PropTypes.func.isRequired,
-		setCurrentStep: PropTypes.func,
-		translate: PropTypes.func.isRequired,
-		socialServiceResponse: PropTypes.object,
-		disableTosText: PropTypes.bool,
-		flowName: PropTypes.string,
-		redirectToAfterLoginUrl: PropTypes.string,
-		isSocialFirst: PropTypes.bool,
-	};
+const SOCIAL_LOGIN_EXPERIMENT = 'calypso_social_login_hide_apple_jetpack';
 
-	static defaultProps = {
-		compact: false,
-	};
+const SocialSignupForm = ( {
+	compact = false,
+	handleResponse,
+	setCurrentStep,
+	translate,
+	socialServiceResponse,
+	disableTosText,
+	flowName,
+	redirectToAfterLoginUrl,
+	isSocialFirst,
+	recordTracksEvent,
+	isDevAccount,
+	oauth2Client,
+	isWoo,
+	showErrorNotice,
+} ) => {
+	const [ isLoading, experimentAssignment ] = useExperiment( SOCIAL_LOGIN_EXPERIMENT );
+	const isTreatment = experimentAssignment?.variationName === 'treatment';
+	const shouldShowApple = ! isLoading && ! isTreatment;
 
-	handleSignup = ( result ) => {
-		const { recordTracksEvent, isDevAccount, handleResponse } = this.props;
+	const handleSignup = ( result ) => {
 		recordTracksEvent( 'calypso_signup_social_button_success', {
 			social_account_type: result.service,
 		} );
@@ -51,11 +55,8 @@ class SocialSignupForm extends Component {
 		} );
 	};
 
-	trackSignupAndRememberRedirect = ( event ) => {
+	const trackSignupAndRememberRedirect = ( event ) => {
 		const service = event.currentTarget.getAttribute( 'data-social-service' );
-
-		const { recordTracksEvent, oauth2Client, redirectToAfterLoginUrl, showErrorNotice, translate } =
-			this.props;
 
 		recordTracksEvent( 'calypso_signup_social_button_click', {
 			social_account_type: service,
@@ -86,58 +87,62 @@ class SocialSignupForm extends Component {
 		}
 	};
 
-	render() {
-		const {
-			compact,
-			translate,
-			socialServiceResponse,
-			disableTosText,
-			isSocialFirst,
-			flowName,
-			isWoo,
-			setCurrentStep,
-		} = this.props;
+	return (
+		<Card
+			className={ clsx( 'auth-form__social', 'is-signup', {
+				'is-social-first': isSocialFirst,
+			} ) }
+		>
+			{ ! compact && (
+				<p className="auth-form__social-text">{ translate( 'Or create an account using:' ) }</p>
+			) }
 
-		return (
-			<Card
-				className={ clsx( 'auth-form__social', 'is-signup', {
-					'is-social-first': isSocialFirst,
-				} ) }
-			>
-				{ ! compact && (
-					<p className="auth-form__social-text">{ translate( 'Or create an account using:' ) }</p>
-				) }
+			<div className="auth-form__social-buttons">
+				<div className="auth-form__social-buttons-container">
+					<GoogleSocialButton
+						responseHandler={ handleSignup }
+						onClick={ trackSignupAndRememberRedirect }
+					/>
 
-				<div className="auth-form__social-buttons">
-					<div className="auth-form__social-buttons-container">
-						<GoogleSocialButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-						/>
-
+					{ shouldShowApple && (
 						<AppleLoginButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
+							responseHandler={ handleSignup }
+							onClick={ trackSignupAndRememberRedirect }
 							socialServiceResponse={ socialServiceResponse }
 							queryString={ isWpccFlow( flowName ) ? window?.location?.search?.slice( 1 ) : '' }
 						/>
+					) }
 
-						<GithubSocialButton
-							responseHandler={ this.handleSignup }
-							onClick={ this.trackSignupAndRememberRedirect }
-							socialServiceResponse={ socialServiceResponse }
-						/>
-						{ isSocialFirst && (
-							<UsernameOrEmailButton onClick={ () => setCurrentStep( 'email' ) } />
-						) }
-					</div>
-					{ ! isWoo && ! disableTosText && <SocialToS /> }
+					<GithubSocialButton
+						responseHandler={ handleSignup }
+						onClick={ trackSignupAndRememberRedirect }
+						socialServiceResponse={ socialServiceResponse }
+					/>
+					{ isSocialFirst && <UsernameOrEmailButton onClick={ () => setCurrentStep( 'email' ) } /> }
 				</div>
-				{ isWoo && ! disableTosText && <SocialToS /> }
-			</Card>
-		);
-	}
-}
+				{ ! isWoo && ! disableTosText && <SocialToS /> }
+			</div>
+			{ isWoo && ! disableTosText && <SocialToS /> }
+		</Card>
+	);
+};
+
+SocialSignupForm.propTypes = {
+	compact: PropTypes.bool,
+	handleResponse: PropTypes.func.isRequired,
+	setCurrentStep: PropTypes.func,
+	translate: PropTypes.func.isRequired,
+	socialServiceResponse: PropTypes.object,
+	disableTosText: PropTypes.bool,
+	flowName: PropTypes.string,
+	redirectToAfterLoginUrl: PropTypes.string,
+	isSocialFirst: PropTypes.bool,
+	recordTracksEvent: PropTypes.func.isRequired,
+	isDevAccount: PropTypes.bool,
+	oauth2Client: PropTypes.object,
+	isWoo: PropTypes.bool,
+	showErrorNotice: PropTypes.func.isRequired,
+};
 
 export default connect(
 	( state ) => {

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -13,6 +13,9 @@ jest.mock( 'calypso/components/data/document-head', () => () => 'DocumentHead' )
 jest.mock( 'calypso/components/social-buttons/google', () => () => 'GoogleSocialButton' );
 jest.mock( 'calypso/components/social-buttons/apple', () => () => 'AppleLoginButton' );
 jest.mock( 'calypso/components/social-buttons/github', () => () => 'GitHubLoginButton' );
+jest.mock( 'calypso/blocks/login/use-social-login-experiment', () => ( {
+	useSocialLoginExperiment: () => [ false, { variationName: 'control' } ],
+} ) );
 
 const render = ( el, options ) =>
 	renderWithProvider( el, {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Addresses https://github.com/Automattic/wp-calypso/issues/100587

## Proposed Changes

* Hide two buttons from Login and Signup User Step per request by Design

Log-in when assigned to Treatment
<img width="931" alt="Screenshot 2025-05-16 at 10 32 04" src="https://github.com/user-attachments/assets/f777309c-8056-4d77-85b2-e19429864694" />

User step:
<img width="608" alt="Screenshot 2025-05-16 at 10 32 32" src="https://github.com/user-attachments/assets/17f49081-54ec-4568-91c9-2cc2cbb2b449" />

<img width="874" alt="Screenshot 2025-05-16 at 13 51 45" src="https://github.com/user-attachments/assets/b6a6d15e-61fe-4641-82a3-c5007691662b" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* Use 22252-explat-experiment
* Assign yourself to treatment
* Go over /log-in and setup/onboarding
* Ensure the screens above are visible
* Assign yourself to control
* 3 buttons visible (or 4)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
