### PR TITLE
SubscriberDataViews: rely on supplied siteId prop

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -12,8 +12,7 @@ import { getCouponsAndGiftsEnabledForSiteId } from 'calypso/state/memberships/se
 import { errorNotice } from 'calypso/state/notices/actions';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
-import { isSimpleSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { isSimpleSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { SubscribersFilterBy, SubscribersSortBy, SubscribersStatus } from '../../constants';
 import { getSubscriptionIdFromSubscriber } from '../../helpers';
 import { useSubscriptionPlans, useUnsubscribeModal } from '../../hooks';
@@ -94,26 +93,26 @@ const defaultView: View = {
 	},
 };
 
-const SubscriberDataViews = ( {
+export default function SubscriberDataViews( {
 	siteId,
 	onGiftSubscription,
 	isUnverified,
 	subscriberId,
-}: SubscriberDataViewsProps ) => {
+}: SubscriberDataViewsProps ) {
 	const dispatch = useDispatch();
 	const isMobile = useBreakpoint( '<660px' );
 	const recordSubscriberClicked = useRecordSubscriberClicked();
 	const recordSubscriberSearch = useRecordSubscriberSearch();
 	const recordSubscriberFilter = useRecordSubscriberFilter();
 	const recordSubscriberSort = useRecordSubscriberSort();
-	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const isSimple = useSelector( ( state ) => isSimpleSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isStaging = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ filters, setFilters ] = useState< SubscribersFilterBy[] >( [ SubscribersFilterBy.All ] );
 	const [ selectedSubscriber, setSelectedSubscriber ] = useState< Subscriber | null >( null );
-	const isSimple = useSelector( isSimpleSite );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const isStaging = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 
 	const couponsAndGiftsEnabled = useSelector( ( state ) =>
 		getCouponsAndGiftsEnabledForSiteId( state, siteId )
@@ -627,6 +626,4 @@ const SubscriberDataViews = ( {
 			/>
 		</div>
 	);
-};
-
-export default SubscriberDataViews;
+}

--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Gravatar, TimeSince } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { DataViews, type View, type Action, Operator } from '@wordpress/dataviews';
+import { DataViews, type View, type ViewTable, type Action, Operator } from '@wordpress/dataviews';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { trash } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
@@ -75,7 +75,7 @@ const getSubscriptionDate = ( subscriber: Subscriber ): string => {
 	return subscriber.date_subscribed || '';
 };
 
-const defaultView: View = {
+const defaultView: ViewTable = {
 	type: 'table',
 	titleField: 'name',
 	mediaField: 'media',


### PR DESCRIPTION
Followup to #103425. The `SubscriberDataViews` component receives a `siteId` prop that should be the sole authority on which site to work with. The component should not look at the "currently selected site". In practice the `siteId` prop will always be the currently selected site, so there's no behavior change, but the component shouldn't look at two places.

## Testing instructions:
Verify that the subscribers data view still works as expected.