### PR TITLE
DataViews: Add text filtering operators: `contains`, `notContains`, and `startsWith`

### DIFF
--- a/packages/dataviews/CHANGELOG.automattic.md
+++ b/packages/dataviews/CHANGELOG.automattic.md
@@ -12,6 +12,7 @@
 - Adds new story that combines DataViews and DataForm.
 - Add user input filter support based on the `Edit` property of the field type definitions.
 - Add new filter operators: `lessThan`, `greaterThan`, `lessThanOrEqual`, and `greaterThanOrEqual` for numeric and comparable fields.
+- Add new filter operators: `contains`, `notContains`, `startsWith` for text fields.
 
 ## 0.1.1
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1202,8 +1202,11 @@ Operators:
 | `greaterThan`        | Single item    | `GREATER THAN`. The item's field is numerically greater than a single value.| Age is greater than 65                             |
 | `lessThanOrEqual`    | Single item    | `LESS THAN OR EQUAL TO`. The item's field is numerically less than or equal to a single value. | Age is less than or equal to 18         |
 | `greaterThanOrEqual` | Single item    | `GREATER THAN OR EQUAL TO`. The item's field is numerically greater than or equal to a single value. | Age is greater than or equal to 65      |
+| `contains` | Text           | `CONTAINS`. The item's field contains the given substring.               | Title contains: Mars                              |
+| `notContains` | Text        | `NOT CONTAINS`. The item's field does not contain the given substring.  | Description doesn't contain: photo                |
+| `startsWith` | Text         | `STARTS WITH`. The item's field starts with the given substring.        | Title starts with: Mar                            |
 
