### PR TITLE
Experiment streamlining the plans grid + checkout: Update the plan interval dropdown - take 2

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -18,7 +18,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
 import {
 	getItemVariantCompareToPrice,
-	getItemVariantDiscountPercentage,
+	getItemVariantDiscount,
 } from '../item-variation-picker/util';
 import type { WPCOMProductVariant } from '../item-variation-picker';
 import './style.scss';
@@ -187,7 +187,7 @@ export function CheckoutSidebarPlanUpsell() {
 		upsellVariant,
 		currentVariant
 	);
-	const percentSavings = getItemVariantDiscountPercentage( upsellVariant, currentVariant );
+	const percentSavings = getItemVariantDiscount( upsellVariant, currentVariant );
 	if ( percentSavings === 0 ) {
 		debug( 'percent savings is too low', percentSavings );
 		return null;

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import {
 	useStreamlinedPriceExperiment,
@@ -37,14 +37,27 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 		isStreamlinedPriceDropdownTreatment( streamlinedPriceExperimentAssignment ) &&
 		isWpComPlan( selectedItem.product_slug );
 
+	const [ optimisticSelectedItem, setOptimisticSelectedItem ] = useState< string | null >( null );
+
+	useEffect( () => {
+		if ( isStreamlinedPrice ) {
+			setOptimisticSelectedItem( selectedItem.product_slug );
+		}
+	}, [ selectedItem.product_slug, isStreamlinedPrice ] );
+
 	// Multi-year domain products must be compared by volume because they have the same product id.
-	const selectedVariantIndexRaw = variants.findIndex( ( variant ) =>
-		isMultiYearDomainProduct( selectedItem )
-			? selectedItem.volume === variant.volume
-			: selectedItem.product_id === variant.productId
-	);
-	// findIndex returns -1 if it fails and we want null.
-	const selectedVariantIndex = selectedVariantIndexRaw > -1 ? selectedVariantIndexRaw : null;
+	const selectedVariantIndex = useMemo( () => {
+		const rawIndex = variants.findIndex( ( variant ) => {
+			if ( isStreamlinedPrice && optimisticSelectedItem ) {
+				return variant.productSlug === optimisticSelectedItem;
+			}
+			// If not optimistic, or optimisticSelectedItem is not set, use the original logic
+			return isMultiYearDomainProduct( selectedItem )
+				? selectedItem.volume === variant.volume && variant.productId === selectedItem.product_id
+				: selectedItem.product_id === variant.productId;
+		} );
+		return rawIndex > -1 ? rawIndex : null;
+	}, [ variants, isStreamlinedPrice, optimisticSelectedItem, selectedItem ] );
 
 	// reset the dropdown highlight when the selected product changes
 	useEffect( () => {
@@ -54,10 +67,13 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 	// wrapper around onChangeItemVariant to close up dropdown on change
 	const handleChange = useCallback(
 		( uuid: string, productSlug: string, productId: number, volume?: number ) => {
+			if ( isStreamlinedPrice ) {
+				setOptimisticSelectedItem( productSlug );
+			}
 			onChangeItemVariant( uuid, productSlug, productId, volume );
 			toggle( null );
 		},
-		[ onChangeItemVariant, toggle ]
+		[ onChangeItemVariant, toggle, isStreamlinedPrice ]
 	);
 
 	const selectNextVariant = useCallback( () => {

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -2,13 +2,18 @@ import {
 	isJetpackPlan,
 	isJetpackProduct,
 	isMultiYearDomainProduct,
+	isWpComPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import {
+	useStreamlinedPriceExperiment,
+	isStreamlinedPriceDropdownTreatment,
+} from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { JetpackItemVariantDropDownPrice } from './jetpack-variant-dropdown-price';
-import { CurrentOption, Dropdown, OptionList, Option } from './styles';
+import { CurrentOption, Dropdown, OptionList, Option, WPCheckoutCheckIcon } from './styles';
 import { ItemVariantDropDownPrice } from './variant-dropdown-price';
 import type { ItemVariationPickerProps, WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
@@ -27,6 +32,10 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 } ) => {
 	const translate = useTranslate();
 	const [ highlightedVariantIndex, setHighlightedVariantIndex ] = useState< number | null >( null );
+	const [ , streamlinedPriceExperimentAssignment ] = useStreamlinedPriceExperiment();
+	const isStreamlinedPrice =
+		isStreamlinedPriceDropdownTreatment( streamlinedPriceExperimentAssignment ) &&
+		isWpComPlan( selectedItem.product_slug );
 
 	// Multi-year domain products must be compared by volume because they have the same product id.
 	const selectedVariantIndexRaw = variants.findIndex( ( variant ) =>
@@ -121,13 +130,22 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 		return null;
 	}
 
+	let compareTo = undefined;
+	if ( isStreamlinedPrice ) {
+		compareTo = variants.find( ( variant ) => variant.termIntervalInMonths === 1 );
+	}
 	const ItemVariantDropDownPriceWrapper: FunctionComponent< { variant: WPCOMProductVariant } > = (
 		props
 	) =>
 		isJetpack( props.variant ) ? (
 			<JetpackItemVariantDropDownPrice { ...props } allVariants={ variants } />
 		) : (
-			<ItemVariantDropDownPrice { ...props } product={ selectedItem } />
+			<ItemVariantDropDownPrice
+				{ ...props }
+				product={ selectedItem }
+				isStreamlinedPrice={ isStreamlinedPrice }
+				compareTo={ compareTo }
+			/>
 		);
 
 	return (
@@ -143,6 +161,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				onClick={ () => toggle( id ) }
 				open={ isOpen }
 				role="button"
+				isStreamlinedPrice={ isStreamlinedPrice }
 			>
 				{ selectedVariantIndex !== null ? (
 					<ItemVariantDropDownPriceWrapper variant={ variants[ selectedVariantIndex ] } />
@@ -157,6 +176,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 					highlightedVariantIndex={ highlightedVariantIndex }
 					selectedItem={ selectedItem }
 					handleChange={ handleChange }
+					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) }
 		</Dropdown>
@@ -168,15 +188,19 @@ function ItemVariantOptionList( {
 	highlightedVariantIndex,
 	selectedItem,
 	handleChange,
+	isStreamlinedPrice,
 }: {
 	variants: WPCOMProductVariant[];
 	highlightedVariantIndex: number | null;
 	selectedItem: ResponseCartProduct;
 	handleChange: ( uuid: string, productSlug: string, productId: number, volume?: number ) => void;
+	isStreamlinedPrice: boolean;
 } ) {
-	const compareTo = variants.find( ( variant ) => variant.productId === selectedItem.product_id );
+	const compareTo = isStreamlinedPrice
+		? variants.find( ( variant ) => variant.termIntervalInMonths === 1 )
+		: variants.find( ( variant ) => variant.productId === selectedItem.product_id );
 	return (
-		<OptionList role="listbox" tabIndex={ -1 }>
+		<OptionList role="listbox" tabIndex={ -1 } isStreamlinedPrice={ isStreamlinedPrice }>
 			{ variants.map( ( variant, index ) => (
 				<ItemVariantOption
 					key={ variant.productSlug + variant.variantLabel.noun }
@@ -193,6 +217,7 @@ function ItemVariantOptionList( {
 					variant={ variant }
 					allVariants={ variants }
 					selectedItem={ selectedItem }
+					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) ) }
 		</OptionList>
@@ -206,6 +231,7 @@ function ItemVariantOption( {
 	variant,
 	allVariants,
 	selectedItem,
+	isStreamlinedPrice,
 }: {
 	isSelected: boolean;
 	onSelect: () => void;
@@ -213,6 +239,7 @@ function ItemVariantOption( {
 	variant: WPCOMProductVariant;
 	allVariants: WPCOMProductVariant[];
 	selectedItem: ResponseCartProduct;
+	isStreamlinedPrice: boolean;
 } ) {
 	const { variantLabel, productId, productSlug } = variant;
 	return (
@@ -222,6 +249,7 @@ function ItemVariantOption( {
 			aria-label={ variantLabel.noun }
 			data-product-slug={ productSlug }
 			role="option"
+			isStreamlinedPrice={ isStreamlinedPrice }
 			onClick={ onSelect }
 			selected={ isSelected }
 		>
@@ -232,8 +260,10 @@ function ItemVariantOption( {
 					variant={ variant }
 					compareTo={ compareTo }
 					product={ selectedItem }
+					isStreamlinedPrice={ isStreamlinedPrice }
 				/>
 			) }
+			{ isStreamlinedPrice && isSelected && <WPCheckoutCheckIcon /> }
 		</Option>
 	);
 }

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -161,7 +161,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				onClick={ () => toggle( id ) }
 				open={ isOpen }
 				role="button"
-				isStreamlinedPrice={ isStreamlinedPrice }
+				detached={ isStreamlinedPrice }
 			>
 				{ selectedVariantIndex !== null ? (
 					<ItemVariantDropDownPriceWrapper variant={ variants[ selectedVariantIndex ] } />
@@ -200,7 +200,7 @@ function ItemVariantOptionList( {
 		? variants.find( ( variant ) => variant.termIntervalInMonths === 1 )
 		: variants.find( ( variant ) => variant.productId === selectedItem.product_id );
 	return (
-		<OptionList role="listbox" tabIndex={ -1 } isStreamlinedPrice={ isStreamlinedPrice }>
+		<OptionList role="listbox" tabIndex={ -1 } detached={ isStreamlinedPrice }>
 			{ variants.map( ( variant, index ) => (
 				<ItemVariantOption
 					key={ variant.productSlug + variant.variantLabel.noun }
@@ -249,9 +249,9 @@ function ItemVariantOption( {
 			aria-label={ variantLabel.noun }
 			data-product-slug={ productSlug }
 			role="option"
-			isStreamlinedPrice={ isStreamlinedPrice }
 			onClick={ onSelect }
 			selected={ isSelected }
+			detached={ isStreamlinedPrice }
 		>
 			{ isJetpack( variant ) ? (
 				<JetpackItemVariantDropDownPrice variant={ variant } allVariants={ allVariants } />

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -244,7 +244,4 @@ export const IntroPricingText = styled.span`
 export const PriceTextContainer = styled.span`
 	font-size: 14px;
 	text-align: right;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-end;
 `;

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -22,7 +22,7 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 
 	${ ( props ) =>
 		props.open &&
-		! props.isStreamlinedPrice &&
+		! props.detached &&
 		css`
 			border-radius: 3px 3px 0 0;
 		` }
@@ -44,7 +44,7 @@ export const Option = styled.li< OptionProps >`
 	position: relative;
 
 	${ ( props ) =>
-		props.isStreamlinedPrice &&
+		props.detached &&
 		css`
 			padding-top: 14px;
 			padding-bottom: 14px;
@@ -55,7 +55,7 @@ export const Option = styled.li< OptionProps >`
 	}
 
 	${ ( props ) =>
-		! props.isStreamlinedPrice
+		! props.detached
 			? css`
 					&.item-variant-option--selected {
 						background: var( --studio-wordpress-blue-50 );
@@ -94,14 +94,14 @@ export const Dropdown = styled.div`
 	}
 `;
 
-export const OptionList = styled.ul< { isStreamlinedPrice: boolean } >`
+export const OptionList = styled.ul< { detached: boolean } >`
 	position: absolute;
 	width: 100%;
 	z-index: 4;
 	margin: 0;
 	box-shadow: rgba( 0, 0, 0, 0.16 ) 0px 1px 4px;
 	${ ( props ) =>
-		props.isStreamlinedPrice &&
+		props.detached &&
 		css`
 			box-shadow:
 				0px 50px 43px 0px rgba( 0, 0, 0, 0.02 ),
@@ -110,7 +110,7 @@ export const OptionList = styled.ul< { isStreamlinedPrice: boolean } >`
 				0px 5px 15px 0px rgba( 0, 0, 0, 0.08 );
 			margin-top: 10px;
 
-			${ Option }:first-child {
+			${ Option }:first-of-type {
 				border-top-left-radius: 3px;
 				border-top-right-radius: 3px;
 			}

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -244,4 +244,7 @@ export const IntroPricingText = styled.span`
 export const PriceTextContainer = styled.span`
 	font-size: 14px;
 	text-align: right;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
 `;

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { CheckIcon } from '../check-icon';
 import { CurrentOptionProps, OptionProps } from './types';
 
 export const CurrentOption = styled.button< CurrentOptionProps >`
@@ -21,6 +22,7 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 
 	${ ( props ) =>
 		props.open &&
+		! props.isStreamlinedPrice &&
 		css`
 			border-radius: 3px 3px 0 0;
 		` }
@@ -39,14 +41,46 @@ export const Option = styled.li< OptionProps >`
 	align-items: center;
 	/* the calc aligns the price with the price in CurrentOption */
 	padding: 10px calc( 14px + 24px + 16px ) 10px 16px;
+	position: relative;
+
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			padding-top: 14px;
+			padding-bottom: 14px;
+		` }
 
 	&:hover {
 		background: var( --studio-wordpress-blue-5 );
 	}
 
-	&.item-variant-option--selected {
-		background: var( --studio-wordpress-blue-50 );
-		color: #fff;
+	${ ( props ) =>
+		! props.isStreamlinedPrice
+			? css`
+					&.item-variant-option--selected {
+						background: var( --studio-wordpress-blue-50 );
+						color: #fff;
+					}
+			  `
+			: css`
+					&.item-variant-option--selected * {
+						color: var( --studio-black );
+					}
+			  ` }
+`;
+
+export const WPCheckoutCheckIcon = styled( CheckIcon )`
+	fill: ${ ( props ) => props.theme.colors.success };
+	margin-right: 4px;
+	position: absolute;
+	top: 50%;
+	right: 16px;
+	transform: translateY( -50% );
+	.rtl & {
+		margin-right: 0;
+		margin-left: 4px;
+		right: auto;
+		left: 16px;
 	}
 `;
 
@@ -60,12 +94,27 @@ export const Dropdown = styled.div`
 	}
 `;
 
-export const OptionList = styled.ul`
+export const OptionList = styled.ul< { isStreamlinedPrice: boolean } >`
 	position: absolute;
 	width: 100%;
 	z-index: 4;
 	margin: 0;
 	box-shadow: rgba( 0, 0, 0, 0.16 ) 0px 1px 4px;
+	${ ( props ) =>
+		props.isStreamlinedPrice &&
+		css`
+			box-shadow:
+				0px 50px 43px 0px rgba( 0, 0, 0, 0.02 ),
+				0px 30px 36px 0px rgba( 0, 0, 0, 0.04 ),
+				0px 15px 27px 0px rgba( 0, 0, 0, 0.07 ),
+				0px 5px 15px 0px rgba( 0, 0, 0, 0.08 );
+			margin-top: 10px;
+
+			${ Option }:first-child {
+				border-top-left-radius: 3px;
+				border-top-right-radius: 3px;
+			}
+		` }
 
 	${ Option } {
 		margin-top: -1px;
@@ -97,6 +146,28 @@ export const Discount = styled.span`
 
 	@media ( max-width: 660px ) {
 		width: 100%;
+	}
+`;
+
+export const DiscountAbsolute = styled.span< {
+	color: string;
+	backgroundColor: string;
+} >`
+	text-align: center;
+	color: ${ ( props ) => props.color };
+	display: block;
+	background-color: ${ ( props ) => props.backgroundColor };
+	padding: 0 10px;
+	border-radius: 4px;
+	font-size: 12px;
+	line-height: 20px;
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+	// Keep selected state override for now, adjust if needed
+	.item-variant-option--selected & {
+		color: ${ ( props ) => props.color };
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/types.ts
@@ -42,8 +42,10 @@ export type OnChangeItemVariant = (
 
 export type CurrentOptionProps = {
 	open: boolean;
+	isStreamlinedPrice: boolean;
 };
 
 export type OptionProps = {
 	selected: boolean;
+	isStreamlinedPrice: boolean;
 };

--- a/client/my-sites/checkout/src/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/types.ts
@@ -42,10 +42,10 @@ export type OnChangeItemVariant = (
 
 export type CurrentOptionProps = {
 	open: boolean;
-	isStreamlinedPrice: boolean;
+	detached?: boolean;
 };
 
 export type OptionProps = {
 	selected: boolean;
-	isStreamlinedPrice: boolean;
+	detached?: boolean;
 };

--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -61,30 +61,10 @@ export function getItemVariantCompareToPrice(
 	return ( compareTo.priceInteger / compareTo.termIntervalInMonths ) * variant.termIntervalInMonths;
 }
 
-export function getItemVariantDiscountPercentage(
-	variant: WPCOMProductVariant,
-	compareTo?: WPCOMProductVariant
-): number {
-	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
-
-	// Ignore intro discount if it is a 1 month only discount
-	const variantPrice =
-		variant.introductoryInterval === 1 && variant.introductoryTerm === 'month'
-			? variant.priceBeforeDiscounts
-			: variant.priceInteger;
-
-	// Extremely low "discounts" are possible if the price of the longer term has been rounded
-	// if they cannot be rounded to at least a percentage point we should not show them.
-	const discountPercentage = compareToPriceForVariantTerm
-		? Math.round( 100 - ( variantPrice / compareToPriceForVariantTerm ) * 100 )
-		: 0;
-
-	return discountPercentage;
-}
-
 export function getItemVariantDiscount(
 	variant: WPCOMProductVariant,
-	compareTo?: WPCOMProductVariant
+	compareTo?: WPCOMProductVariant,
+	discountType: 'percentage' | 'absolute' = 'percentage'
 ): number {
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 
@@ -94,9 +74,19 @@ export function getItemVariantDiscount(
 			? variant.priceBeforeDiscounts
 			: variant.priceInteger;
 
+	if ( ! compareToPriceForVariantTerm ) {
+		return 0;
+	}
+
+	if ( discountType === 'absolute' ) {
+		return compareToPriceForVariantTerm - variantPrice;
+	}
+
 	// Extremely low "discounts" are possible if the price of the longer term has been rounded
 	// if they cannot be rounded to at least a percentage point we should not show them.
-	const discount = compareToPriceForVariantTerm ? compareToPriceForVariantTerm - variantPrice : 0;
+	const discountPercentage = Math.round(
+		100 - ( variantPrice / compareToPriceForVariantTerm ) * 100
+	);
 
-	return discount;
+	return discountPercentage;
 }

--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -81,3 +81,22 @@ export function getItemVariantDiscountPercentage(
 
 	return discountPercentage;
 }
+
+export function getItemVariantDiscount(
+	variant: WPCOMProductVariant,
+	compareTo?: WPCOMProductVariant
+): number {
+	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
+
+	// Ignore intro discount if it is a 1 month only discount
+	const variantPrice =
+		variant.introductoryInterval === 1 && variant.introductoryTerm === 'month'
+			? variant.priceBeforeDiscounts
+			: variant.priceInteger;
+
+	// Extremely low "discounts" are possible if the price of the longer term has been rounded
+	// if they cannot be rounded to at least a percentage point we should not show them.
+	const discount = compareToPriceForVariantTerm ? compareToPriceForVariantTerm - variantPrice : 0;
+
+	return discount;
+}

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,4 +1,5 @@
 import { isMultiYearDomainProduct } from '@automattic/calypso-products';
+import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -6,6 +7,7 @@ import { FunctionComponent } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import {
 	Discount,
+	DiscountAbsolute,
 	DoNotPayThis,
 	IntroPricing,
 	IntroPricingText,
@@ -14,7 +16,11 @@ import {
 	PriceTextContainer,
 	Variant,
 } from './styles';
-import { getItemVariantDiscountPercentage, getItemVariantCompareToPrice } from './util';
+import {
+	getItemVariantDiscountPercentage,
+	getItemVariantDiscount,
+	getItemVariantCompareToPrice,
+} from './util';
 import type { WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -31,14 +37,45 @@ const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent
 	);
 };
 
+const DiscountPrice: FunctionComponent< {
+	price: string;
+	termIntervalInMonths: number;
+} > = ( { price, termIntervalInMonths } ) => {
+	const translate = useTranslate();
+
+	// Determine colors for DiscountAbsolute based on term
+	let discountColor = colorStudio.colors[ 'Green 80' ];
+	let discountBackgroundColor = colorStudio.colors[ 'Green 10' ];
+
+	if ( termIntervalInMonths === 12 ) {
+		discountColor = colorStudio.colors[ 'Green 50' ];
+		discountBackgroundColor = colorStudio.colors[ 'Green 0' ]; // As per original request for yearly
+	} else if ( termIntervalInMonths === 24 ) {
+		discountColor = colorStudio.colors[ 'Green 80' ];
+		discountBackgroundColor = colorStudio.colors[ 'Green 5' ]; // As per original request for 2-yearly (using Green 5 as "Green" is ambiguous)
+	}
+
+	return (
+		<DiscountAbsolute color={ discountColor } backgroundColor={ discountBackgroundColor }>
+			{ translate( 'Save %(price)s', { args: { price } } ) }
+		</DiscountAbsolute>
+	);
+};
+
 export const ItemVariantDropDownPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 	product: ResponseCartProduct;
-} > = ( { variant, compareTo, product } ) => {
+	isStreamlinedPrice: boolean;
+} > = ( { variant, compareTo, product, isStreamlinedPrice } ) => {
 	const isMobile = useMobileBreakpoint();
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
 	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
+	const discount = formatCurrency( getItemVariantDiscount( variant, compareTo ), variant.currency, {
+		stripZeros: true,
+		isSmallestUnit: true,
+	} );
+
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
 		stripZeros: true,
 		isSmallestUnit: true,
@@ -180,21 +217,44 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	// or if it's a Jetpack 2 or 3-year plan
 	const canDisplayDiscountPercentage = ! isIntroductoryOffer;
 
+	const label =
+		variant.termIntervalInMonths === 1 && isStreamlinedPrice
+			? translate( 'Month' )
+			: variant.variantLabel.noun;
 	return (
 		<Variant>
 			<Label>
-				{ variant.variantLabel.noun }
-				{ hasDiscount && isMobile && <DiscountPercentage percent={ discountPercentage } /> }
+				{ label }
+				{ hasDiscount &&
+					isMobile &&
+					( isStreamlinedPrice ? (
+						<DiscountPrice
+							price={ discount }
+							termIntervalInMonths={ variant.termIntervalInMonths }
+						/>
+					) : (
+						<DiscountPercentage percent={ discountPercentage } />
+					) ) }
 			</Label>
 			<PriceTextContainer>
-				{ hasDiscount && ! isMobile && canDisplayDiscountPercentage && (
-					<DiscountPercentage percent={ discountPercentage } />
-				) }
-				{ hasDiscount && ! isIntroductoryOffer && (
+				{ hasDiscount &&
+					! isMobile &&
+					canDisplayDiscountPercentage &&
+					( isStreamlinedPrice ? (
+						<DiscountPrice
+							price={ discount }
+							termIntervalInMonths={ variant.termIntervalInMonths }
+						/>
+					) : (
+						<DiscountPercentage percent={ discountPercentage } />
+					) ) }
+				{ hasDiscount && ! isIntroductoryOffer && ! isStreamlinedPrice && (
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
 
-				<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
+				{ ! isStreamlinedPrice && (
+					<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
+				) }
 				<IntroPricing>
 					{ ! isMultiYearDomain && (
 						<IntroPricingText>

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -221,6 +221,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 		variant.termIntervalInMonths === 1 && isStreamlinedPrice
 			? translate( 'Month' )
 			: variant.variantLabel.noun;
+
 	return (
 		<Variant>
 			<Label>
@@ -252,16 +253,25 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
 				) }
 
-				{ ! isStreamlinedPrice && (
+				{ isStreamlinedPrice ? (
+					! canDisplayDiscountPercentage && (
+						<DiscountPrice
+							price={ discount }
+							termIntervalInMonths={ variant.termIntervalInMonths }
+						/>
+					)
+				) : (
 					<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
 				) }
-				<IntroPricing>
-					{ ! isMultiYearDomain && (
-						<IntroPricingText>
-							{ isIntroductoryOffer && translatedIntroOfferDetails() }
-						</IntroPricingText>
-					) }
-				</IntroPricing>
+				{ ! isStreamlinedPrice && (
+					<IntroPricing>
+						{ ! isMultiYearDomain && (
+							<IntroPricingText>
+								{ isIntroductoryOffer && translatedIntroOfferDetails() }
+							</IntroPricingText>
+						) }
+					</IntroPricing>
+				) }
 			</PriceTextContainer>
 		</Variant>
 	);

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -16,11 +16,7 @@ import {
 	PriceTextContainer,
 	Variant,
 } from './styles';
-import {
-	getItemVariantDiscountPercentage,
-	getItemVariantDiscount,
-	getItemVariantCompareToPrice,
-} from './util';
+import { getItemVariantDiscount, getItemVariantCompareToPrice } from './util';
 import type { WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -70,11 +66,15 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 } > = ( { variant, compareTo, product, isStreamlinedPrice } ) => {
 	const isMobile = useMobileBreakpoint();
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
-	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
-	const discount = formatCurrency( getItemVariantDiscount( variant, compareTo ), variant.currency, {
-		stripZeros: true,
-		isSmallestUnit: true,
-	} );
+	const discountPercentage = getItemVariantDiscount( variant, compareTo );
+	const discount = formatCurrency(
+		getItemVariantDiscount( variant, compareTo, 'absolute' ),
+		variant.currency,
+		{
+			stripZeros: true,
+			isSmallestUnit: true,
+		}
+	);
 
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
 		stripZeros: true,

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -66,7 +66,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	variant: WPCOMProductVariant;
 	compareTo?: WPCOMProductVariant;
 	product: ResponseCartProduct;
-	isStreamlinedPrice: boolean;
+	isStreamlinedPrice?: boolean;
 } > = ( { variant, compareTo, product, isStreamlinedPrice } ) => {
 	const isMobile = useMobileBreakpoint();
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -3,7 +3,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { getItemVariantDiscountPercentage } from './util';
+import { getItemVariantDiscount } from './util';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
@@ -69,7 +69,7 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 	compareTo?: WPCOMProductVariant;
 } > = ( { variant, compareTo } ) => {
 	const translate = useTranslate();
-	const discountPercentage = getItemVariantDiscountPercentage( variant, compareTo );
+	const discountPercentage = getItemVariantDiscount( variant, compareTo );
 
 	const pricePerMonth = Math.round( variant.priceInteger / variant.termIntervalInMonths );
 

--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -14,7 +14,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
-import { getItemVariantDiscountPercentage } from '../item-variation-picker/util';
+import { getItemVariantDiscount } from '../item-variation-picker/util';
 
 import './style.scss';
 
@@ -172,7 +172,7 @@ const useCalculatedDiscounts = () => {
 	];
 
 	return {
-		percentSavings: getItemVariantDiscountPercentage( biennial, current ),
+		percentSavings: getItemVariantDiscount( biennial, current ),
 		priceBreakdown,
 		finalBreakdown,
 	};

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -24,9 +24,8 @@ import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import {
-	isStreamlinedPriceRadioTreatment,
-	isStreamlinedPriceDropdownTreatment,
 	useStreamlinedPriceExperiment,
+	isStreamlinedPriceCheckoutTreatment,
 } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -384,6 +383,12 @@ function LineItemWrapper( {
 
 	const [ isStreamlinedPriceExperimentLoading, streamlinedPriceExperimentAssignment ] =
 		useStreamlinedPriceExperiment();
+
+	const isStreamlinedPrice =
+		! isStreamlinedPriceExperimentLoading &&
+		isStreamlinedPriceCheckoutTreatment( streamlinedPriceExperimentAssignment ) &&
+		isWpComPlan( product.product_slug );
+
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
@@ -399,20 +404,7 @@ function LineItemWrapper( {
 			return true;
 		}
 
-		if (
-			isWpComPlan( variant.productSlug ) &&
-			! isStreamlinedPriceExperimentLoading &&
-			( isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment ) ||
-				isStreamlinedPriceDropdownTreatment( streamlinedPriceExperimentAssignment ) )
-		) {
-			return true;
-		}
-
-		if (
-			isWpComPlan( variant.productSlug ) &&
-			! isStreamlinedPriceExperimentLoading &&
-			isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment )
-		) {
+		if ( isStreamlinedPrice ) {
 			return true;
 		}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -394,7 +394,7 @@ function LineItemWrapper( {
 		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
 		const isMarketplace = product.extra?.is_marketplace_product;
 
-		if ( isJetpack || isAkismet || isMarketplace ) {
+		if ( isJetpack || isAkismet || isMarketplace || streamlinedPriceExperimentAssignment ) {
 			return true;
 		}
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -25,6 +25,7 @@ import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 import {
 	isStreamlinedPriceRadioTreatment,
+	isStreamlinedPriceDropdownTreatment,
 	useStreamlinedPriceExperiment,
 } from 'calypso/my-sites/plans-features-main/hooks/use-streamlined-price-experiment';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -401,7 +402,8 @@ function LineItemWrapper( {
 		if (
 			isWpComPlan( variant.productSlug ) &&
 			! isStreamlinedPriceExperimentLoading &&
-			isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment )
+			( isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment ) ||
+				isStreamlinedPriceDropdownTreatment( streamlinedPriceExperimentAssignment ) )
 		) {
 			return true;
 		}

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -394,7 +394,15 @@ function LineItemWrapper( {
 		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
 		const isMarketplace = product.extra?.is_marketplace_product;
 
-		if ( isJetpack || isAkismet || isMarketplace || streamlinedPriceExperimentAssignment ) {
+		if ( isJetpack || isAkismet || isMarketplace ) {
+			return true;
+		}
+
+		if (
+			isWpComPlan( variant.productSlug ) &&
+			! isStreamlinedPriceExperimentLoading &&
+			isStreamlinedPriceRadioTreatment( streamlinedPriceExperimentAssignment )
+		) {
 			return true;
 		}
 

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -41,6 +41,13 @@ export function isStreamlinedPriceRadioTreatment( variationName?: string | null 
 	return variationName.includes( 'checkout_radio' );
 }
 
+export function isStreamlinedPriceDropdownTreatment( variationName?: string | null ) {
+	if ( ! variationName ) {
+		return false;
+	}
+	return variationName.includes( 'checkout_dropdown' );
+}
+
 export function isStreamlinedPriceCheckoutTreatment( variationName?: string | null ) {
 	if ( ! variationName ) {
 		return false;

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -47,7 +47,6 @@ export function isStreamlinedPriceDropdownTreatment( variationName?: string | nu
 	}
 	return variationName.includes( 'checkout_dropdown' );
 }
-
 export function isStreamlinedPriceCheckoutTreatment( variationName?: string | null ) {
 	if ( ! variationName ) {
 		return false;

--- a/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-streamlined-price-experiment.ts
@@ -47,6 +47,7 @@ export function isStreamlinedPriceDropdownTreatment( variationName?: string | nu
 	}
 	return variationName.includes( 'checkout_dropdown' );
 }
+
 export function isStreamlinedPriceCheckoutTreatment( variationName?: string | null ) {
 	if ( ! variationName ) {
 		return false;

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -12,7 +12,7 @@ interface RadioButtonWrapperProps {
 	highlighted?: boolean;
 }
 
-const RadioButtonWrapper = styled.div<
+export const RadioButtonWrapper = styled.div<
 	RadioButtonWrapperProps & React.HTMLAttributes< HTMLDivElement >
 >`
 	position: relative;

--- a/packages/composite-checkout/src/components/radio-button.tsx
+++ b/packages/composite-checkout/src/components/radio-button.tsx
@@ -12,7 +12,7 @@ interface RadioButtonWrapperProps {
 	highlighted?: boolean;
 }
 
-export const RadioButtonWrapper = styled.div<
+const RadioButtonWrapper = styled.div<
 	RadioButtonWrapperProps & React.HTMLAttributes< HTMLDivElement >
 >`
 	position: relative;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to p58i-kUT-p2
Fixes and restores changes from https://github.com/Automattic/wp-calypso/pull/103418 that were reverted in https://github.com/Automattic/wp-calypso/pull/103481


## Proposed Changes

* adapts the plan interval dropdown to match the new design
<img width="480" alt="Screenshot 2025-05-14 at 14 13 08" src="https://github.com/user-attachments/assets/d6eb6e8b-b8be-45a5-8e7b-22f7a9e9a6c4" />
* compared to https://github.com/Automattic/wp-calypso/pull/103418 it remove a CSS change that broke the control version of the dropdown.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We're experimenting with streamlining the plans and checkout user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* To test this feature, you'll need to be assigned to eithe `plans_1y_checkout_dropdown` or`plans_3y_checkout_dropdown` of the experiment variations of calypso_streamlined_plans_checkout
* Add a WPCOM plan, a domain and a Titan email subscription to the cart
* The updated plan interval dropdown component should be updated for the WPCOM plan

|Before|After|
|------|-----|
|<img width="720" alt="Screenshot 2025-05-15 at 10 21 04" src="https://github.com/user-attachments/assets/b035af74-ff76-4622-ac93-2a39974a27d4" />|<img width="715" alt="Screenshot 2025-05-15 at 10 24 21" src="https://github.com/user-attachments/assets/0d8d0caf-fdf0-4600-af6d-379b40b9f7c1" />|
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
