### PR TITLE
Bump up the resource class for WP Desktop Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
     # version to keep this one working for now.
       - image: cimg/node:22.9.0-browsers
     <<: *desktop_defaults
-    resource_class: medium+
+    resource_class: large
     shell: /bin/bash --login
     environment:
       CONFIG_ENV: release


### PR DESCRIPTION
## Proposed Changes

* Bump the [resource class](https://circleci.com/docs/configuration-reference/#resourceclass) for WP Desktop Linux builds to resolve an [OOM error](https://support.circleci.com/hc/en-us/articles/115014359648-Exit-Code-137-Out-of-Memory).

## Why are these changes being made?

* To resolve the following error when CI runs the build:

```
➤ YN0000: · Yarn 4.0.2
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 791ms
➤ YN0000: ┌ Fetch step

Exited with code exit status 137
```

Similarly to [what we've done before](https://github.com/Automattic/wp-calypso/pull/93641).

## Testing Instructions

* Check that wp-desktop-linux ran successfully in CI.