### PR TITLE
Update logged-out invite screen to match the logged-in one

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -24,32 +24,42 @@ body.is-section-accept-invite {
 .invite-accept-logged-out-wrapper {
 	width: 100%;
 	margin: 0 auto;
-	@media (min-width: $break-small) {
-		width: 372px;
-		margin-top: 100px;
-	}
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	box-sizing: border-box;
 	font-family: $font-sf-pro-text;
+
+	.invite-form-header {
+		flex: 0.5;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		max-height: 340px;
+	}
 
 	.invite-form-header__title {
 		color: var(--studio-gray-100, #2c3338);
 		text-align: center;
 		font-family: $recoleta-font-family;
 		font-size: 2rem;
-		line-height: normal;
-		letter-spacing: 0.2px;
+		line-height: 1.26;
+		a {
+			text-decoration: none;
+		}
 	}
 
 	.invite-form-header__explanation {
 		color: var(--studio-gray-50, #2c3338);
 		text-align: center;
-		margin-top: 14px;
+		margin-top: 6px;
+		font-size: 14px;
 	}
 
 	.card.logged-out-form {
 		box-shadow: none;
 		padding: 0;
-		margin: 0;
-		max-width: 372px;
+		margin: 0 auto;
 		background: none;
 
 		button.is-primary {
@@ -84,18 +94,19 @@ body.is-section-accept-invite {
 			margin-bottom: 0;
 		}
 	}
+	.signup-form {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+	}
 
 	.signup-form__passwordless-form-wrapper {
 		.signup-form__terms-of-service-link {
-			margin: 16px 0;
+			margin: 30px 0 16px;
 			color: var(--studio-gray-50, #2c3338);
 			font-size: $font-body-small; // 14px
 			line-height: 20px;
-			a {
-				color: var(--studio-gray-80, #2c3338);
-				font-style: normal;
-				text-decoration-line: underline;
-			}
 		}
 	}
 
@@ -104,13 +115,7 @@ body.is-section-accept-invite {
 		padding: 0;
 	}
 	.logged-out-form__link-item {
-		color: var(--studio-gray-90, #2c3338);
-		font-weight: 500;
-		text-underline-offset: 5px;
-		margin-top: 32px;
-		padding: 0;
-		&:hover {
-			color: var(--studio-blue-50, #0675c4);
-		}
+		color: var(--color-link);
+		font-size: 12px;
 	}
 }

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -34,42 +34,42 @@ class InviteFormHeader extends Component {
 
 		switch ( role ) {
 			case 'administrator':
-				title = this.props.translate( 'Sign up to start managing {{siteLink/}}.', {
+				title = this.props.translate( 'Sign up to start managing {{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
 					},
 				} );
 				break;
 			case 'editor':
-				title = this.props.translate( 'Sign up to start editing {{siteLink/}}.', {
+				title = this.props.translate( 'Sign up to start editing {{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
 					},
 				} );
 				break;
 			case 'author':
-				title = this.props.translate( 'Sign up to start writing for {{siteLink/}}.', {
+				title = this.props.translate( 'Sign up to start writing for {{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
 					},
 				} );
 				break;
 			case 'contributor':
-				title = this.props.translate( 'Sign up to start contributing to {{siteLink/}}.', {
+				title = this.props.translate( 'Sign up to start contributing to {{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
 					},
 				} );
 				break;
 			case 'subscriber':
-				title = this.props.translate( 'Sign up to start your subscription to {{siteLink/}}.', {
+				title = this.props.translate( 'Sign up to start your subscription to {{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
 					},
 				} );
 				break;
 			case 'viewer':
-				title = this.props.translate( 'Sign up to begin viewing {{siteLink/}}.', {
+				title = this.props.translate( 'Sign up to begin viewing {{siteLink/}}', {
 					components: {
 						siteLink: this.getSiteLink(),
 					},
@@ -77,7 +77,7 @@ class InviteFormHeader extends Component {
 				break;
 			case 'follower':
 				title = this.props.translate(
-					'Sign up to start following {{siteLink/}} in the WordPress.com Reader.',
+					'Sign up to start following {{siteLink/}} in the WordPress.com Reader',
 					{
 						components: {
 							siteLink: this.getSiteLink(),
@@ -87,7 +87,7 @@ class InviteFormHeader extends Component {
 				break;
 			default:
 				title = this.props.translate(
-					'Sign up to join {{siteLink/}} as: {{strong}}%(siteRole)s{{/strong}}.',
+					'Sign up to join {{siteLink/}} as: {{strong}}%(siteRole)s{{/strong}}',
 					{
 						args: {
 							siteRole: role,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/issues/100416#issuecomment-2865970033

## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/103289 where a new design was implemented. This adapts the logged-out version of the invite screen to match the new design.
* remove site title underline
* adjust the paragraph width and font size
* more space above the submit button
* move the Already have a WordPress.com account? to the bottom and in blue

<img width="480" alt="Screenshot 2025-05-16 at 14 26 13" src="https://github.com/user-attachments/assets/7c9367f5-5afa-4392-959b-aba7b739f596" />



## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

We want the logged-out screen to match the new logged-in version.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Send yourself an invite from the User screen
* Access the emailed link both as a logged-in user and logged-out
* The logged-out screen should be updated and match the logged-in one

|Logged-out|Logged-in|
|-----|-----|
|<img width="1537" alt="Screenshot 2025-05-16 at 14 21 59" src="https://github.com/user-attachments/assets/4fba84d6-fd5a-4ab4-96ca-138ff61798d0" />|<img width="1428" alt="Screenshot 2025-05-16 at 14 23 53" src="https://github.com/user-attachments/assets/1af899a5-04c6-478a-88fc-9b622947cc69" />|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