-`is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, and `greaterThanOrEqual` are single-selection operators, while `isAny`, `isNone`, `isAll`, and `isNotAll` are multi-selection. A filter with no operators declared will support the `isAny` and `isNone` multi-selection operators by default. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded, and the filter won't allow selecting more than one item.
+`is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `contains`, `notContains`, and `startsWith` are single-selection operators, while `isAny`, `isNone`, `isAll`, and `isNotAll` are multi-selection. A filter with no operators declared will support the `isAny` and `isNone` multi-selection operators by default. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded, and the filter won't allow selecting more than one item.
 
 Example:
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -512,7 +512,7 @@ const Example = () => {
 
 A single item to be edited.
 
-It can be thought of as a single record coming from the `data` property of `DataViews` — though it doesn't need to be. It can be totally separated or a mix of records if your app supports bulk editing.
+It can be thought of as a single record coming from the `data` property of `DataViews` — though it doesn't need to be. It can be totally separated or a mix of records if your app supports bulk editing.
 
 #### `fields`: `Object[]`
 
@@ -882,7 +882,7 @@ Example:
 
 ### `header`
 
-React component used by the layouts to display the field name — useful to add icons, etc. It's complementary to the `label` property.
+React component used by the layouts to display the field name — useful to add icons, etc. It's complementary to the `label` property.
 
 -   Type: React component.
 -   Optional.

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -40,6 +40,9 @@ import {
 	OPERATOR_GREATER_THAN,
 	OPERATOR_LESS_THAN_OR_EQUAL,
 	OPERATOR_GREATER_THAN_OR_EQUAL,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
 } from '../../constants';
 import type {
 	Filter,
@@ -184,9 +187,7 @@ const FilterText = ( {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is less than or equal to: 10". */
-				__(
-					'<Name>%1$s is less than or equal to: </Name><Value>%2$s</Value>'
-				),
+				__( '<Name>%1$s is less than or equal to: </Name><Value>%2$s</Value>' ),
 				filter.name,
 				activeElements[ 0 ].label
 			),
@@ -198,9 +199,43 @@ const FilterText = ( {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is greater than or equal to: 10". */
-				__(
-					'<Name>%1$s is greater than or equal to: </Name><Value>%2$s</Value>'
-				),
+				__( '<Name>%1$s is greater than or equal to: </Name><Value>%2$s</Value>' ),
+				filter.name,
+				activeElements[ 0 ].label
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_CONTAINS ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Title contains: Mars". */
+				__( '<Name>%1$s contains: </Name><Value>%2$s</Value>' ),
+				filter.name,
+				activeElements[ 0 ].label
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_NOT_CONTAINS ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Description doesn't contain: photo". */
+				__( "<Name>%1$s doesn't contain: </Name><Value>%2$s</Value>" ),
+				filter.name,
+				activeElements[ 0 ].label
+			),
+			filterTextWrappers
+		);
+	}
+
+	if ( filterInView?.operator === OPERATOR_STARTS_WITH ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: 1: Filter name. 2: Filter value. e.g.: "Title starts with: Mar". */
+				__( '<Name>%1$s starts with: </Name><Value>%2$s</Value>' ),
 				filter.name,
 				activeElements[ 0 ].label
 			),

--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -187,7 +187,9 @@ const FilterText = ( {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is less than or equal to: 10". */
-				__( '<Name>%1$s is less than or equal to: </Name><Value>%2$s</Value>' ),
+				__(
+					'<Name>%1$s is less than or equal to: </Name><Value>%2$s</Value>'
+				),
 				filter.name,
 				activeElements[ 0 ].label
 			),
@@ -199,7 +201,9 @@ const FilterText = ( {
 		return createInterpolateElement(
 			sprintf(
 				/* translators: 1: Filter name. 2: Filter value. e.g.: "Price is greater than or equal to: 10". */
-				__( '<Name>%1$s is greater than or equal to: </Name><Value>%2$s</Value>' ),
+				__(
+					'<Name>%1$s is greater than or equal to: </Name><Value>%2$s</Value>'
+				),
 				filter.name,
 				activeElements[ 0 ].label
 			),

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -652,6 +652,9 @@ export const fields: Field< SpaceObject >[] = [
 		type: 'text',
 		enableHiding: false,
 		enableGlobalSearch: true,
+		filterBy: {
+			operators: [ 'contains', 'notContains', 'startsWith' ],
+		},
 	},
 	{
 		id: 'date',

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -20,6 +20,9 @@ export const OPERATOR_LESS_THAN = 'lessThan';
 export const OPERATOR_GREATER_THAN = 'greaterThan';
 export const OPERATOR_LESS_THAN_OR_EQUAL = 'lessThanOrEqual';
 export const OPERATOR_GREATER_THAN_OR_EQUAL = 'greaterThanOrEqual';
+export const OPERATOR_CONTAINS = 'contains';
+export const OPERATOR_NOT_CONTAINS = 'notContains';
+export const OPERATOR_STARTS_WITH = 'startsWith';
 
 export const ALL_OPERATORS = [
 	OPERATOR_IS,
@@ -32,6 +35,9 @@ export const ALL_OPERATORS = [
 	OPERATOR_GREATER_THAN,
 	OPERATOR_LESS_THAN_OR_EQUAL,
 	OPERATOR_GREATER_THAN_OR_EQUAL,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
 ];
 
 export const SINGLE_SELECTION_OPERATORS = [
@@ -41,6 +47,9 @@ export const SINGLE_SELECTION_OPERATORS = [
 	OPERATOR_GREATER_THAN,
 	OPERATOR_LESS_THAN_OR_EQUAL,
 	OPERATOR_GREATER_THAN_OR_EQUAL,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
 ];
 
 export const OPERATORS: Record< Operator, { key: string; label: string } > = {
@@ -83,6 +92,18 @@ export const OPERATORS: Record< Operator, { key: string; label: string } > = {
 	[ OPERATOR_GREATER_THAN_OR_EQUAL ]: {
 		key: 'greater-than-or-equal-filter',
 		label: __( 'Greater than or equal' ),
+	},
+	[ OPERATOR_CONTAINS ]: {
+		key: 'contains-filter',
+		label: __( 'Contains' ),
+	},
+	[ OPERATOR_NOT_CONTAINS ]: {
+		key: 'not-contains-filter',
+		label: __( "Doesn't contain" ),
+	},
+	[ OPERATOR_STARTS_WITH ]: {
+		key: 'starts-with-filter',
+		label: __( 'Starts with' ),
 	},
 };
 

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -8,13 +8,7 @@ import type {
 	Operator,
 } from '../types';
 import { renderFromElements } from '../utils';
-import {
-	OPERATOR_IS_ANY,
-	OPERATOR_IS_NONE,
-	OPERATOR_CONTAINS,
-	OPERATOR_NOT_CONTAINS,
-	OPERATOR_STARTS_WITH,
-} from '../constants';
+import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../constants';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
 	return direction === 'asc'
@@ -33,11 +27,7 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [
-	OPERATOR_CONTAINS,
-	OPERATOR_NOT_CONTAINS,
-	OPERATOR_STARTS_WITH,
-];
+const operators: Operator[] = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];
 
 export default {
 	sort,

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -8,7 +8,13 @@ import type {
 	Operator,
 } from '../types';
 import { renderFromElements } from '../utils';
-import { OPERATOR_IS_ANY, OPERATOR_IS_NONE } from '../constants';
+import {
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
+} from '../constants';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
 	return direction === 'asc'
@@ -27,7 +33,11 @@ function isValid( value: any, context?: ValidationContext ) {
 	return true;
 }
 
-const operators: Operator[] = [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ];
+const operators: Operator[] = [
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
+];
 
 export default {
 	sort,

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -17,6 +17,9 @@ import {
 	OPERATOR_GREATER_THAN,
 	OPERATOR_LESS_THAN_OR_EQUAL,
 	OPERATOR_GREATER_THAN_OR_EQUAL,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
 } from './constants';
 import { normalizeFields } from './normalize-fields';
 import type { Field, View } from './types';
@@ -165,6 +168,54 @@ export function filterSortAndPaginate< Item >(
 					filteredData = filteredData.filter( ( item ) => {
 						const fieldValue = field.getValue( { item } );
 						return fieldValue >= filter.value;
+					} );
+				} else if (
+					filter.operator === OPERATOR_CONTAINS &&
+					filter?.value !== undefined
+				) {
+					filteredData = filteredData.filter( ( item ) => {
+						const fieldValue = field.getValue( { item } );
+						return (
+							typeof fieldValue === 'string' &&
+							filter.value &&
+							fieldValue
+								.toLowerCase()
+								.includes(
+									String( filter.value ).toLowerCase()
+								)
+						);
+					} );
+				} else if (
+					filter.operator === OPERATOR_NOT_CONTAINS &&
+					filter?.value !== undefined
+				) {
+					filteredData = filteredData.filter( ( item ) => {
+						const fieldValue = field.getValue( { item } );
+						return (
+							typeof fieldValue === 'string' &&
+							filter.value &&
+							! fieldValue
+								.toLowerCase()
+								.includes(
+									String( filter.value ).toLowerCase()
+								)
+						);
+					} );
+				} else if (
+					filter.operator === OPERATOR_STARTS_WITH &&
+					filter?.value !== undefined
+				) {
+					filteredData = filteredData.filter( ( item ) => {
+						const fieldValue = field.getValue( { item } );
+						return (
+							typeof fieldValue === 'string' &&
+							filter.value &&
+							fieldValue
+								.toLowerCase()
+								.startsWith(
+									String( filter.value ).toLowerCase()
+								)
+						);
 					} );
 				}
 			}

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -329,6 +329,62 @@ describe( 'filters', () => {
 		);
 	} );
 
+	it( 'should filter using CONTAINS operator for text fields', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'title',
+						operator: 'contains',
+						value: 'nep',
+					},
+				],
+			},
+			fields
+		);
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].title ).toBe( 'Neptune' );
+	} );
+
+	it( 'should filter using NOT_CONTAINS operator for text fields', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'description',
+						operator: 'notContains',
+						value: 'description',
+					},
+				],
+			},
+			fields
+		);
+		// Only 'NASA photo' and 'La planète Vénus' do not contain 'description'
+		expect( result.map( ( r ) => r.description ) ).toEqual( [
+			'NASA photo',
+			'La planète Vénus',
+		] );
+	} );
+
+	it( 'should filter using STARTS_WITH operator for text fields', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				filters: [
+					{
+						field: 'title',
+						operator: 'startsWith',
+						value: 'Mar',
+					},
+				],
+			},
+			fields
+		);
+		expect( result.map( ( r ) => r.title ) ).toContain( 'Mars' );
+	} );
+
 	it( 'should filter using LESS THAN operator for datetime', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -49,7 +49,10 @@ export type Operator =
 	| 'lessThan'
 	| 'greaterThan'
 	| 'lessThanOrEqual'
-	| 'greaterThanOrEqual';
+	| 'greaterThanOrEqual'
+	| 'contains'
+	| 'notContains'
+	| 'startsWith';
 
 export type FieldType = 'text' | 'integer' | 'datetime' | 'media' | 'boolean';
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of WOOA7S-123


## Proposed Changes

Similar to https://github.com/Automattic/wp-calypso/pull/103525, this PR introduces new filtering capabilities for text fields in the data views. The operators `contains`, `notContains`, and `startsWith` have been added to the constants and implemented in the filtering logic. 

Additionally, corresponding tests have been created to ensure functionality and the README has been updated to reflect these new operators.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Some use cases in Woo Analytics require filters that accept user-provided input — like "Product Name starts with "Woo" and "SKU contains "123".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn dataviews:storybook:start`
* Go to http://localhost:57863/?path=/story/dataviews-dataviews--default
* Select the `title` filter
* Select operator `contains`
* Enter any characters
* Confirm that the filter applied correctly
* Try other operators, e.g. `notContains` and `startsWith`


https://github.com/user-attachments/assets/059c70ce-c537-4ea5-9899-dd967caa465c

<img width="322" alt="Screenshot 2025-05-22 at 15 24 16" src="https://github.com/user-attachments/assets/f7e8aa5e-f376-49ef-83ac-aecec2b32857" />
<img width="217" alt="Screenshot 2025-05-22 at 15 23 59" src="https://github.com/user-attachments/assets/1c492070-8ec6-4795-b8e3-a1c13caf974a" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
