### PR TITLE
Apply column layout to migration instructions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,8 +1,11 @@
 import { captureException } from '@automattic/calypso-sentry';
 import { CircularProgressBar } from '@automattic/components';
 import { LaunchpadContainer } from '@automattic/launchpad';
-import { StepContainer } from '@automattic/onboarding';
+import { Step, StepContainer } from '@automattic/onboarding';
+import { FixedColumnOnTheLeftLayout } from '@automattic/onboarding/src/step-container-v2';
+import { translate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import { MigrationStatus } from 'calypso/data/site-migration/landing/types';
 import { useUpdateMigrationStatus } from 'calypso/data/site-migration/landing/use-update-migration-status';
 import { useMigrationStickerMutation } from 'calypso/data/site-migration/use-migration-sticker';
@@ -14,6 +17,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useDispatch } from 'calypso/state';
 import { resetSite } from 'calypso/state/sites/actions';
+import { shouldUseStepContainerV2MigrationFlow } from '../../../helpers/should-use-step-container-v2';
 import { HostingBadge } from './hosting-badge';
 import { MigrationInstructions } from './migration-instructions';
 import { ProvisionStatus } from './provision-status';
@@ -21,8 +25,8 @@ import { SitePreview } from './site-preview';
 import { Steps } from './steps';
 import { useSteps } from './steps/use-steps';
 import { SupportNudge } from './support-nudge';
-import type { Step } from '../../types';
 import './style.scss';
+import type { Step as StepType } from '../../types';
 
 interface PreparationEventsHookOptions {
 	migrationKeyStatus: string;
@@ -79,7 +83,7 @@ const usePreparationEventsAndLogs = ( {
 	}, [ flow, preparationError, siteId ] );
 };
 
