### PR TITLE
Dashboard v2: remove safari sliding animation

### DIFF
--- a/client/dashboard/app/view-transitions.scss
+++ b/client/dashboard/app/view-transitions.scss
@@ -47,12 +47,19 @@ main div.dashboard-header-bar {
 	height: 100%;
 }
 
-.dashboard-page-layout__content {
-	view-transition-name: page-layout-content;
+// Large and small must be separate so they don't cross-animate.
+.dashboard-page-layout.is-large .dashboard-page-layout__content {
+	view-transition-name: page-layout-content-large;
 }
 
-::view-transition-old(page-layout-content),
-::view-transition-new(page-layout-content) {
+.dashboard-page-layout.is-small .dashboard-page-layout__content {
+	view-transition-name: page-layout-content-small;
+}
+
+::view-transition-old(page-layout-content-large),
+::view-transition-new(page-layout-content-large),
+::view-transition-old(page-layout-content-small),
+::view-transition-new(page-layout-content-small) {
 	// Never expand the main content horizontally, but allow it to shrink.
 	width: auto;
 	// Also disable shrinking. Leaving it commented out to test.


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #103278

## Proposed Changes

* Separate transition names for small and large layouts. This will prevent the browsers from cross animating theme because they no longer share the same name.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In safari, manually update the entry dashboard stylesheet and switch between site overview and site settings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
