### PR TITLE
Blocked sites: improve layout

### DIFF
--- a/client/blocks/reader-post-card/blocked.jsx
+++ b/client/blocks/reader-post-card/blocked.jsx
@@ -30,7 +30,7 @@ class PostBlocked extends Component {
 				<p className="reader-post-card__blocked-description">
 					{ translate( 'You have blocked %(site_name)s.', {
 						args: { site_name: post.site_name },
-					} ) }
+					} ) }{ ' ' }
 					<button onClick={ this.unblock } className="reader-post-card__blocked-undo">
 						{ translate( 'Undo?' ) }
 					</button>

--- a/client/me/site-blocks/list-item-placeholder.jsx
+++ b/client/me/site-blocks/list-item-placeholder.jsx
@@ -1,13 +1,9 @@
-import { PureComponent } from 'react';
-
-class SiteBlockListItemPlaceholder extends PureComponent {
-	render() {
-		return (
-			<div className="site-blocks__list-item is-placeholder">
-				<span className="site-blocks__list-item-placeholder-text">Blocked site</span>
-			</div>
-		);
-	}
-}
+const SiteBlockListItemPlaceholder = () => {
+	return (
+		<div className="site-blocks__list-item is-placeholder" aria-hidden="true">
+			<span className="site-blocks__list-item-placeholder-text">Blocked site</span>
+		</div>
+	);
+};
 
 export default SiteBlockListItemPlaceholder;

--- a/client/me/site-blocks/list-item-placeholder.jsx
+++ b/client/me/site-blocks/list-item-placeholder.jsx
@@ -1,9 +1,0 @@
-const SiteBlockListItemPlaceholder = () => {
-	return (
-		<div className="site-blocks__list-item is-placeholder" aria-hidden="true">
-			<span className="site-blocks__list-item-placeholder-text">Blocked site</span>
-		</div>
-	);
-};
-
-export default SiteBlockListItemPlaceholder;