-const SiteMigrationInstructions: Step< {
+const SiteMigrationInstructions: StepType< {
 	submits: {
 		destination?: 'migration-started';
 		how?: ( typeof HOW_TO_MIGRATE_OPTIONS )[ 'DO_IT_FOR_ME' ];
@@ -90,6 +94,7 @@ const SiteMigrationInstructions: Step< {
 	const queryParams = useQuery();
 	const fromUrl = queryParams.get( 'from' ) ?? '';
 	const dispatch = useDispatch();
+	const useContainerV2 = shouldUseStepContainerV2MigrationFlow( flow );
 
 	const { mutate: updateMigrationStatus } = useUpdateMigrationStatus( siteId );
 
@@ -175,6 +180,7 @@ const SiteMigrationInstructions: Step< {
 	const migrationInstructions = (
 		<MigrationInstructions
 			withPreview={ withPreview }
+			withTitle={ ! useContainerV2 }
 			progress={
 				<CircularProgressBar
 					size={ 40 }
@@ -201,6 +207,26 @@ const SiteMigrationInstructions: Step< {
 			{ migrationInstructions }
 		</div>
 	);
+
+	if ( useContainerV2 ) {
+		const title = translate( 'Let’s migrate your site' );
+		return (
+			<>
+				<DocumentHead title={ title } />
+				<FixedColumnOnTheLeftLayout
+					fixedColumnWidth={ 3 }
+					topBar={
+						<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
+					}
+					heading={ <FixedColumnOnTheLeftLayout.Heading text={ title } /> }
+					// className="site-migration-instructions-v2"
+				>
+					{ migrationInstructions }
+					<SitePreview />
+				</FixedColumnOnTheLeftLayout>
+			</>
+		);
+	}
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -210,22 +210,51 @@ const SiteMigrationInstructions: StepType< {
 
 	if ( useContainerV2 ) {
 		const title = translate( 'Let’s migrate your site' );
+		const topBar = (
+			<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
+		);
+		const progressCircle = (
+			<CircularProgressBar
+				size={ 40 }
+				enableDesktopScaling
+				numberOfSteps={ steps.length }
+				currentStep={ completedSteps }
+			/>
+		);
+		if ( ! withPreview ) {
+			return (
+				<>
+					<DocumentHead title={ title } />
+					<Step.CenteredColumnLayout
+						columnWidth={ 4 }
+						topBar={ topBar }
+						heading={
+							<>
+								<Step.Heading
+									text={
+										<div className="site-migration-instructions__heading">
+											{ progressCircle }
+											{ title }
+										</div>
+									}
+								/>
+							</>
+						}
+					>
+						{ migrationInstructions }
+					</Step.CenteredColumnLayout>
+				</>
+			);
+		}
 		return (
 			<>
 				<DocumentHead title={ title } />
 				<FixedColumnOnTheLeftLayout
 					fixedColumnWidth={ 3 }
-					topBar={
-						<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
-					}
+					topBar={ topBar }
 					heading={
 						<>
-							<CircularProgressBar
-								size={ 40 }
-								enableDesktopScaling
-								numberOfSteps={ steps.length }
-								currentStep={ completedSteps }
-							/>
+							{ progressCircle }
 							<FixedColumnOnTheLeftLayout.Heading text={ title } />
 						</>
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -177,18 +177,20 @@ const SiteMigrationInstructions: StepType< {
 		navigation.submit?.( { how: HOW_TO_MIGRATE_OPTIONS.DO_IT_FOR_ME } );
 	}, [ navigation ] );
 
+	const progressCircle = (
+		<CircularProgressBar
+			size={ 40 }
+			enableDesktopScaling
+			numberOfSteps={ steps.length }
+			currentStep={ completedSteps }
+		/>
+	);
+
 	const migrationInstructions = (
 		<MigrationInstructions
 			withPreview={ withPreview }
 			isContainerV2={ useContainerV2 }
-			progress={
-				<CircularProgressBar
-					size={ 40 }
-					enableDesktopScaling
-					numberOfSteps={ steps.length }
-					currentStep={ completedSteps }
-				/>
-			}
+			progress={ progressCircle }
 		>
 			<div className="site-migration-instructions__steps">
 				<Steps steps={ steps } />
@@ -213,14 +215,7 @@ const SiteMigrationInstructions: StepType< {
 		const topBar = (
 			<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
 		);
-		const progressCircle = (
-			<CircularProgressBar
-				size={ 40 }
-				enableDesktopScaling
-				numberOfSteps={ steps.length }
-				currentStep={ completedSteps }
-			/>
-		);
+
 		if ( ! withPreview ) {
 			return (
 				<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -260,7 +260,10 @@ const SiteMigrationInstructions: StepType< {
 					}
 				>
 					{ migrationInstructions }
-					<SitePreview />
+					<>
+						{ showHostingBadge && <HostingBadge hostingName={ hostingDetails.name } /> }
+						<SitePreview />
+					</>
 				</FixedColumnOnTheLeftLayout>
 			</>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -25,8 +25,8 @@ import { SitePreview } from './site-preview';
 import { Steps } from './steps';
 import { useSteps } from './steps/use-steps';
 import { SupportNudge } from './support-nudge';
-import './style.scss';
 import type { Step as StepType } from '../../types';
+import './style.scss';
 
 interface PreparationEventsHookOptions {
 	migrationKeyStatus: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -180,7 +180,7 @@ const SiteMigrationInstructions: StepType< {
 	const migrationInstructions = (
 		<MigrationInstructions
 			withPreview={ withPreview }
-			withTitle={ ! useContainerV2 }
+			isContainerV2={ useContainerV2 }
 			progress={
 				<CircularProgressBar
 					size={ 40 }
@@ -218,8 +218,17 @@ const SiteMigrationInstructions: StepType< {
 					topBar={
 						<Step.TopBar rightElement={ <SupportNudge onAskForHelp={ navigateToDoItForMe } /> } />
 					}
-					heading={ <FixedColumnOnTheLeftLayout.Heading text={ title } /> }
-					// className="site-migration-instructions-v2"
+					heading={
+						<>
+							<CircularProgressBar
+								size={ 40 }
+								enableDesktopScaling
+								numberOfSteps={ steps.length }
+								currentStep={ completedSteps }
+							/>
+							<FixedColumnOnTheLeftLayout.Heading text={ title } />
+						</>
+					}
 				>
 					{ migrationInstructions }
 					<SitePreview />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/index.tsx
@@ -7,12 +7,14 @@ interface Props {
 	progress: ReactNode;
 	withPreview?: boolean;
 	children: ReactNode;
+	withTitle?: boolean;
 }
 
 export const MigrationInstructions: FC< Props > = ( {
 	progress,
 	withPreview = false,
 	children,
+	withTitle = true,
 } ) => {
 	const translate = useTranslate();
 
@@ -25,9 +27,11 @@ export const MigrationInstructions: FC< Props > = ( {
 			<div className="migration-instructions__progress">{ progress }</div>
 
 			<div className="migration-instructions__content">
-				<h1 className="migration-instructions__title">
-					{ translate( 'Let’s migrate your site' ) }
-				</h1>
+				{ withTitle && (
+					<h1 className="migration-instructions__title">
+						{ translate( 'Let’s migrate your site' ) }
+					</h1>
+				) }
 				<p className="migration-instructions__description">
 					{ translate( 'Follow these steps to get started:' ) }
 				</p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/index.tsx
@@ -7,14 +7,14 @@ interface Props {
 	progress: ReactNode;
 	withPreview?: boolean;
 	children: ReactNode;
-	withTitle?: boolean;
+	isContainerV2?: boolean;
 }
 
 export const MigrationInstructions: FC< Props > = ( {
 	progress,
 	withPreview = false,
 	children,
-	withTitle = true,
+	isContainerV2 = false,
 } ) => {
 	const translate = useTranslate();
 
@@ -22,12 +22,13 @@ export const MigrationInstructions: FC< Props > = ( {
 		<div
 			className={ clsx( 'migration-instructions', {
 				'migration-instructions--with-preview': withPreview,
+				'migration-instructions--container-v2': isContainerV2,
 			} ) }
 		>
-			<div className="migration-instructions__progress">{ progress }</div>
+			{ ! isContainerV2 && <div className="migration-instructions__progress">{ progress }</div> }
 
 			<div className="migration-instructions__content">
-				{ withTitle && (
+				{ ! isContainerV2 && (
 					<h1 className="migration-instructions__title">
 						{ translate( 'Let’s migrate your site' ) }
 					</h1>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/migration-instructions/style.scss
@@ -51,6 +51,10 @@
 	}
 }
 
+.migration-instructions--with-preview.migration-instructions--container-v2 {
+	width: auto;
+}
+
 .migration-instructions__content {
 	flex: 1;
 	display: flex;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/index.tsx
@@ -10,13 +10,15 @@ export const SitePreview: FC = () => {
 	const fromUrl = useQuery().get( 'from' ) || '';
 
 	const { mShotsOption, previewRef } = useSitePreviewMShotImageHandler( fromUrl );
+	const label = translate( 'Preview of the site being imported' );
 
 	return (
 		<div className="migration-instructions-from-preview" ref={ previewRef }>
 			<SiteThumbnail
 				mShotsUrl={ fromUrl }
 				className="migration-instructions-from-preview__screenshot"
-				alt={ translate( 'Preview of the site being imported' ) }
+				alt={ label }
+				aria-label={ label }
 				mshotsOption={ mShotsOption }
 				width={ mShotsOption ? mShotsOption.w : undefined }
 				height={ mShotsOption ? mShotsOption.h : undefined }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/site-preview/style.scss
@@ -4,6 +4,7 @@ $radius: 20px; /* stylelint-disable-line scales/radii */
 	flex: 1;
 	border-radius: $radius;
 	box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07), 0 3px 10px rgba(0, 0, 0, 0.04);
+	height: 100%;
 
 	& &__screenshot {
 		border: solid 12px var(--color-neutral-0);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -23,6 +23,15 @@
 		}
 	}
 }
+.site-migration-instructions__heading .circular__progress-bar {
+	position: relative;
+	margin-left: 0;
+	margin-bottom: 16px;
+	@include break-large {
+		position: absolute;
+		margin-left: 46px;
+	}
+}
 
 .site-migration-instructions__steps {
 	flex: 1;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -3,7 +3,9 @@
 @import "@automattic/onboarding/styles/mixins";
 
 .step-route.site-migration-instructions {
-	@include onboarding-block-margin;
+	&:not(:has(> .step-container-v2)) {
+		@include onboarding-block-margin;
+	}
 
 	.step-container {
 		padding: 0 0 60px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -82,11 +82,7 @@ describe( 'SiteMigrationInstructions', () => {
 	it( 'should render preview column', async () => {
 		const { container } = render();
 
-		expect(
-			container.querySelector(
-				'.migration-instructions-from-preview, .launchpad-container__main-content'
-			)
-		).toBeInTheDocument();
+		expect( container.getByLabelText( 'Preview of the site being imported' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should not render preview column if from is not informed', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -82,7 +82,11 @@ describe( 'SiteMigrationInstructions', () => {
 	it( 'should render preview column', async () => {
 		const { container } = render();
 
-		expect( container.querySelector( '.launchpad-container__main-content' ) ).toBeInTheDocument();
+		expect(
+			container.querySelector(
+				'.migration-instructions-from-preview, .launchpad-container__main-content'
+			)
+		).toBeInTheDocument();
 	} );
 
 	it( 'should not render preview column if from is not informed', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/test/index.tsx
@@ -80,9 +80,9 @@ describe( 'SiteMigrationInstructions', () => {
 	} );
 
 	it( 'should render preview column', async () => {
-		const { container } = render();
-
-		expect( container.getByLabelText( 'Preview of the site being imported' ) ).toBeInTheDocument();
+		const { queryByText } = render();
+		// Tests that the SitePreview component is rendered
+		expect( queryByText( 'SitePreview Component' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should not render preview column if from is not informed', async () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes DOTOBRD-64

## Proposed Changes

Apply the [new container v2 column layout](https://github.com/Automattic/wp-calypso/pull/103255) to the site migration instructions step.

This is still a WIP since 
 * we might need some changes on the new Layout or design input.
 * I need to conditionally add support when no preview is available.
 * Fix the tests

*Desktop with preview*
|before|after|
|-|-|
|<img width="1576" alt="image" src="https://github.com/user-attachments/assets/77566c58-0629-4540-aedf-a1b54aa7f9bf" />|<img width="1586" alt="image" src="https://github.com/user-attachments/assets/d7f13963-4329-4248-b223-453ad17cea68" />|

*Mobile with preview*
|before|after|
|-|-|
|<img width="464" alt="image" src="https://github.com/user-attachments/assets/7297bed8-f105-48ef-9ca1-455052a58fdd" />|<img width="461" alt="image" src="https://github.com/user-attachments/assets/e39312ef-1791-4ec6-88c2-8b0a5ec97c01" />|

*Desktop without preview*
|before|after|
|-|-|
|<img width="1593" alt="image" src="https://github.com/user-attachments/assets/6112c250-4f1d-4b41-8192-03d53ac6eeea" />|<img width="1593" alt="image" src="https://github.com/user-attachments/assets/bb5d0eef-81c1-4940-af07-cdf8b1286dbb" />|

*Mobile without preview*
|before|after|
|-|-|
|<img width="462" alt="image" src="https://github.com/user-attachments/assets/e104f998-b2ac-41ad-b520-4ac2e48f59bf" />|<img width="463" alt="image" src="https://github.com/user-attachments/assets/fce0976e-4829-4608-98b6-92cf045b77db" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

To conform with the rest of the onboarding design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the calypso.live link in the comments
* Navigate to `/setup/site-migration`
* Enter a WP site (a jurassic ninja site will work)
* Click on the top right link to go through the Do it yourself experience
* Pay
* Check the mobile/desktop view
* Remove the `from` query param from the URL and reload to load the view without preview.
* Check the mobile/desktop view without the preview


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
