### PR TITLE
Remove Button and style overrides from "Visit stats" link

### DIFF
--- a/client/sites/components/plan-stats/plan-site-visits.tsx
+++ b/client/sites/components/plan-stats/plan-site-visits.tsx
@@ -188,9 +188,7 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 				: `/stats/month/${ siteSlug }`;
 
 		return (
-			<Button
-				variant="link"
-				css={ { textDecoration: 'none !important', fontSize: 'inherit' } }
+			<a
 				href={ statsPageUrl }
 				onClick={ () => {
 					dispatch( recordTracksEvent( 'calypso_hosting_overview_visit_stats_click' ) );
@@ -199,7 +197,7 @@ export function PlanSiteVisits( { siteId }: PlanSiteVisitsProps ) {
 				{ translate( 'Visit stats', {
 					comment: 'A link taking the user to more detailed site statistics',
 				} ) }
-			</Button>
+			</a>
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->



## Proposed Changes

Fixes DOTCOM-13131

The "Visit stats" link was centre aligned when it should have been left aligned. This is because the Button uses inline-flex.

We were already overriding default Button styles to get the link look we wanted, so better to use a plain <a> and get the left-alignment we want for free.

**Before**

![image](https://github.com/user-attachments/assets/00dd312e-9bbe-4706-9d52-13e1878f2297)

**After**

![CleanShot 2025-05-16 at 11 13 29@2x](https://github.com/user-attachments/assets/84489a3f-f75d-454b-bf6a-a7fc963aa3ef)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This is a visual regression

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test in Calypso at `/overview/{{ site slug }}`

Although it doesn't do anything special, make sure to double check mobile layout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
