### PR TITLE
Hosting Dashboard V2: Add notices

### DIFF
--- a/client/dashboard/app/root/index.tsx
+++ b/client/dashboard/app/root/index.tsx
@@ -6,6 +6,7 @@ import NotFound from '../404';
 import CommandPalette from '../command-palette';
 import { useAppContext } from '../context';
 import Header from '../header';
+import Snackbars from '../snackbars';
 import './style.scss';
 
 function Root() {
@@ -29,6 +30,7 @@ function Root() {
 				</CatchNotFound>
 			</main>
 			<CommandPalette />
+			<Snackbars />
 		</div>
 	);
 }

--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -1,0 +1,23 @@
+import { SnackbarList } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import './style.scss';
+
+// Last three notices. Slices from the tail end of the list.
+const MAX_VISIBLE_NOTICES = -3;
+
+export default function Snackbars() {
+	const notices = useSelect( ( select ) => select( noticesStore ).getNotices(), [] );
+	const { removeNotice } = useDispatch( noticesStore );
+	const snackbarNotices = notices
+		.filter( ( { type } ) => type === 'snackbar' )
+		.slice( MAX_VISIBLE_NOTICES );
+
+	return (
+		<SnackbarList
+			notices={ snackbarNotices }
+			className="dashboard-snackbars"
+			onRemove={ removeNotice }
+		/>
+	);
+}

--- a/client/dashboard/app/snackbars/index.tsx
+++ b/client/dashboard/app/snackbars/index.tsx
@@ -15,6 +15,7 @@ export default function Snackbars() {
 
 	return (
 		<SnackbarList
+			// @ts-expect-error Bypass typecheck as WPNoticeAction is structurally incompatible with NoticeAction
 			notices={ snackbarNotices }
 			className="dashboard-snackbars"
 			onRemove={ removeNotice }

--- a/client/dashboard/app/snackbars/style.scss
+++ b/client/dashboard/app/snackbars/style.scss
@@ -1,0 +1,11 @@
+@import "@wordpress/base-styles/variables";
+
+.dashboard-snackbars {
+	position: fixed;
+	left: 0;
+	bottom: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	margin: $grid-unit-20;
+}

--- a/client/package.json
+++ b/client/package.json
@@ -107,6 +107,7 @@
 		"@wordpress/i18n": "^5.23.0",
 		"@wordpress/icons": "^10.23.0",
 		"@wordpress/is-shallow-equal": "^5.23.0",
+		"@wordpress/notices": "5.23.0",
 		"@wordpress/private-apis": "^1.23.0",
 		"@wordpress/react-i18n": "^4.23.0",
 		"@wordpress/viewport": "^6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14400,6 +14400,7 @@ __metadata:
     "@wordpress/i18n": "npm:^5.23.0"
     "@wordpress/icons": "npm:^10.23.0"
     "@wordpress/is-shallow-equal": "npm:^5.23.0"
+    "@wordpress/notices": "npm:5.23.0"
     "@wordpress/private-apis": "npm:^1.23.0"
     "@wordpress/react-i18n": "npm:^4.23.0"
     "@wordpress/viewport": "npm:^6.23.0"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13159

## Proposed Changes

* Introduce global snackbars on v2

Example:

<img width="300" src="https://github.com/user-attachments/assets/4f009e36-ba00-4adf-b341-61e58e93beda" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Display notices to inform users of the result of their actions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/v2/sites/:site/settings
* Click the "Restore" button to trigger "Re-install plugins & themes"
* Ensure you can see the snackbar after the request is finished

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
