### PR TITLE
DataForm: implement toggleGroup Edit control

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Add a new DataForm Edit control: `toggle-group`, which renders a `<ToggleGroupControl />`.
+- Add a new DataForm Edit control: `toggleGroup`, which renders a `<ToggleGroupControl />`.
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 - Pin the actions column on the table view when the width is insufficient.

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Add a new DataForm Edit control: `toggle-group`, which renders a `<ToggleGroupControl />`.
 - Implement the `media` field type definition and allow type definitions to provide a new default: `enableSorting`.
 - Add new `boolean` field type definition and edit control. Field type definitions are able to define a default render function that will be used if the field doesn't define one.
 - Pin the actions column on the table view when the width is insufficient.

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -88,6 +88,7 @@ const fields = [
 		id: 'status',
 		label: 'Status',
 		type: 'text' as const,
+		Edit: 'toggle-group' as const,
 		elements: [
 			{ value: 'draft', label: 'Draft' },
 			{ value: 'published', label: 'Published' },
@@ -136,6 +137,7 @@ export const Default = ( {
 				'order',
 				'sticky',
 				'author',
+				'status',
 				'reviewer',
 				'password',
 				'date',

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -88,7 +88,7 @@ const fields = [
 		id: 'status',
 		label: 'Status',
 		type: 'text' as const,
-		Edit: 'toggle-group' as const,
+		Edit: 'toggleGroup' as const,
 		elements: [
 			{ value: 'draft', label: 'Draft' },
 			{ value: 'published', label: 'Published' },

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -30,7 +30,7 @@ const FORM_CONTROLS: FormControls = {
 	radio,
 	select,
 	text,
-	'toggle-group': toggleGroup,
+	toggleGroup,
 };
 
 export function getControl< Item >(

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -16,6 +16,7 @@ import integer from './integer';
 import radio from './radio';
 import select from './select';
 import text from './text';
+import toggleGroup from './toggle-group';
 import boolean from './boolean';
 
 interface FormControls {
@@ -29,6 +30,7 @@ const FORM_CONTROLS: FormControls = {
 	radio,
 	select,
 	text,
+	'toggle-group': toggleGroup,
 };
 
 export function getControl< Item >(

--- a/packages/dataviews/src/dataform-controls/toggle-group.tsx
+++ b/packages/dataviews/src/dataform-controls/toggle-group.tsx
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps } from '../types';
+
+export default function ToggleGroup< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	const { id } = field;
+	const value = field.getValue( { item: data } );
+
+	const onChangeControl = useCallback(
+		( newValue: string | number | undefined ) =>
+			onChange( {
+				[ id ]: newValue,
+			} ),
+		[ id, onChange ]
+	);
+
+	if ( field.elements ) {
+		return (
+			<ToggleGroupControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				isBlock
+				label={ field.label }
+				help={ field.description }
+				onChange={ onChangeControl }
+				value={ value }
+				hideLabelFromVision={ hideLabelFromVision }
+			>
+				{ field.elements.map( ( el ) => (
+					<ToggleGroupControlOption
+						key={ el.value }
+						label={ el.label }
+						value={ el.value }
+					/>
+				) ) }
+			</ToggleGroupControl>
+		);
+	}
+
+	return null;
+}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to https://github.com/Automattic/wp-calypso/pull/103426#discussion_r2091542603

## Proposed Changes

This PR introduces a new `Edit` control, `toggleGroup`, to DataForm fields.

<img width="1171" alt="image" src="https://github.com/user-attachments/assets/e70c8b4e-19f0-4372-80bb-b2675b8cd981" />


## Testing Instructions

1. Run `yarn workspace @automattic/dataviews storybook:start`
2. Verify you can play around with the `Status` field which uses the new `toggleGroup` control.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
