### PR TITLE
SubscribersHeader: rely on supplied siteId prop

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
+++ b/client/my-sites/subscribers/components/subscriber-data-views/subscriber-data-views.tsx
@@ -560,7 +560,7 @@ const SubscriberDataViews = ( {
 		>
 			<section className="subscriber-data-views__list">
 				<SubscribersHeader
-					selectedSiteId={ siteId || undefined }
+					siteId={ siteId }
 					disableCta={ isUnverified || isStaging }
 					hideSubtitle={ !! selectedSubscriber }
 					hideAddButtonLabel={ isMobile || !! selectedSubscriber }

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -15,7 +15,7 @@ import { useRecordExport } from '../../tracks';
 import '../shared/popover-style.scss';
 
 type SubscribersHeaderPopoverProps = {
-	siteId: number | undefined;
+	siteId: number | null;
 	openMigrateSubscribersModal: () => void;
 };
 
@@ -31,7 +31,7 @@ const SubscribersHeaderPopover = ( {
 		{ page: 'subscribers', blog: siteId, blog_subscribers: 'csv', type: 'all' },
 		'https://dashboard.wordpress.com/wp-admin/index.php'
 	);
-	const { data: subscribersTotals } = useSubscriberCountQuery( siteId ?? null );
+	const { data: subscribersTotals } = useSubscriberCountQuery( siteId );
 	const hasSubscribers = subscribersTotals?.email_subscribers ?? 0 > 0;
 	const recordExport = useRecordExport();
 	const currentUserSiteCount = useSelector( getCurrentUserSiteCount );

--- a/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header/subscribers-header.tsx
@@ -5,13 +5,12 @@ import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { plus } from '@wordpress/icons';
 import { translate, fixMe } from 'i18n-calypso';
-import { useEffect, ReactElement } from 'react';
+import { useEffect } from 'react';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import NavigationHeader from 'calypso/components/navigation-header';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useSelector } from 'calypso/state';
-import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import isSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { useAddSubscribersCallback, useMigrateSubscribersCallback } from '../../hooks';
 import { AddSubscribersModal } from '../add-subscribers-modal';
 import { MigrateSubscribersModal } from '../migrate-subscribers-modal';
@@ -24,7 +23,7 @@ enum SubscriberModalType {
 }
 
 type SubscribersHeaderProps = {
-	selectedSiteId: number | undefined;
+	siteId: number | null;
 	disableCta: boolean;
 	hideSubtitle?: boolean;
 	hideAddButtonLabel?: boolean;
@@ -33,15 +32,14 @@ type SubscribersHeaderProps = {
 const HELP_CENTER_STORE = HelpCenter.register();
 
 export const SubscribersHeader = ( {
-	selectedSiteId,
+	siteId,
 	disableCta,
 	hideSubtitle,
 	hideAddButtonLabel = false,
-}: SubscribersHeaderProps ): ReactElement => {
+}: SubscribersHeaderProps ) => {
 	const localizeUrl = useLocalizeUrl();
 	const { setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
-	const siteId = useSelector( getSelectedSiteId ) ?? null;
-	const isWPCOMSite = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+	const isWPCOMSite = useSelector( ( state ) => isSiteWPCOM( state, siteId ) );
 	const supportUrl = ! isWPCOMSite
 		? 'https://jetpack.com/support/newsletter/customize-the-newsletter-experience/#manage-subscribers'
 		: 'https://wordpress.com/support/subscribers/ ';
@@ -144,7 +142,7 @@ export const SubscribersHeader = ( {
 					{ ...{ [ hideAddButtonLabel ? 'label' : 'text' ]: translate( 'Add subscribers' ) } }
 				/>
 				<SubscribersHeaderPopover
-					siteId={ selectedSiteId }
+					siteId={ siteId }
 					openMigrateSubscribersModal={ () =>
 						setShowSubscriberModal( SubscriberModalType.MIGRATE )
 					}

--- a/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
+++ b/client/my-sites/subscribers/hooks/use-add-subscribers-callback.ts
@@ -4,8 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'calypso/state';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 
 /**
  * This callback is used to fire off a notice when the subscribers are added.
@@ -18,7 +17,7 @@ export const useAddSubscribersCallback = ( siteId: number | null ) => {
 	const isJetpackNonAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -97,7 +96,6 @@ export const useAddSubscribersCallback = ( siteId: number | null ) => {
 				notice = message as string;
 				if ( code === 'subscriber_import_limit_reached' && typeof message === 'string' ) {
 					noticeArgs.button = translate( 'Upgrade' );
-					const siteSlug = selectedSiteSlug || ''; // Use a default if siteSlug is not available
 					noticeArgs.href = isJetpackNonAtomic
 						? `https://cloud.jetpack.com/pricing/${ siteSlug }`
 						: `https://wordpress.com/plans/${ siteSlug }`;


### PR DESCRIPTION
Another follow-up to #103425. The `useAddSubscribersCallback` hook and the `SubscribersHeader` component have a `siteId` prop/param, they don't need to look at the selected site in Redux.