### PR TITLE
Revert "Components: add Storybook as peer-dependency"

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -80,8 +80,7 @@
 	"peerDependencies": {
 		"@wordpress/data": "^10.23.0",
 		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
-		"storybook": "^8.6.12"
+		"react-dom": "^18.3.1"
 	},
 	"devDependencies": {
 		"@automattic/calypso-build": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,7 +883,6 @@ __metadata:
     "@wordpress/data": ^10.23.0
     react: ^18.3.1
     react-dom: ^18.3.1
-    storybook: ^8.6.12
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#103291

Tests passed in the PR (rebased) branch but I can't get them pass on Calypso. Let's try revert.