### PR TITLE
Hosting Dashboard V2: Add transfer site action to settings

### DIFF
--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -150,6 +150,19 @@ const siteSettingsSubscriptionGiftingRoute = createRoute( {
 	)
 );
 
+const siteSettingsTransferSiteRoute = createRoute( {
+	getParentRoute: () => siteRoute,
+	path: 'settings/transfer-site',
+	loader: ( { params: { siteSlug } } ) =>
+		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+} ).lazy( () =>
+	import( '../sites/settings-transfer-site' ).then( ( d ) =>
+		createLazyRoute( 'site-settings-transfer-site' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } />,
+		} )
+	)
+);
+
 const domainsRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'domains',
@@ -315,6 +328,7 @@ const createRouteTree = ( config: AppConfig ) => {
 				siteSettingsRoute,
 				siteSettingsSiteVisibilityRoute,
 				siteSettingsSubscriptionGiftingRoute,
+				siteSettingsTransferSiteRoute,
 			] )
 		);
 	}

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -153,8 +153,7 @@ const siteSettingsSubscriptionGiftingRoute = createRoute( {
 const siteSettingsTransferSiteRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings/transfer-site',
-	loader: ( { params: { siteSlug } } ) =>
-		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+	loader: ( { params: { siteSlug } } ) => queryClient.ensureQueryData( siteQuery( siteSlug ) ),
 } ).lazy( () =>
 	import( '../sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-transfer-site' )( {

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -153,7 +153,6 @@ const siteSettingsSubscriptionGiftingRoute = createRoute( {
 const siteSettingsTransferSiteRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings/transfer-site',
-	loader: ( { params: { siteSlug } } ) => queryClient.ensureQueryData( siteQuery( siteSlug ) ),
 } ).lazy( () =>
 	import( '../sites/settings-transfer-site' ).then( ( d ) =>
 		createLazyRoute( 'site-settings-transfer-site' )( {

--- a/client/dashboard/data/constants.ts
+++ b/client/dashboard/data/constants.ts
@@ -20,6 +20,7 @@ export const SITE_FIELDS = [
 	'is_wpcom_atomic',
 	'launch_status',
 	'site_migration',
+	'site_owner',
 	'options',
 	'jetpack',
 	'jetpack_modules',

--- a/client/dashboard/data/types.ts
+++ b/client/dashboard/data/types.ts
@@ -9,6 +9,7 @@ export interface Profile {
 }
 
 export interface User {
+	ID: number;
 	username: string;
 	display_name: string;
 	avatar_URL?: string;
@@ -94,6 +95,7 @@ export interface Site {
 	site_migration: {
 		migration_status: string;
 	} | null;
+	site_owner: number;
 	jetpack: boolean;
 	jetpack_modules: string[];
 }

--- a/client/dashboard/sites/hooks/use-can-transfer-site.ts
+++ b/client/dashboard/sites/hooks/use-can-transfer-site.ts
@@ -1,0 +1,15 @@
+import { useAuth } from '../../app/auth';
+import type { Site } from '../../data/types';
+
+export function useCanTransferSite( { site }: { site?: Site } ) {
+	const { user } = useAuth();
+
+	// TODO: The following types of the site are not allowed to transfer the ownership:
+	// * NonAtomicJetpackSite
+	// * P2 Hub
+	// * WP For Teams
+	// * VIP Site
+	// * Staging site
+	// We may need to handle this via endpoint somewhere. See canCurrentUserStartSiteOwnerTransfer.
+	return site?.site_owner === user.ID;
+}

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -1,0 +1,83 @@
+import { DataForm } from '@automattic/dataviews';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import type { Field, SimpleFormField } from '@automattic/dataviews';
+
+type ConfirmNewOwnerFormData = {
+	email: string;
+};
+
+const fields: Field< ConfirmNewOwnerFormData >[] = [
+	{
+		id: 'email',
+		label: __( 'Email' ),
+		type: 'text' as const,
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ { id: 'email' } as SimpleFormField ],
+};
+
+export function ConfirmNewOwnerForm( {
+	siteSlug,
+	handleSubmit,
+}: {
+	siteSlug: string;
+	handleSubmit: ( event: React.FormEvent ) => void;
+} ) {
+	const [ formData, setFormData ] = useState( {
+		email: '',
+	} );
+
+	return (
+		<VStack spacing={ 1 }>
+			<VStack style={ { padding: '8px 0' } }>
+				<Text size="15px" weight={ 500 } lineHeight="32px">
+					{ __( 'Confirm new owner' ) }
+				</Text>
+				<Text lineHeight="20px">
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %(siteSlug)s - the current site slug */
+							__(
+								"Ready to transfer <strong>%(siteSlug)s</strong> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
+							),
+							{
+								siteSlug,
+							}
+						),
+						{
+							strong: <strong />,
+						}
+					) }
+				</Text>
+			</VStack>
+			<form onSubmit={ handleSubmit }>
+				<VStack spacing={ 4 } style={ { padding: '8px 0' } }>
+					<DataForm< ConfirmNewOwnerFormData >
+						data={ formData }
+						fields={ fields }
+						form={ form }
+						onChange={ ( edits: Partial< ConfirmNewOwnerFormData > ) => {
+							setFormData( ( data ) => ( { ...data, ...edits } ) );
+						} }
+					/>
+					<HStack justify="flex-start">
+						<Button variant="primary" type="submit">
+							{ __( 'Continue' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
+++ b/client/dashboard/sites/settings-transfer-site/confirm-new-owner-form.tsx
@@ -1,4 +1,4 @@
-import { DataForm } from '@automattic/dataviews';
+import { DataForm, isItemValid } from '@automattic/dataviews';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -8,7 +8,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { useState } from 'react';
-import type { Field, SimpleFormField } from '@automattic/dataviews';
+import type { Field } from '@automattic/dataviews';
 
 type ConfirmNewOwnerFormData = {
 	email: string;
@@ -18,13 +18,13 @@ const fields: Field< ConfirmNewOwnerFormData >[] = [
 	{
 		id: 'email',
 		label: __( 'Email' ),
-		type: 'text' as const,
+		type: 'email' as const,
 	},
 ];
 
 const form = {
 	type: 'regular' as const,
-	fields: [ { id: 'email' } as SimpleFormField ],
+	fields: [ 'email' ],
 };
 
 export function ConfirmNewOwnerForm( {
@@ -37,6 +37,8 @@ export function ConfirmNewOwnerForm( {
 	const [ formData, setFormData ] = useState( {
 		email: '',
 	} );
+
+	const isSaveDisabled = ! isItemValid( formData, fields, form );
 
 	return (
 		<VStack spacing={ 1 }>
@@ -72,7 +74,7 @@ export function ConfirmNewOwnerForm( {
 						} }
 					/>
 					<HStack justify="flex-start">
-						<Button variant="primary" type="submit">
+						<Button variant="primary" type="submit" disabled={ isSaveDisabled }>
 							{ __( 'Continue' ) }
 						</Button>
 					</HStack>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -1,49 +1,20 @@
-import { DataForm } from '@automattic/dataviews';
 import { useQuery } from '@tanstack/react-query';
 import { notFound } from '@tanstack/react-router';
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalText as Text,
-	Button,
-	Card,
-	CardBody,
-} from '@wordpress/components';
+import { Card, CardBody, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { __ } from '@wordpress/i18n';
 import { siteQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
 import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SettingsPageHeader from '../settings-page-header';
-import type { Field, SimpleFormField } from '@automattic/dataviews';
-
-type FormData = {
-	email: string;
-};
-
-const fields: Field< FormData >[] = [
-	{
-		id: 'email',
-		label: __( 'Email' ),
-		type: 'text' as const,
-	},
-];
-
-const form = {
-	type: 'regular' as const,
-	fields: [ { id: 'email' } as SimpleFormField ],
-};
+import { ConfirmNewOwnerForm } from './confirm-new-owner-form';
 
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const canTransferSite = useCanTransferSite( { site } );
-	const [ formData, setFormData ] = useState( {
-		email: '',
-	} );
 
 	// TODO: Integrate with the API.
-	const handleSubmit = ( event: React.FormEvent ) => {
+	const handleConfirmNewOwner = ( event: React.FormEvent ) => {
 		event.preventDefault();
 	};
 
@@ -61,50 +32,20 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 			header={
 				<SettingsPageHeader
 					title={ __( 'Transfer site' ) }
-					description={ __( 'Transfer ownership of this site to another WordPress.com user.' ) }
+					description={ createInterpolateElement(
+						__(
+							'Transfer this site to a new or existing site member with just a few clicks. <a>Learn more.</a>'
+						),
+						{
+							a: <ExternalLink href="#learn-more" />,
+						}
+					) }
 				/>
 			}
 		>
 			<Card>
 				<CardBody>
-					<VStack>
-						<Text size="15px" weight={ 500 } lineHeight="20px">
-							{ __( 'Confirm new owner' ) }
-						</Text>
-						<Text variant="muted" lineHeight="20px">
-							{ createInterpolateElement(
-								sprintf(
-									/* translators: %(siteSlug)s - the current site slug */
-									__(
-										"Ready to transfer <strong>%(siteSlug)s</strong> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
-									),
-									{
-										siteSlug,
-									}
-								),
-								{
-									strong: <strong />,
-								}
-							) }
-						</Text>
-						<form onSubmit={ handleSubmit }>
-							<VStack spacing={ 4 }>
-								<DataForm< FormData >
-									data={ formData }
-									fields={ fields }
-									form={ form }
-									onChange={ ( edits: FormData ) => {
-										setFormData( ( data ) => ( { ...data, ...edits } ) );
-									} }
-								/>
-								<HStack justify="flex-start">
-									<Button variant="primary" type="submit">
-										{ __( 'Continue' ) }
-									</Button>
-								</HStack>
-							</VStack>
-						</form>
-					</VStack>
+					<ConfirmNewOwnerForm siteSlug={ siteSlug } handleSubmit={ handleConfirmNewOwner } />
 				</CardBody>
 			</Card>
 		</PageLayout>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -1,0 +1,98 @@
+import { DataForm } from '@automattic/dataviews';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+	Button,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import PageLayout from '../../components/page-layout';
+import SettingsPageHeader from '../settings-page-header';
+import type { Field, SimpleFormField } from '@automattic/dataviews';
+
+type FormData = {
+	email: string;
+};
+
+const fields: Field< FormData >[] = [
+	{
+		id: 'email',
+		label: __( 'Email' ),
+		type: 'text' as const,
+	},
+];
+
+const form = {
+	type: 'regular' as const,
+	fields: [ { id: 'email' } as SimpleFormField ],
+};
+
+export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
+	const [ formData, setFormData ] = useState( {
+		email: '',
+	} );
+
+	// TODO: Integrate with the API.
+	const handleSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<SettingsPageHeader
+					title={ __( 'Transfer site' ) }
+					description={ __( 'Transfer ownership of this site to another WordPress.com user.' ) }
+				/>
+			}
+		>
+			<Card>
+				<CardBody>
+					<VStack>
+						<Text size="15px" weight={ 500 } lineHeight="20px">
+							{ __( 'Confirm new owner' ) }
+						</Text>
+						<Text variant="muted" lineHeight="20px">
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %(siteSlug)s - the current site slug */
+									__(
+										"Ready to transfer <strong>%(siteSlug)s</strong> and its associated purchases? Simply enter the new owner's email below, or choose an existing user to start the transfer process."
+									),
+									{
+										siteSlug,
+									}
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</Text>
+						<form onSubmit={ handleSubmit }>
+							<VStack spacing={ 4 }>
+								<DataForm< FormData >
+									data={ formData }
+									fields={ fields }
+									form={ form }
+									onChange={ ( edits: FormData ) => {
+										setFormData( ( data ) => ( { ...data, ...edits } ) );
+									} }
+								/>
+								<HStack justify="flex-start">
+									<Button variant="primary" type="submit">
+										{ __( 'Continue' ) }
+									</Button>
+								</HStack>
+							</VStack>
+						</form>
+					</VStack>
+				</CardBody>
+			</Card>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -34,10 +34,10 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 					title={ __( 'Transfer site' ) }
 					description={ createInterpolateElement(
 						__(
-							'Transfer this site to a new or existing site member with just a few clicks. <a>Learn more.</a>'
+							'Transfer this site to a new or existing site member with just a few clicks. <learnMoreLink />.'
 						),
 						{
-							a: <ExternalLink href="#learn-more" />,
+							learnMoreLink: <ExternalLink href="#learn-more">{ __( 'Learn more' ) }</ExternalLink>,
 						}
 					) }
 				/>

--- a/client/dashboard/sites/settings-transfer-site/index.tsx
+++ b/client/dashboard/sites/settings-transfer-site/index.tsx
@@ -1,4 +1,6 @@
 import { DataForm } from '@automattic/dataviews';
+import { useQuery } from '@tanstack/react-query';
+import { notFound } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -10,7 +12,9 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { siteQuery } from '../../app/queries';
 import PageLayout from '../../components/page-layout';
+import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import SettingsPageHeader from '../settings-page-header';
 import type { Field, SimpleFormField } from '@automattic/dataviews';
 
@@ -32,6 +36,8 @@ const form = {
 };
 
 export default function SettingsTransferSite( { siteSlug }: { siteSlug: string } ) {
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const canTransferSite = useCanTransferSite( { site } );
 	const [ formData, setFormData ] = useState( {
 		email: '',
 	} );
@@ -40,6 +46,14 @@ export default function SettingsTransferSite( { siteSlug }: { siteSlug: string }
 	const handleSubmit = ( event: React.FormEvent ) => {
 		event.preventDefault();
 	};
+
+	if ( ! site ) {
+		return null;
+	}
+
+	if ( ! canTransferSite ) {
+		throw notFound();
+	}
 
 	return (
 		<PageLayout

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -1,24 +1,12 @@
 import { __experimentalHeading as Heading } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useAuth } from '../../app/auth';
 import { ActionList } from '../../components/action-list';
 import RouterLinkButton from '../../components/router-link-button';
+import { useCanTransferSite } from '../hooks/use-can-transfer-site';
 import type { Site } from '../../data/types';
 
 const TransferSite = ( { site }: { site: Site } ) => {
-	const { site_owner, slug } = site;
-	const { user } = useAuth();
-
-	// TODO: The following types of the site are not allowed to transfer the ownership:
-	// * NonAtomicJetpackSite
-	// * P2 Hub
-	// * WP For Teams
-	// * VIP Site
-	// * Staging site
-	// We may need to handle this via endpoint somewhere. See canCurrentUserStartSiteOwnerTransfer.
-	if ( site_owner !== user.ID ) {
-		return null;
-	}
+	const { slug } = site;
 
 	return (
 		<ActionList.ActionItem
@@ -38,7 +26,10 @@ const TransferSite = ( { site }: { site: Site } ) => {
 };
 
 export default function DangerZone( { site }: { site: Site } ) {
-	const actions = [ <TransferSite key="transfer-site" site={ site } /> ].filter( Boolean );
+	const canTransferSite = useCanTransferSite( { site } );
+	const actions = [ canTransferSite && <TransferSite key="transfer-site" site={ site } /> ].filter(
+		Boolean
+	);
 
 	if ( ! actions.length ) {
 		return null;

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -1,7 +1,8 @@
-import { __experimentalHeading as Heading, Button } from '@wordpress/components';
+import { __experimentalHeading as Heading } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAuth } from '../../app/auth';
 import { ActionList } from '../../components/action-list';
+import RouterLinkButton from '../../components/router-link-button';
 import type { Site } from '../../data/types';
 
 const TransferSite = ( { site }: { site: Site } ) => {
@@ -14,7 +15,7 @@ const TransferSite = ( { site }: { site: Site } ) => {
 	// * WP For Teams
 	// * VIP Site
 	// * Staging site
-	// See canCurrentUserStartSiteOwnerTransfer.
+	// We may need to handle this via endpoint somewhere. See canCurrentUserStartSiteOwnerTransfer.
 	if ( site_owner !== user.ID ) {
 		return null;
 	}
@@ -24,13 +25,13 @@ const TransferSite = ( { site }: { site: Site } ) => {
 			title={ __( 'Transfer site' ) }
 			description={ __( 'Transfer ownership of this site to another WordPress.com user.' ) }
 			actions={
-				<Button
+				<RouterLinkButton
 					variant="secondary"
 					size="compact"
-					href={ `/sites/${ slug }/settings/transfer-site` }
+					to={ `/sites/${ slug }/settings/transfer-site` }
 				>
 					{ __( 'Transfer' ) }
-				</Button>
+				</RouterLinkButton>
 			}
 		/>
 	);

--- a/client/dashboard/sites/settings/danger-zone.tsx
+++ b/client/dashboard/sites/settings/danger-zone.tsx
@@ -1,0 +1,52 @@
+import { __experimentalHeading as Heading, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useAuth } from '../../app/auth';
+import { ActionList } from '../../components/action-list';
+import type { Site } from '../../data/types';
+
+const TransferSite = ( { site }: { site: Site } ) => {
+	const { site_owner, slug } = site;
+	const { user } = useAuth();
+
+	// TODO: The following types of the site are not allowed to transfer the ownership:
+	// * NonAtomicJetpackSite
+	// * P2 Hub
+	// * WP For Teams
+	// * VIP Site
+	// * Staging site
+	// See canCurrentUserStartSiteOwnerTransfer.
+	if ( site_owner !== user.ID ) {
+		return null;
+	}
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Transfer site' ) }
+			description={ __( 'Transfer ownership of this site to another WordPress.com user.' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					href={ `/sites/${ slug }/settings/transfer-site` }
+				>
+					{ __( 'Transfer' ) }
+				</Button>
+			}
+		/>
+	);
+};
+
+export default function DangerZone( { site }: { site: Site } ) {
+	const actions = [ <TransferSite key="transfer-site" site={ site } /> ].filter( Boolean );
+
+	if ( ! actions.length ) {
+		return null;
+	}
+
+	return (
+		<>
+			<Heading>{ __( 'Danger zone' ) }</Heading>
+			<ActionList>{ actions }</ActionList>
+		</>
+	);
+}

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import SiteVisibilitySettingsSummary from '../settings-site-visibility/summary';
 import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting/summary';
+import DangerZone from './danger-zone';
 import SiteActions from './site-actions';
 
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
@@ -30,6 +31,7 @@ export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
 				</VStack>
 			</Card>
 			<SiteActions site={ site } />
+			<DangerZone site={ site } />
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-13175
Design: QOBjujZah0UlGDDdLKZhzi-fi-3728_167218

## Proposed Changes

* Add "Danger zone" to Settings
* Add "Transfer site" to "Danger zone"
* Add the route of the "Transfer site"
* Add the first screen of the "Transfer site"
* Out of scope:
  * Integrate with the endpoint
  * Add Stepper component
  * Other screens: Start Transfer, Email Confirmation, Email Sent
  * The ability to transfer site (some types of the site are not allowed to transfer the ownership)

| Settings | Transfer site: Step 1 |
| - | - |
| ![image](https://github.com/user-attachments/assets/993cfbbf-4367-4356-a682-c0802c1668fe) | ![image](https://github.com/user-attachments/assets/94bbe8d8-3aa7-46ee-b055-559ba3b88f44) |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /v2
* Select any site, and navigate to Settings
* Ensure you can see the "Danger zone"
* Click the "Transfer" button on the "Transfer site"
* Ensure you can navigate to the "Transfer site" screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?