### PR TITLE
Blaze Pro 2FA login screen: fix layout and styling issues

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -339,6 +339,7 @@ export default withCurrentRoute(
 				( ! isJetpackLogin &&
 					Boolean( currentQuery?.client_id ) === false &&
 					Boolean( currentQuery?.oauth2_client_id ) === false &&
+					! oauth2Client &&
 					! isWooJPC ) ||
 				isPartnerPortal;
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -339,7 +339,7 @@ export default withCurrentRoute(
 				( ! isJetpackLogin &&
 					Boolean( currentQuery?.client_id ) === false &&
 					Boolean( currentQuery?.oauth2_client_id ) === false &&
-					! oauth2Client &&
+					! isBlazePro &&
 					! isWooJPC ) ||
 				isPartnerPortal;
 

--- a/client/layout/masterbar/blaze-pro.scss
+++ b/client/layout/masterbar/blaze-pro.scss
@@ -581,7 +581,7 @@ body.is-section-signup {
 		}
 	}
 
-	.wp-login__main.main {
+	.wp-login__main.main:has(.login form.is-blaze-pro) {
 		max-width: unset;
 	}
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -52,22 +52,24 @@ const enhanceContextWithLogin = ( context ) => {
 
 	const previousHash = context.state || {};
 	const { client_id, user_email, user_name, id_token, state } = previousHash;
+	const currentState = context.store.getState();
 	const socialServiceResponse = client_id
 		? { client_id, user_email, user_name, id_token, state }
 		: null;
 	const isJetpackLogin = isJetpack === 'jetpack';
 	const clientId = query?.client_id;
 	const oauth2ClientId = query?.oauth2_client_id;
-	const oauth2Client =
-		getOAuth2Client( context.store.getState(), Number( clientId || oauth2ClientId ) ) || {};
+	const oauth2Client = getOAuth2Client( currentState, Number( clientId || oauth2ClientId ) ) || {};
 	const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
 	const isPartnerPortalClient = isPartnerPortalOAuth2Client( oauth2Client );
-	const isWooJPC = isWooJPCFlow( context.store.getState() );
+	const isWooJPC = isWooJPCFlow( currentState );
+	const isBlazePro = getIsBlazePro( currentState );
 
 	const isWhiteLogin =
 		( ! isJetpackLogin &&
 			Boolean( clientId ) === false &&
 			Boolean( oauth2ClientId ) === false &&
+			! isBlazePro &&
 			! isWooJPC ) ||
 		isPartnerPortalClient;
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow up to: #102811 and #103445, thanks to @adamwoodnz for catching this!

## Proposed Changes

* Ensure Blaze Pro 2FA screens don't get the `is-white-login` treatment (they skip it in the usual login screen, but the 2FA screen was still getting the top masterbar + common styling)
* In `logged-out`, factor in that the oauth2 client isn't always in the query string. On the 2FA screen, it's in state, so we need to include that in the check for `isWhiteLogin`
* Ensure that the styling that unsets the max width on the login form only applies when the expected login form is present. This will allow the 2FA version of the screen for Blaze Pro to not be full width, and render as expected.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* As raised in https://github.com/Automattic/wp-calypso/pull/102811#issuecomment-2892557836 the login 2FA screen for Blaze Pro is currently not displaying correctly

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incognito browser and with a WordPress.com account that has 2FA enabled, go to https://blazepro.com/ and go to log in
* Once you land on the log in screen, copy the query string for the route and paste it into a local URL with this branch checked out, and paste it into your browser bar after this url: `http://calypso.localhost:3000/log-in/`
* That should take you to the Blaze Pro login screen
* Log in with your username and password, and check that the 2FA screen displays correctly
* Smoke test other variations of the login screens to make sure nothing is broken as a result of this PR

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/08f4eec0-75ec-4953-a943-7a3a4db040db) | ![image](https://github.com/user-attachments/assets/547abef9-2835-4040-9a09-d3e1aa9123e3) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
