### PR TITLE
DataViews: Add comparison operators for filtering

### DIFF
--- a/client/sites/hooks/use-initialize-dataviews-page.ts
+++ b/client/sites/hooks/use-initialize-dataviews-page.ts
@@ -1,6 +1,6 @@
 import { usePrevious } from '@wordpress/compose';
 import { useEffect, useRef } from 'react';
-import type { View } from '@wordpress/dataviews';
+import type { View } from '@automattic/dataviews';
 
 // DataViews' pagination always resets when the search component is mounted, even though the search term has not changed.
 // This is a bug which has a fix in https://github.com/WordPress/gutenberg/pull/61307.

--- a/client/sites/hooks/use-tracks-event-on-filter-change.ts
+++ b/client/sites/hooks/use-tracks-event-on-filter-change.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteStatusGroups } from '../components/sites-dataviews';
-import type { Filter } from '@wordpress/dataviews';
+import type { Filter } from '@automattic/dataviews';
 
 type TracksEventData = [ name: string, value: string ];
 

--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -11,6 +11,7 @@
 - Enhance filter component styles.
 - Adds new story that combines DataViews and DataForm.
 - Add user input filter support based on the `Edit` property of the field type definitions.
+- Add new filter operators: `lessThan`, `greaterThan`, `lessThanOrEqual`, and `greaterThanOrEqual` for numeric and comparable fields.
 
 ## 0.1.1
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1198,8 +1198,12 @@ Operators:
 | `isNone`   | Multiple items | `NOT OR`. The item's field is not present in a list of values.          | Author is none: Admin, Editor                      |
 | `isAll`    | Multiple items | `AND`. The item's field has all of the values in the list.              | Category is all: Book, Review, Science Fiction     |
 | `isNotAll` | Multiple items | `NOT AND`. The item's field doesn't have all of the values in the list. | Category is not all: Book, Review, Science Fiction |
+| `lessThan`           | Single item    | `LESS THAN`. The item's field is numerically less than a single value.      | Age is less than 18                                |
+| `greaterThan`        | Single item    | `GREATER THAN`. The item's field is numerically greater than a single value.| Age is greater than 65                             |
+| `lessThanOrEqual`    | Single item    | `LESS THAN OR EQUAL TO`. The item's field is numerically less than or equal to a single value. | Age is less than or equal to 18         |
+| `greaterThanOrEqual` | Single item    | `GREATER THAN OR EQUAL TO`. The item's field is numerically greater than or equal to a single value. | Age is greater than or equal to 65      |
 
