### PR TITLE
Updating loading label and removing input loader

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -1,11 +1,4 @@
-import {
-	Card,
-	Button,
-	FormLabel,
-	FormInputValidation,
-	Gridicon,
-	Spinner,
-} from '@automattic/components';
+import { Card, Button, FormLabel, FormInputValidation, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -78,7 +71,8 @@ class JetpackConnectSiteUrlInput extends Component {
 
 	renderButtonLabel() {
 		const { isSearch, translate } = this.props;
-		if ( ! this.props.isFetching ) {
+
+		if ( ! this.props.isFetching && ! this.state.isUnloading ) {
 			if ( ! this.props.isInstall ) {
 				return translate( 'Continue' );
 			}
@@ -187,6 +181,9 @@ class JetpackConnectSiteUrlInput extends Component {
 	render() {
 		const { candidateSites, isFetching, isSearch, translate, url, autoFocus } = this.props;
 
+		const isDisabled = this.isFormSubmitDisabled();
+		const isBusy = this.isFormSubmitBusy();
+
 		return (
 			<div>
 				<FormLabel htmlFor="siteUrl">{ translate( 'Site address' ) }</FormLabel>
@@ -214,7 +211,6 @@ class JetpackConnectSiteUrlInput extends Component {
 							value={ url }
 						/>
 					) }
-					{ isFetching ? <Spinner /> : null }
 					{ this.renderError() }
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
@@ -222,8 +218,8 @@ class JetpackConnectSiteUrlInput extends Component {
 					<Button
 						className="jetpack-connect__connect-button"
 						primary
-						disabled={ this.isFormSubmitDisabled() }
-						busy={ this.isFormSubmitBusy() }
+						disabled={ isDisabled }
+						busy={ isBusy }
 						onClick={ this.handleFormSubmit }
 					>
 						{ this.renderButtonLabel() }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Relates to MYJP-123

## Proposed Changes

* remove spinner from URL input
* make sure that the `setting up...` label is visible throughout the whole process

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* unifying UI loaders

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch
* create a JN site in another tab, copy its URL
* navigate to `/sites` on the live branch
* Click on a Add new site button
* Click Via Jetpack plugin
* Enter a URL and continue
* Verify that the label `setting up...` is visible until redirecting and that input doesn't have any spinners

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
