### PR TITLE
Hosting Dashboard v2: Add Actions section to settings

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -57,7 +57,7 @@ export function siteQuery( siteIdOrSlug: string ) {
 				site.jetpack && site.jetpack_modules.includes( 'monitor' )
 					? fetchSiteMonitorUptime( site.ID )
 					: undefined,
-				site.options?.is_wpcom_atomic ? fetchPHPVersion( site.ID ) : undefined,
+				site.is_wpcom_atomic ? fetchPHPVersion( site.ID ) : undefined,
 			] );
 			return {
 				site,

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -15,21 +15,23 @@ import {
 	fetchBasicMetrics,
 	fetchPerformanceInsights,
 	updateSiteSettings,
+	restoreSitePlanSoftware,
 } from '../data';
+import { SITE_FIELDS } from '../data/constants';
 import { queryClient } from './query-client';
 import type { Profile, SiteSettings, UrlPerformanceInsights } from '../data/types';
 import type { Query } from '@tanstack/react-query';
 
 export function sitesQuery() {
 	return {
-		queryKey: [ 'sites' ],
+		queryKey: [ 'sites', SITE_FIELDS ],
 		queryFn: fetchSites,
 	};
 }
 
 export function siteQuery( siteIdOrSlug: string ) {
 	return {
-		queryKey: [ 'site', siteIdOrSlug ],
+		queryKey: [ 'site', siteIdOrSlug, SITE_FIELDS ],
 		queryFn: async () => {
 			// Site usually takes the longest, so kick it off first.
 			const sitePromise = fetchSite( siteIdOrSlug );
@@ -123,6 +125,12 @@ export function siteSettingsMutation( siteId: string ) {
 			} ) );
 			queryClient.invalidateQueries( { queryKey: [ 'site', siteId ] } );
 		},
+	};
+}
+
+export function restoreSitePlanSoftwareMutation( siteId: string ) {
+	return {
+		mutationFn: () => restoreSitePlanSoftware( siteId ),
 	};
 }
 

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -17,7 +17,6 @@ export const SITE_FIELDS = [
 	'is_deleted',
 	'is_coming_soon',
 	'is_private',
-	'is_wpcom_staging_site',
 	'launch_status',
 	'site_migration',
 	'options',

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -1,3 +1,26 @@
 export enum DotcomFeatures {
 	SUBSCRIPTION_GIFTING = 'subscription-gifting',
+	COPY_SITE = 'copy-site',
 }
+
+export const SITE_FIELDS = [
+	'ID',
+	'slug',
+	'URL',
+	'name',
+	'icon',
+	'subscribers_count',
+	'plan',
+	'active_modules',
+	'capabilities',
+	'is_a8c',
+	'is_deleted',
+	'is_coming_soon',
+	'is_private',
+	'is_wpcom_staging_site',
+	'launch_status',
+	'site_migration',
+	'options',
+	'jetpack',
+	'jetpack_modules',
+];

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -17,6 +17,7 @@ export const SITE_FIELDS = [
 	'is_deleted',
 	'is_coming_soon',
 	'is_private',
+	'is_wpcom_atomic',
 	'launch_status',
 	'site_migration',
 	'options',

--- a/client/dashboard/data/index.ts
+++ b/client/dashboard/data/index.ts
@@ -1,4 +1,5 @@
 import wpcom from 'calypso/lib/wp';
+import { SITE_FIELDS } from './constants';
 import type {
 	Domain,
 	Email,
@@ -30,25 +31,7 @@ export const updateProfile = async ( data: Partial< Profile > ) => {
 	return await wpcom.req.post( '/me/settings', data );
 };
 
-const SITE_FIELDS = [
-	'ID',
-	'slug',
-	'URL',
-	'name',
-	'icon',
-	'subscribers_count',
-	'plan',
-	'active_modules',
-	'is_a8c',
-	'is_deleted',
-	'is_coming_soon',
-	'is_private',
-	'launch_status',
-	'site_migration',
-	'options',
-	'jetpack',
-	'jetpack_modules',
-].join( ',' );
+const JOINED_SITE_FIELDS = SITE_FIELDS.join( ',' );
 
 export const fetchSites = async (): Promise< Site[] > => {
 	const { sites } = await wpcom.req.get(
@@ -60,14 +43,17 @@ export const fetchSites = async (): Promise< Site[] > => {
 			site_visibility: 'all',
 			include_domain_only: 'true',
 			site_activity: 'active',
-			fields: SITE_FIELDS,
+			fields: JOINED_SITE_FIELDS,
 		}
 	);
 	return sites;
 };
 
 export const fetchSite = async ( siteIdOrSlug: string ): Promise< Site > => {
-	return await wpcom.req.get( { path: `/sites/${ siteIdOrSlug }` }, { fields: SITE_FIELDS } );
+	return await wpcom.req.get(
+		{ path: `/sites/${ siteIdOrSlug }` },
+		{ fields: JOINED_SITE_FIELDS }
+	);
 };
 
 export const fetchSiteMediaStorage = async ( siteIdOrSlug: string ): Promise< MediaStorage > => {
@@ -350,6 +336,13 @@ function toRawSiteSettings( settings: Partial< SiteSettings > ): any {
 	}
 	return rawSettings;
 }
+
+export const restoreSitePlanSoftware = async ( siteIdOrSlug: string ) => {
+	return wpcom.req.post( {
+		path: `/sites/${ siteIdOrSlug }/hosting/restore-plan-software`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
 
 export const fetchBasicMetrics = async ( url: string ): Promise< BasicMetricsData > => {
 	return wpcom.req.get(

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -63,7 +63,6 @@ export interface Plan {
 export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
-	is_wpcom_atomic?: boolean;
 	blog_public: number;
 	is_redirect?: boolean;
 }
@@ -86,6 +85,7 @@ export interface Site {
 	is_deleted: boolean;
 	is_coming_soon: boolean;
 	is_private: boolean;
+	is_wpcom_atomic: boolean;
 	launch_status: string | boolean;
 	site_migration: {
 		migration_status: string;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -44,7 +44,6 @@ export interface Domain {
 export interface SitePlan {
 	product_name: string;
 	product_name_short: string;
-	product_slug: string;
 	expired: boolean;
 	is_free: boolean;
 	billing_period: 'Yearly' | 'Monthly';

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -44,6 +44,7 @@ export interface Domain {
 export interface SitePlan {
 	product_name: string;
 	product_name_short: string;
+	product_slug: string;
 	expired: boolean;
 	is_free: boolean;
 	billing_period: 'Yearly' | 'Monthly';
@@ -78,6 +79,7 @@ export interface Site {
 	};
 	plan?: SitePlan;
 	active_modules?: string[];
+	capabilities: Record< string, Record< string, boolean > >;
 	subscribers_count: number;
 	// Can be undefined for deleted sites.
 	options?: SiteOptions;
@@ -85,6 +87,7 @@ export interface Site {
 	is_deleted: boolean;
 	is_coming_soon: boolean;
 	is_private: boolean;
+	is_wpcom_staging_site: boolean;
 	launch_status: string | boolean;
 	site_migration: {
 		migration_status: string;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -60,6 +60,10 @@ export interface Plan {
 	user_facing_expiry?: string;
 }
 
+export interface SiteCapabilities {
+	manage_options: boolean;
+}
+
 export interface SiteOptions {
 	software_version: string;
 	admin_url: string;
@@ -77,7 +81,7 @@ export interface Site {
 	};
 	plan?: SitePlan;
 	active_modules?: string[];
-	capabilities: Record< string, Record< string, boolean > >;
+	capabilities: SiteCapabilities;
 	subscribers_count: number;
 	// Can be undefined for deleted sites.
 	options?: SiteOptions;

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -87,7 +87,6 @@ export interface Site {
 	is_deleted: boolean;
 	is_coming_soon: boolean;
 	is_private: boolean;
-	is_wpcom_staging_site: boolean;
 	launch_status: string | boolean;
 	site_migration: {
 		migration_status: string;

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -6,19 +6,15 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { siteQuery, siteSettingsQuery } from '../../app/queries';
-import { ActionList } from '../../components/action-list';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
-import useActions from './use-actions';
+import SiteActions from './site-actions';
 
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: siteData } = useQuery( siteQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
-	const actions = useActions( {
-		site: siteData.site,
-	} );
 
 	if ( ! siteData || ! settings ) {
 		return null;
@@ -39,16 +35,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					/>
 				</VStack>
 			</Card>
-			{ !! actions.length && (
-				<>
-					<Heading>{ __( 'Actions' ) }</Heading>
-					<ActionList>
-						{ actions.map( ( action, i ) => (
-							<ActionList.ActionItem key={ i } { ...action } />
-						) ) }
-					</ActionList>
-				</>
-			) }
+			<SiteActions site={ site } />
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -6,14 +6,19 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { siteQuery, siteSettingsQuery } from '../../app/queries';
+import { ActionList } from '../../components/action-list';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
+import useActions from './use-actions';
 
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 	const { data: siteData } = useQuery( siteQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
+	const actions = useActions( {
+		site: siteData.site,
+	} );
 
 	if ( ! siteData || ! settings ) {
 		return null;
@@ -34,6 +39,16 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 					/>
 				</VStack>
 			</Card>
+			{ !! actions.length && (
+				<>
+					<Heading>{ __( 'Actions' ) }</Heading>
+					<ActionList>
+						{ actions.map( ( action, i ) => (
+							<ActionList.ActionItem key={ i } { ...action } />
+						) ) }
+					</ActionList>
+				</>
+			) }
 		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -1,8 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
+import {
+	__experimentalHeading as Heading,
+	Button,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { restoreSitePlanSoftwareMutation } from '../../app/queries';
+import { ActionList } from '../../components/action-list';
 import { DotcomFeatures } from '../../data/constants';
 import type { Site } from '../../data/types';
 
@@ -59,11 +63,26 @@ const useCopySite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site 
 	};
 };
 
-const useActions = ( { site }: { site: Site } ) => {
+export default function SiteActions( { site }: { site: Site } ) {
 	const restorePlanSoftware = useRestorePlanSoftware( site );
 	const copySite = useCopySite( site );
+	const actions = [
+		restorePlanSoftware,
+		copySite,
+	].filter( Boolean );
 
-	return [ restorePlanSoftware, copySite ].filter( Boolean );
-};
+	if ( ! actions.length ) {
+		return null;
+	}
 
-export default useActions;
+	return (
+		<>
+			<Heading>{ __( 'Actions' ) }</Heading>
+			<ActionList>
+				{ actions.map( ( action, i ) => (
+					<ActionList.ActionItem key={ i } { ...action } />
+				) ) }
+			</ActionList>
+		</>
+	);
+}

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -7,10 +7,10 @@ import { ActionList } from '../../components/action-list';
 import { DotcomFeatures } from '../../data/constants';
 import type { Site } from '../../data/types';
 
-const useRestorePlanSoftware = ( { slug, options }: Site ) => {
+const useRestorePlanSoftware = ( { slug, is_wpcom_atomic }: Site ) => {
 	const mutation = useMutation( restoreSitePlanSoftwareMutation( slug ) );
 
-	if ( ! options?.is_wpcom_atomic ) {
+	if ( ! is_wpcom_atomic ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -69,8 +69,8 @@ export default function SiteActions( { site }: { site: Site } ) {
 		<>
 			<Heading>{ __( 'Actions' ) }</Heading>
 			<ActionList>
-				{ actions.map( ( action, i ) => (
-					<ActionList.ActionItem key={ i } { ...action } />
+				{ actions.map( ( action ) => (
+					<ActionList.ActionItem key={ action.title } { ...action } />
 				) ) }
 			</ActionList>
 		</>

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -1,8 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import {
-	__experimentalHeading as Heading,
-	Button,
-} from '@wordpress/components';
+import { __experimentalHeading as Heading, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { restoreSitePlanSoftwareMutation } from '../../app/queries';
@@ -13,7 +10,7 @@ import type { Site } from '../../data/types';
 const useRestorePlanSoftware = ( { slug, options }: Site ) => {
 	const mutation = useMutation( restoreSitePlanSoftwareMutation( slug ) );
 
-	if ( ! options.is_wpcom_atomic ) {
+	if ( ! options?.is_wpcom_atomic ) {
 		return null;
 	}
 
@@ -66,10 +63,7 @@ const useCopySite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site 
 export default function SiteActions( { site }: { site: Site } ) {
 	const restorePlanSoftware = useRestorePlanSoftware( site );
 	const copySite = useCopySite( site );
-	const actions = [
-		restorePlanSoftware,
-		copySite,
-	].filter( Boolean );
+	const actions = [ restorePlanSoftware, copySite ].filter( ( value ) => !! value );
 
 	if ( ! actions.length ) {
 		return null;

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -9,8 +9,9 @@ import { ActionList } from '../../components/action-list';
 import { DotcomFeatures } from '../../data/constants';
 import type { Site } from '../../data/types';
 
-const useRestorePlanSoftware = ( { slug, is_wpcom_atomic }: Site ) => {
+const RestorePlanSoftware = ( { site }: { site: Site } ) => {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { slug, is_wpcom_atomic } = site;
 	const mutation = useMutation( restoreSitePlanSoftwareMutation( slug ) );
 
 	const handleClick = () => {
@@ -33,52 +34,58 @@ const useRestorePlanSoftware = ( { slug, is_wpcom_atomic }: Site ) => {
 		return null;
 	}
 
-	return {
-		title: __( 'Re-install plugins & themes' ),
-		description: __(
-			'If your website is missing plugins and themes that come with your plan you can re-install them here.'
-		),
-		actions: (
-			<Button
-				variant="secondary"
-				size="compact"
-				isBusy={ mutation.isPending }
-				onClick={ handleClick }
-			>
-				{ __( 'Restore' ) }
-			</Button>
-		),
-	};
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Re-install plugins & themes' ) }
+			description={ __(
+				'If your website is missing plugins and themes that come with your plan you can re-install them here.'
+			) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					isBusy={ mutation.isPending }
+					onClick={ handleClick }
+				>
+					{ __( 'Restore' ) }
+				</Button>
+			}
+		/>
+	);
 };
 
-const useDuplicateSite = ( { capabilities, plan, slug }: Site ) => {
+const DuplicateSite = ( { site }: { site: Site } ) => {
+	const { capabilities, plan, slug } = site;
+
 	if (
 		! ( capabilities.manage_options && plan?.features.active.includes( DotcomFeatures.COPY_SITE ) )
 	) {
 		return null;
 	}
 
-	return {
-		title: __( 'Duplicate site' ),
-		description: __( 'Create a duplicate of this site.' ),
-		actions: (
-			<Button
-				variant="secondary"
-				size="compact"
-				href={ addQueryArgs( '/setup/copy-site', {
-					sourceSlug: slug,
-				} ) }
-			>
-				{ __( 'Duplicate' ) }
-			</Button>
-		),
-	};
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Duplicate site' ) }
+			description={ __( 'Create a duplicate of this site.' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					href={ addQueryArgs( '/setup/copy-site', {
+						sourceSlug: slug,
+					} ) }
+				>
+					{ __( 'Duplicate' ) }
+				</Button>
+			}
+		/>
+	);
 };
 
 export default function SiteActions( { site }: { site: Site } ) {
-	const restorePlanSoftware = useRestorePlanSoftware( site );
-	const duplicateSite = useDuplicateSite( site );
-	const actions = [ restorePlanSoftware, duplicateSite ].filter( ( value ) => !! value );
+	const actions = [ <RestorePlanSoftware site={ site } />, <DuplicateSite site={ site } /> ].filter(
+		Boolean
+	);
 
 	if ( ! actions.length ) {
 		return null;
@@ -87,11 +94,7 @@ export default function SiteActions( { site }: { site: Site } ) {
 	return (
 		<>
 			<Heading>{ __( 'Actions' ) }</Heading>
-			<ActionList>
-				{ actions.map( ( action ) => (
-					<ActionList.ActionItem key={ action.title } { ...action } />
-				) ) }
-			</ActionList>
+			<ActionList>{ actions }</ActionList>
 		</>
 	);
 }

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -32,7 +32,7 @@ const useRestorePlanSoftware = ( { slug, options }: Site ) => {
 	};
 };
 
-const useCopySite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site ) => {
+const useDuplicateSite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site ) => {
 	if (
 		! (
 			capabilities.manage_options &&
@@ -44,8 +44,8 @@ const useCopySite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site 
 	}
 
 	return {
-		title: __( 'Copy site' ),
-		description: __( 'Copy this site with all of its data to a new site.' ),
+		title: __( 'Duplicate site' ),
+		description: __( 'Create a duplicate of this site.' ),
 		actions: (
 			<Button
 				variant="secondary"
@@ -54,7 +54,7 @@ const useCopySite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site 
 					sourceSlug: slug,
 				} ) }
 			>
-				{ __( 'Copy' ) }
+				{ __( 'Duplicate' ) }
 			</Button>
 		),
 	};
@@ -62,8 +62,8 @@ const useCopySite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site 
 
 export default function SiteActions( { site }: { site: Site } ) {
 	const restorePlanSoftware = useRestorePlanSoftware( site );
-	const copySite = useCopySite( site );
-	const actions = [ restorePlanSoftware, copySite ].filter( ( value ) => !! value );
+	const duplicateSite = useDuplicateSite( site );
+	const actions = [ restorePlanSoftware, duplicateSite ].filter( ( value ) => !! value );
 
 	if ( ! actions.length ) {
 		return null;

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -83,9 +83,10 @@ const DuplicateSite = ( { site }: { site: Site } ) => {
 };
 
 export default function SiteActions( { site }: { site: Site } ) {
-	const actions = [ <RestorePlanSoftware site={ site } />, <DuplicateSite site={ site } /> ].filter(
-		Boolean
-	);
+	const actions = [
+		<RestorePlanSoftware key="restore-plan-software" site={ site } />,
+		<DuplicateSite key="duplicate-site" site={ site } />,
+	].filter( Boolean );
 
 	if ( ! actions.length ) {
 		return null;

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -9,10 +9,11 @@ import { ActionList } from '../../components/action-list';
 import { DotcomFeatures } from '../../data/constants';
 import type { Site } from '../../data/types';
 
+const canRestorePlanSoftware = ( { is_wpcom_atomic }: Site ) => is_wpcom_atomic;
+
 const RestorePlanSoftware = ( { site }: { site: Site } ) => {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { slug, is_wpcom_atomic } = site;
-	const mutation = useMutation( restoreSitePlanSoftwareMutation( slug ) );
+	const mutation = useMutation( restoreSitePlanSoftwareMutation( site.slug ) );
 
 	const handleClick = () => {
 		mutation.mutate( undefined, {
@@ -29,10 +30,6 @@ const RestorePlanSoftware = ( { site }: { site: Site } ) => {
 			},
 		} );
 	};
-
-	if ( ! is_wpcom_atomic ) {
-		return null;
-	}
 
 	return (
 		<ActionList.ActionItem
@@ -54,15 +51,10 @@ const RestorePlanSoftware = ( { site }: { site: Site } ) => {
 	);
 };
 
+const canDuplicateSite = ( { capabilities, plan }: Site ) =>
+	capabilities.manage_options && plan?.features.active.includes( DotcomFeatures.COPY_SITE );
+
 const DuplicateSite = ( { site }: { site: Site } ) => {
-	const { capabilities, plan, slug } = site;
-
-	if (
-		! ( capabilities.manage_options && plan?.features.active.includes( DotcomFeatures.COPY_SITE ) )
-	) {
-		return null;
-	}
-
 	return (
 		<ActionList.ActionItem
 			title={ __( 'Duplicate site' ) }
@@ -72,7 +64,7 @@ const DuplicateSite = ( { site }: { site: Site } ) => {
 					variant="secondary"
 					size="compact"
 					href={ addQueryArgs( '/setup/copy-site', {
-						sourceSlug: slug,
+						sourceSlug: site.slug,
 					} ) }
 				>
 					{ __( 'Duplicate' ) }
@@ -84,8 +76,10 @@ const DuplicateSite = ( { site }: { site: Site } ) => {
 
 export default function SiteActions( { site }: { site: Site } ) {
 	const actions = [
-		<RestorePlanSoftware key="restore-plan-software" site={ site } />,
-		<DuplicateSite key="duplicate-site" site={ site } />,
+		canRestorePlanSoftware( site ) && (
+			<RestorePlanSoftware key="restore-plan-software" site={ site } />
+		),
+		canDuplicateSite( site ) && <DuplicateSite key="duplicate-site" site={ site } />,
 	].filter( Boolean );
 
 	if ( ! actions.length ) {

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -32,13 +32,9 @@ const useRestorePlanSoftware = ( { slug, options }: Site ) => {
 	};
 };
 
-const useDuplicateSite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site ) => {
+const useDuplicateSite = ( { capabilities, plan, slug }: Site ) => {
 	if (
-		! (
-			capabilities.manage_options &&
-			! is_wpcom_staging_site &&
-			plan?.features.active.includes( DotcomFeatures.COPY_SITE )
-		)
+		! ( capabilities.manage_options && plan?.features.active.includes( DotcomFeatures.COPY_SITE ) )
 	) {
 		return null;
 	}

--- a/client/dashboard/sites/settings/site-actions.tsx
+++ b/client/dashboard/sites/settings/site-actions.tsx
@@ -1,6 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { __experimentalHeading as Heading, Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 import { restoreSitePlanSoftwareMutation } from '../../app/queries';
 import { ActionList } from '../../components/action-list';
@@ -8,7 +10,24 @@ import { DotcomFeatures } from '../../data/constants';
 import type { Site } from '../../data/types';
 
 const useRestorePlanSoftware = ( { slug, is_wpcom_atomic }: Site ) => {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const mutation = useMutation( restoreSitePlanSoftwareMutation( slug ) );
+
+	const handleClick = () => {
+		mutation.mutate( undefined, {
+			onSuccess: () => {
+				createSuccessNotice(
+					__( 'Requested restoration of plugins and themes that come with your plan.' ),
+					{ type: 'snackbar' }
+				);
+			},
+			onError: () => {
+				createErrorNotice( __( 'Failed to request restoration of plan plugin and themes.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
+	};
 
 	if ( ! is_wpcom_atomic ) {
 		return null;
@@ -24,7 +43,7 @@ const useRestorePlanSoftware = ( { slug, is_wpcom_atomic }: Site ) => {
 				variant="secondary"
 				size="compact"
 				isBusy={ mutation.isPending }
-				onClick={ () => mutation.mutate() }
+				onClick={ handleClick }
 			>
 				{ __( 'Restore' ) }
 			</Button>

--- a/client/dashboard/sites/settings/use-actions.tsx
+++ b/client/dashboard/sites/settings/use-actions.tsx
@@ -1,0 +1,69 @@
+import { useMutation } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { restoreSitePlanSoftwareMutation } from '../../app/queries';
+import { DotcomFeatures } from '../../data/constants';
+import type { Site } from '../../data/types';
+
+const useRestorePlanSoftware = ( { slug, options }: Site ) => {
+	const mutation = useMutation( restoreSitePlanSoftwareMutation( slug ) );
+
+	if ( ! options.is_wpcom_atomic ) {
+		return null;
+	}
+
+	return {
+		title: __( 'Re-install plugins & themes' ),
+		description: __(
+			'If your website is missing plugins and themes that come with your plan you can re-install them here.'
+		),
+		actions: (
+			<Button
+				variant="secondary"
+				size="compact"
+				isBusy={ mutation.isPending }
+				onClick={ () => mutation.mutate() }
+			>
+				{ __( 'Restore' ) }
+			</Button>
+		),
+	};
+};
+
+const useCopySite = ( { capabilities, is_wpcom_staging_site, plan, slug }: Site ) => {
+	if (
+		! (
+			capabilities.manage_options &&
+			! is_wpcom_staging_site &&
+			plan?.features.active.includes( DotcomFeatures.COPY_SITE )
+		)
+	) {
+		return null;
+	}
+
+	return {
+		title: __( 'Copy site' ),
+		description: __( 'Copy this site with all of its data to a new site.' ),
+		actions: (
+			<Button
+				variant="secondary"
+				size="compact"
+				href={ addQueryArgs( '/setup/copy-site', {
+					sourceSlug: slug,
+				} ) }
+			>
+				{ __( 'Copy' ) }
+			</Button>
+		),
+	};
+};
+
+const useActions = ( { site }: { site: Site } ) => {
+	const restorePlanSoftware = useRestorePlanSoftware( site );
+	const copySite = useCopySite( site );
+
+	return [ restorePlanSoftware, copySite ].filter( Boolean );
+};
+
+export default useActions;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13160

## Proposed Changes

* Add Actions section to settings
  * Re-install plugins & themes
  * Duplicate site (The same as the "Copy site" on v1)
* TODO:
  * Will handle "Show a success or failure notice after restoring plugins and theme" in the follow-up PR

![image](https://github.com/user-attachments/assets/49ea5319-00af-4a17-87b4-ca068d1896fd)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any site
* Select Settings
* You should see nothing on your site with free plan, personal plan, premium plan
* You should see "Re-install plugins & themes" action on your atomic site
  * Click the "Restore" button should trigger the endpoint to restore plugins & themes on your site
  * TODO: How to inform user the result
* You should see "Copy site" on your site with business plan or above
  * Click the "Copy" button will navigate to the copy site flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