-`is` and `isNot` are single-selection operators, while `isAny`, `isNone`, `isAll`, and `isNotALl` are multi-selection. A filter with no operators declared will support the `isAny` and `isNone` multi-selection operators by default. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded, and the filter won't allow selecting more than one item.
+`is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, and `greaterThanOrEqual` are single-selection operators, while `isAny`, `isNone`, `isAll`, and `isNotAll` are multi-selection. A filter with no operators declared will support the `isAny` and `isNone` multi-selection operators by default. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded, and the filter won't allow selecting more than one item.
 
 Example:
 

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -240,6 +240,7 @@ function OperatorSelector( {
 				</FlexItem>
 
 				<SelectControl
+					className="dataviews-filters__summary-operators-filter-select"
 					label={ __( 'Conditions' ) }
 					value={ value }
 					options={ operatorOptions }

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -36,6 +36,10 @@ import {
 	OPERATOR_IS_NONE,
 	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
+	OPERATOR_LESS_THAN,
+	OPERATOR_GREATER_THAN,
+	OPERATOR_LESS_THAN_OR_EQUAL,
+	OPERATOR_GREATER_THAN_OR_EQUAL,
 } from '../../constants';
 import type {
 	Filter,
@@ -145,6 +149,58 @@ const FilterText = ( {
 			sprintf(
 				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is not: Admin". */
 				__( '<Name>%1$s is not: </Name><Value>%2$s</Value>' ),
+				filter.name,
+				activeElements[ 0 ].label
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_LESS_THAN ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is not: Admin". */
+				__( '<Name>%1$s is less than: </Name><Value>%2$s</Value>' ),
+				filter.name,
+				activeElements[ 0 ].label
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_GREATER_THAN ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is not: Admin". */
+				__( '<Name>%1$s is greater than: </Name><Value>%2$s</Value>' ),
+				filter.name,
+				activeElements[ 0 ].label
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_LESS_THAN_OR_EQUAL ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is less than or equal to: Admin". */
+				__(
+					'<Name>%1$s is less than or equal to: </Name><Value>%2$s</Value>'
+				),
+				filter.name,
+				activeElements[ 0 ].label
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_GREATER_THAN_OR_EQUAL ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is greater than or equal to: Admin". */
+				__(
+					'<Name>%1$s is greater than or equal to: </Name><Value>%2$s</Value>'
+				),
 				filter.name,
 				activeElements[ 0 ].label
 			),

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -159,7 +159,7 @@ const FilterText = ( {
 	if ( filterInView?.operator === OPERATOR_LESS_THAN ) {
 		return createInterpolateElement(
 			sprintf(
-				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is not: Admin". */
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is less than: 10". */
 				__( '<Name>%1$s is less than: </Name><Value>%2$s</Value>' ),
 				filter.name,
 				activeElements[ 0 ].label
@@ -171,7 +171,7 @@ const FilterText = ( {
 	if ( filterInView?.operator === OPERATOR_GREATER_THAN ) {
 		return createInterpolateElement(
 			sprintf(
-				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is not: Admin". */
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is greater than: 10". */
 				__( '<Name>%1$s is greater than: </Name><Value>%2$s</Value>' ),
 				filter.name,
 				activeElements[ 0 ].label
@@ -183,7 +183,7 @@ const FilterText = ( {
 	if ( filterInView?.operator === OPERATOR_LESS_THAN_OR_EQUAL ) {
 		return createInterpolateElement(
 			sprintf(
-				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is less than or equal to: Admin". */
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is less than or equal to: 10". */
 				__(
 					'<Name>%1$s is less than or equal to: </Name><Value>%2$s</Value>'
 				),
@@ -197,7 +197,7 @@ const FilterText = ( {
 	if ( filterInView?.operator === OPERATOR_GREATER_THAN_OR_EQUAL ) {
 		return createInterpolateElement(
 			sprintf(
-				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is greater than or equal to: Admin". */
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is greater than or equal to: 10". */
 				__(
 					'<Name>%1$s is greater than or equal to: </Name><Value>%2$s</Value>'
 				),

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -21,7 +21,7 @@ import { default as AddFilter, AddFilterMenu } from './add-filter';
 import ResetFilters from './reset-filters';
 import DataViewsContext from '../dataviews-context';
 import { sanitizeOperators } from '../../utils';
-import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from '../../constants';
+import { ALL_OPERATORS, SINGLE_SELECTION_OPERATORS } from '../../constants';
 import type { NormalizedFilter, NormalizedField, View } from '../../types';
 
 export function useFilters( fields: NormalizedField< any >[], view: View ) {
@@ -43,7 +43,7 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 				name: field.label,
 				elements: field.elements ?? [],
 				singleSelection: operators.some( ( op ) =>
-					[ OPERATOR_IS, OPERATOR_IS_NOT ].includes( op )
+					SINGLE_SELECTION_OPERATORS.includes( op )
 				),
 				operators,
 				isVisible:

--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -22,7 +22,7 @@
 	line-height: $default-line-height;
 
 	.components-popover__content {
-		min-width: 230px;
+		width: 230px;
 		border-radius: $grid-unit-05;
 	}
 
@@ -50,6 +50,14 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		flex-shrink: 0; /* Prevents this element from shrinking */
+		max-width: calc(100% - 55px);
+	}
+
+	.dataviews-filters__summary-operators-filter-select {
+		width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
 	}
 }
 

--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -22,7 +22,7 @@
 	line-height: $default-line-height;
 
 	.components-popover__content {
-		width: 230px;
+		min-width: 230px;
 		border-radius: $grid-unit-05;
 	}
 

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -16,6 +16,10 @@ export const OPERATOR_IS_ANY = 'isAny';
 export const OPERATOR_IS_NONE = 'isNone';
 export const OPERATOR_IS_ALL = 'isAll';
 export const OPERATOR_IS_NOT_ALL = 'isNotAll';
+export const OPERATOR_LESS_THAN = 'lessThan';
+export const OPERATOR_GREATER_THAN = 'greaterThan';
+export const OPERATOR_LESS_THAN_OR_EQUAL = 'lessThanOrEqual';
+export const OPERATOR_GREATER_THAN_OR_EQUAL = 'greaterThanOrEqual';
 
 export const ALL_OPERATORS = [
 	OPERATOR_IS,
@@ -24,7 +28,21 @@ export const ALL_OPERATORS = [
 	OPERATOR_IS_NONE,
 	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
+	OPERATOR_LESS_THAN,
+	OPERATOR_GREATER_THAN,
+	OPERATOR_LESS_THAN_OR_EQUAL,
+	OPERATOR_GREATER_THAN_OR_EQUAL,
 ];
+
+export const SINGLE_SELECTION_OPERATORS = [
+	OPERATOR_IS,
+	OPERATOR_IS_NOT,
+	OPERATOR_LESS_THAN,
+	OPERATOR_GREATER_THAN,
+	OPERATOR_LESS_THAN_OR_EQUAL,
+	OPERATOR_GREATER_THAN_OR_EQUAL,
+];
+
 export const OPERATORS: Record< Operator, { key: string; label: string } > = {
 	[ OPERATOR_IS ]: {
 		key: 'is-filter',
@@ -49,6 +67,22 @@ export const OPERATORS: Record< Operator, { key: string; label: string } > = {
 	[ OPERATOR_IS_NOT_ALL ]: {
 		key: 'is-not-all-filter',
 		label: __( 'Is not all' ),
+	},
+	[ OPERATOR_LESS_THAN ]: {
+		key: 'less-than-filter',
+		label: __( 'Less than' ),
+	},
+	[ OPERATOR_GREATER_THAN ]: {
+		key: 'greater-than-filter',
+		label: __( 'Greater than' ),
+	},
+	[ OPERATOR_LESS_THAN_OR_EQUAL ]: {
+		key: 'less-than-or-equal-filter',
+		label: __( 'Less than or equal' ),
+	},
+	[ OPERATOR_GREATER_THAN_OR_EQUAL ]: {
+		key: 'greater-than-or-equal-filter',
+		label: __( 'Greater than or equal' ),
 	},
 };
 

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -8,7 +8,14 @@ import type {
 	ValidationContext,
 } from '../types';
 import { renderFromElements } from '../utils';
-import { OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
+import {
+	OPERATOR_IS,
+	OPERATOR_IS_NOT,
+	OPERATOR_LESS_THAN,
+	OPERATOR_GREATER_THAN,
+	OPERATOR_LESS_THAN_OR_EQUAL,
+	OPERATOR_GREATER_THAN_OR_EQUAL,
+} from '../constants';
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	return direction === 'asc' ? a - b : b - a;
@@ -34,7 +41,14 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [ OPERATOR_IS, OPERATOR_IS_NOT ];
+const operators: Operator[] = [
+	OPERATOR_IS,
+	OPERATOR_IS_NOT,
+	OPERATOR_LESS_THAN,
+	OPERATOR_GREATER_THAN,
+	OPERATOR_LESS_THAN_OR_EQUAL,
+	OPERATOR_GREATER_THAN_OR_EQUAL,
+];
 
 export default {
 	sort,

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -13,6 +13,10 @@ import {
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
+	OPERATOR_LESS_THAN,
+	OPERATOR_GREATER_THAN,
+	OPERATOR_LESS_THAN_OR_EQUAL,
+	OPERATOR_GREATER_THAN_OR_EQUAL,
 } from './constants';
 import { normalizeFields } from './normalize-fields';
 import type { Field, View } from './types';
@@ -129,6 +133,38 @@ export function filterSortAndPaginate< Item >(
 				} else if ( filter.operator === OPERATOR_IS_NOT ) {
 					filteredData = filteredData.filter( ( item ) => {
 						return filter.value !== field.getValue( { item } );
+					} );
+				} else if (
+					filter.operator === OPERATOR_LESS_THAN &&
+					filter.value !== undefined
+				) {
+					filteredData = filteredData.filter( ( item ) => {
+						const fieldValue = field.getValue( { item } );
+						return fieldValue < filter.value;
+					} );
+				} else if (
+					filter.operator === OPERATOR_GREATER_THAN &&
+					filter.value !== undefined
+				) {
+					filteredData = filteredData.filter( ( item ) => {
+						const fieldValue = field.getValue( { item } );
+						return fieldValue > filter.value;
+					} );
+				} else if (
+					filter.operator === OPERATOR_LESS_THAN_OR_EQUAL &&
+					filter.value !== undefined
+				) {
+					filteredData = filteredData.filter( ( item ) => {
+						const fieldValue = field.getValue( { item } );
+						return fieldValue <= filter.value;
+					} );
+				} else if (
+					filter.operator === OPERATOR_GREATER_THAN_OR_EQUAL &&
+					filter.value !== undefined
+				) {
+					filteredData = filteredData.filter( ( item ) => {
+						const fieldValue = field.getValue( { item } );
+						return fieldValue >= filter.value;
 					} );
 				}
 			}

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -258,6 +258,160 @@ describe( 'filters', () => {
 		expect( result[ 9 ].title ).toBe( 'Saturn' );
 		expect( result[ 10 ].title ).toBe( 'Uranus' );
 	} );
+
+	it( 'should filter using LESS THAN operator for integer', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'satellites',
+						operator: 'lessThan',
+						value: 2,
+					},
+				],
+			},
+			fields
+		);
+		expect( result.every( ( item ) => item.satellites < 2 ) ).toBe( true );
+	} );
+
+	it( 'should filter using GREATER THAN operator for integer', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'satellites',
+						operator: 'greaterThan',
+						value: 10,
+					},
+				],
+			},
+			fields
+		);
+		expect( result.every( ( item ) => item.satellites > 10 ) ).toBe( true );
+	} );
+
+	it( 'should filter using LESS THAN OR EQUAL operator for integer', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'satellites',
+						operator: 'lessThanOrEqual',
+						value: 1,
+					},
+				],
+			},
+			fields
+		);
+		expect( result.every( ( item ) => item.satellites <= 1 ) ).toBe( true );
+	} );
+
+	it( 'should filter using GREATER THAN OR EQUAL operator for integer', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'satellites',
+						operator: 'greaterThanOrEqual',
+						value: 27,
+					},
+				],
+			},
+			fields
+		);
+		expect( result.every( ( item ) => item.satellites >= 27 ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'should filter using LESS THAN operator for datetime', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'date',
+						operator: 'lessThan',
+						value: '1970-01-01',
+					},
+				],
+			},
+			fields
+		);
+		expect(
+			result.every(
+				( item ) => new Date( item.date ) < new Date( '1970-01-01' )
+			)
+		).toBe( true );
+	} );
+
+	it( 'should filter using GREATER THAN operator for datetime', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'date',
+						operator: 'greaterThan',
+						value: '2000-01-01',
+					},
+				],
+			},
+			fields
+		);
+		expect(
+			result.every(
+				( item ) => new Date( item.date ) > new Date( '2000-01-01' )
+			)
+		).toBe( true );
+	} );
+
+	it( 'should filter using LESS THAN OR EQUAL operator for datetime', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'date',
+						operator: 'lessThanOrEqual',
+						value: '1970-01-01',
+					},
+				],
+			},
+			fields
+		);
+		expect(
+			result.every(
+				( item ) => new Date( item.date ) <= new Date( '1970-01-01' )
+			)
+		).toBe( true );
+	} );
+
+	it( 'should filter using GREATER THAN OR EQUAL operator for datetime', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'date',
+						operator: 'greaterThanOrEqual',
+						value: '2000-01-01',
+					},
+				],
+			},
+			fields
+		);
+		expect(
+			result.every(
+				( item ) => new Date( item.date ) >= new Date( '2000-01-01' )
+			)
+		).toBe( true );
+	} );
 } );
 
 describe( 'sorting', () => {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -45,7 +45,11 @@ export type Operator =
 	| 'isAny'
 	| 'isNone'
 	| 'isAll'
-	| 'isNotAll';
+	| 'isNotAll'
+	| 'lessThan'
+	| 'greaterThan'
+	| 'lessThanOrEqual'
+	| 'greaterThanOrEqual';
 
 export type FieldType = 'text' | 'integer' | 'datetime' | 'media' | 'boolean';
 

--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -3,10 +3,9 @@
  */
 import {
 	ALL_OPERATORS,
-	OPERATOR_IS,
-	OPERATOR_IS_NOT,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
+	SINGLE_SELECTION_OPERATORS,
 } from './constants';
 import type { DataViewRenderFieldProps, NormalizedField } from './types';
 
@@ -25,12 +24,12 @@ export function sanitizeOperators< Item >( field: NormalizedField< Item > ) {
 
 	// Do not allow mixing single & multiselection operators.
 	// Remove multiselection operators if any of the single selection ones is present.
-	if (
-		operators.includes( OPERATOR_IS ) ||
-		operators.includes( OPERATOR_IS_NOT )
-	) {
+	const hasSingleSelectionOperator = operators.some( ( operator ) =>
+		SINGLE_SELECTION_OPERATORS.includes( operator )
+	);
+	if ( hasSingleSelectionOperator ) {
 		operators = operators.filter( ( operator ) =>
-			[ OPERATOR_IS, OPERATOR_IS_NOT ].includes( operator )
+			SINGLE_SELECTION_OPERATORS.includes( operator )
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of WOOA7S-123


## Proposed Changes

Add the following comparison operators for filtering:

- Less than
- Greater than
- Less than or equal
- Greater than or equal

Changes:

- Introduced new operators in constants and types.
- Implemented filtering logic in filter-and-sort-data-view.
- Updated filter component to handle new operators.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Some use cases in Woo Analytics require filters that accept user-provided input — like "Price greater than 100",  or "Order Total less than 100". 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dataviews:storybook:start`
* Go to http://localhost:57863/?path=/story/dataviews-dataviews--default
* Select the `Satellites` filter
* Select operator `greater than`
* Enter `10`
* Confirm that the filter applied correctly
* Try other operators, e.g. `less than`


https://github.com/user-attachments/assets/5f07feca-fc5c-481b-bb03-da642a955616



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