--- a/client/me/site-blocks/list-item.jsx
+++ b/client/me/site-blocks/list-item.jsx
@@ -21,8 +21,6 @@ class SiteBlockListItem extends Component {
 		if ( ! site ) {
 			return null;
 		}
-		//eslint-disable-next-line
-		console.log( site );
 
 		return (
 			<div className="site-blocks__list-item">

--- a/client/me/site-blocks/list-item.jsx
+++ b/client/me/site-blocks/list-item.jsx
@@ -1,4 +1,4 @@
-import { Button, ExternalLink } from '@automattic/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -21,18 +21,23 @@ class SiteBlockListItem extends Component {
 		if ( ! site ) {
 			return null;
 		}
+		//eslint-disable-next-line
+		console.log( site );
 
 		return (
 			<div className="site-blocks__list-item">
-				<ExternalLink href={ site.URL }>{ site.name }</ExternalLink>
+				<ExternalLink target="_blank" href={ site.URL }>
+					{ site.name || site.title || site.slug || site.feed_URL }
+				</ExternalLink>
 				<Button
-					scary
-					borderless
+					__next40pxDefaultSize
+					isDestructive
+					variant="tertiary"
 					className="site-blocks__remove-button"
 					title={ translate( 'Unblock site' ) }
 					onClick={ this.unblockSite }
 				>
-					<span>{ translate( 'Unblock' ) }</span>
+					{ translate( 'Unblock' ) }
 				</Button>
 			</div>
 		);

--- a/client/me/site-blocks/main.jsx
+++ b/client/me/site-blocks/main.jsx
@@ -19,7 +19,6 @@ import {
 	getSiteBlocksLastPage,
 } from 'calypso/state/reader/site-blocks/selectors';
 import SiteBlockListItem from './list-item';
-import SiteBlockListItemPlaceholder from './list-item-placeholder';
 
 import './style.scss';
 
@@ -36,7 +35,13 @@ class SiteBlockList extends Component {
 
 	renderPlaceholders() {
 		return times( 2, ( i ) => (
-			<SiteBlockListItemPlaceholder key={ 'site-block-list-item-placeholder-' + i } />
+			<div
+				aria-hidden="true"
+				className="site-blocks__list-item is-placeholder"
+				key={ 'site-block-list-item-placeholder-' + i }
+			>
+				<span className="site-blocks__list-item-placeholder-text">Blocked site</span>
+			</div>
 		) );
 	}
 

--- a/client/me/site-blocks/main.jsx
+++ b/client/me/site-blocks/main.jsx
@@ -67,7 +67,9 @@ class SiteBlockList extends Component {
 						<InlineSupportLink
 							showIcon={ false }
 							supportPostId={ 32011 }
-							supportLink={ localizeUrl( 'https://wordpress.com/support/reader/#blocking-sites' ) }
+							supportLink={ localizeUrl(
+								'https://wordpress.com/support/reader/#interact-with-posts'
+							) }
 						/>
 					</p>
 

--- a/client/me/site-blocks/style.scss
+++ b/client/me/site-blocks/style.scss
@@ -1,5 +1,6 @@
 .site-blocks__list {
 	border-bottom: 1px solid var(--color-neutral-0);
+	max-width: 480px;
 }
 
 .site-blocks__list-item {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Resolves DOTCOM-13038

## Proposed Changes

* Update layout to be tighter

    Before
    <img width="1077" alt="Screenshot 2025-05-16 at 13 19 27" src="https://github.com/user-attachments/assets/78b56e61-2889-406e-a280-7fdbe748a972" />

    After
    <img width="1078" alt="Screenshot 2025-05-16 at 13 19 36" src="https://github.com/user-attachments/assets/89de3bf5-9f2a-48c5-9fb8-78cf99ecec8a" />


* Update "Readme" link to point to right section when opened

    Before
    <img width="557" alt="Screenshot 2025-05-16 at 13 14 50" src="https://github.com/user-attachments/assets/10a1e0a3-8781-4dce-b268-f2810d57a2f5" />

    After
    <img width="551" alt="Screenshot 2025-05-16 at 13 14 46" src="https://github.com/user-attachments/assets/5ed65609-4896-4ac3-8160-21bc56ff924c" />

* Use core components for external link and button

    Before (regular+hover)
    <img width="456" alt="Screenshot 2025-05-16 at 13 17 32" src="https://github.com/user-attachments/assets/51225f32-dc5e-44f5-a0a3-6d0af9021b91" />
    <img width="391" alt="Screenshot 2025-05-16 at 13 20 31" src="https://github.com/user-attachments/assets/835f85ef-533e-4ada-93c2-c9aece7adbce" />

    After (regular+hover)
    <img width="464" alt="Screenshot 2025-05-16 at 13 17 41" src="https://github.com/user-attachments/assets/31319c73-13e6-406c-87bd-a6b8d4cee0f3" />
    <img width="393" alt="Screenshot 2025-05-16 at 13 20 41" src="https://github.com/user-attachments/assets/4a7126ac-9f06-471d-a37d-b8cbd1e3b364" />

* Add fallback when site name missing

    Before
    <img width="237" alt="Screenshot 2025-05-16 at 13 18 22" src="https://github.com/user-attachments/assets/290aef02-6d8d-40b4-8479-37d8cb1ad6b8" />

    After
    <img width="192" alt="Screenshot 2025-05-16 at 13 18 27" src="https://github.com/user-attachments/assets/e3995579-7995-41b8-bb76-25340250e2cd" />

* In the Reader, add space between "undo" and text in blocking confirmation

    Before
    <img width="774" alt="Screenshot 2025-05-16 at 12 49 12" src="https://github.com/user-attachments/assets/53b54634-9f8c-4f18-98bf-f244ce2202b9" />

    After
    <img width="770" alt="Screenshot 2025-05-16 at 12 50 02" src="https://github.com/user-attachments/assets/f179a4d4-807f-457c-8a78-f5eaa1de4570" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
