### PR TITLE
Fix: Missing signup link in non-English logged-out invite screen

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -16,6 +16,8 @@ body.is-section-accept-invite {
 	}
 	.invite-accept__form {
 		height: 100%;
+		display: flex;
+		flex-direction: column;
 	}
 	.layout__content {
 		padding: 24px;
@@ -26,7 +28,7 @@ body.is-section-accept-invite {
 	margin: 0 auto;
 	display: flex;
 	flex-direction: column;
-	height: 100%;
+	flex: 1;
 	box-sizing: border-box;
 	font-family: $font-sf-pro-text;
 

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -269,8 +269,8 @@ class InviteAccept extends Component {
 
 		return (
 			<div className={ containerClasses }>
-				{ this.localeSuggestions() }
 				<div className={ formClasses }>
+					{ this.localeSuggestions() }
 					{ this.isMatchEmailError() && user && (
 						<Notice
 							text={ this.props.translate( 'This invite is only valid for %(email)s.', {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://github.com/Automattic/wp-calypso/pull/103490

## Proposed Changes

Fixes an layout issue where the locale suggestion was pushing the bottom `Already have a WordPress.com account?` outside the screen.

<img width="480" alt="Screenshot 2025-05-19 at 13 56 10" src="https://github.com/user-attachments/assets/a6d06897-9cf9-4a66-8485-672dd606476b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Fixes an issue introduced by updating the logged-out invite screen to match the logged-in.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions from https://github.com/Automattic/wp-calypso/pull/103490
* Show a non-English locale of the page by appending `/{locale}` to the end (not including query params)
* Ensure the `Already have a WordPress.com account?` link in the bottom is visible
<img width="480" alt="Screenshot 2025-05-19 at 13 55 21" src="https://github.com/user-attachments/assets/afced2e0-cc1f-4d52-9ea2-970542350f93" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
