### PR TITLE
Domains: fix help link to point to domains privacy page, props donalirl

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -456,9 +456,9 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/transfer-domain-registration/#before-you-get-started',
 		post_id: 41298,
 	},
-	'public-vs-private-registration-and-gdpr': {
-		link: 'https://wordpress.com/support/domains/register-domain/#public-versus-private-registration-and-gdpr',
-		post_id: 2784,
+	'domain-registrations-and-privacy': {
+		link: 'https://wordpress.com/support/domains/domain-registrations-and-privacy/#privacy-protection',
+		post_id: 143935,
 	},
 	'https-ssl': {
 		link: 'https://wordpress.com/support/domains/https-ssl/',

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -117,7 +117,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 					components: {
 						a: (
 							<InlineSupportLink
-								supportContext="public-vs-private-registration-and-gdpr"
+								supportContext="domain-registrations-and-privacy"
 								showIcon={ false }
 							/>
 						),


### PR DESCRIPTION
Props @donalirl 

**Context**
Edit a domain and open the Contact Information panel. Click the "learn more" link.

It opens: https://wordpress.com/support/domains/register-domain/#public-versus-private-registration-and-gdpr

It should open: https://wordpress.com/support/domains/domain-registrations-and-privacy/

**Impact**: The new link has more information about privacy protection than the current link, so this update will be more helpful to users.