### PR TITLE
Fix styling of ExternalLinks within Cards

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -57,11 +57,3 @@
 		}
 	}
 }
-
-.components-external-link__contents {
-	text-decoration: none;
-
-	&:hover {
-		text-decoration: underline;
-	}
-}

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -181,13 +181,11 @@
 		a,
 		a:visited,
 		button.is-link {
-			text-decoration: underline;
 			color: var(--color-text-inverted);
 			line-height: inherit;
 
 			&:hover {
 				color: var(--color-text-inverted);
-				text-decoration: none;
 			}
 
 			.is-transparent-info & {

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -10,18 +10,6 @@
 			justify-content: space-between;
 		}
 	}
-
-	// Removes underline from the ↗ icon
-	a.components-external-link.components-external-link {
-		text-decoration: none;
-		.components-external-link__contents {
-			text-decoration: underline;
-		}
-		&:hover .components-external-link__contents,
-		&:active .components-external-link__contents {
-			text-decoration: none;
-		}
-	}
 }
 
 .card.notification-settings-push-notification-settings__settings {

--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -13,10 +13,10 @@
 	// Card class name is too generic. Which results and this component randomly getting borders.
 	border: none;
 
-	 a {
+	a:not(.components-external-link) {
 		text-decoration: none;
 	}
-	p a {
+	p a:not(.components-external-link) {
 		text-decoration: underline;
 	}
 

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -196,31 +196,6 @@ $blueberry-color: #3858e9;
 			.odie-button-link, .components-external-link {
 				color: $blueberry-color;
 			}
-
-			.components-external-link {
-				text-decoration: underline;
-
-				&:hover {
-					text-decoration: none;
-				}
-
-				& > span:first-child::after { 
-					content: "\00a0";
-	
-					&:hover {
-						text-decoration: none;
-					}
-				}
-
-				.components-external-link__contents:hover {
-					text-decoration: none;
-				}
-
-				.components-external-link__icon {
-					margin-left: 0;
-				}
-			}
-			
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DSGCOM-105

## Proposed Changes

* Remove underline override for the ExternalLink component.
* Exempt ExternalLink from link styling within cards so that the default component behaviour is used.
* Remove CSS overrides for correcting underlines on ExternalLinks within Notices.

| Before | After |
|--------|--------|
| <img width="240" alt="Screenshot 2025-05-16 at 10 24 16" src="https://github.com/user-attachments/assets/f4f952c3-ae92-4ef7-98ec-107580f367e4" /> | <img width="240" alt="Screenshot 2025-05-16 at 10 23 43" src="https://github.com/user-attachments/assets/03c46533-99ec-46cc-97bb-13637800766f" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To ensure that the arrow in the ExternalLink component is not underlined.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Run `yarn start`.
* Navigate to `/me`.
* Observer the gravatar link at the bottom of the form.
* Check for other cases of ExternalLink within the dashboard.
