### PR TITLE
A4A: Fix parsing bug with Signup data via request parameter.

### DIFF
--- a/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
+++ b/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
@@ -41,9 +41,9 @@ const sanitizePhone = ( phoneNumber: string | null ) => {
 };
 
 /**
- * Sanitizes comma-separated values into an array
+ * Sanitizes string array
  */
-const sanitizeArrayFromString = ( values: string[] ): string[] => {
+const sanitizeStringArray = ( values: string[] ): string[] => {
 	if ( ! values ) {
 		return [];
 	}
@@ -64,13 +64,13 @@ export function getSignupDataFromRequestParameters(): AgencyDetailsPayload | nul
 	}
 
 	// Parse arrays from comma-separated strings
-	const servicesOffered = sanitizeArrayFromString(
+	const servicesOffered = sanitizeStringArray(
 		( getQueryArg( window.location.href, 'services_offered' ) as string[] ) ?? []
 	);
-	const productsOffered = sanitizeArrayFromString(
+	const productsOffered = sanitizeStringArray(
 		( getQueryArg( window.location.href, 'products_offered' ) as string[] ) ?? []
 	);
-	const productsToOffer = sanitizeArrayFromString(
+	const productsToOffer = sanitizeStringArray(
 		( getQueryArg( window.location.href, 'products_to_offer' ) as string[] ) ?? []
 	);
 

--- a/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
+++ b/client/a8c-for-agencies/sections/signup/lib/signup-data-from-reqest-parameters.ts
@@ -1,3 +1,4 @@
+import { getQueryArg } from '@wordpress/url';
 import { isValidUrl } from 'calypso/a8c-for-agencies/components/form/utils';
 import { AgencyDetailsPayload } from '../agency-details-form/types';
 
@@ -42,14 +43,11 @@ const sanitizePhone = ( phoneNumber: string | null ) => {
 /**
  * Sanitizes comma-separated values into an array
  */
-const sanitizeArrayFromString = ( value: string | null ): string[] => {
-	if ( ! value ) {
+const sanitizeArrayFromString = ( values: string[] ): string[] => {
+	if ( ! values ) {
 		return [];
 	}
-	return value
-		.split( ',' )
-		.map( ( item ) => sanitizeString( item ) )
-		.filter( Boolean );
+	return values.map( ( item ) => sanitizeString( item ) ).filter( Boolean );
 };
 
 export function getSignupDataFromRequestParameters(): AgencyDetailsPayload | null {
@@ -66,9 +64,15 @@ export function getSignupDataFromRequestParameters(): AgencyDetailsPayload | nul
 	}
 
 	// Parse arrays from comma-separated strings
-	const servicesOffered = sanitizeArrayFromString( searchParams.get( 'services_offered' ) );
-	const productsOffered = sanitizeArrayFromString( searchParams.get( 'products_offered' ) );
-	const productsToOffer = sanitizeArrayFromString( searchParams.get( 'products_to_offer' ) );
+	const servicesOffered = sanitizeArrayFromString(
+		( getQueryArg( window.location.href, 'services_offered' ) as string[] ) ?? []
+	);
+	const productsOffered = sanitizeArrayFromString(
+		( getQueryArg( window.location.href, 'products_offered' ) as string[] ) ?? []
+	);
+	const productsToOffer = sanitizeArrayFromString(
+		( getQueryArg( window.location.href, 'products_to_offer' ) as string[] ) ?? []
+	);
 
 	// Get phone number
 	const phone = sanitizePhone( searchParams.get( 'phone_number' ) );


### PR DESCRIPTION
This PR fixes a bug with Signup data (Services, products offered, and products to offer) not being parsed correctly, causing it to pass blank data.

Follow up on https://github.com/Automattic/wp-calypso/pull/103447

## Proposed Changes

* The `URLSearchParams` doesn't really work well with array data. Instead we use the `getQueryArg` helper function to parse array data like the Services and products offered fields.

## Why are these changes being made?

* This is part of the Improved A4A Onboarding project that enhances the conversion rate.

## Testing Instructions

* Spin up this branch locally (This is needed as Horizon doesn't play well with login flows)
* Access the link below via Browser Incognito (Feel free to change the fields for your testing)
 http://agencies.localhost:3000/signup/finish?address_line1&address_line2&address_city&address_state&address_postal_code&work_with_clients_other&approach_and_challenges&first_name=James&last_name=Guidaven&email=james.kenneth.guidaven+teascmachascksan@automattic.com&agency_name=JK%20Test%20Agency&agency_url=http://jkguidaven.github.io&agency_size=51-100&number_sites=21-50&user_type=developer_at_agency&services_offered%5B0%5D=strategy_consulting&services_offered%5B1%5D=ecommerce_development&products_offered%5B0%5D=WordPress.com&products_to_offer%5B0%5D=WooCommerce&address_country=PH&phone_number=+639296998983&client_id=95932 
* Please create a new WP account.
* Confirm that when the P2 management post (fJMWL-p2) is created, the **Services Offered**, **Products Offered** and **Products to offer** are not null.
   <img width="816" alt="Screenshot 2025-05-19 at 6 18 51 PM" src="https://github.com/user-attachments/assets/12df2bf1-684f-4e59-80bb-461742844d82" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?