### PR TITLE
Remove the jetpack/magic-link-signup flag

### DIFF
--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -25,8 +25,6 @@ productionConfig.features.is_running_in_jetpack_site =
 // Set is is_running_in_woo_site to true if the dashboard is running on the Blaze Ads plugin
 productionConfig.features.is_running_in_blaze_plugin = isBlazePlugin;
 
-productionConfig.features[ 'jetpack/magic-link-signup' ] = true;
-
 // Set is is_running_in_woo_site to true if the dashboard is running on a Woo site
 productionConfig.features.is_running_in_woo_site = isWooStore;
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -155,7 +155,6 @@ export class LoginForm extends Component {
 		if (
 			currentRoute &&
 			currentRoute.includes( '/log-in/jetpack' ) &&
-			config.isEnabled( 'jetpack/magic-link-signup' ) &&
 			requestError.code === 'unknown_user' &&
 			! this.props.isWooJPC
 		) {

--- a/client/blocks/login/login-header.tsx
+++ b/client/blocks/login/login-header.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { capitalize } from 'lodash';
 import A4APlusWpComLogo from 'calypso/a8c-for-agencies/components/a4a-plus-wpcom-logo';
@@ -183,12 +182,9 @@ export function getHeaderText(
 	} else if ( isFromMigrationPlugin ) {
 		headerText = translate( 'Log in to your account' );
 	} else if ( isJetpack && ! isFromAutomatticForAgenciesPlugin ) {
-		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
-		headerText = isJetpackMagicLinkSignUpFlow
-			? translate(
-					'Log in or create a WordPress.com account to supercharge your site with powerful growth, performance, and security tools.'
-			  )
-			: translate( 'Log in or create a WordPress.com account to set up Jetpack' );
+		headerText = translate(
+			'Log in or create a WordPress.com account to supercharge your site with powerful growth, performance, and security tools.'
+		);
 	}
 
 	if ( isFromAkismet ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -902,9 +902,8 @@ export class JetpackAuthorize extends Component {
 			);
 		}
 
-		// Accounts created through the new Magic Link-based signup flow (enabled with the
-		// 'jetpack/magic-link-signup' feature flag) are created with a username based on the user's
-		// email address. For this reason, we want to display both the username and the email address
+		// Accounts created through the Magic Link-based signup flow are created with a username based on the
+		// user's email address. For this reason, we want to display both the username and the email address
 		// so users can start making the connection between the two immediately. Otherwise, users might
 		// not recognize their username since they didn't create it.
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -865,7 +865,6 @@ export class JetpackAuthorize extends Component {
 		const { authorizeSuccess } = this.props.authorizationData;
 		const isWpcomMigration = this.isFromMigrationPlugin();
 		const isWooDnaFlow = this.getWooDnaConfig().isWooDnaFlow();
-		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
 
 		if ( isWpcomMigration ) {
 			const { display_name, email } = this.props.user;
@@ -916,7 +915,7 @@ export class JetpackAuthorize extends Component {
 		// is an intermediate step and the user will be redirected to the WooCommerce onboarding flow.
 		// Seeing this new username/email address can cause confusion because they have already set up
 		// a Woo account under their own email address.
-		if ( isWooDnaFlow && isJetpackMagicLinkSignUpFlow ) {
+		if ( isWooDnaFlow ) {
 			return connected
 				? translate( 'Account connected successfully' )
 				: translate( 'Connecting your account' );
@@ -1152,7 +1151,6 @@ export class JetpackAuthorize extends Component {
 		const { translate } = this.props;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
 		const { from } = this.props.authQuery;
-		const isJetpackMagicLinkSignUpFlow = config.isEnabled( 'jetpack/magic-link-signup' );
 
 		if (
 			this.retryingAuth ||
@@ -1173,19 +1171,12 @@ export class JetpackAuthorize extends Component {
 
 		return (
 			<LoggedOutFormLinks>
-				{ ! isJetpackMagicLinkSignUpFlow && this.renderBackToWpAdminLink() }
 				<LoggedOutFormLinkItem
 					href={ loginURL }
 					onClick={ ( e ) => this.handleSignIn( e, loginURL ) }
 				>
 					{ translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
-				{ ! isJetpackMagicLinkSignUpFlow && (
-					<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
-						{ translate( 'Create a new account' ) }
-					</LoggedOutFormLinkItem>
-				) }
-				{ ! isJetpackMagicLinkSignUpFlow && <HelpButton /> }
 			</LoggedOutFormLinks>
 		);
 	}

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -160,40 +160,9 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         >
           <a
             class="logged-out-form__link-item"
-            href="http://an.example.site/wp-admin/admin.php?page=jetpack"
-          >
-            <svg
-              class="gridicon gridicons-arrow-left needs-offset-y"
-              height="18"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <use
-                xlink:href="gridicons.svg#gridicons-arrow-left"
-              />
-            </svg>
-             
-            Return to %(sitename)s
-          </a>
-          <a
-            class="logged-out-form__link-item"
             href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F&from=banner-44-slide-1-dashboard"
           >
             Sign in as a different user
-          </a>
-          <a
-            class="logged-out-form__link-item"
-          >
-            Create a new account
-          </a>
-          <a
-            class="logged-out-form__link-item jetpack-connect__help-button"
-            href="https://jetpack.com/contact-support?hpi=1"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Get help setting up Jetpack
           </a>
         </div>
       </div>

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import config from '@automattic/calypso-config';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import deepFreeze from 'deep-freeze';
@@ -77,12 +76,6 @@ jest.mock( '../persistence-utils', () => ( {
 	isSsoApproved: ( clientId ) => clientId === APPROVE_SSO_CLIENT_ID,
 } ) );
 
-jest.mock( '@automattic/calypso-config', () => {
-	const mock = () => '';
-	mock.isEnabled = jest.fn();
-	return mock;
-} );
-
 function renderWithRedux( ui ) {
 	return renderWithProvider( ui, {
 		reducers: {
@@ -96,13 +89,8 @@ function renderWithRedux( ui ) {
 
 let windowOpenSpy;
 
-// If feature flag is jetpack/magic-link-signup then false, else true
 beforeEach( () => {
 	windowOpenSpy = jest.spyOn( global.window, 'open' ).mockImplementation( jest.fn() );
-	config.isEnabled.mockImplementation( ( flag ) => {
-		const disabledFlags = [ 'jetpack/magic-link-signup' ];
-		return ! disabledFlags.includes( flag );
-	} );
 } );
 
 afterEach( () => {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -211,7 +211,7 @@ export function qrCodeLogin( context, next ) {
 }
 
 function getHandleEmailedLinkFormComponent( flow ) {
-	if ( flow === 'jetpack' && config.isEnabled( 'jetpack/magic-link-signup' ) ) {
+	if ( flow === 'jetpack' ) {
 		return HandleEmailedLinkFormJetpackConnect;
 	}
 	return HandleEmailedLinkForm;

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1360,8 +1360,7 @@ class MagicLogin extends Component {
 			! this.props.isFromAutomatticForAgenciesPlugin &&
 			! this.props.isJetpackLogin;
 
-		// If this is part of the Jetpack login flow and the `jetpack/magic-link-signup` feature
-		// flag is enabled, some steps will display a different UI
+		// If this is part of the Jetpack login flow, some steps will display a different UI
 		const requestLoginEmailFormProps = {
 			...( this.props.isJetpackLogin ? { flow: 'jetpack' } : {} ),
 			createAccountForNewUser: true,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -433,19 +433,11 @@ export class Login extends Component {
 		}
 
 		if ( ( isWoo || isBlazePro ) && isLoginView ) {
-			return (
-				<>
-					<LoginFooter lostPasswordLink={ this.getLostPasswordLink() } shouldRenderTos />
-				</>
-			);
+			return <LoginFooter lostPasswordLink={ this.getLostPasswordLink() } shouldRenderTos />;
 		}
 
 		if ( isSocialFirst ) {
-			return (
-				<>
-					<LoginFooter lostPasswordLink={ this.getLostPasswordLink() } />
-				</>
-			);
+			return <LoginFooter lostPasswordLink={ this.getLostPasswordLink() } />;
 		}
 
 		const shouldRenderFooter =
@@ -453,19 +445,17 @@ export class Login extends Component {
 
 		if ( shouldRenderFooter ) {
 			return (
-				<>
-					<LoginLinks
-						locale={ locale }
-						twoFactorAuthType={ twoFactorAuthType }
-						isWhiteLogin={ isWhiteLogin }
-						isGravPoweredClient={ isGravPoweredClient }
-						signupUrl={ signupUrl }
-						usernameOrEmail={ this.state.usernameOrEmail }
-						oauth2Client={ this.props.oauth2Client }
-						getLostPasswordLink={ this.getLostPasswordLink.bind( this ) }
-						renderSignUpLink={ this.renderSignUpLink.bind( this ) }
-					/>
-				</>
+				<LoginLinks
+					locale={ locale }
+					twoFactorAuthType={ twoFactorAuthType }
+					isWhiteLogin={ isWhiteLogin }
+					isGravPoweredClient={ isGravPoweredClient }
+					signupUrl={ signupUrl }
+					usernameOrEmail={ this.state.usernameOrEmail }
+					oauth2Client={ this.props.oauth2Client }
+					getLostPasswordLink={ this.getLostPasswordLink.bind( this ) }
+					renderSignUpLink={ this.renderSignUpLink.bind( this ) }
+				/>
 			);
 		}
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -449,11 +448,8 @@ export class Login extends Component {
 			);
 		}
 
-		const isJetpackMagicLinkSignUpFlow =
-			isJetpack && config.isEnabled( 'jetpack/magic-link-signup' );
-
 		const shouldRenderFooter =
-			! socialConnect && ! isJetpackMagicLinkSignUpFlow && ! isWCCOM && ! isBlazePro && ! isWooJPC;
+			! socialConnect && ! isJetpack && ! isWCCOM && ! isBlazePro && ! isWooJPC;
 
 		if ( shouldRenderFooter ) {
 			return (

--- a/config/development.json
+++ b/config/development.json
@@ -91,7 +91,6 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
 		"jetpack/golden-token": true,
-		"jetpack/magic-link-signup": true,
 		"jetpack/manage-simple-sites": true,
 		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -53,7 +53,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/magic-link-signup": true,
 		"jetpack/manage-simple-sites": true,
 		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/production.json
+++ b/config/production.json
@@ -68,7 +68,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/magic-link-signup": true,
 		"jetpack/manage-simple-sites": false,
 		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,7 +65,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/magic-link-signup": true,
 		"jetpack/manage-simple-sites": true,
 		"jetpack/onboarding-user-connection-redesign": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -70,7 +70,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/features-section/simple": true,
-		"jetpack/magic-link-signup": true,
 		"jetpack/manage-simple-sites": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,


### PR DESCRIPTION
Removes the `jetpack/magic-link-signup` feature flag that has been always-on for a few years now.

There is a conflict with #103445 because I'm modifying the `getHeaderText` function. Therefore there's no hurry merging this -- it should be up to me to resolve the conflicts after the other PR is merged.

## Testing instructions:
Verify that the affected Jetpack Connect flows still work as expected and that I didn't miss anything.