### PR TITLE
Dashboard v2: performance: lazy load media storage

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -78,6 +78,13 @@ export function sitePHPVersionQuery( siteIdOrSlug: string ) {
 	};
 }
 
+export function siteMediaStorageQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site', siteIdOrSlug, 'media-storage' ],
+		queryFn: () => fetchSiteMediaStorage( siteIdOrSlug ),
+	};
+}
+
 export function domainsQuery() {
 	return {
 		queryKey: [ 'domains' ],

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -78,13 +78,6 @@ export function sitePHPVersionQuery( siteIdOrSlug: string ) {
 	};
 }
 
-export function siteMediaStorageQuery( siteIdOrSlug: string ) {
-	return {
-		queryKey: [ 'site', siteIdOrSlug, 'media-storage' ],
-		queryFn: () => fetchSiteMediaStorage( siteIdOrSlug ),
-	};
-}
-
 export function domainsQuery() {
 	return {
 		queryKey: [ 'domains' ],

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -15,7 +15,6 @@ import {
 	domainsQuery,
 	emailsQuery,
 	profileQuery,
-	siteMediaStorageQuery,
 	siteCurrentPlanQuery,
 	sitePrimaryDomainQuery,
 	siteEngagementStatsQuery,
@@ -83,7 +82,6 @@ const siteOverviewRoute = createRoute( {
 		// Site usually takes the longest, so kick it off first.
 		const sitePromise = queryClient.ensureQueryData( siteQuery( siteSlug ) );
 		// Kick off all independent promises in parallel.
-		const mediaStoragePromise = queryClient.ensureQueryData( siteMediaStorageQuery( siteSlug ) );
 		const currentPlanPromise = queryClient.ensureQueryData( siteCurrentPlanQuery( siteSlug ) );
 		const primaryDomainPromise = queryClient.ensureQueryData( sitePrimaryDomainQuery( siteSlug ) );
 		const engagementStatsPromise = queryClient.ensureQueryData(
@@ -91,7 +89,6 @@ const siteOverviewRoute = createRoute( {
 		);
 		const site = await sitePromise;
 		await Promise.all( [
-			mediaStoragePromise,
 			currentPlanPromise,
 			primaryDomainPromise,
 			engagementStatsPromise,

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import {
 	siteQuery,
-	siteMediaStorageQuery,
 	siteMonitorUptimeQuery,
 	sitePHPVersionQuery,
 	siteCurrentPlanQuery,
@@ -37,7 +36,6 @@ import './style.scss';
 function SiteOverview() {
 	const { siteSlug } = siteRoute.useParams();
 	const { data: site } = useQuery( siteQuery( siteSlug ) );
-	const { data: mediaStorage } = useQuery( siteMediaStorageQuery( siteSlug ) );
 	const { data: siteMonitorUptime } = useQuery( {
 		...siteMonitorUptimeQuery( siteSlug ),
 		enabled: site?.jetpack && site?.jetpack_modules.includes( 'monitor' ),
@@ -50,10 +48,9 @@ function SiteOverview() {
 	const { data: primaryDomain } = useQuery( sitePrimaryDomainQuery( siteSlug ) );
 	const { data: engagementStats } = useQuery( siteEngagementStatsQuery( siteSlug ) );
 
-	if ( ! site || ! mediaStorage || ! currentPlan || ! primaryDomain || ! engagementStats ) {
+	if ( ! site || ! currentPlan || ! primaryDomain || ! engagementStats ) {
 		return;
 	}
-
 	return (
 		<PageLayout
 			header={
@@ -105,7 +102,7 @@ function SiteOverview() {
 					<OverviewSection title={ __( 'Site health' ) } actions={ [] }>
 						<PerformanceCards site={ site } />
 						<UptimeCard siteMonitorUptime={ siteMonitorUptime } />
-						<StorageCard mediaStorage={ mediaStorage } />
+						<StorageCard siteSlug={ siteSlug } />
 					</OverviewSection>
 				</VStack>
 			</HStack>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

<img width="924" alt="Screenshot 2025-05-20 at 13 49 17" src="https://github.com/user-attachments/assets/43f8e0f8-6bca-4d4d-a6b5-7cba19fe6dd2" />

Btw, in reality, the loading indicator for media storage is so fast gone it's not even visible.

## Proposed Changes

* Lazy load media storage data. It's not data that will result in a layout shift and it's fine to pop in a few ms later. Additionally the other site health cards are loaded in way later and have the same loading state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The less requests needed for the initial site endpoint, the better.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that media storage still loads.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
