### PR TITLE
Language Switcher: Replace custom Dialog component with the core Modal.

### DIFF
--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -1,37 +1,52 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .language-picker__modal-search {
 	position: relative;
 	width: 250px;
 }
 
-.language-picker__dialog {
-	&.dialog.card {
-		width: 90%;
-		height: 80%;
-		justify-content: space-between;
+.language-picker__overlay {
+	justify-content: center;
+}
+
+.language-picker__modal {
+	max-width:80%;
+	min-width: 80%;
+	@media (max-width: $break-mobile) {
+		max-width: 90%;
+		min-width: 90%;
+	}
+	.components-modal__header {
+		display:none;
 	}
 
-	.dialog__content {
-		flex: 1 1 auto;
-	}
-
-	.dialog__action-buttons {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		position: relative;
-		margin: 0;
-		padding: 0;
-		// prevent buttons div from covering language options
-		margin-top: 1.5rem;
-
-		.components-button {
-			margin-left: 1rem;
+	.components-modal__content {
+		padding: 24px 0 0 0;
+		margin-top: 24px;
+		display:flex;
+		flex:none;
+		flex-direction: column;
+		width: 100%;
+		>div:nth-child(2) {
+			height: 100%;
+			display: flex;
+			flex-direction: column;
 		}
-	}
 
-	.language-picker-component .language-picker-component__heading {
-		margin: 6px 0 24px;
+		.components-flex-block {
+			flex:none;
+		}
+		.language-picker-component {
+			overflow-y: auto;
+			padding:0 24px;
+			.language-picker-component__heading {
+				margin: 6px 0 24px;
+			}
+			.components-flex {
+				flex:initial;
+			}
+		}
 	}
 }
 

--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -25,9 +25,7 @@
 		padding: 24px 0 0 0;
 		margin-top: 24px;
 		display:flex;
-		flex:none;
-		flex-direction: column;
-		width: 100%;
+		/* Targeting the content div, we can't alter the HTML of the modal itself */
 		>div:nth-child(2) {
 			height: 100%;
 			display: flex;

--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -1,7 +1,7 @@
-import { Dialog, FormLabel, MaterialIcon } from '@automattic/components';
+import { FormLabel, MaterialIcon } from '@automattic/components';
 import { isDefaultLocale, isTranslatedIncompletely } from '@automattic/i18n-utils';
 import LanguagePicker, { createLanguageGroups } from '@automattic/language-picker';
-import { Button } from '@wordpress/components';
+import { Modal, Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
@@ -169,35 +169,36 @@ const LanguagePickerModal: React.FC< Props > = ( {
 		</div>
 	) : null;
 
-	const buttons = [
-		<>{ checkboxes }</>,
-		<div className="language-picker__modal-buttons">
-			<Button variant="link" onClick={ onClose }>
-				{ __( 'Cancel' ) }
-			</Button>
-			<Button
-				variant="secondary"
-				onClick={ () => {
-					onClose();
-					if ( selectedLanguage ) {
-						onSelectLanguage( selectedLanguage, {
-							empathyMode,
-							useFallbackForIncompleteLanguages,
-						} );
-					}
-				} }
-			>
-				{ __( 'Apply Changes' ) }
-			</Button>
-		</div>,
-	];
+	const buttons = (
+		<>
+			<>{ checkboxes }</>
+			<div className="language-picker__modal-buttons">
+				<Button variant="link" onClick={ onClose }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button
+					variant="secondary"
+					onClick={ () => {
+						onClose();
+						if ( selectedLanguage ) {
+							onSelectLanguage( selectedLanguage, {
+								empathyMode,
+								useFallbackForIncompleteLanguages,
+							} );
+						}
+					} }
+				>
+					{ __( 'Apply Changes' ) }
+				</Button>
+			</div>
+		</>
+	);
 
 	return (
-		<Dialog
-			isVisible
-			onClose={ onClose }
-			buttons={ buttons }
-			additionalClassNames="language-picker__dialog"
+		<Modal
+			onRequestClose={ onClose }
+			className="language-picker__modal"
+			overlayClassName="language-picker__overlay"
 		>
 			<QueryLanguageNames />
 			<LanguagePicker
@@ -208,7 +209,8 @@ const LanguagePickerModal: React.FC< Props > = ( {
 				selectedLanguage={ selectedLanguage }
 				localizedLanguageNames={ localizedLanguageNames }
 			/>
-		</Dialog>
+			<div className="confirm-modal__buttons">{ buttons }</div>
+		</Modal>
 	);
 };
 

--- a/client/components/language-picker/modal.tsx
+++ b/client/components/language-picker/modal.tsx
@@ -209,7 +209,7 @@ const LanguagePickerModal: React.FC< Props > = ( {
 				selectedLanguage={ selectedLanguage }
 				localizedLanguageNames={ localizedLanguageNames }
 			/>
-			<div className="confirm-modal__buttons">{ buttons }</div>
+			<div>{ buttons }</div>
 		</Modal>
 	);
 };


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
such as requiring a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes DOTCOM-12873

## Proposed Changes

Replace the `Dialog` component with the core's `Modal`.

## Why are these changes being made?
<!--
It's easy to see what a PR does, but much harder to find out why it was made,
particularly when researching old historical changes. Record an explanation of
the motivation behind this change and how it will help.
-->

The previous modal was unnecessarily large.

Before:
![image](https://github.com/user-attachments/assets/ed216278-bb8f-49c7-92a1-d8d0796d54f7)

After:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/c0739b23-8968-4b30-8432-f3eb472c8616" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be beneficial when the change is visual.
-->

* Visit `/me/account`, open the language switcher modal, and confirm it works correctly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
