### PR TITLE
Support old direct auth (without showing 404)

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -125,6 +125,7 @@ export default ( router ) => {
 			`/log-in/:flow(social-connect)/${ lang }`,
 			`/log-in/:socialService(google|apple|github)/callback/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/${ lang }`,
+			`/log-in/:isJetpack(jetpack)/:socialService(google|apple|github)/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/:action(lostpassword)/${ lang }`,
 			`/log-in/:isGutenboarding(new)/${ lang }`,


### PR DESCRIPTION
## Proposed Changes

We would like to support endpoints that were introduced in Jetpack 14.5 (and redirect them to the regular login page).