### PR TITLE
Domain connection setup: Show @ for root domains and remove fqdn for subdomains

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-advanced-records.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-advanced-records.jsx
@@ -33,7 +33,14 @@ export default function ConnectDomainStepAdvancedRecords( {
 	const aRecords = ipAddresses.map( ( ipAddress ) => {
 		return {
 			type: 'A',
-			name: domain,
+			name: '@',
+			value: ipAddress,
+		};
+	} );
+	const aRecordsSubdomains = ipAddresses.map( ( ipAddress ) => {
+		return {
+			type: 'A',
+			name: domain.replace( `.${ data.root_domain }`, '' ),
 			value: ipAddress,
 		};
 	} );
@@ -47,7 +54,7 @@ export default function ConnectDomainStepAdvancedRecords( {
 	const cnameRecordsSubdomains = [
 		{
 			type: 'CNAME',
-			name: 'www.' + domain,
+			name: 'www.' + domain.replace( `.${ data.root_domain }`, '' ),
 			value: domain,
 		},
 	];
@@ -123,7 +130,7 @@ export default function ConnectDomainStepAdvancedRecords( {
 						'Replace IP addresses (A records) of your subdomain to use the following values:'
 					) }
 				</p>
-				{ renderRecordsList( aRecords ) }
+				{ renderRecordsList( aRecordsSubdomains ) }
 				<p className={ className + '__text' }>
 					{ __(
 						"Next find the CNAME records on your subdomain's settings page and replace them with the following value:"


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/NOMADO-169/update-the-name-texts-on-the-advanced-domain-connection-setup-screen

## Proposed Changes
This PR improves the domain connection experience by correcting how DNS records are displayed in the advanced setup for both root domains and subdomains:
- For root domains, `A` records now display "@" instead of the full domain name.
- For subdomains, `A` records now display only the subdomain part.
- For subdomains, the `CNAME` record for www now displays only the subdomain part, prefixed with `www`.

## Why are these changes being made?
These changes enhance the domain connection process by ensuring DNS record formats are accurate for both root domains and subdomains. Most popular domain registrars (including ours) automatically append the domain name when configuring `A` or `CNAME` records. As a result, displaying the full domain previously led less technical users to mistakenly create records like `domain.ext.domain.ext`, causing connection issues and user frustration.

<table>
  <tr>
    <td colspan="2" align="center"><b>Domains</b></td>
  </tr>
  <tr>
    <td align="center">BEFORE</td>
    <td align="center">AFTER</td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/bba93820-c9bd-4b4c-a75d-ee5040de1860"</td>
    <td><img src="https://github.com/user-attachments/assets/cf1109d3-343e-49ca-9877-9a297b8ea829"</td>
</table>

<table>
  <tr>
    <td colspan="2" align="center"><b>Subdomains</b></td>
  </tr>
  <tr>
    <td align="center">BEFORE</td>
    <td align="center">AFTER</td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1437f7c4-fa4a-4557-8f84-afb79ad796f7"</td>
    <td><img src="https://github.com/user-attachments/assets/89d11efc-b4b1-49d9-8c33-19c20b4117b9"</td>
</table>

## Testing Instructions
This PR depends on this backend update: 183202-ghe-Automattic/wpcom

- Connect a new domain, then follow the advance setup and verify that the A records name show @ instead of the domain name.
- Now test a subdomain connection. The A name records should show the subdomain part and the CNAME should show www + subdomain part.

## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
