### PR TITLE
A4A: Enable Signup v2 in horizon and staging.

### DIFF
--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -36,7 +36,7 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-signup-v2": false,
+		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": true,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -38,7 +38,7 @@
 		"a8c-for-agencies-agency-tier": true,
 		"a4a-pressable-referrals": true,
 		"a4a-updated-add-new-site": true,
-		"a4a-signup-v2": false,
+		"a4a-signup-v2": true,
 		"a4a-signup-v2-via-email": true,
 		"a4a-client-checkout-v2": true,
 		"jetpack/crm-downloads": true


### PR DESCRIPTION
This PR enables the Improved Sign-up flow in Staging and Horizon in preparation for the CFT.

## Proposed Changes

* Enable the 'a4a-signup-v2' feature flag in Staging and Horizon environment.

## Why are these changes being made?
* This is part of the Improved A4A Onboarding project that enhances the conversion rate.

## Testing Instructions

* Use the A4A live link and navigate to `/signup`.
* Confirm you see the new form.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
