### PR TITLE
Add LinkedIn conversion events for wpcom

### DIFF
--- a/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
+++ b/client/lib/analytics/ad-tracking/ad-track-signup-complete.js
@@ -163,5 +163,12 @@ export async function adTrackSignupComplete( { isNewUserSite } ) {
 		window.twq( ...params );
 	}
 
+	// LinkedIn
+	if ( mayWeTrackByTracker( 'linkedin' ) ) {
+		const params = { conversion_id: 19839612 };
+		debug( 'recordSignup: [LinkedIn]', params );
+		window.lintrk( 'track', params );
+	}
+
 	debug( 'recordSignup: dataLayer:', circularReferenceSafeJSONStringify( window.dataLayer, 2 ) );
 }

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -71,6 +71,7 @@ export const TRACKING_IDS = {
 	jetpackTwitterPixelId: 'odlje',
 	wooGoogleTagManagerId: 'GTM-W64W8Q',
 	parselyTracker: 'wordpress.com',
+	wpcomLinkedinId: '7224796',
 };
 // This name is something we created to store a session id for DCM Floodlight session tracking
 export const DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid';

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -158,6 +158,13 @@ export async function recordOrder(
 		window.lintrk( 'track', params );
 	}
 
+	if ( mayWeTrackByTracker( 'linkedin' ) && wpcomJetpackCartInfo.containsWpcomProducts ) {
+		const params = { conversion_id: 19839620 };
+
+		debug( 'recordOrder: [LinkedIn]', params );
+		window.lintrk( 'track', params );
+	}
+
 	if ( mayWeTrackByTracker( 'twitter' ) && wpcomJetpackCartInfo.containsJetpackProducts ) {
 		const params = [ 'event', 'tw-odlje-oekzo', { value: wpcomJetpackCartInfo.jetpackCostUSD } ];
 		debug( 'recordOrder: [Twitter]', params );

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -53,7 +53,9 @@ export function setup() {
 		// Linkedin
 		if ( mayWeInitTracker( 'linkedin' ) ) {
 			setupLinkedinInsight(
-				isJetpackCloud() || isJetpackCheckout() ? TRACKING_IDS.jetpackLinkedinId : null
+				isJetpackCloud() || isJetpackCheckout()
+					? TRACKING_IDS.jetpackLinkedinId
+					: TRACKING_IDS.wpcomLinkedinId
 			);
 		}
 

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -10,6 +10,20 @@ import {
 	TRACKING_IDS,
 } from './constants';
 
+/**
+ * Checks if the current page is a signup or checkout page
+ * @returns {boolean} True if the current page is a signup or checkout page
+ */
+const isSignupOrCheckoutPage = () => {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	const path = window.location.pathname;
+	return (
+		path.startsWith( '/checkout' ) || path.startsWith( '/start' ) || path.startsWith( '/setup' )
+	);
+};
+
 export function setup() {
 	if ( typeof window !== 'undefined' ) {
 		if ( mayWeInitTracker( 'ga' ) ) {
@@ -51,7 +65,7 @@ export function setup() {
 		}
 
 		// Linkedin
-		if ( mayWeInitTracker( 'linkedin' ) ) {
+		if ( mayWeInitTracker( 'linkedin' ) && isSignupOrCheckoutPage() ) {
 			setupLinkedinInsight(
 				isJetpackCloud() || isJetpackCheckout()
 					? TRACKING_IDS.jetpackLinkedinId

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -8,8 +8,6 @@ import {
 	getExceptions,
 } from 'calypso/lib/analytics/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import isJetpackCheckout from '../jetpack/is-jetpack-checkout';
 
 const allAdTrackers = [
 	'bing',
@@ -64,9 +62,7 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	twitter: Bucket.ADVERTISING,
 	facebook: Bucket.ADVERTISING,
 	reddit: Bucket.ADVERTISING,
-
-	// Advertising trackers (only Jetpack Cloud or on Jetpack Checkout):
-	linkedin: isJetpackCloud() || isJetpackCheckout() ? Bucket.ADVERTISING : null,
+	linkedin: Bucket.ADVERTISING,
 
 	// Disabled trackers:
 	quantcast: null,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Add two conversion events for LinkedIn

## Why are these changes being made?

* This is a request by Marketing DOTCOM-13100

## Testing Instructions

* Ensure you're with the ad-tracking feature enabled in your environment. You can enable it in config/development.json or start each flow that needs testing with ?flags=ad-tracking
* With a logged-out browser window, create an account from /setup/onboarding
* Make sure the conversion event is sent 
* You can enable the store sandbox
* Buy a plan
* Make sure the conversion event is sent

Here's how the conversion event looks in Chrome Dev Tools > Network
<img width="1213" alt="Screenshot 2025-05-19 at 12 10 54" src="https://github.com/user-attachments/assets/a62dbafe-3d49-4ee4-a906-ca1d48ba0b22" />

and for Signup
<img width="667" alt="Screenshot 2025-05-19 at 12 46 36" src="https://github.com/user-attachments/assets/5528129c-d472-43b1-a4fb-bb87d8b85c0a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
