### PR TITLE
Use core button on lost password screen

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -143,6 +143,14 @@
 				--wp-components-color-accent: var(--studio-gray-5);
 
 				color: var(--studio-gray-50);
+
+				.components-spinner {
+					--wp-components-color-accent: var(--woo-purple-40);
+				}
+			}
+
+			&.is-busy:has(.components-spinner) {
+				background-image: unset;
 			}
 
 			.components-spinner {
@@ -167,9 +175,11 @@
 .blaze-pro,
 .is-blaze-pro {
 	.components-button:not(.is-destructive) {
+		--color-blaze-pro-darker: color-mix(in srgb, var(--color-blaze-pro), #000 13%);
+
 		--wp-components-color-accent: var(--color-blaze-pro);
-		--wp-components-color-accent-darker-10: var(--color-blaze-pro);
-		--wp-components-color-accent-darker-20: var(--color-blaze-pro);
+		--wp-components-color-accent-darker-10: var(--color-blaze-pro-darker);
+		--wp-components-color-accent-darker-20: var(--color-blaze-pro-darker);
 	}
 }
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -440,6 +440,7 @@ class Login extends Component {
 							redirectToAfterLoginUrl={ this.props.redirectTo }
 							oauth2ClientId={ this.props.oauth2Client && this.props.oauth2Client.id }
 							locale={ locale }
+							isWoo={ isWoo }
 							isWooJPC={ isWooJPC }
 							from={ get( currentQuery, 'from' ) }
 						/>

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -1,9 +1,8 @@
 import page from '@automattic/calypso-router';
 import { FormInputValidation, FormLabel } from '@automattic/components';
-import { Spinner } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import FormsButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { login } from 'calypso/lib/paths';
 import { useDispatch } from 'calypso/state';
@@ -142,9 +141,14 @@ const LostPasswordForm = ( {
 				{ showError && <FormInputValidation isError text={ error } /> }
 			</div>
 			<div className="login__form-action">
-				<FormsButton primary type="submit" disabled={ email.length === 0 || showError || isBusy }>
+				<Button
+					variant="primary"
+					type="submit"
+					disabled={ email.length === 0 || showError || isBusy }
+					__next40pxDefaultSize
+				>
 					{ isBusy ? <Spinner /> : translate( 'Reset my password' ) }
-				</FormsButton>
+				</Button>
 			</div>
 		</form>
 	);

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -7,12 +7,14 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { login } from 'calypso/lib/paths';
 import { useDispatch } from 'calypso/state';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
+
 const LostPasswordForm = ( {
 	redirectToAfterLoginUrl,
 	oauth2ClientId,
 	locale,
 	from,
 	isWooJPC,
+	isWoo,
 } ) => {
 	const translate = useTranslate();
 	const [ email, setEmail ] = useState( '' );
@@ -145,9 +147,10 @@ const LostPasswordForm = ( {
 					variant="primary"
 					type="submit"
 					disabled={ email.length === 0 || showError || isBusy }
+					isBusy={ isBusy }
 					__next40pxDefaultSize
 				>
-					{ isBusy ? <Spinner /> : translate( 'Reset my password' ) }
+					{ isBusy && isWoo ? <Spinner /> : translate( 'Reset my password' ) }
 				</Button>
 			</div>
 		</form>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes [DSGCOM-106: Update primary buttons on Lost Password](https://linear.app/a8c/issue/DSGCOM-106/update-primary-buttons-on-lost-password)

## Proposed Changes

Replace the primary button on the forgot password screen for Woo and Blaze Pro with a core button

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

This button is inconsistent with the buttons on the login, magic login and signup screens, which have all been replaced. For Blaze Pro there are no visible disabled or focused styles.

- Visible disabled and focus styles are necessary for accessibility
- Consistent button styles and behaviours form a more high quality experience

## Testing

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Screenshots

| Before - disabled | After - disabled |
|-|-|
| ![wordpress com_log-in_lostpassword_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirect_ur](https://github.com/user-attachments/assets/125cc521-01dd-4637-89d8-1e5b766d2b37) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirect_ur (5)](https://github.com/user-attachments/assets/39590ec0-d389-4652-b63b-0e4799ca8afa) |
| ![wordpress com_log-in_lostpassword_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a219e9db95944038cb9%26redirect_uri%3](https://github.com/user-attachments/assets/e46d0ef2-719c-43ad-8e82-45ec281a70ec) | ![calypso localhost_3000_log-in_lostpassword_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a219e9db95944038cb9%26redir](https://github.com/user-attachments/assets/670f5406-549b-47c9-ba1c-27f473826c9e) |

| Before - filled and focused | After - filled and focused |
|-|-|
| ![wordpress com_log-in_lostpassword_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirec (1)](https://github.com/user-attachments/assets/94581369-f617-43c8-a6da-9d12585c0ad1) | ![calypso localhost_3000_log-in_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirect_ur (6)](https://github.com/user-attachments/assets/286b2000-1dd6-49dd-8066-f7a1cf206da0) |
| ![wordpress com_log-in_lostpassword_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a219e9db95944038cb9%26redirect_u (1)](https://github.com/user-attachments/assets/b87ba6f1-87ad-4c9a-b14d-629f8aa67b20) | ![calypso localhost_3000_log-in_lostpassword_redirect_to=https%3A%2F%2Fpublic-api wordpress com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a219e9db95944038cb9%26r (1)](https://github.com/user-attachments/assets/caed75d1-d839-4bbb-a0dc-ac7758a8cc1a) |

### Instructions

* Visit the lost password screen for [Woo](http://calypso.localhost:3000/log-in/lostpassword?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D69c7f83c44d9438e013f60308e0d8369725e57fa68d18b558d8b41743976985b%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916) and [Blaze Pro](http://calypso.localhost:3000/log-in/lostpassword?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D99370%26state%3D6e545c7a9932a0a612817faa07992930afae8229e4b11a219e9db95944038cb9%26redirect_uri%3Dhttps%253A%252F%252Fblazepro.tumblr.com%252Fauth%252Fconnected%26blog_id%3D0%26wpcom_connect%3D1%26calypso_env%3Dproduction%26scope%3Dglobal%26from-calypso%3D1&client_id=99370)
* Both should have visibly disabled primary buttons which cannot be accessed
* On filling the email field and the button should become enabled
* On focusing the button there should be visible focus styles, matching those on the login and signup screens
* Submitting the button should send the forgot password request (the actual email send results in a 404 for me locally though, same on trunk 🤷 )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
