### PR TITLE
Docs: Update guidelines for Sass `@import`

### DIFF
--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -146,14 +146,15 @@ Under the hood, we are using webpack and its `sass-loader`, for compiling the st
 To avoid code bloat and have a more consistent experience we use the same breakpoints in all SCSS files whenever possible. DO NOT define your own media queries. We should use the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss). For example:
 
 ```scss
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@use "@wordpress/base-styles/colors";
+@use "@wordpress/base-styles/mixins";
 
 .class-name {
 	margin-bottom: 8px;
 	padding: 12px;
+	color: colors.$gray-900;
 
-	@include break-mobile {
+	@include mixins.break-mobile {
 		margin-bottom: 16px;
 		padding: 24px;
 	}
@@ -170,7 +171,9 @@ If you are adding a new Sass file (global or component-specific), you need to im
 
 ### Imports
 
-- DO declare all of your `@import` dependencies at the top of a file that needs it/them.
+`@import` will soon be completely [deprecated](https://sass-lang.com/documentation/breaking-changes/import/) in favor of `@use`.
+
+- DO declare all of your `@use` dependencies at the top of a file that needs it/them.
 - DON'T `@import` dependencies in a global file and just hope it filters down to your partial.
 
 ### Nesting


### PR DESCRIPTION
Part of #101983

## Proposed Changes

Update the coding guidelines to reflect the deprecation of Sass `@import`.

## Why are these changes being made?

The docs are still encouraging use of an outdated API.

## Testing Instructions

Confirm that the updated explanation makes sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
