### PR TITLE
Keep the loading state until redirect to the overview page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/index.tsx
@@ -41,11 +41,9 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 		isError: isStoreApplicationPasswordError,
 		isPending: isStoreApplicationPasswordPending,
 	} = useStoreApplicationPassword( siteSlug as string );
-	const hasStoreApplicationPasswordResponse =
-		isStoreApplicationPasswordSuccess || isStoreApplicationPasswordError;
 	const isLoading =
 		isAuthorizationSuccessful &&
-		( ! hasStoreApplicationPasswordResponse || isStoreApplicationPasswordPending );
+		( isStoreApplicationPasswordSuccess || isStoreApplicationPasswordPending );
 
 	const isUsingStepContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
@@ -128,18 +126,17 @@ const SiteMigrationApplicationPasswordsAuthorization: StepType< {
 		/>
 	) : undefined;
 
-	const stepContent = ! isLoading ? (
+	const stepContent = (
 		<Authorization
 			onAuthorizationClick={ startAuthorization }
 			onShareCredentialsClick={ navigateToFallbackCredentials }
 		/>
-	) : (
-		<div data-testid="loading-ellipsis">
-			<LoadingEllipsis />
-		</div>
 	);
 
 	if ( isUsingStepContainerV2 ) {
+		if ( isLoading ) {
+			return <Step.Loading title={ title } delay={ 500 } />;
+		}
 		return (
 			<>
 				<DocumentHead title={ title } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-application-password-authorization/test/index.tsx
@@ -23,7 +23,7 @@ const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions
 jest.mock( 'wpcom-proxy-request', () => jest.fn() );
 jest.mock( 'calypso/landing/stepper/hooks/use-site-slug-param' );
 
-const { getByRole, getByTestId, findByText } = screen;
+const { getByRole, findByText, getByLabelText } = screen;
 
 const authorizationUrl = 'https://example.com/authorization.php?appId=123&appName=My%20App';
 const encodedAuthorizationUrl = encodeURIComponent(
@@ -46,7 +46,7 @@ describe( 'SiteMigrationApplicationPasswordAuthorization', () => {
 		render( {}, { initialEntry } );
 
 		await waitFor( () => {
-			expect( getByTestId( 'loading-ellipsis' ) ).toBeVisible();
+			expect( getByLabelText( /Loading/ ) ).toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to DOTCON-33

## Proposed Changes

* Uses the ContainerV2 loading state.
* Keep the loading state while the user is redirected to the Overview page.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have noticed a flickering on the Authorization Step since we added the redirect to the Overview page after the user approves the Application Passwords on the source site.
* By design, the processing of the credentials is started in the Authorization step, but since we added the redirect the Overview page, it appears to flicker because when the processing finished the UI would update while the redirect was triggered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link to test this PR.
* Go through the Assisted Migration flow.
* Once you authorize the Application Passwords, ensure that you see a loading state when you get redirected back to WordPress.com.
* You should be redirected to the Overview page without noticing any flickering in stepper.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
