### PR TITLE
Define max-old-space-size for WP Desktop Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
     resource_class: medium+
     shell: /bin/bash --login
     environment:
+      NODE_OPTIONS: --max-old-space-size=5120
       CONFIG_ENV: release
       PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
       # If, for testing purposes, you want to generate all artifacts in the CI of a PR, uncomment the following line,


### PR DESCRIPTION
## Proposed Changes

* Add the environment variable `NODE_OPTIONS: --max-old-space-size=5120` for Linux builds.

## Why are these changes being made?

* To resolve the following error when CI builds WP Desktop Linux:

```
➤ YN0000: · Yarn 4.0.2
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 791ms
➤ YN0000: ┌ Fetch step

Exited with code exit status 137
```

Related: https://github.com/Automattic/wp-calypso/pull/93641

## Testing Instructions

* Check that wp-desktop-linux ran successfully in CI.