### PR TITLE
Akismet checkout: Copy updates for quantity option labels

### DIFF
--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -150,7 +150,7 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 			preventWidows( translate( '1000 spam calls/mo, up to 2 sites' ) ),
 			preventWidows( translate( '1500 spam calls/mo, up to 3 sites' ) ),
 			preventWidows( translate( '2000 spam calls/mo, up to 4 sites' ) ),
-			preventWidows( translate( 'Unlimited sites (Akismet Business)' ) ),
+			preventWidows( translate( '5000 spam calls/mo, unlimited sites (Akismet Business)' ) ),
 		];
 		const AkBusinessDropdownPosition = dropdownOptions.length;
 		return {

--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -146,10 +146,10 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 	const translate = useTranslate();
 	const { dropdownOptions, AkBusinessDropdownPosition } = useMemo( () => {
 		const dropdownOptions = [
-			preventWidows( translate( '1 Site' ) ),
-			preventWidows( translate( '2 Sites' ) ),
-			preventWidows( translate( '3 Sites' ) ),
-			preventWidows( translate( '4 Sites' ) ),
+			preventWidows( translate( '500 spam calls/mo, up to 1 site' ) ),
+			preventWidows( translate( '1000 spam calls/mo, up to 2 sites' ) ),
+			preventWidows( translate( '1500 spam calls/mo, up to 3 sites' ) ),
+			preventWidows( translate( '2000 spam calls/mo, up to 4 sites' ) ),
 			preventWidows( translate( 'Unlimited sites (Akismet Business)' ) ),
 		];
 		const AkBusinessDropdownPosition = dropdownOptions.length;


### PR DESCRIPTION
Resolves SAFE-90

## Proposed Changes

* This PR nudges the copy for the Akismet pro plan's quantity options.

## Why are these changes being made?

* These are being changed for consistency with options that will also appear on the `akismet.com/pricing` page.
  * Related to SAFE-88
  
BEFORE | AFTER
--- | ---
![before](https://github.com/user-attachments/assets/b943276f-ff53-449e-a888-0de9a87966ed) | ![after](https://github.com/user-attachments/assets/08998447-5a96-4d81-9fb7-8e5688c4dac6)


## Testing Instructions

* Open the calypso.live link in the comments below
* Navigate to `/checkout/akismet/ak_pro5h_yearly`
* Note that the copy changes are reflected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
