### PR TITLE
Dashboard v2: split siteQuery

### DIFF
--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -29,9 +29,11 @@ export function sitesQuery() {
 	};
 }
 
-export function siteQuery( siteIdOrSlug: string ) {
+// To do: split this into separate queries and combine them in the loader
+// instead.
+export function siteOverviewQuery( siteIdOrSlug: string ) {
 	return {
-		queryKey: [ 'site', siteIdOrSlug, SITE_FIELDS ],
+		queryKey: [ 'site', siteIdOrSlug, SITE_FIELDS, 'overview' ],
 		queryFn: async () => {
 			// Site usually takes the longest, so kick it off first.
 			const sitePromise = fetchSite( siteIdOrSlug );
@@ -69,6 +71,13 @@ export function siteQuery( siteIdOrSlug: string ) {
 				engagementStats,
 			};
 		},
+	};
+}
+
+export function siteQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site', siteIdOrSlug ],
+		queryFn: () => fetchSite( siteIdOrSlug ),
 	};
 }
 

--- a/client/dashboard/app/queries.ts
+++ b/client/dashboard/app/queries.ts
@@ -29,55 +29,52 @@ export function sitesQuery() {
 	};
 }
 
-// To do: split this into separate queries and combine them in the loader
-// instead.
-export function siteOverviewQuery( siteIdOrSlug: string ) {
+export function siteQuery( siteIdOrSlug: string ) {
 	return {
-		queryKey: [ 'site', siteIdOrSlug, SITE_FIELDS, 'overview' ],
-		queryFn: async () => {
-			// Site usually takes the longest, so kick it off first.
-			const sitePromise = fetchSite( siteIdOrSlug );
-			// Kick off all independent promises in parallel.
-			const mediaStoragePromise = fetchSiteMediaStorage( siteIdOrSlug );
-			const currentPlanPromise = fetchCurrentPlan( siteIdOrSlug );
-			const primaryDomainPromise = fetchSitePrimaryDomain( siteIdOrSlug );
-			const engagementStatsPromise = fetchSiteEngagementStats( siteIdOrSlug );
-			const site = await sitePromise;
-			const [
-				mediaStorage,
-				currentPlan,
-				primaryDomain,
-				engagementStats,
-				siteMonitorUptime,
-				phpVersion,
-			] = await Promise.all( [
-				mediaStoragePromise,
-				currentPlanPromise,
-				primaryDomainPromise,
-				engagementStatsPromise,
-				// Kick off dependent promises in parallel.
-				site.jetpack && site.jetpack_modules.includes( 'monitor' )
-					? fetchSiteMonitorUptime( site.ID )
-					: undefined,
-				site.is_wpcom_atomic ? fetchPHPVersion( site.ID ) : undefined,
-			] );
-			return {
-				site,
-				mediaStorage,
-				siteMonitorUptime,
-				phpVersion,
-				currentPlan,
-				primaryDomain,
-				engagementStats,
-			};
-		},
+		queryKey: [ 'site', siteIdOrSlug, SITE_FIELDS ],
+		queryFn: () => fetchSite( siteIdOrSlug ),
 	};
 }
 
-export function siteQuery( siteIdOrSlug: string ) {
+export function siteCurrentPlanQuery( siteIdOrSlug: string ) {
 	return {
-		queryKey: [ 'site', siteIdOrSlug ],
-		queryFn: () => fetchSite( siteIdOrSlug ),
+		queryKey: [ 'site', siteIdOrSlug, 'current-plan' ],
+		queryFn: () => fetchCurrentPlan( siteIdOrSlug ),
+	};
+}
+
+export function sitePrimaryDomainQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site', siteIdOrSlug, 'primary-domain' ],
+		queryFn: () => fetchSitePrimaryDomain( siteIdOrSlug ),
+	};
+}
+
+export function siteEngagementStatsQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site', siteIdOrSlug, 'engagement-stats' ],
+		queryFn: () => fetchSiteEngagementStats( siteIdOrSlug ),
+	};
+}
+
+export function siteMediaStorageQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site', siteIdOrSlug, 'media-storage' ],
+		queryFn: () => fetchSiteMediaStorage( siteIdOrSlug ),
+	};
+}
+
+export function siteMonitorUptimeQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site', siteIdOrSlug, 'monitor-uptime' ],
+		queryFn: () => fetchSiteMonitorUptime( siteIdOrSlug ),
+	};
+}
+
+export function sitePHPVersionQuery( siteIdOrSlug: string ) {
+	return {
+		queryKey: [ 'site', siteIdOrSlug, 'php-version' ],
+		queryFn: () => fetchPHPVersion( siteIdOrSlug ),
 	};
 }
 

