### PR TITLE
[site-admin] Add replace option to navigate() for cleaner URL state updates

### DIFF
--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -26,7 +26,7 @@ Initial release of the site-admin package providing a framework for building mod
 ## 0.1.0
 
 - Add `history` package dependency
-- Set `SiteNavigationItem`’s `as` prop automatically based on to or onClick.
+- Set `SiteNavigationItem`'s `as` prop automatically based on to or onClick.
 
 ### Components
 
@@ -51,3 +51,5 @@ Initial release of the site-admin package providing a framework for building mod
 - Expose `<Page />` component
 
 ## Next
+
+* Add `replace` option to navigation options for history management

--- a/packages/site-admin/CHANGELOG.md
+++ b/packages/site-admin/CHANGELOG.md
@@ -26,7 +26,7 @@ Initial release of the site-admin package providing a framework for building mod
 ## 0.1.0
 
 - Add `history` package dependency
-- Set `SiteNavigationItem`'s `as` prop automatically based on to or onClick.
+- Set `SiteNavigationItem`’s `as` prop automatically based on to or onClick.
 
 ### Components
 

--- a/packages/site-admin/src/router/hooks/use-history/index.ts
+++ b/packages/site-admin/src/router/hooks/use-history/index.ts
@@ -80,21 +80,16 @@ export default function useHistory(): UseNavigation {
 		const query = getQueryArgs( rawPath );
 		const path = getPath( 'http://domain.com/' + rawPath ) || '';
 
-		const performPush = () => {
-			const result = beforeNavigate ? beforeNavigate( { path, query } ) : { path, query };
+		const result = beforeNavigate ? beforeNavigate( { path, query } ) : { path, query };
 
-			return browserHistory.push(
-				{
-					search: buildQueryString( {
-						[ pathArg ]: result.path,
-						...result.query,
-					} ),
-				},
-				options.state
-			);
-		};
+		const search = buildQueryString( {
+			[ pathArg ]: result.path,
+			...result.query,
+		} );
 
-		performPush();
+		const method = options.replace ? browserHistory.replace : browserHistory.push;
+
+		return method( { search }, options.state );
 	} );
 
 	return useMemo(

--- a/packages/site-admin/src/router/types.ts
+++ b/packages/site-admin/src/router/types.ts
@@ -141,4 +141,9 @@ export interface NavigationOptions {
 	 * Custom state object that persists across navigation.
 	 */
 	state?: Record< string, any >;
+
+	/**
+	 * If true, replaces the current history entry instead of pushing a new one.
+	 */
+	replace?: boolean;
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes ARC-208

## Proposed Changes

* Adds support for a `replace` option in `navigate()` from `useHistory()`.
* When `replace: true` is passed, the function uses `browserHistory.replace()` instead of `push()` to update the URL without adding a new history entry.

## Why are these changes being made?

Currently, `navigate()` always performs a `push()` operation, even when only the query string changes. This causes issues in interfaces where transient state (e.g., filters, date ranges, pagination) is reflected in the URL.

For example, navigating to:

```
/report?filters[0][key]=status&filters[0][value][0]=completed
```

and then calling:

```
navigate('/report?filters[0][key]=status&filters[0][value][0]=processing')
```

results in two stacked history entries. The browser back button will return to the previous (now stale) filter state. Over time, this leads to cluttered browser history and confusing navigation behavior.

Adding support for `replace: true` enables a more accurate way to reflect updated UI state in the URL by replacing the current history entry — similar to `window.history.replaceState()` or `react-router`'s `navigate(..., { replace: true })`.

## Testing Instructions

* Use `navigate(path, { replace: true })` anywhere in the app.
* Confirm that the browser URL is updated **without** pushing a new entry to the history stack.
* Use the browser back button to verify that stale query states are not preserved.
* Confirm that existing `navigate(path)` calls without `replace` still behave as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
