### PR TITLE
Remove margin from first image.

### DIFF
--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -69,6 +69,7 @@
 
 /* Remove top margin for the element if we don't render the header. */
 .plugin-sections__content:not(:has(+ .plugin-sections__header)) .plugin-sections__banner > img:first-child,
+.plugin-sections__content:not(:has(+ .plugin-sections__header)) > img:first-child,
 .plugin-sections__content:not(:has(+ .plugin-sections__header)) > h1:first-child,
 .plugin-sections__content:not(:has(+ .plugin-sections__header)) > h2:first-child,
 .plugin-sections__content:not(:has(+ .plugin-sections__header)) > h3:first-child,


### PR DESCRIPTION
Follow up to #103450

## Proposed Changes

This removes the margin from the first image as well when viewing plugin information content.


## Testing Instructions

Check out `/plugins/sensei-pro` and expect the first image to not have top margin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
