### PR TITLE
Social buttons: replace disabled CSS class with a prop

### DIFF
--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -151,9 +151,8 @@ export class AppleLoginButton extends Component {
 					customButton
 				) : (
 					<Button
-						className={ clsx( 'a8c-components-wp-button social-buttons__button apple', {
-							disabled: isDisabled,
-						} ) }
+						className="a8c-components-wp-button social-buttons__button apple"
+						disabled={ isDisabled }
 						data-social-service="apple"
 						onClick={ this.handleClick }
 						variant="secondary"

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -181,9 +181,8 @@ export const GitHubLoginButton = ( {
 				customButton
 			) : (
 				<Button
-					className={ clsx( 'a8c-components-wp-button social-buttons__button github', {
-						disabled: isDisabled,
-					} ) }
+					className="a8c-components-wp-button social-buttons__button github"
+					disabled={ isDisabled }
 					data-social-service="github"
 					{ ...eventHandlers }
 					variant="secondary"

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -198,9 +198,7 @@ export class GoogleSocialButton extends Component {
 					customButton
 				) : (
 					<Button
-						className={ clsx( 'a8c-components-wp-button social-buttons__button google', {
-							disabled: isDisabled,
-						} ) }
+						className="a8c-components-wp-button social-buttons__button google"
 						onClick={ this.handleClick }
 						data-social-service="google"
 						disabled={ isDisabled }

--- a/client/components/social-buttons/magic-login.tsx
+++ b/client/components/social-buttons/magic-login.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import MailIcon from 'calypso/components/social-icons/mail';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -29,9 +28,8 @@ export const MagicLoginButton = ( { loginUrl }: MagicLoginButtonProps ) => {
 
 	return (
 		<Button
-			className={ clsx( 'a8c-components-wp-button social-buttons__button magic-login-link', {
-				disabled: isDisabled,
-			} ) }
+			className="a8c-components-wp-button social-buttons__button magic-login-link"
+			disabled={ isDisabled }
 			href={ loginUrl }
 			onClick={ handleClick }
 			data-e2e-link="magic-login-link"

--- a/client/components/social-buttons/qr-code.tsx
+++ b/client/components/social-buttons/qr-code.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
-import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -39,9 +38,8 @@ export default function QrCodeLoginButton( { loginUrl }: QrCodeLoginButtonProps 
 
 	return (
 		<Button
-			className={ clsx( 'a8c-components-wp-button social-buttons__button', {
-				disabled: isDisabled,
-			} ) }
+			className="a8c-components-wp-button social-buttons__button"
+			disabled={ isDisabled }
 			href={ loginUrl }
 			onClick={ handleClick }
 			data-e2e-link="magic-login-link"

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -10,10 +10,6 @@
 		border-radius: 0;
 		margin-right: auto;
 		fill: inherit;
-
-		&.disabled {
-			display: none;
-		}
 	}
 
 	> span {

--- a/client/components/social-buttons/username-or-email.tsx
+++ b/client/components/social-buttons/username-or-email.tsx
@@ -18,19 +18,17 @@ export const UsernameOrEmailButton = ( { onClick }: UsernameOrEmailButtonProps )
 
 	return (
 		<Button
-			className={ clsx( 'a8c-components-wp-button social-buttons__button', {
-				disabled: isDisabled,
-			} ) }
+			className="a8c-components-wp-button social-buttons__button"
 			onClick={ onClick }
 			disabled={ isDisabled }
 			variant="secondary"
 			__next40pxDefaultSize
 		>
 			<WordPressLogo
-				className={ clsx( 'social-icons', {
-					'social-icons--enabled': ! isDisabled,
-					'social-icons--disabled': !! isDisabled,
-				} ) }
+				className={ clsx(
+					'social-icons',
+					isDisabled ? 'social-icons--disabled' : 'social-icons--enabled'
+				) }
 				size={ 20 }
 			/>
 			<span className="social-buttons__service-name">{ __( 'Continue with email' ) }</span>

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -937,21 +937,6 @@ $colophon-height: 50px;
 			}
 		}
 
-		.social-buttons__button {
-			border: 1px solid var(--color-accent-dark);
-			color: var(--color-accent-dark);
-			box-shadow: none;
-			max-width: 310px;
-			height: 48px;
-			margin-left: auto;
-			margin-right: auto;
-
-			&.disabled {
-				border-color: var(--studio-gray-30);
-				color: var(--studio-gray-30);
-			}
-		}
-
 		.card {
 			padding: 0;
 			box-shadow: none;
@@ -1094,19 +1079,6 @@ $colophon-height: 50px;
 			text-decoration: underline;
 			color: var(--color-neutral-60);
 			font-size: $font-body-small;
-		}
-
-		.auth-form__social,
-		.login__form-social {
-			.social-buttons__button {
-				border-color: var(--studio-woocommerce-purple);
-				color: var(--studio-woocommerce-purple);
-
-				&.disabled {
-					border-color: var(--studio-gray-30);
-					color: var(--studio-gray-30);
-				}
-			}
 		}
 
 		.logged-out-form__footer,


### PR DESCRIPTION
Fixing a little bug I noticed while looking at usages of the `wp-button-override` styles. The social login button shouldn't have the `.disabled` CSS class, but instead we should pass a `disabled` prop to the WP/Components `Button`.

The `.disabled` class never has a style associated with it--I verified that by adding it manually and checking in Styles Inspector that there is not rule.

On the other hand, the WP Components `Button` has styles for the `:disabled` pseudo-class and for the `[aria-disabled="true"]` attribute.

## Testing instructions:
Verify that the social login buttons still work as expected:

<img width="699" alt="Screenshot 2025-05-19 at 11 35 37" src="https://github.com/user-attachments/assets/3ffb4dd5-d69f-42d4-a0d3-ae20339aea7c" />

The disabled state is probably not even used anywhere, because the `isFormDisabled` prop is never passed to any of the social buttons! In theory the buttons should be disabled when there is a login request (async REST request) in flight.
