### PR TITLE
Plan upsell modal: Fix wrong mention of "transfer your domain" in modal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -1,6 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { UrlFriendlyTermType } from '@automattic/calypso-products';
+import {
+	UrlFriendlyTermType,
+	WithSnakeCaseSlug,
+	isDomainTransfer,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
@@ -74,7 +78,7 @@ export interface UnifiedPlansStepProps {
 	submitSignupStep?: (
 		stepInfo: {
 			stepName: string;
-			domainItem?: { meta?: string };
+			domainItem?: { meta?: string; product_slug?: string };
 			isPurchasingItem?: boolean;
 			stepSectionName?: string;
 			siteUrl?: string;
@@ -93,7 +97,7 @@ export interface UnifiedPlansStepProps {
 		siteId?: number | null;
 		siteSlug?: string | null;
 		siteUrl?: string | null;
-		domainItem?: { meta?: string } | null;
+		domainItem?: { meta?: string; product_slug?: string } | null;
 		siteTitle?: string | null;
 		username?: string | null;
 		coupon?: string | null;
@@ -371,7 +375,7 @@ function UnifiedPlansStep( {
 			return translate( 'The right plan for the right project' );
 		}
 
-		return translate( 'There’s a plan for you' );
+		return translate( "There's a plan for you" );
 	};
 
 	const getSubheaderText = () => {
@@ -479,6 +483,10 @@ function UnifiedPlansStep( {
 		( ONBOARDING_FLOW === flowName && ( paidDomainName != null || isPaidTheme ) ) ||
 		deemphasizeFreePlanFromProps;
 
+	const isDomainTransferSelected = domainItem?.product_slug
+		? isDomainTransfer( { product_slug: domainItem.product_slug } as WithSnakeCaseSlug )
+		: false;
+
 	const stepContent = (
 		<div>
 			{ 'invalid' === step?.status && (
@@ -490,6 +498,7 @@ function UnifiedPlansStep( {
 			) }
 			<PlansFeaturesMain
 				paidDomainName={ paidDomainName }
+				isDomainTransfer={ isDomainTransferSelected }
 				freeSubdomain={ freeWPComSubdomain }
 				siteTitle={ siteTitle ?? undefined }
 				signupFlowUserName={ username ?? undefined }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -20,14 +20,15 @@ export type ModalType =
 	| typeof PAID_PLAN_IS_REQUIRED_DIALOG
 	| typeof MODAL_LOADER;
 
-export type DomainPlanDialogProps = {
+export interface DomainPlanDialogProps {
 	paidDomainName?: string;
 	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	selectedThemeType?: string;
 	upsellPremiumPlan?: boolean;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
-};
+	isDomainTransfer?: boolean;
+}
 
 type ModalContainerProps = {
 	isModalOpen: boolean;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-paid-domain-dialog.tsx
@@ -20,6 +20,7 @@ export function PaidPlanPaidDomainDialog( {
 	generatedWPComSubdomain,
 	onFreePlanSelected,
 	onPlanSelected,
+	isDomainTransfer,
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
@@ -41,9 +42,13 @@ export function PaidPlanPaidDomainDialog( {
 				{ translate( 'Paid plan required' ) }
 			</Heading>
 			<SubHeading id="plan-upsell-modal-description">
-				{ translate(
-					'To transfer your domain, you’ll need a paid plan. Choose annual billing and get the domain free for a year.'
-				) }
+				{ isDomainTransfer
+					? translate(
+							"To transfer your domain, you'll need a paid plan. Choose annual billing and get the domain free for a year."
+					  )
+					: translate(
+							"To register your domain, you'll need a paid plan. Choose annual billing and get the domain free for a year."
+					  ) }
 			</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -125,6 +125,7 @@ export interface PlansFeaturesMainProps {
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
 	intervalType?: Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >;
+	isDomainTransfer?: boolean;
 	/**
 	 * An array of intervals to be displayed in the plan type selector. Defaults to [ 'yearly', '2yearly', '3yearly', 'monthly' ]
 	 */
@@ -229,6 +230,7 @@ const PlansFeaturesMain = ( {
 	coupon,
 	onPlanIntervalUpdate,
 	selectedThemeType,
+	isDomainTransfer,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	// TODO: Remove temporary eslint disable
@@ -779,6 +781,7 @@ const PlansFeaturesMain = ( {
 					modalType={ resolveModal( lastClickedPlan ) }
 					generatedWPComSubdomain={ resolvedSubdomainName }
 					selectedThemeType={ selectedThemeType }
+					isDomainTransfer={ isDomainTransfer }
 					onClose={ () => setIsModalOpen( false ) }
 					onFreePlanSelected={ ( isDomainRetained ) => {
 						if ( ! isDomainRetained ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/DOTOBRD-134/onboarding-paid-plan-required-modal-showing-wrong-text

## Proposed Changes

* Addresses the case where the plan upsell modal renders with _"To transfer your domain, ..."_ despite the selected domain being for registration
* We try to differentiate between the two cases now (domain transfer vs domain registration). Media below. 

## Media

| Registration | Transfer |
|--------|--------|
| <img width="755" alt="Screenshot 2025-05-15 at 6 42 17 PM" src="https://github.com/user-attachments/assets/6dc2b579-f4da-4e34-8ef8-2fa80398f64b" /> | <img width="741" alt="Screenshot 2025-05-15 at 6 42 59 PM" src="https://github.com/user-attachments/assets/3f413f0e-0395-47da-b1b7-3531b9c2926c" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes https://linear.app/a8c/issue/DOTOBRD-134/onboarding-paid-plan-required-modal-showing-wrong-text

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` and choose "Use a domain I own" to initiate the domain-transfer process
* Select `Transfer your domain` option
* On the plans step pick the free plan (through the link in the sub-header)
* Confirm the modal renders with the correct/respective text
* Repeat, but pick a paid domain and not a transfer.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
