### PR TITLE
Revert "Experiment streamlining the plans grid + checkout: Update the plan interval dropdown"

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -18,7 +18,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
 import {
 	getItemVariantCompareToPrice,
-	getItemVariantDiscount,
+	getItemVariantDiscountPercentage,
 } from '../item-variation-picker/util';
 import type { WPCOMProductVariant } from '../item-variation-picker';
 import './style.scss';
@@ -187,7 +187,7 @@ export function CheckoutSidebarPlanUpsell() {
 		upsellVariant,
 		currentVariant
 	);
-	const percentSavings = getItemVariantDiscount( upsellVariant, currentVariant );
+	const percentSavings = getItemVariantDiscountPercentage( upsellVariant, currentVariant );
 	if ( percentSavings === 0 ) {
 		debug( 'percent savings is too low', percentSavings );
 		return null;

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -2,18 +2,13 @@ import {
 	isJetpackPlan,
 	isJetpackProduct,
 	isMultiYearDomainProduct,
-	isWpComPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
-import {
-	useStreamlinedPriceExperiment,
-	isStreamlinedPriceDropdownTreatment,
-} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { JetpackItemVariantDropDownPrice } from './jetpack-variant-dropdown-price';
-import { CurrentOption, Dropdown, OptionList, Option, WPCheckoutCheckIcon } from './styles';
+import { CurrentOption, Dropdown, OptionList, Option } from './styles';
 import { ItemVariantDropDownPrice } from './variant-dropdown-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
@@ -32,32 +27,15 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 } ) => {
 	const translate = useTranslate();
 	const [ highlightedVariantIndex, setHighlightedVariantIndex ] = useState< number | null >( null );
-	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
-	const isStreamlinedPrice =
-		isStreamlinedPriceDropdownTreatment( streamlinedPriceExperimentAssignment ) &&
-		isWpComPlan( selectedItem.product_slug );
-
-	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState< string | null >( null );
-
-	useEffect( () => {
-		if ( isStreamlinedPrice ) {
-			setOptimisticSelectedItem( selectedItem.product_slug );
-		}
-	}, [ selectedItem.product_slug, isStreamlinedPrice ] );
 
 	// Multi-year domain products must be compared by volume because they have the same product id.
-	const selectedVariantIndex = useMemo( () => {
-		const rawIndex = variants.findIndex( ( variant ) => {
-			if ( isStreamlinedPrice && optimisticSelectedItem ) {
-				return variant.productSlug === optimisticSelectedItem;
-			}
-			// If not optimistic, or optimisticSelectedItem is not set, use the original logic
-			return isMultiYearDomainProduct( selectedItem )
-				? selectedItem.volume === variant.volume && variant.productId === selectedItem.product_id
-				: selectedItem.product_id === variant.productId;
-		} );
-		return rawIndex > -1 ? rawIndex : null;
-	}, [ variants, isStreamlinedPrice, optimisticSelectedItem, selectedItem ] );
+	const selectedVariantIndexRaw = variants.findIndex( ( variant ) =>
+		isMultiYearDomainProduct( selectedItem )
+			? selectedItem.volume === variant.volume
+			: selectedItem.product_id === variant.productId
+	);
+	// findIndex returns -1 if it fails and we want null.
+	const selectedVariantIndex = selectedVariantIndexRaw > -1 ? selectedVariantIndexRaw : null;
 
 	// reset the dropdown highlight when the selected product changes
 	useEffect( () => {
@@ -67,13 +45,10 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 	// wrapper around onChangeItemVariant to close up dropdown on change
 	const handleChange = useCallback(
 		( uuid: string, productSlug: string, productId: number, volume?: number ) => {
-			if ( isStreamlinedPrice ) {
-				setOptimisticSelectedItem( productSlug );
-			}
 			onChangeItemVariant( uuid, productSlug, productId, volume );
 			toggle( null );
 		},
-		[ onChangeItemVariant, toggle, isStreamlinedPrice ]
+		[ onChangeItemVariant, toggle ]
 	);
 
 	const selectNextVariant = useCallback( () => {
@@ -146,22 +121,13 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 		return null;
 	}
 
-	let compareTo = undefined;
-	if ( isStreamlinedPrice ) {
-		compareTo = variants.find( ( variant ) => variant.termIntervalInMonths === 1 );
-	}
 	const ItemVariantDropDownPriceWrapper: FunctionComponent< { variant: WPCOMProductVariant } > = (
 		props
 	) =>
 		isJetpack( props.variant ) ? (
 			<JetpackItemVariantDropDownPrice { ...props } allVariants={ variants } />
 		) : (
-			<ItemVariantDropDownPrice
-				{ ...props }
-				product={ selectedItem }
-				isStreamlinedPrice={ isStreamlinedPrice }
-				compareTo={ compareTo }
-			/>
+			<ItemVariantDropDownPrice { ...props } product={ selectedItem } />
 		);
 
 	return (
@@ -177,7 +143,6 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				onClick={ () => toggle( id ) }
 				open={ isOpen }
 				role="button"
-				detached={ isStreamlinedPrice }
 			>
 				{ selectedVariantIndex !== null ? (
 					<ItemVariantDropDownPriceWrapper variant={ variants[ selectedVariantIndex ] } />
@@ -192,7 +157,6 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 					highlightedVariantIndex={ highlightedVariantIndex }
 					selectedItem={ selectedItem }
 					handleChange={ handleChange }
-					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) }
 		</Dropdown>
@@ -204,19 +168,15 @@ function ItemVariantOptionList( {
 	highlightedVariantIndex,
 	selectedItem,
 	handleChange,
-	isStreamlinedPrice,
 }: {
 	variants: WPCOMProductVariant[];
 	highlightedVariantIndex: number | null;
 	selectedItem: ResponseCartProduct;
 	handleChange: ( uuid: string, productSlug: string, productId: number, volume?: number ) => void;
-	isStreamlinedPrice: boolean;
 } ) {
-	const compareTo = isStreamlinedPrice
-		? variants.find( ( variant ) => variant.termIntervalInMonths === 1 )
-		: variants.find( ( variant ) => variant.productId === selectedItem.product_id );
+	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
 	return (
-		<OptionList role="listbox" tabIndex={ -1 } detached={ isStreamlinedPrice }>
+		<OptionList role="listbox" tabIndex={ -1 }>
 			{ variants.map( ( variant, index ) => (
 				<ItemVariantOption
 					key={ variant.productSlug + variant.variantLabel.noun }
@@ -233,7 +193,6 @@ function ItemVariantOptionList( {
 					variant={ variant }
 					allVariants={ variants }
 					selectedItem={ selectedItem }
-					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) ) }
 		</OptionList>
@@ -247,7 +206,6 @@ function ItemVariantOption( {
 	variant,
 	allVariants,
 	selectedItem,
-	isStreamlinedPrice,
 }: {
 	isSelected: boolean;
 	onSelect: () => void;
@@ -255,7 +213,6 @@ function ItemVariantOption( {
 	variant: WPCOMProductVariant;
 	allVariants: WPCOMProductVariant[];
 	selectedItem: ResponseCartProduct;
-	isStreamlinedPrice: boolean;
 } ) {
 	const { variantLabel, productId, productSlug } = variant;
 	return (
@@ -267,7 +224,6 @@ function ItemVariantOption( {
 			role="option"
 			onClick={ onSelect }
 			selected={ isSelected }
-			detached={ isStreamlinedPrice }
 		>
 			{ isJetpack( variant ) ? (
 				<JetpackItemVariantDropDownPrice variant={ variant } allVariants={ allVariants } />
@@ -276,10 +232,8 @@ function ItemVariantOption( {
 					variant={ variant }
 					compareTo={ compareTo }
 					product={ selectedItem }
-					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) }
-			{ isStreamlinedPrice && isSelected && <WPCheckoutCheckIcon /> }
 		</Option>
 	);
 }

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { CheckIcon } from '../check-icon';
 import { CurrentOptionProps, OptionProps } from './types';
 
 export const CurrentOption = styled.button< CurrentOptionProps >`
@@ -22,7 +21,6 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 
 	${ ( props ) =>
 		props.open &&
-		! props.detached &&
 		css`
 			border-radius: 3px 3px 0 0;
 		` }
@@ -41,46 +39,14 @@ export const Option = styled.li< OptionProps >`
 	align-items: center;
 	/* the calc aligns the price with the price in CurrentOption */
 	padding: 10px calc( 14px + 24px + 16px ) 10px 16px;
-	position: relative;
-
-	${ ( props ) =>
-		props.detached &&
-		css`
-			padding-top: 14px;
-			padding-bottom: 14px;
-		` }
 
 	&:hover {
 		background: var( --studio-wordpress-blue-5 );
 	}
 
-	${ ( props ) =>
-		! props.detached
-			? css`
-					&.item-variant-option--selected {
-						background: var( --studio-wordpress-blue-50 );
-						color: #fff;
-					}
-			  `
-			: css`
-					&.item-variant-option--selected * {
-						color: var( --studio-black );
-					}
-			  ` }
-`;
-
-export const WPCheckoutCheckIcon = styled( CheckIcon )`
-	fill: ${ ( props ) => props.theme.colors.success };
-	margin-right: 4px;
-	position: absolute;
-	top: 50%;
-	right: 16px;
-	transform: translateY( -50% );
-	.rtl & {
-		margin-right: 0;
-		margin-left: 4px;
-		right: auto;
-		left: 16px;
+	&.item-variant-option--selected {
+		background: var( --studio-wordpress-blue-50 );
+		color: #fff;
 	}
 `;
 
@@ -94,27 +60,12 @@ export const Dropdown = styled.div`
 	}
 `;
 
-export const OptionList = styled.ul< { detached: boolean } >`
+export const OptionList = styled.ul`
 	position: absolute;
 	width: 100%;
 	z-index: 4;
 	margin: 0;
 	box-shadow: rgba( 0, 0, 0, 0.16 ) 0px 1px 4px;
-	${ ( props ) =>
-		props.detached &&
-		css`
-			box-shadow:
-				0px 50px 43px 0px rgba( 0, 0, 0, 0.02 ),
-				0px 30px 36px 0px rgba( 0, 0, 0, 0.04 ),
-				0px 15px 27px 0px rgba( 0, 0, 0, 0.07 ),
-				0px 5px 15px 0px rgba( 0, 0, 0, 0.08 );
-			margin-top: 10px;
-
-			${ Option }:first-of-type {
-				border-top-left-radius: 3px;
-				border-top-right-radius: 3px;
-			}
-		` }
 
 	${ Option } {
 		margin-top: -1px;
@@ -146,28 +97,6 @@ export const Discount = styled.span`
 
 	@media ( max-width: 660px ) {
 		width: 100%;
-	}
-`;
-
-export const DiscountAbsolute = styled.span< {
-	color: string;
-	backgroundColor: string;
-} >`
-	text-align: center;
-	color: ${ ( props ) => props.color };
-	display: block;
-	background-color: ${ ( props ) => props.backgroundColor };
-	padding: 0 10px;
-	border-radius: 4px;
-	font-size: 12px;
-	line-height: 20px;
-	.rtl & {
-		margin-right: 0;
-		margin-left: 8px;
-	}
-	// Keep selected state override for now, adjust if needed
-	.item-variant-option--selected & {
-		color: ${ ( props ) => props.color };
 	}
 `;
 
@@ -244,7 +173,4 @@ export const IntroPricingText = styled.span`
 export const PriceTextContainer = styled.span`
 	font-size: 14px;
 	text-align: right;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-end;
 `;

--- a/client/my-sites/checkout/src/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/types.ts
@@ -42,10 +42,8 @@ export type OnChangeItemVariant = (
 
 export type CurrentOptionProps = {
 	open: boolean;
-	detached?: boolean;
 };
 
 export type OptionProps = {
 	selected: boolean;
-	detached?: boolean;
 };

--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -61,10 +61,9 @@ export function getItemVariantCompareToPrice(
 	return ( compareTo.priceInteger / compareTo.termIntervalInMonths ) * variant.termIntervalInMonths;
 }
 
-export function getItemVariantDiscount(
+export function getItemVariantDiscountPercentage(
 	variant: WPCOMProductVariant,
-	compareTo?: WPCOMProductVariant,
-	discountType: 'percentage' | 'absolute' = 'percentage'
+	compareTo?: WPCOMProductVariant
 ): number {
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 
@@ -74,19 +73,11 @@ export function getItemVariantDiscount(
 			? variant.priceBeforeDiscounts
 			: variant.priceInteger;
 
-	if ( ! compareToPriceForVariantTerm ) {
-		return 0;
-	}
-
-	if ( discountType === 'absolute' ) {
-		return compareToPriceForVariantTerm - variantPrice;
-	}
-
 	// Extremely low "discounts" are possible if the price of the longer term has been rounded
 	// if they cannot be rounded to at least a percentage point we should not show them.
-	const discountPercentage = Math.round(
-		100 - ( variantPrice / compareToPriceForVariantTerm ) * 100
-	);
+	const discountPercentage = compareToPriceForVariantTerm
+		? Math.round( 100 - ( variantPrice / compareToPriceForVariantTerm ) * 100 )
+		: 0;
 
 	return discountPercentage;
 }

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,5 +1,4 @@
 import { isMultiYearDomainProduct } from '@automattic/calypso-products';
-import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -7,7 +6,6 @@ import { FunctionComponent } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import {
 	Discount,
-	DiscountAbsolute,
 	DoNotPayThis,
 	IntroPricing,
 	IntroPricingText,
@@ -16,7 +14,7 @@ import {
 	PriceTextContainer,
 	Variant,
 } from './styles';
-import { getItemVariantDiscount, getItemVariantCompareToPrice } from './util';
+import { getItemVariantDiscountPercentage, getItemVariantCompareToPrice } from './util';
 import type { WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -33,49 +31,14 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
-const DiscountPrice: FunctionComponent< {
-	price: string;
-	termIntervalInMonths: number;
-} > = ( { price, termIntervalInMonths } ) => {
-	const translate = useTranslate();
-
-	// Determine colors for DiscountAbsolute based on term
-	let discountColor = colorStudio.colors[ 'Green 80' ];
-	let discountBackgroundColor = colorStudio.colors[ 'Green 10' ];
-
-	if ( termIntervalInMonths === 12 ) {
-		discountColor = colorStudio.colors[ 'Green 50' ];
-		discountBackgroundColor = colorStudio.colors[ 'Green 0' ]; // As per original request for yearly
-	} else if ( termIntervalInMonths === 24 ) {
-		discountColor = colorStudio.colors[ 'Green 80' ];
-		discountBackgroundColor = colorStudio.colors[ 'Green 5' ]; // As per original request for 2-yearly (using Green 5 as "Green" is ambiguous)
-	}
-
-	return (
-		<DiscountAbsolute color={ discountColor } backgroundColor={ discountBackgroundColor }>
-			{ translate( 'Save %(price)s', { args: { price } } ) }
-		</DiscountAbsolute>
-	);
-};
-
 export const ItemVariantDropDownPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 	product: ResponseCartProduct;
-	isStreamlinedPrice?: boolean;
-} > = ( { variant, compareTo, product, isStreamlinedPrice } ) => {
+} > = ( { variant, compareTo, product } ) => {
 	const isMobile = useMobileBreakpoint();
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
-	const discountPercentage = getItemVariantDiscount( variant, compareTo );
-	const discount = formatCurrency(
-		getItemVariantDiscount( variant, compareTo, 'absolute' ),
-		variant.currency,
-		{
-			stripZeros: true,
-			isSmallestUnit: true,
-		}
-	);
-
+	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
 		stripZeros: true,
 		isSmallestUnit: true,
@@ -217,61 +180,28 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	// or if it's a Jetpack 2 or 3-year plan
 	const canDisplayDiscountPercentage = ! isIntroductoryOffer;
 
-	const label =
-		variant.termIntervalInMonths === 1 && isStreamlinedPrice
-			? translate( 'Month' )
-			: variant.variantLabel.noun;
-
 	return (
 		<Variant>
 			<Label>
-				{ label }
-				{ hasDiscount &&
-					isMobile &&
-					( isStreamlinedPrice ? (
-						<DiscountPrice
-							price={ discount }
-							termIntervalInMonths={ variant.termIntervalInMonths }
-						/>
-					) : (
-						<DiscountPercentage percent={ discountPercentage } />
-					) ) }
+				{ variant.variantLabel.noun }
+				{ hasDiscount && isMobile && <DiscountPercentage percent={ discountPercentage } /> }
 			</Label>
 			<PriceTextContainer>
-				{ hasDiscount &&
-					! isMobile &&
-					canDisplayDiscountPercentage &&
-					( isStreamlinedPrice ? (
-						<DiscountPrice
-							price={ discount }
-							termIntervalInMonths={ variant.termIntervalInMonths }
-						/>
-					) : (
-						<DiscountPercentage percent={ discountPercentage } />
-					) ) }
-				{ hasDiscount && ! isIntroductoryOffer && ! isStreamlinedPrice && (
+				{ hasDiscount && ! isMobile && canDisplayDiscountPercentage && (
+					<DiscountPercentage percent={ discountPercentage } />
+				) }
+				{ hasDiscount && ! isIntroductoryOffer && (
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
 
-				{ isStreamlinedPrice ? (
-					! canDisplayDiscountPercentage && (
-						<DiscountPrice
-							price={ discount }
-							termIntervalInMonths={ variant.termIntervalInMonths }
-						/>
-					)
-				) : (
-					<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
-				) }
-				{ ! isStreamlinedPrice && (
-					<IntroPricing>
-						{ ! isMultiYearDomain && (
-							<IntroPricingText>
-								{ isIntroductoryOffer && translatedIntroOfferDetails() }
-							</IntroPricingText>
-						) }
-					</IntroPricing>
-				) }
+				<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
+				<IntroPricing>
+					{ ! isMultiYearDomain && (
+						<IntroPricingText>
+							{ isIntroductoryOffer && translatedIntroOfferDetails() }
+						</IntroPricingText>
+					) }
+				</IntroPricing>
 			</PriceTextContainer>
 		</Variant>
 	);

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -3,7 +3,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { getItemVariantDiscount } from './util';
+import { getItemVariantDiscountPercentage } from './util';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
@@ -69,7 +69,7 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
 	const translate = useTranslate();
-	const discountPercentage = getItemVariantDiscount( variant, compareTo );
+	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
 
 	const pricePerMonth = Math.round( variant.priceInteger / variant.termIntervalInMonths );
 

--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -14,7 +14,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
-import { getItemVariantDiscount } from '../item-variation-picker/util';
+import { getItemVariantDiscountPercentage } from '../item-variation-picker/util';
 
 import './style.scss';
 
@@ -172,7 +172,7 @@ const useCalculatedDiscounts = () => {
 	];
 
 	return {
-		percentSavings: getItemVariantDiscount( biennial, current ),
+		percentSavings: getItemVariantDiscountPercentage( biennial, current ),
 		priceBreakdown,
 		finalBreakdown,
 	};

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -24,8 +24,8 @@ import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import {
+	isStreamlinedPriceRadioTreatment,
 	useStreamlinedPriceExperiment,
-	isStreamlinedPriceCheckoutTreatment,
 } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -383,12 +383,6 @@ function LineItemWrapper( {
 
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
 		useStreamlinedPriceExperiment();
-
-	const isStreamlinedPrice =
-		! isStreamlinedPriceExperimentLoading &&
-		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
-		isWpComPlan( product.product_slug );
-
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
@@ -404,7 +398,11 @@ function LineItemWrapper( {
 			return true;
 		}
 
-		if ( isStreamlinedPrice ) {
+		if (
+			isWpComPlan( variant.productSlug ) &&
+			! isStreamlinedPriceExperimentLoading &&
+			isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment )
+		) {
 			return true;
 		}
 

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -41,13 +41,6 @@ export function isStreamlinedPriceRadioTreatment( variationName?: string | null 
 	return variationName.includes( 'checkout_radio' );
 }
 
-export function isStreamlinedPriceDropdownTreatment( variationName?: string | null ) {
-	if ( ! variationName ) {
-		return false;
-	}
-	return variationName.includes( 'checkout_dropdown' );
-}
-
 export function isStreamlinedPriceCheckoutTreatment( variationName?: string | null ) {
 	if ( ! variationName ) {
 		return false;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103418

This revert addresses a layout issue on the control version of the dropdown selector:
<img width="480" alt="Screenshot 2025-05-16 at 10 06 21" src="https://github.com/user-attachments/assets/2c680425-6268-46f6-a96e-22762b1a8445" />
