### PR TITLE
Notifications: add toggle to switch all email notifications on and off

### DIFF
--- a/client/me/notification-settings/wpcom-settings/style.scss
+++ b/client/me/notification-settings/wpcom-settings/style.scss
@@ -1,3 +1,12 @@
 .wpcom-settings__notification-settings-emailcategory {
 	margin-bottom: 20px;
 }
+
+.wpcom-settings__notification-settings-emailsection-toggle {
+	margin-bottom: 40px;
+
+	.components-toggle-control__label {
+		font-size: 16px;
+		font-weight: 600;
+	}
+}


### PR DESCRIPTION


Part of DOTCOM-13142

## Proposed Changes
- split email options for wpcom and jetpack for better control
- add toggle to switch entire section on or off

## Why are these changes being made?
Design review DOTCOM-13031

## Testing Instructions

Visit Notifications Settings at wordpress.com/me and navigate to "Updates" tab. See a global toggle at the top of each section (WPCOM and Jetpack). See that the global toggle turns all other toggles on/off respectfully.

<img width="487" alt="image" src="https://github.com/user-attachments/assets/78f68329-b8e6-4f58-a679-238ec22014e9" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