--- a/client/dashboard/app/query-client.ts
+++ b/client/dashboard/app/query-client.ts
@@ -19,7 +19,7 @@ const maxAge = 1000 * 60 * 60 * 24; // 24 hours
 const [ , persistPromise ] = persistQueryClient( {
 	queryClient,
 	persister,
-	buster: '1', // Bump when query data shape changes.
+	buster: '2', // Bump when query data shape changes.
 	maxAge,
 	dehydrateOptions: {
 		shouldDehydrateQuery: ( { queryKey } ) => {

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -15,6 +15,7 @@ import {
 	domainsQuery,
 	emailsQuery,
 	profileQuery,
+	siteOverviewQuery,
 } from './queries';
 import { queryClient } from './query-client';
 import Root from './root';
@@ -62,7 +63,6 @@ const sitesRoute = createRoute( {
 const siteRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'sites/$siteSlug',
-	loader: ( { params: { siteSlug } } ) => queryClient.ensureQueryData( siteQuery( siteSlug ) ),
 } ).lazy( () =>
 	import( '../sites/site' ).then( ( d ) =>
 		createLazyRoute( 'site' )( {
@@ -74,6 +74,12 @@ const siteRoute = createRoute( {
 const siteOverviewRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: '/',
+	loader: ( { params: { siteSlug } } ) =>
+		Promise.all( [
+			// Needed for header. To do: fix.
+			queryClient.ensureQueryData( siteQuery( siteSlug ) ),
+			queryClient.ensureQueryData( siteOverviewQuery( siteSlug ) ),
+		] ),
 } ).lazy( () =>
 	import( '../sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'site-overview' )( {
@@ -108,7 +114,10 @@ const siteSettingsRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: 'settings',
 	loader: ( { params: { siteSlug } } ) =>
-		queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+		Promise.all( [
+			queryClient.ensureQueryData( siteQuery( siteSlug ) ),
+			queryClient.ensureQueryData( siteSettingsQuery( siteSlug ) ),
+		] ),
 } ).lazy( () =>
 	import( '../sites/settings' ).then( ( d ) =>
 		createLazyRoute( 'site-settings' )( {

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -15,7 +15,12 @@ import {
 	domainsQuery,
 	emailsQuery,
 	profileQuery,
-	siteOverviewQuery,
+	siteMediaStorageQuery,
+	siteCurrentPlanQuery,
+	sitePrimaryDomainQuery,
+	siteEngagementStatsQuery,
+	siteMonitorUptimeQuery,
+	sitePHPVersionQuery,
 } from './queries';
 import { queryClient } from './query-client';
 import Root from './root';
@@ -74,12 +79,31 @@ const siteRoute = createRoute( {
 const siteOverviewRoute = createRoute( {
 	getParentRoute: () => siteRoute,
 	path: '/',
-	loader: ( { params: { siteSlug } } ) =>
-		Promise.all( [
-			// Needed for header. To do: fix.
-			queryClient.ensureQueryData( siteQuery( siteSlug ) ),
-			queryClient.ensureQueryData( siteOverviewQuery( siteSlug ) ),
-		] ),
+	loader: async ( { params: { siteSlug } } ) => {
+		// Site usually takes the longest, so kick it off first.
+		const sitePromise = queryClient.ensureQueryData( siteQuery( siteSlug ) );
+		// Kick off all independent promises in parallel.
+		const mediaStoragePromise = queryClient.ensureQueryData( siteMediaStorageQuery( siteSlug ) );
+		const currentPlanPromise = queryClient.ensureQueryData( siteCurrentPlanQuery( siteSlug ) );
+		const primaryDomainPromise = queryClient.ensureQueryData( sitePrimaryDomainQuery( siteSlug ) );
+		const engagementStatsPromise = queryClient.ensureQueryData(
+			siteEngagementStatsQuery( siteSlug )
+		);
+		const site = await sitePromise;
+		await Promise.all( [
+			mediaStoragePromise,
+			currentPlanPromise,
+			primaryDomainPromise,
+			engagementStatsPromise,
+			// Kick off dependent promises in parallel.
+			site.jetpack && site.jetpack_modules.includes( 'monitor' )
+				? queryClient.ensureQueryData( siteMonitorUptimeQuery( siteSlug ) )
+				: undefined,
+			site.options?.is_wpcom_atomic
+				? queryClient.ensureQueryData( sitePHPVersionQuery( siteSlug ) )
+				: undefined,
+		] );
+	},
 } ).lazy( () =>
 	import( '../sites/overview' ).then( ( d ) =>
 		createLazyRoute( 'site-overview' )( {

--- a/client/dashboard/app/router.tsx
+++ b/client/dashboard/app/router.tsx
@@ -99,7 +99,7 @@ const siteOverviewRoute = createRoute( {
 			site.jetpack && site.jetpack_modules.includes( 'monitor' )
 				? queryClient.ensureQueryData( siteMonitorUptimeQuery( siteSlug ) )
 				: undefined,
-			site.options?.is_wpcom_atomic
+			site.is_wpcom_atomic
 				? queryClient.ensureQueryData( sitePHPVersionQuery( siteSlug ) )
 				: undefined,
 		] );

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
-import { siteQuery } from '../../app/queries';
+import { siteOverviewQuery } from '../../app/queries';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -28,7 +28,7 @@ import './style.scss';
 
 function SiteOverview() {
 	const { siteSlug } = siteRoute.useParams();
-	const { data } = useQuery( siteQuery( siteSlug ) );
+	const { data } = useQuery( siteOverviewQuery( siteSlug ) );
 
 	if ( ! data ) {
 		return;

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -9,7 +9,15 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
-import { siteOverviewQuery } from '../../app/queries';
+import {
+	siteQuery,
+	siteMediaStorageQuery,
+	siteMonitorUptimeQuery,
+	sitePHPVersionQuery,
+	siteCurrentPlanQuery,
+	sitePrimaryDomainQuery,
+	siteEngagementStatsQuery,
+} from '../../app/queries';
 import { siteRoute } from '../../app/router';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -28,20 +36,24 @@ import './style.scss';
 
 function SiteOverview() {
 	const { siteSlug } = siteRoute.useParams();
-	const { data } = useQuery( siteOverviewQuery( siteSlug ) );
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
+	const { data: mediaStorage } = useQuery( siteMediaStorageQuery( siteSlug ) );
+	const { data: siteMonitorUptime } = useQuery( {
+		...siteMonitorUptimeQuery( siteSlug ),
+		enabled: site?.jetpack && site?.jetpack_modules.includes( 'monitor' ),
+	} );
+	const { data: phpVersion } = useQuery( {
+		...sitePHPVersionQuery( siteSlug ),
+		enabled: site?.options?.is_wpcom_atomic,
+	} );
+	const { data: currentPlan } = useQuery( siteCurrentPlanQuery( siteSlug ) );
+	const { data: primaryDomain } = useQuery( sitePrimaryDomainQuery( siteSlug ) );
+	const { data: engagementStats } = useQuery( siteEngagementStatsQuery( siteSlug ) );
 
-	if ( ! data ) {
+	if ( ! site || ! mediaStorage || ! currentPlan || ! primaryDomain || ! engagementStats ) {
 		return;
 	}
-	const {
-		site,
-		mediaStorage,
-		siteMonitorUptime,
-		phpVersion,
-		currentPlan,
-		primaryDomain,
-		engagementStats,
-	} = data;
+
 	return (
 		<PageLayout
 			header={

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -44,7 +44,7 @@ function SiteOverview() {
 	} );
 	const { data: phpVersion } = useQuery( {
 		...sitePHPVersionQuery( siteSlug ),
-		enabled: site?.options?.is_wpcom_atomic,
+		enabled: site?.is_wpcom_atomic,
 	} );
 	const { data: currentPlan } = useQuery( siteCurrentPlanQuery( siteSlug ) );
 	const { data: primaryDomain } = useQuery( sitePrimaryDomainQuery( siteSlug ) );

--- a/client/dashboard/sites/settings-site-visibility/index.tsx
+++ b/client/dashboard/sites/settings-site-visibility/index.tsx
@@ -8,15 +8,13 @@ import { LaunchForm } from './launch-form';
 import { PrivacyForm } from './privacy-form';
 
 export default function SiteVisibilitySettings( { siteSlug }: { siteSlug: string } ) {
-	const { data: siteData } = useQuery( siteQuery( siteSlug ) );
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
 	const mutation = useMutation( siteSettingsMutation( siteSlug ) );
 
-	if ( ! settings || ! siteData ) {
+	if ( ! settings || ! site ) {
 		return null;
 	}
-
-	const { site } = siteData;
 
 	return (
 		<PageLayout

--- a/client/dashboard/sites/settings-subscription-gifting/index.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/index.tsx
@@ -36,15 +36,15 @@ const form = {
 };
 
 export default function SubscriptionGiftingSettings( { siteSlug }: { siteSlug: string } ) {
-	const { data: siteData } = useQuery( siteQuery( siteSlug ) );
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const { data } = useQuery( siteSettingsQuery( siteSlug ) );
 	const mutation = useMutation( siteSettingsMutation( siteSlug ) );
 
-	if ( ! data || ! siteData ) {
+	if ( ! data || ! site ) {
 		return null;
 	}
 
-	if ( ! hasSubscriptionGiftingFeature( siteData.site ) ) {
+	if ( ! hasSubscriptionGiftingFeature( site ) ) {
 		throw notFound();
 	}
 

--- a/client/dashboard/sites/settings/index.tsx
+++ b/client/dashboard/sites/settings/index.tsx
@@ -13,14 +13,12 @@ import SubscriptionGiftingSettingsSummary from '../settings-subscription-gifting
 import SiteActions from './site-actions';
 
 export default function SiteSettings( { siteSlug }: { siteSlug: string } ) {
-	const { data: siteData } = useQuery( siteQuery( siteSlug ) );
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
 	const { data: settings } = useQuery( siteSettingsQuery( siteSlug ) );
 
-	if ( ! siteData || ! settings ) {
+	if ( ! site || ! settings ) {
 		return null;
 	}
-
-	const { site } = siteData;
 
 	return (
 		<PageLayout size="small" header={ <PageHeader title={ __( 'Settings' ) } /> }>

--- a/client/dashboard/sites/site/index.tsx
+++ b/client/dashboard/sites/site/index.tsx
@@ -13,13 +13,11 @@ import Switcher from './switcher';
 function Site() {
 	const isDesktop = useViewportMatch( 'medium' );
 	const { siteSlug } = siteRoute.useParams();
-	const { data } = useQuery( siteQuery( siteSlug ) );
+	const { data: site } = useQuery( siteQuery( siteSlug ) );
 
-	if ( ! data ) {
+	if ( ! site ) {
 		return;
 	}
-
-	const { site } = data;
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Problems

* Site Settings route is not waiting for the site data, it only has the site settings in the loader data.
* Currently all the other site meta data like engagement, media, php version, plan etc. load for the settings page, even though they're only needed for the overview page.

## Proposed Changes

* Fix the loaders.
* Split the site queries into separate queries so they can be picked from at the route level.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Performance and clarity 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Everything should work as before.
* No /vitits fetches etc. for settings page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
